### PR TITLE
docs(sessions): plan to collapse search and issues noise via session grouping

### DIFF
--- a/specs/session-problems/0-problems.md
+++ b/specs/session-problems/0-problems.md
@@ -1,0 +1,283 @@
+## Session problems
+
+This document is the index of known problems with the current session
+implementation, ordered by development priority based on dependencies. Each
+problem points to a more specific document where its solution is explored in
+depth.
+
+Items earlier in the list must be solved (at least to a working baseline)
+before items later in the list, because the latter assume the former are in
+place.
+
+---
+
+## Future-state UX context
+
+Today the sidebar has a single **Traces** entry. Inside that route, two
+view toggles flip between a per-trace listing and a per-session listing
+("Traces" / "Sessions" tabs in the page header). Search is a separate
+top-level route. So the surfaces in play are:
+
+- **Traces route, "Traces" tab** — current trace listing.
+- **Traces route, "Sessions" tab** — current session listing.
+- **Search route** — full-text + semantic search, returning trace rows.
+
+The end state for the navigation chrome is **explicitly an open product
+decision**:
+
+- Option (a) — keep two separate sections (Traces and Sessions as
+  sibling top-level entries, or as the current tabbed view).
+- Option (b) — collapse to one Sessions surface that absorbs trace
+  browsing via the row-expansion pattern.
+
+Either way, the **behaviors** that this epic introduces are independent of
+that navigation decision and stand on their own:
+
+- **One list view per surface, paginated by session.** Search results,
+  issues, and the sessions tab all render session rows. Per-trace
+  pagination is broken by construction (see the core constraint below).
+- **One filter bar per surface.** Filters cover the union of trace and
+  session dimensions, evaluated against the session row (per
+  `./4-filter-parity.md`). The traces tab keeps its own filter bar; the
+  parity work makes the sessions filter bar cover everything the traces
+  one does.
+- **Search is a query parameter on the sessions surface, not its own
+  semantics.** Typing in the search input adds `q=…` to the URL and
+  re-renders the same session listing with hit badges on matching trace
+  rows in each row's inline expansion.
+- **One click contract on a session row.** Clicking a session row
+  always opens the session panel (header with metadata, Conversation tab
+  with one trace). For multi-trace sessions the row also expands inline
+  showing every constituent trace, with matching ones highlighted when a
+  search is active. The expansion is the trace navigator; the panel is
+  the trace reader.
+
+This epic implements the behavior **inside the search route** as the
+first cut — that's where the most painful noise lives today. Lifting the
+same component tree into the Sessions tab (and, if (b) wins, replacing
+the Traces tab entirely) is the next item *after* this set. Everything
+in this document is scoped to the search-route cut and is forward-compatible
+with either navigation outcome.
+
+---
+
+## Core constraint — pagination is by session, not by trace
+
+All listing surfaces (search results, issues view, sessions table) must
+paginate on **session rows**, not trace rows. Trace-level pagination is
+broken by construction: a 25-result page can collapse to 3 unique
+conversations if a single session matched on ten turns. The user is led to
+expect 25 distinct things and gets 3 — fewer real results than the page
+size advertises, and the same conversation repeated over and over.
+
+This is a hard architectural constraint, not a UX preference. It shapes the
+choices in every problem below:
+
+- **#2 session-level search** — the collapse must happen inside the query
+  so cursors, counts, and the "results per page" affordance are
+  session-stable. Collapsing in the UI after fetching trace rows is not
+  acceptable: it would silently shrink each page.
+- **#3 session issue dedup** — same shape on the issues view. A session
+  with ten matching turns of the same issue counts as one paginated row,
+  and the issues counter reflects distinct sessions.
+- **#4 filter parity** — filters are evaluated against the session row;
+  one matching session yields one paginated row regardless of how many
+  of its traces individually qualify.
+- **#6 session detail panel** — the click target from a paginated session
+  row is the panel, not a per-trace drawer.
+
+Counters rendered alongside any of these surfaces ("25 results", "8
+issues this week", "3 sessions filtered") count distinct sessions for the
+same reason.
+
+### Precondition — every trace is a session
+
+For the constraint above to apply universally, every trace has to map to a
+session. Today it doesn't: `sessions_mv` filters `WHERE session_id != ''`,
+so any trace produced without `gen_ai.conversation.id` (one-shot
+completions, non-chat workloads, older SDKs) is invisible to a
+session-paginated listing.
+
+We treat **orphan traces as 1-trace sessions**, with `session_id`
+synthesized from the trace_id when the SDK didn't supply one. Mechanically
+that's a `GROUP BY coalesce(nullIf(session_id, ''), toString(trace_id))` in
+`sessions_mv` and dropping the `WHERE session_id != ''` filter. The
+sessions table becomes a strict superset over traces — orphans show up
+with `trace_count = 1`, and every downstream surface (search, issues,
+filters, panel) gets a single code path. This lands as part of #1
+(materialization parity) below.
+
+**The same coalesce expression is the canonical session_id everywhere
+downstream of ingest.** Scores carry it (so issue dedup groups correctly),
+the search rollup uses it (so search never returns orphan-fragment rows),
+and any future read path that needs a "trace's session" should derive it
+the same way rather than reading `traces.session_id` raw. This convention
+is what lets the spec set treat `session_id` as an always-present grouping
+key — no `IS NULL` branches anywhere.
+
+### Contract — session_id propagation
+
+For session aggregates to be correct, `gen_ai.conversation.id` must be set
+on **every span of a conversational trace, or none of them.** The Latitude
+SDK propagates the attribute automatically via OTel context, so anyone
+using it inherits the contract for free. OTel-direct customers using
+auto-instrumentation libraries around third-party GenAI SDKs (Vercel AI,
+LangChain, Anthropic SDK direct) must propagate the attribute manually to
+their framework spans — auto-instrumentation only tags LLM-call spans by
+default.
+
+When the contract is violated (mixed binding inside a single trace), the
+trace's LLM spans form a normal session row and the framework spans form a
+separate **orphan-fragment** session row keyed on `toString(trace_id)`.
+Orphan fragments are visually distinguishable: `tokens_total = 0`,
+`cost_total_microcents = 0`, `models = []`, `trace_count = 1`. The
+sessions list dims them by default via a "has LLM activity" filter chip
+(see #4 filter parity), so the noise stays contained.
+
+---
+
+### 1. Session materialization parity with traces
+
+Session materialization is missing 1-to-1 aggregations with traces. We are
+missing `duration` and `TTFT` at minimum. Audit every field present in
+materialized traces and decide for each whether the session row needs a
+counterpart (sum, max, min, first, or last depending on the field) until we
+reach parity.
+
+This item also lands the **orphan-trace-as-session** change from the
+precondition above: replace the `sessions_mv` filter with a synthesized
+group key so every trace is a session.
+
+- **Why this position:** This is the data-layer foundation. Filtering,
+  sorting, displaying, and freshness weighting all assume the session row
+  carries the same kind of information a trace row does. Anything we build
+  before this is patching on top of an incomplete schema. The orphan-trace
+  fix has to ship in the same migration because every downstream surface
+  assumes the sessions table covers every trace.
+- **Dependencies:** None.
+- **Blocks:** filter parity, session detail panel, freshness sort, and
+  partially session-level search (it needs these fields to render result
+  cards). Also blocks the core constraint from applying universally —
+  without the orphan-trace fix, session-paginated listings silently hide
+  one-shot traces.
+
+→ Spec: `./1-parity-traces-sessions.md`
+
+---
+
+### 2. Search paginates and counts by session, not by trace
+
+Search today returns results per trace, so a single session that matched on
+ten turns occupies ten rows of the page and the user gets three real
+conversations instead of the 25 the page size promised. This is the direct
+manifestation of the core constraint above: the collapse to one row per
+session has to happen **inside the search query**, so the cursor advances
+one session at a time, the result counter reflects distinct sessions, and
+each page delivers what the page size advertises. Each row must still carry
+enough information to render which of the session's traces matched and how
+strongly.
+
+- **Why this position:** This is the core change to the search pipeline.
+  Several downstream problems (search highlights, freshness sort) depend on
+  the pipeline operating at the session level rather than the trace level.
+  It has to happen before refinements to that pipeline are worth building.
+- **Dependencies:** Benefits from materialization parity so the collapsed
+  session row has the fields needed to render a useful result card.
+- **Blocks:** search highlights, freshness sort.
+
+→ Spec: `./2-session-level-search.md`
+
+---
+
+### 3. Issues paginate and count by session, not by trace
+
+Same shape as #2, applied to the issues view: the same issue currently
+surfaces once per matching trace, so a session that triggered an issue on
+ten turns floods the page with ten rows. Per the core constraint, the issue
+view has to paginate and count distinct sessions — one row per
+`(session, issue)`, with the underlying matching traces discoverable from
+that row.
+
+- **Why this position:** Same conceptual fix as session-level search —
+  collapse to session — applied to the issues stream instead of the search
+  stream. Pairing the two keeps the deduplication logic consistent across
+  surfaces and avoids two divergent implementations.
+- **Dependencies:** Conceptually parallel to session-level search.
+- **Blocks:** session detail panel (the panel surfaces issues; they should
+  already be deduplicated by then).
+
+→ Spec: `./3-session-issue-dedup.md`
+
+---
+
+### 4. Filter parity between sessions and traces
+
+Sessions are missing several filters that traces already have, notably
+`traceName` and `traceId`. Audit every filter available on traces and
+replicate the meaningful ones on sessions, deciding for each how it should
+behave when a session contains traces with multiple values for the field.
+
+- **Why this position:** Once sessions are the unit of search and carry the
+  required fields, filters are the next visible UX gap. Doing this here
+  avoids users hitting a half-functional filter bar right after session
+  search lands.
+- **Dependencies:** Materialization parity for the underlying fields;
+  benefits from session-level search.
+
+→ Spec: `./4-filter-parity.md`
+
+---
+
+### 5. Search highlights work with session results
+
+The problems already listed in `./5-search-highlights.md` need to be fixed on
+their own merits. On top of that, highlights must operate on session-level
+matches — i.e. across the merged set of traces inside a session — not on a
+single trace at a time.
+
+- **Why this position:** Highlights are a presentation layer on top of the
+  search pipeline. Implementing them before session-level search would mean
+  building them twice — once for trace results, then again for session
+  results.
+- **Dependencies:** Hard-depends on session-level search. Pre-existing scope
+  is documented in `./5-search-highlights.md`.
+
+→ Spec: `./5-search-highlights.md`
+
+---
+
+### 6. Session detail panel
+
+The sessions table needs its own panel where users can see:
+
+1. The full conversation with all annotations across all of the session's
+   traces.
+2. Session metadata and the issues associated to the session (likely a join
+   with scores).
+
+- **Why this position:** This is the consumer of most of the data foundation
+  work. It needs materialized fields and deduplicated issues to render
+  correctly. Building it earlier means designing UI against incomplete data
+  and reworking it later. Lifecycle status is derived inline at read time
+  (`live` / `idle` from `now() - max_end_time`); no separate state table.
+- **Dependencies:** Materialization parity, issue dedup.
+
+→ Spec: `./6-session-panel.md`
+
+---
+
+### 7. Freshness-weighted session ordering
+
+Session results are currently ordered purely by relevance. We want a balance
+of relevance and freshness. One candidate approach: round relevance into
+buckets of 0.1–0.9, then sort by recency inside each bucket — so highly
+relevant results stay near the top while fresher items win ties.
+
+- **Why this position:** A refinement on top of an otherwise-correct session
+  search pipeline. Tackling freshness before session-level search lands
+  would be wasted work, because the result set itself was wrong. The
+  freshness axis is `max_end_time` from `sessions` directly, with a 1-hour
+  clock-skew clamp — no separate lifecycle resolution needed.
+- **Dependencies:** Session-level search.
+
+→ Spec: `./7-freshness-weighted-sort.md`

--- a/specs/session-problems/1-parity-traces-sessions.md
+++ b/specs/session-problems/1-parity-traces-sessions.md
@@ -1,0 +1,1009 @@
+# Session materialization parity with traces
+
+## Goal
+
+The `sessions` ClickHouse table is fed by the same `spans` source as `traces`,
+but the `sessions_mv` definition is a strict subset of `traces_mv` and has
+fallen behind every time `traces` got a new column. Every downstream feature
+(session-level search, filter parity, the session detail panel, freshness-sorted
+results) assumes a session row carries the same kind of information a trace row
+does. Today it doesn't.
+
+This document audits every column in `traces`, lists the corresponding column
+(or absence thereof) in `sessions`, and proposes a concrete aggregation
+strategy for each missing field. It also covers the migration shape and the
+pipeline change.
+
+Scope is **column-level parity in the CH materialization layer**. The
+`SessionRepository` is missing read methods present on `TraceRepository`
+(`histogramByProjectId`, `findByTraceId`-analog, `getDistribution`,
+`countAnnotatedByProjectId`, …) — that gap is adjacent and gets called out at
+the end, but the methods themselves are out of scope here.
+
+## Source of truth
+
+Both materialized tables aggregate the same source table, `spans`, via
+`AggregatingMergeTree`-backed materialized views. The `spans` table is the
+append-only ingestion target.
+
+| Layer | Source / File |
+|---|---|
+| Source table | `spans` — `packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00001_create_spans.sql:3` |
+| Trace destination table | `traces` — `…/00002_materialized_traces.sql:10` (subsequent ALTERs in `00004`, `00005`, `00008`, `00011`) |
+| Trace materialized view | `traces_mv` — current shape in `…/00011_plan_aware_retention.sql:16` |
+| Session destination table | `sessions` — `…/00007_sessions.sql:4` (one ALTER in `00008`) |
+| Session materialized view | `sessions_mv` — current shape in `…/00008_simulation_id.sql:78` |
+| Generated current schema (post-migration) | `packages/platform/testkit/src/clickhouse/schema.sql:58` (sessions), `:235` (traces), `:278` (traces_mv), `:94` (sessions_mv) |
+| Trace listing repo | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:287` (`LIST_SELECT`) |
+| Session listing repo | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:21` (`LIST_SELECT`) |
+| Trace filter registry | `packages/platform/db-clickhouse/src/registries/trace-fields.ts:7` |
+| Session filter registry | `packages/platform/db-clickhouse/src/registries/session-fields.ts:4` |
+| Domain trace entity | `packages/domain/spans/src/entities/trace.ts:19` |
+| Domain session entity | `packages/domain/spans/src/entities/session.ts:17` |
+
+Both `traces` and `sessions` are `AggregatingMergeTree` partitioned by
+`toYYYYMM(min_start_time)`. The `traces_mv` groups by
+`(organization_id, project_id, trace_id)`; the `sessions_mv` groups by
+`(organization_id, project_id, session_id)` **filtered** by
+`session_id != ''` (a span without a session is excluded entirely from
+sessions, but every span — session or not — flows into traces).
+
+**This filter is being removed.** Per the core constraint in `0-problems.md`,
+every trace must paginate as a session — orphan spans without a
+`gen_ai.conversation.id` need to surface in the sessions listing as
+1-trace sessions, not be silently dropped. The new grouping expression is
+`(organization_id, project_id, coalesce(nullIf(session_id, ''), toString(trace_id)))`,
+which collapses real-session spans by their supplied id and synthesizes a
+session per `trace_id` for orphans. The sessions table becomes a strict
+superset over traces. The concrete SQL change lands in the
+`sessions_mv` redefinition in §"Proposed `sessions_mv` and `sessions` shape"
+below.
+
+## Current state — `traces` materialization
+
+Pulled directly from the post-migration schema dump
+(`packages/platform/testkit/src/clickhouse/schema.sql:235`) and cross-checked
+against the live MV in `…/00011_plan_aware_retention.sql:16`. Columns are
+grouped by what the row carries semantically.
+
+### Identity / grouping keys
+
+| Column | CH type | Notes |
+|---|---|---|
+| `organization_id` | `LowCardinality(String)` | Part of `ORDER BY`. |
+| `project_id` | `LowCardinality(String)` | Part of `ORDER BY`. |
+| `trace_id` | `FixedString(32)` | Part of `ORDER BY`; OTel trace id. |
+
+### Timing
+
+| Column | CH type | Built from |
+|---|---|---|
+| `min_start_time` | `SimpleAggregateFunction(min, DateTime64(9, 'UTC'))` | `min(start_time)` over spans. |
+| `max_end_time` | `SimpleAggregateFunction(max, DateTime64(9, 'UTC'))` | `max(end_time)` over spans. |
+| `time_of_first_token` | `SimpleAggregateFunction(min, DateTime64(9, 'UTC'))` | `min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, time_to_first_token_ns), <sentinel>))` — sentinel `2261-01-01` means "no span produced a first token". `traces_mv` line, `…/00011_plan_aware_retention.sql:61-65`. |
+| `duration_ns` | `Int64 ALIAS` | `reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time)` — computed at read time. |
+| `time_to_first_token_ns` | `Int64 ALIAS` | `if(time_of_first_token < 2261-01-01, reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time), 0)` — sentinel-aware. |
+
+### Counts
+
+| Column | CH type | Built from |
+|---|---|---|
+| `span_count` | `SimpleAggregateFunction(sum, UInt64)` | `count()` per group. |
+| `error_count` | `SimpleAggregateFunction(sum, UInt64)` | `countIf(status_code = 2)`. |
+
+### Tokens
+
+| Column | CH type | Built from |
+|---|---|---|
+| `tokens_input` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_input)`. |
+| `tokens_output` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_output)`. |
+| `tokens_cache_read` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_cache_read)`. |
+| `tokens_cache_create` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_cache_create)`. |
+| `tokens_reasoning` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_reasoning)`. |
+| `tokens_total` | `SimpleAggregateFunction(sum, UInt64)` | `sum(tokens_total)` (spans column itself is MATERIALIZED, not user-set). |
+
+### Cost (microcents)
+
+| Column | CH type | Built from |
+|---|---|---|
+| `cost_input_microcents` | `SimpleAggregateFunction(sum, UInt64)` | `sum(cost_input_microcents)`. |
+| `cost_output_microcents` | `SimpleAggregateFunction(sum, UInt64)` | `sum(cost_output_microcents)`. |
+| `cost_total_microcents` | `SimpleAggregateFunction(sum, UInt64)` | `sum(cost_total_microcents)`. |
+
+### Identifiers carried through
+
+| Column | CH type | Built from |
+|---|---|---|
+| `session_id` | `AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(session_id, start_time, session_id != '')` — last non-empty session_id wins. |
+| `user_id` | `AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(user_id, start_time, user_id != '')`. |
+| `simulation_id` | `AggregateFunction(argMaxIf, FixedString(24), DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(simulation_id, start_time, simulation_id != '')`. |
+
+### Set-valued metadata
+
+| Column | CH type | Built from |
+|---|---|---|
+| `tags` | `SimpleAggregateFunction(groupUniqArrayArray, Array(String))` | `groupUniqArrayArray(tags)`. |
+| `metadata` | `SimpleAggregateFunction(maxMap, Map(String, String))` | `maxMap(metadata)` — per-key max wins on conflict. |
+| `models` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(model, model != '')`. |
+| `providers` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(provider, provider != '')`. |
+| `service_names` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(service_name, service_name != '')`. |
+
+### Root-span attribution
+
+| Column | CH type | Built from |
+|---|---|---|
+| `root_span_id` | `AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8)` | `argMinIfState(span_id, start_time, parent_span_id = '')` — earliest parentless span. |
+| `root_span_name` | `AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMinIfState(name, start_time, parent_span_id = '')`. |
+
+### Detail-only message payloads
+
+Only read by `findByTraceId` via `DETAIL_SELECT`
+(`trace-repository.ts:324`). Big ZSTD(3)-compressed JSON; not in `LIST_SELECT`.
+
+| Column | CH type | Built from |
+|---|---|---|
+| `input_messages` | `AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMinIfState(input_messages, start_time, input_messages != '')` — **first** span with input. |
+| `last_input_messages` | `AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(input_messages, end_time, output_messages != '')` — input of the last span that produced output. |
+| `output_messages` | `AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(output_messages, end_time, output_messages != '')` — **last** span with output. |
+| `system_instructions` | `AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMinIfState(system_instructions, start_time, system_instructions != '')` — earliest non-empty. |
+
+### Retention
+
+| Column | CH type | Built from |
+|---|---|---|
+| `retention_days` | `SimpleAggregateFunction(max, UInt16)` | `max(retention_days)` — per-plan TTL knob. Drives `TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE`. Added in `…/00011_plan_aware_retention.sql:11`. |
+
+## Current state — `sessions` materialization
+
+Pulled from `packages/platform/testkit/src/clickhouse/schema.sql:58` and
+cross-checked against the live MV in `…/00008_simulation_id.sql:78`.
+
+### Identity / grouping keys
+
+| Column | CH type |
+|---|---|
+| `organization_id` | `LowCardinality(String)` |
+| `project_id` | `LowCardinality(String)` |
+| `session_id` | `String` (not `FixedString` — sessions are arbitrary tenant-supplied ids). |
+
+### Carried through from spans
+
+| Column | CH type | Built from |
+|---|---|---|
+| `trace_count` | `AggregateFunction(uniqExact, FixedString(32))` | `uniqExactState(trace_id)` — distinct trace_ids in the session. |
+| `trace_ids` | `AggregateFunction(groupUniqArray, FixedString(32))` | `groupUniqArrayState(trace_id)` — full set; sessions only. |
+| `span_count` | `SimpleAggregateFunction(sum, UInt64)` | `count()`. |
+| `error_count` | `SimpleAggregateFunction(sum, UInt64)` | `countIf(status_code = 2)`. |
+| `min_start_time` | `SimpleAggregateFunction(min, DateTime64(9, 'UTC'))` | `min(start_time)`. |
+| `max_end_time` | `SimpleAggregateFunction(max, DateTime64(9, 'UTC'))` | `max(end_time)`. |
+| `duration_ns` | `Int64 ALIAS` | `reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time)`. |
+| `tokens_input`, `tokens_output`, `tokens_cache_read`, `tokens_cache_create`, `tokens_reasoning`, `tokens_total` | `SimpleAggregateFunction(sum, UInt64)` | `sum(...)`. |
+| `cost_input_microcents`, `cost_output_microcents`, `cost_total_microcents` | `SimpleAggregateFunction(sum, UInt64)` | `sum(...)`. |
+| `user_id` | `AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(user_id, start_time, user_id != '')`. |
+| `tags` | `SimpleAggregateFunction(groupUniqArrayArray, Array(String))` | `groupUniqArrayArray(tags)`. |
+| `metadata` | `SimpleAggregateFunction(maxMap, Map(String, String))` | `maxMap(metadata)`. |
+| `models` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(model, model != '')`. |
+| `providers` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(provider, provider != '')`. |
+| `service_names` | `AggregateFunction(groupUniqArrayIf, String, UInt8)` | `groupUniqArrayIfState(service_name, service_name != '')`. |
+| `simulation_id` | `AggregateFunction(argMaxIf, FixedString(24), DateTime64(9, 'UTC'), UInt8)` | `argMaxIfState(simulation_id, start_time, simulation_id != '')`. |
+
+No `time_of_first_token`, no `root_span_*`, no message payloads, no
+`retention_days`.
+
+## Gap table
+
+Side-by-side. Trace column → session counterpart. "Field semantics" describes
+what the value means in the session row. Aggregation strategies are written
+against `spans` (the source the MV reads), not against trace rows — the MV
+runs per span insert, so there is no "trace row" available at MV time. Where
+the trace MV uses one strategy and a different one makes semantic sense at
+the session level, both are noted.
+
+| Trace column | Session column today | Status | Proposed session aggregation (over every `spans` row, grouped on synthesized `session_id`) | Field semantics for session |
+|---|---|---|---|---|
+| `organization_id` | `organization_id` | OK | `GROUP BY` key. | Identity. |
+| `project_id` | `project_id` | OK | `GROUP BY` key. | Identity. |
+| `trace_id` | n/a (sessions group by `session_id`) | n/a — different grain. | Replaced by `trace_count` / `trace_ids` aggregates. | One session contains many traces. |
+| `span_count` | `span_count` | OK | `count()`. | Total spans across all traces in the session. |
+| `error_count` | `error_count` | OK | `countIf(status_code = 2)`. | Total error spans. |
+| `min_start_time` | `min_start_time` | OK | `min(start_time)`. | Earliest activity. |
+| `max_end_time` | `max_end_time` | OK | `max(end_time)`. | Latest activity. |
+| `duration_ns` (ALIAS) | `duration_ns` (ALIAS) | **SEMANTIC CHANGE** | Drop the existing ALIAS. Add a real `SimpleAggregateFunction(sum, Int64)` column populated as `sum(if((parent_span_id = '' OR parent_span_id = '0000000000000000') AND end_time > start_time, reinterpretAsInt64(end_time) - reinterpretAsInt64(start_time), 0))` — sum of root-span durations, with broader root detection and a clock-skew guard. | Active execution time across all traces in the session (NOT wall-clock). Wall-clock is recoverable on the fly from `max_end_time - min_start_time`. See "On `duration_ns` semantics" below for limitations. |
+| `time_of_first_token` | **MISSING** | **MISSING** | `min(if(time_to_first_token_ns > 0, addNanoseconds(start_time, time_to_first_token_ns), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC')))` — identical pattern to `traces_mv`. `SimpleAggregateFunction(min, DateTime64(9, 'UTC'))`. | Absolute instant of the earliest first token across the entire session. Sentinel = "no first-token instrumented in this session". |
+| `time_to_first_token_ns` (ALIAS) | **MISSING** | **MISSING** | `Int64 ALIAS if(time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'), reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time), 0)`. | Time-to-first-token of the session, measured from session start to the first first-token across all traces. Effectively `min(per-trace TTFT)` weighted by absolute trace start — the user's "how fast does this session start responding" metric. |
+| `tokens_input` | `tokens_input` | OK | `sum(tokens_input)`. | Total prompt tokens. |
+| `tokens_output` | `tokens_output` | OK | `sum(tokens_output)`. | Total completion tokens. |
+| `tokens_cache_read` | `tokens_cache_read` | OK | `sum(tokens_cache_read)`. | Total cache reads. |
+| `tokens_cache_create` | `tokens_cache_create` | OK | `sum(tokens_cache_create)`. | Total cache creates. |
+| `tokens_reasoning` | `tokens_reasoning` | OK | `sum(tokens_reasoning)`. | Total reasoning tokens. |
+| `tokens_total` | `tokens_total` | OK | `sum(tokens_total)`. | Total tokens. |
+| `cost_input_microcents` | `cost_input_microcents` | OK | `sum(cost_input_microcents)`. | Total input cost. |
+| `cost_output_microcents` | `cost_output_microcents` | OK | `sum(cost_output_microcents)`. | Total output cost. |
+| `cost_total_microcents` | `cost_total_microcents` | OK | `sum(cost_total_microcents)`. | Total cost. |
+| `session_id` (argMaxIf) | `session_id` (`GROUP BY` key) | n/a — at session grain it IS the key. | — | Identity. |
+| `user_id` | `user_id` | OK | `argMaxIfState(user_id, start_time, user_id != '')`. | Last non-empty `user_id` observed in the session — a session is typically one user, but spans can be re-tagged. |
+| `simulation_id` | `simulation_id` | OK | `argMaxIfState(simulation_id, start_time, simulation_id != '')`. | Last non-empty simulation id observed in the session. |
+| `tags` | `tags` | OK | `groupUniqArrayArray(tags)`. | Union of all tags across spans. |
+| `metadata` | `metadata` | OK | `maxMap(metadata)`. | Per-key max of metadata values. |
+| `models` | `models` | OK | `groupUniqArrayIfState(model, model != '')`. | All models used in the session. |
+| `providers` | `providers` | OK | `groupUniqArrayIfState(provider, provider != '')`. | All providers. |
+| `service_names` | `service_names` | OK | `groupUniqArrayIfState(service_name, service_name != '')`. | All services. |
+| `root_span_id` | **MISSING** | **MISSING (open question — see below)** | A session has no single root span; consider `argMinIfState(span_id, start_time, parent_span_id = '' OR parent_span_id = '0000000000000000')` to record the earliest root span (the root of the **first trace**). | "Where the session started." Less meaningful than for a trace but still useful for the session detail panel header. See open question. |
+| `root_span_name` | **MISSING** | **MISSING** | `argMinIfState(name, start_time, parent_span_id = '' OR parent_span_id = '0000000000000000')` — earliest root span name. Predicate matches `duration_ns`'s root detection. | The first trace's root span name. Drives the session card's primary label, analogous to `root_span_name` on the trace card. |
+| `input_messages` | **MISSING** | **MISSING (detail-only)** | `argMinIfState(input_messages, start_time, input_messages != '')` — input of the **earliest** span that has input. | The session opener. Renders in the session detail panel as the first message. |
+| `last_input_messages` | **MISSING** | **MISSING (detail-only)** | `argMaxIfState(input_messages, end_time, output_messages != '')` — input of the **latest** span that produced output. | The most recent user turn that the model responded to. Used to render "current state" in the panel. |
+| `output_messages` | **MISSING** | **MISSING (detail-only)** | `argMaxIfState(output_messages, end_time, output_messages != '')` — output of the **latest** span that produced output. | The most recent assistant response. |
+| `system_instructions` | **MISSING** | **MISSING (detail-only)** | `argMinIfState(system_instructions, start_time, system_instructions != '')` — the earliest non-empty system. | The system instructions that opened the session. If the session re-instruments the system mid-conversation we keep the **first**; the detail panel can still pull per-trace system out of `traces` if needed. |
+| `retention_days` | **MISSING** | **MISSING** | `SimpleAggregateFunction(max, UInt16)` initialized from `max(retention_days)` over spans. | Drives the same plan-aware `TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE` we apply to `traces`. Without it, session retention diverges from trace retention. |
+
+### Trace columns intentionally NOT mirrored
+
+- `traces.trace_id` has no counterpart — sessions group by `session_id`,
+  so the analog is the **set** of trace ids the session contains, already
+  carried in `sessions.trace_ids` (`AggregateFunction(groupUniqArray, FixedString(32))`)
+  and the cardinality count in `sessions.trace_count`.
+
+### Session-specific columns with no trace counterpart
+
+- `trace_count` (`uniqExact(trace_id)`) and `trace_ids` (`groupUniqArray(trace_id)`)
+  exist on sessions but not on traces, by design — a trace is by definition
+  one trace_id. They stay.
+
+## On `duration_ns` semantics
+
+`duration_ns` on sessions is **redefined** in this spec. The trace
+column stays as-is (wall-clock from `min_start_time` to `max_end_time`,
+which for a single trace is also its active execution time). The
+session column changes meaning.
+
+### Today (wrong for sessions)
+
+`duration_ns` is an `Int64 ALIAS` computed as
+`reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time)`
+— wall-clock from first activity to last. For a session this is
+misleading: two sessions with the same wall-clock window can do wildly
+different amounts of work.
+
+| Session A | Session B |
+|---|---|
+| Spans 2 days | Spans 2 days |
+| 24 traces averaging 12 hours each | 24 traces averaging 5 minutes each |
+| Wall-clock window: 2 days | Wall-clock window: 2 days |
+| Active execution: ~12 d (sum) | Active execution: ~2 h (sum) |
+
+The current `duration_ns` reports the same 2 days for both.
+
+### After this spec
+
+`duration_ns` on sessions becomes a real
+`SimpleAggregateFunction(sum, Int64)` column storing the **sum of
+per-trace active execution times**. Computed at MV time as:
+
+```sql
+sum(if(
+    (parent_span_id = '' OR parent_span_id = '0000000000000000')
+        AND end_time > start_time,
+    reinterpretAsInt64(end_time) - reinterpretAsInt64(start_time),
+    toInt64(0)
+)) AS duration_ns
+```
+
+Finalized at read time as `sum(duration_ns)` in `LIST_SELECT`.
+
+This is the active-execution-time semantic the user actually cares
+about. Wall-clock is still trivially recoverable when needed (the
+panel header's "started 2 days ago" copy uses
+`now() - min_start_time` or `max_end_time - min_start_time` directly
+off the timestamp columns; no derived column required).
+
+### Why "root spans only"
+
+`sessions_mv` groups by `(org, project, session_id)` and runs per span,
+so we can't first group by trace_id and take each trace's duration. The
+naive `sum(end_time - start_time)` over **all** spans double-counts: a
+parent span's window already contains its children's windows, so
+summing both adds the child time twice.
+
+Filtering to **root spans** avoids the double count. Each trace's
+active duration equals its root span's duration (or sum-of-root-durations
+when a trace has multiple parent-less roots — rare; sum is still a
+defensible read of "top-level work"). The session-level `sum(...)` then
+sums those across all of the session's traces, which is what "active
+duration of a session" means.
+
+### Root-span detection: broader than `parent_span_id = ''`
+
+We treat a span as a root if **either** of these holds:
+
+- `parent_span_id = ''` — the conventional OTel "no parent" signal.
+- `parent_span_id = '0000000000000000'` — the all-zeros sentinel some
+  OTLP exporters emit instead of an empty string.
+
+Both shapes appear in customer telemetry. Matching only the empty
+string would silently miss legitimate roots from exporters using the
+sentinel, dropping those traces' contribution to `duration_ns` to zero.
+The same broader predicate is used for `root_span_id` / `root_span_name`
+in `sessions_mv` for consistency — if a span is a root for one purpose,
+it's a root for all of them.
+
+### Asymmetry with traces is intentional
+
+On traces, `duration_ns = max_end_time - min_start_time` (the existing
+ALIAS) stays correct. A trace is one continuous unit of work — there
+are no idle gaps inside a trace — so wall-clock and active execution
+coincide. The asymmetry only kicks in at the session level, which is
+where the wall-clock definition was actively wrong.
+
+The cost of this asymmetry is that "compare a session's `duration_ns`
+to its constituent traces' `duration_ns`s" doesn't yield max-of-traces;
+it yields sum-of-traces. Worth documenting on the entity; not worth
+splitting into two columns.
+
+### Clock-skew guard
+
+The `end_time > start_time` predicate inside the `if` keeps a span with
+client-reported clock drift (negative duration) from polluting the
+sum. Same defensive pattern the trace `time_to_first_token_ns` ALIAS
+uses. Note this only catches **negative** drift — a span with a
+positive runaway duration (`end_time` 10 years in the future) is
+**not** clamped. See "Known limitations" below.
+
+### Known limitations
+
+The formula is honest about which edge cases produce surprising
+numbers. None of these are corrected at the MV level because the
+corrections would either require per-trace logic the MV can't express,
+or would silently mask bugs that customers need to see.
+
+| Case | Effect on `duration_ns` | Why we don't "fix" it |
+|---|---|---|
+| **Trace with no root span at all** (every span has a non-root `parent_span_id`, e.g. root was dropped during ingestion or all spans reference parents outside the trace) | Trace contributes 0 to the session sum. Other timing columns (`min_start_time`, `max_end_time`) are unaffected. | The MV can't detect "this trace has no root span" without per-trace grouping. Wall-clock is still recoverable for affected sessions via `max_end_time - min_start_time`; the customer's instrumentation needs fixing anyway. |
+| **Trace with multiple root spans, running in parallel** | Both root durations are summed; total can exceed the trace's wall-clock window. | Intentional. `duration_ns` is "compute time spent", not wall-clock. Same posture as the cross-trace parallelism case below. |
+| **Concurrent traces in one session** (e.g. agent fires off two simultaneous requests, each its own `trace_id`) | Both traces' durations are summed even though wall-clock overlaps. | Intentional — same reasoning as multiple-roots. Users who need to detect parallelism can compare `sum(duration_ns)` to wall-clock `reinterpretAsInt64(max(max_end_time)) - reinterpretAsInt64(min(min_start_time))`. |
+| **Root span with `end_time` drifted far into the future** (forgotten finalization, clock skew) | The bad span's contribution dominates the sum; `duration_ns` reads in the years/centuries. | Deliberately not capped. A capped value would silently mask a real instrumentation bug — the customer needs to see the obvious-wrong number to investigate. Trace-side `duration_ns` has the same vulnerability and isn't capped either; matching behavior beats one-sided patching. |
+| **Root span with `end_time < start_time`** (negative duration from clock skew) | Caught by the `end_time > start_time` guard; contributes 0. | Logical nonsense, distinct from "anomalous but meaningful". Zero is the only honest answer. |
+| **All spans of a trace use an unusual `parent_span_id` sentinel** (not empty, not all-zeros) | Trace contributes 0. | Falls under "no root span" — same outcome, same reasoning. If a third sentinel pattern appears in production, add it to the predicate at that time. |
+| **Spans arriving out of order** (child span lands before parent in separate insert blocks) | Initially under-counts because the child block sees no root. The parent block, when it arrives, contributes its duration as a partial. `AggregatingMergeTree` merges the partials in the background. Eventually consistent. | Transient under-count, no special handling needed. |
+
+## On `time_to_first_token_ns` semantics
+
+For a single trace, TTFT is unambiguous: time from `min_start_time` to the
+first first-token instant across spans. For a session containing multiple
+traces, we have a choice:
+
+| Option | Definition | Surface |
+|---|---|---|
+| **A — Session-opening TTFT (proposed)** | `min(time_of_first_token) - min(start_time)` — the gap from when the session started to when the first token of any span ever streamed. | Matches the trace definition mechanically (same SQL pattern). |
+| B — Min per-trace TTFT | Smallest TTFT across the session's traces, ignoring inter-trace timing. | Requires the materialization to know trace boundaries, which `sessions_mv` doesn't (it groups by `session_id`, not `trace_id`). |
+| C — Avg per-trace TTFT | Average across traces. | Same constraint as B; also distorted by silent/zero-TTFT traces. |
+
+Option A is the only one expressible at MV time without re-grouping by
+trace_id, and it mirrors the trace definition exactly. It answers the
+question users actually ask in the freshness/responsiveness context: *"how
+quickly does this session start producing output?"*
+
+If we ever want per-trace TTFT statistics at the session grain (B/C), the
+right place is the read path: a CTE that selects from `traces` filtered to
+the session's `trace_ids` and computes whatever rollup you want. Don't push
+that into `sessions_mv`.
+
+## Proposed `sessions_mv` and `sessions` shape
+
+Single migration that brings `sessions` to full parity with `traces` for
+the columns that have a session-meaningful counterpart. Mirrors the
+`traces_mv` pattern row-for-row so future ALTERs can be applied identically
+to both tables.
+
+```sql
+-- duration_ns on sessions is being redefined from a wall-clock ALIAS to a
+-- real "sum of per-trace active execution time" aggregate column. The drop
+-- and re-add must run in this order — CH doesn't support MODIFY COLUMN to
+-- change a column from ALIAS to a real aggregate.
+ALTER TABLE sessions DROP COLUMN IF EXISTS duration_ns;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS duration_ns
+        SimpleAggregateFunction(sum, Int64)
+        DEFAULT 0
+        CODEC(T64, ZSTD(1))
+        AFTER max_end_time,
+    ADD COLUMN IF NOT EXISTS time_of_first_token
+        SimpleAggregateFunction(min, DateTime64(9, 'UTC'))
+        CODEC(Delta(8), ZSTD(1))
+        AFTER duration_ns,
+    ADD COLUMN IF NOT EXISTS time_to_first_token_ns Int64 ALIAS if(
+        time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'),
+        reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
+        0
+    ) AFTER time_of_first_token,
+    ADD COLUMN IF NOT EXISTS root_span_id
+        AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(1))
+        AFTER service_names,
+    ADD COLUMN IF NOT EXISTS root_span_name
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(1))
+        AFTER root_span_id,
+    ADD COLUMN IF NOT EXISTS input_messages
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(3))
+        AFTER root_span_name,
+    ADD COLUMN IF NOT EXISTS last_input_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(3))
+        AFTER input_messages,
+    ADD COLUMN IF NOT EXISTS output_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(3))
+        AFTER last_input_messages,
+    ADD COLUMN IF NOT EXISTS system_instructions
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8)
+        CODEC(ZSTD(3))
+        AFTER output_messages,
+    ADD COLUMN IF NOT EXISTS retention_days
+        SimpleAggregateFunction(max, UInt16)
+        DEFAULT 90
+        CODEC(T64, ZSTD(1));
+
+ALTER TABLE sessions
+    MODIFY TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;
+
+DROP VIEW IF EXISTS sessions_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    -- Every trace must paginate as a session (see 0-problems.md core constraint).
+    -- Spans with no gen_ai.conversation.id synthesize a session keyed on
+    -- trace_id, so orphan traces surface as 1-trace sessions.
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+
+    -- Active execution time: sum of root-span durations across the session's
+    -- traces. Distinguishes a 2-day session that worked 12 h/day from a 2-day
+    -- session that worked 5 min/day. See "On duration_ns semantics" above for
+    -- the rationale, the limitations, and why we don't cap runaway values.
+    -- Wall-clock is recoverable from min/max_*_time directly.
+    sum(if(
+        (s.parent_span_id = '' OR s.parent_span_id = '0000000000000000')
+            AND s.end_time > s.start_time,
+        reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+        toInt64(0)
+    ))                                                               AS duration_ns,
+
+    min(if(
+        s.time_to_first_token_ns > 0,
+        addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+        toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC')
+    ))                                                               AS time_of_first_token,
+
+    sum(s.tokens_input)                                              AS tokens_input,
+    sum(s.tokens_output)                                             AS tokens_output,
+    sum(s.tokens_cache_read)                                         AS tokens_cache_read,
+    sum(s.tokens_cache_create)                                       AS tokens_cache_create,
+    sum(s.tokens_reasoning)                                          AS tokens_reasoning,
+    sum(s.tokens_total)                                              AS tokens_total,
+
+    sum(s.cost_input_microcents)                                     AS cost_input_microcents,
+    sum(s.cost_output_microcents)                                    AS cost_output_microcents,
+    sum(s.cost_total_microcents)                                     AS cost_total_microcents,
+
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+
+    -- Root detection matches the duration_ns predicate above: both bare
+    -- empty string and the all-zeros OTLP sentinel count as roots.
+    argMinIfState(s.span_id, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_id,
+    argMinIfState(s.name, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '') AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '')  AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '') AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '') AS system_instructions,
+
+    max(s.retention_days)                                            AS retention_days
+
+FROM spans AS s
+GROUP BY s.organization_id, s.project_id, session_id;
+```
+
+Notes on the shape:
+
+- The previous `WHERE s.session_id != ''` filter is **removed**. Every span
+  now produces a session row — real sessions keyed by `gen_ai.conversation.id`,
+  orphan traces keyed by their `trace_id` cast to a string. `trace_count = 1`
+  is the natural marker for the orphan case, and downstream surfaces don't
+  branch on it. See the core constraint in `0-problems.md` for the user-facing
+  reason; see "On orphan-trace sessions" below for the read-time implications.
+- `root_span_id` / `root_span_name` use `argMinIf` on the earliest parent-less
+  span observed in the session, which is the root span of the session's
+  first trace. The session detail panel can present this as the session's
+  "primary trace name" without an extra join against `traces`.
+- `time_of_first_token` uses the same sentinel-based pattern as
+  `traces_mv` — drop-in from `…/00011_plan_aware_retention.sql:61-65`.
+- `retention_days` aligns session TTL with trace TTL. Without it, sessions
+  would be retained at the table-level default forever, drifting from
+  `traces` after `00011`.
+- `last_input_messages` is keyed on `end_time + output_messages != ''`, same
+  as on `traces`. The intent — "input that the last responsive span saw" —
+  carries over verbatim.
+
+## On orphan-trace sessions
+
+Spans without `gen_ai.conversation.id` produce a session row whose
+`session_id` is the trace_id as a hex string. Implications worth recording:
+
+- **`trace_count` is the orphan marker.** Pure orphan sessions always have
+  `trace_count = 1` and `trace_ids = [the same trace_id the session_id was
+  derived from]`. The UI may render them differently (no "session of N
+  turns" badge), but the storage shape is the same. Treat `trace_count = 1`
+  as a derived predicate, not as a separate row class.
+- **`session_id` column type is unchanged.** `sessions.session_id` is
+  already `String` (not `FixedString`) per `…/00007_sessions.sql:4`, so a
+  32-character hex trace_id fits without a schema change.
+- **No risk of collision with real session ids.** Real `session_id`s are
+  arbitrary tenant-supplied strings (commonly UUIDs, short slugs, or
+  database ids). A 32-char lowercase hex trace_id matches the `FixedString(32)`
+  format only by coincidence; in practice tenants don't pick OTel trace ids
+  as their conversation ids. If a collision ever happens, the two rows
+  merge — same `(org, project, session_id)` key — which is a no-op for
+  every aggregation in the MV. It would conflate one orphan trace with one
+  real session of the same id, which is a strictly tenant-controlled
+  outcome.
+- **`trace_ids` invariant.** For orphan sessions, `trace_ids = [trace_id]`
+  and `session_id = toString(trace_id)`. Anything that wants to look up
+  the underlying trace can use either field; the panel and search-result
+  navigation pick `trace_ids[0]`.
+
+### SDK contract and mixed binding
+
+For the rollup to be correct, `gen_ai.conversation.id` must be set on
+**every span of a conversational trace, or none of them.** This is the
+SDK-side contract documented in `0-problems.md`. The Latitude SDK propagates
+the attribute automatically via OTel context — any project using the
+Latitude SDK satisfies the contract by construction.
+
+OTel-direct customers using auto-instrumentation libraries (HTTP frameworks
++ third-party GenAI SDKs) are the case where the contract can be violated.
+By default, auto-instrumentation only tags the GenAI SDK's own LLM-call
+spans; surrounding HTTP / DB / auth spans of the same trace carry empty
+`session_id`. When this happens the trace produces **two session rows**:
+
+| Row | Built from | Visual signature |
+|---|---|---|
+| Real session (`session_id = 'conv-xyz'`) | LLM-tagged spans | `tokens_total > 0`, `cost_total_microcents > 0`, non-empty `models`, real `output_messages` |
+| Orphan fragment (`session_id = toString(trace_id)`) | Framework spans only | `tokens_total = 0`, `cost_total_microcents = 0`, `models = []`, empty `output_messages`, `trace_count = 1` |
+
+The orphan fragment is noise. It's not actively misleading — it represents
+the framework overhead of one conversational request — but it doubles the
+rows in the sessions list for affected customers. Mitigation lives at two
+layers:
+
+- **Filter-bar default**: a "has LLM activity" chip (`tokens_total > 0 OR
+  length(models) > 0`) is applied by default on the sessions list and
+  hides orphan fragments. Documented in `./4-filter-parity.md`.
+- **Documentation**: the OTel-direct integration guide tells customers to
+  propagate `gen_ai.conversation.id` to all spans of a conversational
+  trace, with a copy-paste OTel context-propagator snippet. Latitude-SDK
+  users don't need to read it.
+
+Reconciliation (server-side merging of fragments back into the real
+session) is **not** a goal of this spec. The contract is the contract;
+violations produce visible-but-bounded noise; if mixed binding becomes
+common enough to matter, we add reconciliation later as a separate item.
+
+### Why every downstream surface uses the coalesce expression directly
+
+The MV's `session_id` field is the canonical id. Anywhere outside the MV
+that needs to derive "this trace's session" — score writes, search
+rollups, listing queries that join from `traces` — should apply the same
+expression on the trace row:
+
+```sql
+coalesce(nullIf(traces.session_id, ''), toString(traces.trace_id))
+```
+
+(where `traces.session_id` is the `argMaxIfMerge` finalization of the
+trace's resolved session_id). This guarantees that every layer arrives at
+the same canonical id without coordinating through `sessions` directly,
+and that orphan traces always get the synthesized id without an `IS NULL`
+branch downstream. The exact use of this expression is documented in
+`./3-session-issue-dedup.md` (score writes) and `./2-session-level-search.md`
+(rollup grouping).
+
+## Read path changes — `SessionRepository.LIST_SELECT`
+
+The repo's `LIST_SELECT` at
+`packages/platform/db-clickhouse/src/repositories/session-repository.ts:21`
+needs to project the new columns through the same `*Merge` finalizers as
+`traces`. Below is the proposed shape; identical in form to the trace
+repo's `LIST_SELECT` (`trace-repository.ts:287`):
+
+```ts
+const LIST_SELECT = `
+  organization_id,
+  project_id,
+  session_id,
+  uniqExactMerge(trace_count)  AS trace_count,
+  groupUniqArrayMerge(trace_ids) AS trace_ids,
+  sum(span_count)              AS span_count,
+  sum(error_count)             AS error_count,
+  min(min_start_time)          AS start_time,
+  max(max_end_time)            AS end_time,
+  sum(duration_ns)             AS duration_ns,  -- active execution time, NOT wall-clock
+  if(
+    min(time_of_first_token) < toDateTime64('2261-01-01', 9, 'UTC'),
+    reinterpretAsInt64(min(time_of_first_token))
+      - reinterpretAsInt64(min(min_start_time)),
+    0
+  )                              AS time_to_first_token_ns,
+  sum(tokens_input)            AS tokens_input,
+  sum(tokens_output)           AS tokens_output,
+  sum(tokens_cache_read)       AS tokens_cache_read,
+  sum(tokens_cache_create)     AS tokens_cache_create,
+  sum(tokens_reasoning)        AS tokens_reasoning,
+  sum(tokens_total)            AS tokens_total,
+  sum(cost_input_microcents)   AS cost_input_microcents,
+  sum(cost_output_microcents)  AS cost_output_microcents,
+  sum(cost_total_microcents)   AS cost_total_microcents,
+  argMaxIfMerge(user_id)       AS user_id,
+  groupUniqArrayArray(tags)    AS tags,
+  maxMap(metadata)             AS metadata,
+  groupUniqArrayIfMerge(models)        AS models,
+  groupUniqArrayIfMerge(providers)     AS providers,
+  groupUniqArrayIfMerge(service_names) AS service_names,
+  argMaxIfMerge(simulation_id)         AS simulation_id,
+  argMinIfMerge(root_span_id)          AS root_span_id,
+  argMinIfMerge(root_span_name)        AS root_span_name
+`
+```
+
+And a `DETAIL_SELECT` once the session detail panel lands, mirroring
+`trace-repository.ts:324`:
+
+```ts
+const DETAIL_SELECT = `${LIST_SELECT},
+  argMinIfMerge(input_messages)        AS input_messages,
+  argMaxIfMerge(last_input_messages)   AS last_input_messages,
+  argMaxIfMerge(output_messages)       AS output_messages,
+  argMinIfMerge(system_instructions)   AS system_instructions
+`
+```
+
+The repo's `toDomainSession` (`session-repository.ts:128`) needs to widen
+to populate `timeToFirstTokenNs`, `rootSpanId`, `rootSpanName`. The domain
+`sessionSchema` (`packages/domain/spans/src/entities/session.ts:17`) gets
+the same fields. A `SessionDetail` schema parallel to `traceDetailSchema`
+(`packages/domain/spans/src/entities/trace.ts:68`) is the natural home for
+the message payload fields, kept off the list endpoint for the same
+list-payload-budget reason.
+
+### Filter registry
+
+`SESSION_FIELD_REGISTRY` (`packages/platform/db-clickhouse/src/registries/session-fields.ts:4`)
+gains:
+
+```ts
+ttft: { column: "time_to_first_token_ns", chType: "Int64" },
+// + once session-level root span name lands:
+name: { column: "root_span_name", chType: "String" },
+```
+
+The `status` field (`overall_status` on traces was dropped in `…/00005`, so
+neither table has it) — `error_count > 0` is the OK/ERROR signal for both.
+A future filter-parity pass can add a synthetic `status` filter that
+translates to `error_count = 0` / `error_count > 0`, but it doesn't need
+a new column.
+
+## Pipeline — how rows are produced
+
+### Today
+
+```
+client SDK
+   │
+   ▼
+OTLP ingest → SpanRepository.insert (db-clickhouse/src/repositories/span-repository.ts:410)
+                                         │
+                                         ▼
+                                     spans (ReplacingMergeTree)
+                                         │  (ClickHouse-native MV trigger,
+                                         │   runs per-block on insert)
+              ┌──────────────────────────┴──────────────────────────┐
+              ▼                                                     ▼
+        traces_mv → traces                                  sessions_mv → sessions
+        (AggregatingMergeTree, ORDER BY trace_id)           (AggregatingMergeTree, ORDER BY session_id)
+```
+
+There is **no worker** in this path. Both `traces` and `sessions` are
+populated entirely inside ClickHouse from `spans` inserts. The
+`trace-search:refreshTrace` worker referenced in `specs/trace-search.md`
+is downstream of this — it indexes already-materialized traces for
+full-text/semantic search and is unrelated to the materialization itself.
+
+There is also **no Postgres mirror** of either table — `Session` and
+`Trace` are CH-only entities at the storage layer. Postgres carries
+organizations, projects, scores' relational links, but not the
+session/trace rollups.
+
+### After this change
+
+Same shape — only the `sessions_mv` definition changes. The pipeline
+remains "insert into spans → ClickHouse fans out via two MVs". No new
+worker, no new queue, no Postgres write.
+
+The MV swap (`DROP VIEW; CREATE VIEW`) is the only moment a session insert
+can land on the source table without being projected. Both runs of the MV
+DDL in `00008_simulation_id.sql` and `00004_user_id_and_metadata.sql`
+follow this drop-and-recreate pattern; the existing `traces_mv` migrations
+accept the same brief gap. In practice the migration runs on a quiescent
+deployment slot; the gap is sub-second.
+
+### One operational gotcha worth flagging
+
+ClickHouse MVs fire on **inserted blocks**, not on the destination table
+state. If a single trace's spans arrive split across two inserts, both
+`traces_mv` and `sessions_mv` produce two partial rows for the same
+`(org, project, trace_id)` / `(org, project, session_id)`. The
+`AggregatingMergeTree` engine merges them in the background. That's why
+both repos finalize partials at read time with `*Merge` /
+`sum`/`min`/`max` and `GROUP BY` (see `LIST_SELECT` patterns above and
+the explicit comment in `…/00002_materialized_traces.sql:6-9`).
+This is already the operating model; the changes here don't shift it.
+
+## Migration / backfill
+
+### Forward migration
+
+One migration file (paired clustered/unclustered, same shape as `00008`):
+
+```
+clickhouse/migrations/unclustered/00016_session_parity.sql
+clickhouse/migrations/clustered/00016_session_parity.sql
+```
+
+Structure:
+
+1. `ALTER TABLE sessions DROP COLUMN IF EXISTS duration_ns;` — drops the
+   existing wall-clock ALIAS so the next step can re-add the name as a
+   real `SimpleAggregateFunction` column with the new active-execution
+   semantics. Must be a separate statement before the bulk ADD; CH
+   doesn't allow swapping an ALIAS into an aggregate column inside a
+   single ALTER.
+2. `ALTER TABLE sessions ADD COLUMN … (all new columns including the new
+   `duration_ns`) … AFTER …` — single ALTER to minimize DDL metadata churn
+   (same comment in `…/00008_simulation_id.sql:5`).
+3. `ALTER TABLE sessions MODIFY TTL …` — apply plan-aware retention.
+4. `DROP VIEW IF EXISTS sessions_mv;`
+5. `CREATE MATERIALIZED VIEW sessions_mv TO sessions AS SELECT …;`
+
+The clustered variant adds `ON CLUSTER default` and switches
+`AggregatingMergeTree` → `ReplicatedAggregatingMergeTree`, same as the
+existing pair (`…/clustered/00007_sessions.sql` vs `…/unclustered/00007_sessions.sql`).
+
+### Backfill strategy
+
+Two scenarios depending on operational priorities:
+
+**Option 1 — Forward-only (recommended).** New columns default to:
+
+- `duration_ns`: column DEFAULT 0. Existing session rows read as 0
+  until a new span lands. This is a **noticeable change** for old
+  sessions — they used to render their wall-clock window as duration
+  and will now render 0 until they ingest something new. Callers that
+  show "duration" on the sessions list need to tolerate 0 on
+  pre-migration rows (the same way they tolerate 0 TTFT on
+  pre-`…/00005` traces). Wall-clock is still readable on the fly from
+  `max_end_time - min_start_time` for any UI that wants a non-zero
+  number on legacy rows (no separate derived column — see Decisions
+  below).
+- `time_of_first_token`: the sentinel `2261-01-01` (effectively NULL via the
+  ALIAS path; `time_to_first_token_ns` ALIAS returns 0).
+- `root_span_id`, `root_span_name`, `input_messages`, `last_input_messages`,
+  `output_messages`, `system_instructions`: `*State` aggregate functions
+  default to zero-byte empty state; their `*Merge` finalizers return empty
+  string / `FixedString` zeros.
+- `retention_days`: column DEFAULT 90.
+
+For sessions that haven't received an insert since the migration, all new
+columns read as empty/zero. New inserts (i.e. new spans on existing
+sessions, or fully new sessions) immediately produce correct values for
+those sessions going forward.
+
+This is the same forward-only stance that `specs/trace-search.md` takes for
+the search corpus. Justification:
+
+- The MV runs per insert. For a session that's still active (still
+  receiving spans), the next ingested span produces a partial row with the
+  new columns filled in, which the `AggregatingMergeTree` merges with the
+  existing partials. No worker required.
+- For closed sessions, the new columns stay empty. UI must tolerate empty
+  `rootSpanName`, zero `timeToFirstTokenNs`, etc. — this is the same
+  tolerance the trace path already has for traces ingested before
+  `…/00005` and `…/00008`.
+
+**Option 2 — Backfill via re-aggregation.** If product wants historical
+sessions to carry the new columns:
+
+```sql
+INSERT INTO sessions
+SELECT
+    organization_id,
+    project_id,
+    coalesce(nullIf(session_id, ''), toString(trace_id))           AS session_id,
+    uniqExactState(trace_id)                                       AS trace_count,
+    groupUniqArrayState(trace_id)                                  AS trace_ids,
+    count()                                                        AS span_count,
+    countIf(status_code = 2)                                       AS error_count,
+    min(start_time)                                                AS min_start_time,
+    max(end_time)                                                  AS max_end_time,
+    sum(if((parent_span_id = '' OR parent_span_id = '0000000000000000')
+               AND end_time > start_time,
+           reinterpretAsInt64(end_time) - reinterpretAsInt64(start_time),
+           toInt64(0)))                                            AS duration_ns,
+    min(if(time_to_first_token_ns > 0,
+           addNanoseconds(start_time, toInt64(time_to_first_token_ns)),
+           toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
+    sum(tokens_input), sum(tokens_output), sum(tokens_cache_read),
+    sum(tokens_cache_create), sum(tokens_reasoning), sum(tokens_total),
+    sum(cost_input_microcents), sum(cost_output_microcents), sum(cost_total_microcents),
+    argMaxIfState(user_id, start_time, user_id != '')              AS user_id,
+    groupUniqArrayArray(tags)                                      AS tags,
+    maxMap(metadata)                                               AS metadata,
+    groupUniqArrayIfState(model, model != '')                      AS models,
+    groupUniqArrayIfState(provider, provider != '')                AS providers,
+    groupUniqArrayIfState(service_name, service_name != '')        AS service_names,
+    argMaxIfState(simulation_id, start_time, simulation_id != '')  AS simulation_id,
+    argMinIfState(span_id, start_time,
+        parent_span_id = '' OR parent_span_id = '0000000000000000') AS root_span_id,
+    argMinIfState(name, start_time,
+        parent_span_id = '' OR parent_span_id = '0000000000000000') AS root_span_name,
+    argMinIfState(input_messages, start_time, input_messages != '') AS input_messages,
+    argMaxIfState(input_messages, end_time, output_messages != '')  AS last_input_messages,
+    argMaxIfState(output_messages, end_time, output_messages != '') AS output_messages,
+    argMinIfState(system_instructions, start_time, system_instructions != '') AS system_instructions,
+    max(retention_days)                                            AS retention_days
+FROM spans
+WHERE start_time >= now() - INTERVAL <N> DAY
+GROUP BY organization_id, project_id, coalesce(nullIf(session_id, ''), toString(trace_id));
+```
+
+This produces additional partial rows for every session in the window;
+`AggregatingMergeTree`'s background merges fold them into the existing
+rows. `<N>` should match the desired backfill horizon. Per-org or
+per-project chunking is straightforward by adding `AND organization_id =
+{...}` and looping in a maintenance script.
+
+**Recommendation:** ship Option 1 (forward-only). If a customer explicitly
+asks for historical session enrichment, run Option 2 scoped to that
+project. It is the same posture as `trace-search`'s "no first-class
+backfill in the product UI".
+
+### `ReplacingMergeTree` vs `AggregatingMergeTree` consideration
+
+The `sessions` table is `AggregatingMergeTree`, and stays so. The
+`SimpleAggregateFunction(min|max|sum, …)` + `AggregateFunction(arg*If, …)`
+columns are the right primitives for incremental, idempotent
+materialization — every new span lands as a partial row, merges fold
+partials together, queries finalize via `sum`/`min`/`max`/`*Merge`.
+
+`ReplacingMergeTree` would only make sense if sessions were
+**worker-computed snapshots** (one row per session, replaced wholesale on
+the next refresh). They aren't — they're a true streaming roll-up. Don't
+change the engine.
+
+For comparison: the search-corpus tables `trace_search_documents` and
+`trace_search_embeddings` ARE `ReplacingMergeTree`
+(`testkit/src/clickhouse/schema.sql:362,379`), because the trace-search
+worker computes them as wholesale snapshots indexed at trace-end. That
+pipeline is parallel and unrelated.
+
+## Files that change
+
+| Layer | File | Change |
+|---|---|---|
+| Migration | `packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql` (new) | ALTER + DROP/CREATE MV. |
+| Migration | `packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql` (new) | Same with `ON CLUSTER default` and `ReplicatedAggregatingMergeTree`. |
+| Generated schema | `packages/platform/testkit/src/clickhouse/schema.sql` | Regenerated via `pnpm --filter @platform/db-clickhouse ch:schema:dump` after applying migrations. |
+| Domain entity | `packages/domain/spans/src/entities/session.ts:17` | Add `timeToFirstTokenNs`, `rootSpanId`, `rootSpanName`. |
+| Domain entity | `packages/domain/spans/src/entities/session.ts` | Add `sessionDetailSchema` and `SessionDetail` paralleling `traceDetailSchema`. |
+| Repo port | `packages/domain/spans/src/ports/session-repository.ts:61` | Update `SessionMetrics` to add `timeToFirstTokenNs: NumericRollup`; update `emptySessionMetrics`. |
+| Repo impl | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:21` | Extend `LIST_SELECT` with new columns, add `DETAIL_SELECT`, widen `SessionListRow`, update `toDomainSession`, add a `findBySessionId` method that returns `SessionDetail`. |
+| Repo impl | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:310` | Add `time_to_first_token_ns` to `aggregateMetricsByProjectId` so the metric matches `TraceRepository`. |
+| Filter registry | `packages/platform/db-clickhouse/src/registries/session-fields.ts:4` | Add `ttft`, `name` (root_span_name). |
+| Sort columns | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:163` | Add `ttft` to `SORT_COLUMNS`. |
+
+The list intentionally does NOT touch trace-side files — every change here
+is additive to sessions.
+
+## Adjacent — read-path methods sessions doesn't have
+
+Called out for completeness; not in this spec's implementation scope.
+`SessionRepository` is a strict subset of `TraceRepository`:
+
+| `TraceRepository` method | Session counterpart | Comment |
+|---|---|---|
+| `listByProjectId` | `listByProjectId` | Present. |
+| `countByProjectId` | `countByProjectId` | Present; doesn't accept `searchQuery`. |
+| `aggregateMetricsByProjectId` | `aggregateMetricsByProjectId` | Present; missing `tokensTotal` + `timeToFirstTokenNs` rollups (the trace version has both). |
+| `histogramByProjectId` | **MISSING** | Sessions list page has no histogram. |
+| `findByTraceId` (returns `TraceDetail`) | **MISSING** | No `findBySessionId`; session detail panel needs one. |
+| `getDistribution` | **MISSING** | No percentile distribution for duration/cost/ttft on sessions. Blocks `gtePercentile` filters on sessions. |
+| `countAnnotatedByProjectId` | **MISSING** | No equivalent. |
+| `matchesFiltersByTraceId` | **MISSING** | Used for trace-filter materialization in scores; sessions analogue might or might not be needed. |
+| `getCohortBaselineByTags` | **MISSING** | Cohort baselines are trace-specific (per-tag-combo); no session-level analogue planned. |
+| `findLastTraceAt` | **MISSING** | Sessions has no equivalent; freshness sort will need one. |
+| `distinctFilterValues` | `distinctFilterValues` | Present; covers `tags`, `models`, `providers`, `serviceNames`. |
+
+These methods depend on the materialization columns in this spec being in
+place first (every "MISSING" above wants `time_to_first_token_ns` or
+`root_span_name` to be usable). They are the work item this spec unblocks.
+
+## Decisions
+
+- **`root_span_id` for sessions = first-trace-root.** The proposed shape
+  (`argMinIfState(span_id, start_time, parent_span_id = '' OR parent_span_id = '0000000000000000')`)
+  returns the earliest parent-less span — the root of the session's
+  **first trace**. Stable (doesn't change as the session grows), cheap
+  to compute, and matches "what was this conversation about" for the
+  session card label. Alternatives considered and rejected: last
+  trace's root (volatile — the label changes every new turn) and
+  most-frequently-rooted name (complex materialization for marginal
+  value). The session detail panel may override per-row if UX wants a
+  different label in some context.
+
+- **No separately exposed wall-clock duration column.** Sessions
+  `duration_ns` is active execution time per "On `duration_ns`
+  semantics". Wall-clock is recoverable at any read site as
+  `reinterpretAsInt64(endTime) - reinterpretAsInt64(startTime)` from
+  the same row — one subtraction, no need for an ALIAS or a stored
+  column. If a UI surfaces both side-by-side often enough that the
+  per-query arithmetic gets repetitive, callers add a local helper.
+
+- **`models` / `providers` / `service_names` keep union semantics on
+  sessions.** Both tables collect the union of values across child
+  spans via `groupUniqArrayIf`. Union is right for the filter question
+  users ask — "find sessions that used GPT-4" via `hasAny`. The
+  "most-recent model" question is a different filter; if product
+  demand surfaces, we add a separate `current_model` column (one
+  extra `argMaxIf` aggregate) rather than redefining the existing
+  semantic.
+
+- **`retention_days` uses `max` across the session's spans.** Matches
+  the trace-side aggregate. Edge case: if a project's retention
+  changes mid-session (30-day → 7-day), `max` keeps the session under
+  the longer retention until the cutoff, which over-retains relative
+  to the project's *current* setting. The alternative — `min` — would
+  under-retain relative to what the customer had been paying for at
+  the start. `max` is the safer default: don't prematurely delete
+  what the customer had been paying to keep. Document the edge case
+  in the migration notes; revisit only if customers complain.
+  (Mid-session retention changes are rare — sessions are typically
+  minutes to hours, plan changes are weeks apart.)
+
+### Resolved elsewhere
+
+- **Session-detail `allMessages` rendering** is no longer needed —
+  `./6-session-panel.md` §5 ("Conversation tab") renders one trace's
+  conversation at a time using the existing `<Conversation>`
+  primitive, not a merged stream. No session-level `allMessages`
+  derivation is required.
+
+- **Status filter (broken `overall_status`)** is resolved in
+  `./4-filter-parity.md` "Status filter — concrete shape". A synthetic
+  status derived from `error_count > 0` fixes both the trace-side bug
+  and the session-side gap in one move.

--- a/specs/session-problems/2-session-level-search.md
+++ b/specs/session-problems/2-session-level-search.md
@@ -1,0 +1,1032 @@
+# Session-level search
+
+Collapse search results to one row per `session_id`, with the row carrying the
+aggregated score across its matching traces and enough metadata to render
+"3 matching turns / best score 0.82" and to drill into a specific trace when
+the user clicks in.
+
+This is a derivative of `specs/trace-search.md`. Read that first. This spec
+only documents the deltas needed to roll trace-level search up to the session
+level. It is _not_ a redesign of the search pipeline — the indexing pipeline,
+the lexical/semantic split, the phrase parser, the embedding model choice,
+and the chunk-level embedding rows are all reused as-is.
+
+## Scope
+
+- **In:** session-level result collapsing for `listTracesByProject` (the
+  search query path), the count / metrics / histogram subqueries that share
+  the same search plan, the cursor shape used by infinite scroll, and the
+  result-row payload the drawer needs to drill into a matching trace.
+- **Out:** session-level _ingestion_ (we do not build a new
+  `session_search_documents` table in V1 — see Decisions); changes to how
+  `parseSearchQuery` or `buildTraceSearchDocument` work; the trace-detail
+  drawer's existing highlight pipeline (the drawer keeps opening on a
+  specific `traceId` — see Drill-in).
+- **Forward-only:** sessions whose traces were indexed before rollout are
+  invisible to search, same as trace search today (`trace-search.md` →
+  Constraints & Limitations / Forward-only rollout).
+
+## Why this is needed
+
+Session 3 in the index doc (`specs/session-problems/0-problems.md:55-72`)
+describes the symptom: a long conversation that hits a search query
+produces 10+ trace rows for the same `session_id`, and other sessions get
+buried below the fold. The current pipeline ranks and paginates at the
+trace level (`packages/platform/db-clickhouse/src/repositories/trace-repository.ts:982-985`),
+so the page-25 limit becomes "top 25 traces" — frequently top 25 turns of
+the same conversation — not "top 25 sessions".
+
+## 1. Current trace-level pipeline (recap)
+
+Active search drives a single ClickHouse query whose result set is one row
+per `trace_id`. The path is:
+
+1. UI submits a free-text query `q` to `listTracesByProject`
+   (`apps/web/src/domains/traces/traces.functions.ts:122-168`) /
+   `countTracesByProject`
+   (`apps/web/src/domains/traces/traces.functions.ts:170-197`) /
+   `getTraceMetricsByProject`
+   (`apps/web/src/domains/traces/traces.functions.ts:258-285`) /
+   `getTraceTimeHistogramByProject`
+   (`apps/web/src/domains/traces/traces.functions.ts:319-349`).
+2. Each handler enters `TraceRepository.listByProjectId` etc. in
+   `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:948`
+   and friends.
+3. `parseSearchQuery` splits the raw input into literal phrases / token
+   phrases / semantic prompt
+   (`packages/domain/spans/src/use-cases/parse-search-query.ts:31-69`).
+4. `planSearch` (`trace-repository.ts:786-791`) optionally calls Voyage
+   for a query embedding via `generateQueryEmbedding`
+   (`trace-repository.ts:759-779`).
+5. `buildSearchPlan` (`trace-repository.ts:218-277`) produces one of
+   three subquery shapes, each returning `(trace_id, relevance_score)`:
+   - **Lexical only** — phrases AND-ed against `trace_search_documents`
+     (`buildLexicalSearchSubquery`, `trace-repository.ts:103-150`).
+     `relevance_score = 0.0`.
+   - **Semantic only** — `cosineDistance` ranking on
+     `trace_search_embeddings` rolled up by `max(...) GROUP BY trace_id`
+     (`buildSemanticSearchSubquery`, `trace-repository.ts:162-186`),
+     gated by `WHERE semantic_score >= 0.30`
+     (`TRACE_SEARCH_MIN_RELEVANCE_SCORE`,
+     `packages/domain/spans/src/constants.ts:138`).
+   - **Hybrid** — lexical filter `LEFT JOIN` semantic rollup, `max()`
+     across (`trace-repository.ts:264-276`).
+6. The list path
+   (`trace-repository.ts:960-1020`) wraps that subquery in:
+
+   ```sql
+   WITH search_results AS (
+     SELECT trace_id, relevance_score FROM (<plan.subquery>)
+   )
+   SELECT ${LIST_SELECT}, search_results.relevance_score
+   FROM traces t
+   INNER JOIN search_results ON t.trace_id = search_results.trace_id
+   WHERE t.organization_id = :org AND t.project_id = :proj
+     ${extraWhere}        -- score-filter subquery if any
+     ${cursorClause}      -- (search_results.relevance_score, t.trace_id) < (:cv, :ct)
+   GROUP BY t.organization_id, t.project_id, t.trace_id, search_results.relevance_score
+   ${finalHaving}          -- HAVING from the FilterSet
+   ORDER BY search_results.relevance_score DESC, t.trace_id DESC
+   LIMIT :pageSize
+   ```
+
+   `LIST_SELECT` is the materialized-trace projection at
+   `trace-repository.ts:287-322`. The cursor is the tuple
+   `(sortValue=relevance_score, traceId)`
+   (`trace-repository.ts:1011-1017`).
+7. `count` / `metrics` / `histogram` paths (`trace-repository.ts:1226-1295`,
+   `:1402-1469`, and the histogram counterpart) re-use the same plan as
+   a filter: `AND trace_id IN (SELECT trace_id FROM (<plan.subquery>))`.
+
+`session_id` is _not_ a column on `trace_search_documents`
+(`packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00009_trace_search_documents.sql:12-44`)
+or on `trace_search_embeddings`
+(`…/unclustered/00013_trace_search_embeddings_chunked.sql:6-23`). It is
+only available on the materialized `traces` table as an `argMaxIfState` over
+spans (`…/unclustered/00011_plan_aware_retention.sql:78`). The
+`traces`-side projection in `LIST_SELECT` resolves it with
+`argMaxIfMerge(session_id)` (`trace-repository.ts:312`). The session
+materialization itself (`sessions` AggregatingMergeTree
++ `sessions_mv`) lives in `…/unclustered/00007_sessions.sql:4-79` and is
+populated from `spans` — its `session_id` is the same key.
+
+## 2. What's broken
+
+The list path collapses _at the trace level_:
+
+```
+GROUP BY t.organization_id, t.project_id, t.trace_id, search_results.relevance_score
+ORDER BY search_results.relevance_score DESC, t.trace_id DESC
+LIMIT 50
+```
+
+(`trace-repository.ts:982-985`)
+
+Concretely:
+
+- A session containing 12 user/assistant turns is materialized as 12 (or
+  more) distinct `trace_id` rows in `traces` (one per LLM call / per
+  trace boundary the customer instrumented). Each of those traces is
+  independently indexed in `trace_search_documents` and
+  `trace_search_embeddings`.
+- When the query matches the session's topic, every one of those traces
+  scores high. The hybrid/semantic subquery returns 12 rows. The list
+  query joins them against `traces`, groups by `trace_id`, sorts by
+  `relevance_score`, returns the first 25.
+- All 25 (or 12, or 8) can be the _same `session_id`_. Other sessions in
+  the project that also match drop off the page.
+
+The downstream UI then has no signal that those 12 rows belong together.
+`SessionsView` (`apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx:194`)
+shows trace rows nested under session rows, but the search page uses
+`TracesView` (`…/-components/traces-view.tsx`) which renders the flat
+trace list. The search-page session pollution is a presentation problem
+_and_ a pagination/scoring problem — pagination is what makes the loss
+fatal: the 26th-best session is unreachable until the user scrolls past
+the duplicate cluster.
+
+`countTracesByProject` is consistent with the duplicate list — it
+returns "12 traces matched" — which is technically true and entirely
+useless. The user wants "1 session, 12 matching turns".
+
+`getTraceMetricsByProject` (the aggregations strip above the table) is
+also computed over the de-duplicated trace set with the search filter
+applied. The numbers themselves are arithmetically correct ("avg cost of
+matching traces") but conceptually mismatched against a session-level
+listing: with the rollup, the aggregation should describe matching
+_sessions_, not the underlying matching turns.
+
+## 3. Proposed pipeline — two designs
+
+The choice is whether to push the rollup _into the query_ (the existing
+trace-level indexes stay; we add a `GROUP BY session_id`) or to build
+new session-level materialized indexes that mirror what already exists
+for traces. The two designs are not mutually exclusive — option B is a
+performance optimization on top of A — but only one is required to ship
+the feature.
+
+### Option A — Query-side rollup over existing indexes
+
+Add `GROUP BY session_id` to the search plan's outer join, replacing the
+existing `GROUP BY trace_id`. The trace-level indexes
+(`trace_search_documents`, `trace_search_embeddings`) and the
+trace-search worker are unchanged.
+
+Aggregations needed on the join row:
+
+- `max(search_results.relevance_score)` → `best_score`
+- `groupArray(t.trace_id)` → `matching_trace_ids`
+- `groupArray(search_results.relevance_score)` → `matching_trace_scores`
+- `count()` → `matching_trace_count`
+- Any aggregate of the `LIST_SELECT` numerical fields rolled up across
+  the traces of the session (sum of costs, span counts, etc. — same
+  shape as the existing `sessions` materialized table at
+  `…/00007_sessions.sql:4-79`).
+
+**Pros**
+
+- Zero new tables, zero schema change, zero backfill. Lands in a single
+  PR.
+- Search corpus stays canonical: one place to reason about lexical
+  text and chunk embeddings, one TTL story, one worker. If we ever fix
+  a bug in `buildTraceSearchDocument` it instantly improves session
+  ranking too.
+- Cheap on freshness: an embedding written 200ms ago is in the next
+  query result. There's no second-stage materialization to wait for.
+- The chunk-level granularity already in `trace_search_embeddings`
+  carries naturally — the per-chunk `argMax` in `5-search-highlights.md`
+  still works because we drill in from the session to its
+  best-scoring trace and route the existing trace-level highlight
+  endpoint from there.
+- Reversible: we can layer Option B on later as a perf optimization
+  without changing the API contract.
+
+**Cons**
+
+- Query cost grows. The plan inner already touches up to 30k chunk rows
+  (`SEMANTIC_SCAN_LIMIT` in `trace-repository.ts:65`); the outer join
+  now groups by `session_id` instead of `trace_id`. Each result row
+  may carry a multi-element `groupArray`. In ClickHouse this is
+  bounded by the lexical/semantic candidate set, not by the project's
+  total session count — so it's similar to the trace-level cost, not
+  worse — but the `groupArray`s allocate memory proportional to the
+  matching-trace fan-out.
+- Cursor is no longer `(relevance_score, trace_id)`. The natural cursor
+  is `(best_score, session_id)`. That's a cursor schema change in the
+  TanStack-Start handler / React Query keys.
+- The session row still has to read from `traces` (for cost / tokens /
+  etc.) _and_ from `sessions` (if we want simulation_id, span counts,
+  user_id at session granularity, etc.) — there's a join graph
+  decision to make (see §4 SQL).
+- No write-time deduplication of the search corpus by session — same
+  text indexed once per trace even when the chunks overlap. (This is
+  actually fine; the embeddings table already tolerates that via the
+  per-chunk `content_hash` dedup at
+  `trace-search-repository.ts:61-90`.)
+
+**Write amplification**: zero — we don't add a new write path.
+
+**Freshness**: same as today, ~debounce after `trace-end:run`
+(`trace-search.md` → Indexing Pipeline).
+
+**Complexity**: ~one PR. `buildSearchPlan` is unchanged; the calling
+list/count/metrics queries swap `GROUP BY trace_id` for `GROUP BY
+session_id` and the cursor logic changes shape.
+
+### Option B — Materialized `session_search_documents` / `session_search_embeddings`
+
+Mirror the existing trace-side tables at the session granularity.
+
+```sql
+-- Lexical: one row per session, concatenated/normalized text across the
+-- session's traces, with the same tokenbf/ngrambf indexes.
+CREATE TABLE session_search_documents (
+  organization_id    LowCardinality(String),
+  project_id         LowCardinality(String),
+  session_id         String,
+  min_start_time     DateTime64(9, 'UTC'),
+  max_end_time       DateTime64(9, 'UTC'),
+  search_text        String,
+  content_hash       FixedString(64),
+  indexed_at         DateTime64(3, 'UTC') DEFAULT now64(3),
+  retention_days     UInt16 DEFAULT 90,
+  INDEX idx_search_text_tokenbf search_text TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+  INDEX idx_search_text_ngrambf search_text TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree(indexed_at)
+PARTITION BY toYYYYMM(min_start_time)
+ORDER BY (organization_id, project_id, session_id)
+TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;
+
+-- Semantic: one row per (session_id, chunk_index), embeddings computed
+-- against the session-level packed conversation.
+CREATE TABLE session_search_embeddings (
+  organization_id  LowCardinality(String),
+  project_id       LowCardinality(String),
+  session_id       String,
+  chunk_index      UInt16,
+  start_time       DateTime64(9, 'UTC'),
+  content_hash     FixedString(64),
+  embedding_model  LowCardinality(String),
+  embedding        Array(Float32),
+  retention_days   UInt16 DEFAULT 30,
+  indexed_at       DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(indexed_at)
+PARTITION BY toYYYYMM(start_time)
+ORDER BY (organization_id, project_id, session_id, chunk_index)
+TTL toDateTime(start_time) + toIntervalDay(retention_days + 30) DELETE;
+```
+
+A `session-search:refreshSession` worker (analogous to
+`apps/workers/src/workers/trace-search.ts`) re-runs
+`buildTraceSearchDocument` over `allMessages` concatenated across the
+session's traces in chronological order. Re-indexing is triggered on
+every `trace-end:run` for any trace belonging to the session — i.e. the
+worker keys on `session_id` and re-runs whenever any of its traces
+changes.
+
+**Pros**
+
+- One row per session at query time, no `groupArray` fan-out, no
+  rollup. Cursor stays the simple `(best_score, session_id)` tuple.
+- Lexical index quality on the concatenated text is _better_ than on
+  per-trace text for cross-turn queries ("user complained about
+  refunds and then asked about cancellation"): the phrase can span
+  trace boundaries.
+- Semantic-side embeddings cover cross-turn context too — useful for
+  multi-turn conversational queries the trace-level chunker can't
+  reach.
+
+**Cons**
+
+- **Re-indexing amplification.** Every new trace in a long session
+  re-builds the entire session document and re-embeds (some of) its
+  chunks. A session with 50 turns triggers ~50 re-indexes; each is
+  effectively `O(session_size)`. The trace-level pipeline trades
+  monotonically per trace.
+- **Freshness lag.** Two-stage materialization — `trace-end:run` →
+  trace-search worker → session-search worker. A second debounce
+  window before the session becomes searchable on the new turn.
+- **Storage.** Adding a second copy of the embedding corpus is the
+  main cost. At XL scale (`trace-search.md` → Cost & Performance) the
+  trace embedding corpus is ~20 GB; the session corpus would be
+  comparable, since session text is the concatenated trace text.
+  Voyage cost roughly doubles at billed tiers.
+- **Operational surface.** Two workers, two tables, two TTLs, two
+  backfill paths, two sets of dashboards. A bug in either one
+  produces two divergent search behaviors (the trace-search worker
+  drift and the session-search worker drift), each of which is hard
+  to debug without observability.
+- **`buildTraceSearchDocument` is trace-shaped today.** Its
+  head/tail turn selection (`build-trace-search-document.ts`'s
+  `selectHeadTailTurns`) and chunking are tuned for a single trace.
+  Composing across traces means either calling it _N_ times and
+  union-ing, or rewriting it to accept a virtual "session
+  conversation". Either is non-trivial and bleeds into the
+  `5-search-highlights.md` semantic-region mapping.
+
+**Write amplification**: ~`session_trace_count` extra writes per turn
+in steady state (re-index of the whole session). Voyage embed calls
+get re-issued for chunks whose content hash changed; turns that didn't
+change skip embedding via the existing `hasEmbeddingWithHash`
+path (`trace-search-repository.ts:61-90`).
+
+**Query cost**: similar to today's trace-level query, since the
+candidate set is one-row-per-session.
+
+**Freshness**: trace-end debounce + session-search debounce.
+
+**Complexity**: ~four PRs minimum (schema, worker, repository, backfill).
+
+## 4. Recommended approach — Option A (query-side rollup)
+
+Ship the query-side rollup first. The "session detail" use case the
+search bar serves is already gated by clicking into a session and from
+there into a trace — i.e. the user is going to land on a single trace's
+drawer anyway. We don't need session-level embedding quality, only
+session-level _result deduplication_, which is a SQL operation.
+
+If profiling later surfaces that the `groupArray` fan-out or the
+session-level grouping is slow at Large/XL scale, we can layer Option B
+without changing the API contract: the read row shape (`session_id` +
+`matching_trace_ids` + `best_score` + `matching_trace_scores` +
+`best_trace_id`) is the same either way.
+
+### 4.1 Recommended row schema
+
+The search plan still returns
+`(trace_id, relevance_score)` from `buildSearchPlan` (no change). The
+outer query now collapses to one row per session:
+
+```ts
+interface SessionSearchRow {
+  readonly session_id: string
+  readonly best_score: number                      // max(relevance_score)
+  readonly best_trace_id: string                   // argMax(trace_id, relevance_score)
+  readonly matching_trace_count: number            // count(distinct trace_id in the search hit set, including lexical-only matches at score = 0)
+  readonly matching_trace_ids: readonly string[]   // groupArray(trace_id) sorted by score DESC
+  readonly matching_trace_scores: readonly number[]
+  // … plus the rolled-up trace-level numerics (cost_total_microcents, span_count, etc.)
+  // matching the existing `SessionRecord` shape from sessions.functions.ts:12-39
+}
+```
+
+Two practical notes on this schema:
+
+- `matching_trace_ids` is capped by the candidate set, not by the
+  session size. A pure-semantic query has at most one row per
+  `(trace_id, chunk_index)` survivor of the `SEMANTIC_SCAN_LIMIT =
+  30_000` cap (`trace-repository.ts:65`). After the per-trace
+  `max(...) GROUP BY trace_id` rollup that's at most 30k distinct
+  trace candidates project-wide; the per-session fan-out is the
+  session's matching-trace count, typically single-digit.
+- `matching_trace_scores` is ordered to match `matching_trace_ids`
+  (CH's `groupArray` is order-preserving when followed by `arraySort`
+  on a parallel array — see SQL below). The drawer route only needs
+  `best_trace_id`; the array is for "show 3 matching turns" UI in the
+  result card.
+
+### 4.2 Score aggregation policy
+
+**Recommendation: `max(relevance_score)`.**
+
+- It matches the existing per-trace rollup (`max(semantic_score) GROUP BY
+  trace_id` at `trace-repository.ts:169-180`) — the trace-level score is
+  already a max-over-chunks; the session-level score becomes
+  max-over-traces-over-chunks. The semantics compose cleanly: "best
+  matching chunk in the best matching trace".
+- It preserves single-best-match precision: a session where _one_ turn
+  is a perfect match for the query stays at the top, instead of being
+  diluted by N other unrelated turns averaged in.
+- It's stable under "session keeps getting longer" — a low-relevance
+  follow-up turn doesn't push the session down the list. Avg or
+  weighted-avg both have that pathology.
+
+Considered and rejected:
+
+- **`avg(score)`** — dilutes single-strong-match sessions; pessimizes
+  against long sessions; hard to interpret cross-session because the
+  matching-trace _count_ skews it.
+- **`max(score) * log(1 + matching_trace_count)`** ("more turns
+  matching = stronger evidence") — tempting but premature. We have
+  zero data on whether "5 turns about refunds" should rank above "1
+  perfectly-matching turn about refunds with score 0.92". Defer until
+  we have telemetry. The `matching_trace_count` field is shipped in
+  the row so the UI can show it without baking it into the score.
+- **`avg(top_k=3 scores)`** — middle ground; defensible but adds a
+  parameter we'd have to tune and a code path we'd have to maintain.
+  Defer.
+
+Score aggregation lives in a single CH expression; switching it later
+is a one-line change behind a `SESSION_SEARCH_SCORE_AGGREGATION`
+constant. Document the chosen aggregation in
+`packages/domain/spans/src/constants.ts` next to the other trace-search
+constants.
+
+### 4.3 Recommended SQL
+
+The outer query becomes (parameter names match the existing
+`buildSearchPlan` `params` shape):
+
+```sql
+WITH search_results AS (
+  SELECT
+    trace_id,
+    relevance_score
+  FROM ( ${plan.subquery} )                  -- unchanged (buildSearchPlan output)
+),
+
+trace_rollup AS (
+  -- The existing trace-deduped projection over `traces`, with the score joined in.
+  -- This is the same shape as the per-trace LIST_SELECT, narrowed to traces that
+  -- matched the search.
+  --
+  -- The `session_id` column applies the canonical coalesce expression from
+  -- ./1-parity-traces-sessions.md so the outer GROUP BY collapses correctly for
+  -- both real sessions (SDK-supplied id) and orphan traces (synthesized
+  -- toString(trace_id)). Reading argMaxIfMerge(t.session_id) directly would
+  -- yield '' for orphan traces and collapse them all into one "empty session"
+  -- group — which is exactly the misclassification we're avoiding.
+  SELECT
+    t.organization_id                                AS organization_id,
+    t.project_id                                     AS project_id,
+    t.trace_id                                       AS trace_id,
+    coalesce(
+      nullIf(argMaxIfMerge(t.session_id), ''),
+      toString(t.trace_id)
+    )                                                AS session_id,
+    ${LIST_SELECT_NUMERICS}                          -- sums for cost/tokens/span_count/etc.
+    min(t.min_start_time)                            AS trace_start_time,
+    max(t.max_end_time)                              AS trace_end_time,
+    search_results.relevance_score                   AS relevance_score
+  FROM traces t
+  INNER JOIN search_results ON t.trace_id = search_results.trace_id
+  WHERE t.organization_id = {organizationId:String}
+    AND t.project_id = {projectId:String}
+    ${extraWhere}                                   -- score-filter subquery
+  GROUP BY
+    t.organization_id, t.project_id, t.trace_id,
+    search_results.relevance_score
+  ${finalHaving}                                    -- HAVING from FilterSet
+)
+
+SELECT
+  organization_id,
+  project_id,
+  session_id,
+
+  -- Score aggregation across the session's matching traces.
+  max(relevance_score)                                            AS best_score,
+  argMax(trace_id, relevance_score)                               AS best_trace_id,
+
+  -- Per-session count of matching traces. Zero-relevance lexical-only
+  -- rows still count (they matched the phrase filter).
+  count()                                                         AS matching_trace_count,
+
+  -- Matching traces sorted by their own relevance, descending. The two
+  -- arrays stay aligned: zip them on the client to render "Trace X · 0.84".
+  arrayMap(
+    pair -> pair.1,
+    arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score)))
+  )                                                               AS matching_trace_ids,
+  arrayMap(
+    pair -> pair.2,
+    arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score)))
+  )                                                               AS matching_trace_scores,
+
+  -- Rolled-up session numerics (sum across the session's matching traces).
+  -- Mirrors `SessionRecord` shape so the UI can render the same cells the
+  -- session listing already supports without a second query.
+  min(trace_start_time)                                           AS session_start_time,
+  max(trace_end_time)                                             AS session_end_time,
+  sum(cost_total_microcents)                                      AS cost_total_microcents,
+  sum(span_count)                                                 AS span_count,
+  sum(error_count)                                                AS error_count,
+  sum(tokens_total)                                               AS tokens_total
+  -- … same shape as session-repository LIST_SELECT (session-repository.ts:21-49)
+
+FROM trace_rollup
+WHERE 1=1                                           -- session_id is always non-empty under coalesce; no filter needed
+  ${sessionCursorClause}                            -- see §4.4
+GROUP BY organization_id, project_id, session_id
+ORDER BY best_score DESC, session_id DESC
+LIMIT {limit:UInt32}
+```
+
+Notes:
+
+- The CTE structure (`search_results` → `trace_rollup` →
+  session-level `SELECT`) preserves the existing `extraWhere` /
+  `finalHaving` semantics from `trace-repository.ts:960-985`: the
+  trace-level filter set (incl. score subqueries) is applied
+  _before_ the session rollup, so a session is only matched on the
+  subset of its traces that pass per-trace filters. This is the
+  right behavior for filters like `tags = X` (only sessions whose
+  matching traces carry that tag), and unambiguous in the edge
+  cases.
+- `argMax(trace_id, relevance_score)` ties are broken
+  non-deterministically — that's fine; the UI links into one of the
+  matching traces and the user can see all of them via
+  `matching_trace_ids`.
+- The `arrayReverseSort(pair -> pair.2, ...)` pattern is ClickHouse's
+  way to keep two arrays aligned: zip via `groupArray((a, b))` then
+  sort the tuple by the second element descending, then unzip with
+  `arrayMap`. Cheaper than a window function and works inside an
+  aggregate clause.
+- **No `WHERE session_id != ''` filter.** Under the coalesce
+  convention from `./1-parity-traces-sessions.md`, every trace row gets
+  a non-empty `session_id` in the rollup CTE (`coalesce(nullIf(...),
+  toString(trace_id))`). Orphan traces — those with no SDK-supplied
+  `session_id` on any span — surface as 1-trace sessions in the
+  search results, identified by their `toString(trace_id)` session_id
+  and the standard `tokens_total = 0` / `models = []` visual
+  signature.
+- `INNER JOIN traces ON t.trace_id = search_results.trace_id` is the
+  same join as today. The `trace_search_documents` /
+  `trace_search_embeddings` tables don't carry `session_id`, so the
+  join through `traces` is how we resolve session membership. This
+  is cheap because `(organization_id, project_id, trace_id)` is the
+  primary key.
+
+### 4.4 Cursor
+
+The cursor moves from `(relevance_score, trace_id)` to
+`(best_score, session_id)`. The `sessionCursorClause` is:
+
+```sql
+AND (best_score, session_id) < ({cursorSortValue:Float64}, {cursorSessionId:String})
+```
+
+Same lexicographic-tuple comparison as today
+(`trace-repository.ts:962-963`), keyed on the session instead of the
+trace. `BATCH_SIZE = 50` and the `+1 / hasMore` semantic
+(`trace-repository.ts:1004-1019`) carry over unchanged.
+
+Because the cursor predicate is on the _outer_ aggregate, it has to be
+applied in a `HAVING` clause (the comparison references `best_score`,
+which is an aggregate). The pattern:
+
+```sql
+GROUP BY organization_id, project_id, session_id
+HAVING (max(relevance_score), session_id) < (
+  {cursorSortValue:Float64}, {cursorSessionId:String}
+)
+ORDER BY best_score DESC, session_id DESC
+LIMIT {limit:UInt32}
+```
+
+This is identical to how non-search session listing pages today
+(`session-repository.ts:216-222`).
+
+### 4.5 Score-filter (`HAVING`) interaction
+
+The existing trace-level path applies `HAVING` _at the trace level_
+(`trace-repository.ts:982-983`). With session rollup we have two
+defensible choices:
+
+- **Apply per-trace, then roll up.** A session matches if at least
+  one of its matching traces passes the HAVING. This is what falls
+  out naturally from the CTE structure above (HAVING is applied in
+  `trace_rollup`).
+- **Apply session-level (post-rollup).** A session matches if the
+  rolled-up aggregate passes the HAVING. E.g. `cost > $5` means "sum
+  of matching-trace costs > $5".
+
+**Recommendation: per-trace.** It matches how `FilterSet` is described
+on the trace list ("traces with cost > X"); a session that contains
+even one trace with cost > X is a session worth surfacing under the
+matching turns. Documented in the spec; can revisit if user feedback
+disagrees.
+
+### 4.6 count / metrics / histogram
+
+These three siblings of the list query (`trace-repository.ts:1226-1295`,
+`:1402-1469`, and the histogram path) currently re-use the search plan
+via `AND trace_id IN (SELECT trace_id FROM (<plan.subquery>))`.
+
+They must move in lockstep with the list:
+
+- **count** returns `count(DISTINCT session_id)` over the matched set
+  (i.e. the same post-rollup row count the user sees in the list).
+  The UI string changes from "12 traces" to "5 sessions · 12 matching
+  turns" — keep both counts available by adding
+  `matching_trace_count_total = sum(matching_trace_count)` to the
+  count query result.
+- **metrics** are rolled up across _sessions_ now, not traces. Most
+  fields are sums of the per-session aggregates that already include
+  cross-trace sums — so the aggregate query reads from the same
+  CTE structure (`trace_rollup` → group-by-session) and the
+  top-level `SELECT` computes `avg(cost_total_microcents)` etc. over
+  session rows.
+- **histogram** is bucketed by session start time (the earliest
+  matching turn). Same CTE shape, with an outer
+  `GROUP BY toStartOfInterval(min(trace_start_time), :bucket)`.
+
+### 4.7 Ordering policy
+
+When `searchQuery` is present, the server orders by `best_score DESC,
+session_id DESC` regardless of the client `sortBy` — same policy as
+trace search today (`trace-search.md` → Ordering policy). The
+column-header sort UI keeps its current "we set the URL param but the
+server still orders by relevance" behavior.
+
+## 5. API and UI impact
+
+### 5.1 Server functions
+
+The search read path currently lives on `listTracesByProject`,
+`countTracesByProject`, `getTraceMetricsByProject`,
+`getTraceTimeHistogramByProject`, and exporters. Two options:
+
+- **A. Branch inside `listTracesByProject`.** When `searchQuery` is
+  present, the handler returns a different shape (`SessionRecord` +
+  matching-trace metadata) instead of `TraceRecord[]`. Client code
+  that consumes the search page (`apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx`)
+  switches over the response variant.
+- **B. Introduce `listSessionsByProject` with a `searchQuery` input.**
+  Keep `listTracesByProject` purely trace-level. The search page
+  uses `listSessionsByProject` when `q` is non-empty. The
+  non-search `/projects/$projectSlug` route, which today calls
+  `listTracesByProject` and doesn't have a session-collapsed mode,
+  is left alone.
+
+**Recommendation: B.** The trace list and the session list are two
+different surfaces (the non-search trace page should keep showing
+traces; the search page should always show sessions when there's an
+active query). Conflating them through a polymorphic
+`listTracesByProject` would force every consumer to handle both
+shapes, including dashboards/exports/etc. that have no reason to
+care.
+
+`listSessionsByProject` already exists at
+`apps/web/src/domains/sessions/sessions.functions.ts:54-94` and the
+ClickHouse repository at
+`packages/platform/db-clickhouse/src/repositories/session-repository.ts:203-269`.
+The new path:
+
+1. Widen the inputValidator on `listSessionsByProject` to accept
+   `searchQuery: z.string().max(500).optional()`.
+2. Add `SessionRepositoryShape.listByProjectId` to optionally take
+   `searchQuery` in its `options` (`session-repository.ts`'s shape
+   at `packages/domain/spans/src/ports/session-repository.ts:47-53`).
+3. Inside the repo, mirror the planSearch / buildSearchPlan dance
+   from `trace-repository.ts:756-791` (extract them into a shared
+   module — see §6 Open questions).
+4. When `searchQuery` is active, run the CTE from §4.3; otherwise
+   keep the existing `FROM sessions` path.
+5. Add the matching-trace fields to the returned `SessionRecord`
+   variant via a parallel `searchMatch` field (do _not_ pollute
+   `SessionRecord` itself; the search match is _per result_, not a
+   property of the session):
+
+   ```ts
+   interface SessionSearchMatch {
+     readonly bestScore: number
+     readonly bestTraceId: string
+     readonly matchingTraceCount: number
+     readonly matchingTraceIds: readonly string[]
+     readonly matchingTraceScores: readonly number[]
+   }
+
+   interface SessionListResult {
+     readonly sessions: readonly SessionRecord[]
+     readonly searchMatches?: Readonly<Record<string, SessionSearchMatch>>
+     // keyed by sessionId; present only when searchQuery was active
+     readonly hasMore: boolean
+     readonly nextCursor?: { sortValue: string; sessionId: string }
+   }
+   ```
+
+   The same parallel-field shape the `5-search-highlights.md` spec
+   recommends for trace-level matched-chunk metadata
+   (`5-search-highlights.md` → "Phase C — Semantic region highlight").
+
+Parallel new fns:
+
+- `countSessionsByProject` — exists today
+  (`sessions.functions.ts:54-94` defines the list and metrics; add
+  count if not already present) — extend with `searchQuery`.
+- `getSessionMetricsByProject` — extend with `searchQuery`.
+- `getSessionTimeHistogramByProject` — add it; sessions don't have a
+  histogram fn today.
+- `enqueueSessionsExport` — exporter for the session selection.
+
+### 5.2 React Query keys
+
+Today's search page keys are scoped to traces:
+
+```
+["tracesInfiniteScroll", projectId, sortBy, sortDirection, filters, q]
+["tracesCount",          projectId, filters, q]
+```
+
+(`apps/web/src/domains/traces/traces.collection.ts:29-55,83-...`)
+
+When `q` is non-empty on the search route, the page switches to:
+
+```
+["sessionsInfiniteScroll", projectId, sortBy, sortDirection, filters, q]
+["sessionsCount",          projectId, filters, q]
+```
+
+Both keys still flow through the same Voyage cache key
+`(text, model, dimensions, "query")` for the embedding call
+(`trace-search.md` → Query-time embedding) — the cache lives at the
+Voyage call site inside the ClickHouse repository and is invariant to
+whether the caller is the trace or session list.
+
+### 5.3 Search page UI
+
+`apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx`
+swaps `TracesView` (line 332-351) for `SessionsView` when `q` is
+non-empty. `SessionsView` already renders expandable session rows
+(`apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx:194-468`):
+
+- Top-level row: session metadata + "**N** matching turns" pill (new
+  column when `searchMatches` is non-empty).
+- Expanded: the session's matching traces, sorted by score, with the
+  score visible per row. Existing expansion logic in
+  `useExpandedSessionTraces` (`sessions-view.tsx:54-98`) calls
+  `listTracesByProject` with a `sessionId` filter; for the search
+  page we substitute that with the `matchingTraceIds` from
+  `searchMatches[sessionId]` so we don't re-query and we preserve
+  rank order.
+
+The "matching turns" pill is a new column. Suggested column id
+`"searchMatches"`, visible only when `q` is non-empty
+(append/remove in the visible-column-ids logic at
+`search/index.tsx:81-84`).
+
+### 5.4 Drawer drill-in
+
+When the user clicks a session row → expanded → individual matching
+trace row, the existing trace-detail drawer flow takes over
+(`search/index.tsx:355-368`). The drawer continues to receive
+`traceId` (one specific trace from `matchingTraceIds`) and uses the
+trace-level highlight pipeline from `5-search-highlights.md`. **No
+change to the drawer is needed for the rollup itself** — the rollup
+is purely a result-list operation.
+
+Clicking the top-level session row (not an expanded trace row) opens
+the drawer on `bestTraceId`. This is the default drill-in: "show me
+why this session matched best".
+
+### 5.5 Drawer prev/next navigation
+
+`search/index.tsx` already supports cycling through results with
+prev/next traces (`canNavigateNext`, `canNavigatePrev`,
+`navigateTrace`). With sessions as the result rows, the natural
+behavior is:
+
+- Inside an expanded session: prev/next cycles _within_ the session's
+  matching traces (score-ordered).
+- Outside an expanded session: prev/next moves to the next session
+  and lands on its `bestTraceId`.
+
+`traceIdsRef` (the flat trace-id list the drawer uses today —
+`search/index.tsx:78`, `sessions-view.tsx:392`) is replaced with a
+session-aware structure carrying the per-session ordered list. The
+drawer doesn't need to know about sessions — it still sees a flat
+list of `traceId`s — but the page assembles that list from the
+session-search payload.
+
+## 6. Edge cases
+
+### 6.1 Session with one matching trace
+
+Identical-to-trace-search behavior. `matching_trace_count = 1`,
+`matching_trace_ids = [traceId]`, `best_score = relevance_score`. UI
+hides the "N matching turns" pill or renders "1 matching turn".
+
+### 6.2 Session with many matching traces (high fan-out)
+
+A 50-turn conversation about a topic that all matches the query.
+`matching_trace_count = 50`. The session row carries 50 ids and 50
+scores in the result payload — at 8 bytes per `Float32` and ~32
+bytes per UUID string that's ~2 KB per session row. Across a page of
+50 sessions, that's ~100 KB — fine. We do _not_ cap the array
+server-side; if a future profile shows the payload getting heavy,
+truncate to the top-K matching traces in the SQL and surface
+`matching_trace_count` separately (the array becomes a preview, the
+count stays accurate).
+
+### 6.3 Session whose traces span multiple days
+
+Each trace has its own `min_start_time` / `max_end_time` from the
+`traces` materialized view. The session-level rollup uses
+`min(trace_start_time)` and `max(trace_end_time)` for the start/end
+times — same shape as the existing `sessions` materialization at
+`…/00007_sessions.sql:58`. The histogram bucket is keyed on the
+session start time (earliest matching turn).
+
+There is a subtle issue with the embedding TTL (30 days,
+`TRACE_SEARCH_EMBEDDING_LOOKBACK_DAYS`): a long-running session
+could have its oldest matching turn drop out of the embedding table
+while the newer turns are still indexed. Behavior degrades
+gracefully — older turns disappear from the embedding side; if they
+still match lexically they remain in the lexical-only branch
+(`trace_search_documents` is 90-day). This is the same
+forward-only, TTL-respecting behavior as trace search today.
+
+### 6.4 Mixed lexical + semantic (hybrid) rollup
+
+`buildSearchPlan` in the hybrid branch already returns
+`(trace_id, relevance_score)` where `relevance_score` is
+`max(sem.semantic_score)` over chunks for traces that match
+phrases, with `0.0` for phrase-only matches that didn't make the
+embedding table (`trace-repository.ts:264-276`).
+
+Two things to verify after the rollup:
+
+- **Lexical-only sessions stay in.** A session whose matching traces
+  all have `relevance_score = 0.0` (phrase matched, no embedding)
+  rolls up to `best_score = 0.0`. They should still appear — ordering
+  is stable (the tie-breaker `session_id DESC`), and the count
+  reports them. **Recommendation: keep them; do not gate `best_score
+  > 0` at the session level.**
+- **Semantic floor.** The pure-semantic branch already applies
+  `WHERE semantic_score >= 0.30` _inside_ `buildSearchPlan`
+  (`trace-repository.ts:249`). The session rollup doesn't re-apply
+  the floor and doesn't need to: the trace candidates have already
+  passed the per-trace gate. A session whose traces individually
+  scored 0.31, 0.32, 0.45 rolls up to `best_score = 0.45` — clean.
+  A session with zero traces above 0.30 produces no row in the
+  outer rollup at all because there's no inner candidate.
+
+### 6.5 The "winning chunk metadata" follow-up
+
+`5-search-highlights.md` proposes carrying `matched_chunk_index`,
+`first_message_index`, `last_message_index` (and friends) through
+the trace-level subquery so the drawer can highlight a chunk-level
+region. With the session rollup, that metadata sits one level deeper
+(per matching trace, not per session). The natural shape:
+
+- `trace_rollup` adds the matched-chunk columns from
+  `5-search-highlights.md` Phase C as additional aggregates per
+  trace.
+- The session-level rollup picks the winning trace via `argMax`
+  and the winning trace's chunk metadata flows through alongside:
+
+  ```sql
+  argMax(matched_chunk_index, relevance_score)        AS best_matched_chunk_index,
+  argMax(matched_first_message_index, relevance_score) AS best_matched_first_message_index,
+  argMax(matched_last_message_index, relevance_score)  AS best_matched_last_message_index
+  ```
+
+  The drawer, when opened on `best_trace_id`, gets the same payload
+  as today's trace-level highlight code path — nothing in
+  `5-search-highlights.md` changes.
+
+### 6.6 Score-filter (`FilterSet` HAVING) combined with session rollup
+
+Already covered in §4.5: HAVING is applied at the per-trace level
+inside `trace_rollup`. A session with one cost-passing trace and four
+cost-failing traces still surfaces, with `matching_trace_count = 1`.
+This is the user's intent — sessions visible in the search are
+sessions that contain something interesting.
+
+### 6.7 Orphan traces (no SDK session_id)
+
+Traces whose spans never carried a `gen_ai.conversation.id` get a
+synthesized session_id of `toString(trace_id)` in the rollup CTE via
+the coalesce expression (see §4.3 and `./1-parity-traces-sessions.md`).
+That means orphan traces **do** surface in session-level search
+results — as 1-trace sessions. Pagination, cursors, and counts
+treat them identically to real sessions; the visual distinction is
+made on the UI side via the same `tokens_total = 0` / `models = []`
+signature used everywhere else.
+
+If a trace matches the search but has no `gen_ai.conversation.id` on
+any of its spans, the result row carries `session_id =
+toString(trace_id)`, `best_trace_id = trace_id`, `matching_trace_ids
+= [trace_id]`. Drawer drill-in (§5.4) opens that single trace
+directly.
+
+### 6.8 `argMaxIfMerge(session_id)` reading semantics
+
+`session_id` on `traces` is an `AggregateFunction(argMaxIf, ...)`
+state (`…/00011_plan_aware_retention.sql:78`); the materialized
+view's `LIST_SELECT` resolves it with `argMaxIfMerge(session_id)`
+(`trace-repository.ts:312`). In the session-rollup CTE we read
+session_id _inside_ `trace_rollup`'s GROUP BY-per-trace context, so
+the merge happens once per trace — same as today's list query —
+producing a plain `String`. We then apply the canonical coalesce
+(`coalesce(nullIf(argMaxIfMerge(t.session_id), ''),
+toString(t.trace_id))`) so orphan traces get their synthesized id
+inside the same projection. The outer session GROUP BY then groups
+on that plain, always-non-empty string. No double-merge edge cases.
+
+## 7. Migration / rollout
+
+Forward-only, same posture as trace search:
+
+1. **Add the SQL path.** Implement Option A in
+   `SessionRepository.listByProjectId` behind an `if (searchQuery)`
+   branch. Wire `searchQuery` through the input schema, repository
+   port, and server function.
+2. **Add sibling fns.** `countSessionsByProject` /
+   `getSessionMetricsByProject` / new histogram, all with
+   `searchQuery` plumbed through and using the same CTE structure.
+3. **Switch the search page.** Behind a feature flag if we want to
+   stage; otherwise just swap `TracesView` → `SessionsView` on
+   `/search` when `q.length > 0`. The non-search routes are
+   unaffected.
+4. **Update React Query collection hooks.** Replace
+   `useTracesInfiniteScroll` + `useTracesCount` on the search page
+   with `useSessionsInfiniteScroll` + `useSessionsCount` (the latter
+   may need creating, depending on whether session count is already
+   exposed).
+5. **Telemetry.** Log per-query: matching session count, sum of
+   matching-trace counts, query latency. We need these to decide
+   whether Option B is ever needed.
+6. **Drawer & highlights.** No change in V1. Phase C of
+   `5-search-highlights.md` continues to work; the drawer is opened
+   on `best_trace_id` or any specific `matchingTraceId`. The
+   trace-level highlight endpoint takes the `q` plus the chosen
+   `traceId` and produces highlights — unchanged.
+
+No backfill is required because the trace-level indexes are reused.
+
+## 8. Future work
+
+- **Option B revisit.** If `matching_trace_count` distributions
+  consistently show high fan-out (e.g. p99 > 30) and query latency
+  becomes the bottleneck, materialize session-level corpora. The
+  expected trigger is XL-scale projects with very long conversations
+  (LangChain/agent-style sessions). The migration path is additive:
+  build `session_search_documents` / `session_search_embeddings`,
+  flip `buildSearchPlan` to consult them, leave the trace-level
+  tables as the fallback / per-trace-highlight source of truth.
+- **Cross-turn semantic queries.** The trace-level chunker can't see
+  across trace boundaries by construction (chunks are turns within
+  a trace). A query like "user asked X then later said Y" can't be
+  served by the trace embeddings even after the session rollup. This
+  is the strongest argument for Option B — but it's a real
+  user-need question, not a perf question. Defer until we have
+  examples.
+- **Freshness-weighted ordering.** Tracked separately in
+  `0-problems.md:148-163`. The session row's `best_score` is the
+  obvious input to a `f(best_score, recency)` blended sort. Slot
+  this in after the rollup ships.
+- **Session-level export.** `enqueueTracesExport`
+  (`traces.functions.ts:389-429`) currently takes a trace selection.
+  After session rollup, the search-page selection is naturally
+  session-shaped — we need to either (a) expand it to traces
+  server-side via `matchingTraceIds`, or (b) introduce
+  `enqueueSessionsExport` with a session-shaped CSV layout. Probably
+  (b).
+- **Score normalization across plans.** Lexical-only returns
+  `relevance_score = 0.0` while semantic returns cosines in roughly
+  `[0.3, 0.9]`. The rollup carries that through, so a phrase-only
+  session lands at `best_score = 0.0` regardless of phrase quality.
+  This is the same shape as trace search today and is consistent
+  with the policy "lexical is a filter, not a scorer"
+  (`trace-search.md` → Configuration Reference / hybrid ranking
+  note). Revisit if/when we add native phrase relevance.
+
+## 9. Open questions
+
+- **`buildSearchPlan` location.** The plan is currently defined inside
+  `TraceRepository`'s closure (`trace-repository.ts:756-791`). The
+  session repository needs the same function. Options: extract it to
+  a shared helper in `packages/platform/db-clickhouse/src/repositories/`
+  (next to `score-filter-subquery.ts`), or move it to the domain
+  package (`packages/domain/spans/src/use-cases/`). The latter is
+  cleaner but requires inverting the AI dependency. Recommendation:
+  extract to a shared helper module
+  `…/db-clickhouse/src/repositories/search-plan.ts` that exports
+  `planSearch` / `buildSearchPlan` / `isActiveSearch`. Both
+  repositories import.
+- **Should the trace search page still exist?** Once
+  `/projects/$projectSlug/search` collapses to sessions by default,
+  is there ever a reason for a "search but show me traces flat" view?
+  Possibly yes for power-users debugging the search itself. Defer to
+  product but the SQL path supports both with zero extra work — the
+  trace-level list query already exists and is unchanged.
+- **Per-session export selection.** What does selecting a session row
+  on the search page mean for export? "All matching traces in the
+  session"? "All traces in the session"? Probably the first — match
+  the visual: the user sees the matching turns, they expect to
+  export those. Confirm with product before shipping the export
+  button on the search page in session mode.
+- **Tie-breaker stability.** When `best_score` ties (especially the
+  `0.0` lexical-only case), `ORDER BY best_score DESC, session_id
+  DESC` is stable but arbitrary. Is there a recency or freshness
+  signal we should prefer over `session_id` as the secondary sort?
+  `max(trace_end_time)` would put recently-active sessions first
+  among ties — defensible. Defer to the freshness-sort spec
+  (`0-problems.md` → §8).
+- **What does "matching turn" mean in the UI string?** "Turn" is
+  user-facing; we've been using "trace" internally and "matching
+  trace" in this spec. Pick one before shipping copy. Suggested:
+  expose "**N** matching turns" in the result card, keep
+  "trace_id" in URLs and API contracts.
+- **Cursor staleness when a new trace lands mid-pagination.** The
+  cursor `(best_score, session_id)` is stable as long as no new
+  trace for an already-paginated session bumps its `best_score`. A
+  new very-high-scoring trace landing mid-scroll could re-rank the
+  session to the top of page 1 while it's already on page 3 — the
+  user might see it again. This is the same forward-time anomaly as
+  trace search today (`trace-search.md` doesn't address it
+  explicitly); accept and document.

--- a/specs/session-problems/3-session-issue-dedup.md
+++ b/specs/session-problems/3-session-issue-dedup.md
@@ -1,0 +1,424 @@
+# Session-level issue deduplication
+
+Issues today are emitted per **score**, and almost every score is bound to a single trace. When a session contains multiple turns that hit the same flagger / evaluator / annotation queue, the resulting issue surfaces N times across the session's traces — once per turn that triggered it. The issues view and the future session-detail panel both want **one row per `(session, issue)`** with the underlying matching traces still discoverable from that row.
+
+This is the same conceptual fix as session-level search (item #3 in `./0-problems.md`), applied to the issues stream. The goal is to consolidate "I have an issue X that fired five times in this conversation" into a single, navigable record, without losing the per-trace granularity that backs investigation, annotations, datasets, and lifecycle.
+
+## Scope
+
+- **In scope.** Issue ↔ trace ↔ session attribution. Display model for the issues page and the session-detail panel. Read-path dedup keys and aggregations. Backfill of existing per-trace stream.
+- **Out of scope.** Issue *discovery* itself (the clustering pipeline in `@domain/issues/use-cases/discover-issue.ts` is unchanged — it still works at score granularity). Postgres `issues` row shape (`packages/platform/db-postgres/src/schema/issues.ts:10`). Issue lifecycle state (`new`/`escalating`/`ongoing`/`resolved`/`regressed`/`ignored`) — those remain per-issue and are orthogonal to session aggregation.
+
+## Current state
+
+### Where issues live
+
+There are **two surfaces** for "an issue":
+
+1. **The `issues` row** in Postgres (`packages/platform/db-postgres/src/schema/issues.ts:10`). One row per `(organization_id, project_id, slug)`. Carries the clustered identity: `name`, `description`, `centroid`, `centroidEmbedding`, `searchDocument`. No `traceId`, no `sessionId`. This is the conceptual issue.
+2. **The `scores` table** in ClickHouse (`packages/platform/db-clickhouse/clickhouse/migrations/clustered/00006_create_scores.sql:3`). One row per individual score, carrying `session_id`, `trace_id`, `span_id`, `issue_id`, `source`, `source_id`, `created_at`, `passed`, `errored`. **This is where the per-trace duplication lives** — three score rows on three traces in the same session, all with `issue_id = X`, become three "occurrences" of the same issue.
+
+The bridge between the two surfaces is `scores.issue_id`. Every analytic — `occurrences`, `firstSeenAt`, `lastSeenAt`, `affectedTracesPercent`, the trend chart, the trace list — is a `GROUP BY issue_id` over `scores` filtered by `issue_id != ''`.
+
+### How an issue is detected and attached to a score
+
+The detection pipeline is event-driven and operates **at score granularity** end to end:
+
+1. A score is published (`@domain/scores` — evaluation result, published annotation, custom score with `feedback`).
+2. The `discoverIssueUseCase` (`packages/domain/issues/src/use-cases/discover-issue.ts:129`) checks eligibility (`checkEligibilityUseCase`, `check-eligibility.ts:23`): published-only, has feedback, not passed, not errored, not already owned.
+3. If eligible, it starts either `issueDiscoveryWorkflow` (no candidate found yet — go embed + hybrid-search + rerank against existing issues, otherwise create) or `assignScoreToKnownIssueWorkflow` (linked evaluation or explicit `issueId` already known).
+4. The terminal step is **always**: `scoreRepository.assignIssueIfUnowned({ scoreId, issueId })` (see `create-issue-from-score.ts:173` and `assign-score-to-issue.ts:167`). This writes `scores.issue_id` for exactly one score row.
+5. An `OutboxEvent` `ScoreAssignedToIssue` is emitted (`assign-score-to-issue.ts:188`); downstream consumers (centroid refresh, escalation recheck) operate at issue granularity but they read scores back out by `issue_id`.
+
+**There is no entity at any layer that says "issue X seen on session S".** Session-level appears only in the score row itself (`scores.session_id`).
+
+### View layer — how the issues page surfaces a row
+
+`listIssuesUseCase` (`packages/domain/issues/src/use-cases/list-issues.ts:422`):
+
+- Page candidates come from `scoreAnalyticsRepository.listIssueWindowMetrics` (`list-issues.ts:486`) — `count() / min(created_at) / max(created_at) FROM scores GROUP BY issue_id` (impl `score-analytics-repository.ts:1060`).
+- Full-history occurrence aggregates from `aggregateByIssues` (`score-analytics-repository.ts:807`).
+- The `IssueListItem.affectedTracesPercent` (`list-issues.ts:732`) is `windowMetric.occurrences / totalTraces`. The **numerator** is `count(scores)` — i.e. it counts score rows, not distinct traces, and so a session with five matching traces contributes five.
+- `IssueListItem.occurrences` (`list-issues.ts:730`) is identically `count(scores)`.
+
+`listIssueTracesUseCase` (`packages/domain/issues/src/use-cases/list-issue-traces.ts:33`) and its CH backing `listTracesByIssue` (`score-analytics-repository.ts:1291`) is the only piece that already does any dedup — but it dedupes at **trace** granularity (`GROUP BY trace_id`), not session. The issue-detail drawer (`apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx:170-188`) renders the result as a flat traces table — one row per trace, no session grouping at all.
+
+### Where the duplication shows up
+
+Three observable places:
+
+| Surface | Symptom |
+|---|---|
+| Issues page row | `occurrences` and `affectedTracesPercent` count every trace separately. A session that triggered "refusal" on five of its turns inflates this issue's `occurrences` by 5. Across the project, a chatty user can dominate an issue's metrics. |
+| Issue-detail drawer's traces table | Five rows of the same conversation, often near-identical except for `traceId`. The user navigating with N/P clicks through what feels like one problem repeated. |
+| Future session-detail panel (`./6-session-panel.md`) | Per 0-problems.md item #4, when the panel renders "issues for this session" it must render each issue once, not once-per-trace. With today's data it cannot. |
+
+The Postgres issue row itself does not duplicate. Lifecycle states do not duplicate. Centroid math does not duplicate (each contributing score is added once). The duplication is **purely a display/query rollup** problem rooted in the per-score storage shape.
+
+## The dedup key
+
+Two scores are "the same issue, same session" iff they share `(organization_id, project_id, issue_id, session_id)`. That tuple is the natural dedup key — the issue table already enforces "same issue" via `issue_id`, and the only thing we're folding is the trace dimension within a single session.
+
+**`session_id` on `scores` is always non-empty** under the coalesce convention from `./1-parity-traces-sessions.md`. Scores are written with the canonical session_id derived from the trace they describe:
+
+```sql
+coalesce(nullIf(traces.session_id, ''), toString(traces.trace_id))
+```
+
+This is the same expression `sessions_mv` uses to assign session_id to its rows, applied at score-write time using the trace's resolved `argMaxIfMerge(session_id)` from the `traces` row. The effect: for any trace, the score's `session_id` matches the canonical session_id of the session that trace belongs to — real session for tagged traces, synthesized `toString(trace_id)` for orphan traces. There is never an empty bucket to special-case.
+
+There is no second key shape to handle: every detection path ends in the same `scoreRepository.assignIssueIfUnowned` call, so every issue-bearing score row has the same `issue_id` semantics regardless of source. Specifically:
+
+- **Annotation-backed issues** (`source = "annotation"`, including system flaggers — see `./remove-system-annotation-queues.md`) share an `issue_id` whenever the centroid match lands them on the same issue. Each turn that gets a refusal flag in the same conversation will land on the same `issue_id` (centroid is stable across the session's feedback variants); they need to dedup.
+- **Evaluation-backed issues** (`source = "evaluation"`) carry the linked `evaluation.issueId` (`packages/domain/evaluations`) and so by construction all evaluation results for a given evaluation in the same session share an `issue_id`. They need to dedup.
+- **Custom-source issues** (`source = "custom"`) go through the same discovery pipeline — same `issue_id`, same dedup behavior.
+- **Errored scores** (`scores.errored = true`) never get an `issue_id` assigned (filtered out in `check-eligibility.ts:49`). They aren't issues; they don't surface on the issues page. If/when they do (proposed in `./0-problems.md`'s open queue), the dedup key would extend naturally — `(issue_id, session_id)` still works because errored scores would still get an `issue_id` assignment.
+- **Outlier / statistical signals.** Per the system-queues design principle (see "Interactions with the system-queues design principle" below), statistical signals (`resource-outliers`) are **not** issues and never become annotation queues. They surface through traces UI filters / `TraceCohort*` infrastructure, not through `scores`. Outlier dedup is out of scope here — there's nothing in `scores` to dedup. If a future "performance regression" failure-mode flagger ships, it would write a normal annotation score and inherit this dedup.
+
+### Edge cases the key handles cleanly
+
+| Case | Behavior under `(issue_id, session_id)` |
+|---|---|
+| Score with `session_id = toString(trace_id)` (orphan trace, no SDK session_id) | Treated as any other session — `(issue_id, session_id = toString(trace_id))` groups the trace's scores into a single 1-trace "session-issue" row. Same code path as conversational sessions; no fallback branch. Under the coalesce convention, raw empty `session_id` never reaches `scores`. |
+| Two issues, one session | Two rows. Same `session_id`, different `issue_id`, no overlap. |
+| Same issue, two sessions | Two rows. Correct: different sessions are different problem instances even if they cluster to the same issue. |
+| Same issue, same session, two traces with different `created_at` | One row. The row carries `firstSeen = min(created_at)`, `lastSeen = max(created_at)`, `matching_trace_ids = [t1, t2]`, `occurrences = 2`. |
+| Score later reassigned to a different issue | `assignIssueIfUnowned` is one-shot (idempotent on first-write). Reassignment is not a current operation — issues are append-only in `scores.issue_id`. If we ever introduce reassignment, the dedup key follows the new `issue_id` because the source of truth is the score row, not a denormalized rollup. |
+
+### Edge cases the key does *not* handle
+
+- **Cross-session merging of "the same conceptual problem".** Two unrelated users hit the same refusal flag in different conversations — that's two session-issue rows. By design. The user wants "one row per session", not "one row per problem class"; the latter is what the issue itself already is.
+- **A session that crosses a model/prompt version boundary** mid-stream. Each turn's score still lands on the same `issue_id` (centroid clusters the failure pattern, not the context). One row, with `matching_trace_ids` spanning both versions. The version split is a filter/cohort question, not a dedup question.
+
+## Schema impact — two options
+
+### Option A: keep per-trace storage, dedup at query/view time
+
+`scores.issue_id` is already populated. Every analytic query gains a `GROUP BY session_id, issue_id` instead of `GROUP BY issue_id`.
+
+**Pros:**
+- **Zero schema migration.** No new table, no MV, no backfill of historical data — every existing score row already has `(issue_id, session_id)` in the right place.
+- **Late-arriving traces are free.** A new score gets inserted into `scores`; the next query against the issues page recomputes the rollup. There is no "session aggregate" to invalidate.
+- **No write amplification.** The score-write hot path stays untouched. No additional consistency surface.
+- **Self-healing on reassign.** If we ever change `assignIssueIfUnowned` to allow reassignment, the rollup just changes on the next read. There is no derived state to fix up.
+
+**Cons:**
+- **Scan cost grows with score volume, not session count.** Every issues-page render groups across the full per-trace scores table. Today the page is already `count() GROUP BY issue_id` over `scores`; widening to `GROUP BY issue_id, session_id` then re-aggregating in TS adds one cardinality level. CH handles this well at small N but is the same cost class as today's existing per-issue scan.
+- **The "list of matching trace_ids per (session, issue)" needs to be carried through every read path.** Either via `groupArray(trace_id) GROUP BY issue_id, session_id` (one CH array column per row, fine up to a few hundred traces per group) or via a separate trace-list endpoint keyed by `(issueId, sessionId)`. We'd need both because the issues-page render wants a count + small sample, and the panel drill-in wants the full list.
+- **`affectedSessionsPercent` requires a second query.** Today `affectedTracesPercent` reuses `traceRepository.countByProjectId` as the denominator. The session analogue needs a `sessionRepository.countByProjectId` (which the sessions materialized view at `00007_sessions.sql` makes cheap, `uniqExact` over the agg state).
+
+### Option B: add a session-level issue rollup table
+
+Introduce a CH `session_issues` table (or an `AggregatingMergeTree` materialized view off `scores`) keyed by `(organization_id, project_id, session_id, issue_id)`.
+
+```sql
+CREATE TABLE session_issues
+(
+    organization_id LowCardinality(FixedString(24)),
+    project_id      LowCardinality(FixedString(24)),
+    session_id      String,
+    issue_id        FixedString(24),
+
+    occurrences     SimpleAggregateFunction(sum, UInt64),
+    trace_ids       AggregateFunction(groupUniqArray, FixedString(32)),
+    matching_traces AggregateFunction(uniqExact, FixedString(32)),
+    first_seen_at   SimpleAggregateFunction(min, DateTime64(3, 'UTC')),
+    last_seen_at    SimpleAggregateFunction(max, DateTime64(3, 'UTC')),
+
+    -- Severity / score rollup across the session for this issue
+    avg_value       AggregateFunction(avg, Float32),
+    failed_count    SimpleAggregateFunction(sum, UInt64),
+    errored_count   SimpleAggregateFunction(sum, UInt64)
+)
+ENGINE = ReplicatedAggregatingMergeTree
+PARTITION BY toYYYYMM(first_seen_at)
+PRIMARY KEY (organization_id, project_id)
+ORDER BY (organization_id, project_id, issue_id, session_id);
+
+CREATE MATERIALIZED VIEW session_issues_mv TO session_issues AS
+SELECT
+    organization_id,
+    project_id,
+    session_id,
+    issue_id,
+    count()                                AS occurrences,
+    groupUniqArrayState(trace_id)          AS trace_ids,
+    uniqExactState(trace_id)               AS matching_traces,
+    min(created_at)                        AS first_seen_at,
+    max(created_at)                        AS last_seen_at,
+    avgState(value)                        AS avg_value,
+    countIf(passed = false AND errored = false) AS failed_count,
+    countIf(errored = true)                AS errored_count
+FROM scores
+WHERE issue_id != ''
+GROUP BY organization_id, project_id, session_id, issue_id;
+```
+
+This mirrors the existing `sessions_mv` / `scores_hourly_buckets_mv` patterns (`00007_sessions.sql:45`, `00015_add_scores_hourly_buckets.sql:24`).
+
+**Pros:**
+- **Issues page reads become single-table point lookups** keyed on `(org, project, issue_id)` — same shape as `scores_hourly_buckets` for escalation. PRIMARY KEY in primary order on `issue_id` means filtering one issue's session rollups is a granule-scoped read regardless of total score volume.
+- **`uniqExact(session_id)` for `affectedSessionsPercent`** comes for free from the MV state without a `GROUP BY session_id` outer query.
+- **`trace_ids` array is materialized**, so the drill-in "show me the traces in this session that hit this issue" is one column read, no second query.
+
+**Cons:**
+- **MVs in CH are insert-time triggers — they don't replay history.** A backfill `INSERT ... SELECT FROM scores` pass is mandatory at rollout (same pattern as `00015_add_scores_hourly_buckets.sql:36-49`).
+- **Schema migration risk.** Adding a new table, an MV, and a backfill is more surface area to validate. The existing rollups have been hardened over time; a new one will surface its own corner cases.
+- **Single bucketing path.** Under the coalesce convention, every score row already carries a canonical `session_id` (real or `toString(trace_id)` for orphan traces), so the MV's `GROUP BY session_id, issue_id` covers every score with `issue_id != ''` without a UNION fallback. No second query path for un-sessioned scores.
+- **Late-arriving traces.** A trace whose `start_time` lands in an already-merged partition: CH handles this via background re-merge of `AggregatingMergeTree`, but for the duration of the lag the rollup is stale. Issues page values will under-count by one until the merge runs. The same lag exists for `sessions_mv` today — it's tolerable but explicit.
+- **Reassignment / deletion drift.** `assignIssueIfUnowned` is one-shot today, but `deleteScore` (`score-analytics-repository.ts:602`) does a `DELETE FROM scores WHERE id = ?` (lightweight mark). The MV does not receive deletions — once a row is in `session_issues`, it stays. We'd need a parallel delete path (rebuild on tombstone) to keep the rollup consistent with raw `scores`. This is the single largest correctness risk.
+- **Write amplification.** Score insert rate doubles in terms of CH writes (raw + MV). At Large/XL profiles this is non-trivial (see `trace-search.md` cost section for reference).
+
+### Hybrid: query-time dedup now, MV when the cost shows up
+
+Run the query-time approach for V1. The MV is a future optimization, **not** a correctness fix. The shape of the read API doesn't change between the two — both produce the same `SessionIssueRow` (defined below). If a tenant's issues-page latency starts hurting (proxy: the per-issue scan in `aggregateByIssues` crosses ~150ms at p95 on real workloads), we add the MV as a transparent backing store.
+
+## Display model
+
+A deduplicated session-issue row is the unit the issues page and the session-detail panel both read. Shape:
+
+```ts
+// packages/domain/issues/src/entities/session-issue.ts  (new)
+
+export interface SessionIssueRow {
+  // -- Identity ------------------------------------------------------------
+  readonly sessionId: SessionId
+  readonly issueId: IssueId
+
+  // -- Aggregates over the matching scores in this (session, issue) -------
+  readonly occurrences: number          // count(scores) in this group — the "5 turns" number
+  readonly firstSeenAt: Date            // min(scores.created_at)
+  readonly lastSeenAt: Date             // max(scores.created_at)
+  readonly avgValue: number             // avg(scores.value) — severity proxy
+  readonly failedCount: number          // countIf(passed = false AND errored = false)
+  readonly erroredCount: number         // countIf(errored = true)
+  readonly sources: readonly ScoreSource[] // groupUniqArray(source) — was this driven by evaluation, annotation, custom, or a mix?
+
+  // -- Drill-in payload ----------------------------------------------------
+  /**
+   * The set of `traceId`s in this session whose scores carry this `issue_id`.
+   * Bounded by per-session trace count (sessions are short; even a chatty
+   * conversation rarely exceeds a few hundred turns), so carrying the full
+   * list inline is cheaper than a second query. The UI uses `traceIds.length`
+   * to render "Issue seen on N turns" and the list itself to render the
+   * navigable trace strip inside the session panel.
+   */
+  readonly matchingTraceIds: readonly TraceId[]
+
+  /**
+   * `groupUniqArray(scores.id)` — pointers back to the individual scores so
+   * the annotation/score detail surfaces (drawer pop-out, dataset add) can
+   * round-trip from "this issue on this session" to the underlying score
+   * rows without a third query. Same cardinality bound as `matchingTraceIds`.
+   */
+  readonly contributingScoreIds: readonly ScoreId[]
+}
+```
+
+The "annotation provenance" question — which annotations across which traces back this row — is answered by `contributingScoreIds`. Every annotation lives on a score (`Score.metadata.rawFeedback` and `annotationAnchor` on the `AnnotationScore` shape, `packages/domain/scores/src/entities/score.ts:90`), so the score-id list is exactly the set of annotations spread across the matching traces. The panel renders them inline in its conversation tab the same way the trace-detail drawer already does, just unioned across multiple traces.
+
+### What the issues page row needs to change
+
+`IssueListItem` in `list-issues.ts:100-122` carries `occurrences` and `affectedTracesPercent`. We add two parallel session-aware counts and leave the per-trace numbers in place (they're still useful for "how many turn-instances are affected"):
+
+```ts
+// addition to IssueListItem (list-issues.ts:100)
+readonly distinctSessions: number              // uniqExact(session_id) — session_id is always non-empty under the coalesce convention
+readonly distinctTraces: number                // uniqExact(trace_id) — what affectedTracesPercent should have been
+readonly affectedSessionsPercent: number       // distinctSessions / totalSessions in the same window
+```
+
+The existing `occurrences` field's semantics get clarified in the comment ("count of scores attributed to this issue — counts every turn separately") to make the new fields' role obvious. The web UI table reads `distinctSessions` as the primary "impact" number going forward; `occurrences` is retained for the drill-in and for ordering ties.
+
+### What the session-detail panel renders
+
+Per `./6-session-panel.md` (item #7 in `0-problems.md`), the panel surfaces "issues associated to the session". The query is `listSessionIssues({ sessionId })` → `readonly SessionIssueRow[]`. Each row renders as:
+
+```
+[icon · issue.name]                 [severity dot · avgValue]
+issue.description — seen on N turns (range firstSeenAt … lastSeenAt)
+[avatar list of source kinds: evaluation / annotation / custom]
+```
+
+Clicking a row scopes the panel's conversation tab to the matching turns (`matchingTraceIds`) and routes annotation popovers to `contributingScoreIds`. Navigation across same-session issues is N/P over `SessionIssueRow[]`.
+
+## Recommended approach
+
+**Option A (query-time dedup), with a strict contract on the read API so we can swap in Option B's MV later without touching consumers.**
+
+### Why
+
+- **Issues are append-only via `assignIssueIfUnowned`** but **scores are not strictly append-only** (`deleteScore` exists). An MV that doesn't track deletes will drift; Option A is read-from-source-of-truth and self-heals.
+- **Late-arriving traces** are the explicit caveat in 0-problems.md item #2 (session end detection): until that lands, sessions can stay "open" for arbitrarily long, and any session-issue rollup must reflect occurrences materializing minutes/hours after the first one. Option A reflects them on the next read; Option B needs the merge to catch up, and we'd be debugging "the row says 4 turns but I see 5 in the panel" race conditions for the duration.
+- **Scan cost is already paid.** `listIssueWindowMetrics`, `aggregateByIssues`, and `listTracesByIssue` are already `GROUP BY` over `scores WHERE issue_id != ''`. The widening to `GROUP BY issue_id, session_id` is the same partition scan with one more grouping key — well under the threshold where an MV becomes worth its complexity.
+- **One read shape, two future implementations.** The repository port (defined below) gives us `listSessionIssuesByIssueId` / `listSessionIssuesBySessionId` as opaque calls. A later MV-backed implementation is a layer swap — same CH platform, no domain change. No consumers care about the storage shape.
+
+### Concrete changes
+
+**Read path. New repository methods on `ScoreAnalyticsRepository` (`packages/domain/scores/src/ports/score-analytics-repository.ts:191`):**
+
+```ts
+// shape returned to consumers
+readonly SessionIssueRow  // as defined above
+
+// list session-issue rollups for one issue (drives the drill-down on the
+// issues page when the user expands "5 affected sessions")
+listSessionIssuesByIssueId(input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly issueId: IssueId
+  readonly limit?: number
+  readonly offset?: number
+  readonly options?: ScoreAnalyticsOptions
+}): Effect.Effect<readonly SessionIssueRow[], RepositoryError, ChSqlClient>
+
+// list session-issue rollups for one session (drives the session-detail panel)
+listSessionIssuesBySessionId(input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly sessionId: SessionId
+  readonly options?: ScoreAnalyticsOptions
+}): Effect.Effect<readonly SessionIssueRow[], RepositoryError, ChSqlClient>
+
+// distinct-session counterpart to `listIssueWindowMetrics` (replaces the
+// per-trace `occurrences` numerator on the issues page)
+listIssueSessionWindowMetrics(input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly issueIds: readonly IssueId[]
+  readonly filters?: FilterSet
+  readonly timeRange?: ScoreAnalyticsTimeRange
+  readonly options?: ScoreAnalyticsOptions
+}): Effect.Effect<readonly IssueSessionWindowMetric[], RepositoryError, ChSqlClient>
+```
+
+with
+
+```ts
+export interface IssueSessionWindowMetric {
+  readonly issueId: IssueId
+  readonly distinctSessions: number   // uniqExact(session_id) — always non-empty under the coalesce convention
+  readonly distinctTraces: number     // uniqExact(trace_id)
+  readonly occurrences: number        // count() — preserved for tie-breakers
+  readonly firstSeenAt: Date
+  readonly lastSeenAt: Date
+}
+```
+
+**CH implementation** for `listSessionIssuesByIssueId` (`packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts` — adjacent to `listTracesByIssue` at `:1291`):
+
+```sql
+SELECT
+  session_id,
+  count()                                AS occurrences,
+  uniqExact(trace_id)                    AS distinct_traces,
+  groupUniqArray(trace_id)               AS trace_ids,
+  groupUniqArray(id)                     AS contributing_score_ids,
+  min(created_at)                        AS first_seen_at,
+  max(created_at)                        AS last_seen_at,
+  avg(value)                             AS avg_value,
+  countIf(passed = false AND errored = false) AS failed_count,
+  countIf(errored = true)                AS errored_count,
+  groupUniqArray(source)                 AS sources
+FROM scores
+WHERE organization_id = {organizationId:String}
+  AND project_id = {projectId:String}
+  AND issue_id = {issueId:FixedString(24)}
+GROUP BY session_id
+ORDER BY last_seen_at DESC, session_id DESC
+LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+```
+
+The `(issue_id, session_id)` predicate hits the `idx_issue_id` and `idx_session_id` bloom filters on `scores` (`00006_create_scores.sql:31,34`), so the read is granule-bounded.
+
+No UNION fallback for un-sessioned scores: under the coalesce convention (`./1-parity-traces-sessions.md`), every score row already carries a canonical `session_id` — real for tagged traces, `toString(trace_id)` for orphan traces. Both group cleanly under `GROUP BY session_id`. The UI distinguishes orphan-trace session rows by the visual signature documented in `0-problems.md` (zero tokens, empty models, `trace_count = 1` on the joined session row), not by a sentinel session_id.
+
+**Issues page integration.** `listIssuesUseCase` (`list-issues.ts:486`) calls `listIssueSessionWindowMetrics` alongside `listIssueWindowMetrics` and exposes both `occurrences` (preserved) and `distinctSessions` (new). `affectedTracesPercent`'s denominator stays `traceRepository.countByProjectId` and gains a sibling `affectedSessionsPercent` whose denominator is `sessionRepository.countByProjectId` (cheap — backed by `sessions_mv` at `00007_sessions.sql:45`). The web view (`apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx:22`) gains a column toggle `affectedSessions` and surfaces it next to `affectedTraces`.
+
+**Issue-detail drawer integration.** `useIssueTracesInfiniteScroll` (`issue-detail-drawer.tsx:170`) stays, but the **default grouping** in the traces table becomes "by session": rows collapse by `sessionId`, expand-on-click to reveal `matchingTraceIds`. The flat list remains accessible behind a toggle for power users who want the per-turn view. Wire-up:
+
+- New endpoint `listIssueSessions` (server fn at `apps/web/src/domains/issues/issues.functions.ts`, sibling of `listIssueTraces` at `:504`) calling `listSessionIssuesByIssueId`. Returns paginated `SessionIssueRow[]`.
+- `issue-detail-drawer.tsx` swaps the inner table to a sectioned list: outer level is sessions, inner level (lazy-loaded on expand from `matchingTraceIds`) is the existing `ProjectTracesTable`. The trace overlay (`:637-676`) is unchanged.
+
+**Session-detail panel integration** (`./6-session-panel.md`). The panel's "issues" tab calls `listSessionIssuesBySessionId`. Each row renders as described in **Display model** above.
+
+### Why not a derived "session-issue" entity in Postgres
+
+We considered a new Postgres `session_issues` table joining `sessions ↔ issues`. Rejected because:
+
+- It would need to be kept in sync with CH-side score writes. Every issue assignment crosses the PG↔CH boundary (issue identity in PG, score row in CH); adding a PG row that mirrors a CH state guarantees drift.
+- The lifecycle of a session-issue is the lifecycle of its underlying scores — there is no PG-side state to persist that isn't already in scores or issues.
+- The MV path (Option B) is the right escape hatch if read cost ever justifies materializing this; layering a PG table on top of an already-rich PG `issues` row + CH `scores` table would be net negative.
+
+## Migration / backfill
+
+**Zero schema changes are required for V1** under the recommended Option A. Existing `scores.session_id` rows already have everything needed:
+
+- **Read path.** Deploy the new repository methods and the `listSessionIssues*` server functions. Update the issues page + issue-detail drawer in the same release to consume `distinctSessions` and the session-grouped trace list.
+- **Backfill data.** Not needed. The `scores` table holds historical `(session_id, issue_id)` pairs going back to issue-discovery rollout. The first read of `listSessionIssuesByIssueId` for any historical issue produces correct numbers from raw history.
+- **Backfill UI state.** Saved sorts, saved filters, and any persisted column visibility may still reference `occurrences` / `affectedTraces`. Leave both fields in place; do not rename. The new `distinctSessions` / `affectedSessions` are additive. Web column registry update in `issues-view.tsx:22` adds the new column with default visibility `false` for existing tenants and `true` for new ones (introduced as a feature-flag-gated default; flips on for everyone after a week of bake time).
+- **CH-side state.** Bloom filters on `session_id` and `issue_id` (`00006_create_scores.sql:31-34`) are already in place — no index changes.
+
+**If we later adopt Option B (MV-backed):**
+
+1. Goose migration: create `session_issues` table + `session_issues_mv` (insert-time trigger).
+2. Goose migration body, in a single transaction: `INSERT INTO session_issues SELECT ... FROM scores WHERE issue_id != '' GROUP BY (org, project, session_id, issue_id)`. Same shape as the `scores_hourly_buckets` backfill at `00015_add_scores_hourly_buckets.sql:36-49`. No `session_id != ''` clause needed — every score row carries a canonical session_id under the coalesce convention.
+3. Switch `ScoreAnalyticsRepositoryLive` for `listSessionIssues*` to read from `session_issues`. Domain/UI unaffected because the repository contract is unchanged.
+4. Wire a tombstone path for `deleteScore` so the MV stays consistent: emit a delete event, and on consumption issue `ALTER TABLE session_issues DELETE WHERE ...`. Or accept that `deleteScore` is rare (admin tool only — confirmed by its absence from the public API) and tolerate eventual recompute via a daily rebuild job. The latter is simpler and matches how `sessions_mv` handles late corrections.
+
+## Interactions with the system-queues design principle
+
+Latitude's broader design principle for system-emitted annotation queues
+draws a sharp line between two kinds of signals:
+
+- **Discrete failure modes** that cluster meaningfully in issue discovery
+  (embeddings + BM25 over LLM-drafted feedback text). These belong in
+  `scores` and surface as issues.
+- **Continuous statistical signals** like latency, cost, or token outliers.
+  These do NOT belong in `scores` and do NOT get an `issue_id`. They
+  surface through `TraceCohort*` infrastructure
+  (`@domain/spans/trace-cohorts.ts`) and the traces UI filters instead —
+  "the unit should be 'new performance regression detected', not 'this
+  individual trace exceeded p99'."
+
+This dedup spec does not change that boundary. Specifically:
+
+- **Everything that ends up in `scores.issue_id`** is, by construction, a discrete failure-mode signal — the eligibility gate (`check-eligibility.ts`) excludes statistical signals from ever being assigned an `issue_id`. So the dedup key `(issue_id, session_id)` operates entirely on the "failure modes" half of the boundary, which is what the principle says belongs there.
+- **Outliers and other continuous signals** surface through `TraceCohort*` infrastructure and the traces UI filters. **Those signals are not deduped by this spec**, and they don't need to be — there is no notion of "session-level outlier" in the cohort model; a cohort is "the set of traces matching a predicate", and grouping by `sessionId` inside a cohort is already a filter operation, not a dedup.
+- **If we ever revisit "outliers as issues"** (the principle leaves this open: the unit should be "new performance regression detected", not "this individual trace exceeded p99"), the new failure-mode flagger would write a normal annotation score with `source = "annotation"`, `sourceId = "SYSTEM"`. That score gets an `issue_id` via discovery and inherits the `(issue_id, session_id)` dedup for free. No additional design surface needed.
+
+The dedup design therefore **reinforces** the system-queues design principle: it makes the per-session-row UI consequence of the "failure modes only" rule concrete (one row per session per failure-mode kind), and it explicitly does not extend rollup machinery to the cohort/outliers side where the rule says rollup is the wrong shape.
+
+## Files this will touch
+
+### Domain layer
+- `packages/domain/scores/src/ports/score-analytics-repository.ts` — add `listSessionIssuesByIssueId`, `listSessionIssuesBySessionId`, `listIssueSessionWindowMetrics`; add `SessionIssueRow`, `IssueSessionWindowMetric` types.
+- `packages/domain/scores/src/testing/fake-score-analytics-repository.ts` — implement new methods over the in-memory score store for unit tests.
+- `packages/domain/issues/src/use-cases/list-issues.ts` — fold `listIssueSessionWindowMetrics` into the candidate pipeline (`:486` siblings); extend `IssueListItem` with `distinctSessions`, `distinctTraces`, `affectedSessionsPercent`.
+- `packages/domain/issues/src/use-cases/list-issue-traces.ts` — keep as the "flat per-trace" read; add `list-issue-sessions.ts` as the new session-grouped reader.
+- `packages/domain/issues/src/use-cases/list-issue-sessions.ts` — new use-case wrapping `listSessionIssuesByIssueId`.
+- `packages/domain/issues/src/use-cases/list-session-issues.ts` — new use-case for the session-panel side, wrapping `listSessionIssuesBySessionId`.
+
+### Platform layer
+- `packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts` — implement the three new methods. Adjacent to `listTracesByIssue` at `:1291`. Reuse `scopeClause` / `scopeParams` (`:75`, `:78`) and `buildIssueAnalyticsWhere` (`:571`).
+- `packages/platform/db-clickhouse/src/repositories/score-repository.ts` (write path) — at score insertion, populate `session_id` via `coalesce(nullIf(traces.session_id, ''), toString(traces.trace_id))` rather than reading the per-span value. The score's session attribution becomes the canonical session_id of the trace it scores, matching `sessions_mv`'s grouping expression. This is what guarantees the dedup `GROUP BY session_id` never sees empty buckets. Open question: do we resolve this at score-write time (read `traces` for each score insert) or backfill the canonical session_id at the next aggregation? Current recommendation: resolve at write time after `trace-end:run` fires, when the trace's `argMaxIfMerge(session_id)` is stable.
+- No schema migration. No `clickhouse/migrations/...` files change.
+
+### Web layer
+- `apps/web/src/domains/issues/issues.functions.ts` — add `listIssueSessions` and `countIssueSessions` server fns (siblings of `listIssueTraces` at `:504`); plumb `distinctSessions` / `affectedSessionsPercent` into `IssueRecord` (`:72-93`).
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx` — add `affectedSessions` column option (`:22`).
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx` — section the inner traces table by session (`:540`), add expand/collapse, lazy-load matching traces per row.
+- `apps/web/src/domains/issues/issues.collection.ts` — `useIssueSessionsInfiniteScroll` and `useIssueSessionsCount` hooks (mirrors `useIssueTracesInfiniteScroll` / `useIssueTracesCount` used at `issue-detail-drawer.tsx:170,187`).
+
+### Session panel (cross-references `./6-session-panel.md`)
+- `packages/domain/sessions/src/use-cases/list-session-issues.ts` (or wherever the session-panel use-cases land) — wrapper around `listSessionIssuesBySessionId`.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/sessions/-components/session-detail-drawer.tsx` — render `SessionIssueRow[]` as the panel's issues tab.
+
+## Open questions
+
+- **Tie-breaking when `lastSeenAt` is equal across multiple sessions for the same issue.** Order by `(lastSeenAt DESC, session_id DESC)` falls out of the query naturally and is stable, but the UI may want richer ordering (severity? source mix?). Punt to v2; if a user reports the order feels arbitrary, revisit.
+- **What's the right denominator for `affectedSessionsPercent` when the user has a time range applied?** Today `traceRepository.countByProjectId({ filters: { startTime: [...] } })` is the denominator for `affectedTracesPercent` (`list-issues.ts:519-524`). The session analogue needs `sessionRepository.countByProjectId({ filters: { minStartTime: [...] } })`. The sessions MV (`00007_sessions.sql:38`) has the `idx_start_time` minmax index, so it's cheap. Confirm the filter shape matches the time-range semantics already in use elsewhere.
+- **`matchingTraceIds` cardinality cap.** A session with thousands of turns (long-running agent) hitting the same issue would balloon `matchingTraceIds`. Cap at e.g. 200 with `arraySlice(groupUniqArray(trace_id), 1, 200)` and expose a separate paginated `listMatchingTraces({ sessionId, issueId, limit, offset })` reader for the rare overflow. Implementer decision; no consumer cares about the full list when N > 50.
+- **Where does session-level lifecycle live?** A user might want to "ignore this issue, but only for this session" — analogous to suppressing a Datadog monitor for a single host. Not addressed here. If we add this, the natural shape is a Postgres `session_issue_overrides` table keyed on `(sessionId, issueId)`, joined in by `listSessionIssues*`. Today the issue-level `ignoredAt` / `resolvedAt` apply globally and that's the only granularity.
+- **Reassignment / merge.** Issue merge (combining two clustering misses) is a future feature. When it lands, the dedup key `(issue_id, session_id)` follows the canonical issue id post-merge — but the historical session-issue rows under the deprecated id need to redirect. Easiest: rewrite `scores.issue_id` during merge (a `UPDATE` via `ALTER TABLE scores UPDATE issue_id = ...` — heavy but rare) and let the next read recompute. Note this is out of scope; flag it now so the dedup-key choice doesn't paint us into a corner later. It doesn't — Option A re-reads from raw scores; Option B's MV needs a rebuild path for merges, which is the same correctness surface as the delete-tombstone path above.
+- **Should `errored` scores ever surface as session-issues?** Today they're filtered out of issue assignment entirely (`check-eligibility.ts:49`). If the "runtime errors" stream (raised in 0-problems.md item #4's "evaluator failures" mention) ever becomes a first-class issue source, its dedup shape is identical to this spec — same key, same shape. No spec-level change needed; just unblock the eligibility gate when the upstream feature lands.

