### PR TITLE
fix(clickhouse): drop LIGHTWEIGHT from 00016 SYNC REPLICA

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -16,18 +16,22 @@
 -- pending bumps from prior failed attempts, so this file is
 -- safe to re-run after a partial application.
 --
--- LIGHTWEIGHT skips waiting on pending merges — only metadata
--- and part-movement entries — so this stays fast even when
--- the table is large and busy. SYNC does not block readers
--- or writers; it only stalls this migration connection.
+-- The mode matters: plain SYSTEM SYNC REPLICA waits for every
+-- fetched log entry — including ALTER_METADATA — to finish
+-- executing on the local replica. LIGHTWEIGHT mode waits only
+-- for part-movement entries (GET_PART, ATTACH_PART, DROP_RANGE,
+-- REPLACE_RANGE, DROP_PART) and explicitly skips ALTER_METADATA,
+-- so it does NOT close the 517 race. We use the default mode
+-- here and accept the wait on pending merges; SYNC does not
+-- block readers or writers, only this migration connection.
 -- ═══════════════════════════════════════════════════════════
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     DROP COLUMN IF EXISTS duration_ns;
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     ADD COLUMN IF NOT EXISTS max_start_time
@@ -56,12 +60,12 @@ ALTER TABLE sessions ON CLUSTER default
     ADD COLUMN IF NOT EXISTS retention_days
         SimpleAggregateFunction(max, UInt16) DEFAULT 90 CODEC(T64, ZSTD(1));
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     MODIFY TTL toDateTime(min_start_time) + toIntervalDay(retention_days + 30) DELETE;
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
 
@@ -138,16 +142,16 @@ GROUP BY
 
 -- SYSTEM SYNC REPLICA between dependent ALTERs — see header.
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 DROP VIEW IF EXISTS sessions_mv ON CLUSTER default;
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     REMOVE TTL;
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     DROP COLUMN IF EXISTS retention_days,
@@ -162,7 +166,7 @@ ALTER TABLE sessions ON CLUSTER default
     DROP COLUMN IF EXISTS duration_ns,
     DROP COLUMN IF EXISTS max_start_time;
 
-SYSTEM SYNC REPLICA sessions ON CLUSTER default LIGHTWEIGHT;
+SYSTEM SYNC REPLICA sessions ON CLUSTER default;
 
 ALTER TABLE sessions ON CLUSTER default
     ADD COLUMN IF NOT EXISTS duration_ns Int64 ALIAS

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -24,6 +24,13 @@
 -- so it does NOT close the 517 race. We use the default mode
 -- here and accept the wait on pending merges; SYNC does not
 -- block readers or writers, only this migration connection.
+--
+-- Docs: https://clickhouse.com/docs/en/sql-reference/statements/system#sync-replica
+--
+-- Scope reminder: SYSTEM SYNC REPLICA is a per-connection wait,
+-- not a cluster configuration change. ON CLUSTER default just
+-- dispatches the wait to every node so each one drains its own
+-- queue locally. Nothing persists after the SYNC returns.
 -- ═══════════════════════════════════════════════════════════
 
 SYSTEM SYNC REPLICA sessions ON CLUSTER default;


### PR DESCRIPTION
## Summary

- Remove `LIGHTWEIGHT` from every `SYSTEM SYNC REPLICA sessions ON CLUSTER default` in `clustered/00016_session_parity.sql` (Up + Down).
- Rewrite the header comment that explained the SYNC choice — the prior version was the inverse of how `LIGHTWEIGHT` actually behaves.
- Link the ClickHouse SYNC REPLICA docs inline so the choice can be re-verified, and note the SYNC's scope explicitly.

## What was happening

#3229 was meant to break the 517 metadata race between the dependent `ALTER TABLE sessions ON CLUSTER default` statements by inserting `SYSTEM SYNC REPLICA … LIGHTWEIGHT` between them. Staging deploy looped on the same error anyway:

```
code: 517, message: Looks like this replica doesn't catchup with latest
ALTER query updates: metadata version on replica is N, while common
metadata is N+1. Please retry this query
```

#3229 picked the wrong `SYSTEM SYNC REPLICA` mode. Per the [ClickHouse docs](https://clickhouse.com/docs/en/sql-reference/statements/system#sync-replica):

- **`LIGHTWEIGHT`** waits only for `GET_PART, ATTACH_PART, DROP_RANGE, REPLACE_RANGE, DROP_PART` queue entries. It **explicitly skips `ALTER_METADATA`**.
- **Default mode** (no modifier) fetches log entries into the local queue and waits until the replica fully processes them — including `ALTER_METADATA`.

`ALTER_METADATA` is the queue-entry type whose lag is exactly what triggers code 517. So #3229's SYNCs were no-ops for the case they were meant to fix, and the cluster kept hitting the same race on every retry.

## Fix

Use plain `SYSTEM SYNC REPLICA sessions ON CLUSTER default;` between every dependent ALTER. This blocks the migration connection until every replica has applied all pending `ALTER_METADATA` entries — which is what closes the 517 window. We pay a wait on pending merges in exchange; `SYNC` still does not block readers or writers on the table, only this migration's connection.

The unclustered variant is unchanged — it has no replication and no SYNCs.

## Scope of the change

`SYSTEM SYNC REPLICA` is a **per-connection wait**, not a cluster configuration change. `ON CLUSTER default` just dispatches that wait to every node so each one drains its own queue locally. Nothing is written to Keeper, no setting is changed, and no table state is altered. Once the SYNC returns, the cluster behaves exactly as before — the only cost is that the migration connection blocks for as long as the queue takes to drain on each replica.

## Staging recovery

The opening `SYSTEM SYNC REPLICA sessions ON CLUSTER default;` at the top of the file now actually drains the accumulated `ALTER_METADATA` entries from the prior failed attempts. Re-running the file from staging's partial state should converge: the SYNC waits out the backlog, then the `DROP COLUMN IF EXISTS` and `ADD COLUMN IF NOT EXISTS` statements no-op cleanly on columns that already exist.

## References

- [`SYSTEM SYNC REPLICA` — ClickHouse docs](https://clickhouse.com/docs/en/sql-reference/statements/system#sync-replica)
- [PR #3229 — original (incorrect) `LIGHTWEIGHT` fix this supersedes](https://github.com/latitude-dev/latitude-llm/pull/3229)

## Test plan

- [ ] Re-trigger the staging migration task — `00016_session_parity.sql` completes without code 517.
- [ ] Confirm production migration (first attempt against clean state) applies cleanly.
- [ ] Local dev (unclustered, file unchanged): no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)