### PR TITLE
feat(sessions): materialization parity with traces (LAT-604)

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/.migration-lock
+++ b/packages/platform/db-clickhouse/clickhouse/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-05-13T17:04:03.426Z
-# Hash: a567848f-595c-4119-b2bd-0cb96bc857e2
+# Generated: 2026-05-20T07:45:06.179Z
+# Hash: f2d24705-ca48-427a-bae7-6e3f0be43e7e
 # Do not manually edit this file.

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -1,0 +1,160 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- ═══════════════════════════════════════════════════════════
+-- Sessions parity with traces (LAT-604) — clustered variant.
+-- See unclustered/00016_session_parity.sql for full notes.
+-- ═══════════════════════════════════════════════════════════
+
+ALTER TABLE sessions ON CLUSTER default
+    DROP COLUMN IF EXISTS duration_ns;
+
+ALTER TABLE sessions ON CLUSTER default
+    ADD COLUMN IF NOT EXISTS duration_ns
+        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_end_time,
+    ADD COLUMN IF NOT EXISTS time_of_first_token
+        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER duration_ns,
+    ADD COLUMN IF NOT EXISTS time_to_first_token_ns Int64 ALIAS if(
+        time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'),
+        reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
+        0
+    ) AFTER time_of_first_token,
+    ADD COLUMN IF NOT EXISTS root_span_id
+        AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,
+    ADD COLUMN IF NOT EXISTS root_span_name
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER root_span_id,
+    ADD COLUMN IF NOT EXISTS input_messages
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER root_span_name,
+    ADD COLUMN IF NOT EXISTS last_input_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER input_messages,
+    ADD COLUMN IF NOT EXISTS output_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER last_input_messages,
+    ADD COLUMN IF NOT EXISTS system_instructions
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER output_messages,
+    ADD COLUMN IF NOT EXISTS retention_days
+        SimpleAggregateFunction(max, UInt16) DEFAULT 90 CODEC(T64, ZSTD(1));
+
+ALTER TABLE sessions ON CLUSTER default
+    MODIFY TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;
+
+DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv ON CLUSTER default TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+
+    sum(if(
+        (s.parent_span_id = '' OR s.parent_span_id = '0000000000000000')
+            AND s.end_time > s.start_time,
+        reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+        toInt64(0)
+    ))                                                               AS duration_ns,
+
+    min(if(
+        s.time_to_first_token_ns > 0,
+        addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+        toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC')
+    ))                                                               AS time_of_first_token,
+
+    sum(s.tokens_input)                                              AS tokens_input,
+    sum(s.tokens_output)                                             AS tokens_output,
+    sum(s.tokens_cache_read)                                         AS tokens_cache_read,
+    sum(s.tokens_cache_create)                                       AS tokens_cache_create,
+    sum(s.tokens_reasoning)                                          AS tokens_reasoning,
+    sum(s.tokens_total)                                              AS tokens_total,
+
+    sum(s.cost_input_microcents)                                     AS cost_input_microcents,
+    sum(s.cost_output_microcents)                                    AS cost_output_microcents,
+    sum(s.cost_total_microcents)                                     AS cost_total_microcents,
+
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+
+    argMinIfState(s.span_id, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_id,
+    argMinIfState(s.name, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '')  AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '')   AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '')  AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '') AS system_instructions,
+
+    max(s.retention_days)                                            AS retention_days
+
+FROM spans AS s
+GROUP BY s.organization_id, s.project_id, session_id;
+
+-- +goose Down
+
+DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
+
+ALTER TABLE sessions ON CLUSTER default
+    REMOVE TTL;
+
+ALTER TABLE sessions ON CLUSTER default
+    DROP COLUMN IF EXISTS retention_days,
+    DROP COLUMN IF EXISTS system_instructions,
+    DROP COLUMN IF EXISTS output_messages,
+    DROP COLUMN IF EXISTS last_input_messages,
+    DROP COLUMN IF EXISTS input_messages,
+    DROP COLUMN IF EXISTS root_span_name,
+    DROP COLUMN IF EXISTS root_span_id,
+    DROP COLUMN IF EXISTS time_to_first_token_ns,
+    DROP COLUMN IF EXISTS time_of_first_token,
+    DROP COLUMN IF EXISTS duration_ns;
+
+ALTER TABLE sessions ON CLUSTER default
+    ADD COLUMN IF NOT EXISTS duration_ns Int64 ALIAS
+        reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time) AFTER max_end_time;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv ON CLUSTER default TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    s.session_id,
+
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+
+    sum(s.tokens_input)                                              AS tokens_input,
+    sum(s.tokens_output)                                             AS tokens_output,
+    sum(s.tokens_cache_read)                                         AS tokens_cache_read,
+    sum(s.tokens_cache_create)                                       AS tokens_cache_create,
+    sum(s.tokens_reasoning)                                          AS tokens_reasoning,
+    sum(s.tokens_total)                                              AS tokens_total,
+
+    sum(s.cost_input_microcents)                                     AS cost_input_microcents,
+    sum(s.cost_output_microcents)                                    AS cost_output_microcents,
+    sum(s.cost_total_microcents)                                     AS cost_total_microcents,
+
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id
+
+FROM spans AS s
+WHERE s.session_id != ''
+GROUP BY s.organization_id, s.project_id, s.session_id;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -97,7 +97,12 @@ AS SELECT
     max(s.retention_days)                                            AS retention_days
 
 FROM spans AS s
