### PR TITLE
fix(spans): Anthropic Agent SDK OTLP span names (LAT-578)

### DIFF
--- a/dev-docs/claude-code-telemetry.md
+++ b/dev-docs/claude-code-telemetry.md
@@ -38,7 +38,9 @@ Each turn produces three kinds of spans, all routed through the existing `apps/i
 | --- | --- | --- |
 | `interaction` | `prompt` | Root of the turn. `user_prompt`, `session.id`, `interaction.duration_ms`. |
 | `llm_request` | `chat` | Child of interaction. `model`, token counts (input/output/cache_read/cache_creation), `gen_ai.input.messages`, `gen_ai.output.messages` (full conversation as JSON). |
-| `tool_execution` | `execute_tool` | Child of llm_request, one per tool call. `tool.name`, `tool.id`, `tool.input`, `tool.output`. |
+| `tool_execution` or `tool` | `execute_tool` | Child of llm_request, one per tool call. `tool.name`, `tool.id`, `tool.input`, `tool.output`. |
+
+The [Anthropic Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) uses the same CLI and can emit OTLP without the hook ([observability](https://code.claude.com/docs/en/agent-sdk/observability)). Native exports often use span **names** such as `claude_code.interaction`, `claude_code.llm_request`, and `claude_code.tool`; ingest maps those to the same operations as `span.type`-based spans (`resolveOperation` in `operation.ts`).
 
 Server-side routing lives in `packages/domain/spans/src/otlp/resolvers/operation.ts` (`CLAUDE_CODE_OPERATION` map) and `packages/domain/spans/src/otlp/content/claude-code.ts`. The `gen_ai.input.messages` / `gen_ai.output.messages` attributes are parsed by the generic `parseGenAICurrent` parser, which takes precedence over `parseClaudeCode`.
 

--- a/docs/telemetry/claude-code.md
+++ b/docs/telemetry/claude-code.md
@@ -162,6 +162,26 @@ The package also ships an optional Bun preload script that wraps `fetch` to capt
 
 The hook is **fail-open**. If anything goes wrong (network error, bad API key, parse error), it logs to stderr (visible with `LATITUDE_DEBUG=1`) and exits cleanly. Claude Code is never blocked by a telemetry failure.
 
+## Anthropic Agent SDK (native OpenTelemetry)
+
+The [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview) runs the same Claude Code CLI in a child process. That CLI can export **OpenTelemetry** traces, metrics, and logs directly to an OTLP endpoint ([Agent SDK observability](https://code.claude.com/docs/en/agent-sdk/observability)). You do **not** need the Stop hook or `@latitude-data/claude-code-telemetry` when you use this path: configure the CLI’s OTLP exporter to point at Latitude’s ingest URL instead.
+
+1. Create a Latitude **API key** and note your project **slug** (same as the hook flow above).
+2. Set the telemetry switches Anthropic documents, including **`CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1`** if you want **traces** (beta), not only metrics or log events.
+3. Aim the OTLP **trace** exporter at Latitude and attach auth headers. The wire format is standard OTLP over HTTP; see [OpenTelemetry exporter (OTEL)](https://docs.latitude.so/telemetry/otel-exporter) for the exact URL and header names. In practice you will set variables along the lines of:
+
+   - `CLAUDE_CODE_ENABLE_TELEMETRY=1`
+   - `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` (required for trace spans such as `claude_code.interaction` and `claude_code.llm_request`)
+   - `OTEL_TRACES_EXPORTER=otlp` (and optionally metrics/logs exporters if you want those signals too)
+   - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://ingest.latitude.so/v1/traces`
+   - `OTEL_EXPORTER_OTLP_TRACES_HEADERS=Authorization=Bearer YOUR_API_KEY,X-Latitude-Project=YOUR_PROJECT_SLUG`
+
+   Use `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` unless your deployment requires gRPC. For short-lived agent runs, shorten the export intervals (`OTEL_TRACES_EXPORT_INTERVAL`, and the metric/log counterparts) so batches flush before the process exits, as described in Anthropic’s docs.
+
+4. If you already use the Latitude **TypeScript or Python SDK** in the host app, you can still rely on the Agent SDK’s **native** export for the subprocess: the CLI emits its own OTLP batches. Optionally start a root span in your app before `query()`; Anthropic propagates W3C `TRACEPARENT` into the CLI so agent spans can nest under your trace.
+
+Latitude’s ingest pipeline maps Claude Code’s span names and attributes into the same trace model as the Stop-hook integration (`claude_code.*` spans and `span.type` values such as `llm_request` and `tool`).
+
 ## Privacy
 
 You should treat this hook as full-fidelity telemetry. Once installed, Latitude receives the verbatim content of every turn: prompts, responses, tool I/O, system prompts, and tool schemas. Important properties:

