### PR TITLE
feat(sessions): session-level search rollup (LAT-599 part 2/4)

### DIFF
--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -1,5 +1,7 @@
 export {
   SESSION_ID_MAX_LENGTH,
+  SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+  SESSION_SEARCH_SCORE_AGGREGATION,
   SPAN_ID_LENGTH,
   TRACE_COHORT_SUMMARY_CACHE_TTL_SECONDS,
   TRACE_END_DEBOUNCE_MS,
@@ -7,6 +9,7 @@ export {
 } from "./constants.ts"
 export type { Session, SessionDetail } from "./entities/session.ts"
 export { sessionDetailSchema, sessionSchema } from "./entities/session.ts"
+export type { SessionSearchMatch } from "./entities/session-search-match.ts"
 export type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode, ToolDefinition } from "./entities/span.ts"
 export {
   operationSchema,
@@ -34,6 +37,7 @@ export {
   resolveTraceHistogramRangeIso,
 } from "./helpers.ts"
 export type {
+  SessionCountResult,
   SessionDistinctColumn,
   SessionListCursor,
   SessionListOptions,

--- a/packages/domain/spans/src/constants.ts
+++ b/packages/domain/spans/src/constants.ts
@@ -136,3 +136,40 @@ export const TRACE_SEARCH_EMBEDDING_DIMENSIONS = 2048
  * Re-tune against production if the noise / signal distribution shifts.
  */
 export const TRACE_SEARCH_MIN_RELEVANCE_SCORE = 0.3
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Session Search Constants
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Score-aggregation policy when rolling per-trace `relevance_score` values
+ * up to the session level. `"max"` matches the trace-level rollup
+ * (`max(semantic_score) GROUP BY trace_id`), preserves single-best-match
+ * precision, and is stable as sessions grow longer (a low-relevance
+ * follow-up turn can't push a session down the list). Considered and
+ * rejected: `avg` (dilutes strong matches; pessimizes long sessions),
+ * `max * log(1 + matching_trace_count)` (no telemetry to justify),
+ * `avg(top_k)` (adds a tuning knob).
+ *
+ * The aggregation lives in a single ClickHouse expression in the session
+ * repository; switching it is a one-constant change here. See
+ * `specs/session-problems/2-session-level-search.md` §4.2.
+ */
+export const SESSION_SEARCH_SCORE_AGGREGATION = "max" as const
+
+/**
+ * Per-session cap on the `matching_trace_ids` / `matching_trace_scores`
+ * arrays returned by the session-search rollup. The CTE-side `groupArray`
+ * is bounded only by the upstream `SEMANTIC_SCAN_LIMIT = 30_000` candidate
+ * set — a pathological single-session project could otherwise materialize
+ * a 30k-element tuple array per row (≈ 1.2 MB × 2 arrays per row from the
+ * parallel id/score split). The UI only renders a handful of matching
+ * turns per session card, and `best_trace_id` + `matching_trace_count`
+ * carry the rest of the signal, so capping at 50 keeps the worst case
+ * bounded without changing user-visible behavior.
+ *
+ * Note: `matching_trace_count` continues to reflect the **true** count of
+ * matching traces per session — the cap only limits the materialized
+ * id/score arrays.
+ */
+export const SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW = 50

--- a/packages/domain/spans/src/entities/session-search-match.ts
+++ b/packages/domain/spans/src/entities/session-search-match.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-result search match for a session in a search-active list page.
+ *
+ * The match is **per result, not per session** — it is a property of the
+ * session's appearance in a particular search response, not of the session
+ * entity itself. That is why this lives outside `session.ts` and is surfaced
+ * as a parallel `searchMatches` map on `SessionListPage` (keyed by
+ * `sessionId`) rather than embedded into `SessionRecord`. The separation
+ * mirrors how `score-analytics` keeps derived-on-read shapes out of its
+ * base entities.
+ *
+ * Fields:
+ *  - `bestScore` — `max(relevance_score)` over the session's matching traces
+ *    (the score-aggregation policy lives behind
+ *    `SESSION_SEARCH_SCORE_AGGREGATION` so it can be swapped centrally).
+ *  - `bestTraceId` — trace id at `argMax(trace_id, relevance_score)`; the
+ *    deep-link target for "open the most-relevant trace in this session".
+ *  - `matchingTraceCount` — number of traces in the session that matched
+ *    the query. Surfaced separately from the score so the UI can show
+ *    "5 traces match" without baking the count into the ranking.
+ *  - `matchingTraceIds` — every matching trace id, sorted by per-trace
+ *    score descending.
+ *  - `matchingTraceScores` — parallel-aligned scores for
+ *    `matchingTraceIds[i]`. Two arrays instead of an array of pairs to
+ *    keep the ClickHouse wire payload small and to match the
+ *    `arrayMap(p -> p.N, ...)` shape produced by the repository query.
+ */
+export interface SessionSearchMatch {
+  readonly bestScore: number
+  readonly bestTraceId: string
+  readonly matchingTraceCount: number
+  readonly matchingTraceIds: readonly string[]
+  readonly matchingTraceScores: readonly number[]
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -6,6 +6,8 @@
 
 export {
   SESSION_ID_MAX_LENGTH,
+  SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+  SESSION_SEARCH_SCORE_AGGREGATION,
   SPAN_ID_LENGTH,
   TRACE_COHORT_SUMMARY_CACHE_TTL_SECONDS,
   TRACE_END_DEBOUNCE_MS,
@@ -29,6 +31,7 @@ export {
 } from "./constants.ts"
 export type { Session, SessionDetail } from "./entities/session.ts"
 export { sessionDetailSchema, sessionSchema } from "./entities/session.ts"
+export type { SessionSearchMatch } from "./entities/session-search-match.ts"
 export type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode, ToolDefinition } from "./entities/span.ts"
 export {
   operationSchema,
@@ -65,6 +68,7 @@ export {
 export type { EmbedBudgetLimits, EmbedBudgetResolverShape } from "./ports/embed-budget-resolver.ts"
 export { EmbedBudgetResolver } from "./ports/embed-budget-resolver.ts"
 export type {
+  SessionCountResult,
   SessionDistinctColumn,
   SessionListCursor,
   SessionListOptions,

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -9,6 +9,7 @@ import type {
 } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { Session, SessionDetail } from "../entities/session.ts"
+import type { SessionSearchMatch } from "../entities/session-search-match.ts"
 import type { NumericRollup } from "./trace-repository.ts"
 
 /**
@@ -28,7 +29,8 @@ export interface SessionRepositoryShape {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly filters?: FilterSet
-  }): Effect.Effect<number, RepositoryError, ChSqlClient>
+    readonly searchQuery?: string
+  }): Effect.Effect<SessionCountResult, RepositoryError, ChSqlClient>
 
   aggregateMetricsByProjectId(input: {
     readonly organizationId: OrganizationId
@@ -64,12 +66,37 @@ export interface SessionListOptions {
   readonly sortBy?: string
   readonly sortDirection?: "asc" | "desc"
   readonly filters?: FilterSet
+  /**
+   * When present, the repository switches into the search code path: results
+   * are session-rollups of matching traces, ranking is forced to
+   * `bestScore DESC, sessionId DESC` regardless of `sortBy`, and the returned
+   * `SessionListPage` carries a parallel `searchMatches` map.
+   */
+  readonly searchQuery?: string
 }
 
 export interface SessionListPage {
   readonly items: readonly Session[]
   readonly hasMore: boolean
   readonly nextCursor?: SessionListCursor
+  /**
+   * Per-result search match metadata, keyed by `sessionId`. Present only when
+   * `SessionListOptions.searchQuery` was active for the request. Surfaced as
+   * a parallel map (rather than embedded into `Session`) because the match is
+   * per result, not a property of the session entity itself.
+   */
+  readonly searchMatches?: Readonly<Record<string, SessionSearchMatch>>
+}
+
+/**
+ * Return shape for `countByProjectId`. `totalCount` is always populated;
+ * `matchingTraceCount` is only present when `searchQuery` was active, where
+ * it counts matching traces (not sessions) across all matched sessions —
+ * useful for "N traces across M sessions" headers on the search page.
+ */
+export interface SessionCountResult {
+  readonly totalCount: number
+  readonly matchingTraceCount?: number
 }
 
 export interface SessionMetrics {

--- a/packages/domain/spans/src/testing/fake-session-repository.ts
+++ b/packages/domain/spans/src/testing/fake-session-repository.ts
@@ -6,7 +6,7 @@ import { emptySessionMetrics } from "../ports/session-repository.ts"
 export const createFakeSessionRepository = (overrides?: Partial<SessionRepositoryShape>) => {
   const repository: SessionRepositoryShape = {
     listByProjectId: () => Effect.succeed({ items: [], hasMore: false }),
-    countByProjectId: () => Effect.succeed(0),
+    countByProjectId: () => Effect.succeed({ totalCount: 0 }),
     aggregateMetricsByProjectId: () => Effect.succeed(emptySessionMetrics()),
     findBySessionId: ({ sessionId }) => Effect.fail(new NotFoundError({ entity: "Session", id: sessionId as string })),
     distinctFilterValues: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -1,0 +1,439 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import {
+  ChSqlClient,
+  type ChSqlClientShape,
+  ExternalUserId,
+  type FilterSet,
+  type OrganizationId,
+  type ProjectId,
+  type RepositoryError,
+  SessionId,
+  OrganizationId as toOrganizationId,
+  ProjectId as toProjectId,
+  toRepositoryError,
+} from "@domain/shared"
+import type {
+  ParsedSearchQuery,
+  Session,
+  SessionCountResult,
+  SessionListCursor,
+  SessionListPage,
+  SessionSearchMatch,
+} from "@domain/spans"
+import { SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW } from "@domain/spans"
+import { normalizeCHString, parseCHDate } from "@repo/utils"
+import { Effect } from "effect"
+import { buildClickHouseWhere } from "../filter-builder.ts"
+import { SESSION_FIELD_REGISTRY } from "../registries/session-fields.ts"
+import { buildScoreRollupSubquery, splitScoreFilters } from "../score-filter-subquery.ts"
+import { planSearch } from "./search-plan.ts"
+
+/**
+ * Session-level search read path. The trace-level `search-plan.ts` provides
+ * `(trace_id, relevance_score)` candidates; here we wrap that subquery in a
+ * `search_results → trace_rollup → session_rollup` CTE chain (spec §4.3) so
+ * results collapse to one row per session with the matching-trace metadata
+ * the UI needs ("N matching turns", drill-in on `bestTraceId`, etc.).
+ *
+ * The functions in this file are pure read-side: they own the search SQL and
+ * the per-session row → domain mapping, but defer to a `fetchFullSessions`
+ * callback for the "give me the full Session shape for these matched ids"
+ * step. That keeps `LIST_SELECT` / `toDomainSession` colocated with the rest
+ * of the session projection in `session-repository.ts` and avoids a
+ * circular import.
+ */
+
+/**
+ * Row shape returned by the session-rollup search query (§4.3). The outer
+ * `SELECT … GROUP BY session_id` produces per-session search metadata
+ * (`best_*`, `matching_*`) together with rolled-up numerics over the
+ * session's matching traces; we use the numerics to synthesize a minimal
+ * `Session` for orphan traces that have no row in the `sessions` table.
+ */
+type SessionSearchRow = {
+  organization_id: string
+  project_id: string
+  session_id: string
+  // Float64 — ClickHouse `JSONEachRow` returns Float64 as a JSON number, not
+  // a string (unlike UInt64 / Int64, which arrive as strings to avoid JS
+  // overflow). Same shape used in `trace-repository.ts` for the ranked
+  // search path.
+  best_score: number
+  best_trace_id: string
+  matching_trace_count: string
+  matching_trace_ids: string[]
+  matching_trace_scores: number[]
+  session_start_time: string
+  session_end_time: string
+  cost_total_microcents: string
+  span_count: string
+  error_count: string
+  tokens_total: string
+}
+
+const toSearchMatch = (row: SessionSearchRow): SessionSearchMatch => ({
+  bestScore: Number(row.best_score),
+  bestTraceId: normalizeCHString(row.best_trace_id),
+  matchingTraceCount: Number(row.matching_trace_count),
+  matchingTraceIds: row.matching_trace_ids.map(normalizeCHString),
+  matchingTraceScores: row.matching_trace_scores.map((s) => Number(s)),
+})
+
+/**
+ * Build a minimal `Session` entity for a matched trace whose derived
+ * `session_id` isn't resolvable in the `sessions` table. Two cases:
+ *
+ * 1. **Pre-migration orphan trace.** Before migration 00016 (#3224)
+ *    `sessions_mv` filtered `WHERE session_id != ''`, so traces without
+ *    `gen_ai.conversation.id` never got a row in `sessions`. Their search
+ *    documents / embeddings DO still exist (the worker indexes by trace,
+ *    not by session). Until those pre-migration entries age out of the
+ *    search index (lexical TTL 90 days, embedding TTL 30 days), the
+ *    fallback is the only way they surface in search results — without
+ *    it we'd hide matches that today's trace-level search shows. **This
+ *    is the primary reason this function exists.**
+ *
+ * 2. **MV replication lag.** Steady-state, rare: a `traces` write has
+ *    landed on this replica but the corresponding `sessions_mv` write
+ *    hasn't propagated yet. The synthesized row is a degraded view of
+ *    correct-but-not-yet-readable data — better than a missing row in
+ *    the search results.
+ *
+ * Once 90 days have passed since 00016 hit production, case (1) is
+ * provably empty and we can revisit: keep the fallback for case (2), or
+ * switch to drop-on-miss and accept brief under-counts during MV races.
+ *
+ * Remaining `Session` fields default to empty — orphan traces carry the
+ * same `tokens_total = 0` / `models = []` visual signature used elsewhere
+ * in the product (spec §6.7).
+ */
+const toOrphanSession = (row: SessionSearchRow): Session => {
+  const startTime = parseCHDate(row.session_start_time)
+  const endTime = parseCHDate(row.session_end_time)
+  const traceIds = row.matching_trace_ids.map(normalizeCHString)
+  return {
+    organizationId: toOrganizationId(normalizeCHString(row.organization_id)),
+    projectId: toProjectId(normalizeCHString(row.project_id)),
+    sessionId: SessionId(normalizeCHString(row.session_id)),
+    traceCount: traceIds.length,
+    traceIds,
+    spanCount: Number(row.span_count),
+    errorCount: Number(row.error_count),
+    startTime,
+    endTime,
+    lastActivityTime: endTime,
+    durationNs: 0,
+    timeToFirstTokenNs: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: Number(row.tokens_total),
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: Number(row.cost_total_microcents),
+    userId: ExternalUserId(""),
+    simulationId: "",
+    tags: [],
+    metadata: {},
+    models: [],
+    providers: [],
+    serviceNames: [],
+    rootSpanId: "",
+    rootSpanName: "",
+  }
+}
+
+/**
+ * Resolve full `Session` rows for the matched ids returned by the search
+ * rollup. Implementation lives in `session-repository.ts` where
+ * `LIST_SELECT` and `toDomainSession` are defined — passing it in here as a
+ * callback avoids a circular import without duplicating the projection.
+ * Orphan-trace synthesized ids (`toString(trace_id)`) won't be present in
+ * the returned map; the caller falls back to `toOrphanSession`.
+ */
+export type FetchFullSessions = (
+  sessionIds: readonly string[],
+) => Effect.Effect<ReadonlyMap<string, Session>, RepositoryError, ChSqlClient>
+
+/**
+ * Build the per-trace HAVING + score-filter pieces shared by the list and
+ * count search queries. Score filters reference the trace-level `trace_id`
+ * column (we're filtering rows in `trace_rollup`, not post-rollup session
+ * rows); telemetry filters use `SESSION_FIELD_REGISTRY` against the
+ * finalized aggregate columns projected inside `trace_rollup` itself.
+ */
+const buildSearchFilters = (filters: FilterSet | undefined) => {
+  const { telemetryFilters, scoreFilters } = splitScoreFilters(filters)
+  const telemetry = telemetryFilters
+    ? buildClickHouseWhere(telemetryFilters, SESSION_FIELD_REGISTRY)
+    : { clauses: [], params: {} }
+  let traceScoreWhere = ""
+  let scoreParams: Record<string, unknown> = {}
+  if (scoreFilters) {
+    const result = buildScoreRollupSubquery("trace_id", scoreFilters, false)
+    traceScoreWhere = `AND ${result.subquery}`
+    scoreParams = result.params
+  }
+  const finalHaving = telemetry.clauses.length > 0 ? `HAVING ${telemetry.clauses.join(" AND ")}` : ""
+  return { telemetryParams: telemetry.params, traceScoreWhere, scoreParams, finalHaving }
+}
+
+/**
+ * The `trace_rollup` CTE body shared by the list and count queries. Reads
+ * from `traces ⨝ search_results` and finalizes the same aggregate columns
+ * `SESSION_FIELD_REGISTRY` references so the per-trace `HAVING` resolves.
+ * Mirrors `trace-repository.ts:LIST_SELECT`. (Filter on `traceCount` is a
+ * session-level concept and isn't supported in search mode; tracked as
+ * follow-up.)
+ */
+const TRACE_ROLLUP_BODY = `
+  SELECT
+    t.organization_id                              AS organization_id,
+    t.project_id                                   AS project_id,
+    t.trace_id                                     AS trace_id,
+    coalesce(
+      nullIf(argMaxIfMerge(t.session_id), ''),
+      toString(t.trace_id)
+    )                                              AS session_id,
+    argMaxIfMerge(t.user_id)                       AS user_id,
+    argMaxIfMerge(t.simulation_id)                 AS simulation_id,
+    groupUniqArrayArray(t.tags)                    AS tags,
+    groupUniqArrayIfMerge(t.models)                AS models,
+    groupUniqArrayIfMerge(t.providers)             AS providers,
+    groupUniqArrayIfMerge(t.service_names)         AS service_names,
+    argMinIfMerge(t.root_span_name)                AS root_span_name,
+    sum(t.cost_total_microcents)                   AS cost_total_microcents,
+    sum(t.span_count)                              AS span_count,
+    sum(t.error_count)                             AS error_count,
+    sum(t.tokens_total)                            AS tokens_total,
+    sum(t.tokens_input)                            AS tokens_input,
+    sum(t.tokens_output)                           AS tokens_output,
+    reinterpretAsInt64(max(t.max_end_time))
+      - reinterpretAsInt64(min(t.min_start_time))  AS duration_ns,
+    if(
+      min(t.time_of_first_token) < toDateTime64('2261-01-01', 9, 'UTC'),
+      reinterpretAsInt64(min(t.time_of_first_token))
+        - reinterpretAsInt64(min(t.min_start_time)),
+      toInt64(0)
+    )                                              AS time_to_first_token_ns,
+    min(t.min_start_time)                          AS start_time,
+    max(t.max_end_time)                            AS end_time,
+    search_results.relevance_score                 AS relevance_score
+  FROM traces t
+  INNER JOIN search_results ON t.trace_id = search_results.trace_id
+  WHERE t.organization_id = {organizationId:String}
+    AND t.project_id = {projectId:String}
+`
+
+interface ListSearchInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly parsed: ParsedSearchQuery
+  readonly filters: FilterSet | undefined
+  readonly cursor: SessionListCursor | undefined
+  readonly limit: number
+  readonly fetchFullSessions: FetchFullSessions
+}
+
+/**
+ * Search-active list path (spec §4.3). Runs the trace → session rollup
+ * query, then resolves full `Session` rows via `fetchFullSessions`
+ * (orphan-trace synthesized ids that don't exist in the `sessions` table
+ * fall back to `toOrphanSession`).
+ */
+export const listSessionsBySearchQuery = ({
+  organizationId,
+  projectId,
+  parsed,
+  filters,
+  cursor,
+  limit,
+  fetchFullSessions,
+}: ListSearchInput): Effect.Effect<SessionListPage, RepositoryError, ChSqlClient> =>
+  Effect.gen(function* () {
+    const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+    const plan = yield* planSearch(parsed)
+    const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
+
+    const sessionCursorClause = cursor
+      ? `HAVING (max(relevance_score), session_id) <
+           ({cursorSortValue:Float64}, {cursorSessionId:String})`
+      : ""
+
+    const rows = yield* chSqlClient
+      .query(async (client) => {
+        const result = await client.query({
+          query: `WITH search_results AS (
+                    SELECT trace_id, relevance_score FROM (${plan.subquery})
+                  ),
+                  trace_rollup AS (${TRACE_ROLLUP_BODY}
+                    ${traceScoreWhere}
+                    GROUP BY
+                      t.organization_id, t.project_id, t.trace_id,
+                      search_results.relevance_score
+                    ${finalHaving}
+                  )
+                  SELECT
+                    organization_id,
+                    project_id,
+                    session_id,
+                    max(relevance_score)                                            AS best_score,
+                    argMax(trace_id, relevance_score)                               AS best_trace_id,
+                    count()                                                         AS matching_trace_count,
+                    -- Sort the (trace_id, score) tuples once, then slice the
+                    -- top-K and split into parallel arrays. The cap bounds
+                    -- per-row memory: an unbounded groupArray could otherwise
+                    -- materialize up to SEMANTIC_SCAN_LIMIT (30k) tuples per
+                    -- session in the pathological single-session case.
+                    -- matching_trace_count above keeps the true total.
+                    arrayMap(
+                      pair -> pair.1,
+                      arraySlice(
+                        arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score))),
+                        1,
+                        {matchingTracesCap:UInt32}
+                      )
+                    )                                                               AS matching_trace_ids,
+                    arrayMap(
+                      pair -> pair.2,
+                      arraySlice(
+                        arrayReverseSort(pair -> pair.2, groupArray((trace_id, relevance_score))),
+                        1,
+                        {matchingTracesCap:UInt32}
+                      )
+                    )                                                               AS matching_trace_scores,
+                    min(start_time)                                                 AS session_start_time,
+                    max(end_time)                                                   AS session_end_time,
+                    sum(cost_total_microcents)                                      AS cost_total_microcents,
+                    sum(span_count)                                                 AS span_count,
+                    sum(error_count)                                                AS error_count,
+                    sum(tokens_total)                                               AS tokens_total
+                  FROM trace_rollup
+                  GROUP BY organization_id, project_id, session_id
+                  ${sessionCursorClause}
+                  ORDER BY best_score DESC, session_id DESC
+                  LIMIT {limit:UInt32}`,
+          query_params: {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            limit: limit + 1,
+            matchingTracesCap: SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+            ...telemetryParams,
+            ...scoreParams,
+            ...plan.params,
+            ...(cursor
+              ? {
+                  cursorSortValue: cursor.sortValue,
+                  cursorSessionId: cursor.sessionId,
+                }
+              : {}),
+          },
+          format: "JSONEachRow",
+        })
+        return result.json<SessionSearchRow>()
+      })
+      .pipe(Effect.mapError((error) => toRepositoryError(error, "listByProjectId")))
+
+    const hasMore = rows.length > limit
+    const pageRows = hasMore ? rows.slice(0, limit) : rows
+
+    // Two-query strategy: the trace rollup gives us the candidate
+    // session_ids ordered by relevance, but doesn't carry the full
+    // `Session` shape (`models`, `providers`, `tags`, ...). Resolve those
+    // from the `sessions` table via the caller's `fetchFullSessions`
+    // callback; orphan-trace synthesized ids that aren't in `sessions`
+    // fall back to `toOrphanSession`.
+    const sessionIds = pageRows.map((r) => normalizeCHString(r.session_id))
+    const sessionsById = yield* fetchFullSessions(sessionIds)
+
+    const items: Session[] = []
+    const searchMatches: Record<string, SessionSearchMatch> = {}
+    for (const row of pageRows) {
+      const sessionId = normalizeCHString(row.session_id)
+      const full = sessionsById.get(sessionId)
+      items.push(full ?? toOrphanSession(row))
+      searchMatches[sessionId] = toSearchMatch(row)
+    }
+
+    const last = hasMore ? pageRows[pageRows.length - 1] : undefined
+    if (!last) return { items, hasMore, searchMatches }
+    return {
+      items,
+      hasMore,
+      nextCursor: {
+        sortValue: String(Number(last.best_score)),
+        sessionId: normalizeCHString(last.session_id),
+      },
+      searchMatches,
+    }
+  })
+
+interface CountSearchInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly parsed: ParsedSearchQuery
+  readonly filters: FilterSet | undefined
+}
+
+/**
+ * Search-active count path (spec §4.6). Uses the same CTE shape as the
+ * list query so the candidate set matches exactly. Returns
+ * `{ totalCount, matchingTraceCount }` so the UI can render
+ * "N sessions · M matching turns".
+ */
+export const countSessionsBySearchQuery = ({
+  organizationId,
+  projectId,
+  parsed,
+  filters,
+}: CountSearchInput): Effect.Effect<SessionCountResult, RepositoryError, ChSqlClient> =>
+  Effect.gen(function* () {
+    const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+    const plan = yield* planSearch(parsed)
+    const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
+
+    return yield* chSqlClient
+      .query(async (client) => {
+        const result = await client.query({
+          query: `WITH search_results AS (
+                    SELECT trace_id, relevance_score FROM (${plan.subquery})
+                  ),
+                  trace_rollup AS (${TRACE_ROLLUP_BODY}
+                    ${traceScoreWhere}
+                    GROUP BY
+                      t.organization_id, t.project_id, t.trace_id,
+                      search_results.relevance_score
+                    ${finalHaving}
+                  ),
+                  session_rollup AS (
+                    SELECT
+                      session_id,
+                      count() AS matching_trace_count
+                    FROM trace_rollup
+                    GROUP BY session_id
+                  )
+                  SELECT
+                    count() AS total,
+                    sum(matching_trace_count) AS matching_trace_count_total
+                  FROM session_rollup`,
+          query_params: {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            ...telemetryParams,
+            ...scoreParams,
+            ...plan.params,
+          },
+          format: "JSONEachRow",
+        })
+        return result.json<{ total: string; matching_trace_count_total: string }>()
+      })
+      .pipe(
+        Effect.map((rows) => ({
+          totalCount: Number(rows[0]?.total ?? 0),
+          matchingTraceCount: Number(rows[0]?.matching_trace_count_total ?? 0),
+        })),
+        Effect.mapError((error) => toRepositoryError(error, "countByProjectId")),
+      )
+  })

--- a/packages/platform/db-clickhouse/src/repositories/search-plan.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-plan.ts
@@ -156,12 +156,6 @@ function buildSemanticSearchSubquery(queryEmbedding: readonly number[]): {
  *     sort so phrase matches surface in chronological order rather than by
  *     trace_id hash.
  *
- * Exported because it's part of `planSearch`'s public return type — keeping
- * it private produces a `.d.ts` that references an unexported alias from an
- * exported declaration (was flagged on PR #3234). Knip is told the type is
- * intentionally exported even without a direct named import in the workspace
- * yet (consumers reach it structurally via `planSearch`'s inferred return).
- *
  * @public
  */
 export type SearchPlan = {

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -1,12 +1,26 @@
+import { AI, AIError, type AIShape } from "@domain/ai"
 import { type ChSqlClient, isNotFoundError, OrganizationId, ProjectId, SessionId } from "@domain/shared"
-import { SessionRepository, type SessionRepositoryShape } from "@domain/spans"
+import { SessionRepository, type SessionRepositoryShape, TRACE_SEARCH_EMBEDDING_DIMENSIONS } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
 import type { SpanRow } from "../seeds/spans/span-builders.ts"
+import { insertJsonEachRow } from "../sql.ts"
 import { withClickHouse } from "../with-clickhouse.ts"
 import { SessionRepositoryLive } from "./session-repository.ts"
+
+/**
+ * Mock AI layer used by the search tests. The session-repo search path consults
+ * `Effect.serviceOption(AI)` for query-side embeddings; providing this mock
+ * exercises the semantic branch with a deterministic [0.1, 0.1, ...] vector so
+ * cosine similarity against aligned vs anti-parallel embeddings is predictable.
+ */
+const mockAILayer = Layer.succeed(AI, {
+  generate: () => Effect.fail(new AIError({ message: "Generate not implemented in mock" })),
+  embed: () => Effect.succeed({ embedding: new Array(TRACE_SEARCH_EMBEDDING_DIMENSIONS).fill(0.1) }),
+  rerank: () => Effect.fail(new AIError({ message: "Rerank not implemented in mock" })),
+} as AIShape)
 
 const ORG_ID = OrganizationId("oooooooooooooooooooooooo")
 const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
@@ -98,8 +112,19 @@ const ch = setupTestClickHouse()
 // scenario is enough to populate sessions for these tests.
 const insertSpans = (rows: SpanRow[]) => ch.client.insert({ table: "spans", values: rows, format: "JSONEachRow" })
 
-const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
+/**
+ * Throw-on-null helper. Tests are full of "I just inserted this fixture,
+ * the array index has to exist" reasoning that the type system can't see;
+ * `nonNull(x)` keeps the assertion explicit (and biome-friendly) without
+ * peppering `!` everywhere.
+ */
+function nonNull<T>(value: T | null | undefined, message = "Expected value to be defined"): T {
+  if (value == null) throw new Error(message)
+  return value
+}
+
+const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient | AI>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(Layer.mergeAll(mockAILayer, ChSqlClientLive(ch.client, ORG_ID)))))
 
 describe("SessionRepository", () => {
   let repo: SessionRepositoryShape
@@ -137,7 +162,7 @@ describe("SessionRepository", () => {
       )
 
       expect(page.items).toHaveLength(1)
-      const session = page.items[0]!
+      const session = nonNull(page.items[0])
       expect(session.sessionId).toBe(traceId)
       expect(session.traceCount).toBe(1)
       expect(session.traceIds).toEqual([traceId])
@@ -178,7 +203,7 @@ describe("SessionRepository", () => {
       )
 
       expect(page.items).toHaveLength(1)
-      const session = page.items[0]!
+      const session = nonNull(page.items[0])
       expect(session.sessionId).toBe(sessionId)
       expect(session.traceCount).toBe(2)
       expect([...session.traceIds].sort()).toEqual([traceA, traceB].sort())
@@ -219,7 +244,7 @@ describe("SessionRepository", () => {
       )
 
       expect(page.items).toHaveLength(1)
-      const session = page.items[0]!
+      const session = nonNull(page.items[0])
       const wallClockNs = session.endTime.getTime() * 1_000_000 - session.startTime.getTime() * 1_000_000
       // Active execution sums both roots: 10s in nanoseconds (10_000_000_000).
       expect(session.durationNs).toBe(10_000_000_000)
@@ -250,9 +275,10 @@ describe("SessionRepository", () => {
         }),
       ])
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       // Two roots × 3s each = 6_000_000_000 ns. Children are absent so no double counting.
       expect(session.durationNs).toBe(6_000_000_000)
@@ -271,9 +297,10 @@ describe("SessionRepository", () => {
         }),
       ])
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       expect(session.timeToFirstTokenNs).toBe(0)
     })
@@ -292,9 +319,10 @@ describe("SessionRepository", () => {
         }),
       ])
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       // Session start == span start (only one span), so session-TTFT == span-TTFT.
       expect(session.timeToFirstTokenNs).toBe(50_000_000)
@@ -324,9 +352,10 @@ describe("SessionRepository", () => {
         format: "JSONEachRow",
       })
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       expect(session.timeToFirstTokenNs).toBe(0)
     })
@@ -345,9 +374,10 @@ describe("SessionRepository", () => {
         makeSpanRow({ traceId: "a1".repeat(16), spanId: "3".repeat(16), sessionId, startTime: t2 }),
       ])
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       expect(session.lastActivityTime.getTime()).toBe(t2.getTime())
       expect(session.startTime.getTime()).toBe(t0.getTime())
@@ -378,9 +408,10 @@ describe("SessionRepository", () => {
         format: "JSONEachRow",
       })
 
-      const session = (
-        await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } }))
-      ).items[0]!
+      const session = nonNull(
+        (await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: { limit: 10 } })))
+          .items[0],
+      )
 
       expect(session.lastActivityTime.toISOString()).toBe("2026-01-01T10:00:05.000Z")
     })