-GROUP BY s.organization_id, s.project_id, session_id;
+-- See unclustered/00016 for why GROUP BY repeats the coalesce expression
+-- instead of referencing the `session_id` SELECT alias.
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));
 
 -- +goose Down
 

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
@@ -1,0 +1,193 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- ═══════════════════════════════════════════════════════════
+-- Sessions parity with traces (LAT-604)
+--
+-- Brings the sessions materialization to column-level parity with traces:
+--
+--   1. duration_ns is redefined from a wall-clock ALIAS to a real
+--      SimpleAggregateFunction(sum, Int64) column storing per-trace
+--      active execution time (sum of root-span durations across the
+--      session). Wall-clock is recoverable on the fly from
+--      max_end_time - min_start_time. See specs/session-problems/
+--      1-parity-traces-sessions.md §"On duration_ns semantics".
+--
+--   2. Adds time_of_first_token (+ time_to_first_token_ns ALIAS),
+--      root_span_id, root_span_name, input/last_input/output_messages,
+--      system_instructions, and retention_days.
+--
+--   3. Removes the `WHERE s.session_id != ''` filter on sessions_mv
+--      and replaces it with a `coalesce(nullIf(session_id, ''),
+--      toString(trace_id))` grouping key — every trace produces a
+--      session row, with orphans keyed on their trace_id. Required by
+--      the 0-problems.md core constraint (session-paginated listings
+--      must cover every trace).
+--
+--   4. Aligns session TTL with traces (retention_days + 30 grace).
+-- ═══════════════════════════════════════════════════════════
+
+-- duration_ns was an Int64 ALIAS (wall-clock). CH doesn't support
+-- MODIFY COLUMN from ALIAS to a real aggregate, so drop first, then
+-- re-add with the new active-execution semantics in the next ALTER.
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS duration_ns;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS duration_ns
+        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_end_time,
+    ADD COLUMN IF NOT EXISTS time_of_first_token
+        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER duration_ns,
+    ADD COLUMN IF NOT EXISTS time_to_first_token_ns Int64 ALIAS if(
+        time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'),
+        reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
+        0
+    ) AFTER time_of_first_token,
+    ADD COLUMN IF NOT EXISTS root_span_id
+        AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,
+    ADD COLUMN IF NOT EXISTS root_span_name
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER root_span_id,
+    ADD COLUMN IF NOT EXISTS input_messages
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER root_span_name,
+    ADD COLUMN IF NOT EXISTS last_input_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER input_messages,
+    ADD COLUMN IF NOT EXISTS output_messages
+        AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER last_input_messages,
+    ADD COLUMN IF NOT EXISTS system_instructions
+        AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)) AFTER output_messages,
+    ADD COLUMN IF NOT EXISTS retention_days
+        SimpleAggregateFunction(max, UInt16) DEFAULT 90 CODEC(T64, ZSTD(1));
+
+ALTER TABLE sessions
+    MODIFY TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;
+
+DROP VIEW IF EXISTS sessions_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    -- Every trace must paginate as a session (see 0-problems.md core constraint).
+    -- Spans with no gen_ai.conversation.id synthesize a session keyed on
+    -- trace_id, so orphan traces surface as 1-trace sessions.
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id))         AS session_id,
+
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+
+    -- Active execution time: sum of root-span durations across the session's
+    -- traces. Wall-clock is recoverable from min/max_*_time directly. See
+    -- 1-parity-traces-sessions.md §"On duration_ns semantics" for rationale
+    -- and limitations (multi-root, concurrent traces, runaway end_time).
+    sum(if(
+        (s.parent_span_id = '' OR s.parent_span_id = '0000000000000000')
+            AND s.end_time > s.start_time,
+        reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time),
+        toInt64(0)
+    ))                                                               AS duration_ns,
+
+    min(if(
+        s.time_to_first_token_ns > 0,
+        addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)),
+        toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC')
+    ))                                                               AS time_of_first_token,
+
+    sum(s.tokens_input)                                              AS tokens_input,
+    sum(s.tokens_output)                                             AS tokens_output,
+    sum(s.tokens_cache_read)                                         AS tokens_cache_read,
+    sum(s.tokens_cache_create)                                       AS tokens_cache_create,
+    sum(s.tokens_reasoning)                                          AS tokens_reasoning,
+    sum(s.tokens_total)                                              AS tokens_total,
+
+    sum(s.cost_input_microcents)                                     AS cost_input_microcents,
+    sum(s.cost_output_microcents)                                    AS cost_output_microcents,
+    sum(s.cost_total_microcents)                                     AS cost_total_microcents,
+
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+
+    -- Root detection: both bare empty and the all-zeros OTLP sentinel count
+    -- as roots. Same predicate used for duration_ns above.
+    argMinIfState(s.span_id, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_id,
+    argMinIfState(s.name, s.start_time,
+        s.parent_span_id = '' OR s.parent_span_id = '0000000000000000') AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '')  AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '')   AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '')  AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '') AS system_instructions,
+
+    max(s.retention_days)                                            AS retention_days
+
+FROM spans AS s
+GROUP BY s.organization_id, s.project_id, session_id;
+
+-- +goose Down
+
+DROP VIEW IF EXISTS sessions_mv;
+
+ALTER TABLE sessions
+    REMOVE TTL;
+
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS retention_days,
+    DROP COLUMN IF EXISTS system_instructions,
+    DROP COLUMN IF EXISTS output_messages,
+    DROP COLUMN IF EXISTS last_input_messages,
+    DROP COLUMN IF EXISTS input_messages,
+    DROP COLUMN IF EXISTS root_span_name,
+    DROP COLUMN IF EXISTS root_span_id,
+    DROP COLUMN IF EXISTS time_to_first_token_ns,
+    DROP COLUMN IF EXISTS time_of_first_token,
+    DROP COLUMN IF EXISTS duration_ns;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS duration_ns Int64 ALIAS
+        reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time) AFTER max_end_time;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
+AS SELECT
+    s.organization_id,
+    s.project_id,
+    s.session_id,
+
+    uniqExactState(s.trace_id)                                       AS trace_count,
+    groupUniqArrayState(s.trace_id)                                  AS trace_ids,
+    count()                                                          AS span_count,
+    countIf(s.status_code = 2)                                       AS error_count,
+
+    min(s.start_time)                                                AS min_start_time,
+    max(s.end_time)                                                  AS max_end_time,
+
+    sum(s.tokens_input)                                              AS tokens_input,
+    sum(s.tokens_output)                                             AS tokens_output,
+    sum(s.tokens_cache_read)                                         AS tokens_cache_read,
+    sum(s.tokens_cache_create)                                       AS tokens_cache_create,
+    sum(s.tokens_reasoning)                                          AS tokens_reasoning,
+    sum(s.tokens_total)                                              AS tokens_total,
+
+    sum(s.cost_input_microcents)                                     AS cost_input_microcents,
+    sum(s.cost_output_microcents)                                    AS cost_output_microcents,
+    sum(s.cost_total_microcents)                                     AS cost_total_microcents,
+
+    argMaxIfState(s.user_id, s.start_time, s.user_id != '')          AS user_id,
+    groupUniqArrayArray(s.tags)                                      AS tags,
+    maxMap(s.metadata)                                               AS metadata,
+    groupUniqArrayIfState(s.model, s.model != '')                    AS models,
+    groupUniqArrayIfState(s.provider, s.provider != '')              AS providers,
+    groupUniqArrayIfState(s.service_name, s.service_name != '')      AS service_names,
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id
+
+FROM spans AS s
+WHERE s.session_id != ''
+GROUP BY s.organization_id, s.project_id, s.session_id;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
@@ -130,7 +130,15 @@ AS SELECT
     max(s.retention_days)                                            AS retention_days
 
 FROM spans AS s
