### PR TITLE
feat(onboarding): collect optional phone number and sync to Loops

### DIFF
--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -59,6 +59,7 @@ export interface AdminUserDetailsDto {
   email: string
   name: string | null
   image: string | null
+  phoneNumber: string | null
   role: "user" | "admin"
   memberships: AdminUserDetailsMembershipDto[]
   sessions: AdminUserSessionDto[]
@@ -95,6 +96,7 @@ const toDto = async (details: AdminUserDetails): Promise<AdminUserDetailsDto> =>
     email: details.email,
     name: details.name,
     image: details.image,
+    phoneNumber: details.phoneNumber,
     role: details.role,
     memberships: details.memberships.map(
       (m: AdminUserMembership): AdminUserDetailsMembershipDto => ({

--- a/apps/web/src/domains/users/user.functions.ts
+++ b/apps/web/src/domains/users/user.functions.ts
@@ -30,6 +30,12 @@ const submitOnboardingSchema = z
       .transform((v) => v.trim())
       .pipe(z.string().min(1))
       .optional(),
+    phoneNumber: z
+      .string()
+      .max(64)
+      .transform((v) => v.trim())
+      .transform((v) => (v.length > 0 ? v : undefined))
+      .optional(),
     stackChoice: z.enum(["coding-agent-machine", "production-agent"]),
   })
   .refine((d) => d.jobTitle !== undefined || d.customJobTitle !== undefined, {
@@ -37,6 +43,7 @@ const submitOnboardingSchema = z
   })
   .transform((d) => ({
     resolvedJobTitle: d.jobTitle ?? d.customJobTitle!,
+    phoneNumber: d.phoneNumber,
     stackChoice: d.stackChoice,
   }))
 
@@ -54,7 +61,11 @@ export const submitOnboarding = createServerFn({ method: "POST" })
 
         yield* sqlClient.transaction(
           Effect.gen(function* () {
-            yield* userRepo.setJobTitle({ userId, jobTitle: data.resolvedJobTitle })
+            yield* userRepo.update({
+              userId,
+              jobTitle: data.resolvedJobTitle,
+              phoneNumber: data.phoneNumber,
+            })
             yield* outbox.write({
               eventName: "UserOnboardingCompleted",
               aggregateType: "user",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -440,12 +440,15 @@ export function OnboardingFlow({
   const form = useForm({
     defaultValues: {
       customJobTitle: "",
+      phoneNumber: "",
     },
     onSubmit: createFormSubmitHandler(
-      async ({ customJobTitle }) => {
+      async ({ customJobTitle, phoneNumber }) => {
         const stack = stackChoice as StackChoice
         const onboardingData =
-          role === "other" ? { customJobTitle, stackChoice: stack } : { jobTitle: role, stackChoice: stack }
+          role === "other"
+            ? { customJobTitle, phoneNumber, stackChoice: stack }
+            : { jobTitle: role, phoneNumber, stackChoice: stack }
         await submitOnboarding({ data: onboardingData })
       },
       {
@@ -593,6 +596,21 @@ export function OnboardingFlow({
                   <Text.H4 color="foregroundMuted">Help Latitude personalize your experience.</Text.H4>
                 </div>
               </div>
+              <form.Field name="phoneNumber">
+                {(field) => (
+                  <Input
+                    type="tel"
+                    label="Phone number (optional)"
+                    description="Helpful if we need to reach you about your setup."
+                    placeholder="+1 555 0100"
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    errors={fieldErrorsAsStrings(field.state.meta.errors)}
+                    maxLength={64}
+                    autoComplete="tel"
+                  />
+                )}
+              </form.Field>
               <div className="flex flex-col gap-3">
                 {ROLE_OPTIONS.map((option) => {
                   const selected = role === option.id

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -65,6 +65,7 @@ function BackofficeUserDetailPage() {
   const propertyEntries: PropertiesStripEntry[] = [
     { label: "User id", value: user.id },
     { label: "Email", value: user.email },
+    ...(user.phoneNumber ? [{ label: "Phone", value: user.phoneNumber }] : []),
     { label: "Created", value: new Date(user.createdAt).toISOString() },
   ]
 

--- a/packages/domain/admin/src/users/get-user-details.test.ts
+++ b/packages/domain/admin/src/users/get-user-details.test.ts
@@ -29,6 +29,7 @@ const mkDetails = (overrides: Partial<AdminUserDetails> = {}): AdminUserDetails 
   email: "target@example.com",
   name: "Target User",
   image: null,
+  phoneNumber: null,
   role: "user",
   memberships: [],
   sessions: [],

--- a/packages/domain/admin/src/users/user-details.ts
+++ b/packages/domain/admin/src/users/user-details.ts
@@ -56,6 +56,7 @@ export const adminUserDetailsSchema = z.object({
   email: z.string(),
   name: z.string().nullable(),
   image: z.string().nullable(),
+  phoneNumber: z.string().nullable(),
   role: z.enum(["user", "admin"]),
   memberships: z.array(adminUserMembershipSchema),
   /**

--- a/packages/domain/marketing/src/ports/marketing-contacts.ts
+++ b/packages/domain/marketing/src/ports/marketing-contacts.ts
@@ -19,6 +19,7 @@ export const marketingUpdateContactInputSchema = z.object({
   email: z.email().optional(),
   firstName: z.string().nullish(),
   jobTitle: z.string().nullish(),
+  phoneNumber: z.string().nullish(),
   userGroup: marketingUserGroupSchema.optional(),
   telemetryEnabled: z.boolean().optional(),
 })

--- a/packages/domain/marketing/src/use-cases/register-contact.test.ts
+++ b/packages/domain/marketing/src/use-cases/register-contact.test.ts
@@ -53,6 +53,7 @@ describe("registerContact", () => {
       email: "ada@example.com",
       name: "Ada Lovelace",
       jobTitle: null,
+      phoneNumber: null,
       emailVerified: true,
       image: null,
       role: "user",

--- a/packages/domain/marketing/src/use-cases/update-contact-onboarding.test.ts
+++ b/packages/domain/marketing/src/use-cases/update-contact-onboarding.test.ts
@@ -44,13 +44,14 @@ const buildLayers = () => {
 }
 
 describe("updateContactOnboarding", () => {
-  it("maps coding-agent-machine to code-agents and includes job title", async () => {
+  it("maps coding-agent-machine to code-agents and includes job title and phone number", async () => {
     const { users, layers } = buildLayers()
     users.set(USER_ID, {
       id: USER_ID,
       email: "ada@example.com",
       name: "Ada Lovelace",
       jobTitle: "Founder",
+      phoneNumber: "+1 555 0100",
       emailVerified: true,
       image: null,
       role: "user",
@@ -72,6 +73,7 @@ describe("updateContactOnboarding", () => {
         email: "ada@example.com",
         firstName: "Ada Lovelace",
         jobTitle: "Founder",
+        phoneNumber: "+1 555 0100",
         userGroup: MARKETING_USER_GROUP_CODE_AGENTS,
       },
     ])
@@ -84,6 +86,7 @@ describe("updateContactOnboarding", () => {
       email: "ada@example.com",
       name: "Ada Lovelace",
       jobTitle: "Founder",
+      phoneNumber: null,
       emailVerified: true,
       image: null,
       role: "user",

--- a/packages/domain/marketing/src/use-cases/update-contact-onboarding.ts
+++ b/packages/domain/marketing/src/use-cases/update-contact-onboarding.ts
@@ -36,6 +36,7 @@ export const updateContactOnboarding = ({ marketingContacts }: { readonly market
       email: user.email,
       firstName: user.name,
       jobTitle: user.jobTitle,
+      phoneNumber: user.phoneNumber,
       userGroup: stackChoiceToUserGroup(input.stackChoice),
     })
   })

--- a/packages/domain/notifications/src/use-cases/create-notification.test.ts
+++ b/packages/domain/notifications/src/use-cases/create-notification.test.ts
@@ -31,6 +31,7 @@ function setup(opts: SetupOpts = {}) {
     email: "user@test.com",
     name: "User",
     jobTitle: null,
+    phoneNumber: null,
     emailVerified: true,
     image: null,
     role: "user",

--- a/packages/domain/notifications/src/use-cases/send-notification-email.test.ts
+++ b/packages/domain/notifications/src/use-cases/send-notification-email.test.ts
@@ -30,6 +30,7 @@ function setup(opts: { readonly project?: Project | null | typeof DEFAULT_PROJEC
     email: "user@test.com",
     name: "Alice",
     jobTitle: null,
+    phoneNumber: null,
     emailVerified: true,
     image: null,
     role: "user",

--- a/packages/domain/users/src/entities/user.ts
+++ b/packages/domain/users/src/entities/user.ts
@@ -26,6 +26,7 @@ export const userSchema = z.object({
   email: z.string().min(1),
   name: z.string().nullable(),
   jobTitle: z.string().nullable(),
+  phoneNumber: z.string().nullable(),
   emailVerified: z.boolean(),
   image: z.string().nullable(),
   role: userRoleSchema,

--- a/packages/domain/users/src/ports/user-repository.ts
+++ b/packages/domain/users/src/ports/user-repository.ts
@@ -3,14 +3,16 @@ import type { Effect } from "effect"
 import { Context } from "effect"
 import type { User } from "../entities/user.ts"
 
-// UserRepository Service with all methods needed by use cases
 export class UserRepository extends Context.Service<
   UserRepository,
   {
     findById: (userId: string) => Effect.Effect<User, NotFoundError | RepositoryError, SqlClient>
     findByEmail: (email: string) => Effect.Effect<User, NotFoundError | RepositoryError, SqlClient>
-    setNameIfMissing: (params: { userId: string; name: string }) => Effect.Effect<void, RepositoryError, SqlClient>
-    setJobTitle: (params: { userId: string; jobTitle: string }) => Effect.Effect<void, RepositoryError, SqlClient>
+    update: (params: {
+      userId: string
+      jobTitle?: string | undefined
+      phoneNumber?: string | undefined
+    }) => Effect.Effect<void, RepositoryError, SqlClient>
     updateNotificationPreferences: (params: {
       userId: string
       preferences: NotificationPreferences

--- a/packages/domain/users/src/testing/fake-user-repository.ts
+++ b/packages/domain/users/src/testing/fake-user-repository.ts
@@ -7,9 +7,7 @@ type UserRepositoryShape = (typeof UserRepository)["Service"]
 
 export const createFakeUserRepository = (overrides?: Partial<UserRepositoryShape>) => {
   const users = new Map<string, User>()
-  const namesSet: { userId: string; name: string }[] = []
-
-  const jobTitlesSet: { userId: string; jobTitle: string }[] = []
+  const updates: { userId: string; jobTitle?: string; phoneNumber?: string }[] = []
 
   const repository: UserRepositoryShape = {
     findById: (userId) => {
@@ -24,21 +22,23 @@ export const createFakeUserRepository = (overrides?: Partial<UserRepositoryShape
       return Effect.succeed(user)
     },
 
-    setNameIfMissing: (params) =>
+    update: (params) =>
       Effect.sync(() => {
-        if (params.name.trim()) {
-          namesSet.push(params)
-        }
-      }),
-
-    setJobTitle: (params) =>
-      Effect.sync(() => {
-        const trimmed = params.jobTitle.trim()
-        if (!trimmed) return
-        jobTitlesSet.push({ userId: params.userId, jobTitle: trimmed })
+        const trimmedJobTitle = params.jobTitle?.trim() || undefined
+        const trimmedPhoneNumber = params.phoneNumber?.trim() || undefined
+        if (!trimmedJobTitle && !trimmedPhoneNumber) return
+        updates.push({
+          userId: params.userId,
+          ...(trimmedJobTitle ? { jobTitle: trimmedJobTitle } : {}),
+          ...(trimmedPhoneNumber ? { phoneNumber: trimmedPhoneNumber } : {}),
+        })
         const existing = users.get(params.userId)
         if (existing) {
-          users.set(params.userId, { ...existing, jobTitle: trimmed })
+          users.set(params.userId, {
+            ...existing,
+            ...(trimmedJobTitle ? { jobTitle: trimmedJobTitle } : {}),
+            ...(trimmedPhoneNumber ? { phoneNumber: trimmedPhoneNumber } : {}),
+          })
         }
       }),
 
@@ -57,5 +57,5 @@ export const createFakeUserRepository = (overrides?: Partial<UserRepositoryShape
     ...overrides,
   }
 
-  return { repository, users, namesSet, jobTitlesSet }
+  return { repository, users, updates }
 }

--- a/packages/domain/users/src/use-cases/delete-user.test.ts
+++ b/packages/domain/users/src/use-cases/delete-user.test.ts
@@ -23,6 +23,7 @@ const createTestUser = (id: string): User => ({
   email: `${id}@example.com`,
   name: "Test User",
   jobTitle: null,
+  phoneNumber: null,
   emailVerified: true,
   image: null,
   role: "user",

--- a/packages/domain/users/src/use-cases/get-account.test.ts
+++ b/packages/domain/users/src/use-cases/get-account.test.ts
@@ -23,6 +23,7 @@ const testUser: User = {
   email: "alice@example.com",
   name: "Alice",
   jobTitle: null,
+  phoneNumber: null,
   emailVerified: true,
   image: null,
   role: "user",

--- a/packages/platform/db-postgres/drizzle/.migration-lock
+++ b/packages/platform/db-postgres/drizzle/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-05-18T12:09:13.433Z
-# Hash: 7d3cad69-93b7-404e-b618-f904a7c99a1d
+# Generated: 2026-05-18T16:15:36.584Z
+# Hash: d75cd924-364c-482e-b190-4813cb1d7f5c
 # Do not manually edit this file.

--- a/packages/platform/db-postgres/drizzle/20260517062033_enable-pgvector-extension/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260517062033_enable-pgvector-extension/snapshot.json
@@ -3,7 +3,7 @@
   "dialect": "postgres",
   "id": "4442c565-0a95-4cb0-9791-262744b2c3f0",
   "prevIds": [
-    "af5a7d32-276b-4b41-a3b3-e5ae50166e87"
+    "a8ce927f-0308-4abd-9771-a01820cf11d4"
   ],
   "ddl": [
     {
@@ -161,6 +161,305 @@
       "name": "notifications",
       "entityType": "tables",
       "schema": "latitude"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
     },
     {
       "isRlsEnabled": false,
@@ -3615,110 +3914,6 @@
       "name": "id",
       "entityType": "columns",
       "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "organization_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "user_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(32)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "type",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "source_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "jsonb",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "payload",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": "now()",
-      "generated": null,
-      "identity": null,
-      "name": "created_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "seen_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "id",
-      "entityType": "columns",
-      "schema": "latitude",
       "table": "outbox_events"
     },
     {
@@ -5760,118 +5955,6 @@
       "nameExplicit": true,
       "columns": [
         {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "created_at",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "id",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": null,
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_recent_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": "\"seen_at\" is null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_unread_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "source_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "(\"payload\"->>'event')",
-          "isExpression": true,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": true,
-      "where": "\"type\" = 'incident' and \"source_id\" is not null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_incident_event_uq",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
           "value": "workspace_id",
           "isExpression": false,
           "asc": true,
@@ -7000,16 +7083,6 @@
         "id"
       ],
       "nameExplicit": false,
-      "name": "notifications_pkey",
-      "schema": "latitude",
-      "table": "notifications",
-      "entityType": "pks"
-    },
-    {
-      "columns": [
-        "id"
-      ],
-      "nameExplicit": false,
       "name": "outbox_events_pkey",
       "schema": "latitude",
       "table": "outbox_events",
@@ -7544,19 +7617,6 @@
       "entityType": "policies",
       "schema": "latitude",
       "table": "issues"
-    },
-    {
-      "as": "PERMISSIVE",
-      "for": "ALL",
-      "roles": [
-        "public"
-      ],
-      "using": "organization_id = get_current_organization_id()",
-      "withCheck": "organization_id = get_current_organization_id()",
-      "name": "notifications_organization_policy",
-      "entityType": "policies",
-      "schema": "latitude",
-      "table": "notifications"
     },
     {
       "as": "PERMISSIVE",

--- a/packages/platform/db-postgres/drizzle/20260517062034_add-pgvector-issue-search/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260517062034_add-pgvector-issue-search/snapshot.json
@@ -163,6 +163,305 @@
       "schema": "latitude"
     },
     {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
       "isRlsEnabled": false,
       "name": "outbox_events",
       "entityType": "tables",
@@ -3644,110 +3943,6 @@
       "name": "id",
       "entityType": "columns",
       "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "organization_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "user_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(32)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "type",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "source_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "jsonb",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "payload",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": "now()",
-      "generated": null,
-      "identity": null,
-      "name": "created_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "seen_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "id",
-      "entityType": "columns",
-      "schema": "latitude",
       "table": "outbox_events"
     },
     {
@@ -5810,118 +6005,6 @@
       "nameExplicit": true,
       "columns": [
         {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "created_at",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "id",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": null,
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_recent_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": "\"seen_at\" is null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_unread_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "source_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "(\"payload\"->>'event')",
-          "isExpression": true,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": true,
-      "where": "\"type\" = 'incident' and \"source_id\" is not null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_incident_event_uq",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
           "value": "workspace_id",
           "isExpression": false,
           "asc": true,
@@ -7050,16 +7133,6 @@
         "id"
       ],
       "nameExplicit": false,
-      "name": "notifications_pkey",
-      "schema": "latitude",
-      "table": "notifications",
-      "entityType": "pks"
-    },
-    {
-      "columns": [
-        "id"
-      ],
-      "nameExplicit": false,
       "name": "outbox_events_pkey",
       "schema": "latitude",
       "table": "outbox_events",
@@ -7594,19 +7667,6 @@
       "entityType": "policies",
       "schema": "latitude",
       "table": "issues"
-    },
-    {
-      "as": "PERMISSIVE",
-      "for": "ALL",
-      "roles": [
-        "public"
-      ],
-      "using": "organization_id = get_current_organization_id()",
-      "withCheck": "organization_id = get_current_organization_id()",
-      "name": "notifications_organization_policy",
-      "entityType": "policies",
-      "schema": "latitude",
-      "table": "notifications"
     },
     {
       "as": "PERMISSIVE",

--- a/packages/platform/db-postgres/drizzle/20260518120913_backfill-ended-at-on-eventful-incidents/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260518120913_backfill-ended-at-on-eventful-incidents/snapshot.json
@@ -163,6 +163,305 @@
       "schema": "latitude"
     },
     {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
       "isRlsEnabled": false,
       "name": "outbox_events",
       "entityType": "tables",
@@ -3644,110 +3943,6 @@
       "name": "id",
       "entityType": "columns",
       "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "organization_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "user_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(32)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "type",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "source_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "jsonb",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "payload",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": "now()",
-      "generated": null,
-      "identity": null,
-      "name": "created_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "seen_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "id",
-      "entityType": "columns",
-      "schema": "latitude",
       "table": "outbox_events"
     },
     {
@@ -5810,118 +6005,6 @@
       "nameExplicit": true,
       "columns": [
         {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "created_at",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "id",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": null,
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_recent_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": "\"seen_at\" is null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_unread_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "source_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "(\"payload\"->>'event')",
-          "isExpression": true,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": true,
-      "where": "\"type\" = 'incident' and \"source_id\" is not null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_incident_event_uq",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
           "value": "workspace_id",
           "isExpression": false,
           "asc": true,
@@ -7050,16 +7133,6 @@
         "id"
       ],
       "nameExplicit": false,
-      "name": "notifications_pkey",
-      "schema": "latitude",
-      "table": "notifications",
-      "entityType": "pks"
-    },
-    {
-      "columns": [
-        "id"
-      ],
-      "nameExplicit": false,
       "name": "outbox_events_pkey",
       "schema": "latitude",
       "table": "outbox_events",
@@ -7594,19 +7667,6 @@
       "entityType": "policies",
       "schema": "latitude",
       "table": "issues"
-    },
-    {
-      "as": "PERMISSIVE",
-      "for": "ALL",
-      "roles": [
-        "public"
-      ],
-      "using": "organization_id = get_current_organization_id()",
-      "withCheck": "organization_id = get_current_organization_id()",
-      "name": "notifications_organization_policy",
-      "entityType": "policies",
-      "schema": "latitude",
-      "table": "notifications"
     },
     {
       "as": "PERMISSIVE",

--- a/packages/platform/db-postgres/drizzle/20260518161536_add-optional-phone-number-to-users/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260518161536_add-optional-phone-number-to-users/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "latitude"."users" ADD COLUMN "phone_number" text;

--- a/packages/platform/db-postgres/drizzle/20260518161536_add-optional-phone-number-to-users/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260518161536_add-optional-phone-number-to-users/snapshot.json
@@ -1,9 +1,9 @@
 {
   "version": "8",
   "dialect": "postgres",
-  "id": "6387965f-5ef9-4ffc-9ff5-8b3eeaf0c3a0",
+  "id": "b6674c85-e550-43f7-ae58-c3b703384b47",
   "prevIds": [
-    "3805cfea-d2a9-4635-b7f5-febe46ab347c"
+    "f60382f0-bd58-4fe9-b738-8b747bd54e86"
   ],
   "ddl": [
     {
@@ -161,305 +161,6 @@
       "name": "notifications",
       "entityType": "tables",
       "schema": "latitude"
-    },
-    {
-      "type": "jsonb",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "notification_preferences",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "users"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "organization_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "user_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(64)",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "kind",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "text",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "idempotency_key",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "varchar(24)",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "project_id",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "jsonb",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "payload",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": true,
-      "dimensions": 0,
-      "default": "now()",
-      "generated": null,
-      "identity": null,
-      "name": "created_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "seen_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "type": "timestamp with time zone",
-      "typeSchema": null,
-      "notNull": false,
-      "dimensions": 0,
-      "default": null,
-      "generated": null,
-      "identity": null,
-      "name": "emailed_at",
-      "entityType": "columns",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "created_at",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "id",
-          "isExpression": false,
-          "asc": false,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": null,
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_recent_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": "\"seen_at\" is null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_user_org_unread_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "user_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "idempotency_key",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": true,
-      "where": null,
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_idempotency_uq",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "nameExplicit": true,
-      "columns": [
-        {
-          "value": "organization_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        },
-        {
-          "value": "project_id",
-          "isExpression": false,
-          "asc": true,
-          "nullsFirst": false,
-          "opclass": null
-        }
-      ],
-      "isUnique": false,
-      "where": "\"project_id\" is not null",
-      "with": "",
-      "method": "btree",
-      "concurrently": false,
-      "name": "notifications_org_project_idx",
-      "entityType": "indexes",
-      "schema": "latitude",
-      "table": "notifications"
-    },
-    {
-      "columns": [
-        "id"
-      ],
-      "nameExplicit": false,
-      "name": "notifications_pkey",
-      "schema": "latitude",
-      "table": "notifications",
-      "entityType": "pks"
-    },
-    {
-      "as": "PERMISSIVE",
-      "for": "ALL",
-      "roles": [
-        "public"
-      ],
-      "using": "organization_id = get_current_organization_id()",
-      "withCheck": "organization_id = get_current_organization_id()",
-      "name": "notifications_organization_policy",
-      "entityType": "policies",
-      "schema": "latitude",
-      "table": "notifications"
     },
     {
       "isRlsEnabled": false,
@@ -2448,6 +2149,32 @@
       "table": "users"
     },
     {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone_number",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
       "type": "timestamp with time zone",
       "typeSchema": null,
       "notNull": true,
@@ -3931,6 +3658,136 @@
       "entityType": "columns",
       "schema": "latitude",
       "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
     },
     {
       "type": "varchar(24)",
@@ -6005,6 +5862,139 @@
       "nameExplicit": true,
       "columns": [
         {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
           "value": "workspace_id",
           "isExpression": false,
           "asc": true,
@@ -7133,6 +7123,16 @@
         "id"
       ],
       "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
       "name": "outbox_events_pkey",
       "schema": "latitude",
       "table": "outbox_events",
@@ -7667,6 +7667,19 @@
       "entityType": "policies",
       "schema": "latitude",
       "table": "issues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
     },
     {
       "as": "PERMISSIVE",

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -149,6 +149,7 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
         // `input: false` keeps it out of Better Auth's signup / update API
         // surface — we write it via our own onboarding server function.
         jobTitle: { type: "string", required: false, input: false },
+        phoneNumber: { type: "string", required: false, input: false },
       },
     },
     /**

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
@@ -38,6 +38,7 @@ export const AdminUserRepositoryLive = Layer.effect(
                 email: users.email,
                 name: users.name,
                 image: users.image,
+                phoneNumber: users.phoneNumber,
                 role: users.role,
                 createdAt: users.createdAt,
               })
@@ -129,6 +130,7 @@ export const AdminUserRepositoryLive = Layer.effect(
             email: row.email,
             name: row.name ?? null,
             image: row.image ?? null,
+            phoneNumber: row.phoneNumber ?? null,
             role: row.role as UserRoleValue,
             memberships: membershipRows.map((m) => ({
               organizationId: m.organizationId,

--- a/packages/platform/db-postgres/src/repositories/user-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/user-repository.ts
@@ -7,7 +7,7 @@ import {
 } from "@domain/shared"
 import type { User } from "@domain/users"
 import { UserRepository } from "@domain/users"
-import { and, eq, isNull, or, sql } from "drizzle-orm"
+import { eq } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { users } from "../schema/better-auth.ts"
@@ -17,6 +17,7 @@ const toDomainUser = (row: typeof users.$inferSelect): User => ({
   email: row.email,
   name: row.name ?? null,
   jobTitle: row.jobTitle ?? null,
+  phoneNumber: row.phoneNumber ?? null,
   emailVerified: row.emailVerified,
   image: row.image ?? null,
   role: row.role,
@@ -63,35 +64,27 @@ export const UserRepositoryLive = Layer.effect(
             )
         }),
 
-      setNameIfMissing: ({ userId, name }: { userId: string; name: string }) =>
+      update: ({
+        userId,
+        jobTitle,
+        phoneNumber,
+      }: {
+        userId: string
+        jobTitle?: string | undefined
+        phoneNumber?: string | undefined
+      }) =>
         Effect.gen(function* () {
-          if (!name.trim()) return
+          const trimmedJobTitle = jobTitle?.trim() || undefined
+          const trimmedPhoneNumber = phoneNumber?.trim() || undefined
+          if (!trimmedJobTitle && !trimmedPhoneNumber) return
 
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           yield* sqlClient.query((db) =>
             db
               .update(users)
               .set({
-                name: name.trim(),
-                updatedAt: new Date(),
-              })
-              .where(
-                and(eq(users.id, userId), or(isNull(users.name), eq(users.name, ""), sql`trim(${users.name}) = ''`)),
-              ),
-          )
-        }),
-
-      setJobTitle: ({ userId, jobTitle }: { userId: string; jobTitle: string }) =>
-        Effect.gen(function* () {
-          const trimmed = jobTitle.trim()
-          if (!trimmed) return
-
-          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
-          yield* sqlClient.query((db) =>
-            db
-              .update(users)
-              .set({
-                jobTitle: trimmed,
+                ...(trimmedJobTitle ? { jobTitle: trimmedJobTitle } : {}),
+                ...(trimmedPhoneNumber ? { phoneNumber: trimmedPhoneNumber } : {}),
                 updatedAt: new Date(),
               })
               .where(eq(users.id, userId)),

--- a/packages/platform/db-postgres/src/schema/better-auth.ts
+++ b/packages/platform/db-postgres/src/schema/better-auth.ts
@@ -55,6 +55,7 @@ export const users = latitudeSchema.table("users", {
    * when set.
    */
   jobTitle: text("job_title"),
+  phoneNumber: text("phone_number"),
   /**
    * Per-channel notification preferences keyed by `NotificationGroup`.
    * `null` when the user has never visited the settings page — readers

--- a/packages/platform/loops/src/client.test.ts
+++ b/packages/platform/loops/src/client.test.ts
@@ -115,6 +115,7 @@ describe("createLoopsContactsSender", () => {
         userId: "user_123",
         email: "new@b.co",
         jobTitle: longTitle,
+        phoneNumber: " +1 555 0100 ",
         telemetryEnabled: true,
       }),
     )
@@ -124,6 +125,7 @@ describe("createLoopsContactsSender", () => {
       properties: {
         email: "new@b.co",
         jobTitle: "x".repeat(MARKETING_FIELD_MAX_LENGTH),
+        phoneNumber: "+1 555 0100",
         telemetryEnabled: true,
       },
     })

--- a/packages/platform/loops/src/client.ts
+++ b/packages/platform/loops/src/client.ts
@@ -110,6 +110,7 @@ export const createLoopsContactsSender = (config: LoopsConfig | undefined): Mark
               email: parsed.email,
               firstName: sanitizeString(parsed.firstName),
               jobTitle: sanitizeString(parsed.jobTitle),
+              phoneNumber: sanitizeString(parsed.phoneNumber),
               userGroup: parsed.userGroup,
               telemetryEnabled: parsed.telemetryEnabled,
             }),


### PR DESCRIPTION
## Summary

- Adds an optional phone number field to the project-onboarding role step
- Persists `users.phone_number` and forwards it to Loops as `phoneNumber` on the contact via the onboarding `updateContact` flow
- Unifies `setJobTitle` + `setPhoneNumber` on `UserRepository` into a single `update({ jobTitle?, phoneNumber? })` method, and removes the unused `setNameIfMissing`

Linear: [LAT-592](https://linear.app/latitude/issue/LAT-592)

> **Heads up:** no Drizzle migration is checked in yet — generate one locally with `pnpm --filter @platform/db-postgres db:generate` (and apply it) before merging.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @domain/users --filter @domain/marketing --filter @domain/notifications --filter @platform/loops test` passes
- [x] Manual: walk through onboarding leaving the phone field blank — submission succeeds, no `phone_number` written
- [x] Manual: walk through onboarding with a phone number — `users.phone_number` is set and the Loops contact shows `phoneNumber`

🤖 Generated with [Claude Code](https://claude.com/claude-code)