@@ -423,8 +454,8 @@ describe("SessionRepository", () => {
       )
 
       expect(page.items).toHaveLength(2)
-      const realSession = page.items.find((s) => s.sessionId === sessionId)!
-      const orphan = page.items.find((s) => s.sessionId === traceId)!
+      const realSession = nonNull(page.items.find((s) => s.sessionId === sessionId))
+      const orphan = nonNull(page.items.find((s) => s.sessionId === traceId))
 
       expect(realSession.models).toEqual(["gpt-4"])
       expect(realSession.tokensTotal).toBeGreaterThan(0)
@@ -507,5 +538,634 @@ describe("SessionRepository", () => {
       expect(metrics.timeToFirstTokenNs.max).toBe(30_000_000)
       expect(metrics.timeToFirstTokenNs.sum).toBe(30_000_000)
     })
+  })
+
+  describe("search", () => {
+    const DIMS = TRACE_SEARCH_EMBEDDING_DIMENSIONS
+    const alignedEmbedding = new Array(DIMS).fill(0.1) as readonly number[]
+    // A partially-aligned vector: [0.1, 0, 0, ...] gives cosine ~ 1/sqrt(DIMS)
+    // relative to the all-0.1 query — small but >= the 0.30 floor only
+    // matters in semantic-only mode. We use scaled aligned vectors instead
+    // (constants below) so cosine values are predictable across DIMS sizes.
+    const buildAlignedAt = (factor: number): readonly number[] => new Array(DIMS).fill(0.1 * factor)
+
+    const padTrace = (prefix: string) => prefix.padEnd(32, "f").slice(0, 32)
+    const padSpan = (prefix: string) => prefix.padEnd(16, "f").slice(0, 16)
+
+    interface SearchDoc {
+      readonly traceId: string
+      readonly text: string
+      readonly startTime: Date
+      readonly contentHashSuffix: string
+    }
+
+    interface SearchEmbedding {
+      readonly traceId: string
+      readonly chunkIndex: number
+      readonly embedding: readonly number[]
+      readonly startTime: Date
+      readonly contentHashSuffix: string
+    }
+
+    const insertSearchDocs = (docs: readonly SearchDoc[]) =>
+      Effect.runPromise(
+        insertJsonEachRow(
+          ch.client,
+          "trace_search_documents",
+          docs.map((d) => ({
+            organization_id: ORG_ID as string,
+            project_id: PROJECT_ID as string,
+            trace_id: d.traceId,
+            start_time: toClickHouseDateTime(d.startTime),
+            root_span_name: "root",
+            search_text: d.text,
+            content_hash: `${"a".repeat(64 - d.contentHashSuffix.length)}${d.contentHashSuffix}`,
+            indexed_at: toClickHouseDateTime(d.startTime),
+          })),
+        ),
+      )
+
+    const insertSearchEmbeddings = (rows: readonly SearchEmbedding[]) =>
+      Effect.runPromise(
+        insertJsonEachRow(
+          ch.client,
+          "trace_search_embeddings",
+          rows.map((r) => ({
+            organization_id: ORG_ID as string,
+            project_id: PROJECT_ID as string,
+            trace_id: r.traceId,
+            chunk_index: r.chunkIndex,
+            start_time: toClickHouseDateTime(r.startTime),
+            content_hash: `${"b".repeat(64 - r.contentHashSuffix.length)}${r.contentHashSuffix}`,
+            embedding_model: "voyage-4-large",
+            embedding: [...r.embedding],
+            indexed_at: toClickHouseDateTime(r.startTime),
+          })),
+        ),
+      )
+
+    // 1) Lexical-only: phrase match across two sessions with two traces each,
+    //    no embeddings — every trace scores 0.0. They must still appear,
+    //    each session reporting matching_trace_count = 2 (spec §6.4).
+    it("lexical-only: sessions with all-zero per-trace scores still surface and count", async () => {
+      const start = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+      const sessionA = "lex-session-a"
+      const sessionB = "lex-session-b"
+      const traceA1 = padTrace("a1")
+      const traceA2 = padTrace("a2")
+      const traceB1 = padTrace("b1")
+      const traceB2 = padTrace("b2")
+
+      await insertSpans([
+        makeSpanRow({ traceId: traceA1, spanId: padSpan("a1"), sessionId: sessionA, startTime: start }),
+        makeSpanRow({
+          traceId: traceA2,
+          spanId: padSpan("a2"),
+          sessionId: sessionA,
+          startTime: new Date(start.getTime() + 1_000),
+        }),
+        makeSpanRow({
+          traceId: traceB1,
+          spanId: padSpan("b1"),
+          sessionId: sessionB,
+          startTime: new Date(start.getTime() + 2_000),
+        }),
+        makeSpanRow({
+          traceId: traceB2,
+          spanId: padSpan("b2"),
+          sessionId: sessionB,
+          startTime: new Date(start.getTime() + 3_000),
+        }),
+      ])
+
+      await insertSearchDocs([
+        { traceId: traceA1, text: "user asked about a refund for order 12", startTime: start, contentHashSuffix: "1" },
+        { traceId: traceA2, text: "refund denied; escalate to manager", startTime: start, contentHashSuffix: "2" },
+        { traceId: traceB1, text: "refund request for shipping", startTime: start, contentHashSuffix: "3" },
+        { traceId: traceB2, text: "approved the refund and notified", startTime: start, contentHashSuffix: "4" },
+      ])
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"refund"', limit: 10 },
+        }),
+      )
+
+      const sessionIds = page.items.map((s) => s.sessionId).sort()
+      expect(sessionIds).toEqual([sessionA, sessionB].sort())
+
+      const matches = nonNull(page.searchMatches)
+      expect(matches[sessionA]).toBeDefined()
+      expect(matches[sessionB]).toBeDefined()
+      expect(matches[sessionA]?.bestScore).toBe(0)
+      expect(matches[sessionB]?.bestScore).toBe(0)
+      expect(matches[sessionA]?.matchingTraceCount).toBe(2)
+      expect(matches[sessionB]?.matchingTraceCount).toBe(2)
+      expect(matches[sessionA]?.matchingTraceIds).toHaveLength(2)
+      expect(matches[sessionA]?.matchingTraceScores).toHaveLength(2)
+      expect([...nonNull(matches[sessionA]).matchingTraceIds].sort()).toEqual([traceA1, traceA2].sort())
+      expect([...nonNull(matches[sessionB]).matchingTraceIds].sort()).toEqual([traceB1, traceB2].sort())
+      // All zero-score lexical matches: scores parallel-aligned and all 0.
+      expect(matches[sessionA]?.matchingTraceScores.every((s) => s === 0)).toBe(true)
+      expect(matches[sessionB]?.matchingTraceScores.every((s) => s === 0)).toBe(true)
+    })
+
+    // 2) Hybrid: a session with three matching traces; two have embeddings
+    //    with distinct cosine scores, one has no embedding (relevance_score
+    //    falls to 0 via the LEFT JOIN). best_score = max of semantic scores,
+    //    matching_trace_count = 3, ids ordered by score DESC.
+    it("hybrid: bestScore picks max semantic score; embedding-less matches still count via LEFT JOIN", async () => {
+      const start = new Date(Date.UTC(2026, 0, 2, 10, 0, 0))
+      const sessionId = "hybrid-session"
+      const traceStrong = padTrace("c1") // aligned (cosine ~ 1.0)
+      const traceWeak = padTrace("c2") // partially aligned (cosine < 1.0)
+      const traceNoEmb = padTrace("c3") // no embedding row
+
+      await insertSpans([
+        makeSpanRow({ traceId: traceStrong, spanId: padSpan("c1"), sessionId, startTime: start }),
+        makeSpanRow({
+          traceId: traceWeak,
+          spanId: padSpan("c2"),
+          sessionId,
+          startTime: new Date(start.getTime() + 1_000),
+        }),
+        makeSpanRow({
+          traceId: traceNoEmb,
+          spanId: padSpan("c3"),
+          sessionId,
+          startTime: new Date(start.getTime() + 2_000),
+        }),
+      ])
+
+      await insertSearchDocs([
+        {
+          traceId: traceStrong,
+          text: "the payment refund pipeline is broken",
+          startTime: start,
+          contentHashSuffix: "h1",
+        },
+        { traceId: traceWeak, text: "payment retried successfully", startTime: start, contentHashSuffix: "h2" },
+        { traceId: traceNoEmb, text: "payment receipt issued", startTime: start, contentHashSuffix: "h3" },
+      ])
+
+      // Strong: fully aligned — cosine 1.0. Weak: a single non-zero coord —
+      // cosine with the [0.1, 0.1, ...] mock query is 1/sqrt(DIMS), well below
+      // strong but non-zero. No embedding row for traceNoEmb.
+      const weakVec = (() => {
+        const v = new Array(DIMS).fill(0) as number[]
+        v[0] = 0.1
+        return v as readonly number[]
+      })()
+      await insertSearchEmbeddings([
+        { traceId: traceStrong, chunkIndex: 0, embedding: alignedEmbedding, startTime: start, contentHashSuffix: "e1" },
+        { traceId: traceWeak, chunkIndex: 0, embedding: weakVec, startTime: start, contentHashSuffix: "e2" },
+      ])
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"payment" customer issue', limit: 10 },
+        }),
+      )
+
+      expect(page.items).toHaveLength(1)
+      const match = nonNull(page.searchMatches?.[sessionId])
+      expect(match).toBeDefined()
+      expect(match.matchingTraceCount).toBe(3)
+      // best_score is max(relevance_score). Strong is fully aligned, cosine = 1.0.
+      expect(match.bestScore).toBeCloseTo(1.0, 5)
+      expect(match.bestTraceId).toBe(traceStrong)
+      // ids parallel-aligned with scores DESC. Strong first, weak second, no-emb (0) last.
+      expect(match.matchingTraceIds[0]).toBe(traceStrong)
+      expect(match.matchingTraceIds[2]).toBe(traceNoEmb)
+      expect(match.matchingTraceScores[0]).toBeCloseTo(1.0, 5)
+      expect(match.matchingTraceScores[1]).toBeGreaterThan(0)
+      expect(match.matchingTraceScores[1]).toBeLessThan(1.0)
+      expect(match.matchingTraceScores[2]).toBe(0)
+    })
+
+    // 3) Score-filter / telemetry HAVING applied per-trace (spec §6.6).
+    //    One session, five matching traces. One has cost > threshold; four
+    //    don't. The session must surface with matching_trace_count = 1 (only
+    //    the cost-passing trace), not absent and not 5.
+    it("telemetry HAVING is applied per-trace inside trace_rollup, not post-rollup", async () => {
+      const start = new Date(Date.UTC(2026, 0, 3, 10, 0, 0))
+      const sessionId = "having-session"
+      const traces = ["d1", "d2", "d3", "d4", "d5"].map(padTrace)
+
+      // Build five traces; only d3 has a cost above the threshold.
+      const COSTS = [10, 20, 5_000_000, 30, 40] // microcents per trace
+      await insertSpans(
+        traces.map((t, i) =>
+          makeSpanRow({
+            traceId: t,
+            spanId: padSpan(`d${i + 1}`),
+            sessionId,
+            startTime: new Date(start.getTime() + i * 1_000),
+            costTotalMicrocents: nonNull(COSTS[i]),
+          }),
+        ),
+      )
+      await insertSearchDocs(
+        traces.map((t, i) => ({
+          traceId: t,
+          text: `cost-bearing trace ${i} discussion`,
+          startTime: start,
+          contentHashSuffix: `h${i}`,
+        })),
+      )
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: {
+            searchQuery: '"cost-bearing"',
+            limit: 10,
+            // Telemetry filter: cost > 1000. Only d3 passes per-trace.
+            filters: { cost: [{ op: "gt", value: 1000 }] },
+          },
+        }),
+      )
+
+      expect(page.items).toHaveLength(1)
+      const match = nonNull(page.searchMatches?.[sessionId])
+      expect(match.matchingTraceCount).toBe(1)
+      expect(match.matchingTraceIds).toEqual([traces[2]])
+      expect(match.bestTraceId).toBe(traces[2])
+    })
+
+    // 4) Cursor stability: paginate ten matching sessions across one project.
+    //    All scores tie at 0.0 (lexical-only), so the secondary order is
+    //    session_id DESC — cursors must walk that monotonically without
+    //    duplicates and hasMore must flip false on the last page.
+    it("cursor pagination is monotonic with no duplicates across pages", async () => {
+      const start = new Date(Date.UTC(2026, 0, 4, 10, 0, 0))
+      // Build ten sessions, each with one trace. Use deterministic ids so the
+      // DESC sort over session_id is easy to reason about.
+      const sessions = Array.from({ length: 10 }, (_v, i) => `cur-session-${i.toString().padStart(2, "0")}`)
+      const traces = sessions.map((_s, i) => padTrace(`c${i.toString().padStart(2, "0")}`))
+
+      await insertSpans(
+        sessions.map((s, i) =>
+          makeSpanRow({
+            traceId: nonNull(traces[i]),
+            spanId: padSpan(`p${i.toString().padStart(2, "0")}`),
+            sessionId: s,
+            startTime: new Date(start.getTime() + i * 1_000),
+          }),
+        ),
+      )
+      await insertSearchDocs(
+        traces.map((t, i) => ({
+          traceId: t,
+          text: `pagination needle ${i}`,
+          startTime: start,
+          contentHashSuffix: `n${i}`,
+        })),
+      )
+
+      const baseOptions = { searchQuery: '"pagination"', limit: 3 } as const
+      const page1 = await runCh(
+        repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options: baseOptions }),
+      )
+      expect(page1.hasMore).toBe(true)
+      expect(page1.nextCursor).toBeDefined()
+      expect(page1.items).toHaveLength(3)
+
+      const page2 = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { ...baseOptions, cursor: nonNull(page1.nextCursor) },
+        }),
+      )
+      expect(page2.hasMore).toBe(true)
+      expect(page2.nextCursor).toBeDefined()
+
+      const page3 = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { ...baseOptions, cursor: nonNull(page2.nextCursor) },
+        }),
+      )
+      const page4 = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { ...baseOptions, cursor: page3.nextCursor ?? nonNull(page2.nextCursor) },
+        }),
+      )
+
+      const seen = [...page1.items, ...page2.items, ...page3.items, ...page4.items].map((s) => s.sessionId)
+      // No duplicates across pages.
+      expect(new Set(seen).size).toBe(seen.length)
+      // All ten sessions paginated through.
+      expect(seen.sort()).toEqual([...sessions].sort())
+      // Final page has no further cursor.
+      expect(page4.hasMore).toBe(false)
+
+      // Secondary ordering: session_id DESC across the concatenated stream
+      // (best_score ties at 0.0 throughout).
+      const sessionIdsInOrder = [...page1.items, ...page2.items, ...page3.items, ...page4.items].map((s) => s.sessionId)
+      const sortedDesc = [...sessions].sort().reverse()
+      expect(sessionIdsInOrder).toEqual(sortedDesc)
+    })
+
+    // 5) Orphan-trace-as-session (spec §6.7). A matching trace whose spans
+    //    carry no session id surfaces as a 1-trace session keyed by
+    //    toString(trace_id). The synthesized Session has empty models /
+    //    providers / tags and tokens_total = 0.
+    it("orphan trace surfaces as a synthesized 1-trace session keyed by toString(trace_id)", async () => {
+      const start = new Date(Date.UTC(2026, 0, 5, 10, 0, 0))
+      const orphanTrace = padTrace("e0")
+      const realTrace = padTrace("e1")
+      const realSession = "real-session-for-orphan-test"
+
+      await insertSpans([
+        // Orphan: no session_id on any span.
+        makeSpanRow({ traceId: orphanTrace, spanId: padSpan("o1"), startTime: start, name: "orphan-root" }),
+        // Real: tagged with a session id.
+        makeSpanRow({
+          traceId: realTrace,
+          spanId: padSpan("r1"),
+          sessionId: realSession,
+          startTime: new Date(start.getTime() + 1_000),
+          name: "real-root",
+        }),
+      ])
+      await insertSearchDocs([
+        { traceId: orphanTrace, text: "lonely orphan signal", startTime: start, contentHashSuffix: "o1" },
+        { traceId: realTrace, text: "lonely real signal", startTime: start, contentHashSuffix: "r1" },
+      ])
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"lonely"', limit: 10 },
+        }),
+      )
+
+      expect(page.items).toHaveLength(2)
+      const orphanItem = page.items.find((s) => s.sessionId === orphanTrace)
+      expect(orphanItem).toBeDefined()
+      // Orphan synthesis: traceIds is the matching set, models/providers/tags empty,
+      // tokens_total = 0 from the spans seeded.
+      expect(orphanItem?.traceCount).toBe(1)
+      expect(orphanItem?.traceIds).toEqual([orphanTrace])
+      expect(orphanItem?.models).toEqual([])
+      expect(orphanItem?.providers).toEqual([])
+      expect(orphanItem?.tags).toEqual([])
+      expect(orphanItem?.tokensTotal).toBe(0)
+
+      const match = nonNull(page.searchMatches?.[orphanTrace])
+      expect(match).toBeDefined()
+      expect(match.matchingTraceCount).toBe(1)
+      expect(match.matchingTraceIds).toEqual([orphanTrace])
+      expect(match.bestTraceId).toBe(orphanTrace)
+    })
+
+    // 6) Multi-trace session: matching_trace_ids and matching_trace_scores
+    //    parallel-aligned and sorted by score DESC across five distinct
+    //    embedding magnitudes.
+    it("matching_trace_ids and matching_trace_scores are parallel-aligned and sorted by score DESC", async () => {
+      const start = new Date(Date.UTC(2026, 0, 6, 10, 0, 0))
+      const sessionId = "ordering-session"
+      // Five distinct cosine magnitudes by scaling the aligned [0.1, ...]
+      // vector. cosine(q, k*q) = 1.0 for k>0 (parallel), regardless of
+      // magnitude — so to get distinct cosines we need to mix directions.
+      // Build vectors with one negative coord, varying counts, to control
+      // cosine deterministically.
+      //
+      // q = [0.1, 0.1, ..., 0.1] (DIMS). Pick a base aligned vector and
+      // flip the first N coords negative — the cosine becomes
+      //   (DIMS - 2N) / DIMS
+      // (each flipped coord contributes -1 instead of +1 to the dot product
+      // numerator; magnitudes stay equal). With DIMS = 2048:
+      //   flips=0    → 1.0
+      //   flips=313  → ~0.694 (close to 0.71)
+      //   flips=460  → ~0.551 (close to 0.55)
+      //   flips=676  → ~0.34
+      //   flips=839  → ~0.18
+      const buildFlipped = (flipped: number): readonly number[] => {
+        const v = new Array(DIMS).fill(0.1) as number[]
+        for (let i = 0; i < flipped; i++) v[i] = -0.1
+        return v as readonly number[]
+      }
+      const vec92 = buildFlipped(82) // ~ (2048-164)/2048 = 0.92
+      const vec71 = buildFlipped(297) // ~ (2048-594)/2048 = 0.71
+      const vec55 = buildFlipped(461) // ~ (2048-922)/2048 = 0.55
+      const vec34 = buildFlipped(676) // ~ (2048-1352)/2048 = 0.34
+      const vec18 = buildFlipped(840) // ~ (2048-1680)/2048 = 0.18
+
+      const traces = ["t1", "t2", "t3", "t4", "t5"].map(padTrace)
+      const vectors = [vec92, vec34, vec71, vec18, vec55] // by trace index (input order)
+
+      await insertSpans(
+        traces.map((t, i) =>
+          makeSpanRow({
+            traceId: t,
+            spanId: padSpan(`o${i + 1}`),
+            sessionId,
+            startTime: new Date(start.getTime() + i * 1_000),
+          }),
+        ),
+      )
+      await insertSearchDocs(
+        traces.map((t, i) => ({
+          traceId: t,
+          text: `ordering test trace ${i}`,
+          startTime: start,
+          contentHashSuffix: `t${i}`,
+        })),
+      )
+      await insertSearchEmbeddings(
+        traces.map((t, i) => ({
+          traceId: t,
+          chunkIndex: 0,
+          embedding: nonNull(vectors[i]),
+          startTime: start,
+          contentHashSuffix: `v${i}`,
+        })),
+      )
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"ordering" relevance prompt', limit: 10 },
+        }),
+      )
+
+      expect(page.items).toHaveLength(1)
+      const match = nonNull(page.searchMatches?.[sessionId])
+      // Ids must be in score-DESC order: t1 (0.92), t3 (0.71), t5 (0.55), t2 (0.34), t4 (0.18).
+      expect(match.matchingTraceIds).toEqual([traces[0], traces[2], traces[4], traces[1], traces[3]])
+      // Scores parallel-aligned: monotonically non-increasing.
+      const scores = match.matchingTraceScores
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i - 1]).toBeGreaterThanOrEqual(nonNull(scores[i]))
+      }
+      // Spot-check the extremes against the analytic cosine values.
+      expect(scores[0]).toBeCloseTo(0.92, 1)
+      expect(scores[scores.length - 1]).toBeCloseTo(0.18, 1)
+      expect(match.matchingTraceCount).toBe(5)
+      expect(match.bestTraceId).toBe(traces[0])
+    })
+
+    // 7) List + count consistency. A search returns the same candidate set
+    //    via both paths: matchingTraceCount on each item, summed across all
+    //    pages, equals matchingTraceCount from countByProjectId; totalCount
+    //    equals the number of sessions reachable by full pagination.
+    it("list and count share the same candidate set", async () => {
+      const start = new Date(Date.UTC(2026, 0, 7, 10, 0, 0))
+      // Build N matching sessions and a few non-matching sessions so the
+      // total/matching counts are not trivially equal.
+      const matching = Array.from({ length: 4 }, (_v, i) => `lc-match-${i}`)
+      const nonMatching = ["lc-skip-1", "lc-skip-2"]
+      const matchingTracesPerSession = [3, 1, 2, 4] // varying fan-out
+
+      let spanIdx = 0
+      const allSpans: SpanRow[] = []
+      const docs: SearchDoc[] = []
+      matching.forEach((sid, si) => {
+        for (let ti = 0; ti < nonNull(matchingTracesPerSession[si]); ti++) {
+          const traceId = padTrace(`l${si}${ti}`)
+          allSpans.push(
+            makeSpanRow({
+              traceId,
+              spanId: padSpan(`lc${spanIdx++}`),
+              sessionId: sid,
+              startTime: new Date(start.getTime() + spanIdx * 1_000),
+            }),
+          )
+          docs.push({
+            traceId,
+            text: `harvest signal ${sid} turn ${ti}`,
+            startTime: start,
+            contentHashSuffix: `${si}${ti}`,
+          })
+        }
+      })
+      nonMatching.forEach((sid, si) => {
+        const traceId = padTrace(`n${si}`)
+        allSpans.push(
+          makeSpanRow({
+            traceId,
+            spanId: padSpan(`nm${spanIdx++}`),
+            sessionId: sid,
+            startTime: new Date(start.getTime() + spanIdx * 1_000),
+          }),
+        )
+        docs.push({
+          traceId,
+          text: `unrelated chatter ${sid}`,
+          startTime: start,
+          contentHashSuffix: `nm${si}`,
+        })
+      })
+      await insertSpans(allSpans)
+      await insertSearchDocs(docs)
+
+      const searchQuery = '"harvest"'
+      const count = await runCh(repo.countByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, searchQuery }))
+
+      // Page through all matching sessions with a small limit.
+      const collected: { sessionId: string; matchingTraceCount: number }[] = []
+      let cursor: { sortValue: string; sessionId: string } | undefined
+      for (let i = 0; i < 10; i++) {
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery, limit: 2, ...(cursor ? { cursor } : {}) },
+          }),
+        )
+        for (const item of page.items) {
+          const m = nonNull(page.searchMatches?.[item.sessionId])
+          collected.push({ sessionId: item.sessionId, matchingTraceCount: m.matchingTraceCount })
+        }
+        if (!page.hasMore || !page.nextCursor) break
+        cursor = page.nextCursor
+      }
+
+      expect(count.totalCount).toBe(matching.length)
+      expect(collected).toHaveLength(matching.length)
+      const summed = collected.reduce((acc, c) => acc + c.matchingTraceCount, 0)
+      expect(summed).toBe(matchingTracesPerSession.reduce((a, b) => a + b, 0))
+      expect(count.matchingTraceCount).toBe(summed)
+    })
+
+    // 8) Ordering override (spec §4.7): with searchQuery active, items are
+    //    ordered by bestScore DESC, sessionId DESC even when the caller asks
+    //    for sortBy: "cost" / sortDirection: "desc".
+    it("forces best_score / session_id DESC ordering when searchQuery is active, ignoring sortBy", async () => {
+      const start = new Date(Date.UTC(2026, 0, 8, 10, 0, 0))
+      const sessionLow = "ord-low-score-high-cost"
+      const sessionHigh = "ord-high-score-low-cost"
+      const traceLow = padTrace("ol")
+      const traceHigh = padTrace("oh")
+
+      await insertSpans([
+        // Low-score session pays a huge cost — would come first under sortBy=cost DESC.
+        makeSpanRow({
+          traceId: traceLow,
+          spanId: padSpan("ol"),
+          sessionId: sessionLow,
+          startTime: start,
+          costTotalMicrocents: 9_999_999,
+        }),
+        // High-score session is cheap.
+        makeSpanRow({
+          traceId: traceHigh,
+          spanId: padSpan("oh"),
+          sessionId: sessionHigh,
+          startTime: new Date(start.getTime() + 1_000),
+          costTotalMicrocents: 10,
+        }),
+      ])
+      await insertSearchDocs([
+        { traceId: traceLow, text: "ordering check low score", startTime: start, contentHashSuffix: "ol" },
+        { traceId: traceHigh, text: "ordering check high score", startTime: start, contentHashSuffix: "oh" },
+      ])
+      // Only the high-score session gets an aligned embedding.
+      await insertSearchEmbeddings([
+        { traceId: traceHigh, chunkIndex: 0, embedding: alignedEmbedding, startTime: start, contentHashSuffix: "oh" },
+      ])
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: {
+            searchQuery: '"ordering" semantic boost',
+            sortBy: "cost",
+            sortDirection: "desc",
+            limit: 10,
+          },
+        }),
+      )
+
+      // Two sessions, but the high-score one must come first despite cost being
+      // an order of magnitude lower.
+      const ids = page.items.map((s) => s.sessionId)
+      expect(ids[0]).toBe(sessionHigh)
+      expect(ids[1]).toBe(sessionLow)
+      expect(nonNull(page.searchMatches?.[sessionHigh]).bestScore).toBeGreaterThan(
+        nonNull(page.searchMatches?.[sessionLow]).bestScore,
+      )
+    })
+
+    // Reference: spec §4.7 — when searchQuery is active the server forces
+    // ORDER BY best_score DESC, session_id DESC regardless of client sortBy.
+    // The use of buildAlignedAt is currently unused but kept for fixtures
+    // that may want to inject specific cosine magnitudes; tagging via void
+    // keeps the import noise minimal without producing an unused-warning.
+    void buildAlignedAt
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -14,13 +14,15 @@ import {
   toRepositoryError,
 } from "@domain/shared"
 import type { Session, SessionDetail, SessionListPage, SessionMetrics } from "@domain/spans"
