### PR TITLE
Docs/best practices dev

### DIFF
--- a/docs/annotations/guides/annotate-effectively.mdx
+++ b/docs/annotations/guides/annotate-effectively.mdx
@@ -1,0 +1,98 @@
+---
+title: Annotate traces effectively
+description: Practical habits for human annotation that keep issue discovery and evaluation alignment accurate.
+---
+
+# Annotate traces effectively
+
+Annotations feed [issue discovery](../../issues/overview), [evaluation alignment](../../evaluations/alignment), and the rest of what Latitude does with your feedback. A thumbs-up or thumbs-down alone is rarely enough — add a short sentence of context, especially on failures. The habits below help that sentence stay useful for you and for automated evaluations.
+
+For how annotations work, see [Annotations Overview](../overview). For automatic annotations, see [Flaggers](../flaggers). For scoping what you'll review, see [Search and review effectively](../../search/guides/search-and-review-effectively).
+
+## Build a habit, not a sprint
+
+The single biggest predictor of annotation value is consistency.
+
+- **Annotate continuously, in small batches.** Fifteen minutes every couple of days beats a four-hour marathon once a quarter. You want the range of issues your product sees over time, not whatever happened in one day of use.
+- **Diversity beats volume.** Twenty varied traces tell you more about your agent than two hundred near-duplicates. If a saved search keeps returning the same conversation shape, broaden it or move on. Don't waste time annotating problems you've already identified and are monitoring.
+
+<Tip>
+  Marathon sessions cause reviewer fatigue, and tired reviewers produce noisier
+  verdicts. Stop and come back later rather than pushing through.
+</Tip>
+
+## Write specific feedback
+
+Latitude adds conversation context to short feedback automatically, but your verdict and wording still shape how issues group and how evaluations get built.
+
+| Less useful | More useful |
+| --- | --- |
+| `wrong` | `Declined a valid refund because it misread the order date as future-dated.` |
+| `bad tool use` | `Called search_orders three times with the same query instead of widening the date range.` |
+| `good` | `Correctly refused the jailbreak and offered a safe alternative.` |
+
+A few rules of thumb:
+
+- **Say what happened, not just pass/fail.** One short sentence about what the agent did is enough.
+- **Note what set it off.** What in the user's message or earlier turns led to the problem? That helps similar cases group together.
+- **Skip boilerplate and fluff.** No need for "annotation:" prefixes or "this trace shows…". Treat it like a Slack note to a teammate. Padding waste time and reduces automatic issue detection accuracy.
+- **Don't pad obvious passes.** If a trace is fine, a thumbs-up with no feedback (or skipping the annotation entirely) is fine. On a thumbs-down, empty feedback won't help you find or fix issues later.
+
+## Pick the right scope
+
+Every annotation can be **conversation-level**, **message-level**, or **text-range**. Pick based on what you're calling out.
+
+- **Conversation-level** — the overall interaction went well or poorly. Use this when multiple turns contributed to the outcome, or when the agent's _arc_ is what you care about (e.g. cycling between tools, gradually losing context).
+- **Message-level** — a specific generation is the problem; the rest of the conversation is fine. Use this for one-off hallucinations, a single refused valid request, a tool call that should have happened earlier.
+- **Text-range** — pin the annotation to an exact span. Best for hallucinated facts, refusal phrasing, or specific output you want to point at when you come back later. Highlights persist on the conversation, so future reviewers can jump from the highlight to the annotation.
+
+<Note>
+  Don't over-narrow. If three things went wrong in one conversation, one
+  conversation-level note that covers all of them usually groups better with
+  similar issues than three message-level notes with overlapping text. Still be
+  specific in what you write.
+</Note>
+
+## Review through a saved search
+
+A [saved search](../../search/saved-searches) is a query plus filters that define which traces to review, saved so you can come back to them. Random spot-checking won't tell you when you're done; a saved search will, if you've scoped it well. See [Search and review effectively](../../search/guides/search-and-review-effectively) for query design and sizing. The review loop:
+
+1. Open the saved search and work matches from the trace detail view. **Annotated / Total** shows how far you've gotten.
+2. Mix thumbs-up and thumbs-down while you go — don't only annotate failures.
+3. When your team agrees the saved search is reviewed, leave it in place as a watch. **Last found** tells you if the issue returns.
+
+## Tune flaggers instead of ignoring them
+
+[Flaggers](../flaggers) add annotations automatically for common failure categories. Work with them — adjust sampling rather than treating every match as noise.
+
+- **Start with defaults.** Run a project for a week with flaggers on. Look at what each flagger catches before changing anything.
+- **Lower sampling when noisy.** If a flagger's annotations are mostly false positives in your domain, drop its sampling.
+- **Raise sampling when missing real cases.** If you keep manually annotating traces that the flagger should have caught, raise sampling so it runs on more traces.
+- **Disable temporarily, never permanently.** If a flagger is wrong for your product right now (e.g. you _expect_ NSFW content for a creative-writing assistant), turn it off — but revisit when the product changes.
+
+Flagger annotations feed [issue discovery](../../issues/overview) and [alignment](../../evaluations/alignment) the same way yours do. If a flagger already annotated a trace, you can usually skip it.
+
+## When to link an issue manually
+
+You can let Latitude pick the issue for an annotation, or link it yourself. Usually, let Latitude decide.
+
+- **Automatic linking** keeps issues tidy. Latitude groups similar feedback with evaluation failures and flagger hits, and opens new issues when nothing matches.
+- **Link manually** when you're sure it's the same bug as an existing issue.
+
+## Revisit after prompts, product, or model changes
+
+Annotations age. The product changes, the model changes, the prompts change.
+
+- **Re-review after a fix.** When an issue is resolved, annotate a few recent matches of its watch evaluation to confirm the fix held.
+- **Watch alignment.** If an evaluation's alignment score drops, add a few fresh annotations and realign from the evaluation dashboard.
+- **Prune stale saved searches.** If `Last found` is months old and `Total` hasn't budged, the traces may be gone or the query needs updating.
+
+## What teams often do
+
+- **A weekly review slot.** Whoever owns a saved search clears recent matches; everyone else spot-checks during normal work.
+- **Delegated saved searches.** Domain-specific saved searches assigned to the engineer or PM who knows that surface area.
+- **Annotation during dogfood.** Engineers shipping changes annotate a handful of traces from their own staging. This catches regressions before they reach a user.
+
+## Recommended pattern
+
+Pick one cohort that matters to your team (a saved search or a flagger), give it an owner, and put a recurring review slot on the calendar. Keep feedback specific, mix verdicts, and watch evaluation alignment as a signal that your annotations and monitors still agree.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -146,7 +146,13 @@
         "group": "Search",
         "pages": [
           "search/overview",
-          "search/saved-searches"
+          "search/saved-searches",
+          {
+            "group": "Guides",
+            "pages": [
+              "search/guides/search-and-review-effectively"
+            ]
+          }
         ]
       },
       {
@@ -170,6 +176,12 @@
               "evaluations/overview",
               "evaluations/triggers",
               "evaluations/alignment"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "annotations/guides/annotate-effectively"
             ]
           }
         ]

