### PR TITLE
fix(web): trace overlay reopening + bundled settings/navbar/annotation/org UX improvements

### DIFF
--- a/apps/web/src/domains/organizations/organizations.functions.ts
+++ b/apps/web/src/domains/organizations/organizations.functions.ts
@@ -1,10 +1,12 @@
 import {
   generateUniqueOrganizationSlugUseCase,
+  MembershipRepository,
   OrganizationRepository,
   provisionOrganizationWorkspaceUseCase,
   updateOrganizationUseCase,
 } from "@domain/organizations"
-import { OrganizationId, UserId } from "@domain/shared"
+import { purgeOrganizationProjectsUseCase } from "@domain/projects"
+import { BadRequestError, ForbiddenError, OrganizationId, UserId } from "@domain/shared"
 import {
   ApiKeyRepositoryLive,
   MembershipRepositoryLive,
@@ -94,6 +96,70 @@ export const updateOrganization = createServerFn({ method: "POST" })
     return await Effect.runPromise(
       updateOrganizationUseCase({ name: data.name, settings: data.settings }).pipe(
         withPostgres(OrganizationRepositoryLive, client, organizationId),
+        withTracing,
+      ),
+    )
+  })
+
+/**
+ * Permanently delete an organization. Guarded so the only org that can be
+ * destroyed is the one you are currently in, you are its `owner`, and there
+ * are no other members — i.e. an org only you can see.
+ *
+ * Deletion is irreversible: each project is soft-deleted and emits a
+ * `ProjectDeleted` event (so the per-project cleanup cascade runs, matching a
+ * manual project deletion), then the org row is removed — its FK cascade drops
+ * memberships, invitations, and OAuth apps. The client then bounces to
+ * `/welcome`, which re-resolves the user's remaining orgs.
+ */
+export const deleteOrganization = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ id: z.string() }))
+  .handler(async ({ data }): Promise<void> => {
+    const { userId, organizationId } = await requireSession()
+
+    // You may only delete the organization you are currently active in. This
+    // keeps the RLS context (active org) aligned with the org being deleted.
+    if (data.id !== organizationId) {
+      throw new ForbiddenError({ message: "You can only delete the organization you are currently in." })
+    }
+
+    const targetId = OrganizationId(data.id)
+
+    // Authorize against the full member list. Read with the admin client so the
+    // count is never narrowed by RLS — an under-count would be a security hole.
+    const adminClient = getAdminPostgresClient()
+    const members = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* MembershipRepository
+        return yield* repo.listByOrganizationId(targetId)
+      }).pipe(withPostgres(MembershipRepositoryLive, adminClient), withTracing),
+    )
+
+    const caller = members.find((member) => member.userId === userId)
+    if (!caller || caller.role !== "owner") {
+      throw new ForbiddenError({ message: "Only the organization owner can delete it." })
+    }
+    if (members.length > 1) {
+      throw new BadRequestError({
+        message: "Remove all other members before deleting the organization.",
+      })
+    }
+
+    const client = getPostgresClient()
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Tear down the org's projects (soft-delete + ProjectDeleted cascade)
+        // before removing the org row. The org delete then cascades members,
+        // invitations, and OAuth apps via FK.
+        yield* purgeOrganizationProjectsUseCase({ actorUserId: userId })
+        const orgRepo = yield* OrganizationRepository
+        yield* orgRepo.delete(targetId)
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(ProjectRepositoryLive, OrganizationRepositoryLive, OutboxEventWriterLive),
+          client,
+          targetId,
+        ),
         withTracing,
       ),
     )

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -209,6 +209,7 @@ function NavHeader() {
     return {
       label: rest || o.name,
       leading: emoji ? <span className="text-base leading-none">{emoji}</span> : null,
+      selected: o.id === organizationId,
       onClick: () => void handleOrgSwitch(o.id),
     }
   })

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -36,7 +36,9 @@ export function ProjectBreadcrumbSegment() {
         options={[
           ...(allProjects?.map((p) => ({
             label: p.name,
+            selected: p.id === project.id,
             onClick: () => {
+              if (p.id === project.id) return
               window.location.href = `/projects/${p.slug}`
             },
           })) ?? []),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
@@ -254,6 +254,7 @@ function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
   const { data: flaggers = [] } = useProjectFlaggers(projectId)
   const flagger = flaggers.find((candidate) => candidate.slug === slug)
   const name = flagger?.name ?? humanizeFlaggerSlug(slug)
+  const label = `${name} flagger`
 
   function openFlaggerSettings(event: { stopPropagation: () => void; preventDefault?: () => void }) {
     if (!projectSlug) return
@@ -269,7 +270,7 @@ function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
   if (!projectSlug) {
     return (
       <Badge variant="secondary" size="small">
-        {name}
+        {label}
       </Badge>
     )
   }
@@ -294,7 +295,7 @@ function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
             }
           }}
         >
-          {name}
+          {label}
         </Badge>
       }
     >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
@@ -2,10 +2,11 @@ import { canUpdateAnnotation, getAnnotationProvenance } from "@domain/annotation
 import { Avatar, Badge, Button, DropdownMenu, Icon, LatitudeLogo, type MenuOption, Text, Tooltip } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { useNavigate, useParams } from "@tanstack/react-router"