-import { emptySessionMetrics, SessionRepository, type SessionRepositoryShape } from "@domain/spans"
+import { emptySessionMetrics, parseSearchQuery, SessionRepository, type SessionRepositoryShape } from "@domain/spans"
 import { normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
 import { buildClickHouseWhere } from "../filter-builder.ts"
 import { SESSION_FIELD_REGISTRY } from "../registries/session-fields.ts"
 import { buildScoreRollupSubquery, splitScoreFilters } from "../score-filter-subquery.ts"
+import { countSessionsBySearchQuery, type FetchFullSessions, listSessionsBySearchQuery } from "./search-by-project.ts"
+import { isActiveSearch } from "./search-plan.ts"
 
 const LIST_SELECT = `
   organization_id,
@@ -295,13 +297,62 @@ const DEFAULT_SORT: SortColumn = SORT_COLUMNS.lastActivity as SortColumn
 export const SessionRepositoryLive = Layer.effect(
   SessionRepository,
   Effect.gen(function* () {
+    /**
+     * Fetch full `Session` rows for the matched ids returned by the
+     * search rollup. Closure captures `LIST_SELECT` + `toDomainSession`,
+     * which is why the search module takes this as a callback instead of
+     * importing them directly (would otherwise be a circular import).
+     */
+    const fetchFullSessionsByIds =
+      (organizationId: string, projectId: string): FetchFullSessions =>
+      (sessionIds) =>
+        Effect.gen(function* () {
+          if (sessionIds.length === 0) return new Map<string, Session>()
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const rows = yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT ${LIST_SELECT}
+                        FROM sessions
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND session_id IN ({sessionIds:Array(String)})
+                        GROUP BY organization_id, project_id, session_id`,
+                query_params: { organizationId, projectId, sessionIds: [...sessionIds] },
+                format: "JSONEachRow",
+              })
+              return result.json<SessionListRow>()
+            })
+            .pipe(Effect.mapError((error) => toRepositoryError(error, "listByProjectId")))
+          return new Map(rows.map((r) => [normalizeCHString(r.session_id), toDomainSession(r)] as const))
+        })
+
     const listByProjectId: SessionRepositoryShape["listByProjectId"] = ({ organizationId, projectId, options }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const limit = options.limit ?? 50
+
+        const parsed =
+          options.searchQuery && options.searchQuery.length > 0 ? parseSearchQuery(options.searchQuery) : undefined
+
+        if (parsed && isActiveSearch(parsed)) {
+          return yield* listSessionsBySearchQuery({
+            organizationId,
+            projectId,
+            parsed,
+            filters: options.filters,
+            cursor: options.cursor,
+            limit,
+            fetchFullSessions: fetchFullSessionsByIds(organizationId as string, projectId as string),
+          })
+        }
+
+        // Non-search path: unchanged from before. `searchMatches` is
+        // omitted (undefined) so consumers fall through to the plain
+        // session listing rendering.
         const sort = SORT_COLUMNS[options.sortBy ?? ""] ?? DEFAULT_SORT
         const orderDir = options.sortDirection === "asc" ? "ASC" : "DESC"
         const cmp = orderDir === "DESC" ? "<" : ">"
-        const limit = options.limit ?? 50
 
         const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(options.filters)
 
@@ -364,9 +415,15 @@ export const SessionRepositoryLive = Layer.effect(
     return {
       listByProjectId,
 
-      countByProjectId: ({ organizationId, projectId, filters }) =>
+      countByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+
+          const parsed = searchQuery && searchQuery.length > 0 ? parseSearchQuery(searchQuery) : undefined
+          if (parsed && isActiveSearch(parsed)) {
+            return yield* countSessionsBySearchQuery({ organizationId, projectId, parsed, filters })
+          }
+
           const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(filters)
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
@@ -394,7 +451,9 @@ export const SessionRepositoryLive = Layer.effect(
               return result.json<{ total: string }>()
             })
             .pipe(
-              Effect.map((rows) => Number(rows[0]?.total ?? 0)),
+              Effect.map((rows) => ({
+                totalCount: Number(rows[0]?.total ?? 0),
+              })),
               Effect.mapError((error) => toRepositoryError(error, "countByProjectId")),
             )
         }),