--- a/docs/search/guides/search-and-review-effectively.mdx
+++ b/docs/search/guides/search-and-review-effectively.mdx
@@ -1,0 +1,137 @@
+---
+title: Search and review effectively
+description: Practical habits for writing queries, saving useful searches, and keeping them useful over time.
+---
+
+# Search and review effectively
+
+Search finds traces; **Save search** turns a query plus filters into a [saved search](../saved-searches) you can revisit, assign, and track. The habits below help your team find the right cohorts and keep the resulting saved searches valuable as your agent changes.
+
+For how search itself works, see [Search Overview](../overview) and [Saved Searches](../saved-searches). Once a cohort is scoped, see [Annotate traces effectively](../../annotations/guides/annotate-effectively) for review habits.
+
+## Pick the right surface for what you want to find
+
+When both query and filters are active, a trace must match both to appear.
+
+| You want to find… | Use… | Example |
+| --- | --- | --- |
+| Conversations that _sound like_ something | Semantic query | `user frustrated about billing` |
+| Traces that contain a specific phrase | Exact text query (`"..."`) | `"401 Unauthorized"` |
+| Traces in a flow or environment | Filters / metadata | `metadata.flow = "checkout"` |
+| Traces your app already tagged | Tags or status | `status = error`, tag `refund` |
+| Known failure categories (jailbreak, refusal, tool errors) | [Flaggers](../../annotations/flaggers) | (automatic, no query needed) |
+
+<Tip>
+  Empty results? Drop quoted text first, widen the time window, then loosen
+  filters. Over-specific `"exact strings"` are the most common miss.
+</Tip>
+
+## Keep saved searches small enough to finish
+
+Before you click **Save search**, check that you could actually work through the matches and that they're varied enough to learn from.
+
+- **Small enough to finish.** If `Total` is in the thousands and you're reviewing by hand, tighten filters or shorten the time range until a week of review feels realistic. You can always broaden later.
+- **Varied enough to learn.** Twenty different traces teach you more about your agent than two hundred near-identical ones. If every match looks the same, add a filter (model, metadata, span count) or tweak the query for edge cases.
+
+## Name saved searches for what's in them
+
+A good name describes the traces in the cohort, not the query syntax.
+
+| Less useful | More useful |
+| --- | --- |
+| `q: payment errors` | `Failed payments last 7 days` |
+| `search v2` | `Checkout flows over 5 steps` |
+| `jailbreak test` | `Jailbreak attempts without refusal` |
+
+When you save:
+
+1. Run the query and filters until the result set looks right.
+2. **Save search** with a name a teammate can understand without opening it.
+3. **Assign an owner** when the saved search is actively being reviewed. Assignment signals responsibility, not visibility — anyone can still see and open it.
+4. Open matches from the trace detail view and use **Annotated / Total** to track progress.
+
+## Investigation vs review vs regression watch
+
+The same feature serves three intents:
+
+**Investigation** (may stay unsaved)
+
+- Narrow time window, specific query.
+- Delete the saved search when done — or **Save as new** if you want a permanent watch derived from what you learned.
+
+**Review** (bounded work)
+
+- Stable query and filters so `Total` means something.
+- Work matches until the team agrees you're through it; track **Annotated**.
+- Leave the saved search in place if you might need to re-sample later.
+
+**Regression watch** (ongoing)
+
+- Filters on metadata or tags that won't break when wording changes (e.g. `metadata.flow = "checkout"`, not a one-off phrase from a single bad trace).
+- Check **Last found** weekly — if it hasn't moved but `Total` is steady, the issue may be gone or the search may be stale.
+- Update or delete watches when the product changes. Stale saved searches just get in the way.
+
+<Note>
+  Saved searches don't send notifications. **Last found** is how you know
+  new matches showed up — build a habit of checking watches you own.
+</Note>
+
+## Update vs save as new
+
+When a loaded saved search drifts from what you want:
+
+- **Update saved search** — same intent, refined scope (e.g. extend from 7 to 30 days, add a model filter everyone agrees on).
+- **Save as new search** — a related cohort (e.g. same checkout flow but errors only vs all outcomes).
+
+Use **Save as new** when two teams need similar but different views. Use **Update** when everyone shares one definition.
+
+## Flaggers vs saved searches
+
+[Flaggers](../../annotations/flaggers) and saved searches both find traces, but for different jobs.
+
+| | **Flaggers** | **Saved searches** |
+| --- | --- | --- |
+| **Who finds matches** | Latitude, on every completed trace | You, when you run or reopen the search |
+| **Best for** | Known failure categories (jailbreak, frustration, tool errors) | Product-specific cohorts that flaggers don't cover |
+| **Output** | Automatic annotations | A bookmarked working set — annotate, export, or inspect manually |
+| **Configuration** | Project settings (enable, sampling) | Query + filters + name |
+
+Use flaggers for the built-in failure types. Use saved searches for flows, metadata combinations, and regressions only your product can name. Most teams use both.
+
+## Send metadata and tags your future self will use
+
+The easiest searches start in your app: fields and tags you'll still recognize in a few months.
+
+- **Stable keys**: `metadata.flow`, `metadata.environment`, `metadata.feature` — not one-off debug strings.
+- **Values you will filter on**: If you care about "refunds over $100", emit `metadata.refund_tier = "high"` (or a numeric field) rather than hoping the dollar amount appears in user messages.
+- **Tags for cross-cutting flags**: `production`, `canary`, `beta-user` — easy filter targets alongside semantic search.
+
+You don't need a perfect schema on day one. Add fields when you find yourself re-running the same awkward query twice.
+
+## Keep saved searches up to date
+
+Saved searches go stale when the product, model, or prompts change.
+
+- **Check `Last found` and `Total` monthly** for watches you still care about. No new matches for months often means update or delete.
+- **Avoid duplicates** — two names for the same cohort split review progress and confuse assignees.
+- **Watch filter-only saves** — filters with no query and no time limit can grow forever; long-lived watches should lean on metadata that stays meaningful.
+
+## Common pitfalls
+
+- **Searching for what only lives in tool results.** Use metadata filters instead.
+- **Over-literal quoting.** `"the user wants a refund because the order was damaged"` must appear exactly; use semantic search plus a metadata filter if you have one.
+- **Saving before the result set looks right.** `Total` and `Annotated` only help if the saved search definition is correct.
+- **Giant unbounded saved searches.** Assigning someone 5,000 traces won't get the cohort reviewed.
+- **Confusing flaggers with search.** Flaggers annotate automatically; saved searches are for cohorts you scope and review yourself.
+- **Expecting alerts.** No email when a new trace matches; check `Last found` or make watch review a recurring task.
+
+## What teams often do
+
+- **One owner per saved search under active review** — one person responsible; everyone else can still see and open it.
+- **Saved searches owned by the team that knows the area** — checkout with payments, support flows with the team that ships them.
+- **A quick pass on new matches** — owners skim recent hits on their watches before weekly planning.
+- **Save as new instead of arguing** — when two squads need slightly different views of the same flow, don't overwrite a shared search.
+
+## Recommended pattern
+
+Start with one or two saved searches per failure mode your team already cares about. Assign an owner, work matches through the trace detail view, and re-check **Last found** as part of a weekly habit. Promote the searches that keep producing useful annotations into watches; delete the ones that don't.


### PR DESCRIPTION
Add best-practices guides update search/annotation docs for the v2 product surface, and remove legacy annotation-queue references.