-GROUP BY s.organization_id, s.project_id, session_id;
+-- Repeat the coalesce expression in GROUP BY (rather than referencing the
+-- `session_id` SELECT alias). `spans` also has a `session_id` column, and
+-- with `prefer_column_name_to_alias = 1` CH would group by the raw column
+-- instead of the coalesced key — silently collapsing every orphan into a
+-- single empty-string session row.
+GROUP BY
+    s.organization_id,
+    s.project_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));
 
 -- +goose Down
 

--- a/packages/platform/testkit/src/clickhouse/schema.sql
+++ b/packages/platform/testkit/src/clickhouse/schema.sql
@@ -66,7 +66,9 @@ CREATE TABLE sessions
     `error_count` SimpleAggregateFunction(sum, UInt64) CODEC(T64, ZSTD(1)),
     `min_start_time` SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)),
     `max_end_time` SimpleAggregateFunction(max, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)),
-    `duration_ns` Int64 ALIAS reinterpretAsInt64(max_end_time) - reinterpretAsInt64(min_start_time),
+    `duration_ns` SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)),
+    `time_of_first_token` SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)),
+    `time_to_first_token_ns` Int64 ALIAS if(time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'), reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time), 0),
     `tokens_input` SimpleAggregateFunction(sum, UInt64) CODEC(T64, ZSTD(1)),
     `tokens_output` SimpleAggregateFunction(sum, UInt64) CODEC(T64, ZSTD(1)),
     `tokens_cache_read` SimpleAggregateFunction(sum, UInt64) CODEC(T64, ZSTD(1)),
@@ -83,6 +85,13 @@ CREATE TABLE sessions
     `providers` AggregateFunction(groupUniqArrayIf, String, UInt8) CODEC(ZSTD(1)),
     `service_names` AggregateFunction(groupUniqArrayIf, String, UInt8) CODEC(ZSTD(1)),
     `simulation_id` AggregateFunction(argMaxIf, FixedString(24), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)),