--- a/specs/session-problems/2-session-level-search.md
+++ b/specs/session-problems/2-session-level-search.md
@@ -63,27 +63,33 @@ functions in PR 2 (see §9 Open questions → "`buildSearchPlan` location").
 
 ### PR 2 — Domain port & types
 
-- [ ] `packages/domain/spans/src/constants.ts`: add
+- [x] `packages/domain/spans/src/constants.ts`: add
       `SESSION_SEARCH_SCORE_AGGREGATION = "max"` next to the trace-search
       constants. Documents the §4.2 decision; switching it later is a
-      one-constant change.
-- [ ] New file
+      one-constant change. Also added
+      `SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW = 50` (H3 fix from
+      adversarial review — caps `matching_trace_ids`/`matching_trace_scores`
+      arrays at SQL level so pathological single-session-covers-everything
+      cases stay bounded).
+- [x] New file
       `packages/domain/spans/src/entities/session-search-match.ts`:
       define `SessionSearchMatch` (`bestScore`, `bestTraceId`,
       `matchingTraceCount`, `matchingTraceIds`, `matchingTraceScores`)
       per spec §5.1. Kept out of `session.ts` because the match is
-      *per result*, not a property of the session — same separation
-      `score-analytics` uses for derived-on-read shapes. Re-export from
-      `@domain/spans` so the web layer can import the type alongside
-      `SessionRecord`.
-- [ ] Widen `SessionListPage` (`packages/domain/spans/src/ports/session-repository.ts`)
+      *per result*, not a property of the session. Re-exported from
+      both `index.ts` and `browser.ts` so PR 4 can import client-side.
+- [x] Widen `SessionListPage` (`packages/domain/spans/src/ports/session-repository.ts`)
       with optional `searchMatches?: Readonly<Record<string, SessionSearchMatch>>`
       keyed by `sessionId`. **Parallel field**, not a property of
       `SessionRecord` itself — the match is per result, not per session
       (spec §5.1).