--- a/specs/session-problems/4-filter-parity.md
+++ b/specs/session-problems/4-filter-parity.md
@@ -1,0 +1,577 @@
+# Filter parity between sessions and traces
+
+## Goal
+
+Sessions list, count, and metrics endpoints accept a `FilterSet`. Today the set
+of fields they recognize is a strict subset of what the traces endpoints
+recognize: `getTextFieldsForMode("sessions")` at
+`apps/web/src/components/filters-builder/constants.ts:37` actively strips
+`name` and `traceId`, and the underlying `SESSION_FIELD_REGISTRY`
+(`packages/platform/db-clickhouse/src/registries/session-fields.ts:4`) is
+missing trace-level columns the trace registry has — most visibly
+`status`, `name`, `traceId`, and `ttft`.
+
+This spec audits every filter exposed on traces, decides for each one whether
+sessions need a counterpart and (where the trace value is per-trace but a
+session contains many traces) which "any / all / first" semantic the session
+counterpart adopts. It builds on the materialization parity proposed in
+`./1-parity-traces-sessions.md` — wherever a session column lands as part of
+that spec, this one wires it into the filter pipeline.
+
+The trace-side `status` filter is currently broken (it references
+`overall_status`, which was dropped in
+`…/00005_drop_overall_status.sql` — confirmed by the schema dump at
+`packages/platform/testkit/src/clickhouse/schema.sql:235-270` having no such
+column). The fix is in scope here: define a synthetic `status` derived from
+`error_count`, applied identically on both sides.
+
+## Source of truth
+
+Both filter pipelines flow through the same boundary:
+
+| Layer | File |
+|---|---|
+| UI filter field catalog | `packages/domain/shared/src/trace-filter-fields.ts:12` |
+| `FilterSet` shape & operator zod schema | `packages/domain/shared/src/filter.ts:32` |
+| ClickHouse generic WHERE/HAVING builder | `packages/platform/db-clickhouse/src/filter-builder.ts:55` |
+| Trace field → CH column registry | `packages/platform/db-clickhouse/src/registries/trace-fields.ts:7` |
+| Session field → CH column registry | `packages/platform/db-clickhouse/src/registries/session-fields.ts:4` |
+| Score-scoped filters (cross-cutting) | `packages/platform/db-clickhouse/src/score-filter-subquery.ts:11` |
+| Trace filter clause assembly | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:553` (`buildTraceFilterClauses`) |
+| Session filter clause assembly | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:170` (`buildSessionFilterClauses`) |
+| Trace listing read path | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:948` (`listByProjectId`) |
+| Session listing read path | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:206` (`listByProjectId`) |
+| Filter sidebar (UI, both modes) | `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx:351` |
+| `getTextFieldsForMode` (UI mode gate) | `apps/web/src/components/filters-builder/constants.ts:37` |
+| Multi-select adapter (per mode) | `apps/web/src/components/filters-builder/multi-select-filter.tsx:42` |
+| Percentile filter resolver (trace-only today) | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:700` (`resolvePercentileFilters`) |
+
+The shared filter shape is the same. The operator set is the same
+(`FILTER_OPERATORS` at `filter.ts:7`). The clause builder is the same
+(`buildClickHouseWhere`). What differs is the per-table column registry and
+the listing path's surrounding query — `traces` uses an inner per-trace
+`GROUP BY trace_id`, `sessions` uses an inner per-session `GROUP BY
+session_id`. Both apply user filters as `HAVING` clauses on the merged
+aggregates the `LIST_SELECT` projects.
+
+## Current trace filters
+
+Pulled from `TRACE_FILTER_FIELDS`
+(`packages/domain/shared/src/trace-filter-fields.ts:12`) and the trace-side
+registry (`packages/platform/db-clickhouse/src/registries/trace-fields.ts:7`).
+
+| Filter | Type | UI control | Operators it accepts (via op support) | Trace CH column | Trace MV provenance |
+|---|---|---|---|---|---|
+| `status` | `status` (enum) | enum chip | `in`, `notIn`, `eq`, `neq` via `mapStatusValue` | `overall_status` (**broken**, column dropped) | Was a derived span-level rollup; replaced by `error_count` signal. |
+| `name` | `text` | contains-input | `contains`, `notContains`, `eq`, `neq` | `root_span_name` | `argMinIf(name, start_time, parent_span_id = '')` — name of the earliest parentless span in the trace. |
+| `traceId` | `text` | contains-input | `contains`, `notContains`, `eq`, `neq`, `in`, `notIn` | `trace_id` | `GROUP BY` key. |
+| `sessionId` | `text` | contains-input | same as traceId | `session_id` (alias from `argMaxIfMerge(session_id)` in `LIST_SELECT`) | `argMaxIfState(session_id, start_time, session_id != '')`. |
+| `simulationId` | `text` | contains-input | same | `simulation_id` (`argMaxIfMerge`) | `argMaxIfState(simulation_id, start_time, simulation_id != '')`. |
+| `userId` | `text` | contains-input | same | `user_id` (`argMaxIfMerge`) | `argMaxIfState(user_id, start_time, user_id != '')`. |
+| `tags` | `multiSelect` | combobox + `hasAny` | `in`, `notIn` | `tags` (array) | `groupUniqArrayArray(tags)` — union across spans. |
+| `models` | `multiSelect` | combobox + `hasAny` | `in`, `notIn` | `models` (array, `groupUniqArrayIfMerge`) | Union of distinct models. |
+| `providers` | `multiSelect` | combobox + `hasAny` | `in`, `notIn` | `providers` (array, `groupUniqArrayIfMerge`) | Union of distinct providers. |
+| `serviceNames` | `multiSelect` | combobox + `hasAny` | `in`, `notIn` | `service_names` (array, `groupUniqArrayIfMerge`) | Union of distinct service names. |
+| `duration` | `numberRange` (percentile) | min/max + percentile tabs | `gt/gte/lt/lte`, `gtePercentile` | `duration_ns` (`Int64 ALIAS`) | `max(end_time) - min(start_time)` — wall clock. |
+| `ttft` | `numberRange` (percentile) | min/max + percentile tabs | same + `gtePercentile` | `time_to_first_token_ns` (`Int64 ALIAS`) | Min first-token instant across spans, minus min start_time. |
+| `cost` | `numberRange` (percentile) | same | same + `gtePercentile` | `cost_total_microcents` | `sum(cost_total_microcents)`. |
+| `spanCount` | `numberRange` | min/max | `gt/gte/lt/lte` | `span_count` | `count()` across spans. |
+| `errorCount` | `numberRange` | min/max | same | `error_count` | `countIf(status_code = 2)`. |
+| `tokensInput` | `numberRange` | min/max | same | `tokens_input` | `sum(tokens_input)`. |
+| `tokensOutput` | `numberRange` | min/max | same | `tokens_output` | `sum(tokens_output)`. |
+| `startTime` (internal) | injected as range | not a UI chip — used by histogram window merge in `helpers.ts:115` | `gte`, `lte` | `start_time` (the `min(min_start_time)` alias from `LIST_SELECT`) | `min(start_time)`. |
+| `metadata.<path>` | `text`-like | metadata sidebar | `eq`/`neq`/`in`/`notIn`/`contains`/`notContains` via `buildMetadataClause` | `metadata[<key>]` via `Map(String, String)` | `maxMap(metadata)`. Cross-cutting (filter-builder.ts:69), works on both tables for free. |
+| `score.passed` | (boolean, cross-cutting) | not a typed UI field — flows via `score.*` keys | scalar ops | `passed` column on `scores`, joined via `buildScoreRollupSubquery` | Per-score evaluation; see `SCORE_FIELD_REGISTRY` at `packages/platform/db-clickhouse/src/registries/score-fields.ts:11`. |
+| `score.errored`, `score.value`, `score.source`, `score.sourceId`, `score.issueId`, `score.simulationId` | (cross-cutting) | not first-class UI fields | scalar ops | see `SCORE_FIELD_REGISTRY` | Filters the score sidecar table; subquery joins on `trace_id` / `session_id`. |
+
+Notes:
+
+- The `status` row is **broken on traces today**. `mapStatusValue`
+  (`packages/platform/db-clickhouse/src/registries/helpers.ts:21`) still
+  maps `"ok"/"error"/"unset"` to ints, and the registry still names
+  `overall_status`, but no such column exists post-`…/00005`. A query
+  referencing this filter fails at execution time. The fix lives in this
+  spec rather than in 1-parity-traces-sessions.md because it's a filter
+  surface, not a materialization gap.
+- `metadata.<path>` and `score.*` already work on both tables — they're
+  cross-cutting in `buildClickHouseWhere` / `buildScoreRollupSubquery`. No
+  per-table registry entry needed.
+
+## Current session filters
+
+Pulled from `SESSION_FIELD_REGISTRY`
+(`packages/platform/db-clickhouse/src/registries/session-fields.ts:4`).
+
+| Filter | Type | UI control | CH column | Notes |
+|---|---|---|---|---|
+| `sessionId` | `text` | contains-input | `session_id` (`GROUP BY` key) | Direct. |
+| `simulationId` | `text` | contains-input | `simulation_id` (`argMaxIfMerge`) | Same shape as traces. |
+| `userId` | `text` | contains-input | `user_id` (`argMaxIfMerge`) | Same shape as traces. |
+| `tags` | `multiSelect` | combobox + `hasAny` | `tags` (array, `groupUniqArrayArray`) | Union across the session's spans. |
+| `models` | `multiSelect` | combobox + `hasAny` | `models` (array, `groupUniqArrayIfMerge`) | Union across the session's spans. |
+| `providers` | `multiSelect` | combobox + `hasAny` | `providers` (array, `groupUniqArrayIfMerge`) | Union across the session's spans. |
+| `serviceNames` | `multiSelect` | combobox + `hasAny` | `service_names` (array, `groupUniqArrayIfMerge`) | Union across the session's spans. |
+| `duration` | `numberRange` | min/max | `duration_ns` (real column after `./1-parity-traces-sessions.md` lands; ALIAS today) | **Active execution time** — sum of per-trace root-span durations, NOT wall-clock. See "On `duration_ns` semantics" in `./1-parity-traces-sessions.md`. No percentile support today (no `getDistribution` analog on sessions). |
+| `cost` | `numberRange` | min/max | `cost_total_microcents` | No percentile support today. |
+| `spanCount` | `numberRange` | min/max | `span_count` | Sum across spans. |
+| `errorCount` | `numberRange` | min/max | `error_count` | Sum across spans. |
+| `traceCount` | `numberRange` | min/max | `trace_count` | Session-specific — no trace counterpart. |
+| `tokensInput`, `tokensOutput` | `numberRange` | min/max | `tokens_input`, `tokens_output` | Direct. |
+| `startTime` (internal) | range | injected by histogram merge | `start_time` alias from `min(min_start_time)` | Same shape as traces. |
+| `metadata.<path>` | (cross-cutting) | metadata sidebar | `metadata[<key>]` | Works for free via `buildClickHouseWhere`. |
+| `score.passed` etc. | (cross-cutting) | n/a — programmatic | scores subquery | Works for free via `buildScoreRollupSubquery("session_id", …)`. |
+
+Sessions accept the same `FilterSet` shape and the same operator set; the UI
+just doesn't surface a chip for fields the registry doesn't know about. An
+attacker (or buggy client) that sends `{ traceId: [...] }` to
+`listSessionsByProject` today gets the field silently dropped by
+`buildClickHouseWhere` (registry miss path, `filter-builder.ts:91`).
+
+## Gap table
+
+Each row picks an "any / all / first" semantic for the session counterpart.
+The choice is forced by what the session MV can express **without
+re-grouping by trace_id at MV time**: the `sessions_mv` groups by
+`session_id`, so columns that fold spans (`sum`, `count`, `max`, `min`,
+`groupUniqArrayIfState`, `argMaxIfState`, `argMinIfState`) naturally collapse
+to a session value. Per-trace-then-rolled-up semantics need a read-path CTE
+joining `sessions.trace_ids` against `traces.<column>`.
+
+| Trace filter | Session today | Status | Proposed semantic (one of any / all / first / aggregate) | Backing session column | Index implications |
+|---|---|---|---|---|---|
+| `status` | MISSING | **MISSING (and broken on traces)** | **Aggregate**. Synthetic across both tables. Map `status = "error"` → `error_count > 0`, `status = "ok"` → `error_count = 0 AND span_count > 0`, `status = "unset"` → `span_count = 0` (effectively unreachable on sessions since `sessions_mv` filters `session_id != ''`; reachable on traces if all spans had `status_code = 0`). Documented in "Status filter" below. | `error_count` and `span_count` — already on both tables. | None. Both columns already in `LIST_SELECT` aliases; `error_count` is a sum, HAVING-side. |
+| `name` | MISSING | **MISSING — adds when materialization parity lands** | **First-trace**. Session's `root_span_name` is `argMinIfState(name, start_time, parent_span_id = '')` — the root span of the **first** trace, per `./1-parity-traces-sessions.md`. Filter behaves as "first trace's name matches X". | `root_span_name` (added by parity migration `00016_session_parity.sql`). | None at filter time — `root_span_name` is finalized in `LIST_SELECT` via `argMinIfMerge`, then HAVING uses the alias. No skip index needed; the cardinality of distinct root-span-names per project is low. |
+| `traceId` | MISSING | **MISSING — semantic discussed below** | **Any-trace**. Session contains the queried `trace_id` if it appears anywhere in `trace_ids`. SQL: `has(trace_ids, {traceId:FixedString(32)})` for `eq`, `hasAny(trace_ids, ...)` for `in`. | `trace_ids` (existing — `AggregateFunction(groupUniqArray, FixedString(32))`, finalized via `groupUniqArrayMerge` in `LIST_SELECT`). | Not adding an index. `trace_ids` is already pulled in `LIST_SELECT`; the HAVING-side `has(...)` runs after the per-session aggregation. The reads are bounded by `(organization_id, project_id)` primary-key range, so we accept the linear scan in the aggregate-then-filter shape we use for everything else. See "Why no skip index for `trace_ids`" below. |
+| `sessionId` | PRESENT | OK | Identity — `GROUP BY` key. | `session_id`. | n/a. |
+| `simulationId` | PRESENT | OK | Last-non-empty (same `argMaxIfState` shape as traces, where the trace took the latest one). | `simulation_id`. | n/a — already a session column. |
+| `userId` | PRESENT | OK | Last-non-empty. Same `argMaxIfState` shape as traces. | `user_id`. | n/a. |
+| `tags` | PRESENT | OK | **Any** (current). Session's `tags` is the union across spans; `hasAny(tags, X)` returns true if any span has any of `X`. | `tags`. | n/a — existing. |
+| `models` | PRESENT | OK | **Any**. Same as tags. | `models`. | n/a. |
+| `providers` | PRESENT | OK | **Any**. | `providers`. | n/a. |
+| `serviceNames` | PRESENT | OK | **Any**. | `service_names`. | n/a. |
+| `duration` | PRESENT | **SEMANTIC CHANGE** | **Aggregate** (active execution time — sum of per-trace root-span durations). Read-side numeric range works on `sum(duration_ns)` after the column becomes a real `SimpleAggregateFunction` per `./1-parity-traces-sessions.md`. Old wall-clock behavior is replaced. | `duration_ns` (real column after parity spec; ALIAS today). | n/a. |
+| `ttft` | MISSING | **MISSING — adds when materialization parity lands** | **Aggregate** (session-opening TTFT). Per `./1-parity-traces-sessions.md`: `min(time_of_first_token) − min(min_start_time)` — the gap from session start to the earliest first token across the session's traces. Same shape as the trace TTFT filter. | `time_to_first_token_ns` (ALIAS, added by parity migration). | n/a. |
+| `cost` | PRESENT | OK | **Aggregate** (sum). | `cost_total_microcents`. | n/a. |
+| `spanCount` | PRESENT | OK | **Aggregate** (sum across all spans in all the session's traces). | `span_count`. | n/a. |
+| `errorCount` | PRESENT | OK | **Aggregate** (sum). Note: a session with three traces, one erroring with 2 error spans, exposes `errorCount = 2`. | `error_count`. | n/a. |
+| `tokensInput` | PRESENT | OK | **Aggregate** (sum). | `tokens_input`. | n/a. |
+| `tokensOutput` | PRESENT | OK | **Aggregate** (sum). | `tokens_output`. | n/a. |
+| `startTime` (internal) | PRESENT | OK | **Aggregate** (`min(min_start_time)` — earliest activity). Same semantic as `traces.startTime`. | alias from `min(min_start_time)`. | Both tables carry an `idx_start_time` `minmax` skip index on `min_start_time` (`schema.sql:86` for sessions, `:270` for traces) so the range pruning works identically. |
+| `metadata.<path>` | (cross-cutting, present) | OK | **Aggregate (per-key max)** — `maxMap(metadata)` is the union with per-key max-wins on conflict. Filter compares `metadata[<key>]` against the value. | `metadata` (Map). | n/a. |
+| `score.*` | (cross-cutting, present) | OK | **Any-score**. `buildScoreRollupSubquery("session_id", …)` returns the set of `session_id`s that have at least one matching score row. `IN (...)` semantics → any score on any of the session's traces matching the predicate keeps the session in. | `scores.session_id`. | n/a — already exists. |
+
+### Trace filters intentionally not mirrored
+
+None. Every trace filter has a session counterpart in the table above. The
+two judgment calls worth flagging:
+
+- `traceId` could have been "INTENTIONALLY SKIPPED" on the grounds that the
+  user can already pivot from a trace to its session via the session column
+  in the trace list. We mirror it anyway because workflows like "find the
+  session that contained this specific trace id" come up in incident
+  response. Cost is low (one column already projected, one `has()`).
+- `name` could have been "INTENTIONALLY SKIPPED" on the grounds that a
+  session contains traces with multiple names. We mirror it as a
+  first-trace-name filter because (a) the UI session card already labels
+  the session by the first trace's root span name in
+  `./1-parity-traces-sessions.md`, and (b) `argMinIf` on `parent_span_id = ''`
+  costs the same one MV column we already added for the panel header.
+
+### Session-specific filters with no trace counterpart
+
+- `traceCount` (`packages/platform/db-clickhouse/src/registries/session-fields.ts:16`)
+  — a session can have multiple traces. A trace has one trace_id by
+  definition. Stays session-only.
+
+## Cross-cutting decisions — defaults by filter type
+
+Future filters will land in one of these categories. To avoid re-deciding
+"any / all / first / aggregate" per filter, this table records the default
+each type adopts. Deviations require justification in the per-filter row.
+
+| Filter type | Default session semantic | Justification | Existing examples |
+|---|---|---|---|
+| **`numberRange` over a sum-able quantity** (`cost`, `tokens*`, `spanCount`, `errorCount`) | **Aggregate (sum across all spans in all the session's traces)** | The MV already aggregates these as `sum()`. The session row's value *is* the aggregate. The user mental model — "sessions where total cost > $X" — matches the sum. No alternative is expressible at MV time without re-grouping. | `cost`, `tokens*`, `spanCount`, `errorCount`. |
+| **`numberRange` over an aggregate or min-instant field** (`duration`, `ttft`, `startTime`) | **Aggregate (sum-of-trace-durations or min-instant per field)** | `duration` is the **sum of per-trace active execution times** (see `./1-parity-traces-sessions.md`, "On `duration_ns` semantics") — it answers "how busy was this session". `ttft` is the earliest first-token-minus-start across the session's traces. `startTime` is `min(start_time)`. All three are existing aggregate definitions; the numeric range works against them as-is. | `duration`, `ttft`, `startTime`. |
+| **`multiSelect` over a span-level dimension** (`tags`, `models`, `providers`, `serviceNames`) | **Any (`hasAny`)** | The MV stores the **union** of values across spans (`groupUniqArrayIf*`), and `hasAny` over the union answers "did any span in this session have any of these values". "All" would require `hasAll` and a flipped mental model the UI doesn't communicate; "first" would require a separate `argMinIf*` column per dimension. Default = any. | All current multiSelect session filters use `hasAny` via `buildClause` at `filter-builder.ts:115`. |
+| **`text` over a per-trace string** (`name`) | **First-trace value** | The session row carries one canonical "primary trace name" — the root span of the earliest trace. That value drives the session card label, so the filter applies to the same thing the user sees on the card. "Any-trace name contains" would need a `groupUniqArrayIf` column on names; we don't add one without a use case. | `name` (after parity). |
+| **`text` over an identifier-set** (`traceId`) | **Any (the set contains)** | A session's set of trace ids is its identity for cross-referencing. "All trace ids contain X" is meaningless; "first trace id contains X" is only useful if the user knows trace ordering, which they don't from the URL bar. Any-trace-id-matches is the natural identity check. | `traceId` (after this spec). |
+| **`text` over a last-known scalar** (`userId`, `simulationId`, `sessionId`) | **Last-non-empty (the existing `argMaxIfState`)** | Same shape on both tables. Users associate a session with a user; the latest non-empty `user_id` reads as "who this session ended up belonging to". | `userId`, `simulationId`. |
+| **`status`** (synthetic enum) | **Aggregate from `error_count` / `span_count`** | A session is "error" if any of its spans errored. Mirrors the trace-side fix. | New, see below. |
+| **`gtePercentile`** | **Project-scoped percentile of the session distribution, with the same `ignoreZeros` rule as traces for TTFT** | Same shape as the existing trace path. Read-side resolver lives in the session repo, structurally identical to `resolvePercentileFilters` at `trace-repository.ts:700`. | Adds with this spec. |
+| **`score.*`** | **Any-score (subquery returns matching `session_id` set)** | Already implemented; the existing `buildScoreRollupSubquery("session_id", …)` is exactly "any score on this session matches". | Existing. |
+
+The pattern that falls out: **default to "any" for span-level dimensions,
+"first" for trace-level string identifiers exposed on the card, "aggregate"
+for everything numeric**. "All" doesn't appear as a default for anything,
+which matches user intent in every observed workflow.
+
+## Default "has LLM activity" chip (orphan-fragment hider)
+
+The coalesce convention in `./1-parity-traces-sessions.md` means every trace
+shows up as a session. For customers using the Latitude SDK with proper
+`gen_ai.conversation.id` propagation, this just works — every conversational
+trace forms a normal session, every non-conversational trace forms a 1-trace
+"orphan" session.
+
+But for OTel-direct customers whose auto-instrumentation only tags
+LLM-call spans (Vercel AI / LangChain / Anthropic SDK inside an Express /
+Next.js trace), the same trace produces **two session rows**: the real
+session built from the LLM spans, plus an "orphan fragment" built from the
+surrounding framework spans. Both reference the same `trace_id`, but the
+orphan fragment has no LLM data — `tokens_total = 0`, `cost_total_microcents
+= 0`, `models = []`, `trace_count = 1`. See `./0-problems.md` for the contract
+discussion and `./1-parity-traces-sessions.md` for the visual signature table.
+
+To keep the sessions list clean for these customers, the filter bar applies
+a **default chip** on the sessions list:
+
+```
+has LLM activity   (tokens_total > 0 OR length(models) > 0)
+```
+
+This is a normal filter chip — the user can clear it explicitly to see
+orphan fragments alongside real sessions (useful for debugging
+instrumentation), or invert it to find traces that *only* have framework
+overhead and no LLM call.
+
+Implementation:
+
+- **Registry entry**: `hasLlmActivity` in `SESSION_FIELD_REGISTRY` maps to
+  the synthetic expression `(tokens_total > 0 OR length(models) > 0)`.
+  Same pattern as the synthetic `status` filter described below.
+- **Default-on at the UI layer**: the sessions list page initializes its
+  filter set with `hasLlmActivity = true` if no filter set was loaded from
+  URL / saved view. The chip renders as removable like any other; it just
+  starts pre-applied. Implementation lives in the same place the default
+  time-range filter is set today.
+- **Pure orphan traces** (no SDK session_id on any span) typically have
+  `models` set on the LLM span — they're 1-trace sessions but still
+  conversational. They satisfy `hasLlmActivity = true`. Only orphan
+  fragments from mixed-binding traces fail it.
+
+This is the user-visible mitigation for the SDK-contract violation case
+documented in `./0-problems.md`. Other filter chips (model, provider,
+tag, etc.) compose with the default chip normally.
+
+## Status filter — concrete shape
+
+The trace registry today references `overall_status`, a column that no
+longer exists. The fix is symmetric:
+
+```ts
+// New helper, replaces mapStatusValue. Lives next to it in helpers.ts.
+function buildStatusHaving(conditions: readonly FilterCondition[]): {
+  clause: string
+  params: Record<string, unknown>
+}
+```
+
+Synthesis rules, applied identically on both tables:
+
+| User value | Session/Trace HAVING fragment |
+|---|---|
+| `"error"` | `error_count > 0` |
+| `"ok"` | `error_count = 0 AND span_count > 0` |
+| `"unset"` | `span_count = 0` (in practice unreachable on sessions since the MV requires `session_id != ''` and a span exists; falsy on traces only for trace rows whose every span was `status_code = 0`) |
+
+Because the synthesized HAVING fragment doesn't fit the
+`{column} {op} {param}` shape that `buildClause` produces, `status` becomes
+a special-cased registry entry: the registry carries a `buildClause` hook
+rather than a `column / chType`. Concretely:
+
+```ts
+// In ChFieldMapping (filter-builder.ts:7), widen to support synthesized clauses:
+export type ChFieldMapping =
+  | ScalarFieldMapping                    // existing { column, chType, ... }
+  | {
+      readonly kind: "synthetic"
+      readonly buildClause: (cond: FilterCondition, paramName: string) =>
+        { clause: string; param: unknown }
+    }
+```
+
+`buildClickHouseWhere` then branches on `mapping.kind === "synthetic"` and
+delegates the clause and param generation. Both registries register
+`status` against the same helper:
+
+```ts
+// trace-fields.ts:8 — REPLACE the broken entry:
+status: { kind: "synthetic", buildClause: buildStatusClause },
+
+// session-fields.ts — ADD:
+status: { kind: "synthetic", buildClause: buildStatusClause },
+```
+
+Where `buildStatusClause` reads the operator off the condition and
+translates `eq/neq/in/notIn` over `{"ok","error","unset"}` into a disjunction
+of the fragments above (e.g. `in: ["error","ok"]` →
+`(error_count > 0 OR (error_count = 0 AND span_count > 0))`).
+
+This collapses two fixes into one: the trace `status` filter starts working
+again, and sessions gain a parity status filter, both with one helper.
+
+## API surface changes
+
+### `SESSION_FIELD_REGISTRY` (`registries/session-fields.ts:4`)
+
+Add (most depend on `./1-parity-traces-sessions.md` having landed first):
+
+```ts
+status: { kind: "synthetic", buildClause: buildStatusClause },
+name:   { column: "root_span_name",        chType: "String" },
+traceId:{ column: "trace_ids",             chType: "String", isArray: true },
+ttft:   { column: "time_to_first_token_ns", chType: "Int64" },
+```
+
+Notes:
+
+- `traceId` is `isArray: true` so `in` / `notIn` become `hasAny` / `NOT
+  hasAny` against `trace_ids` — that's exactly the "session contains this
+  trace id" semantic. For `eq` on a single value, the SQL is
+  `trace_ids = {value:String}` per the generic `buildClause` path, which
+  would mismatch (compares a `FixedString(32)` array to a scalar). Two
+  options:
+  - **Recommended:** extend `ChFieldMapping` with an `arrayContains:
+    boolean` flag that maps `eq` on array fields to `has(<column>,
+    {param:<chType>})` instead of `=`. This adds the same convenience for
+    `tags = "foo"` (today the user has to write `tags in ["foo"]`), which
+    is a small ergonomic win.
+  - Alternative: leave `eq` unsupported on `traceId` and document that the
+    UI emits `in: [value]` for single-value selection. The UI already does
+    that for `tags`; pushing `traceId` through the same path costs nothing.
+- `name` filter accepts the same operators trace `name` accepts
+  (`contains`, `notContains`, `eq`, `neq`) — `buildClause` already routes
+  `contains` to `ILIKE`. No special-casing needed.
+
+### `SessionRepository` port (`packages/domain/spans/src/ports/session-repository.ts`)
+
+`SessionRepositoryShape` widens with one new method needed for
+`gtePercentile` parity:
+
+```ts
+getDistribution(input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly field: PercentileSessionFilterField
+}): Effect.Effect<TraceDistribution, RepositoryError, ChSqlClient>
+```
+
+`PercentileSessionFilterField` lives in `@domain/shared` next to
+`PercentileTraceFilterField`. Initial set:
+
+```ts
+export const PERCENTILE_SESSION_FILTER_FIELDS = ["duration", "ttft", "cost"] as const
+```
+
+— same set as traces. The trace and session distributions are independent
+(a session-cost distribution is not the same as a trace-cost distribution),
+so the resolver must compute against the session aggregate.
+
+### `SessionRepositoryLive` implementation (`session-repository.ts`)
+
+Three changes:
+
+1. **Resolve `gtePercentile` filters before WHERE/HAVING assembly.**
+   Mirror `resolvePercentileFilters` from `trace-repository.ts:700`. Same
+   helper shape; reads from the per-session `LIST_SELECT` subquery. Wire
+   it into `listByProjectId`, `countByProjectId`, and
+   `aggregateMetricsByProjectId` exactly where `buildSessionFilterClauses`
+   is called today (lines 214, 278, 313).
+2. **Adopt the synthetic `status` clause.** No change beyond registering
+   the entry — `buildClickHouseWhere` handles the dispatch.
+3. **Project `trace_ids` already happens in `LIST_SELECT` (line 26).** The
+   HAVING-side `has(trace_ids, …)` uses the merged alias. No SQL changes
+   beyond the registry.
+
+### `listSessionsByProject` server fn (`apps/web/src/domains/sessions/sessions.functions.ts:54`)
+
+The input schema already uses `filterSetSchema` — it accepts any field.
+What changes is which fields the validator allows downstream. We don't
+need a per-field allowlist at the server-fn layer: `buildClickHouseWhere`
+silently drops unknown fields, and the registry update is the single
+source of truth. No code change here.
+
+### `TraceRepository` port
+
+Existing trace-side `getDistribution`
+(`packages/domain/spans/src/ports/trace-repository.ts:124`) covers the
+trace surface unchanged.
+
+## UI surface changes
+
+The filter sidebar is field-driven from a small set of catalogs. Adding
+fields ripples through automatically.
+
+### `getTextFieldsForMode` (`apps/web/src/components/filters-builder/constants.ts:37`)
+
+Drop the exclusion. Today:
+
+```ts
+export function getTextFieldsForMode(mode: FilterMode) {
+  if (mode === "sessions") {
+    return TEXT_FIELDS.filter((f) => f.field !== "name" && f.field !== "traceId")
+  }
+  return TEXT_FIELDS
+}
+```
+
+After this spec — both `name` and `traceId` work on sessions:
+
+```ts
+export function getTextFieldsForMode(_mode: FilterMode) {
+  return TEXT_FIELDS
+}
+```
+
+(The function is kept rather than inlined so future per-mode divergences
+have a place to live.)
+
+### `NUMBER_RANGE_FIELDS` / percentile UI
+
+Today the percentile tab in `NumberFilterSection`
+(`filters-sidebar.tsx:267`) only renders when the field is in
+`PERCENTILE_TRACE_FILTER_FIELDS`. For sessions, the same set
+(`duration`, `ttft`, `cost`) gets percentile support once
+`SessionRepository.getDistribution` is implemented. The
+`PercentileFilter` component
+(`apps/web/src/components/filters-builder/percentile-filter.tsx`) needs to
+know which mode it's in so it can call the session distribution endpoint
+instead of the trace one — a `mode: FilterMode` prop threaded the same way
+as in `MultiSelectFilter`.
+
+### Status filter UI
+
+The trace-side status filter exists as a control today; once the
+synthetic clause replaces the broken column reference, the same control
+applies to sessions. No new component — `getTextFieldsForMode` and the
+existing status filter UI are independent. Confirm the status field reads
+`type: "status"` from `TRACE_FILTER_FIELDS:13` and is rendered by whatever
+already renders it on traces (the trace filter bar — not in
+`filters-sidebar.tsx` but the chip-level UI; the catalog drives both).
+
+### `MultiSelectFilter` adapter — no change
+
+`MultiSelectFilter` already dispatches per mode via `useDistinctValues`
+(`multi-select-filter.tsx:33`). Tags, models, providers, serviceNames all
+work today; this spec doesn't change them.
+
+### Saved searches
+
+Saved-search filters route through `filterSetSchema` and the same
+`buildClickHouseWhere` path. Sessions saved searches with new fields work
+automatically.
+
+## Why no skip index for `trace_ids`
+
+`trace_ids` is an `AggregateFunction(groupUniqArray, FixedString(32))`. A
+bloom_filter index on it would have to apply on the merged value, not the
+per-block partial states `AggregatingMergeTree` actually stores — so it
+can't be a per-row skip index over the raw column without changes to how
+the MV emits the column.
+
+Two reasonable alternatives:
+
+1. **Drop it.** The `traceId` filter on sessions is rare (incident
+   response), the query always scans within a single
+   `(organization_id, project_id)`, and `idx_start_time` already prunes by
+   month. Acceptable for v1.
+2. **Add `idx_trace_ids ... TYPE bloom_filter(0.01) GRANULARITY 1` on a
+   materialized `groupUniqArrayMerge(trace_ids)` column** (i.e. a finalized
+   column rather than an aggregate state). That requires either a second
+   table or a `final` projection; both add complexity disproportionate to
+   the use case. **Don't ship this in v1.**
+
+Recommendation: ship option 1. Revisit if `traceId`-on-sessions becomes a
+hot query.
+
+## Files that change
+
+| Layer | File | Change |
+|---|---|---|
+| Filter helper | `packages/platform/db-clickhouse/src/registries/helpers.ts` | Add `buildStatusClause`; remove `mapStatusValue` (no longer wired to a column). |
+| Filter builder | `packages/platform/db-clickhouse/src/filter-builder.ts:7` | Widen `ChFieldMapping` to support `{ kind: "synthetic", buildClause }`; route in `buildClause` and `buildClickHouseWhere`. Optionally add `arrayContains: boolean` to map scalar `eq` against array fields to `has(…)`. |
+| Trace registry | `packages/platform/db-clickhouse/src/registries/trace-fields.ts:8` | Replace broken `status` entry with synthetic clause. |
+| Session registry | `packages/platform/db-clickhouse/src/registries/session-fields.ts:4` | Add `status`, `name`, `traceId`, `ttft`. |
+| Domain shared | `packages/domain/shared/src/trace-filter-fields.ts` | Add `PERCENTILE_SESSION_FILTER_FIELDS`, `PercentileSessionFilterField`, `isPercentileSessionFilterField` (mirror of the trace versions). Keep `TRACE_FILTER_FIELDS` as the single source for UI catalog. |
+| Session port | `packages/domain/spans/src/ports/session-repository.ts` | Add `getDistribution` method to `SessionRepositoryShape`. |
+| Session repo | `packages/platform/db-clickhouse/src/repositories/session-repository.ts:170` | Mirror `resolvePercentileFilters` from `trace-repository.ts:700`; implement `getDistribution`; wire percentile resolution into `listByProjectId` / `countByProjectId` / `aggregateMetricsByProjectId`. |
+| UI catalog | `apps/web/src/components/filters-builder/constants.ts:37` | Drop the `name` / `traceId` exclusion. |
+| UI percentile | `apps/web/src/components/filters-builder/percentile-filter.tsx` | Accept `mode: FilterMode`; dispatch to session distribution endpoint when `mode === "sessions"`. |
+| UI filter sidebar | `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx:267` | Pass `mode` through to `NumberFilterSection` / `PercentileFilter`. |
+| Sessions domain function | `apps/web/src/domains/sessions/sessions.functions.ts` | Add `getSessionDistribution` server fn paralleling the trace one. |
+
+## Migration / rollout
+
+All changes are additive on the read path. No CH schema change beyond what
+`./1-parity-traces-sessions.md` already proposes. Two ordering constraints:
+
+1. **`./1-parity-traces-sessions.md` must land first.** Until `root_span_name`
+   and `time_to_first_token_ns` exist on `sessions`, the `name` and `ttft`
+   filters can't be registered (`buildClickHouseWhere` would emit a
+   reference to a non-existent column).
+2. **The synthetic `status` filter can land independently.** It only
+   depends on existing columns (`error_count`, `span_count`). It fixes a
+   pre-existing bug on traces, so shipping it ahead of session parity is
+   safe and useful.
+
+Recommended order:
+
+1. Ship `status` synthetic clause (fixes traces, no session migration
+   needed).
+2. Land `./1-parity-traces-sessions.md` migration (`00016_session_parity`).
+3. Ship the rest of this spec (`name`, `traceId`, `ttft`, percentile
+   resolver on sessions).
+
+UI changes ride with whichever phase introduces them — drop the exclusion
+in `getTextFieldsForMode` together with phase 3 so we never expose a chip
+the backend doesn't understand.
+
+## Out of scope (lands in adjacent specs)
+
+- **Session-level search** (the `searchQuery` argument). Trace's
+  `listByProjectId` takes `searchQuery`; sessions doesn't yet. That's
+  `./2-session-level-search.md`, not this spec.
+- **Search highlighting parity** — see `./5-search-highlights.md`.
+- **Freshness-weighted ordering** — see `./7-freshness-weighted-sort.md`.
+  Note that `gtePercentile` on sessions does not contradict relevance
+  ordering; the percentile filter is applied before sort.
+
+## Open questions
+
+- **Default semantic for `name` — first-trace vs any-trace?** Spec picks
+  first-trace because the session card label is the first-trace name. If
+  product later wants "session whose any trace was called X", the right
+  shape is a second column (e.g. `trace_names AggregateFunction(groupUniqArrayIf, String, UInt8)`)
+  added when needed, and a second filter `traceName` distinct from
+  `name`. Don't pre-build it.
+- **`traceId` `eq` ergonomics.** Two options listed above. Recommendation
+  is "add `arrayContains` flag in `ChFieldMapping`", since it benefits
+  `tags` too. Confirm with frontend whether the multi-select UI ever
+  emits `eq` against `tags` today — if not, we can defer the flag and
+  document that single-trace-id selection sends `in: [value]`.
+- **Should `metadata.<path>` reads be normalized to first-trace or
+  union semantics?** The session MV uses `maxMap(metadata)` — per-key
+  max-wins. That means if two traces in a session set
+  `metadata.env = "staging"` and `metadata.env = "production"`, the
+  session row reports the lexicographic max (`"staging"`). Probably
+  acceptable, but worth noting before customers report "I filtered
+  sessions by `env = production` and lost one I expected".
+- **Should `score.*` filters get an "all-traces" mode?** Today the
+  subquery returns sessions with **any** matching score. A common product
+  question is "all of this session's traces passed" — that requires a
+  different shape (count of unique trace_ids in scores ≥ session's
+  `trace_count`, or per-trace evaluation). Not in this spec; logged for
+  future.
+- **Status filter — `"unset"` on sessions.** With the
+  `sessions_mv WHERE session_id != ''` filter, every session row has at
+  least one span. The "unset" status on sessions is therefore effectively
+  unreachable. Decide whether to (a) hide the `unset` option from the
+  session-mode status UI, or (b) keep it and let it match zero rows. (b)
+  is cheaper and consistent with the trace-side behavior; recommendation
+  is (b).
+- **TTFT `ignoreZeros` on sessions.** The percentile resolver on traces
+  ignores 0-valued rows for `ttft` (sentinel for "no LLM"). The session
+  version should mirror that. Confirm `time_to_first_token_ns = 0` is the
+  same sentinel on sessions — by construction from
+  `./1-parity-traces-sessions.md`'s `time_of_first_token` sentinel, yes.

--- a/specs/session-problems/5-search-highlights.md
+++ b/specs/session-problems/5-search-highlights.md
@@ -1,0 +1,586 @@
+# Search highlights
+
+## Goal
+
+When a user opens a trace from the search page, the trace detail drawer should:
+
+1. **Highlight** the spans of conversation text that explain why this trace matched the search.
+2. **Scroll to the first occurrence** on open.
+3. Allow stepping through matches with `N` / `P` (Next / Previous) — reusing the existing `ScrollNavigator`.
+4. Use **distinct colors per match kind** so the user can tell at a glance whether a hit was literal, token-phrase, or semantic.
+5. Support **click-to-explain**: clicking a highlight opens a small popover saying *why* this segment is highlighted (which phrase, which chunk, what score).
+
+This applies to the trace search drawer. The same shape will inform the future Issues panel once `issue discovery` lands on Postgres (`pgvector` + `tsvector`), where the lexical side gains free highlighting via `ts_headline` but the semantic side has the same gap as traces.
+
+## Search types we support today
+
+Source of truth: `parseSearchQuery` (`packages/domain/spans/src/use-cases/parse-search-query.ts:31`) and `buildSearchPlan` (`packages/platform/db-clickhouse/src/repositories/trace-repository.ts:218`).
+
+| Kind | Syntax | Semantics | Backing index |
+|---|---|---|---|
+| **Literal** | `"…"` | Case-sensitive exact substring | `trace_search_documents.search_text`, indexed `LIKE %phrase%` |
+| **Token phrase** | `` `…` `` | Lowercased, ordered token adjacency (case- and punctuation-insensitive) | `trace_search_documents` via `hasAllTokens` prefilter + `hasSubstr(tokens(lower(search_text)))` |
+| **Semantic** | bare text | Natural-language meaning match | `trace_search_embeddings` (one row per chunk), Voyage embedding + cosine, rolled up per-trace via `max(score)` |
+
+These compose into three concrete plans:
+
+- **Phrase-only** — pure filter, no ranking
+- **Semantic-only** — ranked by cosine score, with a minimum relevance floor
+- **Hybrid** — phrases narrow the candidate set, semantic ranks survivors; the relevance floor is dropped because the phrase filter is the precision gate
+
+## Current pipeline — what reaches the drawer
+
+```
+SearchInput (search/index.tsx)
+  └─ q (string)
+       └─ useTracesCount / useTracesInfiniteScroll
+            └─ listTracesByProject / countTracesByProject (server fn)
+                 └─ TraceRepository.listByProjectId
+                      └─ buildSearchPlan → ClickHouse subquery
+                           └─ trace_search_documents (lexical)
+                           └─ trace_search_embeddings (semantic)
+       └─ TracesView → user clicks a row →
+            getTraceDetail (server fn)
+                 └─ TraceDetailRecord { allMessages, inputMessages, outputMessages, systemInstructions }
+                      └─ TraceDetailDrawer
+                           └─ ConversationTab
+                                └─ <Conversation messages highlightRanges /> ← already supports highlights
+```
+
+Once `2-session-level-search.md` lands, the search page swaps `TracesView` for
+`SessionsView` and the same `q` flows through a session-rollup CTE. The
+click target is now the **session panel** (per `./6-session-panel.md`), not
+the trace drawer directly. The panel renders one trace's conversation at
+a time using the same `<Conversation>` primitive the trace drawer uses,
+so the highlight pipeline still operates per-trace — it just renders
+inside the panel's Conversation tab instead of the standalone drawer:
+
+```
+SearchInput (search/index.tsx)
+  └─ q (string)
+       └─ useSessionsCount / useSessionsInfiniteScroll
+            └─ listSessionsByProject / countSessionsByProject (server fn)
+                 └─ SessionRepository.listByProjectId
+                      └─ buildSearchPlan → ClickHouse subquery (trace-level, reused)
+                           └─ trace_search_documents (lexical)
+                           └─ trace_search_embeddings (semantic)
+                      └─ trace_rollup CTE → GROUP BY session_id
+                           └─ best_score, best_trace_id,
+                              matching_trace_ids, matching_trace_scores
+       └─ SessionsView → user clicks a session row
+            ├─ Row expands inline (for multi-trace sessions) — matching
+            │  trace rows in the expansion get a hit-count badge sorted by
+            │  matching_trace_scores
+            └─ Session panel opens with currentTraceId = matching_trace_ids[0]
+                 └─ getSessionDetail(sessionId)            ─┐  ← session metadata for the header
+                 └─ getTraceDetail(currentTraceId)         ─┤
+                 └─ getTraceSearchHighlights(             ─┴─→ SessionDetailDrawer
+                      currentTraceId, q)                        └─ ConversationTab
+                      ↑                                              └─ <Conversation … />
+                      │
+                      └── re-fired when the user clicks a different matching
+                          trace row in the sessions-list row expansion behind
+                          the panel — the expansion is the trace navigator
+                          (see "Session-level result behavior" below)
+```
+
+What's **computed but discarded** before the drawer:
+
+| Signal | Computed? | Reaches drawer? |
+|---|---|---|
+| `relevance_score` per trace | yes (semantic / hybrid) | **No** — dropped at `toTraceRecord` (`apps/web/src/domains/traces/traces.functions.ts:65`) |
+| Winning chunk index (semantic) | implicit via `max-arg`, not preserved | No — `max(...) GROUP BY trace_id` collapses it |
+| Per-phrase / per-substring offsets (lexical) | not computed | No |
+| Per-message provenance | not computed | No — `trace_search_documents.search_text` is normalized whitespace, system-stripped, reasoning-stripped; offsets don't map to `allMessages` |
+| `matching_trace_ids: Array(UUID)` per session | yes, after rollup (`2-session-level-search.md` §4.1) | **Must reach the drawer** — it's the navigation set for cross-trace N/P (see "Session-level result behavior") |
+| `matching_trace_scores: Array(Float32)` per session | yes, sorted aligned with `matching_trace_ids` | **Must reach the drawer** — drives which trace is "primary" and tie-breaks the N/P order |
+| `best_trace_id` per session | yes (`argMax(trace_id, relevance_score)`) | **Yes** — it's the `traceId` the drawer opens on for a session click |
+
+The drawer **does not know `searchQuery` exists** today. `getTraceDetail` doesn't take it.
+
+## UI primitives already in place
+
+The drawer's conversation tab can render highlights with zero changes to the rendering pipeline:
+
+- **`HighlightRange = { messageIndex, partIndex, startOffset, endOffset, type, … }`**
+  (`packages/ui/src/components/genai-conversation/text-selection.tsx:13`)
+- **`sourceMappedTextPlugin`** — rehype plugin that splits markdown text nodes on highlight boundaries and tags each segment with `data-source-start` + `data-source-end` + `data-annotation-id` (or equivalent).
+  (`packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts`)
+- **`highlightAttributes`** — class/data-attr lookup keyed on `HighlightRange["type"]`. Currently knows `"selection"` (yellow) and `"annotation"` (red/emerald/blue per pass-state).
+  (`packages/ui/src/components/genai-conversation/parts/highlight-segments.ts:78`)
+- **`ScrollNavigator`** + `navItemRefs` — already wired to the `N`/`P` hotkeys in the conversation tab. Today it steps through message blocks; it can be parameterized to step through any DOM nodes.
+  (`.../trace-detail-drawer/tabs/conversation-tab.tsx:64-75`, `:185-199`)
+- **Click affordance** — `onAnnotationClick` already routes clicks from highlighted spans via `data-annotation-id`. The same wire can carry search clicks.
+
+### Existing performance cap that constrains the highlight design
+
+The conversation renderer caps each part at **`LARGE_MARKDOWN_CONTENT_THRESHOLD = 20_000` chars** (`packages/utils/src/json-format.ts:7`). Above that threshold, `MarkdownContent` (`packages/ui/src/components/genai-conversation/parts/markdown-content.tsx:139-164`) splits the part into **head + collapsed middle + tail**. The middle is **not in the DOM** until the user clicks `Show N more characters`.
+
+Three consequences for highlights:
+
+1. **Per-part highlight count is naturally bounded** by the rendered head + tail size. The rehype plugin only sees content we've decided to render, so adding highlights doesn't multiply the cost.
+2. **Highlights inside the collapsed middle won't render** unless we react to that. This is the actual UX risk — not "too many highlights", but "hidden highlights" (see Resolved decisions).
+3. **No highlights of any kind render in oversized parts today — pre-existing gap.** In the oversized branch (`markdown-content.tsx:139-164`), head / middle / tail are rendered through `MarkdownBody` (`markdown-content.tsx:105`), which does **not** receive `sourceMappedTextPlugin(highlights)` — only `rehypeHighlightPlugin`. Even if it did, `sourceMappedTextPlugin` reads `position?.start?.offset` from the rehype tree, which is **local to the rendered slice string** (head is `0..headCut`, tail is `0..tail.length`, *not* `(content.length - tail.length)..content.length`). Highlight ranges however carry offsets into the **full original part text**. So today: any annotation or selection that lands in an oversized part silently drops out of view — search highlights would inherit the same bug. The fix is in Phase A scope; see "Oversized-part offset fix" below.
+
+## Design
+
+### Single unified `getTraceSearchHighlights` endpoint
+
+One server function returns *all* highlights regardless of match kind. Server is the source of truth for parsing, tokenization, and chunk metadata; client only renders.
+
+Kept **separate** from `getTraceDetail`:
+- The drawer opens from many places (no query, prev/next trace nav, deep links). Coupling highlights into the detail endpoint forces stale-cache invalidation on every query change.
+- The detail endpoint stays usable by callers that don't care about search.
+- React Query keys cleanly: `["traceDetail", traceId]` and `["traceSearchHighlights", traceId, q]`.
+
+#### Contract
+
+```ts
+// apps/web/src/domains/traces/traces.functions.ts
+export const getTraceSearchHighlights = createServerFn({ method: "GET" })
+  .inputValidator(z.object({
+    projectId: z.string(),
+    traceId: z.string(),
+    searchQuery: z.string().max(500),
+  }))
+  .handler(async ({ data }): Promise<TraceSearchHighlightsResult> => { /* … */ })
+
+interface TraceHighlight {
+  readonly messageIndex: number
+  readonly partIndex: number
+  readonly startOffset: number
+  readonly endOffset: number
+  /**
+   * Render-side discriminator — extends `HighlightRange["type"]` in
+   * `packages/ui/src/components/genai-conversation/text-selection.tsx`.
+   * Values use the `"search-"` prefix to namespace them from existing
+   * highlight types ("selection", "annotation"). The renderer picks the
+   * class/styling for each from `highlightAttributes`.
+   */
+  readonly type: "search-literal" | "search-token" | "search-semantic-region"
+  /**
+   * Metadata about which match produced this highlight. Independent of
+   * the render-side `type` above — `source.kind` is the categorical
+   * meaning of the match ("a literal phrase matched"); `type` is what
+   * the renderer dispatches on. They share the same trichotomy
+   * (literal / token / semantic-region) without the `"search-"` prefix.
+   */
+  readonly source:
+    | { kind: "literal"; phrase: string }
+    | { kind: "token"; phrase: string; matchedTokens: readonly string[] }
+    | { kind: "semantic-region"; chunkIndex: number; score: number }
+}
+
+interface TraceSearchHighlightsResult {
+  readonly highlights: readonly TraceHighlight[]
+  /** Index into `highlights` of the first match in document order, or -1. */
+  readonly firstMatchIndex: number
+}
+```
+
+Drawer fires this in parallel with `getTraceDetail`. The detail call resolves first 99% of the time (it's bigger but on the same backend); highlights apply on arrival like annotations do today. Empty `q` → skip the call.
+
+### Three color channels, mirroring the search-bar pills
+
+Users already learned the pill palette in `SearchInput` (`apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx:455-456`). Mirror it in the drawer for instant visual mapping.
+
+| Match | Pill color in search bar | Drawer highlight |
+|---|---|---|
+| Literal `"…"` | `border-primary/25 bg-primary/10 text-primary` (blue) | Blue background + bottom border |
+| Token `` `…` `` | `border-phrase/30 bg-phrase/10 text-phrase-foreground` (phrase color) | Phrase-color background + bottom border |
+| Semantic | unstyled | Soft amber **block background** on the chunk's message range (region-level, not per-character) |
+
+Keep yellow/red/green/blue reserved for selection + annotations. Search is a new visual layer, not an overload of an existing one.
+
+Implementation: one new switch arm in `highlightAttributes` (`packages/ui/src/components/genai-conversation/parts/highlight-segments.ts:78`) and one widening of `HighlightRange["type"]` in `text-selection.tsx:13`.
+
+### Click-to-explain popover
+
+The rehype plugin already emits per-segment spans with data attributes. Add `data-search-match-id` alongside `data-annotation-id` and a sibling `onSearchMatchClick(matchId)` prop on `<Conversation>`. Click opens a small popover (reuse `AnnotationPopover`'s positioning, simpler content):
+
+- Literal: **Matched phrase** — `"refund"`
+- Token: **Matched ordered tokens** — `refund process` (with the original tokens stream)
+- Semantic: **Best-matching block** — `score 0.84 · chunk 3 of 7`
+
+The popover also carries **per-phrase prev/next buttons** (Phase B): filter `highlights[]` to the same `source.phrase` and step within the filtered list. For `semantic-region` there is only one region per trace so the buttons are disabled in that variant.
+
+### Scroll-to-first + N/P navigation
+
+- On drawer mount with `firstMatchIndex >= 0`, scroll the container to the DOM node whose `data-source-start === highlights[firstMatchIndex].startOffset` and `data-message-index === highlights[firstMatchIndex].messageIndex`.
+- Override the conversation tab's existing `N`/`P` hotkeys when `searchQuery` is present: step through *highlights* (in document order) instead of message blocks. When `searchQuery` is empty, fall back to existing message-block behavior.
+- `ScrollNavigator`'s `itemRefs` prop already accepts arbitrary refs — collect refs to the first highlight per message (or per chunk for semantic regions) and pass those instead of `navItemRefs`.
+
+### Collapsed-middle interaction
+
+When a highlight falls inside the collapsed middle of a `MarkdownContent` part:
+
+- The "Show N more characters" affordance becomes **"Show N more characters · M matches hidden"**.
+- If the scroll-to-first target is inside the collapsed middle, auto-expand that middle on mount before scrolling.
+- N/P navigation does **not** auto-expand other collapsed middles. Buttons keep stepping through visible matches; the count badge on the affordance signals there's more to see if the user expands.
+
+### Oversized-part offset fix (pre-existing bug, fixed in Phase A)
+
+`sourceMappedTextPlugin` emits `data-source-start` / `data-source-end` from the rehype tree's `position.offset`, which is **local to the markdown string passed to ReactMarkdown**. The normal-sized path passes the full part text, so local offsets equal full-part offsets. The oversized path passes head/middle/tail slices, so the AST's positions are local to each slice — meaning emitted `data-source-start` for the same DOM position differs depending on whether the part rendered through the normal or oversized branch.
+
+Two options to fix:
+
+- **(a)** Per-slice, intersect each highlight with the slice's `[sliceStart, sliceEnd)` window, then subtract `sliceStart` before passing to `sourceMappedTextPlugin`. Highlights work, but everything downstream that reads `data-source-start` (click handlers, scroll-to-offset, annotation-offset resolver) sees slice-local offsets and would need a per-slice translation table.
+- **(b) Recommended.** Pass a `sliceSourceStart: number` through `MarkdownBody` → `sourceMappedTextPlugin`, and emit `data-source-start = position.offset + sliceSourceStart` (and the same for `data-source-end`). The DOM attributes then always carry full-part-text coordinates, and **nothing downstream changes** — annotations, selections, click routing, scroll-to-first all keep working in their existing coordinate system.
+
+Both also require passing `highlights` into `MarkdownBody` (currently it doesn't receive them at all). For (b), highlights flow through unchanged; the plugin uses the slice offset only when emitting attributes, not when matching highlights against AST text-node positions. (Equivalent: pre-shift highlight offsets to slice-local before passing, then emit with the shift undone — same arithmetic, less plumbing.)
+
+This change fixes the pre-existing gap for annotations and selections in oversized parts, in addition to enabling search highlights. Treat that as a bonus, not as scope creep — it's the same code path either way.
+
+### Semantic match mapping: chunk → message range
+
+The semantic side of the search pipeline matches against **embedding chunks**, not messages. To highlight a semantic hit, we need to translate a winning chunk back into the message indices that contributed to it. This section spells out that mapping, the edge cases that fall out of how `buildTraceSearchDocument` currently builds chunks, and how the result is rendered without forcing a character-offset model where it doesn't fit.
+
+#### The chunk-build pipeline today
+
+`buildTraceSearchDocument` (`packages/domain/spans/src/use-cases/build-trace-search-document.ts:226`) transforms messages into chunks through four passes:
+
+1. **`extractTurns(messages)`** (line 78) — groups messages into conversational turns. Each turn starts on a `user` message (or the first non-system message if the conversation opens otherwise) and extends through the response/tool-call sequence up to the next user message. **System messages are filtered out entirely.** Tool-call response parts and reasoning parts are also filtered. Output is `string[]` — message indices are dropped on the floor.
+2. **`selectHeadTailTurns(turns)`** (line 107) — when total turn text exceeds the per-trace budget, walks the tail first (resolution carries more signal), then the head. Returns a non-contiguous subset of turns in document order. Middle turns are discarded.
+3. **`packChunks(turns)`** (line 138) — greedy packs adjacent turns into chunks up to `TRACE_SEARCH_CHUNK_MAX_CHARS`. A turn larger than that cap splits into overlapping sub-chunks of `TRACE_SEARCH_CHUNK_OVERLAP_CHARS`. Output is `ChunkPayload[]` — turn boundaries are dropped on the floor.
+4. **`normalizeChunkText`** — whitespace normalization, lone-surrogate replacement.
+
+Two passes throw away the structural information we need: `extractTurns` drops message indices, `packChunks` drops turn boundaries.
+
+#### What needs to change
+
+Carry the structure through, don't try to reconstruct it later:
+
+- **`extractTurns`** emits `{ text, firstMessageIndex, lastMessageIndex }[]`. Both indices refer to positions in the **original `allMessages` array** — including system messages, even though those are filtered from the turn text. Indexing against `allMessages` keeps the indices stable against the renderer, which iterates that array.
+- **`selectHeadTailTurns`** preserves per-turn metadata when picking turns; no other changes.
+- **`packChunks`** emits chunks carrying the **union of the message ranges** of every turn that went in:
+  - `firstMessageIndex = min(turn.firstMessageIndex)` across packed turns
+  - `lastMessageIndex  = max(turn.lastMessageIndex)`  across packed turns
+  When a single oversized turn splits into overlapping sub-chunks, every sub-chunk inherits that turn's full `firstMessageIndex` / `lastMessageIndex` — the sub-chunks all map to the same conversational region. We don't try to subdivide a turn across messages; turns are atomic for the mapping.
+- **`TraceSearchChunk`** (line 20) gains `firstMessageIndex` and `lastMessageIndex` alongside `chunkIndex`, `text`, `contentHash`.
+
+#### Storage
+
+Two new columns on `trace_search_embeddings`:
+
+```sql
+first_message_index UInt32 NOT NULL,
+last_message_index  UInt32 NOT NULL,
+```
+
+Both populated at ingest. Neither is indexed — they ride along with the embedding as payload.
+
+#### Read path: surviving the per-trace rollup
+
+`buildSemanticSearchSubquery` (`packages/platform/db-clickhouse/src/repositories/trace-repository.ts:162`) collapses per-chunk scores via `max(semantic_score) GROUP BY trace_id`. That discards which chunk won. The fix uses `argMax` to keep the winning chunk's metadata:
+
+```sql
+SELECT
+  trace_id,
+  max(semantic_score)                            AS relevance_score,
+  argMax(chunk_index, semantic_score)            AS matched_chunk_index,
+  argMax(first_message_index, semantic_score)    AS matched_first_message_index,
+  argMax(last_message_index, semantic_score)     AS matched_last_message_index
+FROM (...)
+GROUP BY trace_id
+```
+
+In the hybrid plan with `LEFT JOIN`, the same `argMax` pattern applies to the joined semantic side; the lexical side has no chunk metadata to carry. Pure phrase-only plans return `NULL` for the matched-chunk columns and the endpoint emits zero semantic-region highlights — the same trace can still surface literal / token highlights.
+
+The `SearchPlan` type widens to `{ ranked, subquery, params, semanticMetadata: boolean }`. When `semanticMetadata` is true, the outer `LIST_SELECT` projects the matched-chunk columns out of the join; otherwise, it doesn't.
+
+#### Why character offsets don't apply at this layer
+
+Semantic-region highlights are **block-level**, not character-level. Three reasons character offsets are the wrong model here:
+
+1. **The chunk text is normalized.** `normalizeChunkText` collapses whitespace and strips lone surrogates. Mapping a character position inside a chunk back to the original message text would require reversing those transforms — possible but error-prone.
+2. **Tool-call and reasoning parts are stripped from chunk text.** A character offset inside a chunk does not correspond to a character offset in the rendered message.
+3. **What the user wants to know is "this region of the conversation matched"** — not "these specific characters in message 7 matched". The chunk-level granularity is what the embedding actually scored; pretending we can localize it further at this layer is a lie. (Future option: re-embed individual messages within the chunk at view time — deferred, see dropped option above.)
+
+So the `HighlightRange` for a semantic match uses **whole-message coverage**: one range per message in the matched span, with `startOffset` / `endOffset` ignored at render time for this type:
+
+```ts
+// One range per messageIndex in [matched_first_message_index, matched_last_message_index].
+// startOffset/endOffset/partIndex are placeholders; render path keys on `type`.
+{
+  messageIndex,
+  partIndex: 0,
+  startOffset: 0,
+  endOffset: 0,
+  type: "search-semantic-region",
+  source: {
+    kind: "semantic-region",
+    chunkIndex:  matched_chunk_index,
+    score:       relevance_score,
+  },
+}
+```
+
+Render-side, the new `"search-semantic-region"` arm of `highlightAttributes` applies a class to the **message container element** rather than wrapping inline text segments (e.g. `bg-amber-50/40 dark:bg-amber-400/10 ring-1 ring-amber-200/50`). Inline `"search-literal"` / `"search-token"` highlights inside the same message still render on top of the block tint, so the two layers compose visually without conflict. The rehype plugin, `data-source-start` machinery, and click-to-explain hit zones stay entirely in service of literal / token highlights where character offsets are meaningful.
+
+#### Edge cases that fall out of the model
+
+| Case | Behavior |
+|---|---|
+| **Chunk would span head + tail across the discarded middle** | Can't happen — tail-first selection picks contiguous turns from each end and `packChunks` packs only adjacent turns. A single chunk never crosses the head/tail gap; `firstMessageIndex` and `lastMessageIndex` always describe one contiguous range. |
+| **Winning chunk is a split sub-chunk of one oversized turn** | All sub-chunks of that turn carry the same `firstMessageIndex` and `lastMessageIndex`. The `argMax` returns the winning sub-chunk's `chunkIndex` for the popover, but the rendered region is identical to any other sub-chunk of the same turn. |
+| **System messages interleaved inside the matched region** | `firstMessageIndex` / `lastMessageIndex` index into `allMessages` (with system rows present). The endpoint skips role=`system` at highlight emission anyway, so a system message inside the range simply produces no highlight for itself — the visual tint may visually span across it, which is honest about what the chunk covered. |
+| **Reasoning-only or tool-response-only messages inside the region** | Chunk text didn't include those parts, but the message range still does. The block tint covers them. Trying to subtract them at render time would imply a precision we don't have. |
+| **Empty chunk after normalization** | `buildTraceSearchDocument` already skips these (`build-trace-search-document.ts:243`); they never reach the embedding table. No special handling needed. |
+| **Chunk index non-monotonic in message order** | True under tail-first selection. The `chunkIndex` shown in the popover reflects pack order, not document order. The popover labels it as "best-matching block" without implying chronology. The on-screen position is still correct because the renderer uses `firstMessageIndex` / `lastMessageIndex`, not `chunkIndex`. |
+| **Partial-backfill state (Phase D in flight)** | Older `trace_search_embeddings` rows lack the new columns. Phase D backfills by re-running `buildTraceSearchDocument` against the source trace and matching by `(trace_id, chunk_index, content_hash)`. Until backfill completes, traces with `NULL` in the new columns return zero semantic-region highlights from the endpoint; literal / token highlights still return normally. Silent partial coverage is better than misleading. |
+
+#### Where this lands in the contract
+
+`TraceHighlight["source"]` already has:
+
+```ts
+| { kind: "semantic-region"; chunkIndex: number; score: number }
+```
+
+That stays as-is. The endpoint emits one `TraceHighlight` per non-system message in the matched range, all sharing the same `source` object. A future precision boost (re-embed at view time) would emit multiple narrower ranges with their own per-message scores — the contract doesn't change, only the granularity of what the server emits.
+
+#### Implementation summary
+
+| Layer | File | Change |
+|---|---|---|
+| Build | `packages/domain/spans/src/use-cases/build-trace-search-document.ts` | Thread `firstMessageIndex` / `lastMessageIndex` through `extractTurns` → `selectHeadTailTurns` → `packChunks`. Extend `TraceSearchChunk` (line 20). |
+| Storage | `packages/platform/db-clickhouse/schema/` + `…/repositories/trace-search-repository.ts` | Add `first_message_index UInt32`, `last_message_index UInt32` to `trace_search_embeddings`. Write at insert. |
+| Read | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:162` | `argMax(chunk_index, semantic_score)` + matched-range columns in `buildSemanticSearchSubquery`. Widen `SearchPlan` and project columns through `LIST_SELECT`. |
+| API | `apps/web/src/domains/traces/traces.functions.ts` | Plumb matched-chunk metadata onto trace rows (parallel `searchMatch` field, not stuffed into `TraceRecord`). Extend `getTraceSearchHighlights` to emit `semantic-region` highlights from it. |
+| Render | `packages/ui/src/components/genai-conversation/parts/highlight-segments.ts` + `<Conversation>` | New `"search-semantic-region"` branch (the same `"search-"`-prefixed namespace as the literal/token types added in Phase A); apply class to the message-container element instead of inline span wrapping. |
+| Backfill | `apps/workers/src/scripts/backfill-trace-search.ts` | Re-derive provenance from existing traces; match by `(trace_id, chunk_index, content_hash)`; idempotent. |
+
+## Resolved decisions
+
+- **System messages are skipped.** `getTraceSearchHighlights` walks `allMessages` filtering out `role === "system"`. This matches what the server search index does today (system messages are stripped at ingest in `buildTraceSearchDocument`), so the drawer cannot show hits the server search itself would never return.
+- **No cap on highlights per trace.** The conversation renderer already enforces a **per-part** budget at `LARGE_MARKDOWN_CONTENT_THRESHOLD = 20_000` chars; above that, the middle is collapsed out of the DOM entirely. That means per-part highlight count is bounded by what we render in head+tail, and the rehype plugin never sees content we haven't already chosen to render. Real content-bearing queries (feature names, error codes, IDs, domain terms) produce 1–20 hits across a trace anyway. A blanket per-trace cap is solving a problem the existing render budget already constrains. If profiling later surfaces a real perf cliff, derive a cap from the cliff — not from a guess.
+- **Hidden highlights, not too many, are the real risk.** When a search hit lives inside the collapsed middle of a long tool-call response, the user opens the drawer "to see why this trace matched" and sees nothing. Handled in Phase A by (a) replacing the affordance with **"Show N more characters · M matches hidden"** and (b) auto-expanding when scroll-to-first targets a hidden range.
+- **Spans tab does not get highlights.** Only the Conversation tab. The Spans tree doesn't render through `<Conversation>`, and the user value sits squarely in the conversation view.
+- **Per-phrase prev/next from the popover** — yes, included in Phase B. Cost is low because the global N/P infrastructure already exists; this is just filtering `highlights[]` to the same `source.phrase` and stepping within the filtered list.
+
+## Options that were considered and dropped
+
+### ❌ Lexical-proxy highlighting for semantic queries
+
+Strip stopwords from the semantic prompt and highlight tokens that appear in the text.
+
+**Rejected**: dishonest. Semantic search exists precisely so that a query like *"complaint about refunds"* can match a trace that says *"I want my money back"*. Highlighting only the literal keywords would either show nothing (defeating the point) or imply the trace matched lexically when it didn't. Worse than honest silence.
+
+### ❌ Re-embedding messages at view time
+
+Embed every message against the query embedding on each drawer open.
+
+**Rejected for now**: real Voyage cost per drawer open, proportional to trace size. Not worth it given Phase C (chunk-region highlight) already answers "why did this match" at acceptable granularity. Could revisit later as an optional precision boost, behind a feature flag.
+
+### ❌ Rerank-based span scoring
+
+Use `rerank-2.5` over message-level snippets.
+
+**Rejected**: rerank still scores whole candidates, not spans within them. Only works if we first chop the trace into snippets — which is Phase C in disguise, plus rerank cost. No incremental value.
+
+## Notes for issue search (out of scope for this iteration but informs the shape)
+
+Once Issues land on Postgres (migration `20260517062034_add-pgvector-issue-search`, `IssueRepository.hybridSearch` at `packages/platform/db-postgres/src/repositories/issue-repository.ts:275`):
+
+- **Lexical side gets `ts_headline()` for free** — Postgres can return `Refunds <b>complaint</b> about …` directly out of the FTS engine.
+- **Semantic side has the identical gap** as traces — pgvector cosine on a centroid is a score, not a span. The same "matched-region" approach would translate, scaled to the smaller surface (issue name + description vs. trace conversation).
+
+When the Issues UI ships, the highlight types here (`literal | token | semantic-region`) can extend to issues with the same color contract.
+
+## Phasing
+
+Each phase is independently shippable.
+
+**Phase A — Literal + token highlights, no schema change**
+
+- New `getTraceSearchHighlights` endpoint that parses `q`, walks `traceDetail.allMessages` (skipping role=system), and returns `literal` + `token` ranges. Token tokenization matches `tokenizePhrase` from `trace-repository.ts:72` so the highlights are faithful to what the index matched.
+- Drawer wiring: drawer accepts `searchQuery` prop (threaded from `q` in `search/index.tsx`), conversation tab calls the new hook, feeds `HighlightRange[]` into `<Conversation>`.
+- New `"search-literal"` and `"search-token"` `HighlightRange["type"]` values with the pill-mirroring colors.
+- Scroll-to-first on mount, with auto-expand if the first match is inside a collapsed middle.
+- Replace the "Show N more characters" affordance with "Show N more characters · M matches hidden" when applicable.
+- **Oversized-part offset fix.** Thread `sliceSourceStart` through `MarkdownBody` → `sourceMappedTextPlugin` so emitted `data-source-start` / `data-source-end` always carry full-part-text coordinates, and pass `highlights` into `MarkdownBody` (currently dropped). Also fixes the pre-existing bug where annotations and selections silently fail to render inside oversized parts.
+
+**Phase B — Click-to-explain popover + N/P highlight navigation**
+
+- Sibling popover component to `AnnotationPopover` for search matches.
+- `data-search-match-id` plumbing through the rehype plugin.
+- N/P override when `searchQuery` is non-empty.
+- Per-phrase prev/next buttons inside the popover.
+
+**Phase C — Semantic region highlight (schema migration)**
+
+- Schema: add `first_message_index`, `last_message_index` to `trace_search_embeddings`.
+- Ingest: thread message indices through `buildTraceSearchDocument`.
+- Read: `argMax(chunk_index, semantic_score)` + range columns in `buildSemanticSearchSubquery`.
+- Plumb the winning chunk's range onto each trace row (parallel `searchMatch` field, not stuffed into `TraceRecord` itself).
+- Extend `getTraceSearchHighlights` to emit one `semantic-region` highlight covering the message-range.
+- New `"search-semantic-region"` `HighlightRange["type"]` with soft amber block background.
+
+**Phase D — Backfill**
+
+- Update `apps/workers/src/scripts/backfill-trace-search.ts` to populate the new chunk-range columns on existing rows.
+- Rolling backfill, idempotent on `(content_hash, chunk_index)`.
+
+## Files this will touch
+
+### Phase A
+- `apps/web/src/domains/traces/traces.functions.ts` — new `getTraceSearchHighlights` server fn.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx:355` — pass `q` to drawer.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx` — accept `searchQuery`, thread to conversation tab.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx` — call new hook, merge with annotation `highlightRanges`, scroll-to-first, auto-expand-on-target-hidden.
+- `apps/web/src/lib/hooks/` — `useTraceSearchHighlights` (React Query wrapper).
+- `packages/ui/src/components/genai-conversation/text-selection.tsx` — widen `HighlightRange["type"]`.
+- `packages/ui/src/components/genai-conversation/parts/highlight-segments.ts` — add color branches.
+- `packages/ui/src/components/genai-conversation/parts/markdown-content.tsx` — "M matches hidden" affordance + auto-expand prop; thread `highlights` and `sliceSourceStart` into `MarkdownBody`.
+- `packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts` — accept `sliceSourceStart` and add it when emitting `data-source-start` / `data-source-end`.
+- `packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.test.ts` — add coverage for non-zero `sliceSourceStart` (regression for the pre-existing oversized-part gap).
+
+### Phase B
+- `packages/ui/src/components/genai-conversation/conversation.tsx` — `onSearchMatchClick` prop.
+- `packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts` — emit `data-search-match-id`.
+- New `SearchMatchPopover` next to `AnnotationPopover`.
+
+### Phase C
+- `packages/domain/spans/src/use-cases/build-trace-search-document.ts` — thread `messageIndex`.
+- `packages/platform/db-clickhouse/schema/` — `trace_search_embeddings` columns.
+- `packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts` — write new columns.
+- `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:162` — `argMax`, plumb through `SearchPlan` + `LIST_SELECT`.
+- `apps/web/src/domains/traces/traces.functions.ts` — extend trace row with `searchMatch` field.
+
+### Phase D
+- `apps/workers/src/scripts/backfill-trace-search.ts`.
+
+## Session-level result behavior
+
+Once `2-session-level-search.md` and `6-session-panel.md` land, every row in
+the search results represents one session, and clicking a row opens the
+**session panel** (not the trace drawer directly). The panel's
+Conversation tab renders one trace's conversation at a time using the
+same `<Conversation>` primitive the trace drawer uses, so the highlight
+pipeline stays per-trace — it just renders inside the panel.
+
+### Result row schema (recap)
+
+From `2-session-level-search.md` §4.1, each session result row carries:
+
+```ts
+interface SessionSearchMatch {
+  readonly bestScore: number
+  readonly bestTraceId: string                       // argMax(trace_id, relevance_score)
+  readonly matchingTraceCount: number
+  readonly matchingTraceIds: readonly string[]       // sorted by score DESC
+  readonly matchingTraceScores: readonly number[]    // aligned with matchingTraceIds
+}
+```
+
+### Click contract on a session row in search mode
+
+Per `./6-session-panel.md` §3 ("Which trace does the Conversation tab
+show?"), clicking a session row in search mode opens the session panel
+with `currentTraceId = matchingTraceIds[0]` — the first (highest-scored)
+matching trace. The panel's Conversation tab fires
+`getTraceSearchHighlights(currentTraceId, q)` in parallel with
+`getTraceDetail(currentTraceId)` and scrolls to the first highlight on
+arrival.
+
+The session-level `bestScore` and `matchingTraceCount` do not influence
+the highlight computation itself; they only inform the initial
+`currentTraceId` choice. The existing `getTraceSearchHighlights`
+contract (`traceId` + `q`) stays exactly as documented above.
+
+### Cross-trace navigation lives in the sessions-list row expansion
+
+For multi-trace sessions, the sessions-list row also **expands inline**
+beside/behind the panel, showing every trace in the session ordered by
+`start_time`. Trace rows in the expansion that appear in
+`matchingTraceIds` get a visual hit-count badge derived from
+`matchingTraceScores`. Clicking a different matching trace row in the
+expansion sets the panel's `currentTraceId` to that trace; the
+Conversation tab re-fires `getTraceDetail` + `getTraceSearchHighlights`
+and re-scrolls to its first hit.
+
+That's the cross-trace navigation surface — the row expansion, not a
+chip in the panel header. Justifications:
+
+- The expansion already exists today (`useExpandedSessionTraces`) and
+  the user has it open as soon as they click the session row. Putting a
+  second cross-trace affordance inside the panel duplicates it.
+- The expansion can show titles, scores, and per-trace hit counts in
+  parallel — far more information than a header chip can fit.
+- The panel header stays small and identical between browse and search
+  modes; less UI churn between contexts.
+
+### N/P stays within the current trace's highlights
+
+Same decision as before: `N`/`P` steps through `highlights[]` in
+document order within the **currently shown** trace. Crossing to
+another matching trace is a separate, explicit gesture — clicking a
+different trace row in the row expansion. Justification:
+
+- N/P is a tight in-frame operation. Overloading it to also reload the
+  panel's Conversation tab with a different `traceId` changes its
+  perceived weight from "scroll to the next match" to "navigate to the
+  next trace". Users will not understand the same key doing both.
+- Highlights inside one trace are bounded (1–20 hits per trace in real
+  queries). Running out of N/P targets is rare; when it does happen,
+  the user picks the next matching trace from the expansion explicitly.
+
+### Per-trace re-highlighting (when `currentTraceId` changes)
+
+When the user clicks a different trace in the row expansion, the
+panel's Conversation tab needs highlights for the new `traceId`. React
+Query keys highlights on `["traceSearchHighlights", traceId, q]`, so
+the second-trace fetch is independent and cacheable. Two strategies:
+
+- **On-demand refetch (V1).** Panel re-fires
+  `getTraceSearchHighlights(newTraceId, q)` on the trace switch.
+  Latency is one endpoint call; while it's in flight the conversation
+  renders without highlights, same as any first-time drawer open.
+- **Prefetch all matching traces on panel open (V1.5).** When the
+  panel opens from a search result, fire
+  `queryClient.prefetchQuery(["traceSearchHighlights", traceId, q])`
+  in parallel for **every** id in `matchingTraceIds`. `matchingTraceCount`
+  is bounded by the session's trace count (typically <20), so this is
+  bounded work; each call is scoped to one trace's `allMessages`.
+  Cross-trace clicks in the expansion feel instant.
+
+Recommendation: ship V1 on-demand, add the full-prefetch in V1.5 behind
+a feature flag, default-on once telemetry confirms the cost is fine.
+`getTraceDetail` follows the same pattern — also `traceId`-keyed, also
+cached, also independently fetchable per trace switch.
+
+### Session-specific open questions
+
+> Specific to the session extension; the spec-global open questions live
+> in the section below.
+
+- **Highlight-badge styling in the row expansion.** The matching-trace
+  badge in the expansion needs a concrete visual: hit count? score?
+  both? Score bucket color? This is more a `sessions-list-row.md` concern
+  than a highlights concern; flagged here so the two specs stay aligned
+  when the row expansion lands.
+- **Highlight cache invalidation when `q` changes mid-session-browse.**
+  Edge case: user opens session A in search mode (panel on `matchingTraceIds[0]`),
+  switches via the expansion to a second matching trace, edits `q`. The
+  panel is still open on the second trace. React Query keys highlights
+  on `(traceId, q)` so the highlight set updates automatically — but
+  the row expansion's badges are derived from the *previous* `q`'s
+  `matchingTraceIds`. Recommendation: close the panel when `q` changes
+  (we already close it when filters change). Confirm.
+- **Empty highlight set on a non-best trace.** The session result row
+  lists every trace whose `relevance_score > 0` (lexical-only matches
+  included at `score = 0`). Some of those traces matched purely
+  lexically with `relevance_score = 0` and won't produce semantic-region
+  highlights — but they will produce literal/token highlights for the
+  phrase that matched. Verify this end-to-end before shipping: a
+  session whose `matching_trace_ids` includes pure-lexical entries
+  should still highlight the phrase in those traces' panel conversation.
+- **What happens on a search-result click for a session that has zero
+  `matchingTraceIds`?** Shouldn't be possible — by construction every
+  session in the search results has at least one matching trace. But
+  defensively, if `matchingTraceIds` is empty, fall back to the
+  browse-mode default (last trace by `start_time`).
+
+## Open questions
+
+(none currently — keep iterating as design surfaces edge cases.)

--- a/specs/session-problems/6-session-panel.md
+++ b/specs/session-problems/6-session-panel.md
@@ -1,0 +1,624 @@
+# Session detail panel
+
+A right-side drawer that opens on session-row click. Mirrors the trace
+drawer's shape — sticky header, lazy-mounted tabs, the existing
+`<Conversation>` primitive — but uses a session-level header (metadata
+header, status pill, copyable id) and a Conversation tab that renders
+**one trace at a time**. The "which trace" decision is fully owned by
+this spec (§3); navigation between traces of the same session lives in
+the sessions-list row expansion, not in the panel.
+
+## Scope
+
+- **In:** the panel UI; a new server fn for session-level header metadata;
+  the wiring from the sessions list, the search results, the row
+  expansion, and deep links into the panel; the four-case trace-selection
+  contract (browse / search × 1-trace / multi-trace).
+- **Out:** column additions on `sessions` (`./1-parity-traces-sessions.md`);
+  issue dedup query (`./3-session-issue-dedup.md`); the trace conversation
+  rendering primitive itself — the panel reuses the existing
+  `<Conversation>` from `packages/ui/src/components/genai-conversation`
+  exactly as the trace drawer does. There is no merged-stream renderer
+  in this spec.
+
+## Position in the dependency chain
+
+Two foundations exist by the time the panel is built:
+
+| Foundation | What it gives the panel |
+|---|---|
+| `./1-parity-traces-sessions.md` | Header fields on the session row — `timeToFirstTokenNs`, `rootSpanId`, `rootSpanName`, `retentionDays`, status-derivation inputs, message previews. Also defines `SessionDetail` paralleling `TraceDetail` and `findBySessionId` repo method. |
+| `./3-session-issue-dedup.md` | `listSessionIssuesBySessionId({ organizationId, projectId, sessionId })` returning `SessionIssueRow[]`. Drives the Issues tab. |
+
+Lifecycle status (`live` / `idle`) is derived inline at read time from
+`now() - max_end_time` (see `0-problems.md`). No PG state table, no cron.
+
+The Conversation tab inherits everything the trace drawer already does —
+`<Conversation>` primitive, `getTraceDetail`, `getTraceSearchHighlights`,
+annotation rendering, scroll-to-first, `N`/`P` navigation, oversized-part
+collapsing. We do not duplicate any of that here.
+
+---
+
+## 1. Current state
+
+Today the sessions list has expandable rows (`useExpandedSessionTraces`,
+`sessions-view.tsx:80`) that reveal the session's constituent trace rows
+inline. There is no panel — clicking a session row only toggles the
+expansion. Trace rows in the expansion link out to the trace detail
+drawer.
+
+Missing:
+
+- A panel that surfaces session-level metadata (status, duration, TTFT,
+  cost, models, trace count) in one place.
+- A reading surface that lets the user move between the session's traces
+  without losing context.
+- A consistent click contract — today, "open the session" and "open a
+  trace inside the session" are different gestures with different
+  affordances.
+
+After this spec:
+
+- Clicking a session row **always** opens the session panel.
+- The panel shows session metadata in its header and **one trace's
+  conversation** in its Conversation tab.
+- For multi-trace sessions, the row also expands inline (current
+  behavior). The expansion is the trace navigator — clicking a different
+  trace row swaps which trace the panel is rendering.
+
+---
+
+## 2. Trace drawer as the template
+
+The session panel mirrors the trace drawer (`trace-detail-drawer.tsx`)
+in structure:
+
+- **Right-side `DetailDrawer`** with persistable width
+  (`drawerStoreKey: "session-detail-drawer-width"`, sibling of the
+  trace-drawer key).
+- **Sticky header** with title, status pill, key chips, copyable id,
+  then the tab bar.
+- **Lazy-mounted tabs** via `visitedTabs`, identical pattern to
+  `trace-detail-drawer.tsx:229,:241-247,:378-427`.
+- **URL-synced active tab** via `useParamState`
+  (`urlSyncedTabs={true}`), so deep links restore which tab the user
+  was on. The trace drawer that opens on top of the panel (e.g. when
+  the user clicks a turn inside the Conversation tab to drill into the
+  trace's full detail view) is mounted with `urlSyncedTabs={false}` to
+  keep the parent route's URL clean — same pattern as the issue-detail
+  drawer's nested trace overlay (`issues/-components/issue-detail-drawer.tsx:655-675`).
+
+What it does **not** mirror:
+
+- **No `Spans` tab.** Sessions aren't a single span tree. Span-tree
+  drill-in is per-trace and reached by opening the trace drawer on top
+  of the panel.
+- **No `Trace` tab.** Its session-level analog is the **Metadata** tab.
+- **No standalone `Traces` tab.** This functionality lives in the
+  sessions-list **row expansion**, which is already on screen behind
+  the panel. Putting a "Traces" tab in the panel would duplicate the
+  expansion's UI.
+
+---
+
+## 3. Which trace does the Conversation tab show?
+
+The panel always renders session metadata + one trace's conversation.
+The selection of which trace depends on how the panel was opened:
+
+| Case | Initial `currentTraceId` |
+|---|---|
+| Browse, 1-trace session (real or orphan) | `trace_ids[0]` — the one trace |
+| Browse, multi-trace session | The **last** trace by `start_time` — most recent activity |
+| Search, 1-trace session | `trace_ids[0]`, scrolled to first highlight |
+| Search, multi-trace session | The **first matching** trace in score order from `matchingTraceIds[0]`, scrolled to first highlight |
+| Deep link with `?sessionId=…&traceId=…` | The supplied `traceId` (must be in the session's `trace_ids`) |
+| Deep link with `?sessionId=…` only | Last trace by `start_time` |
+| Any case where the resolved trace is somehow not in `trace_ids` | Fall back to last trace, log a non-fatal error |
+
+### Multi-trace navigation
+
+For multi-trace sessions, the sessions-list **row expansion** shows
+every trace in the session, ordered by `start_time` ascending. When a
+search is active, the matching traces from `matchingTraceIds` get a
+visual hit-count badge / highlight (per `./5-search-highlights.md`'s
+session-result behavior). Clicking a different trace row in that
+expansion sets the panel's `currentTraceId` to that trace, which:
+
+1. Re-fires `getTraceDetail(newTraceId)`.
+2. Re-fires `getTraceSearchHighlights(newTraceId, q)` if `q` is non-empty.
+3. The Conversation tab re-renders with the new content. Scroll position
+   resets to the first highlight (if search) or the top (if not).
+
+The expansion **is** the trace navigator. The panel has no internal
+trace switcher; if the user wants to read a different trace, they pick
+it from the expansion behind/beside the drawer.
+
+### Why "last trace" as the default
+
+For browse-mode multi-trace, the default trace shown when the panel
+opens has to be one specific trace. We pick the **last** because:
+
+- Users opening a session for the first time are usually checking
+  current state ("what's this conversation up to now?"), not session
+  history.
+- The last trace is also what `output_messages` / `last_input_messages`
+  on the session row preview (per `./1-parity-traces-sessions.md`). Panel
+  default matching row preview reduces "wait, why am I seeing this?"
+  surprise.
+- For 1-trace sessions, "last" and "only" coincide — same code path.
+
+If we later add UX that wants the first trace as default (e.g. "review
+this session from the start"), it overrides via deep-link `?traceId=…`.
+
+---
+
+## 4. Information architecture
+
+### Header
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  My Session · Refund flow                  ●live · 12s ago        │  ← root_span_name + status pill
+│  ⏱ 12m 34s · TTFT 1.2s · 7 traces · 142 spans (2 err) · $0.034   │  ← duration / TTFT / counts / cost
+│  📋 Copy session id  •  s_x9...3b                                  │  ← copyable id
+│  ─── Conversation ───── Issues 3 ──── Metadata ────                │  ← tabs (Conversation default)
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Fields and their source:
+
+| Element | Source |
+|---|---|
+| Title | `session.rootSpanName` (parity spec). Falls back to the literal session id when empty. For orphan sessions where `session_id = toString(trace_id)`, falls back to the synthesized id displayed as a short prefix. |
+| Status pill (`live` / `idle`) | Derived in `LIST_SELECT`: `now64() - max_end_time < toIntervalMinute({sessionLiveThresholdMinutes})` → `live`, else `idle`. Default threshold = 5 minutes. Color: green dot for `live`, muted for `idle`. Pill text reads "Live · 3m ago" or "Idle · 42m ago". |
+| Duration | `formatDuration(session.durationNs)`. **Active execution time** — sum of per-trace durations, not wall-clock. A 2-day session that worked 5 min/day renders as ~2 hours, not ~2 days. See `./1-parity-traces-sessions.md` "On `duration_ns` semantics". If the panel ever wants to also surface the wall-clock window, compute it on the fly as `endTime - startTime` from the same row. |
+| TTFT | `formatDuration(session.timeToFirstTokenNs)`; renders "—" when 0 (sentinel = no first-token instrumented). |
+| Trace count | `session.traceCount`. |
+| Span count + error suffix | `session.spanCount` and `session.errorCount`. |
+| Cost | `formatPrice(session.costTotalMicrocents / 100_000_000)`. |
+| Copyable session id | `<CopyableText value={sessionId} displayValue={sessionId.slice(0, 7)} />`. |
+
+### Orphan and orphan-fragment rendering
+
+The header degrades naturally for the two adjacent edge cases (see
+`./1-parity-traces-sessions.md` "SDK contract and mixed binding"):
+
+| Case | Header rendering |
+|---|---|
+| **Pure orphan** (`trace_count = 1`, no SDK `session_id`) | Title falls back to the root span name of the only trace; "1 trace" badge instead of "N traces". TTFT / cost may or may not be set depending on whether the trace had LLM activity. |
+| **Orphan fragment** (`tokens_total = 0`, `cost_total_microcents = 0`, `models = []`, `trace_count = 1`) | Title reads as the framework-overhead slice of the request. TTFT and cost render "—" / "$0". Conversation tab is empty (no LLM spans). Metadata tab is still populated. |
+
+These rows are filtered out of the default sessions list view by the
+"has LLM activity" filter chip (`./4-filter-parity.md`). Users who turn
+that filter off can open them; the panel is honest about what's inside.
+
+### Tabs
+
+Three tabs. `Conversation` is the default visit.
+
+| Tab id | Label | Hotkey | Behavior |
+|---|---|---|---|
+| `conversation` | Conversation | `Shift+1` | Default open. Renders `currentTraceId`'s conversation via `<Conversation>`. |
+| `issues` | Issues `<N>` | `Shift+2` | Lazy-mounted. Pill count from `listSessionIssuesBySessionId().length`. |
+| `metadata` | Metadata | `Shift+3` | Lazy-mounted. Header-style detail sections. |
+
+The **Traces tab** that an earlier draft of this spec proposed is
+removed — its job is done by the sessions-list row expansion.
+
+---
+
+## 5. Conversation tab
+
+Renders one trace's conversation. Uses the **exact same primitive** the
+trace drawer's Conversation tab uses
+(`trace-detail-drawer/tabs/conversation-tab.tsx`). Concretely:
+
+```ts
+<ConversationTab
+  trace={traceDetail}                         // from getTraceDetail(currentTraceId)
+  searchQuery={q}                             // from URL ?q=…
+  highlightRanges={searchHighlights}          // from getTraceSearchHighlights(currentTraceId, q)
+  onAnnotationClick={…}
+  // mounted with the same props the trace drawer uses today
+/>
+```
+
+The component is reused **as a child** of both the trace drawer and the
+session panel; the panel doesn't reimplement any of conversation
+rendering. That gets us, for free:
+
+- Annotation rendering and the per-message `messageAnnotationSlot`.
+- `<ScrollNavigator>` with `N`/`P` stepping through messages (or
+  through highlights when search is active — see `./5-search-highlights.md`).
+- The `LARGE_MARKDOWN_CONTENT_THRESHOLD` cap and "Show N more
+  characters" affordance.
+- The oversized-part offset fix from `./5-search-highlights.md` Phase A.
+
+### What happens when `currentTraceId` changes
+
+`currentTraceId` is the panel's local state. It changes when:
+
+1. The panel first opens (initial value from §3).
+2. The user clicks a different trace row in the sessions-list row
+   expansion behind the panel.
+3. A deep link is loaded with a new `?traceId=…`.
+
+On change:
+
+1. The panel updates `currentTraceId` in URL params
+   (`useParamState("traceId", …)`).
+2. React Query fires `getTraceDetail(newTraceId)` and
+   `getTraceSearchHighlights(newTraceId, q)` if `q` is non-empty. Cache
+   keys `["traceDetail", newTraceId]` and
+   `["traceSearchHighlights", newTraceId, q]` are independent — the old
+   trace's data stays cached.
+3. The Conversation tab re-renders. Scroll resets to the first highlight
+   (if search) or top (if not).
+
+The Issues tab and Metadata tab do **not** refetch on a trace switch —
+they read session-level data which doesn't depend on which trace is
+being viewed.
+
+### Click behavior on a turn
+
+Clicking a turn in the Conversation tab opens the **trace detail
+drawer overlaid on the session panel**, same as the issue drawer's
+nested trace overlay (`issue-detail-drawer.tsx:655-675`). Overlay
+mounting:
+
+```ts
+<TraceDetailDrawer
+  open={!!overlayTraceId}
+  traceId={overlayTraceId}
+  urlSyncedTabs={false}                       // parent URL stays clean
+  onClose={() => setOverlayTraceId(null)}
+/>
+```
+
+The overlay carries the full trace detail surface — Spans tab,
+Annotations tab, full Trace tab. The panel underneath stays mounted.
+Closing the overlay returns to the panel's current trace + tab.
+
+### Annotating from the panel
+
+Users can add annotations directly from the Conversation tab on the
+**currently-shown trace**. The flow and underlying primitives are
+identical to the trace drawer — the existing `messageAnnotationSlot`
+expander, the inline annotation form, the score-write call all carry
+over unchanged. What changes is the user-facing language around
+ownership:
+
+- **Annotations attach to the current trace's span, not to the session.**
+  An annotation is a statement about a specific moment (a particular
+  message produced by a particular span), so the natural anchor is the
+  trace it lives in. The session view rolls these up; it doesn't own
+  them.
+- **Success-toast wording is explicit about anchoring.** When an
+  annotation is saved from the panel, the confirmation toast reads
+  "Annotation added to turn N of this session" (rather than the trace
+  drawer's "Annotation added"), so the user's mental model is right
+  from the first interaction. `N` is the trace's position by
+  `start_time` within `session.traceIds`.
+- **New traces arriving later do not migrate older annotations.** If a
+  user annotates turn 5, and turn 6 later lands in the same session,
+  the annotation stays on turn 5. The Conversation tab's default
+  `currentTraceId` advances to the latest trace per §3, so a later
+  visitor opens on turn 6 by default — but the annotation on turn 5 is
+  still discoverable via (a) the Issues tab if the annotation became a
+  score with an `issue_id`, (b) navigating back to turn 5 through the
+  row expansion. This is the correct behavior, not a bug — annotations
+  describe moments, not sessions.
+- **Session-level annotations are explicitly out of scope.** "This
+  whole conversation was bad" doesn't have a useful anchor; if a
+  specific turn was bad, annotate that turn. If no specific turn was
+  bad, the annotation tends to collapse into "this session was a 7/10"
+  feedback, which is a different ontology. We don't add session-grain
+  scores to `scores` (no `target_kind = 'session'`); we don't build a
+  session-grain annotation surface in this spec. If product demand
+  surfaces it later, that's a separate feature.
+
+---
+
+## 6. Issues tab
+
+Driven by `listSessionIssuesBySessionId` (`./3-session-issue-dedup.md`).
+One row per `(issue_id, session_id)` in the session.
+
+### Row layout
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ 🔴  Refusal on payment-related turns        4 turns · 2m ago       │
+│      Last seen: 14:32 · First seen: 14:20                          │
+│      Affected traces: t_a1, t_b2, t_c3, t_d4   [hover to expand]   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Fields from `SessionIssueRow`:
+
+| Element | Field |
+|---|---|
+| Title | Joined from PG `issues.name`. |
+| Occurrence count | `occurrences` (per `./3-session-issue-dedup.md` — count of contributing scores). |
+| First seen / Last seen | `firstSeenAt`, `lastSeenAt`. |
+| Affected traces | `matchingTraceIds`. Each trace id is clickable. |
+
+### Click behavior on an affected trace
+
+Clicking an affected trace id (or the issue row itself) is **one user
+gesture** that does three things behind the scenes:
+
+1. Sets the panel's `currentTraceId` to that trace.
+2. Switches the active tab from `Issues` to `Conversation`.
+3. Scrolls to the message the annotation is anchored to, then
+   briefly flashes a highlight on that message (reusing the
+   `ScrollNavigator`'s existing target-flash affordance) so the user's
+   eye lands on it immediately rather than just "near it."
+
+Even though the implementation involves three internal transitions,
+the user perceives a single response: "I clicked the issue and the
+annotated turn is right there." Two design polishes keep that
+perception honest:
+
+- **Prefetch on Issues-tab visit.** When the Issues tab is mounted,
+  the panel issues
+  `queryClient.prefetchQuery(["traceDetail", traceId])` for every
+  unique `traceId` in the loaded `SessionIssueRow.matchingTraceIds`
+  arrays. `matchingTraceCount` per row × number of rows is bounded by
+  the session's `traceCount` (typically <20); each prefetch is one
+  trace's `getTraceDetail` call. Cross-trace clicks then feel
+  instant. Same shape as the search-mode prefetch in
+  `./5-search-highlights.md`'s "Per-trace re-highlighting".
+- **Targeted post-scroll flash.** After the tab switch and scroll, the
+  annotated message gets a short visual emphasis (background pulse or
+  ring) tied to `data-annotation-id`. Same primitive the trace drawer
+  already uses when an annotation hash-link is opened. This is the
+  difference between "we landed on the right turn" feeling correct
+  vs. feeling sloppy.
+
+Same mechanic as the row-expansion path; the issue row is just a
+secondary entry point into "switch trace + go to a specific message."
+
+### Why this isn't a "weird UX of session → trace → conversation"
+
+A natural worry with the rollup model is that drilling into an
+annotation requires the user to traverse three surfaces (session
+panel → trace panel → conversation → scroll). In this design, the
+session panel **is** the conversation surface — the Conversation tab
+inside it is the same `<Conversation>` primitive the trace drawer
+renders. Switching `currentTraceId` doesn't navigate between distinct
+surfaces; it changes which trace the panel's tab is rendering. The
+two polishes above make that change feel like "the annotation is
+right there" rather than "I just navigated three layers deep."
+
+If telemetry later shows the transition still feels heavy, the
+fallback affordance is a popover-on-issue-row mode: click an issue
+row → popover with the annotation text + a secondary "View in
+conversation" button. We don't ship that by default; it's a parking
+spot if the polished version fails real-use feedback.
+
+### Empty / loading / error states
+
+- Empty (no issues): "No issues detected in this session."
+- Loading: skeleton rows.
+- Error: "Couldn't load issues — retry." Standard hook error UI.
+
+---
+
+## 7. Metadata tab
+
+Session-level fields, none of which depend on `currentTraceId`. Read
+once on tab visit.
+
+### Sections (top to bottom)
+
+1. **Identifiers** —
+   - `Session ID` (copyable)
+   - `Organization ID`, `Project ID`
+   - `Root span ID` (from `session.rootSpanId`, parity spec) — copyable
+   - `User ID`, `Simulation ID` if present
+2. **Timing** —
+   - `Started at` — `session.startTime`.
+   - `Last activity` — `session.endTime` (i.e. `max_end_time` from the
+     materialization).
+   - `Status` — same `live` / `idle` derivation as the header pill.
+3. **Volume and cost** —
+   - `Total traces`, `Total spans`, `Error spans`
+   - `Total tokens` (with breakdown: input, output, cache read/create, reasoning)
+   - `Total cost` (with breakdown: input, output)
+4. **Models and providers** —
+   - `Models used` — `session.models` array
+   - `Providers` — `session.providers` array
+   - `Service names` — `session.serviceNames` array
+5. **Tags and metadata** —
+   - `Tags` — `session.tags` array, rendered as chips
+   - `Metadata` — `session.metadata` map, key/value table
+6. **Retention** —
+   - `Retention days` — `session.retentionDays`. Useful for power users
+     auditing plan-tier retention.
+
+---
+
+## 8. Server functions
+
+Two are new; the others are reused from existing surfaces.
+
+### `getSessionDetail({ projectId, sessionId })` (new)
+
+Single-session point lookup for the header + metadata tab. No
+conversation content (that comes from `getTraceDetail`).
+
+```ts
+export const getSessionDetail = createServerFn({ method: "GET" })
+  .inputValidator(z.object({
+    projectId: z.string(),
+    sessionId: z.string(),
+  }))
+  .handler(async ({ data }): Promise<SessionDetailRecord | null> => { /* ... */ })
+
+export interface SessionDetailRecord extends SessionRecord {
+  // From 1-parity-traces-sessions.md
+  readonly timeToFirstTokenNs: number
+  readonly rootSpanId: string
+  readonly rootSpanName: string
+  readonly retentionDays: number
+  readonly systemInstructions: GenAISystem
+
+  // Derived inline from now() - max_end_time
+  readonly status: "live" | "idle"
+
+  // Carried for the Conversation tab's initial-trace decision
+  readonly traceIds: readonly string[]      // ordered by start_time asc
+  readonly lastTraceId: string              // = traceIds[traceIds.length - 1]
+}
+```
+
+Backed by a new repo method `SessionRepository.findBySessionId({
+organizationId, projectId, sessionId })` returning a `SessionDetail`
+(parity spec's analog of `TraceDetail`). The repo impl projects through
+`DETAIL_SELECT` from
+`packages/platform/db-clickhouse/src/repositories/session-repository.ts`,
+paralleling `TraceRepository.findByTraceId` at `trace-repository.ts:1613-1643`.
+
+### `getTraceDetail({ projectId, traceId })` (reused)
+
+Existing. Called whenever the panel's `currentTraceId` changes.
+
+### `getTraceSearchHighlights({ projectId, traceId, searchQuery })` (reused)
+
+Existing, introduced by `./5-search-highlights.md`. Called alongside
+`getTraceDetail` when `q` is non-empty.
+
+### `listSessionIssuesBySessionId({ projectId, sessionId })` (reused)
+
+From `./3-session-issue-dedup.md`. Drives the Issues tab.
+
+---
+
+## 9. Navigation
+
+### Opening the panel
+
+| Source | Initial trace per §3 | URL |
+|---|---|---|
+| Sessions list row click | Last trace (browse) / first matching (search) | `?sessionId=…&traceId=<resolved>` |
+| Row expansion's trace row click | The clicked trace | `?sessionId=…&traceId=<clicked>` |
+| Search result row click | First matching trace | `?sessionId=…&traceId=<first-match>&q=…` |
+| Issue row → "View session" link | Last trace | `?sessionId=…&traceId=<last>` |
+| Deep link | Per §3 | (as supplied) |
+
+In every case the URL carries the session id and the resolved initial
+trace id. Reload restores state.
+
+### Closing
+
+Standard drawer close: `Esc`, click the backdrop, or the close button.
+URL params are cleared on close. The sessions-list row expansion stays
+expanded if it was open (it's an independent piece of state).
+
+### Inter-panel navigation
+
+The panel can be open simultaneously with:
+
+- The sessions-list row expansion (it's the trace navigator)
+- The trace detail drawer overlay (when the user drills into a turn)
+- The issue detail drawer overlay (when the user clicks an issue row's
+  "open issue" link — out of scope here, but the pattern works)
+
+Closing each surface peels one layer at a time.
+
+---
+
+## 10. Live updates
+
+- **Status pill** polls `getSessionDetail` every **30 seconds** when
+  `status === "live"`. Polling stops when the panel becomes `idle` or
+  is closed. Re-uses the existing React Query refetch interval pattern.
+- **Conversation tab** does **not** auto-poll. The user reloads
+  manually to pick up new turns on the currently-shown trace. Rationale:
+  cross-trace polling (a new trace appears that the panel isn't
+  showing) is out of scope — the row expansion would surface a new
+  trace row, and the user picks whether to switch into it.
+- **Issues tab** does not auto-poll. Same reasoning — the panel is for
+  reading, not for live-monitoring.
+
+If down the line we want a live-tail experience for the active trace,
+that's a Conversation-tab feature that lives in `<Conversation>`
+itself, behind a separate spec.
+
+---
+
+## 11. Files this will touch
+
+### Domain layer
+
+- `packages/domain/spans/src/entities/session.ts` — already widened by
+  parity spec. The panel doesn't add fields beyond what's already there.
+- `packages/domain/spans/src/ports/session-repository.ts:12` — add
+  `findBySessionId({ organizationId, projectId, sessionId }):
+  Effect.Effect<SessionDetail | null, RepositoryError, ChSqlClient>`.
+- `packages/domain/sessions/src/use-cases/get-session-detail.ts` (new)
+  — composes `findBySessionId`.
+- Reuses existing `findByTraceId` (trace drawer's data source) and
+  `listSessionIssuesBySessionId` (issue dedup spec).
+
+### Platform layer (CH)
+
+- `packages/platform/db-clickhouse/src/repositories/session-repository.ts`
+  — add `findBySessionId` + `DETAIL_SELECT`. Same shape as parity
+  spec's "Files that change" — this is its consumer.
+
+### Web layer
+
+- `apps/web/src/domains/sessions/sessions.functions.ts` — add
+  `getSessionDetail` server fn.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx`
+  (new) — the panel component. Mirrors
+  `trace-detail-drawer.tsx`'s structure (header, tabs, lazy mount).
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/`
+  — sub-folder for the three tab components:
+  - `conversation-tab.tsx` — thin wrapper around the existing
+    `ConversationTab` from the trace drawer, parameterized on
+    `currentTraceId`.
+  - `issues-tab.tsx` — list of `SessionIssueRow`.
+  - `metadata-tab.tsx` — detail sections.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/sessions/-components/sessions-view.tsx`
+  — wire row click to open the panel; thread the row expansion's
+  selected trace into the panel's `currentTraceId`.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx`
+  — wire search-result row click to open the panel on the first matching
+  trace (this is the entry point this epic ships first; the lift into
+  unified `sessions` happens later per `0-problems.md`'s future-state UX
+  context).
+- `apps/web/src/domains/sessions/sessions.collection.ts` — add
+  `useSessionDetail` hook (React Query wrapper).
+
+---
+
+## 12. Open questions
+
+- **"Open in full session conversation view" as a power-user feature.**
+  Some users may want to read the whole multi-trace conversation as a
+  continuous stream (the original session-panel design). That's a
+  separate surface — likely a dedicated route or full-page mode rather
+  than a tab in the drawer. Park until we see whether the trace-by-trace
+  navigation via row expansion meets the need.
+- **Pre-fetch the last trace's detail when the user hovers a session
+  row?** Cheap and would make the panel feel instant. Probably worth
+  doing for the initial cut. Confirm with telemetry once shipped.
+- **Pre-fetch all matching traces' highlights when opening a search
+  result?** `matchingTraceIds` is bounded by the session's trace count
+  (typically <20). Firing N parallel `getTraceSearchHighlights` calls
+  on panel open is bounded work, and it makes cross-trace clicks in the
+  expansion instant. Probably worth doing in V1 — flagged so we can
+  measure cost before turning it on by default.
+- **What happens if `currentTraceId` deep-links to a trace that's not
+  in the session's `trace_ids`?** Fallback per §3 (last trace + warn).
+  Worth deciding whether the URL gets rewritten to the fallback or
+  just gets ignored.
+- **Annotation badge on the row expansion's trace rows.** Should the
+  expansion show a count of annotations per trace, mirroring the
+  hit-count badge for search results? Probably yes, but it's a
+  sessions-list spec concern, not a panel concern.