+    `root_span_id` AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)),
+    `root_span_name` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)),
+    `input_messages` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)),
+    `last_input_messages` AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)),
+    `output_messages` AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)),
+    `system_instructions` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(3)),
+    `retention_days` SimpleAggregateFunction(max, UInt16) DEFAULT 90 CODEC(T64, ZSTD(1)),
     INDEX idx_start_time min_start_time TYPE minmax GRANULARITY 1
 )
 ENGINE = AggregatingMergeTree
@@ -102,6 +111,8 @@ CREATE MATERIALIZED VIEW sessions_mv TO sessions
     `error_count` UInt64,
     `min_start_time` DateTime64(9, 'UTC'),
     `max_end_time` DateTime64(9, 'UTC'),
+    `duration_ns` Int64,
+    `time_of_first_token` DateTime64(9, 'UTC'),
     `tokens_input` UInt64,
     `tokens_output` UInt64,
     `tokens_cache_read` UInt64,
@@ -117,18 +128,27 @@ CREATE MATERIALIZED VIEW sessions_mv TO sessions
     `models` AggregateFunction(groupUniqArrayIf, String, UInt8),
     `providers` AggregateFunction(groupUniqArrayIf, String, UInt8),
     `service_names` AggregateFunction(groupUniqArrayIf, String, UInt8),
-    `simulation_id` AggregateFunction(argMaxIf, FixedString(24), DateTime64(9, 'UTC'), UInt8)
+    `simulation_id` AggregateFunction(argMaxIf, FixedString(24), DateTime64(9, 'UTC'), UInt8),
+    `root_span_id` AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8),
+    `root_span_name` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8),
+    `input_messages` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8),
+    `last_input_messages` AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8),
+    `output_messages` AggregateFunction(argMaxIf, String, DateTime64(9, 'UTC'), UInt8),
+    `system_instructions` AggregateFunction(argMinIf, String, DateTime64(9, 'UTC'), UInt8),
+    `retention_days` UInt16
 )
 AS SELECT
     s.organization_id,
     s.project_id,