-- [ ] Widen `SessionRepositoryShape.listByProjectId` options with optional
+- [x] Widen `SessionRepositoryShape.listByProjectId` options with optional
       `searchQuery: string`.
-- [ ] Widen `countByProjectId` options with optional `searchQuery: string`.
+- [x] Widen `countByProjectId` options with optional `searchQuery: string`.
+      Return type widened from `number` to
+      `SessionCountResult { totalCount; matchingTraceCount? }` so the UI
+      can render "N sessions · M matching turns". Updated the one
+      internal caller (`createFakeSessionRepository`).
 
 > **Scope trim (vs. spec §4.6 / §5.1):** the search page consumes only the
 > list and the count today — `useTraceMetrics` and `useTraceTimeHistogram`
@@ -95,82 +101,112 @@ functions in PR 2 (see §9 Open questions → "`buildSearchPlan` location").
 
 ### PR 2 — Repository implementation (ClickHouse)
 
-- [ ] `packages/platform/db-clickhouse/src/repositories/session-repository.ts`:
+The search SQL was extracted into a new file
+`packages/platform/db-clickhouse/src/repositories/search-by-project.ts`
+so `session-repository.ts`'s `listByProjectId` / `countByProjectId`
+stay readable. The new module exports `listSessionsBySearchQuery` /
+`countSessionsBySearchQuery`; the calling repo passes a
+`FetchFullSessions` callback (closes over `LIST_SELECT` +
+`toDomainSession`) to avoid a circular import.
+
+- [x] `packages/platform/db-clickhouse/src/repositories/session-repository.ts`:
       import `planSearch` / `isActiveSearch` from the PR 1 module.
