### PR TITLE
feat(web): search syntax legend + unified settings header

### DIFF
--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -320,16 +320,18 @@ export function AppSidebar({
 
         <div className="flex min-h-0 flex-1 flex-col">
           <nav
-            className={cn("flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-6", {
-              "items-center": collapsed,
+            className={cn("flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto py-6", {
+              "items-center px-2": collapsed,
+              "px-6": !collapsed,
             })}
           >
             {children({ collapsed })}
           </nav>
           {footer ? (
             <nav
-              className={cn("flex shrink-0 flex-col gap-1 px-6 pb-6", {
-                "items-center": collapsed,
+              className={cn("flex shrink-0 flex-col gap-1 pb-6", {
+                "items-center px-2": collapsed,
+                "px-6": !collapsed,
               })}
             >
               {footer({ collapsed })}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-syntax-legend.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-syntax-legend.tsx
@@ -1,0 +1,62 @@
+import { Button, cn, Icon, Popover, PopoverContent, PopoverTrigger, Text } from "@repo/ui"
+import { CircleHelpIcon } from "lucide-react"
+
+type Entry = {
+  readonly label: string
+  readonly pillClassName?: string
+  readonly example: string
+  readonly description: string
+}
+
+const ENTRIES: readonly Entry[] = [
+  {
+    label: "Semantic",
+    example: "checkout error",
+    description: "Plain words search by meaning. Results don't need to contain the exact text.",
+  },
+  {
+    label: "Literal",
+    pillClassName: "border-primary/25 bg-primary/10 text-primary",
+    example: '"401 Unauthorized"',
+    description: "Wrap in double quotes for an exact match, including capitalization and punctuation.",
+  },
+  {
+    label: "Phrase",
+    pillClassName: "border-phrase/30 bg-phrase/10 text-phrase-foreground",
+    example: "`refund payment failed`",
+    description: "Wrap in backticks to match these words in this order. Capitalization is ignored.",
+  },
+]
+
+export function SearchSyntaxLegend() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Search syntax help">
+          <Icon icon={CircleHelpIcon} size="sm" color="foregroundMuted" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={6} className="w-80">
+        <Text.H5M>Search syntax</Text.H5M>
+        <ul className="mt-3 flex flex-col gap-3">
+          {ENTRIES.map((entry) => (
+            <li key={entry.label} className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Text.H6B>{entry.label}</Text.H6B>
+                <span
+                  className={cn(
+                    "inline-flex h-5 items-center rounded-full px-2 font-mono text-[11px]",
+                    entry.pillClassName ?? "text-muted-foreground",
+                  )}
+                >
+                  {entry.example}
+                </span>
+              </div>
+              <Text.H6 color="foregroundMuted">{entry.description}</Text.H6>
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -38,6 +38,7 @@ import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { SaveSearchModal } from "./-components/save-search-modal.tsx"
 import { SavedSearchesList } from "./-components/saved-searches-list.tsx"
+import { SearchSyntaxLegend } from "./-components/search-syntax-legend.tsx"
 
 const SEARCH_QUERY_MAX_LENGTH = 500
 
@@ -217,6 +218,7 @@ function SearchPage() {
               </Tooltip>
             ) : null}
             <SearchInput key={q} initialValue={q} onSubmit={setQ} />
+            <SearchSyntaxLegend />
           </div>
         </Layout.ActionsRow>
       </Layout.Actions>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -1,19 +1,39 @@
 import { Text } from "@repo/ui"
 import type { ReactNode } from "react"
 
-interface SettingsPageProps {
-  title: string
-  description?: string
-  children: ReactNode
+interface SettingsPageTitleProps {
+  readonly children: ReactNode
 }
 
-export function SettingsPage({ title, description, children }: SettingsPageProps) {
+export function SettingsPageTitle({ children }: SettingsPageTitleProps) {
+  return <Text.H3M>{children}</Text.H3M>
+}
+
+interface SettingsPageProps {
+  readonly title: ReactNode
+  readonly description?: ReactNode
+  readonly actions?: ReactNode
+  readonly children: ReactNode
+}
+
+export function SettingsPage({ title, description, actions, children }: SettingsPageProps) {
+  const header = (
+    <div className="flex flex-col gap-1">
+      {typeof title === "string" ? <SettingsPageTitle>{title}</SettingsPageTitle> : title}
+      {description ? <Text.H6M color="foregroundMuted">{description}</Text.H6M> : null}
+    </div>
+  )
+
   return (
     <>
-      <div className="flex flex-col gap-1">
-        <Text.H3 weight="bold">{title}</Text.H3>
-        {description ? <Text.H5 color="foregroundMuted">{description}</Text.H5> : null}
-      </div>
+      {actions ? (
+        <div className="flex flex-row items-start justify-between gap-4">
+          {header}
+          <div className="shrink-0">{actions}</div>
+        </div>
+      ) : (
+        header
+      )}
       <div className="flex flex-col gap-6">{children}</div>
     </>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -52,6 +52,7 @@ import { authClient } from "../../../../../lib/auth-client.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
 import { useAuthenticatedUser } from "../../../-route-data.ts"
+import { SettingsPage } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/account")({
   component: AccountSettingsPage,
@@ -443,8 +444,7 @@ function AccountSettingsPage() {
   })
 
   return (
-    <>
-      <Text.H4 weight="bold">Account</Text.H4>
+    <SettingsPage title="Account" description="Manage your personal account">
       <form
         className="flex w-full flex-col gap-3 @[800px]:w-1/2"
         onSubmit={(e) => {
@@ -491,6 +491,6 @@ function AccountSettingsPage() {
           </Button>
         </div>
       </div>
-    </>
+    </SettingsPage>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/billing.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../../../../domains/billing/billing.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
+import { SettingsPage, SettingsPageTitle } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/billing")({
   loader: async () => ({
@@ -23,16 +24,10 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
 
 function BillingUnavailableFallback({ error, reset }: { error: unknown; reset: () => void }) {
   return (
-    <>
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-1">
-          <Text.H4 weight="bold">Billing</Text.H4>
-          <Text.H5 color="foregroundMuted">
-            We couldn't load your billing data right now. This usually clears up after a refresh. If it keeps happening,
-            contact support.
-          </Text.H5>
-        </div>
-      </div>
+    <SettingsPage
+      title="Billing"
+      description="We couldn't load your billing data right now. This usually clears up after a refresh. If it keeps happening, contact support."
+    >
       <div className="flex flex-col gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-5">
         <Text.H6 color="destructive">Billing data unavailable</Text.H6>
         <Text.H6 color="foregroundMuted">{toUserMessage(error)}</Text.H6>
@@ -40,7 +35,7 @@ function BillingUnavailableFallback({ error, reset }: { error: unknown; reset: (
       <div>
         <Button onClick={() => reset()}>Try again</Button>
       </div>
-    </>
+    </SettingsPage>
   )
 }
 
@@ -343,24 +338,22 @@ function BillingSettingsPage() {
   const overview = Route.useLoaderData({ select: (data) => data.overview })
 
   return (
-    <>
-      <div className="flex flex-col gap-2">
+    <SettingsPage
+      title={
         <div className="flex items-center gap-3">
-          <Text.H4 weight="bold">Billing</Text.H4>
+          <SettingsPageTitle>Billing</SettingsPageTitle>
           <Badge
             variant={overview.planSlug === "free" ? "secondary" : overview.planSlug === "pro" ? "default" : "outline"}
           >
             {overview.planSlug?.toUpperCase()}
           </Badge>
         </div>
-        <Text.H5 color="foregroundMuted">
-          Current period: {formatPeriodDate(overview.periodStart)} to {formatPeriodDate(overview.periodEnd)}
-        </Text.H5>
-      </div>
-
+      }
+      description={`Current period: ${formatPeriodDate(overview.periodStart)} to ${formatPeriodDate(overview.periodEnd)}`}
+    >
       <BillingOverviewCards />
       <BillingActionsSection />
       <SpendingLimitSection key={overview.spendingLimitCents ?? "no-limit"} />
-    </>
+    </SettingsPage>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/keys.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/keys.tsx
@@ -35,6 +35,7 @@ import { revokeOAuthKeyMutation, useOAuthKeysCollection } from "../../../../../d
 import type { OAuthKeyRecord } from "../../../../../domains/oauth/oauth-keys.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
+import { SettingsPage } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/keys")({
   component: KeysSettingsPage,
@@ -398,21 +399,24 @@ function KeysSettingsPage() {
   const oauthKeys = (oauthKeyData ?? []).slice().sort(byCreatedAtDesc)
 
   return (
-    <>
+    <SettingsPage
+      title="Keys"
+      description="Manage API keys and OAuth connections for this organization"
+      actions={
+        <Button variant="outline" onClick={() => setCreateOpen(true)}>
+          <Icon size="sm" icon={PlusIcon} />
+          API Key
+        </Button>
+      }
+    >
       <CreateApiKeyModal open={createOpen} setOpen={setCreateOpen} />
 
       <section className="flex flex-col gap-4">
-        <div className="flex flex-row items-center justify-between">
-          <div className="flex flex-col gap-1">
-            <Text.H4 weight="bold">API Keys</Text.H4>
-            <Text.H5 color="foregroundMuted">
-              Application keys with access to this organization (through API or SDK)
-            </Text.H5>
-          </div>
-          <Button variant="outline" onClick={() => setCreateOpen(true)}>
-            <Icon size="sm" icon={PlusIcon} />
-            API Key
-          </Button>
+        <div className="flex flex-col gap-1">
+          <Text.H4 weight="bold">API Keys</Text.H4>
+          <Text.H5 color="foregroundMuted">
+            Application keys with access to this organization (through API or SDK)
+          </Text.H5>
         </div>
         <div className="flex flex-col gap-2">
           {apiKeysLoading ? <TableSkeleton cols={3} rows={3} /> : <ApiKeysTable apiKeys={apiKeys} />}
@@ -448,6 +452,6 @@ function KeysSettingsPage() {
           )}
         </div>
       </section>
-    </>
+    </SettingsPage>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
@@ -40,6 +40,7 @@ import type { MemberRecord } from "../../../../../domains/members/members.functi
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
 import { useAuthenticatedUser } from "../../../-route-data.ts"
+import { SettingsPage } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/members")({
   component: MembersSettingsPage,
@@ -537,26 +538,25 @@ function MembersSettingsPage() {
   const isAdmin = isOwner || currentUserMembership?.role === "admin"
 
   return (
-    <section className="flex flex-col gap-4">
-      <InviteMemberModal open={inviteOpen} setOpen={setInviteOpen} />
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-col gap-1">
-          <Text.H4 weight="bold">Members</Text.H4>
-          <Text.H5 color="foregroundMuted">Members and pending invitations of this organization</Text.H5>
-        </div>
-        {isAdmin ? (
+    <SettingsPage
+      title="Members"
+      description="Members and pending invitations of this organization"
+      actions={
+        isAdmin ? (
           <Button variant="outline" onClick={() => setInviteOpen(true)}>
             <Icon size="sm" icon={UserPlusIcon} />
             Member
           </Button>
-        ) : null}
-      </div>
+        ) : null
+      }
+    >
+      <InviteMemberModal open={inviteOpen} setOpen={setInviteOpen} />
       <div className="flex flex-col gap-2">
         {isLoading ? <TableSkeleton cols={6} rows={3} /> : null}
         {!isLoading && members.length > 0 ? (
           <MembersTable members={members} currentUserId={user.id} isOwner={isOwner} isAdmin={isAdmin} />
         ) : null}
       </div>
-    </section>
+    </SettingsPage>
   )
 }

--- a/packages/ui/src/components/text/text.tsx
+++ b/packages/ui/src/components/text/text.tsx
@@ -184,6 +184,11 @@ namespace Text {
   })
   H6.displayName = "Text.H6"
 
+  export const H6M = forwardRef<HTMLHeadingElement, Common>(function H6M(props, ref) {
+    return <TextAtom ref={ref as React.Ref<HTMLElement>} size="h6" weight="medium" {...props} />
+  })
+  H6M.displayName = "Text.H6M"
+
   export const H6B = forwardRef<HTMLHeadingElement, Common>(function H6B(props, ref) {
     return <TextAtom ref={ref as React.Ref<HTMLElement>} size="h6" weight="bold" {...props} />
   })


### PR DESCRIPTION
## Summary

- **Search syntax legend (LAT-585):** small `?` button on the right of the project search bar opens a popover explaining the three search modes (semantic, literal `"..."`, phrase `` `...` ``) with example pills that match the colors used by the actual input segments.
- **Unified project settings header:** `SettingsPage` now uses `Text.H3M` title + `Text.H6M` muted description, accepts a `ReactNode` title for composition (e.g. Billing's plan badge), and supports an optional `actions` slot. Adds the missing `Text.H6M` variant. Migrates `billing`, `account`, `members`, and `keys` onto the shared component; pages already using `SettingsPage` (`general`, `flaggers`, `issues`, `organization`) pick up the new sizing automatically.
- **Collapsed sidebar overflow fix:** the 64px collapsed rail used `p-6` plus 40px nav buttons, overflowing by ~24px; combined with `overflow-y-auto`, CSS promoted `overflow-x` to `auto` and a horizontal scrollbar appeared. Switch to `px-2` in the collapsed state so nav + footer fit inside the rail.

Closes LAT-585.

## Test plan

- [x] Open a project search, verify the `?` next to the search bar opens a popover listing semantic / literal / phrase with matching pill colors.
- [x] Visit each settings page (General, Issues, Flaggers, Organization, Members, Keys, Billing, Account) and confirm titles are consistent (H3M) with H6M muted descriptions; Billing shows the plan badge next to the title.
- [x] Confirm Members "Invite" and Keys "API Key" buttons sit in the header `actions` slot.
- [x] Toggle the app sidebar to collapsed (⌘B) and confirm no horizontal scrollbar appears in nav or footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)