--- a/specs/session-problems/7-freshness-weighted-sort.md
+++ b/specs/session-problems/7-freshness-weighted-sort.md
@@ -1,0 +1,796 @@
+# Freshness-weighted session ordering
+
+Blend relevance and freshness in the session-level search result list, so a
+user typing a query gets back results that are both topically on-target **and**
+sorted with the live, recently-active sessions surfaced ahead of equally-
+relevant but stale ones. The unit of ranking is one row per session as defined
+by `2-session-level-search.md`; this spec adds a second axis on top of
+`best_score` and reshapes the `ORDER BY` and the cursor.
+
+This is a refinement spec. It does not change `buildSearchPlan`, the
+trace-level indexes, or the rollup CTE structure. It changes one expression in
+the outer `SELECT` (the sort key), the `HAVING`/cursor clause, and the
+public-facing cursor shape carried by `SessionListPage.nextCursor`.
+
+Read first:
+
+- `specs/session-problems/2-session-level-search.md` — defines the rollup CTE,
+  the cursor `(best_score, session_id)`, and how list / count / metrics /
+  histogram share the same plan. This spec extends that pipeline.
+- `specs/session-problems/1-parity-traces-sessions.md` — defines the
+  `max_end_time` column on `sessions` (`max(end_time)` over the session's
+  spans). This is the canonical "last activity" timestamp; freshness
+  derives directly from it.
+
+## Scope
+
+- **In:** the `ORDER BY` clause inside the session-level search list query,
+  the matching `HAVING` (cursor) clause, the cursor shape returned in
+  `SessionListPage.nextCursor`, the constants/knobs that control the freshness
+  weighting, and how the count / metrics / histogram siblings stay aligned
+  with the new sort key.
+- **Out:** changes to ranking when no `searchQuery` is active — the non-search
+  session listing keeps its existing sort axes (`start_time`, `duration`,
+  `cost`, `traceCount` per `session-repository.ts:163-168`). Freshness
+  weighting is a search-result concern; outside search, the user already
+  picks the axis with the column-header sort UI.
+- **Out:** anything to do with the trace-level search page. Trace search keeps
+  `ORDER BY relevance_score DESC, trace_id DESC` (`trace-repository.ts:984`).
+
+## 1. Current state — what `ORDER BY` looks like today
+
+Today's session-level search list query, defined in
+`specs/session-problems/2-session-level-search.md` §4.3 (lines 432-505), ends
+with:
+
+```sql
+GROUP BY organization_id, project_id, session_id
+ORDER BY best_score DESC, session_id DESC
+LIMIT {limit:UInt32}
+```
+
+(see `2-session-level-search.md:503` and the cursor pattern at lines 540-563).
+
+The cursor predicate sits in a `HAVING` because `best_score` is an aggregate:
+
+```sql
+HAVING (max(relevance_score), session_id) <
+       ({cursorSortValue:Float64}, {cursorSessionId:String})
+```
+
+The `nextCursor` returned to the client is `{ sortValue, sessionId }` where
+`sortValue` is the page's last row's `best_score` serialized as a string —
+same shape as `SessionListCursor` in
+`packages/domain/spans/src/ports/session-repository.ts:42-45`:
+
+```ts
+export interface SessionListCursor {
+  readonly sortValue: string
+  readonly sessionId: string
+}
+```
+
+The two-field cursor is sufficient for stable keyset pagination as long as the
+`ORDER BY` tuple agrees with the cursor tuple. `2-session-level-search.md` §9
+already flagged that the `session_id` tie-breaker is "stable but arbitrary"
+and explicitly deferred to this spec: *"Is there a recency or freshness
+signal we should prefer over `session_id` as the secondary sort?
+`max(trace_end_time)` would put recently-active sessions first among ties —
+defensible. Defer to the freshness-sort spec."* (`2-session-level-search.md:992`).
+
+This spec answers that — and extends the answer past the tie-breaker case to
+the general "blend the two axes" question.
+
+## 2. Why pure relevance is wrong
+
+A user opens the search page on a long-lived project and types `"refund
+request"`. The session-level search returns one row per session whose traces
+matched the query. Suppose three sessions matched:
+
+| Session | best_score | last activity (`max_end_time`) |
+|---|---|---|
+| `S-A` | 0.87 | 18 months ago — long-resolved support escalation from 2024 |
+| `S-B` | 0.85 | this morning — open conversation, customer waiting |
+| `S-C` | 0.42 | five minutes ago — fresh, possibly-related complaint |
+
+Pure `ORDER BY best_score DESC` lands `S-A` first, then `S-B`, then `S-C`.
+That ordering is defensible for a research / forensic use case ("what was the
+single best match in our entire history?") but it's wrong for the modal
+session-search user, who is investigating live behavior: they want `S-B`
+first (a real, recent, high-quality match), then `S-C` (a recent moderate
+match worth triaging), and only then the 18-month-old artifact. The fact that
+the historical session edges the live one by 0.02 in cosine similarity is not
+a meaningful preference — it's noise inside the bi-encoder's confidence
+band — and it's letting an effectively-dead row dominate the first screen.
+
+The pathology generalizes. Session corpora monotonically grow; over months
+and years the corpus accumulates many high-scoring stale rows for every query
+shape that has come up before. As a project ages, the top of the search
+results list calcifies — the same handful of canonical past conversations
+crowd out anything new that touches the same topic. The user can't see what
+their *current* system is doing because their query is being answered by
+their system's history. The fix has to push freshness up the priority list
+without nuking relevance: a 0.85-scoring session from this morning should
+beat a 0.87-scoring session from 18 months ago, but a 0.42-scoring session
+from 5 minutes ago should not beat a 0.85-scoring session from this morning.
+The challenge is calibrating where the relevance gap stops being meaningful
+and freshness starts to dominate.
+
+## 3. The freshness axis
+
+We need one column per session that answers "how recently was this session
+active?", with the following properties:
+
+1. **Bounded by reality.** A client with a wrong clock cannot make a session
+   look fresher than `now()`. Defense lives in CH at read time, not in the
+   client.
+2. **Stable enough for cursor pagination.** The value can move forward when
+   new traces land — that's the whole point — but the *cursor* has to encode
+   the value at the moment the page was issued so subsequent page-fetches
+   compare against the same baseline.
+3. **Cheap.** Already materialized; no join, no extra subquery.
+
+### Candidate timestamps
+
+| Source | Where | Behavior |
+|---|---|---|
+| `traces.max_end_time` per matching trace | Joined into `trace_rollup` via the existing join to `traces` (`2-session-level-search.md:498-502`). | Bounding-box of the **matching** traces. `max(trace_end_time)` is the latest matching turn's end. |
+| `sessions.max_end_time` | CH `sessions` AggregatingMergeTree (`packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00007_sessions.sql:16-17`); read via `max(max_end_time) AS end_time` in `session-repository.ts:30`. | Latest span end_time across the **whole** session. The session's canonical "last activity". |
+
+### Recommendation: `sessions.max_end_time`
+
+Use the session-level `max_end_time` (the whole session's latest activity),
+not the per-matching-trace `max(trace_end_time)`. Three reasons:
+
+1. **Definition match.** It's the same value the panel header uses for
+   "Last activity" and the same value the panel uses to derive its
+   `live` / `idle` status pill (`now() - max_end_time` against
+   `SESSION_LIVE_THRESHOLD_MS`). Freshness sort sharing that definition
+   means "fresh in the sort" and "live in the pill" line up: a user
+   wondering why an old-looking session is at the top can always check
+   the pill for the answer.
+2. **Robust to single-trace matches.** A session active today whose only
+   matching turn is from six months ago should still rank as fresh — the
+   conversation is alive, the query just happened to hit an old quote. Using
+   `max(trace_end_time)` from `trace_rollup` would penalize that case
+   incorrectly; using `sessions.max_end_time` does not. See §6.3 for the
+   worked example.
+3. **Trivially available.** It's already on the `sessions` row and the
+   rollup CTE in `2-session-level-search.md` is going to need to join through
+   `sessions` anyway to get `session_id` (today the join goes through
+   `traces`; see Open Questions about pulling other session-row fields).
+   Worst case it's a cheap extra column on the existing join.
+
+### Clock-skew defense
+
+A span whose client-reported `end_time` lies in the future would otherwise
+make a session sort as "infinitely fresh" forever. Sort against
+`least(max_end_time, now64(9, 'UTC') + INTERVAL 1 HOUR)`:
+
+```sql
+least(max(max_end_time), now64(9, 'UTC') + toIntervalHour(1)) AS last_activity_at
+```
+
+The `+1 HOUR` window absorbs honest small skews (NTP drift, batch-finalized
+spans) without collapsing them to `now()` exactly, while still capping the
+2099-dated junk-span case.
+
+## 4. Options considered
+
+Three viable shapes for combining `best_score` and `last_activity_at`. All
+three preserve the existing rollup CTE; they differ in the outer `ORDER BY`
+expression and the cursor shape.
+
+### Option A — Bucketed relevance + recency within bucket (the user's proposal)
+
+Round `best_score` into 10 fixed-width buckets and sort by recency inside
+each bucket. The recency axis is `last_activity_at DESC`.
+
+```sql
+-- New expression in the outer SELECT:
+floor(best_score * 10) / 10 AS relevance_bucket  -- in {0.0, 0.1, 0.2, …, 0.9, 1.0}
+
+ORDER BY
+  relevance_bucket DESC,
+  last_activity_at DESC,
+  session_id DESC
+```
+
+**Bucket math.** `floor(best_score * 10) / 10` partitions `[0.0, 1.0]` into
+ten half-open intervals `[0.0, 0.1), [0.1, 0.2), …, [0.9, 1.0)`, plus the
+singleton bucket `{1.0}` (a perfect cosine 1.0 lands in its own bucket).
+Boundaries are deterministic: `best_score = 0.85` and `best_score = 0.89999`
+both land in bucket `0.8`; `best_score = 0.9` lands in bucket `0.9`. The
+floor's left-closed/right-open semantic means the bucket containing a value
+`x` is always `floor(x * 10) / 10`, never ambiguous.
+
+In ClickHouse the `floor()` function returns a `Float32`/`Float64` matching
+its argument's type — `best_score` is `Float64` from
+`max(search_results.relevance_score)` — so the bucket column is `Float64`
+with a fixed dust of decimals (`0.1` is `0.10000000000000001` in IEEE 754,
+but it compares equal to itself within the same query, so cursor stability
+is preserved).
+
+**Cursor.** Three fields, lexicographically compared:
+
+```sql
+HAVING (
+  floor(max(relevance_score) * 10) / 10,
+  least(max(max_end_time), now64(9, 'UTC') + toIntervalHour(1)),
+  session_id
+) < (
+  {cursorBucket:Float64},
+  {cursorLastActivityAt:DateTime64(9, 'UTC')},
+  {cursorSessionId:String}
+)
+```
+
+The cursor shape changes from `{ sortValue, sessionId }` to
+`{ bucket, lastActivityAt, sessionId }`. Same keyset-pagination contract as
+today, just one extra field. See §5 for the wire shape.
+
+**Pros**
+
+- Matches the user mental model — "approximately-same-relevance, fresher
+  first" — in one sentence. The §2 failure mode (18-month-old 0.87 beats
+  this-morning 0.85) is gone for any pair inside the same bucket.
+- Relevance still dominates across bucket boundaries: a 0.85 always beats
+  a 0.79 no matter how fresh.
+- One knob: bucket width. Wider → favor freshness; narrower → favor
+  relevance.
+- Cursor stays a deterministic tuple comparison.
+
+**Cons**
+
+- **Boundary cliffs.** `0.8001` and `0.7999` sit in adjacent buckets and
+  can be displaced by many rows despite a 0.0002 score gap. Price of
+  the simplicity.
+- **Cursor instability on bucket bump.** A new high-scoring trace can
+  lift a paginated session into a higher bucket. Same forward-time
+  anomaly as `2-session-level-search.md:999-1006`; the bucket jump is
+  more visible than a continuous-score nudge but not more frequent.
+- **No score variance inside a bucket.** `0.99` and `0.90` are
+  indistinguishable. Acceptable in `[0.9, 1.0)` but more debatable in
+  `[0.3, 0.4)` where the band spans the signal floor
+  (`TRACE_SEARCH_MIN_RELEVANCE_SCORE = 0.3`, `constants.ts:138`).
+
+**Query cost.** Negligible. The bucket expression is a pure scalar
+computation on the outer aggregate; ClickHouse handles it inside the same
+group-by pass. The `HAVING` cursor predicate is the same tuple comparison as
+today, with one more field.
+
+**Tunability.** The bucket width is one constant. Tied to a single
+`SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH = 0.1` in `constants.ts`. Cheap to
+A/B if we ever want to (0.05 = more buckets, 0.2 = fewer, etc.).
+
+**Edge surprises.** Lexical-only matches all have `best_score = 0.0`, so
+they all share bucket `0.0` (see `2-session-level-search.md:822-833`); inside
+that bucket they sort by `last_activity_at` — which is the right behavior.
+Phrase-only matches naturally separate themselves into "freshest first"
+without any extra plumbing.
+
+### Option B — Continuous composite score (exponential decay)
+
+Combine the two axes into a single scalar:
+
+```
+composite_score = best_score * exp(-lambda * age_days)
+```
+
+where `age_days = (now() - last_activity_at) / (1 day)` and `lambda` is
+chosen so that a fixed half-life `T_half` means `exp(-lambda * T_half) = 0.5`,
+i.e. `lambda = ln(2) / T_half`.
+
+The codebase already uses this pattern for the issue-discovery centroid
+decay: `packages/domain/issues/src/helpers.ts:70-74` uses
+`alpha = 0.5 ** (delta / halfLifeMilliseconds)` for an analogous
+exponential half-life decay, with `CENTROID_HALF_LIFE_SECONDS = 14 * 86400`
+(`packages/domain/issues/src/constants.ts:125`). The session-search version
+operates at read time inside ClickHouse instead of inside the worker, but
+the math is the same.
+
+In CH:
+
+```sql
+best_score * exp(
+  -ln(2) * dateDiff('day',
+    least(max(max_end_time), now64(9, 'UTC') + toIntervalHour(1)),
+    now64(9, 'UTC')
+  ) / {halfLifeDays:Float64}
+) AS composite_score
+
+ORDER BY composite_score DESC, session_id DESC
+```
+
+**Tuning `T_half`.** The half-life is the moment when an old session of
+relevance `x` ties a fresh session of relevance `x / 2`. Decay multiplies,
+so a session at 0.4 can *never* beat a fresh session at 0.8 — the
+freshness benefit is *proportional*. A recent 0.42 only beats an old 0.85
+once `0.42 > 0.85 * exp(-lambda * age)`, i.e. once the old session's
+decay multiplier falls below `0.42/0.85 ≈ 0.49`, slightly later than one
+half-life. Default `T_half = 7 days` is a reasonable starting point.
+
+**Cursor.** Two fields, like today, but the sort value is the composite:
+
+```sql
+HAVING (composite_score, session_id) <
+       ({cursorSortValue:Float64}, {cursorSessionId:String})
+```
+
+The wire cursor shape doesn't change at all — `{ sortValue: string;
+sessionId: string }` keeps working.
+
+**Pros**
+
+- Smooth — no boundary cliffs.
+- Reuses today's 2-field cursor shape exactly. No client changes.
+- Mirrors `updateIssueCentroid` (`helpers.ts:107-130`).
+
+**Cons**
+
+- **Leapfrog.** With a short half-life, a 0.42 can climb above a 0.87.
+  User reads "0.42 above 0.87" and has to reason about decay.
+- **Half-life is a soft knob.** No principled answer; tune to taste.
+- **Cursor unstable under decay.** `composite_score` depends on
+  `now64()`, which moves between page fetches; the strict-less-than
+  comparison can drop or duplicate boundary rows. Fix: snapshot
+  `now()` at first request and thread the snapshot through every
+  paginated call. Extra wire field, extra wiring. Option A is exempt
+  because `floor()` of a stable `best_score` doesn't depend on `now()`.
+- **`exp()` per row.** Cheap relative to `cosineDistance` already in
+  the pipeline, but worth noting.
+
+**Query cost.** One `dateDiff` + one `exp` per row in the outer
+aggregation. Cheaper than the existing cosine, more expensive than a
+`floor()`. Negligible.
+
+**Tunability.** One knob, the half-life. Ship as
+`SESSION_SEARCH_RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000` for
+symmetry with the issue centroid constant.
+
+**Edge surprises.** Sessions with `best_score = 0.0` (lexical-only) all
+sort to the bottom regardless of recency: `0.0 * exp(...) = 0.0`. That's
+worse than Option A, where lexical-only rows still sort among themselves
+by recency. We'd have to special-case `best_score = 0.0` to fall back to a
+recency-only ordering inside that band — adding back a branch we got rid
+of when we picked "continuous".
+
+### Option C — Two-pass / rerank by recency
+
+Pull the top-K by pure relevance (K large, e.g. 200), then rerank that set
+by `last_activity_at` for the user-visible page.
+
+```sql
+SELECT … FROM (
+  SELECT * FROM session_rollup
+  ORDER BY best_score DESC
+  LIMIT 200
+)
+ORDER BY last_activity_at DESC, session_id DESC
+LIMIT 50
+```
+
+**Pros**
+
+- Trivially understandable: "200 most relevant, ordered by freshness".
+- Inside the shortlist there's no boundary cliff.
+
+**Cons**
+
+- **Pagination is broken.** The shortlist is computed per request. A
+  cursor cannot express "below row 200 in the relevance shortlist"
+  because that boundary moves under inserts. Offset-based pagination is
+  the only option and offsets re-order under inserts.
+- **The 201st-best-relevance session is invisible no matter how fresh.**
+  Single hard cliff at K — worse boundary semantics than Option A.
+
+**Query cost.** Two passes; intermediate state. Comparable to today.
+
+**Tunability.** One knob (K). Same boundary-cliff pathology as A but at
+a single global threshold.
+
+**Cursor stability.** No keyset cursor that survives concurrent updates.
+
+### Summary table
+
+| | Option A — Buckets | Option B — Decay | Option C — Two-pass |
+|---|---|---|---|
+| Sort key | `(bucket, last_activity_at, session_id)` | `(composite_score, session_id)` | `(rerank_position)` |
+| Cursor fields | 3 | 2 (same as today, value differs) | offset (unstable) |
+| Cursor stable under concurrent inserts | Same as today within bucket; cross-bucket the row jumps | Composite drifts as `now()` advances; mitigated by snapshot | No |
+| Boundary cliff | Yes, at bucket edges (knob-controlled) | No (smooth) | Yes, at K (single cliff) |
+| Lexical-only (`0.0`) rows order | By recency within bucket 0.0 | All collapse to 0 | Likely never in top-K |
+| Knobs to tune | bucket width (default 0.1) | half-life (default 7 days) | K (default 200) |
+| Read-time cost | floor + tuple cmp | exp + dateDiff + cmp | inner ORDER BY + LIMIT + outer ORDER BY |
+| Wire cursor change | Yes (1 extra field) | No (same shape) | Yes (offset) |
+| Affinity with §1 quote from `2-session-level-search.md:992` | Direct (recency tie-breaker generalized) | Indirect | Indirect |
+
+## 5. Recommended approach — Option A
+
+**Ship the bucketed sort.** The bucket-width knob maps directly to the
+user mental model ("approximately-same-relevance → fresher wins"), the
+cursor stays a deterministic tuple, lexical-only rows still order by
+recency, and we don't have to take a dependency on snapshotting `now()`
+across requests. Option B is a credible alternative — and if we ever ship
+both behind a feature flag, the cursor shape from A is a strict superset
+of B's, so we can switch the inner mechanic without breaking client URL
+state. Option C is rejected outright on pagination.
+
+### 5.1 Concrete SQL — full outer query
+
+The outer `SELECT` from `2-session-level-search.md` §4.3, with the freshness
+additions inlined. Diff against `2-session-level-search.md:464-505`:
+
+```sql
+SELECT
+  organization_id,
+  project_id,
+  session_id,
+
+  -- Score aggregation across the session's matching traces (unchanged).
+  max(relevance_score)                                            AS best_score,
+  argMax(trace_id, relevance_score)                               AS best_trace_id,
+
+  -- NEW: freshness axis. `max(max_end_time)` is the session's last activity
+  -- — the same value the session panel uses as "Last activity" and for the
+  -- live/idle pill. The `least(…, now + 1 HOUR)` clamp absorbs client-clock
+  -- skew without collapsing honest small drift to now() exactly.
+  least(
+    max(max_end_time),
+    now64(9, 'UTC') + toIntervalHour(1)
+  )                                                               AS last_activity_at,
+
+  -- NEW: relevance bucket. floor(score * 10) / 10 partitions [0, 1] into
+  -- ten 0.1-wide buckets {0.0, 0.1, ..., 0.9}, plus the singleton 1.0 for an
+  -- exact cosine of 1. Lexical-only sessions (best_score = 0.0) land in bucket 0.0
+  -- and order by last_activity_at among themselves.
+  floor(max(relevance_score) * {bucketWidth:Float64} * 10) /
+    ({bucketWidth:Float64} * 10)                                  AS relevance_bucket,
+  -- ^ Parameterized form. Default {bucketWidth:Float64} = 1.0 → buckets of width 0.1.
+  --   Set to 2.0 for buckets of width 0.05; 0.5 for buckets of width 0.2; etc.
+  --   See §5.4 on knob plumbing.
+
+  -- Existing aggregates (unchanged from 2-session-level-search.md §4.3):
+  count()                                                         AS matching_trace_count,
+  arrayMap(
+    pair -> pair.1,
+    arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score)))
+  )                                                               AS matching_trace_ids,
+  arrayMap(
+    pair -> pair.2,
+    arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score)))
+  )                                                               AS matching_trace_scores,
+
+  min(trace_start_time)                                           AS session_start_time,
+  max(trace_end_time)                                             AS session_end_time,
+  sum(cost_total_microcents)                                      AS cost_total_microcents,
+  sum(span_count)                                                 AS span_count,
+  sum(error_count)                                                AS error_count,
+  sum(tokens_total)                                               AS tokens_total
+
+FROM trace_rollup
+WHERE session_id != ''
+  ${sessionCursorClause}     -- HAVING, see §5.2
+GROUP BY organization_id, project_id, session_id
+
+-- NEW: ORDER BY uses the bucket + freshness + session_id tuple.
+ORDER BY
+  relevance_bucket  DESC,
+  last_activity_at  DESC,
+  session_id        DESC
+
+LIMIT {limit:UInt32}
+```
+
+**Surfacing `sessions.max_end_time`.** The rollup CTE in
+`2-session-level-search.md` reads from `traces`. Two options: (a) extend
+`trace_rollup` with a `LEFT JOIN sessions` to pull `s.max_end_time`
+through; (b) use `max(trace_rollup.trace_end_time)` instead. Recommend
+(a) — see §6.3: a session with one old matching trace but live activity
+*outside* the matching set should still rank as fresh; (b) penalizes
+that case. The join is cheap (`sessions` shares the
+`(organization_id, project_id, session_id)` primary key), and the
+right-hand side is unique per session, so `any(sess.max_end_time)` is
+safe inside `trace_rollup`:
+
+```sql
+-- inside trace_rollup:
+any(sess.max_end_time)                                  AS session_max_end_time
+FROM traces t
+INNER JOIN search_results ON t.trace_id = search_results.trace_id
+LEFT JOIN sessions sess ON
+     sess.organization_id = t.organization_id
+ AND sess.project_id     = t.project_id
+ AND sess.session_id     = argMaxIfMerge(t.session_id)
+```
+
+The outer SELECT then reads `least(max(session_max_end_time),
+now() + 1 HOUR) AS last_activity_at`.
+
+**Knob form.** The parameterized expression
+`floor(score * bucketWidth * 10) / (bucketWidth * 10)` keeps the knob as
+"buckets per unit of relevance": `bucketWidth = 1.0` (default) → 10
+buckets, reads `floor(score * 10) / 10` exactly; `2.0` → 20 buckets of
+width 0.05; etc.
+
+### 5.2 Cursor encoding
+
+The wire shape changes. From `SessionListCursor` today
+(`packages/domain/spans/src/ports/session-repository.ts:42-45`):
+
+```ts
+export interface SessionListCursor {
+  readonly sortValue: string
+  readonly sessionId: string
+}
+```
+
+To, for the search variant only:
+
+```ts
+// Lives next to SessionListCursor in
+// packages/domain/spans/src/ports/session-repository.ts (or beside it in a
+// new file alongside the search-mode types introduced by
+// 2-session-level-search.md §5.1).
+export interface SessionSearchCursor {
+  readonly relevanceBucket: number       // 0.0, 0.1, ..., 0.9, or 1.0
+  readonly lastActivityAt: string        // ISO-8601, ns precision dropped to ms
+  readonly sessionId: string
+}
+```
+
+Three fields, lexicographic. The `HAVING` predicate inside the outer query
+becomes:
+
+```sql
+HAVING (
+  floor(max(relevance_score) * 10) / 10,
+  least(max(any_session_max_end_time), now64(9, 'UTC') + toIntervalHour(1)),
+  session_id
+) < (
+  {cursorBucket:Float64},
+  {cursorLastActivityAt:DateTime64(9, 'UTC')},
+  {cursorSessionId:String}
+)
+```
+
+with `cmp = <` for `DESC, DESC, DESC` ordering (as today). When
+`sortDirection = "asc"` is requested under search, the comparator inverts
+to `>`; in practice search ignores client-side `sortBy/sortDirection` and
+always orders by the relevance+freshness tuple, mirroring the policy from
+`trace-search.md` §"Ordering policy" (line 133) — so this is mostly
+defensive.
+
+**Tie-breaker semantics.** Two sessions with the same bucket and the
+same `last_activity_at` to nanosecond precision are essentially
+impossible by accident (`max_end_time` is a 9-digit-fraction DateTime64),
+but possible under deliberate construction (synthetic data, replays). The
+final `session_id` tie-breaker resolves them deterministically. Same
+posture as today.
+
+**Cursor returned to the client** (the `nextCursor` field of
+`SessionListPage`):
+
+```ts
+{
+  relevanceBucket: 0.8,                    // last row's bucket
+  lastActivityAt: '2026-05-19T11:24:31.000Z',
+  sessionId: '01HXYZ…',
+}
+```
+
+Wire-format: the bucket is serialized as a number (decoded with
+`parseFloat`); `lastActivityAt` as an ISO string parsed back to
+`DateTime64`; `sessionId` as a string. Same `String(...)` pattern as the
+existing cursor encoding (`session-repository.ts:265`).
+
+### 5.3 Count / metrics / histogram alignment
+
+These three already share the rollup CTE with the list path per
+`2-session-level-search.md` §4.6. They do **not** need the freshness sort
+applied — they aggregate over the matched set, not enumerate it page by
+page — but they do need to be consistent about *which* matched set they
+operate over. Three checks:
+
+- **count**: returns `count(DISTINCT session_id)` over the rolled-up
+  rows. The freshness sort doesn't change which rows match, so the count
+  is unchanged. No bucket math in this path.
+- **metrics**: aggregates over rolled-up rows. Same: same row set, no
+  ordering involved. No change.
+- **histogram**: bucketed by session start time. Same row set, no
+  ordering involved. No change.
+
+In other words, the freshness sort is purely a list-path concern. The
+sibling queries don't need a `last_activity_at` column or a
+`relevance_bucket` column.
+
+### 5.4 Knob surfacing
+
+Three constants in `packages/domain/spans/src/constants.ts`, grouped under
+a new comment block adjacent to the existing trace-search constants:
+
+```ts
+// ═══════════════════════════════════════════════════════════════════════════════
+// Session Search — Freshness-Weighted Ordering
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Width of the relevance bucket used when sorting session search results.
+ *
+ * Sessions are sorted by `(relevance_bucket, last_activity_at, session_id)`
+ * where `relevance_bucket = floor(best_score / RELEVANCE_BUCKET_WIDTH) *
+ * RELEVANCE_BUCKET_WIDTH`. A wider bucket favors freshness (more sessions
+ * share a tier, recency dominates); a narrower bucket favors relevance.
+ *
+ * 0.1 is the default: with TRACE_SEARCH_MIN_RELEVANCE_SCORE = 0.3 the
+ * non-empty buckets are {0.3-0.4, 0.4-0.5, ..., 0.9-1.0}, giving seven
+ * recency-sorted tiers above the lexical-only floor.
+ */
+export const SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH = 0.1
+
+/**
+ * Maximum future skew (milliseconds) tolerated when reading max_end_time
+ * for the freshness sort. A span with end_time more than this far in the
+ * future is clamped to now() + this interval, preventing client-clock-skew
+ * junk from floating to the top of search results forever.
+ */
+export const SESSION_SEARCH_MAX_CLOCK_SKEW_MS = 60 * 60 * 1000
+```
+
+The constants are read once at repository construction and passed as
+query parameters to ClickHouse (`bucketWidth`, `clockSkewMs`,
+`boostActive`). They are *not* env-var-driven — these are product
+decisions, not deployment-environment decisions, and they need to stay
+identical across all dynos. If/when we eventually expose them per project
+(see Open Questions), the resolution path will be the same per-org
+resolver that `EmbedBudgetResolver` uses for the embedding budget knobs
+(`constants.ts:96-99`), not env vars.
+
+### 5.5 Files touched
+
+| Layer | File | Change |
+|---|---|---|
+| Domain constants | `packages/domain/spans/src/constants.ts:138` (end of file) | Add `SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH`, `SESSION_SEARCH_MAX_CLOCK_SKEW_MS`. |
+| Domain port | `packages/domain/spans/src/ports/session-repository.ts:42-45` | Add `SessionSearchCursor` type alongside `SessionListCursor`; widen `SessionListPage.nextCursor` to `SessionListCursor \| SessionSearchCursor` (or split into two page types — see Open Questions). |
+| CH repository (search path introduced by 2-session-level-search.md) | `packages/platform/db-clickhouse/src/repositories/session-repository.ts` (the `if (plan?.ranked)` branch added by `2-session-level-search.md` §7) | Extend the outer SELECT with `relevance_bucket` + `last_activity_at`; swap the `ORDER BY` and `HAVING` clauses for the three-field form; widen `nextCursor` shape. |
+| Server fn | `apps/web/src/domains/sessions/sessions.functions.ts` (the `listSessionsByProject` shape introduced by `2-session-level-search.md` §5.1) | Pass the new cursor shape through to the client. |
+| Client collection hook | `apps/web/src/domains/sessions/sessions.collection.ts:31-46` | `initialPageParam` type widens to the cursor union; `getNextPageParam` already returns `lastPage?.nextCursor` so no logic change. |
+| React Query key | `apps/web/src/domains/sessions/sessions.collection.ts:30` | If we expose the bucket width per project eventually, the bucket width belongs in the query key; today the constant is global, so the key is unchanged. |
+
+No CH migration is needed — all freshness fields are derived at read time
+from existing columns. No PG migration is needed. No worker changes.
+
+## 6. Edge cases
+
+### 6.1 Live vs idle sessions
+
+The panel's status pill distinguishes `live` (recent activity, within
+`SESSION_LIVE_THRESHOLD_MS`) from `idle` (older). The freshness axis
+already captures this implicitly: a `live` session by definition has a
+`last_activity_at` close to `now()` and will sort above any `idle`
+session within the same relevance bucket. No additional priority tier
+is needed in the baseline — the timestamp itself does the work.
+
+### 6.2 Score ties at bucket boundaries
+
+`floor()` is unambiguous: `0.7999 → 0.7`, `0.8000 → 0.8`. SQL side is
+clean; the UX question is whether the user reads it as "0.80 beat
+0.7999 unfairly" or "different relevance, 0.80 wins". The
+matching-turn pill from `2-session-level-search.md` §5.3 shows match
+count, not score, so the boundary is mostly invisible in the UI. If
+boundary effects become a complaint, shrink buckets to 0.05 width by
+flipping the constant. Document the semantic in the constant's comment
+("`floor`-based, left-closed/right-open, except the singleton 1.0
+bucket") and move on.
+
+### 6.3 Old matching trace in a fresh session vs fresh matching trace in an old session
+
+Two cases, both subtle:
+
+- **Session-A:** a customer-support thread that has been live all week,
+  with hundreds of recent turns. The user's query `"refund request"`
+  matches one turn from six months ago and nothing recent.
+  `matching_trace_count = 1`; the matching trace is old; the *session*
+  is fresh.
+- **Session-B:** a long-resolved thread that ended six months ago. The
+  user's query matches three of its turns. `matching_trace_count = 3`;
+  the matching traces are all old; the *session* is old.
+
+If freshness uses `max(trace_rollup.trace_end_time)` (the freshness of
+the **matching** traces, the simpler option (b) in §5.1), both sessions
+sort as equally old. That's wrong — Session-A is alive; Session-B is
+dead.
+
+If freshness uses `sessions.max_end_time` (the freshness of the
+**whole** session, recommended option (a) in §5.1), Session-A correctly
+sorts ahead of Session-B. The matching turns can be old; what matters
+for freshness ranking is "is this conversation still alive?".
+
+This is the §3 "session-level not trace-level" choice in concrete form.
+Use `sessions.max_end_time`.
+
+### 6.4 Cursor stability under concurrent inserts
+
+Two failure modes when a new trace lands mid-scroll:
+
+1. **Bucket bump.** A new high-scoring trace lifts a session's
+   `best_score` from 0.79 → 0.81, moving it from bucket 0.7 to 0.8.
+   If the user already paged past bucket 0.8, the row re-appears on
+   the new bucket. Same forward-time anomaly as
+   `2-session-level-search.md:999-1006`; document and accept.
+2. **Freshness bump.** A new span advances `last_activity_at`. The
+   strict-less-than cursor `(bucket, last_activity_at, session_id) <
+   (cursorBucket, cursorLastActivityAt, cursorSessionId)` correctly
+   excludes the row from subsequent pages; the user only sees the
+   duplicate if they reload page 1.
+
+Bucket bumps are *more visibly* anomalous than the continuous-score
+case (the row jumps across dozens of others), but not more frequent.
+If duplicates become a complaint, add client-side dedupe-by-sessionId
+in the page-flatten step of `useSessionsInfiniteScroll`
+(`apps/web/src/domains/sessions/sessions.collection.ts:58`).
+
+### 6.5 Lexical-only matches (`best_score = 0.0`)
+
+Lexical-only sessions all land in bucket 0.0 and sort by
+`last_activity_at DESC` among themselves. This is the right behavior —
+phrase matches alone are a filter not a ranking signal
+(`2-session-level-search.md:822-833`, `trace-search.md` §"Why no native
+phrase relevance"), so freshness is the only signal available. A
+project with *only* lexical-only hits gets a coherent page of "latest
+sessions whose text contains this phrase".
+
+### 6.6 Clock skew and missing timestamps
+
+`sessions.max_end_time` is never `NULL` (every session row requires at
+least one span with `session_id` and `end_time`). Future-dated spans
+(NTP drift, batch-finalized) are absorbed by the `+ 1 HOUR` clamp; two
+clamped sessions tie at `now() + 1 HOUR` and break on `session_id`.
+
+### 6.7 Re-opened sessions
+
+A previously-idle session that receives a new span advances
+`max_end_time` automatically (the MV merges the new partial). The
+freshness sort reads the merged value, so the re-opened session
+correctly sorts as fresh again. No separate "re-opened" concept
+exists in the schema.
+
+### 6.8 Embedding TTL eviction
+
+A semantic-scored session older than 30 days
+(`TRACE_SEARCH_EMBEDDING_LOOKBACK_DAYS`, `constants.ts:64`) loses its
+embedding contribution and may collapse from `best_score ≈ 0.45` to
+`0.0` (lexical-only). It drops to bucket 0.0 and sorts by recency from
+there. Acceptable — the session was already aging off the top of the
+sort by then. `sessions.max_end_time` itself doesn't expire on the
+30-day cadence; the `sessions` aggregate TTL is much longer.
+
+## 7. Open questions
+
+- **Per-org/per-project bucket width.** Defaulting to 0.1 is fine for
+  V1. If a research-heavy org wants 0.05 (favor score) and a live-ops
+  org wants 0.2 (favor freshness), route resolution through the same
+  per-org resolver pattern as the embedding-budget constants
+  (`constants.ts:96-99`). Until plans land, hardcoded constant.
+- **Expose the bucket in the UI?** Probably not in V1 — the
+  `matching_trace_count` pill from `2-session-level-search.md` §5.3
+  already gives a relative-strength cue. Reconsider if §6.2 boundary
+  effects become a complaint.
+- **`SessionListCursor` vs `SessionSearchCursor` typing.** Pick
+  between a plain union (`SessionListCursor | SessionSearchCursor`,
+  callers branch on presence of `relevanceBucket`) and a discriminated
+  union with a `kind` tag. Either works.
+- **Surface `last_activity_at` in `SessionRecord`?** Today
+  `Session.endTime` is `max(max_end_time)` already
+  (`session-repository.ts:30`). The clamp is only on the sort key; the
+  displayed `endTime` keeps its raw value (so a wonky-clock span is
+  *visible* to the user but doesn't poison the sort).
+- **Active-boost (§6.1) on or off by default.** Ship off; re-evaluate
+  after a sprint of telemetry.
+- **Histogram bucket key.** `2-session-level-search.md` §4.6 keys the
+  histogram on `min(trace_start_time)`. Worth asking whether to use
+  `last_activity_at` instead so the list-sort axis matches the
+  timeline axis. Defer.
+- **Interaction with score-filter (`HAVING`).** Filters narrow inside
+  `trace_rollup` per `2-session-level-search.md` §4.5; freshness sort
+  runs on the outer aggregate. The two don't interfere.


### PR DESCRIPTION
## TL;DR

The user-visible problem: search results and the issues view are full of duplicate rows because both paginate by **trace**. A conversational session that matched on 10 turns floods a 25-result page with 10 near-identical rows of the same conversation. Users see ~3 real results out of the 25 the page size promised.

This RFC set documents the data and UX changes to fix that by making **the session the unit of pagination, sort, filter, and click everywhere**. No production code in this PR — only specs.

## What's in here

A new directory `specs/session-problems/`:

- `0-problems.md` — the index. Core constraint, SDK contract, future-state UX context, dependency-ordered problem list.
- One RFC per problem (1-…md through 7-…md), each a self-contained technical doc with file:line refs, ClickHouse SQL, server-fn signatures, tradeoffs, and open questions.

Files are number-prefixed so the development order is visible in the directory listing.

## The 7 problems, in dependency order

| # | Spec | What it's about |
|---|---|---|
| 1 | `1-parity-traces-sessions.md` | Add missing session-level columns (TTFT, root span, retention, …). Redefine `duration_ns` to active execution time (sum of root-span durations), not wall-clock. Make every trace a session via a coalesce in `sessions_mv` so orphan traces surface as 1-trace sessions. |
| 2 | `2-session-level-search.md` | Collapse search results to one row per session via query-side rollup over the existing trace-level indexes. No new MVs. |
| 3 | `3-session-issue-dedup.md` | Dedup issues at session level via query-time `GROUP BY (issue_id, session_id)`. Scores carry the canonical session_id from the same coalesce. |
| 4 | `4-filter-parity.md` | Sessions get the same filters as traces (including a synthetic `status` that fixes a pre-existing trace-side bug). Default "has LLM activity" chip hides orphan-fragment noise. |
| 5 | `5-search-hightlights.md` | Extend the existing trace-highlights spec so highlights render in the session panel's Conversation tab. |
| 6 | `6-session-panel.md` | Side panel that opens on session-row click. Header with session metadata + one trace's conversation. Expansion in the sessions list is the trace navigator. |
| 7 | `7-freshness-weighted-sort.md` | Bucketed-relevance sort with recency tiebreaker on `max_end_time`. |

## Core decisions

- **Pagination is by session, not by trace** — a hard architectural constraint that shapes every downstream spec. A page of 25 shows 25 distinct conversations.
- **Every trace is a session.** Orphan traces (no SDK `gen_ai.conversation.id`) surface as 1-trace sessions via `coalesce(nullIf(session_id, ''), toString(trace_id))` in `sessions_mv`. The same expression is the canonical session_id everywhere downstream — scores, search rollup, panel.
- **SDK contract:** `gen_ai.conversation.id` must be on every span of a conversational trace, or none of them. Latitude SDK propagates automatically; OTel-direct customers using third-party GenAI libraries propagate manually. Mixed-binding traces produce an orphan-fragment row that's visually distinguishable (`tokens_total=0`, `models=[]`) and hidden by default via a filter chip.
- **`duration_ns` is active execution time**, not wall-clock. Two sessions that span 2 days can differ wildly in how much real work happened; we measure work, not elapsed time. Wall-clock is still derivable on the fly when needed.
- **Session panel renders one trace at a time.** Default trace is the last (browse) or first matching (search). For multi-trace sessions, the sessions-list row expands inline showing all constituent traces — the expansion is the trace navigator, the panel is the trace reader. Clicking a different trace in the expansion swaps which trace the panel renders.
- **Lifecycle status is `live` / `idle`**, derived inline from `now() - max_end_time` in the read query. No PG state table, no cron, no end-detection pipeline — those were specced earlier and dropped after we realized the search/issues problem doesn't need them.

## Future direction (documented in `0-problems.md`)

Today the sidebar has a single **Traces** entry with Traces/Sessions tabs, plus a separate **Search** route. The future shape is an open product decision between (a) keeping Traces and Sessions as separate sections and (b) collapsing to a single Sessions surface that absorbs trace browsing via the row expansion. Either way, the behaviors in this PR lift cleanly into either outcome. This epic ships the behavior inside the search route as the first cut.

## How to read it

Start with `0-problems.md` — the index, core constraint, and ordered dep graph. Pick any individual RFC to deep-dive; each links back to its prerequisites.

## What this PR is NOT

- Not implementation. No production code changes.
- Not final design — open questions are called out explicitly inside each RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)