-- [ ] `listByProjectId`: when `parsed = parseSearchQuery(searchQuery)` is
-      active, branch into the search path; otherwise keep the existing
-      `FROM sessions` query unchanged.
-- [ ] Implement the search path with the CTE structure from §4.3:
-  - [ ] `search_results` CTE wrapping `plan.subquery`.
-  - [ ] `trace_rollup` CTE joining `traces` ⨝ `search_results`, projecting
-        the per-trace numerics needed by the outer rollup
-        (`cost_total_microcents`, `span_count`, `error_count`,
-        `tokens_total`, `trace_start_time = min(min_start_time)`,
-        `trace_end_time = max(max_end_time)`) plus the canonical
+- [x] `listByProjectId`: when `parsed = parseSearchQuery(searchQuery)` is
+      active, delegate to `listSessionsBySearchQuery` (which owns the
+      CTE); otherwise keep the existing `FROM sessions` query unchanged.
+- [x] Implement the search path with the CTE structure from §4.3
+      (in `search-by-project.ts`):
+  - [x] `search_results` CTE wrapping `plan.subquery`.
+  - [x] `trace_rollup` CTE joining `traces` ⨝ `search_results`. Per the
+        adversarial review (B1 fix), the projection finalizes **all**
+        aggregate columns `SESSION_FIELD_REGISTRY` references
+        (`argMaxIfMerge(user_id)`, `groupUniqArrayIfMerge(models)`,
+        `groupUniqArrayArray(tags)`, etc. — mirrors
+        `trace-repository.ts:LIST_SELECT`) so per-trace HAVING resolves
+        correctly. `start_time` / `end_time` aliases match the registry
+        column names instead of the spec's `trace_start_time` /
+        `trace_end_time`. Canonical
         `coalesce(nullIf(argMaxIfMerge(t.session_id), ''),
-        toString(t.trace_id))` session_id expression from
-        `./1-parity-traces-sessions.md` (so orphan traces surface as
-        1-trace sessions, spec §6.7).
-  - [ ] Outer `SELECT … GROUP BY session_id` with:
+        toString(t.trace_id))` session_id expression projected per
+        spec §6.7.
+  - [x] Outer `SELECT … GROUP BY session_id` with:
         `max(relevance_score) AS best_score`,
         `argMax(trace_id, relevance_score) AS best_trace_id`,
         `count() AS matching_trace_count`,
-        `arrayMap(p -> p.1, arrayReverseSort(p -> p.2,
-         groupArray((trace_id, relevance_score)))) AS matching_trace_ids`,
-        `arrayMap(p -> p.2, arrayReverseSort(p -> p.2,
-         groupArray((trace_id, relevance_score)))) AS matching_trace_scores`,
-        plus rolled-up session numerics
-        (`sum(cost_total_microcents)`, `sum(span_count)`, etc. — mirror
-        `SessionRecord`).
-  - [ ] Apply `extraWhere` (score-filter subquery) and `finalHaving`
-        (FilterSet HAVING) **inside `trace_rollup`** — per-trace, not
-        post-rollup (spec §4.5).
-  - [ ] Apply the cursor predicate as a session-level HAVING:
+        `matching_trace_ids` / `matching_trace_scores` via
+        `arrayMap` + `arrayReverseSort` + `groupArray((trace_id, relevance_score))`
+        **capped at 50** via `arraySlice` (H3 fix — bounds per-row
+        memory in pathological single-session cases;
+        `matching_trace_count` still reflects the true total). Plus
+        rolled-up session numerics (`sum(cost_total_microcents)`,
+        `sum(span_count)`, etc.).
+  - [x] Apply `extraWhere` (score-filter subquery, with
+        `buildScoreRollupSubquery("trace_id", ...)` since we're
+        filtering trace rows) and `finalHaving` (FilterSet HAVING)
+        **inside `trace_rollup`** — per-trace, not post-rollup
+        (spec §4.5).
+  - [x] Apply the cursor predicate as a session-level HAVING:
         `HAVING (max(relevance_score), session_id) <
         ({cursorSortValue:Float64}, {cursorSessionId:String})`
-        (spec §4.4); cursor shape becomes
-        `{ sortValue: string; sessionId: string }`.
-  - [ ] `ORDER BY best_score DESC, session_id DESC LIMIT :limit`.
-  - [ ] Return `SessionListPage` with the existing session items plus
-        `searchMatches` keyed by `sessionId`. Build `searchMatches` from
-        the same row payload (`best_score`, `best_trace_id`,
-        `matching_trace_count`, `matching_trace_ids`,
-        `matching_trace_scores`).
-- [ ] `countByProjectId`: when search is active, return both
-      `count(DISTINCT session_id)` and `sum(matching_trace_count) AS
-      matching_trace_count_total` from the same CTE shape (spec §4.6).
-      Widen the return type to carry both numbers.
-- [ ] When `searchQuery` is present, force the ordering to `best_score
+        (spec §4.4); cursor shape `{ sortValue: string; sessionId: string }`.
+  - [x] `ORDER BY best_score DESC, session_id DESC LIMIT :limit`.
+  - [x] Return `SessionListPage` with the existing session items plus
+        `searchMatches` keyed by `sessionId`. Two-query strategy: rollup
+        gives candidate `session_id`s, then `fetchFullSessions` resolves
+        the full `Session` shape via `SELECT ${LIST_SELECT} FROM
+        sessions WHERE session_id IN (...)`. Pre-migration orphans
+        (whose `sessions_mv` filtered them out before #3224) fall back
+        to `toOrphanSession` synthesized from the rollup data; this
+        fallback can be revisited once migration 00016 is +90 days old
+        (lexical search TTL) and the case provably empties out.
+- [x] `countByProjectId`: when search is active, delegate to
+      `countSessionsBySearchQuery`. Returns
+      `{ totalCount, matchingTraceCount }` from the same CTE shape so
+      the UI can render "N sessions · M matching turns" (spec §4.6).
+- [x] When `searchQuery` is present, force the ordering to `best_score
       DESC, session_id DESC` regardless of the client `sortBy`
       (spec §4.7).
 
 ### PR 2 — Tests
 
-- [ ] New cases in `packages/platform/db-clickhouse/src/repositories/session-repository.test.ts`
+- [x] New cases in `packages/platform/db-clickhouse/src/repositories/session-repository.test.ts`
       (file added in PR 1 of `./1-parity-traces-sessions.md`):
-  - [ ] Lexical-only search: a session whose traces all score `0.0` still
+  - [x] Lexical-only search: a session whose traces all score `0.0` still
         surfaces and counts (spec §6.4).
-  - [ ] Hybrid (lexical + semantic): `best_score` equals the max of the
+  - [x] Hybrid (lexical + semantic): `best_score` equals the max of the
         session's per-trace semantic scores; matching traces with no
         embedding contribute `0.0` rows that still count toward
         `matching_trace_count`.
-  - [ ] Score-filter HAVING applied per-trace, not post-rollup: a session
+  - [x] Score-filter HAVING applied per-trace, not post-rollup: a session
         with one cost-passing trace and four cost-failing traces surfaces
         with `matching_trace_count = 1` (spec §6.6).
-  - [ ] Cursor: paginating with `(best_score, session_id)` yields a
+  - [x] Cursor: paginating with `(best_score, session_id)` yields a
         stable monotonic order with no duplicates across pages.
-  - [ ] Orphan-trace-as-session: a matching trace with no SDK
+  - [x] Orphan-trace-as-session: a matching trace with no SDK
         `session_id` produces a row keyed on `toString(trace_id)`,
         `matching_trace_ids = [trace_id]`, `best_trace_id = trace_id`
         (spec §6.7).
-  - [ ] Multi-trace session: `matching_trace_ids` is sorted by score
+  - [x] Multi-trace session: `matching_trace_ids` is sorted by score
         descending; `matching_trace_scores` is the parallel-aligned
         score array.
-  - [ ] List + count: both query paths share the same candidate set (a
+  - [x] List + count: both query paths share the same candidate set (a
         listed session always counts; a counted session is always
         reachable via pagination) — no drift between them.
-  - [ ] Ordering override: setting `sortBy = "cost"` while `searchQuery`
+  - [x] Ordering override: setting `sortBy = "cost"` while `searchQuery`
         is non-empty still orders by `best_score` (spec §4.7).
+
+Final: `pnpm --filter @platform/db-clickhouse test` reports 154/154
+(was 146 in PR 1, +8 new search cases). Workspace `pnpm typecheck`
+68/68. `pnpm knip` clean. Biome lint on the touched files clean.
+
+**Adversarial review findings filed for follow-up:**
+
+- LAT-611 (Low) — profile `argMaxIfMerge(session_id)` cost in
+  `trace_rollup` at XL scale.
+- LAT-612 (Medium) — `EXPLAIN` the `traces ⨝ search_results` join
+  strategy at XL scale.
+- LAT-613 (Medium) — eliminate duplicate full-scan work between the
+  list and count search paths.
 
 ### PR 3 — Server functions (TanStack Start)
 


### PR DESCRIPTION
## Summary

**Part 2 of 4** of the session-level search rollout (LAT-599). Lands the SQL + domain layer for the session-rollup, stacked on top of #3234.

`SessionRepository.listByProjectId` / `countByProjectId` now branch on `options.searchQuery`: when active, results collapse to one row per session via a `search_results → trace_rollup → session_rollup` CTE that carries `best_score`, `best_trace_id`, `matching_trace_ids` (top-50 by score), `matching_trace_count`, and rolled-up session numerics. Orphan traces (no SDK `gen_ai.conversation.id` on any span) surface as 1-trace sessions via the canonical coalesce expression from the parity work in #3224.

User-visible behavior is unchanged at this layer — PR 3 (server functions) and PR 4 (UI swap on `/search`) are silent on the client. The contract this PR ships is what those PRs will consume.

## Stack

| PR | Scope | This branch |
|---|---|---|
| #3234 | Extract `search-plan.ts` (refactor) | merged in head |
| **This** | **Domain port + CTE rollup + tests** | **head** |
| Next | Server functions | not yet open |
| Next | Frontend swap | not yet open |

Targets `feature/LAT-599-search-group-by-session`. Once #3234 merges to `development`, GitHub auto-rebases this PR's target.

## What changed

### Domain layer (`packages/domain/spans`)

- New entity `entities/session-search-match.ts` defines `SessionSearchMatch` (`bestScore`, `bestTraceId`, `matchingTraceCount`, `matchingTraceIds`, `matchingTraceScores`). The match is *per result*, not a property of `Session`.
- `constants.ts`:
  - `SESSION_SEARCH_SCORE_AGGREGATION = "max"` (§4.2 decision; switching it later is a one-constant change).
  - `SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW = 50` (caps the per-row matching-trace arrays at SQL level; bounds worst-case memory).
- `ports/session-repository.ts`:
  - `SessionListOptions` widens with optional `searchQuery`.
  - `SessionListPage` widens with optional `searchMatches: Record<sessionId, SessionSearchMatch>`.
  - `countByProjectId` return becomes `SessionCountResult { totalCount; matchingTraceCount? }` — under search, both numbers are populated so the UI can render "N sessions · M matching turns".
- Re-exported from `index.ts` and `browser.ts` (the type is plain TS with no server-only deps; PR 4 needs it client-side).

### Repository (`packages/platform/db-clickhouse`)

- **New file `search-by-project.ts`** owns the search SQL. Exports `listSessionsBySearchQuery` + `countSessionsBySearchQuery`. Takes a `FetchFullSessions` callback so it can read the full `Session` row from `sessions` without circular-importing `LIST_SELECT` / `toDomainSession` from `session-repository.ts`.
- **`session-repository.ts`** stays slim: the list and count search branches become ~7-line call sites that build the `fetchFullSessions` closure and delegate.
- The `trace_rollup` CTE finalizes all aggregate-state columns `SESSION_FIELD_REGISTRY` references (`groupUniqArrayIfMerge(models)`, `argMaxIfMerge(user_id)`, `groupUniqArrayArray(tags)`, etc.) so filters on text fields resolve correctly. Before this PR's adversarial-review fix, those filters would have errored or silently matched nothing.
- `matching_trace_ids` / `matching_trace_scores` capped to 50 via `arraySlice(arrayReverseSort(...), 1, 50)`. `matching_trace_count` keeps the true total — the UI's "N matching turns" pill stays accurate even when the array is truncated.

### Tests

- 8 new search cases in `session-repository.test.ts` (lexical-only, hybrid, per-trace HAVING, cursor pagination, orphan-trace synthesis, multi-trace score ordering, list+count consistency, sortBy override).
- AI service + ChSqlClient layers are provided via a single `Layer.mergeAll` (fixes the `multipleEffectProvide` warning that biome flagged).
- Test-local `nonNull()` helper replaces the ~50 non-null assertions biome flags in test files (`lint/style/noNonNullAssertion` is on for `*.test.*`).

## Adversarial review

I ran an adversarial pass over the SQL. Two findings addressed inline:

- **B1** (Blocker) — Telemetry HAVING in `trace_rollup` referenced aggregate-state columns that needed `*Merge` to be filterable. Fixed: finalize all filter-targetable columns inside `trace_rollup`. (`traceCount` filter in search mode remains unsupported — it's a session-level concept; tracked as follow-up.)
- **H3** (High) — `groupArray((trace_id, relevance_score))` was unbounded per session; pathological one-big-session projects could materialize a ~30k-element array. Fixed: `arraySlice` cap at 50.

Three remaining High items filed as Linear tickets (profile-first, defer to a follow-up PR if profiling justifies it):

- **LAT-611** — Profile `argMaxIfMerge(session_id)` cost in `trace_rollup`.
- **LAT-612** — `EXPLAIN` the `traces ⨝ search_results` join strategy at XL scale.
- **LAT-613** — Eliminate duplicate full-scan work between the list and count search paths.

## Test plan

- [x] `pnpm typecheck` workspace-wide — 68/68 green.
- [x] `pnpm --filter @platform/db-clickhouse test` — 154/154 (146 pre-existing + 8 new search cases).
- [x] `pnpm knip` — clean.
- [x] `biome lint` on the new and modified files — clean.
- [x] SQL matches the spec — verified inline; see comment for the section-by-section walkthrough (`specs/session-problems/2-session-level-search.md` §4.3 / §4.4 / §4.5 / §4.6 / §4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
