### PR TITLE
fix(charts): keep incident histogram tooltips on screen (LAT-593)

### DIFF
--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -252,6 +252,10 @@ const formatTimeShort = (iso: string): string => {
     : d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
 }
 
+/** Scroll incident rows when many overlap one bucket; bounds tooltip height for ECharts confine. */
+const INCIDENT_TOOLTIP_SCROLL_STYLE =
+  "max-height:min(45vh,360px);overflow-y:auto;overscroll-behavior:contain;margin-top:4px;padding-right:6px"
+
 /**
  * Renders the per-bucket incident block appended below the bar tooltip body. Returns an empty
  * string when no incidents fall in the bucket — callers can concatenate unconditionally.
@@ -283,7 +287,7 @@ export function renderIncidentsTooltipBlock(
       return `<div style="margin-top:4px">${dot}<b>${kindLabel}</b> · <span style="opacity:0.75">${sevLabel}</span><div style="margin-left:14px;opacity:0.65;font-size:11px">${escapeHtml(timing)}</div>${issueLine}</div>`
     })
     .join("")
-  return `${header}${items}`
+  return `${header}<div style="${INCIDENT_TOOLTIP_SCROLL_STYLE}">${items}</div>`
 }
 
 export function formatIncidentKindLabel(kind: AlertIncidentKind): string {

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -72,6 +72,9 @@ export function buildBarChartOption(
     },
     tooltip: {
       trigger: "axis",
+      // Keep HTML tooltips inside the chart so tall content (e.g. long incident lists with scroll)
+      // does not paint past the viewport edge when flipped above the pointer.
+      confine: true,
       // `enterable` lets users move into the tooltip to follow links inside it (e.g., per-incident
       // anchors in overlay-enriched tooltips); harmless for plain bar tooltips.
       enterable: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Hovering a dense bucket on the traces histogram or issues analytics chart could produce a very tall HTML tooltip. ECharts defaulted to flipping the box above the pointer when it would not fit below; with many incidents the combined height still exceeded the chart top, so the first rows were clipped with no way to scroll.

## Change

- Wrap the per-bucket incident rows in a scroll container capped at `min(45vh, 360px)` so list height stays bounded while the bucket summary line stays visible.
- Set `tooltip.confine: true` on `BarChart` options so ECharts clamps the tooltip box to the chart area after positioning, matching the bounded content height.

## Testing

- `pnpm --filter @repo/ui typecheck` (pass)
- `pnpm exec biome check` on touched files (pass)
- `@app/web` typecheck fails in this environment on missing `@latitude-data/telemetry` (pre-existing workspace issue), not from these edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-593](https://linear.app/latitude/issue/LAT-593/incident-hover-card-overflows-with-many-incidents)

<div><a href="https://cursor.com/agents/bc-0a37602b-fb81-48e4-af99-5235b1c79307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a37602b-fb81-48e4-af99-5235b1c79307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

