### PR TITLE
Fix telemetry package compatibility metadata

### DIFF
--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed advisory TypeScript 6 and OpenAI Agents peer dependencies from the runtime package so consumers no longer get peer warnings for tools they do not use.
+- Pointed the CommonJS export's declaration condition at `dist/index.d.cts` so TypeScript resolves CJS consumers against CJS declarations.
+
 ## [3.0.0-alpha.12] - 2026-05-16
 
 ### Changed

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -30,7 +30,7 @@
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     }
@@ -79,14 +79,5 @@
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
-  },
-  "peerDependencies": {
-    "@openai/agents": ">=0.9.0",
-    "typescript": "^6.0.3"
-  },
-  "peerDependenciesMeta": {
-    "@openai/agents": {
-      "optional": true
-    }
   }
 }

--- a/packages/telemetry/typescript/src/package.test.ts
+++ b/packages/telemetry/typescript/src/package.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+type PackageJson = {
+  readonly peerDependencies?: Record<string, string>
+  readonly exports?: {
+    readonly "."?: {
+      readonly require?: {
+        readonly types?: string
+      }
+    }
+  }
+}
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as PackageJson
+
+describe("published package metadata", () => {
+  it("does not publish advisory LLM SDK peer dependencies", () => {
+    expect(packageJson.peerDependencies ?? {}).not.toHaveProperty("@openai/agents")
+    expect(packageJson.peerDependencies ?? {}).not.toHaveProperty("typescript")
+  })
+
+  it("points CommonJS type resolution at CommonJS declarations", () => {
+    expect(packageJson.exports?.["."]?.require?.types).toBe("./dist/index.d.cts")
+  })
+})


### PR DESCRIPTION
## what changed

Removes runtime peer dependency declarations from `@latitude-data/telemetry` for TypeScript and OpenAI Agents. TypeScript remains a dev dependency for building the SDK, and OpenAI Agents remains a dev dependency for package development, but consumers no longer get peer warnings for TS 5.x apps or for not using the optional OpenAI Agents integration.

Updates the CommonJS export metadata to resolve declarations through `dist/index.d.cts` instead of the ESM declaration file. This gives CommonJS/NodeNext consumers the matching declaration condition when importing the package.

Adds a package metadata unit test covering both compatibility expectations.

## verification

- `pnpm --filter @latitude-data/telemetry check`
- `pnpm --filter @latitude-data/telemetry typecheck`
- `pnpm --filter @latitude-data/telemetry test`
- `pnpm --filter @latitude-data/telemetry build`
- pre-commit `pnpm format`
- pre-commit `pnpm knip`
