### PR TITLE
refactor(web): complete createFormSubmitHandler migration for remaining forms

### DIFF
--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -22,7 +22,7 @@ interface ServerError {
  * Returns `{ _tag, message, status }` when the error was produced by
  * `errorHandler`, otherwise falls back to the raw error message with no tag.
  */
-export function parseServerError(err: unknown): ServerError {
+function parseServerError(err: unknown): ServerError {
   const raw = err instanceof Error ? err.message : String(err)
   try {
     const parsed = JSON.parse(raw)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/dataset-name-edit.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/dataset-name-edit.tsx
@@ -1,11 +1,128 @@
-import { Button, CopyableText, DropdownMenu, Input, Label, Modal, Text, toast } from "@repo/ui"
+import { Button, CopyableText, DropdownMenu, Input, Modal, Text, Textarea, useToast } from "@repo/ui"
+import { useForm } from "@tanstack/react-form"
 import { useNavigate } from "@tanstack/react-router"
 import { Loader2, Trash2 } from "lucide-react"
 import { useCallback, useState } from "react"
 import type { DatasetRecord } from "../../../../../../domains/datasets/datasets.functions.ts"
 import { deleteDatasetFunction, updateDataset } from "../../../../../../domains/datasets/datasets.functions.ts"
 import { getQueryClient } from "../../../../../../lib/data/query-client.tsx"
-import { parseServerError } from "../../../../../../lib/errors.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../../lib/form-server-action.ts"
+
+function DatasetEditModal({
+  dataset,
+  open,
+  onOpenChange,
+  onSuccess,
+}: {
+  dataset: DatasetRecord
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess?: () => void
+}) {
+  const projectId = dataset.projectId
+  const { toast: showToast } = useToast()
+
+  const form = useForm({
+    defaultValues: {
+      name: dataset.name,
+      description: dataset.description ?? "",
+    },
+    onSubmit: createFormSubmitHandler(
+      async (value) => {
+        return await updateDataset({
+          data: {
+            datasetId: dataset.id,
+            name: value.name,
+            description: value.description.trim() === "" ? null : value.description,
+          },
+        })
+      },
+      {
+        onSuccess: () => {
+          const qc = getQueryClient()
+          qc.invalidateQueries({ queryKey: ["datasets", projectId] })
+          qc.invalidateQueries({ queryKey: ["dataset", dataset.id] })
+          onOpenChange(false)
+          onSuccess?.()
+          showToast({ description: "Dataset updated" })
+        },
+        onError: (error) => {
+          showToast({ variant: "destructive", description: toUserMessage(error) })
+        },
+      },
+    ),
+  })
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (next) {
+          form.reset({ name: dataset.name, description: dataset.description ?? "" })
+        }
+      }}
+      title="Edit dataset"
+      description="Update the dataset name and description."
+      dismissible
+      footer={
+        <div className="flex flex-row items-center gap-2 justify-end">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={form.state.isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              void form.handleSubmit()
+            }}
+            disabled={form.state.isSubmitting}
+            isLoading={form.state.isSubmitting}
+          >
+            Save
+          </Button>
+        </div>
+      }
+    >
+      <form
+        className="flex flex-col gap-4"
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
+        <form.Field name="name">
+          {(field) => (
+            <Input
+              id="dataset-edit-name"
+              label="Name"
+              value={field.state.value}
+              onChange={(event) => field.handleChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void form.handleSubmit()
+              }}
+              disabled={form.state.isSubmitting}
+              errors={fieldErrorsAsStrings(field.state.meta.errors)}
+            />
+          )}
+        </form.Field>
+        <form.Field name="description">
+          {(field) => (
+            <Textarea
+              id="dataset-edit-description"
+              label="Description"
+              value={field.state.value}
+              onChange={(event) => field.handleChange(event.target.value)}
+              disabled={form.state.isSubmitting}
+              minRows={4}
+              maxRows={8}
+              errors={fieldErrorsAsStrings(field.state.meta.errors)}
+            />
+          )}
+        </form.Field>
+      </form>
+    </Modal>
+  )
+}
 
 export function DatasetNameEdit({
   dataset,
@@ -18,49 +135,14 @@ export function DatasetNameEdit({
 }) {
   const projectId = dataset.projectId
   const navigate = useNavigate()
+  const { toast } = useToast()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
-  const [editName, setEditName] = useState(dataset.name)
-  const [editDescription, setEditDescription] = useState(dataset.description ?? "")
-  const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   const openEdit = useCallback(() => {
-    setEditName(dataset.name)
-    setEditDescription(dataset.description ?? "")
-    setError(null)
     setEditOpen(true)
-  }, [dataset.description, dataset.name])
-
-  const saveEdit = useCallback(async () => {
-    setSaving(true)
-    setError(null)
-    try {
-      await updateDataset({
-        data: {
-          datasetId: dataset.id,
-          name: editName,
-          description: editDescription.trim() === "" ? null : editDescription,
-        },
-      })
-      const qc = getQueryClient()
-      qc.invalidateQueries({ queryKey: ["datasets", projectId] })
-      qc.invalidateQueries({ queryKey: ["dataset", dataset.id] })
-      setEditOpen(false)
-      onSuccess?.()
-      toast({ description: "Dataset updated" })
-    } catch (e) {
-      const { _tag, message } = parseServerError(e)
-      if (_tag === "DuplicateDatasetNameError" || _tag === "ValidationError") {
-        setError(message)
-      } else {
-        setError(message)
-      }
-    } finally {
-      setSaving(false)
-    }
-  }, [dataset.id, editDescription, editName, onSuccess, projectId])
+  }, [])
 
   const confirmDelete = useCallback(async () => {
     setDeleting(true)
@@ -77,7 +159,7 @@ export function DatasetNameEdit({
     } catch (e) {
       toast({
         variant: "destructive",
-        description: parseServerError(e).message,
+        description: toUserMessage(e),
       })
     } finally {
       setDeleting(false)
@@ -127,56 +209,12 @@ export function DatasetNameEdit({
         ) : null}
       </div>
 
-      <Modal
+      <DatasetEditModal
+        dataset={dataset}
         open={editOpen}
         onOpenChange={setEditOpen}
-        title="Edit dataset"
-        description="Update the dataset name and description."
-        dismissible
-        footer={
-          <div className="flex flex-row items-center gap-2 justify-end">
-            <Button variant="outline" onClick={() => setEditOpen(false)} disabled={saving}>
-              Cancel
-            </Button>
-            <Button onClick={() => void saveEdit()} disabled={saving}>
-              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Save
-            </Button>
-          </div>
-        }
-      >
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="dataset-edit-name">Name</Label>
-            <Input
-              id="dataset-edit-name"
-              value={editName}
-              onChange={(e) => setEditName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void saveEdit()
-              }}
-              disabled={saving}
-              aria-invalid={Boolean(error)}
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="dataset-edit-description">Description</Label>
-            <textarea
-              id="dataset-edit-description"
-              value={editDescription}
-              onChange={(e) => setEditDescription(e.target.value)}
-              disabled={saving}
-              rows={4}
-              className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-            />
-          </div>
-          {error ? (
-            <div role="alert">
-              <Text.H6 color="destructive">{error}</Text.H6>
-            </div>
-          ) : null}
-        </div>
-      </Modal>
+        {...(onSuccess ? { onSuccess } : {})}
+      />
 
       <Modal
         open={deleteOpen}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../../../../../domains/evaluations/evaluation-alignment.functions.ts"
 import { invalidateIssueQueries } from "../../../../../../domains/issues/issues.collection.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { createFormSubmitHandler } from "../../../../../../lib/form-server-action.ts"
 import { AlignmentStatsModal } from "./alignment-stats-modal.tsx"
 import { EvaluationFilterModal } from "./evaluation-filter-modal.tsx"
 import { formatPercent, getAlignmentVariant } from "./issue-formatters.ts"
@@ -130,8 +131,8 @@ function SamplingModalForm({
     defaultValues: {
       sampling: evaluation.trigger.sampling,
     },
-    onSubmit: async ({ value }) => {
-      try {
+    onSubmit: createFormSubmitHandler(
+      async (value) => {
         await updateIssueEvaluationSampling({
           data: {
             projectId,
@@ -140,13 +141,18 @@ function SamplingModalForm({
             sampling: value.sampling,
           },
         })
-        onClose()
-        await invalidateIssueQueries(projectId, issueId)
-        toast({ description: "Sampling updated." })
-      } catch (error) {
-        toast({ variant: "destructive", description: toUserMessage(error) })
-      }
-    },
+      },
+      {
+        onSuccess: async () => {
+          onClose()
+          await invalidateIssueQueries(projectId, issueId)
+          toast({ description: "Sampling updated." })
+        },
+        onError: (error) => {
+          toast({ variant: "destructive", description: toUserMessage(error) })
+        },
+      },
+    ),
   })
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes latitude-dev/latitude-llm#2732 (Linear AGE-66).

Most settings and dashboard forms were already migrated in #2738. This PR finishes the migration for the last TanStack Form usages that still handled server calls manually.

## Changes

- **Issue drawer sampling modal** — `SamplingModalForm` now uses `createFormSubmitHandler` with `onSuccess` (close modal, invalidate issue queries, toast) and `onError` (destructive toast).
- **Dataset edit modal** — Rebuilt the edit flow on `useForm` + `createFormSubmitHandler` + `fieldErrorsAsStrings` so Zod validation from `updateDataset` maps to the name/description fields; domain errors (e.g. duplicate name) still surface via `onError` toast.
- **`parseServerError`** — Stopped exporting it from `apps/web/src/lib/errors.ts`; it is only used internally by `toUserMessage` after the dataset edit migration dropped the last direct import.

## Verification

- `pnpm --filter @app/web typecheck` — no new errors in touched files (pre-existing `@latitude-data/telemetry` resolution warnings remain in this environment).
- Grep confirms no remaining `onSubmit: async` handlers under `apps/web`.
- All `useForm` call sites in `apps/web` now route through `createFormSubmitHandler`.

## Out of scope

Modals that use local state without TanStack Form (e.g. add-to-dataset, evaluation filter scope, login) were left unchanged; they do not fit the `useForm` + field-meta pattern without a larger UI rewrite.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-66](https://linear.app/latitude/issue/AGE-66/migrate-forms-to-use-createformsubmithandler-pattern)

<div><a href="https://cursor.com/agents/bc-337b21a9-b3a7-4fcb-8618-d46015d6044d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-337b21a9-b3a7-4fcb-8618-d46015d6044d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