-    s.session_id,
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id)) AS session_id,
     uniqExactState(s.trace_id) AS trace_count,
     groupUniqArrayState(s.trace_id) AS trace_ids,
     count() AS span_count,
     countIf(s.status_code = 2) AS error_count,
     min(s.start_time) AS min_start_time,
     max(s.end_time) AS max_end_time,
+    sum(if(((s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AND (s.end_time > s.start_time), reinterpretAsInt64(s.end_time) - reinterpretAsInt64(s.start_time), toInt64(0))) AS duration_ns,
+    min(if(s.time_to_first_token_ns > 0, addNanoseconds(s.start_time, toInt64(s.time_to_first_token_ns)), toDateTime64('2261-01-01 00:00:00.000000000', 9, 'UTC'))) AS time_of_first_token,
     sum(s.tokens_input) AS tokens_input,
     sum(s.tokens_output) AS tokens_output,
     sum(s.tokens_cache_read) AS tokens_cache_read,
@@ -144,13 +164,19 @@ AS SELECT
     groupUniqArrayIfState(s.model, s.model != '') AS models,
     groupUniqArrayIfState(s.provider, s.provider != '') AS providers,
     groupUniqArrayIfState(s.service_name, s.service_name != '') AS service_names,
-    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id
+    argMaxIfState(s.simulation_id, s.start_time, s.simulation_id != '') AS simulation_id,
+    argMinIfState(s.span_id, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_id,
+    argMinIfState(s.name, s.start_time, (s.parent_span_id = '') OR (s.parent_span_id = '0000000000000000')) AS root_span_name,
+    argMinIfState(s.input_messages, s.start_time, s.input_messages != '') AS input_messages,
+    argMaxIfState(s.input_messages, s.end_time, s.output_messages != '') AS last_input_messages,
+    argMaxIfState(s.output_messages, s.end_time, s.output_messages != '') AS output_messages,
+    argMinIfState(s.system_instructions, s.start_time, s.system_instructions != '') AS system_instructions,
+    max(s.retention_days) AS retention_days
 FROM spans AS s
-WHERE s.session_id != ''
 GROUP BY
     s.organization_id,
     s.project_id,
-    s.session_id;
+    session_id;
 
 CREATE TABLE spans
 (
@@ -214,6 +240,7 @@ CREATE TABLE spans
     `tool_input` String DEFAULT '' CODEC(ZSTD(3)),
     `tool_output` String DEFAULT '' CODEC(ZSTD(3)),
     `ingested_at` DateTime64(3, 'UTC') DEFAULT now64(3) CODEC(Delta(8), LZ4),
+    `retention_days` UInt16 DEFAULT 90 CODEC(T64, ZSTD(1)),
     INDEX idx_trace_id trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 2,
     INDEX idx_model model TYPE bloom_filter(0.01) GRANULARITY 4,

--- a/packages/platform/testkit/src/clickhouse/schema.sql
+++ b/packages/platform/testkit/src/clickhouse/schema.sql
@@ -176,7 +176,7 @@ FROM spans AS s
 GROUP BY
     s.organization_id,
     s.project_id,
-    session_id;
+    coalesce(nullIf(s.session_id, ''), toString(s.trace_id));
 
 CREATE TABLE spans
 (

--- a/specs/session-problems/1-parity-traces-sessions.md
+++ b/specs/session-problems/1-parity-traces-sessions.md
@@ -1,5 +1,61 @@
 # Session materialization parity with traces
 
+## Implementation tasks
+
+Tracking checklist for the work this spec describes. Grouped by PR boundary;
+within each group, order is execution order. Boxes use `- [ ]` (unchecked)
+and flip to `- [x]` as the work lands.
+
+### PR 1 — ClickHouse schema layer (LAT-604)
+
+- [x] Scaffold migration 00016 via `pnpm --filter @platform/db-clickhouse ch:create session_parity` (creates both clustered + unclustered files).
+- [x] Fill `clickhouse/migrations/unclustered/00016_session_parity.sql`:
+  - [x] `ALTER TABLE sessions DROP COLUMN IF EXISTS duration_ns;` (drops the wall-clock ALIAS so it can be re-added as a real aggregate).
+  - [x] Single `ALTER TABLE sessions ADD COLUMN …` adding `duration_ns`, `time_of_first_token`, `time_to_first_token_ns` (ALIAS), `root_span_id`, `root_span_name`, `input_messages`, `last_input_messages`, `output_messages`, `system_instructions`, `retention_days` — all with explicit `AFTER` clauses to mirror trace column order.
+  - [x] `ALTER TABLE sessions MODIFY TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;`.
+  - [x] `DROP VIEW IF EXISTS sessions_mv;`.
+  - [x] `CREATE MATERIALIZED VIEW sessions_mv TO sessions AS SELECT …` with the new shape: `coalesce(nullIf(session_id, ''), toString(trace_id))` grouping key (no `WHERE session_id != ''`), root-span-sum `duration_ns`, sentinel `time_of_first_token`, `argMinIf` root_span_* projections, message payloads, `max(retention_days)`.
+- [x] Fill `clickhouse/migrations/clustered/00016_session_parity.sql` mirroring the unclustered file with `ON CLUSTER default` on every DDL statement.
+- [x] Apply locally: `pnpm --filter @platform/db-clickhouse db:up`.
+- [x] Regenerate `packages/platform/testkit/src/clickhouse/schema.sql` via `pnpm --filter @platform/db-clickhouse ch:schema:dump` and commit. (Surgical patch instead of full regen — chdb chokes on the CH-26.2 `text` index from migration 00012 that was hand-stripped from the prior dump.)
+- [x] Verify orphan-trace produces a 1-trace session (`session_id = toString(trace_id)`).
+- [x] Verify a multi-trace conversational session aggregates with `trace_count = N` and non-empty `models` after merge.
+- [x] Verify `sum(duration_ns)` diverges from `max_end_time - min_start_time` (active execution vs wall-clock) for a session with idle gaps.
+- [x] Verify TTFT sentinel: a session with no first-token reads `time_to_first_token_ns = 0`; a session with one reads positive.
+- [x] Confirm trace path untouched: `pnpm --filter @platform/db-clickhouse test` passes (133/133).
+
+### PR 2 — Domain entity
+
+- [ ] `packages/domain/spans/src/entities/session.ts`: add `timeToFirstTokenNs`, `rootSpanId`, `rootSpanName` to `sessionSchema`.
+- [ ] Same file: add `sessionDetailSchema` and `SessionDetail` paralleling `traceDetailSchema` (extends `sessionSchema` with `inputMessages`, `lastInputMessages`, `outputMessages`, `systemInstructions`).
+
+### PR 2 — Repository port
+
+- [ ] `packages/domain/spans/src/ports/session-repository.ts`: extend `SessionMetrics` with `timeToFirstTokenNs: NumericRollup`; update `emptySessionMetrics`.
+
+### PR 2 — Repository implementation
+
+- [ ] `packages/platform/db-clickhouse/src/repositories/session-repository.ts`: extend `LIST_SELECT` with `time_to_first_token_ns` (sentinel-aware finalization), `argMinIfMerge(root_span_id)`, `argMinIfMerge(root_span_name)`.
+- [ ] Same file: add `DETAIL_SELECT` projecting `argMinIfMerge(input_messages)`, `argMaxIfMerge(last_input_messages)`, `argMaxIfMerge(output_messages)`, `argMinIfMerge(system_instructions)`.
+- [ ] Widen `SessionListRow` (and add a `SessionDetailRow`) to match.
+- [ ] Update `toDomainSession` to populate the three new fields; add a `toDomainSessionDetail`.
+- [ ] Add `findBySessionId(projectId, sessionId)` returning `SessionDetail`, mirroring `findByTraceId`.
+- [ ] Add `time_to_first_token_ns` rollup to `aggregateMetricsByProjectId` so session metrics match trace metrics.
+
+### PR 2 — Filter registry & sort columns
+
+- [ ] `packages/platform/db-clickhouse/src/registries/session-fields.ts`: add `ttft: { column: "time_to_first_token_ns", chType: "Int64" }` and `name: { column: "root_span_name", chType: "String" }`.
+- [ ] `session-repository.ts` `SORT_COLUMNS`: add `ttft: { expr: "time_to_first_token_ns", chType: "Int64", rowKey: "time_to_first_token_ns" }`.
+
+### PR 2 — Tests
+
+- [ ] New file `packages/platform/db-clickhouse/src/repositories/session-repository.test.ts` (no existing file) modeled on `trace-repository.test.ts`.
+- [ ] Cover orphan-trace-as-session: spans without `gen_ai.conversation.id` produce a row keyed on `toString(trace_id)` with `trace_count = 1`.
+- [ ] Cover active-execution `duration_ns`: multi-root and concurrent-trace scenarios sum independently of wall-clock.
+- [ ] Cover TTFT sentinel: no-first-token → 0; with first-token → positive.
+- [ ] Cover `root_span_name` population: comes from the earliest root span across the session's first trace.
+- [ ] Cover the mixed-binding case: a real session + an orphan-fragment session emitted by the same trace ID, verifying `tokens_total = 0` on the orphan fragment.
+
 ## Goal
 
 The `sessions` ClickHouse table is fed by the same `spans` source as `traces`,


### PR DESCRIPTION
## Summary

Brings `sessions_mv` to column-level parity with `traces_mv` so every session row carries the same kind of information a trace row does. This is the data-layer foundation that the rest of the [session-problems epic](../blob/development/specs/session-problems/0-problems.md) builds on (filter parity, session-level search, session detail panel, freshness-sorted results).

Scope of this PR is **only the ClickHouse schema/MV layer** — domain entity, repository, filter-registry and tests are tracked as PR 2 in the spec's task checklist.

### Two semantic shifts ship together

- **`duration_ns` redefinition.** Was a wall-clock `Int64 ALIAS` (`max_end_time - min_start_time`). Now a real `SimpleAggregateFunction(sum, Int64)` storing sum of root-span durations across the session's traces. Distinguishes a 2-day session that worked 5 min/day from a 2-day session that worked 12 h/day. Wall-clock stays trivially recoverable on the fly. See spec §"On `duration_ns` semantics".
- **Orphan-trace-as-session.** Drops the `WHERE session_id != ''` filter and groups on `coalesce(nullIf(session_id, ''), toString(trace_id))`. Every trace surfaces as a session (orphans as 1-trace sessions). This is the precondition for session-paginated listings to cover every trace per the [core constraint](../blob/development/specs/session-problems/0-problems.md#core-constraint--pagination-is-by-session-not-by-trace).

### Other columns added

`time_of_first_token` + sentinel-aware `time_to_first_token_ns` ALIAS, `root_span_id`, `root_span_name`, `input_messages` / `last_input_messages` / `output_messages` / `system_instructions`, `retention_days`. Session TTL aligned with traces (`retention_days + 30` grace).

Backfill is **forward-only**: pre-migration session rows read new columns as 0/empty/sentinel until they ingest a new span. Matches the trace-search posture.

## Test plan

- [x] `pnpm --filter @platform/db-clickhouse ch:up` applies 00016 in <500ms
- [x] `pnpm --filter @platform/db-clickhouse test` passes (133/133)
- [x] `pnpm --filter @domain/spans --filter @platform/db-clickhouse typecheck` clean
- [x] Smoke test against live CH (`org_check` project) verified:
  - [x] Orphan span (empty `session_id`) → session row keyed on `toString(trace_id)` with `trace_count = 1`
  - [x] Real session keyed on supplied `gen_ai.conversation.id`
  - [x] `sum(duration_ns)` ≈ 10s vs wall-clock ≈ 1h05s for a 2-trace session with idle gap (~360× divergence)
  - [x] TTFT sentinel: 0 when no first-token instrumented, positive when it is
  - [x] `root_span_name` captured via `argMinIfMerge`
- [x] Reviewer to double-check `schema.sql` patch is acceptable in lieu of full regen — `ch:schema:dump` reintroduces the CH 26.2 `text` index from migration 00012 that chdb can't parse and that was hand-stripped from the prior dump. PR 2 (or a separate cleanup) should harden `dump-schema.sh` to sanitize chdb-incompatible features

## Follow-up

PR 2 — read path consumers — is tracked in the spec checklist at `specs/session-problems/1-parity-traces-sessions.md`. It covers the domain entity widening, `LIST_SELECT` / `DETAIL_SELECT` / `findBySessionId`, filter registry (`ttft`, `name`), and the new `session-repository.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)