### PR TITLE
fix(ui)+perf(issues): expandable large markdown + skip ClickHouse on empty projects

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Text } from "@repo/ui"
 import { ExternalLinkIcon, SearchAlert } from "lucide-react"
 
-export function IssuesEmptyState() {
+export function IssuesEmptyState({ isLoading = false }: { readonly isLoading?: boolean }) {
   return (
     <div className="h-full w-full flex items-center justify-center p-8">
       <div className="max-w-lg flex flex-col items-center gap-6 text-center">
@@ -9,18 +9,21 @@ export function IssuesEmptyState() {
           <Icon icon={SearchAlert} size="lg" color="foregroundMuted" />
         </div>
         <div className="flex flex-col items-center gap-2">
-          <Text.H3 centered>No issues yet</Text.H3>
+          <Text.H3 centered>{isLoading ? "Loading issues" : "No issues yet"}</Text.H3>
           <Text.H5 color="foregroundMuted" centered>
-            Issues are discovered automatically by grouping failed annotations left on your traces. Start annotating
-            traces to surface recurring problems here.
+            {isLoading
+              ? "Preparing your issues view."
+              : "Issues are discovered automatically by grouping failed annotations left on your traces. Start annotating traces to surface recurring problems here."}
           </Text.H5>
         </div>
-        <a href="https://docs.latitude.so/issues/overview" target="_blank" rel="noopener noreferrer">
-          <Button>
-            <Icon size="sm" icon={ExternalLinkIcon} />
-            Read the docs
-          </Button>
-        </a>
+        {!isLoading ? (
+          <a href="https://docs.latitude.so/issues/overview" target="_blank" rel="noopener noreferrer">
+            <Button>
+              <Icon size="sm" icon={ExternalLinkIcon} />
+              Read the docs
+            </Button>
+          </a>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -317,7 +317,13 @@ function IssuesPage() {
   const showEmptyState = !showSkeletons && hasNoIssues
 
   if (isLoading && hasNoIssues) {
-    return null
+    return (
+      <Layout>
+        <Layout.Content>
+          <IssuesEmptyState isLoading />
+        </Layout.Content>
+      </Layout>
+    )
   }
 
   if (showEmptyState) {

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -233,6 +233,53 @@ describe("listIssuesUseCase", () => {
     traceCount = 0
   })
 
+  it("returns the empty issue shape without querying ClickHouse when the project has no issues", async () => {
+    const now = new Date("2026-04-10T00:00:00.000Z")
+    const { repository: issueRepository } = createFakeIssueRepository([])
+    const { repository: evaluationRepository } = createEvaluationRepository()
+    const {
+      repository: scoreAnalyticsRepository,
+      windowMetricInputs,
+      aggregateInputs,
+      histogramInputs,
+    } = createScoreAnalyticsRepository({
+      windowMetrics: [],
+      fullHistoryOccurrences: [],
+    })
+    let traceCountCalls = 0
+    const { repository: traceRepository } = createFakeTraceRepository({
+      countByProjectId: () =>
+        Effect.sync(() => {
+          traceCountCalls += 1
+          return 0
+        }),
+    })
+
+    const result = await Effect.runPromise(
+      listIssuesUseCase({ organizationId, projectId, now }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(IssueRepository, issueRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+            Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+            Layer.succeed(TraceRepository, traceRepository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+          ),
+        ),
+      ),
+    )
+
+    expect(result.items).toEqual([])
+    expect(result.totalCount).toBe(0)
+    expect(result.analytics.totalTraces).toBe(0)
+    expect(result.analytics.histogram.length).toBeGreaterThan(0)
+    expect(windowMetricInputs).toEqual([])
+    expect(aggregateInputs).toEqual([])
+    expect(histogramInputs).toEqual([])
+    expect(traceCountCalls).toBe(0)
+  })
+
   it("enriches the default listing with derived lifecycle states", async () => {
     const now = new Date("2026-04-10T00:00:00.000Z")
     const newestIssue = makeIssue({

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -429,12 +429,59 @@ export const listIssuesUseCase = (
   Effect.gen(function* () {
     const parsed = listIssuesInputSchema.parse(input)
     yield* Effect.annotateCurrentSpan("projectId", String(parsed.projectId))
-    const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
     const issueRepository = yield* IssueRepository
-    const evaluationRepository = yield* EvaluationRepository
-    const traceRepository = yield* TraceRepository
     const now = parsed.now ?? new Date()
     const selectedTimeRange = toScoreAnalyticsTimeRange(parsed.timeRange)
+
+    if (!parsed.issueIds) {
+      const firstIssuePage = yield* issueRepository.list({
+        projectId: parsed.projectId,
+        limit: 1,
+        offset: 0,
+      })
+
+      if (firstIssuePage.items.length === 0) {
+        const histogramTimeRange = resolveHistogramTimeRange({
+          timeRange: parsed.timeRange,
+          now,
+        })
+        const histogramBucketSeconds = pickTraceHistogramBucketSeconds(
+          histogramTimeRange.from.getTime(),
+          histogramTimeRange.to.getTime(),
+        )
+        const histogramScaffold = buildHistogramBucketScaffold({
+          from: histogramTimeRange.from,
+          to: histogramTimeRange.to,
+          bucketSeconds: histogramBucketSeconds,
+        })
+
+        return {
+          analytics: {
+            counts: {
+              newIssues: 0,
+              escalatingIssues: 0,
+              ongoingIssues: 0,
+              regressedIssues: 0,
+              resolvedIssues: 0,
+              seenOccurrences: 0,
+            },
+            histogram: fillBuckets({ scaffold: histogramScaffold, buckets: [] }),
+            histogramBucketSeconds,
+            totalTraces: 0,
+          },
+          items: [],
+          totalCount: 0,
+          hasMore: false,
+          limit: parsed.limit,
+          offset: parsed.offset,
+          occurrencesSum: 0,
+        } satisfies ListIssuesResult
+      }
+    }
+
+    const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+    const evaluationRepository = yield* EvaluationRepository
+    const traceRepository = yield* TraceRepository
 
     const windowMetricsEffect = scoreAnalyticsRepository.listIssueWindowMetrics({
       organizationId: parsed.organizationId,

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
@@ -67,14 +67,23 @@ describe("MarkdownContent", () => {
     expect(markup).toMatch(/<div[^>]*\boverflow-x-auto\b[^>]*>\s*<table\b/)
   })
 
-  it("falls back to a guarded plain-text view for oversized content", () => {
-    const oversizedContent = `${"a".repeat(LARGE_MARKDOWN_CONTENT_THRESHOLD + 1)}END_MARKER`
+  it("splits oversized content into head + collapsed middle + tail rendered as Markdown", () => {
+    const head = "# Head heading\n\n"
+    const filler = "a".repeat(LARGE_MARKDOWN_CONTENT_THRESHOLD)
+    const tail = "\n\n## Tail heading END_MARKER"
+    const oversizedContent = `${head}${filler}${tail}`
 
     const markup = renderToStaticMarkup(<MarkdownContent content={oversizedContent} />)
 
-    expect(markup).toContain("This content is too large to render as Markdown safely")
-    expect(markup).not.toContain("Render markdown anyway")
-    expect(markup).not.toContain("END_MARKER")
+    // Head and tail are rendered as Markdown.
+    expect(markup).toContain("Head heading")
+    expect(markup).toContain("Tail heading")
+    expect(markup).toContain("END_MARKER")
+    expect(markup).toContain("<h1")
+    expect(markup).toContain("<h2")
+    // The collapsed middle exposes a "Show … more characters" affordance,
+    // and the middle bytes themselves are NOT in the initial markup.
+    expect(markup).toMatch(/Show [\d,]+ more characters/)
   })
 
   it("routes JSON object content to the JSON code-block renderer", () => {
@@ -169,13 +178,13 @@ describe("MarkdownContent", () => {
     expect(markup).toContain("<strong>")
   })
 
-  it("falls back to plain-text preview for oversized JSON instead of JsonContent", () => {
+  it("does not route oversized JSON through JsonContent (falls through to the Markdown split fallback)", () => {
     const filler = `"x": "${"a".repeat(LARGE_MARKDOWN_CONTENT_THRESHOLD)}"`
     const oversizedJson = `{${filler}}`
 
     const markup = renderToStaticMarkup(<MarkdownContent content={oversizedJson} />)
 
-    expect(markup).toContain("This content is too large to render as Markdown safely")
     expect(markup).not.toContain('data-content-type="json"')
+    expect(markup).toMatch(/Show [\d,]+ more characters/)
   })
 })

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
@@ -5,9 +5,7 @@ import rehypeHighlight from "rehype-highlight"
 import remarkBreaks from "remark-breaks"
 import remarkEmoji from "remark-emoji"
 import remarkGfm from "remark-gfm"
-import { Button } from "../../button/button.tsx"
 import { CodeBlockControls } from "../../code-block/code-block-controls.tsx"
-import { Text } from "../../text/text.tsx"
 import { TextSelectionContext } from "../text-selection.tsx"
 import { CodeBlockShell } from "./code-block-shell.tsx"
 import { JsonContent } from "./json-content.tsx"
@@ -67,12 +65,53 @@ const markdownComponents: Components = {
     </div>
   ),
 }
-export const LARGE_MARKDOWN_PREVIEW_LENGTH = 12_000
+export const LARGE_MARKDOWN_HEAD_LENGTH = 6_000
+export const LARGE_MARKDOWN_TAIL_LENGTH = 2_000
 
-function getLargeContentPreview(content: string) {
-  if (content.length <= LARGE_MARKDOWN_PREVIEW_LENGTH) return content
+// Snap to the nearest newline within a small radius so we don't cut markdown
+// constructs (lists, fences, headings) mid-syntax on the first/last slice.
+function snapToNewline(content: string, target: number, radius = 400): number {
+  const start = Math.max(0, target - radius)
+  const end = Math.min(content.length, target + radius)
+  const window = content.slice(start, end)
+  const localTarget = target - start
+  let best = -1
+  let bestDist = Infinity
+  for (let i = 0; i < window.length; i++) {
+    if (window[i] !== "\n") continue
+    const dist = Math.abs(i - localTarget)
+    if (dist < bestDist) {
+      best = i
+      bestDist = dist
+    }
+  }
+  return best === -1 ? target : start + best
+}
 
-  return `${content.slice(0, LARGE_MARKDOWN_PREVIEW_LENGTH)}\n\n[truncated ${content.length - LARGE_MARKDOWN_PREVIEW_LENGTH} characters]`
+function splitLargeContent(content: string): { head: string; middle: string; tail: string } {
+  const headCut = snapToNewline(content, LARGE_MARKDOWN_HEAD_LENGTH)
+  const tailCut = snapToNewline(content, content.length - LARGE_MARKDOWN_TAIL_LENGTH)
+  // Guard against a degenerate split where the snapped cuts cross.
+  if (tailCut <= headCut) {
+    return { head: content.slice(0, headCut), middle: "", tail: content.slice(headCut) }
+  }
+  return {
+    head: content.slice(0, headCut),
+    middle: content.slice(headCut, tailCut),
+    tail: content.slice(tailCut),
+  }
+}
+
+function MarkdownBody({ content }: { readonly content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[...remarkPlugins]}
+      rehypePlugins={[rehypeHighlightPlugin]}
+      components={markdownComponents}
+    >
+      {content}
+    </ReactMarkdown>
+  )
 }
 
 export function MarkdownContent({
@@ -92,29 +131,34 @@ export function MarkdownContent({
         : [],
     [selectionCtx, messageIndex, partIndex],
   )
-  const [showFullText, setShowFullText] = useState(false)
+  const [showMiddle, setShowMiddle] = useState(false)
   // Gate the JSON.parse on size so oversized content doesn't pay the parse cost
   // only to be discarded by the large-content fallback below.
   const isJson = useMemo(() => content.length <= LARGE_MARKDOWN_CONTENT_THRESHOLD && isJsonBlock(content), [content])
 
   if (content.length > LARGE_MARKDOWN_CONTENT_THRESHOLD) {
-    const preview = showFullText ? content : getLargeContentPreview(content)
+    const { head, middle, tail } = splitLargeContent(content)
 
     return (
-      <div className="flex flex-col gap-3">
-        <Text.H6 color="foregroundMuted">
-          This content is too large to render as Markdown safely, so we&apos;re showing it as plain text instead.
-        </Text.H6>
-
-        <div className="flex flex-wrap gap-2">
-          <Button variant="outline" size="sm" type="button" onClick={() => setShowFullText((prev) => !prev)}>
-            {showFullText ? "Show preview" : "Show full text"}
-          </Button>
-        </div>
-
-        <pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg bg-background p-3 text-xs">
-          {preview}
-        </pre>
+      <div className="prose prose-sm dark:prose-invert max-w-none wrap-break-word">
+        <MarkdownBody content={head} />
+        {middle.length > 0 &&
+          (showMiddle ? (
+            <MarkdownBody content={middle} />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowMiddle(true)}
+              className="not-prose group my-4 flex w-full items-center gap-3 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <span className="h-px flex-1 bg-border" />
+              <span className="rounded-full border border-border bg-background px-3 py-1 group-hover:bg-muted">
+                Show {middle.length.toLocaleString()} more characters
+              </span>
+              <span className="h-px flex-1 bg-border" />
+            </button>
+          ))}
+        {tail.length > 0 && <MarkdownBody content={tail} />}
       </div>
     )
   }


### PR DESCRIPTION
Two independent improvements bundled in one PR.

## 1. `fix(ui)`: render large markdown content as expandable head + tail

- The previous fallback for content above `LARGE_MARKDOWN_CONTENT_THRESHOLD` (20k chars) rendered the entire message as plain text inside a `<pre>`, which looked out of place in the trace conversation drawer.
- Now the head (~6k chars) and tail (~2k chars) render as proper Markdown via the same `prose` wrapper used by normal-sized content, with a clickable pill separator in between that expands the middle on demand.
- Slice boundaries snap to the nearest newline within ±400 chars so we don't cut Markdown constructs (lists, fences, headings) mid-syntax.
- Threshold itself (`LARGE_MARKDOWN_CONTENT_THRESHOLD`) is unchanged — only the fallback rendering differs.

## 2. `perf(issues)`: short-circuit empty projects + loading empty state

- `listIssuesUseCase` was hitting `ScoreAnalyticsRepository` and `TraceRepository` (ClickHouse) on every call, even when the project had zero issues, only to assemble a zeroed-out analytics payload.
- Now we probe with a cheap `issueRepository.list({ limit: 1 })` first and, when empty, return a scaffolded empty result without touching ClickHouse. New unit test asserts ClickHouse paths and `traceRepository.countByProjectId` are never called in that case.
- On the web side, the Issues page used to render `null` during its initial fetch with no cached data, producing a blank flash before the empty state appeared. We now render `IssuesEmptyState` with a new `isLoading` flag so the layout stays stable.

## Test plan

- [x] `pnpm --filter @repo/ui typecheck` + full vitest suite (77/77)
- [x] `pnpm --filter @domain/issues typecheck` + `list-issues.test.ts` (12/12, including new test)
- [x] `pnpm --filter @app/web typecheck`
- [x] `biome check` on all 6 changed files
- [x] Manual QA (markdown): shipped a 27,583-char Markdown assistant message via the claude-code-telemetry CLI to the local stack; verified head/tail render as Markdown, pill expands to reveal the middle, code fences/tables/blockquotes render correctly.
- [ ] Manual QA (issues): visit a fresh project's Issues page and confirm the loading empty state appears, then transitions cleanly to the no-issues empty state without a blank flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)