-import { EllipsisIcon, GlobeIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
+import { ArrowUpRightIcon, EllipsisIcon, GlobeIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useDeleteAnnotation } from "../../../../../../domains/annotations/annotations.collection.ts"
 import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
+import { useProjectFlaggers } from "../../../../../../domains/flaggers/flaggers.collection.ts"
 import { useIssue } from "../../../../../../domains/issues/issues.collection.ts"
 import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
 import { pickUserFromMembersMap } from "../../../../../../domains/members/pick-users-from-members.ts"
@@ -45,6 +46,7 @@ export function AnnotationCard({
   const linkedIssueName = linkedIssue?.name ?? null
   const linkedIssueDescription = linkedIssue?.description?.trim()
   const provenance = getAnnotationProvenance(annotation)
+  const flaggerSlug = (annotation.metadata as { flaggerSlug?: string })?.flaggerSlug?.trim() || undefined
   const isEditable = canUpdateAnnotation(annotation)
   const isDraft = annotation.draftedAt !== null
   const isAgentDraft = provenance === "agent" && isDraft
@@ -130,9 +132,13 @@ export function AnnotationCard({
           <div className="flex items-center gap-1.5">
             <LatitudeLogo className="h-4 w-4" />
             <Text.H6 weight="bold">Latitude</Text.H6>
-            <Badge variant="secondary" size="small">
-              Agent
-            </Badge>
+            {flaggerSlug ? (
+              <FlaggerBadge projectId={projectId} projectSlug={projectSlug} slug={flaggerSlug} />
+            ) : (
+              <Badge variant="secondary" size="small">
+                Agent
+              </Badge>
+            )}
           </div>
         )}
         {provenance === "api" && (
@@ -225,5 +231,74 @@ export function AnnotationCard({
         </div>
       )}
     </div>
+  )
+}
+
+const humanizeFlaggerSlug = (slug: string) =>
+  slug.replaceAll("-", " ").replace(/\b\w/g, (letter) => letter.toUpperCase())
+
+interface FlaggerBadgeProps {
+  readonly projectId: string
+  readonly projectSlug: string | undefined
+  readonly slug: string
+}
+
+/**
+ * Names the automatic flagger that authored an annotation and, when we know the
+ * current project slug, links to its row in project settings. Falls back to a
+ * humanized slug when the flagger isn't in the project's provisioned list
+ * (e.g. it was de-provisioned after the annotation was created).
+ */
+function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
+  const navigate = useNavigate()
+  const { data: flaggers = [] } = useProjectFlaggers(projectId)
+  const flagger = flaggers.find((candidate) => candidate.slug === slug)
+  const name = flagger?.name ?? humanizeFlaggerSlug(slug)
+
+  function openFlaggerSettings(event: { stopPropagation: () => void; preventDefault?: () => void }) {
+    if (!projectSlug) return
+    event.stopPropagation()
+    event.preventDefault?.()
+    void navigate({
+      to: "/projects/$projectSlug/settings/flaggers",
+      params: { projectSlug },
+      search: { flagger: slug },
+    })
+  }
+
+  if (!projectSlug) {
+    return (
+      <Badge variant="secondary" size="small">
+        {name}
+      </Badge>
+    )
+  }
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <Badge
+          data-no-navigate
+          variant="secondary"
+          size="small"
+          role="button"
+          tabIndex={0}
+          aria-label={`Open the ${name} flagger settings`}
+          className="cursor-pointer hover:bg-muted"
+          iconProps={{ icon: ArrowUpRightIcon, color: "foregroundMuted", placement: "end" }}
+          onClick={openFlaggerSettings}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              openFlaggerSettings(event)
+            }
+          }}
+        >
+          {name}
+        </Badge>
+      }
+    >
+      Flagged automatically by the {name} flagger — open its settings
+    </Tooltip>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -100,7 +100,12 @@ export const TreeRow = memo(function TreeRow({
 
         <SpanIcon span={node.span} />
 
-        <Text.H6 noWrap ellipsis className="flex-1 min-w-0">
+        <Text.H6
+          noWrap
+          ellipsis
+          color={node.span.statusCode === "error" ? "destructive" : "foreground"}
+          className="flex-1 min-w-0"
+        >
           {node.span.name}
         </Text.H6>
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -115,6 +115,12 @@ type LifecycleConfirmationAction = "ignore" | "unignore" | "unresolve"
 
 const ISSUE_TRACE_COLUMN_IDS = ["startTime", "name", "tags", "duration"] as const satisfies readonly TraceColumnId[]
 
+// Must match the trace overlay panel's `duration-300` slide animation. We tear the overlay down
+// with a timer after this delay rather than listening for `transitionend`, because that event
+// never fires when motion is reduced or the transition is interrupted, which would leave the
+// overlay logically open and the trace row stuck in its active state.
+const TRACE_PANEL_TRANSITION_MS = 300
+
 function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
   switch (action) {
     case "ignore":
@@ -180,8 +186,7 @@ export function IssueDetailDrawer({
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
   const [traceOverlayTraceId, setTraceOverlayTraceId] = useState<string | null>(null)
   const [tracePanelEntered, setTracePanelEntered] = useState(false)
-  const traceOverlayClosingRef = useRef(false)
-  const tracePanelRef = useRef<HTMLDivElement>(null)
+  const traceOverlayCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previousTraceOverlayIdRef = useRef<string | null>(null)
 
   const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
@@ -222,16 +227,34 @@ export function IssueDetailDrawer({
     issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
   const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
 
-  const finishCloseTraceOverlay = useCallback(() => {
-    traceOverlayClosingRef.current = false
-    setTraceOverlayTraceId(null)
+  const clearTraceOverlayCloseTimer = useCallback(() => {
+    if (traceOverlayCloseTimerRef.current !== null) {
+      clearTimeout(traceOverlayCloseTimerRef.current)
+      traceOverlayCloseTimerRef.current = null
+    }
   }, [])
+
+  const finishCloseTraceOverlay = useCallback(() => {
+    clearTraceOverlayCloseTimer()
+    setTraceOverlayTraceId(null)
+  }, [clearTraceOverlayCloseTimer])
+
+  const openTraceOverlay = useCallback(
+    (traceId: string) => {
+      clearTraceOverlayCloseTimer()
+      setTraceOverlayTraceId(traceId)
+    },
+    [clearTraceOverlayCloseTimer],
+  )
 
   const requestCloseTraceOverlay = useCallback(() => {
     if (traceOverlayTraceId === null) return
-    traceOverlayClosingRef.current = true
     setTracePanelEntered(false)
-  }, [traceOverlayTraceId])
+    clearTraceOverlayCloseTimer()
+    traceOverlayCloseTimerRef.current = setTimeout(finishCloseTraceOverlay, TRACE_PANEL_TRANSITION_MS)
+  }, [traceOverlayTraceId, clearTraceOverlayCloseTimer, finishCloseTraceOverlay])
+
+  useEffect(() => clearTraceOverlayCloseTimer, [clearTraceOverlayCloseTimer])
 
   useEffect(() => {
     if (traceOverlayTraceId === null) {
@@ -251,19 +274,6 @@ export function IssueDetailDrawer({
     })
     return () => cancelAnimationFrame(id)
   }, [traceOverlayTraceId])
-
-  useEffect(() => {
-    const el = tracePanelRef.current
-    if (!el || traceOverlayTraceId === null) return
-    const onTransitionEnd = (e: TransitionEvent) => {
-      if (e.propertyName !== "transform") return
-      if (traceOverlayClosingRef.current) {
-        finishCloseTraceOverlay()
-      }
-    }
-    el.addEventListener("transitionend", onTransitionEnd)
-    return () => el.removeEventListener("transitionend", onTransitionEnd)
-  }, [traceOverlayTraceId, finishCloseTraceOverlay])
 
   const traceOverlayIndex = traceOverlayTraceId ? traceIds.indexOf(traceOverlayTraceId) : -1
   const canNavigateNextTraceInOverlay =
@@ -551,10 +561,7 @@ export function IssueDetailDrawer({
               isLoading={tracesLoading}
               visibleColumnIds={ISSUE_TRACE_COLUMN_IDS}
               defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
-              onTraceClick={(trace) => {
-                traceOverlayClosingRef.current = false
-                setTraceOverlayTraceId(trace.traceId)
-              }}
+              onTraceClick={(trace) => openTraceOverlay(trace.traceId)}
               getTraceRowAriaLabel={getTraceRowAriaLabel}
               rowInteractionRole="button"
               activeTraceId={traceOverlayTraceId ?? undefined}
@@ -654,7 +661,6 @@ export function IssueDetailDrawer({
             onClick={requestCloseTraceOverlay}
           />
           <div
-            ref={tracePanelRef}
             className={cn(
               "fixed inset-y-0 right-0 z-[50] flex max-h-dvh shadow-2xl will-change-transform transition-transform duration-300 ease-out",
               tracePanelEntered ? "translate-x-0" : "translate-x-full",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -469,9 +469,13 @@ function AccountSettingsPage() {
           )}
         </form.Field>
         <div className="self-start">
-          <Button type="submit" isLoading={form.state.isSubmitting}>
-            Save
-          </Button>
+          <form.Subscribe selector={(state) => state.isSubmitting}>
+            {(isSubmitting) => (
+              <Button type="submit" isLoading={isSubmitting}>
+                Save
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </form>
       <NotificationsSection />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -1,10 +1,12 @@
-import { Label, Switch, Text, useToast } from "@repo/ui"
+import { cn, Label, Switch, Text, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute } from "@tanstack/react-router"
+import { useRef } from "react"
 import { updateFlaggerMutation, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
 import type { FlaggerRecord } from "../../../../../domains/flaggers/flaggers.functions.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
+import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { useRouteProject } from "../-route-data.ts"
 import { SettingsPage } from "./-components/settings-page.tsx"
 
@@ -24,6 +26,17 @@ function ProjectFlaggersSettingsPage() {
 
   const currentProject = project ?? routeProject
   const { data: flaggers = [], isLoading: isLoadingFlaggers } = useProjectFlaggers(currentProject.id)
+
+  // Flagger annotations deep-link here with `?flagger=<slug>` to point at the
+  // flagger that authored them; scroll it into view once and keep it highlighted.
+  const [targetFlaggerSlug] = useParamState("flagger", "")
+  const hasScrolledToTargetRef = useRef(false)
+  const scrollTargetRef = (node: HTMLDivElement | null) => {
+    if (node && !hasScrolledToTargetRef.current) {
+      hasScrolledToTargetRef.current = true
+      node.scrollIntoView({ block: "center", behavior: "smooth" })
+    }
+  }
 
   const handleFlaggerEnabledChange = async (flagger: FlaggerRecord, checked: boolean) => {
     try {
@@ -51,10 +64,14 @@ function ProjectFlaggersSettingsPage() {
         ) : (
           flaggers.map((flagger) => {
             const inputId = `flagger-${flagger.id}`
+            const isTarget = targetFlaggerSlug !== "" && flagger.slug === targetFlaggerSlug
             return (
               <div
                 key={flagger.id}
-                className="flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4"
+                ref={isTarget ? scrollTargetRef : undefined}
+                className={cn("flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4", {
+                  "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget,
+                })}
               >
                 <div className="flex flex-col gap-1">
                   <Label htmlFor={inputId}>{flagger.name}</Label>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -72,9 +72,13 @@ function ProjectGeneralSettingsPage() {
           )}
         </form.Field>
         <div className="self-start">
-          <Button type="submit" isLoading={form.state.isSubmitting}>
-            Save
-          </Button>
+          <form.Subscribe selector={(state) => state.isSubmitting}>
+            {(isSubmitting) => (
+              <Button type="submit" isLoading={isSubmitting}>
+                Save
+              </Button>
+            )}
+          </form.Subscribe>
         </div>
       </form>
       <DeleteProjectSection projectId={currentProject.id} projectName={currentProject.name} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
@@ -1,15 +1,18 @@
 import type { Organization } from "@domain/organizations"
-import { Button, Input, useToast } from "@repo/ui"
+import { Button, FormWrapper, Input, Modal, Text, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { useForm } from "@tanstack/react-form"
 import { createFileRoute } from "@tanstack/react-router"
+import { useState } from "react"
+import { useMembersCollection } from "../../../../../domains/members/members.collection.ts"
 import {
   updateOrganizationMutation,
   useOrganizationsCollection,
 } from "../../../../../domains/organizations/organizations.collection.ts"
+import { deleteOrganization } from "../../../../../domains/organizations/organizations.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
-import { useAuthenticatedOrganizationId } from "../../../-route-data.ts"
+import { useAuthenticatedOrganizationId, useAuthenticatedUser } from "../../../-route-data.ts"
 import { SettingsPage } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/organization")({
@@ -73,15 +76,123 @@ function OrganizationNameForm({ org }: { org: Organization }) {
         )}
       </form.Field>
       <div className="self-start">
-        <form.Subscribe selector={(state) => state.isSubmitting}>
-          {(isSubmitting) => (
-            <Button type="submit" isLoading={isSubmitting}>
-              Save
-            </Button>
-          )}
-        </form.Subscribe>
+        <Button type="submit" isLoading={form.state.isSubmitting}>
+          Save
+        </Button>
       </div>
     </form>
+  )
+}
+
+/**
+ * Danger zone for permanently deleting the organization. Only shown to the org
+ * `owner`; the delete is additionally gated server-side on the caller being the
+ * owner and the sole member. The button stays disabled (with an explanation)
+ * until every other member has been removed.
+ */
+function DeleteOrganizationSection() {
+  const organizationId = useAuthenticatedOrganizationId()
+  const user = useAuthenticatedUser()
+  const { data: org } = useOrganizationsCollection((orgs) =>
+    orgs.where(({ organizations }) => eq(organizations.id, organizationId)).findOne(),
+  )
+  const { data: memberData } = useMembersCollection()
+  const [open, setOpen] = useState(false)
+
+  const members = memberData ?? []
+  const activeMembers = members.filter((member) => member.status === "active")
+  const myMembership = activeMembers.find((member) => member.userId === user.id)
+  const isOwner = myMembership?.role === "owner"
+  // Pending invitations cascade away with the org, so only active members block.
+  const isSoleMember = activeMembers.length === 1
+
+  if (!org || !isOwner) return null
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+      <Text.H4 weight="bold" color="destructive">
+        Delete Organization
+      </Text.H4>
+      <Text.H5 color="destructive">
+        Permanently delete this organization and all of its projects and data. This action cannot be undone.
+      </Text.H5>
+      {!isSoleMember && (
+        <Text.H5 color="foregroundMuted">Remove all other members before you can delete this organization.</Text.H5>
+      )}
+      <div>
+        <DeleteOrganizationConfirmModal open={open} setOpen={setOpen} orgId={org.id} orgName={org.name} />
+        <Button variant="destructive" disabled={!isSoleMember} onClick={() => setOpen(true)}>
+          Delete Organization
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function DeleteOrganizationConfirmModal({
+  open,
+  setOpen,
+  orgId,
+  orgName,
+}: {
+  open: boolean
+  setOpen: (open: boolean) => void
+  orgId: string
+  orgName: string
+}) {
+  const { toast } = useToast()
+  const [confirmText, setConfirmText] = useState("")
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const expectedText = "delete my organization"
+  const isConfirmed = confirmText.toLowerCase() === expectedText
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      await deleteOrganization({ data: { id: orgId } })
+      toast({ description: `Organization "${orgName}" has been deleted.` })
+      // Full navigation to /welcome: its loader re-resolves the user's remaining
+      // orgs and either auto-activates the last one, shows a picker, or prompts
+      // to create one — which also clears the now-stale active org.
+      window.location.href = "/welcome"
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+      setIsDeleting(false)
+    }
+  }
+
+  return (
+    <Modal
+      dismissible
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) setConfirmText("")
+        setOpen(v)
+      }}
+      title="Delete Organization"
+      description={`This action is permanent and cannot be undone. The organization "${orgName}" and all of its projects and data will be deleted.`}
+      footer={
+        <>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" disabled={!isConfirmed || isDeleting} onClick={() => void handleDelete()}>
+            {isDeleting ? "Deleting..." : "Delete Organization"}
+          </Button>
+        </>
+      }
+    >
+      <FormWrapper>
+        <Input
+          type="text"
+          label={`Type "${expectedText}" to confirm`}
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          placeholder={expectedText}
+        />
+      </FormWrapper>
+    </Modal>
   )
 }
 
@@ -90,6 +201,7 @@ function OrganizationSettingsPage() {
     <SettingsPage title="Organization" description="Manage your organization details">
       <div className="flex w-full flex-col gap-6 @[800px]:w-1/2">
         <OrganizationNameSection />
+        <DeleteOrganizationSection />
       </div>
     </SettingsPage>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
@@ -73,9 +73,13 @@ function OrganizationNameForm({ org }: { org: Organization }) {
         )}
       </form.Field>
       <div className="self-start">
-        <Button type="submit" isLoading={form.state.isSubmitting}>
-          Save
-        </Button>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Button type="submit" isLoading={isSubmitting}>
+              Save
+            </Button>
+          )}
+        </form.Subscribe>
       </div>
     </form>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/organization.tsx
@@ -76,9 +76,13 @@ function OrganizationNameForm({ org }: { org: Organization }) {
         )}
       </form.Field>
       <div className="self-start">
-        <Button type="submit" isLoading={form.state.isSubmitting}>
-          Save
-        </Button>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Button type="submit" isLoading={isSubmitting}>
+              Save
+            </Button>
+          )}
+        </form.Subscribe>
       </div>
     </form>
   )

--- a/apps/workers/src/workers/domain-events/user-deletion.ts
+++ b/apps/workers/src/workers/domain-events/user-deletion.ts
@@ -1,8 +1,11 @@
+import { purgeOrganizationProjectsUseCase } from "@domain/projects"
 import type { QueueConsumer } from "@domain/queue"
 import { deleteUserUseCase } from "@domain/users"
 import {
   MembershipRepositoryLive,
   OrganizationRepositoryLive,
+  OutboxEventWriterLive,
+  ProjectRepositoryLive,
   UserRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
@@ -21,9 +24,22 @@ export const createUserDeletionWorker = ({ consumer }: UserDeletionDeps) => {
     delete: (payload) => {
       const pgClient = getAdminPostgresClient()
       const repoLayer = Layer.mergeAll(MembershipRepositoryLive, OrganizationRepositoryLive, UserRepositoryLive)
+      const projectLayer = Layer.mergeAll(ProjectRepositoryLive, OutboxEventWriterLive)
 
-      return deleteUserUseCase({ userId: payload.userId }).pipe(
-        withPostgres(repoLayer, pgClient),
+      return Effect.gen(function* () {
+        const { deletedOrganizationIds } = yield* deleteUserUseCase({ userId: payload.userId }).pipe(
+          withPostgres(repoLayer, pgClient),
+        )
+
+        // Tear down projects of each sole-member org we deleted. Projects have
+        // no FK to the org, so this must run explicitly — scoped per org so the
+        // RLS / SqlClient context matches the projects being purged.
+        for (const organizationId of deletedOrganizationIds) {
+          yield* purgeOrganizationProjectsUseCase({ actorUserId: payload.userId }).pipe(
+            withPostgres(projectLayer, pgClient, organizationId),
+          )
+        }
+      }).pipe(
         withTracing,
         Effect.tap(() => Effect.sync(() => logger.info(`User ${payload.userId} permanently deleted`))),
         Effect.tapError((error) =>

--- a/packages/domain/flaggers/src/use-cases/process-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/process-flaggers.test.ts
@@ -172,6 +172,7 @@ describe("processFlaggersUseCase", () => {
     expect(jailbreakScores[0]?.source).toBe("annotation")
     expect(jailbreakScores[0]?.sourceId).toBe("SYSTEM")
     expect(jailbreakScores[0]?.draftedAt).toBeNull()
+    expect(jailbreakScores[0]?.metadata).toMatchObject({ flaggerSlug: "jailbreaking" })
     expect(deps.enqueued).toEqual([])
   })
 

--- a/packages/domain/flaggers/src/use-cases/process-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/process-flaggers.ts
@@ -225,6 +225,7 @@ const handleMatched = (input: ProcessOneStrategyInput, feedback: string, message
       sessionId: input.trace.sessionId,
       simulationId,
       feedback,
+      flaggerSlug: input.slug,
       messageIndex,
     })
 

--- a/packages/domain/flaggers/src/use-cases/save-flagger-annotation.ts
+++ b/packages/domain/flaggers/src/use-cases/save-flagger-annotation.ts
@@ -52,6 +52,7 @@ export const saveFlaggerAnnotationUseCase = Effect.fn("flaggers.saveFlaggerAnnot
     sessionId: parsedInput.sessionId ?? null,
     simulationId: parsedInput.simulationId ?? null,
     feedback: input.feedback,
+    flaggerSlug: parsedInput.flaggerSlug,
     messageIndex: input.messageIndex,
   })
 

--- a/packages/domain/flaggers/src/use-cases/upsert-flagger-annotation-score.ts
+++ b/packages/domain/flaggers/src/use-cases/upsert-flagger-annotation-score.ts
@@ -10,6 +10,7 @@ interface UpsertFlaggerAnnotationScoreInput {
   readonly sessionId: string | null
   readonly simulationId: string | null
   readonly feedback: string
+  readonly flaggerSlug: string
   readonly messageIndex?: number | undefined
 }
 
@@ -20,9 +21,10 @@ type UpsertFlaggerAnnotationScoreResult =
 /**
  * Dedups + writes the canonical flagger-authored annotation score
  * (`source: "annotation"`, `sourceId: "SYSTEM"`, `draftedAt: null`,
- * `metadata: { rawFeedback }`). Shared by the deterministic
+ * `metadata: { rawFeedback, flaggerSlug }`). Shared by the deterministic
  * `process-flaggers` matched path and the LLM `save-flagger-annotation`
- * path so they can't drift.
+ * path so they can't drift. `flaggerSlug` lets the UI name the flagger and
+ * link to its project settings.
  */
 export const upsertFlaggerAnnotationScore = (input: UpsertFlaggerAnnotationScoreInput) =>
   Effect.gen(function* () {
@@ -53,6 +55,7 @@ export const upsertFlaggerAnnotationScore = (input: UpsertFlaggerAnnotationScore
       feedback: input.feedback,
       metadata: {
         rawFeedback: input.feedback,
+        flaggerSlug: input.flaggerSlug,
         ...(input.messageIndex !== undefined ? { messageIndex: input.messageIndex } : {}),
       },
       error: null,

--- a/packages/domain/organizations/src/use-cases/cleanup-user-memberships.test.ts
+++ b/packages/domain/organizations/src/use-cases/cleanup-user-memberships.test.ts
@@ -63,9 +63,12 @@ describe("cleanupUserMembershipsUseCase", () => {
     seedOrganization(organizations, ORG_1)
     seedMembership(memberships, ORG_1, USER_ID)
 
-    await Effect.runPromise(cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)))
+    const deleted = await Effect.runPromise(
+      cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)),
+    )
 
     expect(organizations.size).toBe(0)
+    expect(deleted).toEqual([ORG_1])
   })
 
   it("removes only the membership when other members exist", async () => {
@@ -74,9 +77,12 @@ describe("cleanupUserMembershipsUseCase", () => {
     seedMembership(memberships, ORG_1, USER_ID)
     seedMembership(memberships, ORG_1, OTHER_USER_ID)
 
-    await Effect.runPromise(cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)))
+    const deleted = await Effect.runPromise(
+      cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)),
+    )
 
     expect(organizations.size).toBe(1)
+    expect(deleted).toEqual([])
     const remainingMembers = [...memberships.values()]
     expect(remainingMembers).toHaveLength(1)
     expect(remainingMembers[0]?.userId).toBe(OTHER_USER_ID)
@@ -94,10 +100,13 @@ describe("cleanupUserMembershipsUseCase", () => {
     seedMembership(memberships, ORG_2, USER_ID)
     seedMembership(memberships, ORG_2, OTHER_USER_ID)
 
-    await Effect.runPromise(cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)))
+    const deleted = await Effect.runPromise(
+      cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)),
+    )
 
     expect(organizations.has(ORG_1)).toBe(false)
     expect(organizations.has(ORG_2)).toBe(true)
+    expect(deleted).toEqual([ORG_1])
 
     const org2Members = [...memberships.values()].filter((m) => m.organizationId === ORG_2)
     expect(org2Members).toHaveLength(1)
@@ -107,9 +116,12 @@ describe("cleanupUserMembershipsUseCase", () => {
   it("is a no-op when user has no memberships", async () => {
     const { organizations, memberships, testLayers } = createTestLayers()
 
-    await Effect.runPromise(cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)))
+    const deleted = await Effect.runPromise(
+      cleanupUserMembershipsUseCase({ userId: USER_ID }).pipe(Effect.provide(testLayers)),
+    )
 
     expect(organizations.size).toBe(0)
     expect(memberships.size).toBe(0)
+    expect(deleted).toEqual([])
   })
 })

--- a/packages/domain/organizations/src/use-cases/cleanup-user-memberships.ts
+++ b/packages/domain/organizations/src/use-cases/cleanup-user-memberships.ts
@@ -1,4 +1,4 @@
-import type { RepositoryError, SqlClient } from "@domain/shared"
+import type { OrganizationId, RepositoryError, SqlClient } from "@domain/shared"
 import type { Effect } from "effect"
 import { Effect as E } from "effect"
 import { MembershipRepository } from "../ports/membership-repository.ts"
@@ -8,9 +8,19 @@ export interface CleanupUserMembershipsInput {
   readonly userId: string
 }
 
+/**
+ * Removes a user's org memberships ahead of account deletion. Organizations the
+ * user was the sole member of are deleted outright; their ids are returned so
+ * the caller can tear down org-scoped data (e.g. projects) that has no FK to
+ * the org and would otherwise be orphaned.
+ */
 export const cleanupUserMembershipsUseCase = (
   input: CleanupUserMembershipsInput,
-): Effect.Effect<void, RepositoryError, MembershipRepository | OrganizationRepository | SqlClient> =>
+): Effect.Effect<
+  readonly OrganizationId[],
+  RepositoryError,
+  MembershipRepository | OrganizationRepository | SqlClient
+> =>
   E.gen(function* () {
     yield* E.annotateCurrentSpan("userId", input.userId)
 
@@ -18,6 +28,7 @@ export const cleanupUserMembershipsUseCase = (
     const orgRepo = yield* OrganizationRepository
 
     const memberships = yield* membershipRepo.listByUserId(input.userId)
+    const deletedOrganizationIds: OrganizationId[] = []
 
     for (const membership of memberships) {
       const orgMembers = yield* membershipRepo.listByOrganizationId(membership.organizationId)
@@ -25,8 +36,11 @@ export const cleanupUserMembershipsUseCase = (
       if (orgMembers.length === 1) {
         // User is the sole member — delete the organization (cascades to membership)
         yield* orgRepo.delete(membership.organizationId)
+        deletedOrganizationIds.push(membership.organizationId)
       } else {
         yield* membershipRepo.delete(membership.id)
       }
     }
+
+    return deletedOrganizationIds
   }).pipe(E.withSpan("organizations.cleanupUserMemberships"))

--- a/packages/domain/projects/src/index.ts
+++ b/packages/domain/projects/src/index.ts
@@ -23,6 +23,10 @@ export {
   listAllProjectsUseCase,
 } from "./use-cases/list-projects.ts"
 export {
+  type PurgeOrganizationProjectsInput,
+  purgeOrganizationProjectsUseCase,
+} from "./use-cases/purge-organization-projects.ts"
+export {
   type UpdateProjectError,
   type UpdateProjectInput,
   updateProjectUseCase,

--- a/packages/domain/projects/src/use-cases/purge-organization-projects.ts
+++ b/packages/domain/projects/src/use-cases/purge-organization-projects.ts
@@ -1,0 +1,50 @@
+import { OutboxEventWriter } from "@domain/events"
+import { SqlClient, toRepositoryError } from "@domain/shared"
+import { Effect } from "effect"
+import { ProjectRepository } from "../ports/project-repository.ts"
+
+export interface PurgeOrganizationProjectsInput {
+  /** Attributed as the actor on each emitted `ProjectDeleted` event. */
+  readonly actorUserId?: string
+}
+
+/**
+ * Soft-delete every project of the current organization and emit a
+ * `ProjectDeleted` event for each, so the per-project cleanup cascade (e.g.
+ * notifications) runs — exactly as if each project had been deleted by hand.
+ *
+ * Scoped to the organization bound on the `SqlClient`: provide a client for the
+ * org being torn down. Used when an organization is deleted, both directly
+ * (org settings danger zone) and as part of account deletion.
+ */
+export const purgeOrganizationProjectsUseCase = Effect.fn("projects.purgeOrganizationProjects")(function* (
+  input: PurgeOrganizationProjectsInput,
+) {
+  const sqlClient = yield* SqlClient
+  const { organizationId } = sqlClient
+
+  yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* ProjectRepository
+      const outboxEventWriter = yield* OutboxEventWriter
+
+      const projects = yield* repo.list()
+      for (const project of projects) {
+        yield* repo.softDelete(project.id)
+        yield* outboxEventWriter
+          .write({
+            eventName: "ProjectDeleted",
+            aggregateType: "project",
+            aggregateId: project.id,
+            organizationId,
+            payload: {
+              organizationId,
+              actorUserId: input.actorUserId ?? "",
+              projectId: project.id,
+            },
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
+      }
+    }),
+  )
+})

--- a/packages/domain/scores/src/entities/score.ts
+++ b/packages/domain/scores/src/entities/score.ts
@@ -90,6 +90,7 @@ export type EvaluationScoreMetadata = z.infer<typeof evaluationScoreMetadataSche
 export const annotationScoreMetadataSchema = baseScoreMetadataSchema
   .extend({
     rawFeedback: z.string(), // original feedback text before enrichment; human-authored for human drafts/published annotations, model-authored for system-created drafts
+    flaggerSlug: z.string().optional(), // slug of the automatic flagger that authored this annotation (only set for flagger-created `sourceId: "SYSTEM"` rows); lets the UI name the flagger and link to its project settings
     ...annotationAnchorFields,
   })
   .superRefine(validateAnnotationAnchor)

--- a/packages/domain/users/src/use-cases/delete-user.ts
+++ b/packages/domain/users/src/use-cases/delete-user.ts
@@ -9,10 +9,14 @@ export interface DeleteUserInput {
 export const deleteUserUseCase = Effect.fn("users.deleteUser")(function* (input: DeleteUserInput) {
   yield* Effect.annotateCurrentSpan("userId", input.userId)
 
-  // Clean up memberships and sole-member organizations
-  yield* cleanupUserMembershipsUseCase({ userId: input.userId })
+  // Clean up memberships and sole-member organizations. The returned org ids
+  // were deleted outright; their org-scoped data (projects) is torn down by the
+  // caller, which can re-scope the SqlClient per organization.
+  const deletedOrganizationIds = yield* cleanupUserMembershipsUseCase({ userId: input.userId })
 
   // Delete the user record (cascades to sessions, accounts)
   const userRepo = yield* UserRepository
   yield* userRepo.delete(input.userId)
+
+  return { deletedOrganizationIds }
 })

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -43,6 +43,8 @@ type ItemOption = {
   iconProps?: IconProps
   /** Custom element rendered before the label, replacing `iconProps` (used for emojis / avatars). */
   leading?: ReactNode
+  /** Marks the item as the currently active selection (highlighted with the primary color). */
+  selected?: boolean
   disabled?: boolean
   hidden?: boolean
 }
@@ -57,6 +59,7 @@ function DropdownItem({
   onElementClick,
   type = "normal",
   label,
+  selected,
   disabled,
 }: ItemOption) {
   const onSelect = useCallback(() => {
@@ -72,11 +75,12 @@ function DropdownItem({
       {...(disabled !== undefined ? { disabled } : {})}
       className={cn("gap-2 items-center cursor-pointer", {
         "cursor-auto pointer-events-none": !onClick,
+        "bg-primary-muted focus:bg-primary-muted-hover": selected,
       })}
     >
       {leading ?? (iconProps ? <Icon {...iconProps} /> : null)}
       <div className="w-full">
-        <Text.H5 color={type === "destructive" ? "destructive" : "foreground"}>{label}</Text.H5>
+        <Text.H5 color={type === "destructive" ? "destructive" : selected ? "primary" : "foreground"}>{label}</Text.H5>
       </div>
     </DropdownMenuItem>
   )


### PR DESCRIPTION
Bundles several small, independent web/UX fixes and improvements that accumulated on this branch.

## Fixes

- **Trace overlay stuck selection** (`fix(issues)`): the issue-detail trace overlay tore itself down only from a CSS `transitionend` listener. When that event never fired (reduced motion, interrupted transition, backgrounded tab), `traceOverlayTraceId` stayed set, the row stayed active, and re-clicking the same trace was a no-op — with a single trace this fully blocked reopening. Replaced with a timer that fires after the slide-out, cleared on (re)open and unmount; also removes a latent risk where a child's bubbling transform transition could close the overlay early.
- **Settings form submit button loading state** (`fix(web)`): the submit button read `form.state.isSubmitting` non-reactively, so it never re-rendered when the flag flipped back to false after a save — it only cleared on the next toast-driven re-render. Wrapped the button in `form.Subscribe` across the organization, project, and account name forms. A follow-up commit restores this on the org name button after a later change reintroduced the non-reactive read.
- **Errored span name color** (`fix(web)`): in the trace detail drawer's span tree, the span name kept its default color when the span errored, unlike the icon, waterfall bar, and duration. Now colored destructive when `statusCode` is `"error"`.

## Improvements

- **Highlight active org/project in navbar dropdowns** (`feat(web)`): added a `selected` option to the shared `DropdownMenu` item (primary-muted background, primary label) and wired it into the organization and project switchers. Clicking the already-selected project no longer triggers a redundant redirect.
- **Identify the flagger behind automatic annotations** (`feat(annotations)`): flagger-created annotations were written as `sourceId: "SYSTEM"` and rendered with a generic "Latitude / Agent" badge, indistinguishable from each other. Now the originating flagger slug is persisted on the annotation score metadata (`annotationScoreMetadataSchema.flaggerSlug`) and threaded through the single `upsertFlaggerAnnotationScore` choke point used by both the deterministic (`process-flaggers`) and LLM (`save-flagger-annotation`) write paths. In the UI, such annotations show the flagger's name as a clickable badge deep-linking to its row in project settings (`settings/flaggers?flagger=<slug>`), where the target is scrolled into view and highlighted. Older rows without a slug keep the "Agent" badge.
- **Allow owners to delete empty organizations** (`feat(organizations)`): added a danger zone to organization settings letting an owner permanently delete an org, gated server-side on the caller being the owner and sole member (active org only). Deleting tears down its projects (soft-delete + `ProjectDeleted` cascade) before removing the org row, whose FK cascade drops members, invitations, and OAuth apps; the client then bounces to `/welcome`. Project teardown is extracted into a shared `purgeOrganizationProjectsUseCase` and also wired into account deletion, so `cleanupUserMembershipsUseCase` returns deleted sole-member org ids for the user-deletion worker to purge with a per-org-scoped `SqlClient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
