### PR TITLE
fix(web): show blank slate when expanding session traces

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -87,10 +87,11 @@ function useExpandedSessionTraces(
       const r = results[i]
       const sessionId = expandedSessionIds[i]
       if (!r || !sessionId) continue
+      const isLoading = r.isPending || (r.isFetching && r.data === undefined)
       if (r.data) {
-        traceMap.set(r.data.sessionId, { data: r.data.traces, isLoading: r.isLoading })
+        traceMap.set(r.data.sessionId, { data: r.data.traces, isLoading })
       } else {
-        traceMap.set(sessionId, { data: [], isLoading: r.isLoading })
+        traceMap.set(sessionId, { data: [], isLoading })
       }
     }
     return traceMap
@@ -430,6 +431,7 @@ export function SessionsView({
     return {
       data: entry.data.map((trace): SessionTableRow => ({ kind: "trace", trace })),
       isLoading: entry.isLoading,
+      blankSlate: "No traces in this session",
     }
   }
 

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -14,8 +14,22 @@ import { useHeaderLayoutLock } from "./use-header-layout-lock.ts"
 
 const ROW_HEIGHT = 40
 const SKELETON_ROW_COUNT = 8
-const EXPANDED_SKELETON_COUNT = 3
 const SELECTION_COLUMN_WIDTH = 48
+
+function renderBlankSlateMessage(message: string, compact = false) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg w-full flex flex-col gap-4 items-center justify-center bg-linear-to-b from-secondary to-transparent px-4",
+        compact ? "py-8" : "py-40",
+      )}
+    >
+      <Text.H5 align="center" display="block" color="foregroundMuted">
+        {message}
+      </Text.H5>
+    </div>
+  )
+}
 
 function nextSortDirection(current: SortDirection | null): SortDirection | null {
   if (current === null) return "desc"
@@ -130,19 +144,12 @@ export function InfiniteTable<T>({
   const lastRow = virtualRows[virtualRows.length - 1]
   const paddingBottom = lastRow ? virtualizer.getTotalSize() - lastRow.end : 0
   const showBlankSlate = !isLoading && data.length === 0
-  const blankSlateText = blankSlate && blankSlate === "string" ? blankSlate : "No data"
   const blankSlateContent =
-    showBlankSlate && blankSlate !== undefined ? (
-      typeof blankSlate === "string" ? (
-        <div className="rounded-lg w-full py-40 flex flex-col gap-4 items-center justify-center bg-linear-to-b from-secondary to-transparent px-4">
-          <Text.H5 align="center" display="block" color="foregroundMuted">
-            {blankSlateText}
-          </Text.H5>
-        </div>
-      ) : (
-        blankSlate
-      )
-    ) : null
+    showBlankSlate && blankSlate !== undefined
+      ? typeof blankSlate === "string"
+        ? renderBlankSlateMessage(blankSlate)
+        : blankSlate
+      : null
   return (
     <div className={cn("flex flex-col min-h-0", scrollAreaLayout === "fill" ? "flex-1" : "w-full max-w-full")}>
       {blankSlateContent ? (
@@ -287,12 +294,25 @@ export function InfiniteTable<T>({
                       : {})}
                     dataIndex={virtualRow.index}
                   />
-                  {expanded?.isLoading &&
-                    Array.from({ length: EXPANDED_SKELETON_COUNT }).map((_, i) => (
-                      <tr key={`exp-skel-${i}`} style={{ opacity: 1 - i / EXPANDED_SKELETON_COUNT }}>
-                        <td colSpan={colCount} className="h-9" />
+                  {expanded?.isLoading && (
+                    <tr>
+                      <td colSpan={colCount} className="p-0 border-none">
+                        {renderBlankSlateMessage("Loading...", true)}
+                      </td>
+                    </tr>
+                  )}
+                  {expanded &&
+                    !expanded.isLoading &&
+                    expanded.data.length === 0 &&
+                    expanded.blankSlate !== undefined && (
+                      <tr>
+                        <td colSpan={colCount} className="p-0 border-none">
+                          {typeof expanded.blankSlate === "string"
+                            ? renderBlankSlateMessage(expanded.blankSlate, true)
+                            : expanded.blankSlate}
+                        </td>
                       </tr>
-                    ))}
+                    )}
                   {expanded &&
                     !expanded.isLoading &&
                     expanded.data.map((subRow) => {
@@ -332,7 +352,7 @@ export function InfiniteTable<T>({
                         />
                       )
                     })}
-                  {isExpanded && (
+                  {isExpanded && expanded && !expanded.isLoading && expanded.data.length > 0 && (
                     <tr>
                       <td colSpan={colCount} className="h-px p-0 border-t border-border pb-2" />
                     </tr>

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -5,16 +5,46 @@ import { cn } from "../../utils/cn.ts"
 import type { SortDirection } from "../../utils/filtersHelpers.ts"
 import { Checkbox } from "../checkbox/checkbox.tsx"
 import { Icon } from "../icons/icons.tsx"
+import { Skeleton } from "../skeleton/skeleton.tsx"
 import { Text } from "../text/text.tsx"
 import { Tooltip } from "../tooltip/tooltip.tsx"
 import { DataRow } from "./data-row.tsx"
 import { HeaderCell } from "./headers/header-cell.tsx"
-import type { InfiniteTableProps } from "./types.ts"
+import type { InfiniteTableColumn, InfiniteTableProps } from "./types.ts"
 import { useHeaderLayoutLock } from "./use-header-layout-lock.ts"
 
 const ROW_HEIGHT = 40
 const SKELETON_ROW_COUNT = 8
+const EXPANDED_SKELETON_COUNT = 3
 const SELECTION_COLUMN_WIDTH = 48
+
+const EXPANDED_SKELETON_CELL_CLASS =
+  "px-4 py-2 first:rounded-l-lg last:rounded-r-lg overflow-hidden align-middle text-sm leading-5"
+
+function renderExpandedSkeletonRows<T>(
+  columns: readonly InfiniteTableColumn<T>[],
+  hasExpansion: boolean,
+  hasSelection: boolean,
+) {
+  return Array.from({ length: EXPANDED_SKELETON_COUNT }, (_, i) => (
+    <tr key={`exp-skel-${i}`} className="bg-secondary" style={{ opacity: 1 - i / EXPANDED_SKELETON_COUNT }}>
+      {hasExpansion && <td className="w-8 px-2 py-2" />}
+      {hasSelection && (
+        <td
+          style={{ width: SELECTION_COLUMN_WIDTH, minWidth: SELECTION_COLUMN_WIDTH, maxWidth: SELECTION_COLUMN_WIDTH }}
+          className={EXPANDED_SKELETON_CELL_CLASS}
+        >
+          <Skeleton className="h-4 w-4" />
+        </td>
+      )}
+      {columns.map((col) => (
+        <td key={col.key} className={EXPANDED_SKELETON_CELL_CLASS}>
+          <Skeleton className="h-4 w-full" />
+        </td>
+      ))}
+    </tr>
+  ))
+}
 
 function renderBlankSlateMessage(message: string, compact = false) {
   return (
@@ -294,13 +324,7 @@ export function InfiniteTable<T>({
                       : {})}
                     dataIndex={virtualRow.index}
                   />
-                  {expanded?.isLoading && (
-                    <tr>
-                      <td colSpan={colCount} className="p-0 border-none">
-                        {renderBlankSlateMessage("Loading...", true)}
-                      </td>
-                    </tr>
-                  )}
+                  {expanded?.isLoading && renderExpandedSkeletonRows(columns, hasExpansion, !!selection)}
                   {expanded &&
                     !expanded.isLoading &&
                     expanded.data.length === 0 &&

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -51,6 +51,8 @@ export interface InfiniteTableSorting {
 export interface ExpandedRows<T> {
   data: readonly T[]
   isLoading?: boolean
+  /** Shown when expanded data finished loading and `data` is empty. */
+  blankSlate?: ReactNode | string
 }
 
 export interface InfiniteTableSharedProps<T> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expanding a session in the sessions table showed an empty dropdown area while traces were loading. The expanded section now shows proper loading skeleton rows and a compact blank slate when a session has no traces.

## Root cause

`InfiniteTable` rendered expanded loading state as bare `<tr>` rows without background or message, so the expanded area looked blank. Session trace queries also relied on `isLoading`, which can be false during the initial fetch window in React Query v5.

## Changes

- **`InfiniteTable`**: Render per-column `Skeleton` rows (with `bg-secondary`) while expanded data loads; keep compact blank slate for empty expanded data via `ExpandedRows.blankSlate`. Hide the trailing separator while loading or when there are no child rows.
- **`SessionsView`**: Treat session trace queries as loading when `isPending` or fetching without data yet; pass `blankSlate: "No traces in this session"` for empty expanded sessions.

## Testing

- `pnpm --filter @repo/ui typecheck`
- Manual: expand a session on the sessions tab and confirm skeleton rows appear while traces load, then trace rows or the empty message render.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f6e1db-8202-4cb3-9207-0f4d7e6acd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f6e1db-8202-4cb3-9207-0f4d7e6acd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