--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -1,6 +1,7 @@
 import { stringAttr } from "../attributes.ts"
+import type { OtlpKeyValue } from "../types.ts"
 import type { Candidate } from "./utils.ts"
-import { fromString } from "./utils.ts"
+import { first, fromString } from "./utils.ts"
 
 const VERCEL_PROVIDER_SUFFIX = /\.(chat|messages|responses|generative-ai|embed)$/
 
@@ -37,7 +38,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
 
 const aliasProvider = (v: string) => PROVIDER_ALIASES[v] ?? v
 
-export const providerCandidates: Candidate<string>[] = [
+const providerCandidates: Candidate<string>[] = [
   fromString("gen_ai.provider.name", aliasProvider), // OTEL GenAI v1.37+
   fromString("gen_ai.system", aliasProvider), // OTEL GenAI v1.36 deprecated
   fromString("llm.system", aliasProvider), // OpenInference / Arize Phoenix
@@ -48,6 +49,19 @@ export const providerCandidates: Candidate<string>[] = [
   }),
   { resolve: (attrs) => (stringAttr(attrs, "span.type") === "llm_request" ? "anthropic" : undefined) }, // Claude Code
 ]
+
+function anthropicProviderFromClaudeCodeSpanName(spanName: string): string | undefined {
+  if (!spanName.startsWith("claude_code.llm_request")) return undefined
+  return "anthropic"
+}
+
+/**
+ * Resolves telemetry provider from span attributes, with a fallback for Agent SDK
+ * span names (`claude_code.llm_request`) when `span.type` is absent.
+ */
+export function resolveProvider(spanAttrs: readonly OtlpKeyValue[], spanName: string): string {
+  return first(providerCandidates, spanAttrs) ?? anthropicProviderFromClaudeCodeSpanName(spanName) ?? ""
+}
 
 export const modelCandidates: Candidate<string>[] = [
   fromString("gen_ai.request.model"), // OTEL GenAI semconv

--- a/packages/domain/spans/src/otlp/resolvers/index.ts
+++ b/packages/domain/spans/src/otlp/resolvers/index.ts
@@ -3,12 +3,12 @@ import type { OtlpKeyValue } from "../types.ts"
 import { resolveMetadata, tagsCandidates } from "./enrichment.ts"
 import {
   modelCandidates,
-  providerCandidates,
+  resolveProvider,
   responseModelCandidates,
   sessionIdCandidates,
   userIdCandidates,
 } from "./identity.ts"
-import { operationCandidates } from "./operation.ts"
+import { resolveOperation } from "./operation.ts"
 import { finishReasonsCandidates, responseIdCandidates } from "./response.ts"
 import type { ResolvedUsage } from "./usage.ts"
 import { resolveUsage } from "./usage.ts"
@@ -28,12 +28,23 @@ interface ResolvedAttributes extends ResolvedUsage {
   readonly errorType: string
 }
 
-export function resolveAttributes(spanAttrs: readonly OtlpKeyValue[], statusCode: string): ResolvedAttributes {
-  const provider = first(providerCandidates, spanAttrs) ?? ""
+interface ResolveAttributesInput {
+  readonly spanAttrs: readonly OtlpKeyValue[]
+  readonly statusCode: string
+  readonly spanName?: string
+}
+
+export function resolveAttributes({
+  spanAttrs,
+  statusCode,
+  spanName = "",
+}: ResolveAttributesInput): ResolvedAttributes {
+  const provider = resolveProvider(spanAttrs, spanName)
   const model = first(modelCandidates, spanAttrs) ?? ""
+  const operation = resolveOperation(spanAttrs, spanName)
 
   return {
-    operation: first(operationCandidates, spanAttrs) ?? "unspecified",
+    operation,
     provider,
     model,
     responseModel: first(responseModelCandidates, spanAttrs) ?? "",

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -1,5 +1,6 @@
 import type { Operation } from "../../entities/span.ts"
-import { fromString } from "./utils.ts"
+import type { OtlpKeyValue } from "../types.ts"
+import { first, fromString } from "./utils.ts"
 
 const OPENINFERENCE_OPERATION: Record<string, Operation> = {
   LLM: "chat",
@@ -42,12 +43,37 @@ const CLAUDE_CODE_OPERATION: Record<string, string> = {
   llm_request: "chat",
   interaction: "prompt",
   tool_execution: "execute_tool",
+  /** Native Claude Code / Agent SDK OTEL (`claude_code.tool` spans) */
+  tool: "execute_tool",
 }
 
-export const operationCandidates = [
+const CLAUDE_CODE_NATIVE_SPAN_PREFIX = "claude_code."
+
+/**
+ * Maps Agent SDK and Claude Code CLI span **names** (`claude_code.*`) when the
+ * `span.type` attribute is absent (native OpenTelemetry export path).
+ */
+function operationFromClaudeCodeNativeSpanName(spanName: string): string | undefined {
+  if (!spanName.startsWith(CLAUDE_CODE_NATIVE_SPAN_PREFIX)) return undefined
+  const rest = spanName.slice(CLAUDE_CODE_NATIVE_SPAN_PREFIX.length)
+  if (rest === "interaction") return "prompt"
+  if (rest === "llm_request") return "chat"
+  if (rest === "tool" || rest.startsWith("tool.")) return "execute_tool"
+  return undefined
+}
+
+const operationCandidates = [
   fromString("gen_ai.operation.name"), // OTEL GenAI semconv (v1.37+ and v1.36)
   fromString("openinference.span.kind", (v) => OPENINFERENCE_OPERATION[v] ?? v.toLowerCase()), // OpenInference / Arize Phoenix
   fromString("llm.request.type", (v) => OPENLLMETRY_OPERATION[v] ?? v), // OpenLLMetry / Traceloop
   fromString("ai.operationId", (v) => VERCEL_OPERATION[v] ?? v), // Vercel AI SDK
   fromString("span.type", (v) => CLAUDE_CODE_OPERATION[v]), // Claude Code
 ]
+
+/**
+ * Resolves span operation from attributes, with a fallback for Agent SDK / CLI
+ * span names (`claude_code.*`) when `span.type` is absent.
+ */
+export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: string): string {
+  return first(operationCandidates, spanAttrs) ?? operationFromClaudeCodeNativeSpanName(spanName) ?? "unspecified"
+}

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -128,25 +128,25 @@ describe("resolveAttributes", () => {
   describe("provider resolution", () => {
     it("resolves from gen_ai.provider.name", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.provider.name", "openai")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.provider).toBe("openai")
     })
 
     it("resolves from gen_ai.system (deprecated)", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.system", "anthropic")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.provider).toBe("anthropic")
     })
 
     it("resolves from OpenInference llm.system", () => {
       const attrs: OtlpKeyValue[] = [strAttr("llm.system", "openai")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.provider).toBe("openai")
     })
 
     it("resolves from Vercel ai.model.provider and strips suffix", () => {
       const attrs: OtlpKeyValue[] = [strAttr("ai.model.provider", "openai.chat")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.provider).toBe("openai")
     })
 
@@ -164,13 +164,13 @@ describe("resolveAttributes", () => {
 
       for (const [key, input, expected] of cases) {
         const attrs: OtlpKeyValue[] = [strAttr(key, input)]
-        const result = resolveAttributes(attrs, "unset")
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.provider).toBe(expected)
       }
     })
 
     it("returns empty string for missing provider", () => {
-      const result = resolveAttributes([], "unset")
+      const result = resolveAttributes({ spanAttrs: [], statusCode: "unset" })
       expect(result.provider).toBe("")
     })
   })
@@ -178,25 +178,25 @@ describe("resolveAttributes", () => {
   describe("model resolution", () => {
     it("resolves from gen_ai.request.model", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.request.model", "gpt-4o")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.model).toBe("gpt-4o")
     })
 
     it("resolves from OpenInference llm.model_name", () => {
       const attrs: OtlpKeyValue[] = [strAttr("llm.model_name", "claude-3-opus")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.model).toBe("claude-3-opus")
     })
 
     it("resolves from Vercel ai.model.id", () => {
       const attrs: OtlpKeyValue[] = [strAttr("ai.model.id", "gpt-4o-mini")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.model).toBe("gpt-4o-mini")
     })
 
     it("resolves from embedding.model_name", () => {
       const attrs: OtlpKeyValue[] = [strAttr("embedding.model_name", "text-embedding-3-small")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.model).toBe("text-embedding-3-small")
     })
   })
@@ -204,13 +204,13 @@ describe("resolveAttributes", () => {
   describe("response model resolution", () => {
     it("resolves from gen_ai.response.model", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.response.model", "gpt-4o-2024-05-13")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.responseModel).toBe("gpt-4o-2024-05-13")
     })
 
     it("resolves from ai.response.model", () => {
       const attrs: OtlpKeyValue[] = [strAttr("ai.response.model", "gpt-4o-mini")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.responseModel).toBe("gpt-4o-mini")
     })
   })
@@ -218,7 +218,7 @@ describe("resolveAttributes", () => {
   describe("operation resolution", () => {
     it("resolves from gen_ai.operation.name", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.operation.name", "chat")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.operation).toBe("chat")
     })
 
@@ -236,7 +236,7 @@ describe("resolveAttributes", () => {
 
       for (const [kind, expected] of cases) {
         const attrs: OtlpKeyValue[] = [strAttr("openinference.span.kind", kind)]
-        const result = resolveAttributes(attrs, "unset")
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.operation).toBe(expected)
       }
     })
@@ -251,7 +251,7 @@ describe("resolveAttributes", () => {
 
       for (const [type, expected] of cases) {
         const attrs: OtlpKeyValue[] = [strAttr("llm.request.type", type)]
-        const result = resolveAttributes(attrs, "unset")
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.operation).toBe(expected)
       }
     })
@@ -269,7 +269,7 @@ describe("resolveAttributes", () => {
 
       for (const [opId, expected] of cases) {
         const attrs: OtlpKeyValue[] = [strAttr("ai.operationId", opId)]
-        const result = resolveAttributes(attrs, "unset")
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.operation).toBe(expected)
       }
     })
@@ -281,7 +281,7 @@ describe("resolveAttributes", () => {
         intAttr("gen_ai.usage.input_tokens", 100),
         intAttr("gen_ai.usage.output_tokens", 50),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensInput).toBe(100)
       expect(result.tokensOutput).toBe(50)
     })
@@ -291,21 +291,21 @@ describe("resolveAttributes", () => {
         intAttr("gen_ai.usage.prompt_tokens", 200),
         intAttr("gen_ai.usage.completion_tokens", 75),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensInput).toBe(200)
       expect(result.tokensOutput).toBe(75)
     })
 
     it("resolves OpenInference token counts", () => {
       const attrs: OtlpKeyValue[] = [intAttr("llm.token_count.prompt", 300), intAttr("llm.token_count.completion", 100)]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensInput).toBe(300)
       expect(result.tokensOutput).toBe(100)
     })
 
     it("resolves Vercel AI token counts", () => {
       const attrs: OtlpKeyValue[] = [intAttr("ai.usage.promptTokens", 500), intAttr("ai.usage.completionTokens", 200)]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensInput).toBe(500)
       expect(result.tokensOutput).toBe(200)
     })
@@ -317,7 +317,7 @@ describe("resolveAttributes", () => {
         intAttr("ai.usage.cachedInputTokens", 4429),
         intAttr("ai.usage.inputTokenDetails.cacheWriteTokens", 4761),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensInput).toBe(1)
       expect(result.tokensCacheRead).toBe(4429)
       expect(result.tokensCacheCreate).toBe(4761)
@@ -332,7 +332,7 @@ describe("resolveAttributes", () => {
         intAttr("gen_ai.usage.cache_creation.input_tokens", 200),
         intAttr("gen_ai.usage.reasoning_tokens", 100),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensCacheRead).toBe(800)
       expect(result.tokensCacheCreate).toBe(200)
       expect(result.tokensReasoning).toBe(100)
@@ -346,14 +346,14 @@ describe("resolveAttributes", () => {
         intAttr("llm.token_count.prompt_details.cache_write", 100),
         intAttr("llm.token_count.completion_details.reasoning", 200),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.tokensCacheRead).toBe(700)
       expect(result.tokensCacheCreate).toBe(100)
       expect(result.tokensReasoning).toBe(200)
     })
 
     it("defaults all token counts to zero when missing", () => {
-      const result = resolveAttributes([], "unset")
+      const result = resolveAttributes({ spanAttrs: [], statusCode: "unset" })
       expect(result.tokensInput).toBe(0)
       expect(result.tokensOutput).toBe(0)
       expect(result.tokensCacheRead).toBe(0)
@@ -370,7 +370,7 @@ describe("resolveAttributes", () => {
         floatAttr("llm.cost.prompt", 0.001),
         floatAttr("llm.cost.completion", 0.002),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.costInputMicrocents).toBe(100_000)
       expect(result.costOutputMicrocents).toBe(200_000)
       expect(result.costIsEstimated).toBe(false)
@@ -384,7 +384,7 @@ describe("resolveAttributes", () => {
         floatAttr("llm.cost.completion", 0.002),
         floatAttr("llm.cost.total", 0.005),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.costTotalMicrocents).toBe(500_000)
     })
 
@@ -393,7 +393,7 @@ describe("resolveAttributes", () => {
         intAttr("gen_ai.usage.input_tokens", 100),
         intAttr("gen_ai.usage.output_tokens", 50),
       ]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.costTotalMicrocents).toBe(0)
     })
   })
@@ -401,19 +401,19 @@ describe("resolveAttributes", () => {
   describe("response metadata", () => {
     it("resolves response ID", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.response.id", "chatcmpl-abc123")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.responseId).toBe("chatcmpl-abc123")
     })
 
     it("resolves Vercel response ID", () => {
       const attrs: OtlpKeyValue[] = [strAttr("ai.response.id", "resp-xyz")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.responseId).toBe("resp-xyz")
     })
 
     it("resolves finish reasons from GenAI array", () => {
       const attrs: OtlpKeyValue[] = [arrayAttr("gen_ai.response.finish_reasons", ["stop"])]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.finishReasons).toEqual(["stop"])
     })
 
@@ -427,7 +427,7 @@ describe("resolveAttributes", () => {
 
       for (const [vercelReason, expected] of cases) {
         const attrs: OtlpKeyValue[] = [strAttr("ai.response.finishReason", vercelReason)]
-        const result = resolveAttributes(attrs, "unset")
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.finishReasons).toEqual([expected])
       }
     })
@@ -436,13 +436,13 @@ describe("resolveAttributes", () => {
   describe("session ID resolution", () => {
     it("resolves from gen_ai.conversation.id", () => {
       const attrs: OtlpKeyValue[] = [strAttr("gen_ai.conversation.id", "conv-123")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.sessionId).toBe("conv-123")
     })
 
     it("resolves from OpenInference session.id", () => {
       const attrs: OtlpKeyValue[] = [strAttr("session.id", "sess-456")]
-      const result = resolveAttributes(attrs, "unset")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.sessionId).toBe("sess-456")
     })
   })
@@ -450,13 +450,13 @@ describe("resolveAttributes", () => {
   describe("error type", () => {
     it("resolves error.type when status is error", () => {
       const attrs: OtlpKeyValue[] = [strAttr("error.type", "TimeoutError")]
-      const result = resolveAttributes(attrs, "error")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "error" })
       expect(result.errorType).toBe("TimeoutError")
     })
 
     it("returns empty string when status is not error", () => {
       const attrs: OtlpKeyValue[] = [strAttr("error.type", "TimeoutError")]
-      const result = resolveAttributes(attrs, "ok")
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "ok" })
       expect(result.errorType).toBe("")
     })
   })

--- a/packages/domain/spans/src/otlp/tests/claude-code.test.ts
+++ b/packages/domain/spans/src/otlp/tests/claude-code.test.ts
@@ -135,4 +135,89 @@ describe("Claude Code OTLP span expansion", () => {
     expect(d.timeToFirstTokenNs).toBe(1_953_000_000)
     expect(d.isStreaming).toBe(true)
   })
+
+  it("maps Agent SDK native span names (claude_code.*) when span.type is absent", () => {
+    const interaction: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "1111111111111111",
+      parentSpanId: "",
+      name: "claude_code.interaction",
+      kind: 1,
+      startTimeUnixNano: "1710590400000000000",
+      endTimeUnixNano: "1710590402008000000",
+      attributes: [str("session.id", SESSION), str("user.id", USER_ID), str("user_prompt", "hello from agent sdk")],
+      status: { code: 1 },
+    }
+    expect(runTransform(interaction).operation).toBe("prompt")
+
+    const llm: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "2222222222222222",
+      parentSpanId: "1111111111111111",
+      name: "claude_code.llm_request",
+      kind: 3,
+      startTimeUnixNano: "1710590402100000000",
+      endTimeUnixNano: "1710590404091000000",
+      attributes: [
+        str("session.id", SESSION),
+        str("user.id", USER_ID),
+        str("model", "claude-sonnet-4-20250514"),
+        int("input_tokens", 5),
+        int("output_tokens", 7),
+        int("ttft_ms", 100),
+      ],
+      status: { code: 1 },
+    }
+    const llmDetail = runTransform(llm)
+    expect(llmDetail.operation).toBe("chat")
+    expect(llmDetail.provider).toBe("anthropic")
+    expect(llmDetail.model).toBe("claude-sonnet-4-20250514")
+
+    const tool: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "3333333333333333",
+      parentSpanId: "1111111111111111",
+      name: "claude_code.tool",
+      kind: 1,
+      startTimeUnixNano: "1710590404100000000",
+      endTimeUnixNano: "1710590404200000000",
+      attributes: [
+        str("session.id", SESSION),
+        str("user.id", USER_ID),
+        str("tool.name", "Read"),
+        str("tool.input", "{}"),
+        str("tool.output", "ok"),
+      ],
+      status: { code: 1 },
+    }
+    expect(runTransform(tool).operation).toBe("execute_tool")
+
+    const toolChild: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "4444444444444444",
+      parentSpanId: "3333333333333333",
+      name: "claude_code.tool.execution",
+      kind: 1,
+      startTimeUnixNano: "1710590404110000000",
+      endTimeUnixNano: "1710590404190000000",
+      attributes: [str("session.id", SESSION)],
+      status: { code: 1 },
+    }
+    expect(runTransform(toolChild).operation).toBe("execute_tool")
+  })
+
+  it("maps span.type tool to execute_tool (native OTEL)", () => {
+    const span: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "5555555555555555",
+      parentSpanId: "",
+      name: "claude_code.tool",
+      kind: 1,
+      startTimeUnixNano: "1710590400000000000",
+      endTimeUnixNano: "1710590401000000000",
+      attributes: [str("span.type", "tool"), str("session.id", SESSION), str("tool.name", "Glob")],
+      status: { code: 1 },
+    }
+    expect(runTransform(span).operation).toBe("execute_tool")
+  })
 })

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -77,7 +77,11 @@ function transformSpan({
   const resourceAttrs = resource?.attributes ?? []
   const statusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
 
-  const resolved = resolveAttributes(spanAttrs, statusCode)
+  const resolved = resolveAttributes({
+    spanAttrs,
+    statusCode,
+    spanName: span.name ?? "",
+  })
   const content = parseContent(spanAttrs)
   const serviceName = stringAttr(resourceAttrs, "service.name") ?? ""
   const performance = resolvePerformance({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **LAT-578** (Anthropic Claude Agent SDK telemetry).

The Agent SDK delegates OpenTelemetry export to the Claude Code CLI subprocess. That path emits span **names** such as `claude_code.interaction`, `claude_code.llm_request`, and `claude_code.tool`, often without the `span.type` attribute our Stop-hook integration relies on. Ingest previously left `operation` as `unspecified` and skipped Anthropic token semantics for those spans.

## Changes

- **OTLP transform** (`resolveAttributes`): optional span-name fallbacks map `claude_code.*` to the same operations as `span.type` (`interaction` → prompt, `llm_request` → chat, `tool` subtree → execute_tool). `claude_code.llm_request` also sets provider to `anthropic` when `span.type` is absent.
- **`span.type` = `tool`**: mapped to `execute_tool` for native CLI telemetry that uses `tool` instead of `tool_execution`.
- **Refactor (review)**: `resolveProvider` / `resolveOperation` helpers; `resolveAttributes` takes a single keyed object (`spanAttrs`, `statusCode`, `spanName`).
- **Tests**: `claude-code.test.ts` covers Agent SDK–style spans and `span.type=tool`.
- **Docs**: `docs/telemetry/claude-code.md` documents native OTLP configuration (`CLAUDE_CODE_ENABLE_TELEMETRY`, `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`, OTLP traces endpoint/headers toward Latitude). `dev-docs/claude-code-telemetry.md` notes the Agent SDK path and span names.

## Verification

`pnpm --filter @domain/spans test src/otlp/tests/claude-code.test.ts` and `pnpm --filter @domain/spans typecheck` pass on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-578](https://linear.app/latitude/issue/LAT-578/test-support-for-anthropics-claude-agent-sdk)

<div><a href="https://cursor.com/agents/bc-557a1040-ed45-4f0b-b6be-cc15260d90b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557a1040-ed45-4f0b-b6be-cc15260d90b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

