### PR TITLE
Add pi telemetry extension

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,6 +58,15 @@ jobs:
       ref: ${{ github.sha }}
     secrets: inherit
 
+  publish-pi-telemetry:
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/publish-pi-telemetry.yml
+    with:
+      ref: ${{ github.sha }}
+    secrets: inherit
+
   publish-python-telemetry:
     permissions:
       contents: write

--- a/.github/workflows/publish-pi-telemetry.yml
+++ b/.github/workflows/publish-pi-telemetry.yml
@@ -1,0 +1,37 @@
+name: Publish Pi Telemetry
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to publish from
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to publish from
+        required: false
+        type: string
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Publish
+        uses: ./.github/actions/publish-npm-package
+        with:
+          package_path: packages/telemetry/pi
+          npm_package: "@latitude-data/pi-telemetry"
+          pnpm_filter: "@latitude-data/pi-telemetry"
+          tag_prefix: pi-telemetry
+          release_name: Pi Telemetry
+          target_commitish: ${{ inputs.ref || github.sha }}

--- a/dev-docs/pi-telemetry.md
+++ b/dev-docs/pi-telemetry.md
@@ -1,0 +1,155 @@
+# Pi coding agent telemetry
+
+Latitude provides a first-party pi coding agent telemetry package at `packages/telemetry/pi`, published as `@latitude-data/pi-telemetry`. It is both:
+
+- a pi package whose extension listens to pi runtime events and emits Latitude-compatible OTLP traces; and
+- a one-shot installer CLI (`latitude-pi`) that adds the package to pi settings and stores Latitude configuration.
+
+The package replaces the generic third-party `mprokopov/pi-otel-telemetry` path when full Latitude trace reconstruction is required. It emits `span.type`, current OpenTelemetry GenAI semantic convention attributes, full prompt/assistant messages, and full tool input/output attributes so Latitude resolves pi activity as `prompt`, `chat`, and `execute_tool` operations rather than generic `unspecified` spans.
+
+## User install model
+
+The single-command install path is:
+
+```bash
+npx -y @latitude-data/pi-telemetry install
+```
+
+Non-interactive installs can provide credentials directly:
+
+```bash
+npx -y @latitude-data/pi-telemetry install \
+  --api-key=lat_xxx \
+  --project=your-project-slug \
+  --yes
+```
+
+The installer writes two files under the pi agent config directory (`$PI_CODING_AGENT_DIR` or `~/.pi/agent`):
+
+| File | Purpose |
+| --- | --- |
+| `settings.json` | Adds the pi package source `npm:@latitude-data/pi-telemetry@<version>` to `packages`, replacing older Latitude pi telemetry entries. Pi auto-installs missing packages on startup. |
+| `latitude-telemetry.json` | Stores `apiKey`, `project`, optional `baseUrl`, `enabled`, `allowConversationAccess`, tags, and metadata. The file is written with mode `0600` because it contains the Latitude API key. |
+
+Restart pi after install so it can install and load the package. `/reload` is useful after changing config once the package is already installed, but startup is the reliable path for the first install.
+
+The CLI also supports:
+
+- `--staging` for `https://staging-ingest.latitude.so`
+- `--dev` for local ingest at `http://localhost:3002`
+- `--base-url=<url>` for a custom ingest base URL
+- `--no-content` to keep structure/timing while scrubbing prompts, responses, tool arguments, tool results, system prompts, and full agent message snapshots
+- `--allow-conversation` to force full content capture on
+- `--pi-dir=<path>` to override the pi config directory
+- `--dry-run` to print the proposed settings/config without writing
+- `uninstall` to remove the package entry and config
+
+Runtime environment variables override config-file values:
+
+| Env var | Meaning |
+| --- | --- |
+| `LATITUDE_API_KEY` | API key used for ingest upload |
+| `LATITUDE_PROJECT` / `LATITUDE_PROJECT_SLUG` | Project slug sent as `X-Latitude-Project` |
+| `LATITUDE_BASE_URL` | Ingest base URL, default `https://ingest.latitude.so` |
+| `LATITUDE_PI_TELEMETRY_ENABLED=0` | Disable the extension for a pi process |
+| `LATITUDE_DEBUG=1` | Log upload diagnostics to stderr and show a pi status indicator |
+| `LATITUDE_PI_ALLOW_CONVERSATION_ACCESS` | `1`/`true`/`yes` enables gated content attributes |
+| `LATITUDE_PI_NO_CONTENT` | `1`/`true`/`yes` disables gated content attributes |
+| `LATITUDE_PI_USER_ID` | Overrides the `user.id` span attribute |
+| `LATITUDE_PI_USER_EMAIL` / `PI_OTEL_USER_EMAIL` | Overrides user email resource/span attributes |
+| `LATITUDE_PI_USER_NAME` / `PI_OTEL_USER_NAME` | Overrides user full-name resource/span attributes |
+
+## Extension architecture
+
+The extension is dependency-light and hand-rolls the OTLP JSON payload instead of using the OpenTelemetry JS SDK. This matches the Claude Code and OpenClaw telemetry packages: the payload subset is small, reload-safe, and avoids global provider ownership inside pi's extension runtime.
+
+Runtime flow:
+
+1. `session_start` reloads config and identity, then shows a small Latitude status indicator when enabled.
+2. `before_agent_start` opens an `interaction` root span for the user prompt.
+3. `turn_start` opens an `llm_request` span for the provider call.
+4. `context` records the exact pi messages being sent to the provider as `gen_ai.input.messages`.
+5. `before_provider_request` enriches the open LLM span with model/request parameters and tool definitions when present in the provider payload.
+6. assistant `message_end` closes the `llm_request` span with `gen_ai.output.messages`, provider/model attributes, token usage, finish reason, and error state.
+7. `tool_execution_start` / `tool_execution_end` create `tool_execution` spans as siblings of LLM spans under the interaction. Tool spans carry full `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` values when content capture is enabled.
+8. `agent_end` closes abandoned spans defensively, enriches the interaction with aggregate assistant messages, builds one OTLP export request, and POSTs it to `${baseUrl}/v1/traces` with `Authorization: Bearer <apiKey>` and `X-Latitude-Project: <project>`.
+
+The extension emits one Latitude trace per pi user prompt/agent run. All spans also carry `session.id` and `gen_ai.session.id`, so Latitude can group related traces into a session using pi's session id. This avoids the third-party extension's long-lived root session span that only flushed fully on pi shutdown.
+
+## Trace shape
+
+```text
+interaction                         span.type=interaction → operation prompt
+├── llm_request                     span.type=llm_request + gen_ai.operation.name=chat
+├── tool_call:<toolName>            span.type=tool_execution + gen_ai.operation.name=execute_tool
+├── llm_request                     next model call after tool results
+└── tool_call:<toolName>
+```
+
+Tool spans are siblings of `llm_request` spans because tools run after a model call completes and before the next model call starts. Nesting tools under the model-call span would incorrectly imply the tool executed during the provider request.
+
+## Latitude resolver contract
+
+The package intentionally emits the attributes Latitude's OTLP resolvers already understand:
+
+| Attribute | Purpose |
+| --- | --- |
+| `span.type=interaction` | Resolved to operation `prompt` by `packages/domain/spans/src/otlp/resolvers/operation.ts`. |
+| `span.type=llm_request` | Claude-Code-compatible fallback and human-readable span typing. |
+| `gen_ai.operation.name=chat` | Resolved to operation `chat`. |
+| `gen_ai.operation.name=execute_tool` | Resolved to operation `execute_tool`. |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | Parts-based GenAI message arrays parsed by `parseGenAICurrent`. |
+| `gen_ai.system_instructions` | Parts-based system prompt array. |
+| `gen_ai.tool.definitions` | Tool definitions from provider payload when pi exposes them. |
+| `gen_ai.provider.name` / `gen_ai.system` | Provider resolution. |
+| `gen_ai.request.model` / `gen_ai.response.model` | Model and response-model resolution. |
+| `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, cache-token variants, `gen_ai.usage.total_tokens` | Token accounting. |
+| `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` | Tool detail reconstruction. |
+| `latitude.tags` / `latitude.metadata` | JSON-string attributes parsed by enrichment resolvers. |
+| `latitude.captured.content` | Explicit boolean that shows whether gated content was included. |
+
+Message normalization is implemented in `src/messages.ts`. It handles pi's session message shapes (`user`, `assistant`, `toolResult`, custom/summary messages, and user bash entries), Anthropic-style content blocks, OpenAI-style `tool_calls`, reasoning/thinking blocks, and image blocks. Unknown blocks are JSON-stringified into text parts so content is not silently dropped.
+
+## Content gate and privacy
+
+Full content capture is on by default because the package's purpose is to reconstruct pi sessions in Latitude. Content-bearing attributes are marked internally with a `:gated` suffix until OTLP encoding. `buildOtlpRequest` strips the suffix when `allowConversationAccess=true`; when false, it omits all gated attributes.
+
+Gated attributes include:
+
+- `user_prompt`
+- `gen_ai.input.messages`
+- `gen_ai.output.messages`
+- `gen_ai.system_instructions`
+- `gen_ai.tool.definitions`
+- `gen_ai.tool.call.arguments`
+- `gen_ai.tool.call.result`
+- `error.message` values that may contain tool/model output
+- full normalized `pi.agent.messages`
+
+Structural attributes such as model, provider, token counts, timings, tool names, session id, cwd metadata, and `latitude.captured.content` remain present in `--no-content` mode.
+
+The package still sends sensitive metadata even with `--no-content`: pi cwd, session file path, user identity, host identity, model names, tool names, token counts, timing, and error types. Users should not enable it for sessions where those values must stay local.
+
+## Package layout
+
+```text
+packages/telemetry/pi/
+├── src/cli.ts              # latitude-pi CLI entry
+├── src/setup.ts            # install/uninstall flow
+├── src/settings-file.ts    # pi settings + config-file helpers
+├── src/extension.ts        # pi extension entry
+├── src/span-builder.ts     # event-to-span state machine
+├── src/messages.ts         # pi/provider message normalization
+├── src/otlp.ts             # SpanRecord → OTLP JSON encoder
+├── src/client.ts           # Latitude ingest POST
+├── src/config.ts           # runtime config + identity resolution
+└── src/*.test.ts           # unit tests for builder, OTLP gate, settings helpers
+```
+
+Package metadata:
+
+- npm package: `@latitude-data/pi-telemetry`
+- bin: `latitude-pi`
+- pi manifest: `pi.extensions = ["./dist/extension.js"]`
+- build: `pnpm --filter @latitude-data/pi-telemetry build`
+- checks: `pnpm --filter @latitude-data/pi-telemetry check`, `typecheck`, `test`

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -111,7 +111,8 @@
             "group": "Agent harnesses",
             "pages": [
               "telemetry/claude-code",
-              "telemetry/openclaw"
+              "telemetry/openclaw",
+              "telemetry/pi-coding-agent"
             ]
           },
           {

--- a/docs/telemetry/pi-coding-agent.md
+++ b/docs/telemetry/pi-coding-agent.md
@@ -1,0 +1,107 @@
+# Pi coding agent telemetry
+
+Stream [pi coding agent](https://pi.dev) sessions into Latitude as traces with the first-party `@latitude-data/pi-telemetry` extension.
+
+After setup, pi prompts appear in your Latitude project's **Traces** view with model calls, prompts, responses, token usage, tool calls, and tool results.
+
+## Prerequisites
+
+- A [Latitude account](https://console.latitude.so/login) with a project
+- A Latitude API key from **Settings → API Keys**
+- Your Latitude project slug from the project sidebar
+- `pi` installed locally
+- Node.js available on your `PATH`
+
+## Install
+
+Run the installer:
+
+```bash
+npx -y @latitude-data/pi-telemetry install
+```
+
+The installer prompts for your API key and project slug, adds the pi extension package to `~/.pi/agent/settings.json`, and writes Latitude config to `~/.pi/agent/latitude-telemetry.json`.
+
+You can also pass values directly:
+
+```bash
+npx -y @latitude-data/pi-telemetry install \
+  --api-key=lat_xxx \
+  --project=your-project-slug \
+  --yes
+```
+
+## Restart and verify
+
+Restart pi so it can install and load the package. Send a prompt that uses the model or a tool, then open your Latitude project and go to **Traces**. The new trace should appear within a few seconds.
+
+A trace includes:
+
+- an `interaction` root span for the pi prompt
+- `llm_request` spans for model calls
+- `tool_call:<name>` spans for tool executions
+- `gen_ai.input.messages` and `gen_ai.output.messages` for prompt/response reconstruction
+- `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` for tool I/O
+
+## Structural-only telemetry
+
+By default, Latitude receives the content needed to reconstruct pi runs, including prompts, assistant responses, system instructions when available, tool arguments, and tool results.
+
+If you want trace structure without conversation or tool content, install with:
+
+```bash
+npx -y @latitude-data/pi-telemetry install --no-content
+```
+
+Structural-only traces still include timing, token usage, provider/model names, tool names, session metadata, user/host identity, and whether content capture was enabled.
+
+## Disable or uninstall
+
+Disable the extension for one pi process:
+
+```bash
+LATITUDE_PI_TELEMETRY_ENABLED=0 pi
+```
+
+Remove the extension and config:
+
+```bash
+npx -y @latitude-data/pi-telemetry uninstall
+```
+
+Restart pi after uninstalling to unload the extension.
+
+## Advanced configuration
+
+The installer stores config in `~/.pi/agent/latitude-telemetry.json`. Environment variables override file values:
+
+| Variable | Description |
+| --- | --- |
+| `LATITUDE_API_KEY` | API key used to upload traces |
+| `LATITUDE_PROJECT` or `LATITUDE_PROJECT_SLUG` | Project slug for `X-Latitude-Project` |
+| `LATITUDE_BASE_URL` | Ingest base URL, default `https://ingest.latitude.so` |
+| `LATITUDE_DEBUG=1` | Print upload diagnostics |
+| `LATITUDE_PI_NO_CONTENT=1` | Disable prompt/response/tool content capture |
+| `LATITUDE_PI_USER_ID` | Override `user.id` |
+| `LATITUDE_PI_USER_EMAIL` | Override user email |
+| `LATITUDE_PI_USER_NAME` | Override user display name |
+
+Use `--staging`, `--dev`, or `--base-url=<url>` during install to target a non-production Latitude ingest endpoint.
+
+## Captured data and privacy
+
+Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Latitude does not redact secrets from captured content.
+
+Disable telemetry or use `--no-content` before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
+
+## Troubleshooting
+
+**No traces appear.** Restart pi or run `/reload`, then send a new prompt. Confirm the API key and project slug are correct.
+
+**HTTP 401.** The API key is missing or invalid. Re-run the installer with a valid key.
+
+**HTTP 400 about `X-Latitude-Project`.** The project slug is missing. Re-run the installer with `--project=your-project-slug`.
+
+**Traces show timing but no prompt/response content.** Structural-only mode is enabled. Reinstall without `--no-content`, or set `LATITUDE_PI_NO_CONTENT=0` and reload pi.
+
+**Need diagnostics.** Run `LATITUDE_DEBUG=1 pi` and trigger another prompt.

--- a/packages/telemetry/pi/CHANGELOG.md
+++ b/packages/telemetry/pi/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the Pi Telemetry extension will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2026-05-21
+
+### Added
+
+- Initial release of the Pi coding agent extension for streaming sessions to Latitude as OTLP traces.
+- Interactive `install` / `uninstall` CLI for managing Pi package settings and Latitude configuration.
+- Optional `--no-content` mode to keep trace structure and metadata while scrubbing captured prompts, responses, tool inputs, and tool outputs.

--- a/packages/telemetry/pi/README.md
+++ b/packages/telemetry/pi/README.md
@@ -1,0 +1,41 @@
+# Latitude pi telemetry
+
+Pi coding agent extension that streams prompts, model turns, tool calls, and tool results to Latitude as OTLP traces.
+
+## Install
+
+```bash
+npx -y @latitude-data/pi-telemetry install
+```
+
+Non-interactive:
+
+```bash
+npx -y @latitude-data/pi-telemetry install \
+  --api-key=lat_xxx \
+  --project=your-project-slug \
+  --yes
+```
+
+The installer writes:
+
+- `~/.pi/agent/settings.json` with the pi package entry `npm:@latitude-data/pi-telemetry@<version>`
+- `~/.pi/agent/latitude-telemetry.json` with Latitude configuration
+
+Restart pi after installation so it can install and load the package.
+
+## Privacy
+
+By default this captures full prompts, assistant responses, tool inputs, and tool outputs. Install with `--no-content` to keep structure, timing, token usage, model names, and tool names while scrubbing content fields.
+
+## Disable
+
+```bash
+LATITUDE_PI_TELEMETRY_ENABLED=0 pi
+```
+
+## Uninstall
+
+```bash
+npx -y @latitude-data/pi-telemetry uninstall
+```

--- a/packages/telemetry/pi/package.json
+++ b/packages/telemetry/pi/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@latitude-data/pi-telemetry",
+  "version": "0.0.1",
+  "description": "Pi coding agent extension that streams sessions to Latitude as OTLP traces",
+  "author": "Latitude Data SL <hello@latitude.so>",
+  "license": "MIT",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "telemetry",
+    "otlp",
+    "opentelemetry",
+    "latitude",
+    "pi-package"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/pi"
+  },
+  "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/pi#readme",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "latitude-pi": "./dist/cli.js"
+  },
+  "main": "./dist/extension.js",
+  "types": "./dist/extension.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/extension.d.ts",
+      "default": "./dist/extension.js"
+    },
+    "./extension": {
+      "types": "./dist/extension.d.ts",
+      "default": "./dist/extension.js"
+    }
+  },
+  "pi": {
+    "extensions": ["./dist/extension.js"]
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --pool=forks --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@clack/prompts": "1.2.0",
+    "picocolors": "1.1.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/telemetry/pi/package.json
+++ b/packages/telemetry/pi/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/pi"
+    "url": "git+https://github.com/latitude-dev/latitude-llm.git#main"
   },
   "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/pi#readme",
   "type": "module",
@@ -23,7 +23,7 @@
     "dist"
   ],
   "bin": {
-    "latitude-pi": "./dist/cli.js"
+    "latitude-pi": "dist/cli.js"
   },
   "main": "./dist/extension.js",
   "types": "./dist/extension.d.ts",
@@ -38,7 +38,9 @@
     }
   },
   "pi": {
-    "extensions": ["./dist/extension.js"]
+    "extensions": [
+      "./dist/extension.js"
+    ]
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/telemetry/pi/src/cli.ts
+++ b/packages/telemetry/pi/src/cli.ts
@@ -1,0 +1,58 @@
+import { normalizeInstallFlags, normalizeUninstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
+import { packageVersion } from "./version.ts"
+
+const usage = `usage: latitude-pi <command> [options]
+
+commands:
+  install               Install the pi extension and configure Latitude export
+  uninstall             Remove the pi extension package entry and config
+  --version, -v         Print the package version
+  --help, -h            Print this message
+
+install options:
+  --api-key=<key>       Pass the Latitude API key non-interactively
+  --project=<slug>      Pass the Latitude project slug non-interactively
+  --staging             Target staging Latitude ingest
+  --dev                 Target local Latitude ingest (http://localhost:3002)
+  --base-url=<url>      Override the Latitude ingest base URL
+  --no-content          Export structure/timing without prompts, responses, or tool I/O
+  --allow-conversation  Force full content capture on
+  --pi-dir=<path>       Override pi config dir (default: $PI_CODING_AGENT_DIR or ~/.pi/agent)
+  --dry-run             Print the proposed settings/config and exit without writing
+  --yes / --no-prompt   Skip prompts (required for non-TTY / CI)
+
+uninstall options:
+  --pi-dir=<path>       Override pi config dir
+  --yes / --no-prompt   Skip the confirmation prompt
+`
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    process.stdout.write(`${packageVersion}\n`)
+    return
+  }
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    process.stdout.write(usage)
+    return
+  }
+
+  const { subcommand, flags } = parseFlags(argv)
+  if (subcommand === "install" || subcommand === undefined) {
+    await runInstall(normalizeInstallFlags(flags))
+    return
+  }
+  if (subcommand === "uninstall") {
+    await runUninstall(normalizeUninstallFlags(flags))
+    return
+  }
+
+  process.stderr.write(`unknown subcommand: ${subcommand}\n`)
+  process.stderr.write(usage)
+  process.exit(1)
+}
+
+main().catch((error) => {
+  process.stderr.write(`${String(error)}\n`)
+  process.exit(1)
+})

--- a/packages/telemetry/pi/src/client.ts
+++ b/packages/telemetry/pi/src/client.ts
@@ -1,0 +1,47 @@
+import type { Logger } from "./logger.ts"
+import type { OtlpExportRequest } from "./types.ts"
+
+export async function postTraces({
+  baseUrl,
+  apiKey,
+  project,
+  payload,
+  logger,
+  timeoutMs = 10_000,
+}: {
+  baseUrl: string
+  apiKey: string
+  project: string
+  payload: OtlpExportRequest
+  logger: Logger
+  timeoutMs?: number
+}): Promise<void> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/traces`
+  const bodyText = JSON.stringify(payload)
+  logger.debug(`POST ${url} (project=${project}, ${bodyText.length} bytes)`)
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "X-Latitude-Project": project,
+      },
+      body: bodyText,
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      logger.warn(`ingest HTTP ${res.status}: ${text.slice(0, 500)}`)
+      return
+    }
+    logger.debug(`ingest HTTP ${res.status}`)
+  } catch (error) {
+    logger.warn(`ingest failed: ${String(error)}`)
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/telemetry/pi/src/config.ts
+++ b/packages/telemetry/pi/src/config.ts
@@ -1,0 +1,137 @@
+import { execSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { hostname, userInfo } from "node:os"
+import { join } from "node:path"
+import type { RuntimeConfig, UserIdentity } from "./types.ts"
+
+export const configFileName = "latitude-telemetry.json"
+
+interface FileConfig {
+  apiKey?: string | undefined
+  project?: string | undefined
+  baseUrl?: string | undefined
+  enabled?: boolean | undefined
+  debug?: boolean | undefined
+  allowConversationAccess?: boolean | undefined
+  tags?: string[] | undefined
+  metadata?: Record<string, string> | undefined
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig {
+  const agentDir = resolvePiAgentDir(env)
+  const file = readFileConfig(join(agentDir, configFileName))
+
+  const apiKey = env.LATITUDE_API_KEY ?? file.apiKey ?? ""
+  const project = env.LATITUDE_PROJECT ?? env.LATITUDE_PROJECT_SLUG ?? file.project ?? ""
+  const baseUrl = env.LATITUDE_BASE_URL ?? file.baseUrl ?? "https://ingest.latitude.so"
+  const debug = env.LATITUDE_DEBUG === "1" || env.LATITUDE_DEBUG === "true" || file.debug === true
+  const allowConversationAccess = resolveAllowConversationAccess(env, file)
+  const explicitEnabled = env.LATITUDE_PI_TELEMETRY_ENABLED ?? env.LATITUDE_TELEMETRY_ENABLED
+  const enabledByFlag =
+    explicitEnabled === undefined ? file.enabled !== false : !["0", "false", "no"].includes(explicitEnabled)
+  const enabled = enabledByFlag && apiKey !== "" && project !== ""
+  const configSource =
+    env.LATITUDE_API_KEY || env.LATITUDE_PROJECT || env.LATITUDE_PROJECT_SLUG
+      ? "env"
+      : file.apiKey || file.project
+        ? "file"
+        : "none"
+
+  return {
+    apiKey,
+    project,
+    baseUrl,
+    enabled,
+    debug,
+    allowConversationAccess,
+    tags: file.tags ?? ["pi"],
+    metadata: file.metadata ?? {},
+    configSource,
+  }
+}
+
+export function resolvePiAgentDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.PI_CODING_AGENT_DIR) return expandHome(env.PI_CODING_AGENT_DIR)
+  return join(userInfo().homedir, ".pi", "agent")
+}
+
+export function resolveIdentity(env: NodeJS.ProcessEnv = process.env): UserIdentity {
+  const email = env.LATITUDE_PI_USER_EMAIL ?? env.PI_OTEL_USER_EMAIL ?? gitConfig("user.email")
+  const fullName = env.LATITUDE_PI_USER_NAME ?? env.PI_OTEL_USER_NAME ?? gitConfig("user.name")
+  const userName = userInfo().username
+  const userId = env.LATITUDE_PI_USER_ID ?? email ?? userName
+
+  return {
+    userId,
+    userName,
+    fullName: fullName ?? "",
+    email: email ?? "",
+    hostName: hostname(),
+  }
+}
+
+function resolveAllowConversationAccess(env: NodeJS.ProcessEnv, file: FileConfig): boolean {
+  const explicit = env.LATITUDE_PI_ALLOW_CONVERSATION_ACCESS ?? env.LATITUDE_ALLOW_CONVERSATION_ACCESS
+  if (explicit !== undefined) return ["1", "true", "yes"].includes(explicit)
+  const noContent = env.LATITUDE_PI_NO_CONTENT ?? env.LATITUDE_NO_CONTENT
+  if (noContent !== undefined) return !["1", "true", "yes"].includes(noContent)
+  return file.allowConversationAccess ?? true
+}
+
+function readFileConfig(path: string): FileConfig {
+  if (!existsSync(path)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown
+    if (!parsed || typeof parsed !== "object") return {}
+    const obj = parsed as Record<string, unknown>
+    return {
+      apiKey: stringValue(obj.apiKey),
+      project: stringValue(obj.project),
+      baseUrl: stringValue(obj.baseUrl),
+      enabled: booleanValue(obj.enabled),
+      debug: booleanValue(obj.debug),
+      allowConversationAccess: booleanValue(obj.allowConversationAccess),
+      tags: stringArrayValue(obj.tags),
+      metadata: stringRecordValue(obj.metadata),
+    }
+  } catch {
+    return {}
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function stringArrayValue(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : undefined
+}
+
+function stringRecordValue(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const out: Record<string, string> = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "string") out[key] = item
+    else if (typeof item === "number" || typeof item === "boolean") out[key] = String(item)
+  }
+  return out
+}
+
+function gitConfig(key: string): string | undefined {
+  try {
+    const value = execSync(`git config --global ${key}`, { encoding: "utf8", timeout: 2_000 }).trim()
+    return value === "" ? undefined : value
+  } catch {
+    return undefined
+  }
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return userInfo().homedir
+  if (path.startsWith("~/")) return join(userInfo().homedir, path.slice(2))
+  return path
+}

--- a/packages/telemetry/pi/src/extension.ts
+++ b/packages/telemetry/pi/src/extension.ts
@@ -1,0 +1,99 @@
+import { postTraces } from "./client.ts"
+import { loadConfig, resolveIdentity } from "./config.ts"
+import { createLogger } from "./logger.ts"
+import { buildOtlpRequest } from "./otlp.ts"
+import { PiSpanBuilder } from "./span-builder.ts"
+import type { PiExtensionAPI } from "./types.ts"
+
+export default function latitudePiTelemetry(pi: PiExtensionAPI): void {
+  let config = loadConfig()
+  let identity = resolveIdentity()
+  let logger = createLogger(config.debug)
+  let builder = new PiSpanBuilder(config, identity)
+
+  pi.on("session_start", async (_event, ctx) => {
+    config = loadConfig()
+    identity = resolveIdentity()
+    logger = createLogger(config.debug)
+    builder = new PiSpanBuilder(config, identity)
+
+    if (!config.enabled) {
+      if (config.debug && ctx.hasUI && ctx.ui?.setStatus) ctx.ui.setStatus("latitude", "Latitude off")
+      logger.debug(`disabled (source=${config.configSource})`)
+      return
+    }
+
+    if (ctx.hasUI && ctx.ui?.setStatus) {
+      const label = ctx.ui.theme?.fg?.("dim", "Latitude") ?? "Latitude"
+      ctx.ui.setStatus("latitude", label)
+    }
+    logger.debug(`enabled (project=${config.project}, source=${config.configSource})`)
+  })
+
+  pi.on("session_shutdown", async () => {
+    builder.reset()
+  })
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (!config.enabled) return
+    builder.onBeforeAgentStart(event, ctx)
+  })
+
+  pi.on("turn_start", async (event, ctx) => {
+    if (!config.enabled) return
+    builder.onTurnStart(event, ctx)
+  })
+
+  pi.on("context", async (event) => {
+    if (!config.enabled) return
+    builder.onContext(event)
+  })
+
+  pi.on("before_provider_request", async (event) => {
+    if (!config.enabled) return
+    builder.onBeforeProviderRequest(event)
+  })
+
+  pi.on("message_end", async (event) => {
+    if (!config.enabled) return
+    builder.onMessageEnd(event)
+  })
+
+  pi.on("turn_end", async (event) => {
+    if (!config.enabled) return
+    builder.onTurnEnd(event)
+  })
+
+  pi.on("tool_execution_start", async (event, ctx) => {
+    if (!config.enabled) return
+    builder.onToolExecutionStart(event, ctx)
+  })
+
+  pi.on("tool_execution_end", async (event) => {
+    if (!config.enabled) return
+    builder.onToolExecutionEnd(event)
+  })
+
+  pi.on("session_compact", async (event) => {
+    if (!config.enabled) return
+    builder.onSessionCompact(event)
+  })
+
+  pi.on("agent_end", async (event, ctx) => {
+    if (!config.enabled) return
+    const result = builder.onAgentEnd(event, ctx)
+    if (!result || result.spans.length === 0) return
+
+    const payload = buildOtlpRequest(result, {
+      allowConversationAccess: config.allowConversationAccess,
+      identity,
+    })
+    await postTraces({
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
+      project: config.project,
+      payload,
+      logger,
+    })
+  })
+}

--- a/packages/telemetry/pi/src/logger.ts
+++ b/packages/telemetry/pi/src/logger.ts
@@ -1,0 +1,15 @@
+export interface Logger {
+  debug(message: string): void
+  warn(message: string): void
+}
+
+export function createLogger(debugEnabled: boolean): Logger {
+  return {
+    debug(message) {
+      if (debugEnabled) process.stderr.write(`[latitude-pi] ${message}\n`)
+    },
+    warn(message) {
+      process.stderr.write(`[latitude-pi] ${message}\n`)
+    },
+  }
+}

--- a/packages/telemetry/pi/src/messages.ts
+++ b/packages/telemetry/pi/src/messages.ts
@@ -1,0 +1,264 @@
+import type { GenAIMessage, MessagePart, MessageRole } from "./types.ts"
+
+const allowedRoles: ReadonlySet<MessageRole> = new Set(["system", "user", "assistant", "tool"])
+
+export function normalizeMessages(raw: readonly unknown[] | undefined): GenAIMessage[] {
+  const out: GenAIMessage[] = []
+  for (const message of raw ?? []) {
+    const normalized = normalizeMessage(message)
+    if (normalized) out.push(normalized)
+  }
+  return out
+}
+
+export function normalizeMessage(raw: unknown): GenAIMessage | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  const rawRole = typeof obj.role === "string" ? obj.role : undefined
+
+  if (rawRole === "toolResult") return normalizePiToolResult(obj)
+  if (rawRole === "custom" || rawRole === "branchSummary" || rawRole === "compactionSummary") {
+    return normalizeContentMessage("system", obj.content ?? obj.summary ?? raw)
+  }
+  if (rawRole === "bashExecution") return normalizeBashExecution(obj)
+
+  const role = coerceRole(rawRole)
+  if (Array.isArray(obj.parts)) {
+    const parts = obj.parts.filter((part): part is MessagePart => part !== null && typeof part === "object")
+    return { role, parts: parts.length > 0 ? parts : [{ type: "text", content: safeJson(raw) }] }
+  }
+
+  return normalizeContentMessage(role, obj.content ?? obj.text ?? obj.message ?? raw, obj)
+}
+
+export function userMessageFromPrompt(prompt: string, images: readonly unknown[] | undefined): GenAIMessage {
+  const parts: MessagePart[] = []
+  if (prompt.length > 0) parts.push({ type: "text", content: prompt })
+  for (const image of images ?? []) {
+    const part = normalizeImageBlock(image)
+    if (part) parts.push(part)
+  }
+  if (parts.length === 0) parts.push({ type: "text", content: "" })
+  return { role: "user", parts }
+}
+
+export function systemInstructionsParts(systemPrompt: string | undefined): MessagePart[] | undefined {
+  if (!systemPrompt) return undefined
+  return [{ type: "text", content: systemPrompt }]
+}
+
+function normalizeContentMessage(
+  role: MessageRole,
+  content: unknown,
+  envelope?: Record<string, unknown>,
+): GenAIMessage {
+  if (typeof content === "string") {
+    const parts: MessagePart[] = content.length > 0 ? [{ type: "text", content }] : []
+    appendOpenAIToolCalls(parts, envelope?.tool_calls)
+    return { role, parts: parts.length > 0 ? parts : [{ type: "text", content: "" }] }
+  }
+
+  if (Array.isArray(content)) {
+    const parts: MessagePart[] = []
+    for (const block of content) {
+      const normalized = normalizeBlock(block)
+      if (normalized) parts.push(normalized)
+    }
+    appendOpenAIToolCalls(parts, envelope?.tool_calls)
+    return { role, parts: parts.length > 0 ? parts : [{ type: "text", content: safeJson(content) }] }
+  }
+
+  const parts: MessagePart[] = [{ type: "text", content: safeJson(content) }]
+  appendOpenAIToolCalls(parts, envelope?.tool_calls)
+  return { role, parts }
+}
+
+function normalizePiToolResult(obj: Record<string, unknown>): GenAIMessage {
+  const toolCallId = typeof obj.toolCallId === "string" ? obj.toolCallId : ""
+  return {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: toolCallId,
+        response: toolResultValue(obj),
+      },
+    ],
+  }
+}
+
+function normalizeBashExecution(obj: Record<string, unknown>): GenAIMessage {
+  return {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "user_bash",
+        response: {
+          command: obj.command,
+          output: obj.output,
+          exitCode: obj.exitCode,
+          cancelled: obj.cancelled,
+          truncated: obj.truncated,
+        },
+      },
+    ],
+  }
+}
+
+export function toolResultValue(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return raw
+  const obj = raw as Record<string, unknown>
+  const content = contentToText(obj.content)
+  const details = obj.details
+  if (details === undefined) return content
+  return { content, details }
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return safeJson(content)
+  const parts: string[] = []
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block)
+      continue
+    }
+    if (!block || typeof block !== "object") continue
+    const obj = block as Record<string, unknown>
+    if (obj.type === "text" && typeof obj.text === "string") {
+      parts.push(obj.text)
+    } else if (obj.type === "image") {
+      parts.push("[image]")
+    } else {
+      parts.push(safeJson(obj))
+    }
+  }
+  return parts.join("\n")
+}
+
+function normalizeBlock(raw: unknown): MessagePart | undefined {
+  if (typeof raw === "string") return { type: "text", content: raw }
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  const type = typeof obj.type === "string" ? obj.type : "text"
+
+  if (type === "text") {
+    const content =
+      typeof obj.content === "string" ? obj.content : typeof obj.text === "string" ? obj.text : safeJson(raw)
+    return { type: "text", content }
+  }
+  if (type === "thinking") {
+    const content = typeof obj.thinking === "string" ? obj.thinking : typeof obj.content === "string" ? obj.content : ""
+    return { type: "reasoning", content }
+  }
+  if (type === "reasoning") {
+    return { type: "reasoning", content: typeof obj.content === "string" ? obj.content : safeJson(raw) }
+  }
+  if (type === "toolCall") {
+    return {
+      type: "tool_call",
+      id: typeof obj.id === "string" ? obj.id : "",
+      name: typeof obj.name === "string" ? obj.name : "",
+      arguments: obj.arguments ?? {},
+    }
+  }
+  if (type === "tool_call") {
+    return {
+      type: "tool_call",
+      id: typeof obj.id === "string" ? obj.id : "",
+      name: typeof obj.name === "string" ? obj.name : "",
+      arguments: obj.arguments ?? obj.input ?? {},
+    }
+  }
+  if (type === "tool_use") {
+    return {
+      type: "tool_call",
+      id: typeof obj.id === "string" ? obj.id : "",
+      name: typeof obj.name === "string" ? obj.name : "",
+      arguments: obj.input ?? {},
+    }
+  }
+  if (type === "tool_result") {
+    return {
+      type: "tool_call_response",
+      id: typeof obj.tool_use_id === "string" ? obj.tool_use_id : "",
+      response: obj.content ?? "",
+    }
+  }
+  if (type === "tool_call_response") {
+    return {
+      type: "tool_call_response",
+      id: typeof obj.id === "string" ? obj.id : "",
+      response: obj.response ?? "",
+    }
+  }
+
+  const image = normalizeImageBlock(obj)
+  if (image) return image
+
+  return { type, content: safeJson(raw) }
+}
+
+function normalizeImageBlock(raw: unknown): MessagePart | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  if (obj.type !== "image") return undefined
+
+  const data = typeof obj.data === "string" ? obj.data : undefined
+  const mimeType = typeof obj.mimeType === "string" ? obj.mimeType : undefined
+  if (data) return { type: "uri", modality: "image", uri: `data:${mimeType ?? "image/unknown"};base64,${data}` }
+
+  const source = obj.source
+  if (source && typeof source === "object") {
+    const src = source as Record<string, unknown>
+    const url = typeof src.url === "string" ? src.url : undefined
+    const sourceData = typeof src.data === "string" ? src.data : undefined
+    const mediaType =
+      typeof src.mediaType === "string"
+        ? src.mediaType
+        : typeof src.media_type === "string"
+          ? src.media_type
+          : undefined
+    if (url) return { type: "uri", modality: "image", uri: url }
+    if (sourceData)
+      return { type: "uri", modality: "image", uri: `data:${mediaType ?? "image/unknown"};base64,${sourceData}` }
+  }
+  return undefined
+}
+
+function appendOpenAIToolCalls(parts: MessagePart[], raw: unknown): void {
+  if (!Array.isArray(raw)) return
+  for (const tc of raw) {
+    if (!tc || typeof tc !== "object") continue
+    const obj = tc as Record<string, unknown>
+    const fn = obj.function && typeof obj.function === "object" ? (obj.function as Record<string, unknown>) : undefined
+    let parsedArgs = fn?.arguments
+    if (typeof parsedArgs === "string") {
+      try {
+        parsedArgs = JSON.parse(parsedArgs) as unknown
+      } catch {
+        // Keep the original string when the provider sent non-JSON arguments.
+      }
+    }
+    parts.push({
+      type: "tool_call",
+      id: typeof obj.id === "string" ? obj.id : "",
+      name: typeof fn?.name === "string" ? fn.name : "",
+      arguments: parsedArgs ?? {},
+    })
+  }
+}
+
+function coerceRole(role: string | undefined): MessageRole {
+  return role && allowedRoles.has(role as MessageRole) ? (role as MessageRole) : "user"
+}
+
+export function safeJson(value: unknown): string {
+  try {
+    if (typeof value === "string") return value
+    return JSON.stringify(value)
+  } catch {
+    return ""
+  }
+}

--- a/packages/telemetry/pi/src/otlp.test.ts
+++ b/packages/telemetry/pi/src/otlp.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import { buildOtlpRequest } from "./otlp.ts"
+import type { BuildResult, OtlpKeyValue, UserIdentity } from "./types.ts"
+
+const identity: UserIdentity = {
+  userId: "owner@example.com",
+  email: "owner@example.com",
+  userName: "owner",
+  fullName: "Owner",
+  hostName: "host",
+}
+
+function attrMap(attrs: OtlpKeyValue[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const attr of attrs) {
+    if (attr.value.stringValue !== undefined) out[attr.key] = attr.value.stringValue
+    else if (attr.value.intValue !== undefined) out[attr.key] = attr.value.intValue
+    else if (attr.value.boolValue !== undefined) out[attr.key] = String(attr.value.boolValue)
+    else if (attr.value.doubleValue !== undefined) out[attr.key] = String(attr.value.doubleValue)
+  }
+  return out
+}
+
+function result(): BuildResult {
+  return {
+    traceId: "a".repeat(32),
+    spans: [
+      {
+        traceId: "a".repeat(32),
+        spanId: "1".repeat(16),
+        parentSpanId: "",
+        name: "llm_request",
+        startMs: 1_000,
+        endMs: 1_100,
+        outcome: "ok",
+        attrs: {
+          "span.type": "llm_request",
+          "gen_ai.operation.name": "chat",
+          "gen_ai.input.messages:gated": [{ role: "user", parts: [{ type: "text", content: "hello" }] }],
+          "gen_ai.output.messages:gated": [{ role: "assistant", parts: [{ type: "text", content: "hi" }] }],
+          "gen_ai.response.finish_reasons": ["stop"],
+          "latitude.tags": ["pi"],
+          "latitude.metadata": { "pi.cwd": "/repo" },
+        },
+      },
+    ],
+  }
+}
+
+describe("buildOtlpRequest", () => {
+  it("encodes gated GenAI content as JSON strings when content capture is enabled", () => {
+    const req = buildOtlpRequest(result(), { allowConversationAccess: true, identity })
+    const span = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const attrs = attrMap(span?.attributes ?? [])
+
+    expect(attrs["span.type"]).toBe("llm_request")
+    expect(attrs["gen_ai.operation.name"]).toBe("chat")
+    expect(JSON.parse(attrs["gen_ai.input.messages"] ?? "[]")).toEqual([
+      { role: "user", parts: [{ type: "text", content: "hello" }] },
+    ])
+    expect(JSON.parse(attrs["gen_ai.output.messages"] ?? "[]")).toEqual([
+      { role: "assistant", parts: [{ type: "text", content: "hi" }] },
+    ])
+    expect(attrs["gen_ai.input.messages:gated"]).toBeUndefined()
+    expect(attrs["latitude.captured.content"]).toBe("true")
+  })
+
+  it("scrubs gated attributes when content capture is disabled", () => {
+    const req = buildOtlpRequest(result(), { allowConversationAccess: false, identity })
+    const span = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const attrs = attrMap(span?.attributes ?? [])
+
+    expect(attrs["span.type"]).toBe("llm_request")
+    expect(attrs["gen_ai.operation.name"]).toBe("chat")
+    expect(attrs["gen_ai.input.messages"]).toBeUndefined()
+    expect(attrs["gen_ai.output.messages"]).toBeUndefined()
+    expect(attrs["latitude.captured.content"]).toBe("false")
+  })
+
+  it("encodes latitude tags and metadata as JSON string attributes", () => {
+    const req = buildOtlpRequest(result(), { allowConversationAccess: true, identity })
+    const span = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const attrs = attrMap(span?.attributes ?? [])
+
+    expect(attrs["latitude.tags"]).toBe('["pi"]')
+    expect(attrs["latitude.metadata"]).toBe('{"pi.cwd":"/repo"}')
+  })
+
+  it("encodes GenAI finish reasons as OTLP string arrays for Latitude's resolver", () => {
+    const req = buildOtlpRequest(result(), { allowConversationAccess: true, identity })
+    const span = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const finishReasons = span?.attributes.find((attr) => attr.key === "gen_ai.response.finish_reasons")
+
+    expect(finishReasons?.value.arrayValue?.values).toEqual([{ stringValue: "stop" }])
+    expect(finishReasons?.value.stringValue).toBeUndefined()
+  })
+})

--- a/packages/telemetry/pi/src/otlp.ts
+++ b/packages/telemetry/pi/src/otlp.ts
@@ -54,7 +54,7 @@ function toOtlpSpan(span: BuildResult["spans"][number], allowConversationAccess:
 }
 
 function encodeAttr(key: string, value: AttrValue): OtlpKeyValue | undefined {
-  if (value === undefined || value === null) return undefined
+  if (value === undefined) return undefined
   if (typeof value === "string") return str(key, value)
   if (typeof value === "boolean") return bool(key, value)
   if (typeof value === "number")

--- a/packages/telemetry/pi/src/otlp.ts
+++ b/packages/telemetry/pi/src/otlp.ts
@@ -1,0 +1,115 @@
+import { arch, hostname, platform, release } from "node:os"
+import type {
+  AttrValue,
+  BuildResult,
+  OtlpExportRequest,
+  OtlpKeyValue,
+  OtlpResourceSpans,
+  OtlpSpan,
+  UserIdentity,
+} from "./types.ts"
+import { packageVersion } from "./version.ts"
+
+const scopeName = "@latitude-data/pi-telemetry"
+
+interface BuildOptions {
+  allowConversationAccess: boolean
+  identity: UserIdentity
+}
+
+export function buildOtlpRequest(result: BuildResult, options: BuildOptions): OtlpExportRequest {
+  const spans = result.spans.map((span) => toOtlpSpan(span, options.allowConversationAccess))
+  const rs: OtlpResourceSpans = {
+    resource: { attributes: resourceAttrs(options.identity) },
+    scopeSpans: [{ scope: { name: scopeName, version: packageVersion }, spans }],
+  }
+  return { resourceSpans: [rs] }
+}
+
+function toOtlpSpan(span: BuildResult["spans"][number], allowConversationAccess: boolean): OtlpSpan {
+  const attrs: OtlpKeyValue[] = []
+  for (const [rawKey, value] of Object.entries(span.attrs)) {
+    if (value === undefined || value === null) continue
+    const isGated = rawKey.endsWith(":gated")
+    if (isGated && !allowConversationAccess) continue
+    const key = isGated ? rawKey.slice(0, -":gated".length) : rawKey
+    const encoded = encodeAttr(key, value)
+    if (encoded) attrs.push(encoded)
+  }
+  attrs.push(bool("latitude.captured.content", allowConversationAccess))
+  if (span.endMs !== undefined) attrs.push(int("pi.duration_ms.computed", Math.max(0, span.endMs - span.startMs)))
+
+  const statusCode = span.outcome === "error" ? 2 : 1
+  return {
+    traceId: span.traceId,
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId,
+    name: span.name,
+    kind: 1,
+    startTimeUnixNano: msToNs(span.startMs),
+    endTimeUnixNano: msToNs(span.endMs ?? span.startMs),
+    attributes: attrs,
+    status: span.errorMessage ? { code: statusCode, message: span.errorMessage } : { code: statusCode },
+  }
+}
+
+function encodeAttr(key: string, value: AttrValue): OtlpKeyValue | undefined {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === "string") return str(key, value)
+  if (typeof value === "boolean") return bool(key, value)
+  if (typeof value === "number")
+    return Number.isInteger(value) ? int(key, value) : { key, value: { doubleValue: value } }
+  if (key === "gen_ai.response.finish_reasons" && isStringArray(value)) {
+    return { key, value: { arrayValue: { values: value.map((item) => ({ stringValue: item })) } } }
+  }
+  return str(key, safeJson(value))
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function resourceAttrs(identity: UserIdentity): OtlpKeyValue[] {
+  return stripUndef([
+    str("service.name", "pi-coding-agent"),
+    str("service.version", packageVersion),
+    str("telemetry.sdk.name", scopeName),
+    str("telemetry.sdk.version", packageVersion),
+    str("host.name", hostname()),
+    str("host.arch", arch()),
+    str("os.type", platform()),
+    str("os.version", release()),
+    str("user.name", identity.userName),
+    identity.email ? str("user.email", identity.email) : undefined,
+    identity.fullName ? str("user.full_name", identity.fullName) : undefined,
+  ])
+}
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+
+function int(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(Math.trunc(value)) } }
+}
+
+function bool(key: string, value: boolean): OtlpKeyValue {
+  return { key, value: { boolValue: value } }
+}
+
+function stripUndef(items: Array<OtlpKeyValue | undefined>): OtlpKeyValue[] {
+  return items.filter((item): item is OtlpKeyValue => item !== undefined)
+}
+
+function msToNs(ms: number): string {
+  return (BigInt(Math.trunc(ms)) * 1_000_000n).toString()
+}
+
+function safeJson(value: unknown): string {
+  try {
+    if (typeof value === "string") return value
+    return JSON.stringify(value)
+  } catch {
+    return ""
+  }
+}

--- a/packages/telemetry/pi/src/settings-file.test.ts
+++ b/packages/telemetry/pi/src/settings-file.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { addPackage, hasPackage, removePackage } from "./settings-file.ts"
+
+describe("pi settings package helpers", () => {
+  it("adds a pinned npm package source and replaces previous Latitude entries", () => {
+    const settings = addPackage(
+      {
+        theme: "dark",
+        packages: [
+          "npm:@latitude-data/pi-telemetry@0.0.0",
+          "npm:other-package",
+          { source: "@latitude-data/pi-telemetry@0.0.0", extensions: [] },
+        ],
+      },
+      "npm:@latitude-data/pi-telemetry@0.0.1",
+    )
+
+    expect(settings.theme).toBe("dark")
+    expect(settings.packages).toEqual(["npm:other-package", "npm:@latitude-data/pi-telemetry@0.0.1"])
+    expect(hasPackage(settings)).toBe(true)
+  })
+
+  it("removes string and object package entries", () => {
+    const settings = removePackage({
+      packages: ["npm:@latitude-data/pi-telemetry@0.0.1", { source: "npm:@latitude-data/pi-telemetry" }, "npm:x"],
+    })
+
+    expect(settings.packages).toEqual(["npm:x"])
+    expect(hasPackage(settings)).toBe(false)
+  })
+})

--- a/packages/telemetry/pi/src/settings-file.ts
+++ b/packages/telemetry/pi/src/settings-file.ts
@@ -1,0 +1,115 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { configFileName } from "./config.ts"
+
+export const packageName = "@latitude-data/pi-telemetry"
+
+export interface PiTelemetryConfigFile {
+  apiKey: string
+  project: string
+  baseUrl?: string | undefined
+  enabled: boolean
+  debug?: boolean | undefined
+  allowConversationAccess: boolean
+  tags: string[]
+  metadata: Record<string, string>
+}
+
+interface PiSettings {
+  packages?: Array<string | PiPackageEntry> | undefined
+  [key: string]: unknown
+}
+
+interface PiPackageEntry {
+  source?: string | undefined
+  [key: string]: unknown
+}
+
+interface PiPaths {
+  agentDir: string
+  settingsPath: string
+  configPath: string
+  settingsBackupPath: string
+  configBackupPath: string
+}
+
+export function pathsForAgentDir(agentDir: string): PiPaths {
+  return {
+    agentDir,
+    settingsPath: join(agentDir, "settings.json"),
+    configPath: join(agentDir, configFileName),
+    settingsBackupPath: join(agentDir, "settings.json.latitude-bak"),
+    configBackupPath: join(agentDir, `${configFileName}.latitude-bak`),
+  }
+}
+
+export function readSettings(path: string): PiSettings {
+  if (!existsSync(path)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as PiSettings) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeSettings(path: string, settings: PiSettings): void {
+  writeJsonAtomic(path, settings, 0o644)
+}
+
+export function readTelemetryConfig(path: string): Partial<PiTelemetryConfigFile> {
+  if (!existsSync(path)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Partial<PiTelemetryConfigFile>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeTelemetryConfig(path: string, config: PiTelemetryConfigFile): void {
+  writeJsonAtomic(path, config, 0o600)
+}
+
+export function addPackage(settings: PiSettings, source: string): PiSettings {
+  const packages = Array.isArray(settings.packages) ? [...settings.packages] : []
+  const filtered = packages.filter((entry) => !isLatitudePackageEntry(entry))
+  filtered.push(source)
+  return { ...settings, packages: filtered }
+}
+
+export function removePackage(settings: PiSettings): PiSettings {
+  const packages = Array.isArray(settings.packages)
+    ? settings.packages.filter((entry) => !isLatitudePackageEntry(entry))
+    : []
+  return { ...settings, packages }
+}
+
+export function hasPackage(settings: PiSettings): boolean {
+  return Array.isArray(settings.packages) && settings.packages.some(isLatitudePackageEntry)
+}
+
+export function backupIfExists(path: string, backupPath: string): void {
+  if (!existsSync(path)) return
+  mkdirSync(dirname(backupPath), { recursive: true })
+  writeFileSync(backupPath, readFileSync(path))
+}
+
+function isLatitudePackageEntry(entry: string | PiPackageEntry): boolean {
+  const source = typeof entry === "string" ? entry : entry.source
+  if (!source) return false
+  return normalizePackageSource(source).startsWith(packageName)
+}
+
+function normalizePackageSource(source: string): string {
+  return source.startsWith("npm:") ? source.slice("npm:".length) : source
+}
+
+function writeJsonAtomic(path: string, value: unknown, mode: number): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`
+  writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, { mode })
+  renameSync(tempPath, path)
+}

--- a/packages/telemetry/pi/src/setup.ts
+++ b/packages/telemetry/pi/src/setup.ts
@@ -1,0 +1,317 @@
+import { existsSync, rmSync } from "node:fs"
+import { cancel, intro, isCancel, log, note, outro, password, text } from "@clack/prompts"
+import pc from "picocolors"
+import { resolvePiAgentDir } from "./config.ts"
+import {
+  addPackage,
+  backupIfExists,
+  hasPackage,
+  type PiTelemetryConfigFile,
+  packageName,
+  pathsForAgentDir,
+  readSettings,
+  readTelemetryConfig,
+  removePackage,
+  writeSettings,
+  writeTelemetryConfig,
+} from "./settings-file.ts"
+import { packageVersion } from "./version.ts"
+
+const docsUrl = "https://docs.latitude.so/telemetry/pi-coding-agent"
+
+interface EnvironmentConfig {
+  name: "production" | "staging" | "dev"
+  label: string
+  app: string
+  ingest: string
+}
+
+const productionEnv: EnvironmentConfig = {
+  name: "production",
+  label: "production",
+  app: "https://console.latitude.so",
+  ingest: "https://ingest.latitude.so",
+}
+
+const stagingEnv: EnvironmentConfig = {
+  name: "staging",
+  label: "staging",
+  app: "https://staging.latitude.so",
+  ingest: "https://staging-ingest.latitude.so",
+}
+
+const devEnv: EnvironmentConfig = {
+  name: "dev",
+  label: "local dev",
+  app: "http://localhost:3000",
+  ingest: "http://localhost:3002",
+}
+
+interface InstallFlags {
+  apiKey?: string | undefined
+  project?: string | undefined
+  baseUrl?: string | undefined
+  environment?: EnvironmentConfig | undefined
+  allowConversationAccess?: boolean | undefined
+  piDir?: string | undefined
+  dryRun?: boolean | undefined
+  noPrompt?: boolean | undefined
+}
+
+interface UninstallFlags {
+  piDir?: string | undefined
+  noPrompt?: boolean | undefined
+}
+
+const valueFlags = new Set(["api-key", "project", "base-url", "pi-dir"])
+
+export function parseFlags(argv: string[]): {
+  subcommand: string | undefined
+  flags: Record<string, string | boolean>
+} {
+  const [subcommand, ...rest] = argv
+  const flags: Record<string, string | boolean> = {}
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]
+    if (!arg?.startsWith("--")) continue
+    const eq = arg.indexOf("=")
+    if (eq >= 0) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1)
+      continue
+    }
+    const key = arg.slice(2)
+    const next = rest[i + 1]
+    if (valueFlags.has(key) && next !== undefined && !next.startsWith("--")) {
+      flags[key] = next
+      i += 1
+    } else {
+      flags[key] = true
+    }
+  }
+  return { subcommand, flags }
+}
+
+export function normalizeInstallFlags(flags: Record<string, string | boolean>): InstallFlags {
+  let environment: EnvironmentConfig | undefined
+  if (flags.staging === true) environment = stagingEnv
+  if (flags.dev === true) {
+    if (environment) throw new Error("--staging and --dev are mutually exclusive")
+    environment = devEnv
+  }
+
+  let allowConversationAccess: boolean | undefined
+  if (flags["no-content"] === true || flags["no-conversation"] === true) allowConversationAccess = false
+  if (flags["allow-conversation"] === true) allowConversationAccess = true
+
+  return {
+    apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
+    project: typeof flags.project === "string" ? flags.project : undefined,
+    baseUrl: typeof flags["base-url"] === "string" ? flags["base-url"] : undefined,
+    environment,
+    allowConversationAccess,
+    piDir: typeof flags["pi-dir"] === "string" ? flags["pi-dir"] : undefined,
+    dryRun: flags["dry-run"] === true,
+    noPrompt: flags.yes === true || flags["no-prompt"] === true,
+  }
+}
+
+export function normalizeUninstallFlags(flags: Record<string, string | boolean>): UninstallFlags {
+  return {
+    piDir: typeof flags["pi-dir"] === "string" ? flags["pi-dir"] : undefined,
+    noPrompt: flags.yes === true || flags["no-prompt"] === true,
+  }
+}
+
+export async function runInstall(flags: InstallFlags = {}): Promise<void> {
+  const canPrompt = !flags.noPrompt && process.stdin.isTTY === true
+  if (canPrompt) {
+    await runInteractiveInstall(flags)
+    return
+  }
+  await runFlagDrivenInstall(flags)
+}
+
+async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
+  intro(pc.bgCyan(pc.black(" Latitude · pi telemetry ")))
+
+  const env = flags.environment ?? productionEnv
+  const paths = pathsForAgentDir(resolvePiAgentDirFromFlags(flags))
+  const existing = readTelemetryConfig(paths.configPath)
+
+  note(
+    [
+      "Captures pi coding agent prompts, model turns, tool calls,",
+      "token usage, prompts/responses, and tool I/O as Latitude traces.",
+      "",
+      `${pc.dim("Docs")} ${pc.cyan(docsUrl)}`,
+      env.name === "production" ? undefined : pc.yellow(`Using ${env.label} ingest (${env.ingest})`),
+    ]
+      .filter((line): line is string => line !== undefined)
+      .join("\n"),
+    "About",
+  )
+
+  log.info(`Using pi config dir: ${pc.dim(paths.agentDir)}`)
+  log.info(`Create an API key at ${pc.cyan(`${env.app}/settings/api-keys`)}`)
+
+  const apiKey = await promptApiKey(flags.apiKey ?? existing.apiKey)
+  const project = await promptProject(flags.project ?? existing.project)
+  const allowConversationAccess = flags.allowConversationAccess ?? existing.allowConversationAccess ?? true
+
+  applyInstall({
+    paths,
+    apiKey,
+    project,
+    baseUrl: flags.baseUrl ?? (env.name === "production" ? undefined : env.ingest),
+    allowConversationAccess,
+    dryRun: flags.dryRun === true,
+  })
+
+  note(
+    [
+      flags.dryRun ? "Dry-run only — nothing was written." : "Installed. Restart pi so it can load the package.",
+      `Traces will be sent to project ${pc.cyan(project)}.`,
+    ].join("\n"),
+    "Next step",
+  )
+  outro(flags.dryRun ? pc.dim("(dry-run)") : pc.green("✓ Installed"))
+}
+
+async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
+  const paths = pathsForAgentDir(resolvePiAgentDirFromFlags(flags))
+  const existing = readTelemetryConfig(paths.configPath)
+  const env = flags.environment ?? productionEnv
+  const apiKey = flags.apiKey ?? existing.apiKey
+  const project = flags.project ?? existing.project
+  if (!apiKey || !project) {
+    throw new Error("Non-interactive install requires --api-key=... and --project=... (or run in a TTY).")
+  }
+
+  applyInstall({
+    paths,
+    apiKey,
+    project,
+    baseUrl: flags.baseUrl ?? existing.baseUrl ?? (env.name === "production" ? undefined : env.ingest),
+    allowConversationAccess: flags.allowConversationAccess ?? existing.allowConversationAccess ?? true,
+    dryRun: flags.dryRun === true,
+  })
+
+  if (flags.dryRun) {
+    process.stdout.write("Dry-run only — nothing was written.\n")
+  } else {
+    process.stdout.write(
+      `Installed Latitude pi telemetry in ${paths.agentDir}. Restart pi so it can load the package.\n`,
+    )
+  }
+}
+
+function applyInstall({
+  paths,
+  apiKey,
+  project,
+  baseUrl,
+  allowConversationAccess,
+  dryRun,
+}: {
+  paths: ReturnType<typeof pathsForAgentDir>
+  apiKey: string
+  project: string
+  baseUrl?: string | undefined
+  allowConversationAccess: boolean
+  dryRun: boolean
+}): void {
+  const settingsBefore = readSettings(paths.settingsPath)
+  const settingsAfter = addPackage(settingsBefore, `npm:${packageName}@${packageVersion}`)
+  const existingConfig = readTelemetryConfig(paths.configPath)
+  const config: PiTelemetryConfigFile = {
+    apiKey,
+    project,
+    ...(baseUrl ? { baseUrl } : {}),
+    enabled: true,
+    debug: existingConfig.debug ?? false,
+    allowConversationAccess,
+    tags: existingConfig.tags ?? ["pi"],
+    metadata: existingConfig.metadata ?? {},
+  }
+
+  if (dryRun) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          settingsPath: paths.settingsPath,
+          configPath: paths.configPath,
+          settingsAfter,
+          config: { ...config, apiKey: config.apiKey ? "<redacted>" : "" },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    return
+  }
+
+  backupIfExists(paths.settingsPath, paths.settingsBackupPath)
+  backupIfExists(paths.configPath, paths.configBackupPath)
+  writeSettings(paths.settingsPath, settingsAfter)
+  writeTelemetryConfig(paths.configPath, config)
+}
+
+export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
+  const paths = pathsForAgentDir(resolvePiAgentDirFromFlags(flags))
+  const settingsBefore = readSettings(paths.settingsPath)
+  const installed = hasPackage(settingsBefore)
+  if (!installed && !existsSync(paths.configPath)) {
+    process.stdout.write("Latitude pi telemetry is not installed.\n")
+    return
+  }
+
+  if (!flags.noPrompt && process.stdin.isTTY === true) {
+    intro(pc.bgYellow(pc.black(" Latitude · pi telemetry — uninstall ")))
+    const confirmed = await text({
+      message: "Type uninstall to remove Latitude pi telemetry",
+      placeholder: "uninstall",
+    })
+    if (isCancel(confirmed) || confirmed !== "uninstall") onCancel()
+  } else if (!flags.noPrompt) {
+    throw new Error("Non-interactive uninstall requires --yes / --no-prompt.")
+  }
+
+  const settingsAfter = removePackage(settingsBefore)
+  backupIfExists(paths.settingsPath, paths.settingsBackupPath)
+  backupIfExists(paths.configPath, paths.configBackupPath)
+  writeSettings(paths.settingsPath, settingsAfter)
+  if (existsSync(paths.configPath)) rmSync(paths.configPath)
+  process.stdout.write(`Removed Latitude pi telemetry from ${paths.agentDir}. Restart pi to unload it.\n`)
+}
+
+function resolvePiAgentDirFromFlags(flags: InstallFlags | UninstallFlags): string {
+  if (flags.piDir) return flags.piDir
+  return resolvePiAgentDir()
+}
+
+async function promptApiKey(existing: string | undefined): Promise<string> {
+  const result = await password({
+    message: "Latitude API key",
+    mask: "•",
+    ...(existing ? { placeholder: "reuse existing key" } : {}),
+    validate: (value) => (value || existing ? undefined : "Required"),
+  })
+  if (isCancel(result)) onCancel()
+  return result || existing || ""
+}
+
+async function promptProject(existing: string | undefined): Promise<string> {
+  const result = await text({
+    message: "Latitude project slug",
+    placeholder: existing ?? "my-project",
+    ...(existing ? { initialValue: existing } : {}),
+    validate: (value) => (value ? undefined : "Required"),
+  })
+  if (isCancel(result)) onCancel()
+  return result
+}
+
+function onCancel(): never {
+  cancel("Cancelled — nothing was changed")
+  process.exit(1)
+}

--- a/packages/telemetry/pi/src/span-builder.test.ts
+++ b/packages/telemetry/pi/src/span-builder.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest"
+import { PiSpanBuilder } from "./span-builder.ts"
+import type { PiContext, RuntimeConfig, UserIdentity } from "./types.ts"
+
+const config: RuntimeConfig = {
+  apiKey: "lat_test",
+  project: "default-project",
+  baseUrl: "http://localhost:3002",
+  enabled: true,
+  debug: false,
+  allowConversationAccess: true,
+  tags: ["pi"],
+  metadata: {},
+  configSource: "file",
+}
+
+const identity: UserIdentity = {
+  userId: "owner@example.com",
+  email: "owner@example.com",
+  userName: "owner",
+  fullName: "Owner",
+  hostName: "host",
+}
+
+function ctx(): PiContext {
+  return {
+    cwd: "/repo/app",
+    sessionManager: {
+      getSessionId: () => "sess-1",
+      getSessionFile: () => "/tmp/session.jsonl",
+      getSessionName: () => "Build feature",
+    },
+  }
+}
+
+describe("PiSpanBuilder", () => {
+  it("emits interaction, llm_request, and tool_execution spans with Latitude-friendly attributes", () => {
+    const builder = new PiSpanBuilder(config, identity)
+
+    builder.onBeforeAgentStart({ prompt: "read package.json", systemPrompt: "You are pi." }, ctx())
+    builder.onTurnStart({ turnIndex: 0, timestamp: 1_000 }, ctx())
+    builder.onContext({ messages: [{ role: "user", content: "read package.json" }] })
+    builder.onBeforeProviderRequest({ payload: { model: "claude-sonnet-4-5", max_tokens: 1000, stream: true } })
+    builder.onMessageEnd({
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "package.json" } }],
+        usage: { input: 120, output: 14, cacheRead: 5, cacheWrite: 0, totalTokens: 139 },
+        stopReason: "toolUse",
+        timestamp: 1_100,
+      },
+    })
+
+    builder.onToolExecutionStart({ toolCallId: "tool-1", toolName: "read", args: { path: "package.json" } }, ctx())
+    builder.onToolExecutionEnd({
+      toolCallId: "tool-1",
+      toolName: "read",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: '{"name":"app"}' }],
+        details: { path: "package.json" },
+      },
+    })
+
+    const result = builder.onAgentEnd({ messages: [] }, ctx())
+    expect(result).toBeDefined()
+    const spans = result?.spans ?? []
+    expect(spans).toHaveLength(3)
+
+    const interaction = spans.find((span) => span.name === "interaction")
+    const llm = spans.find((span) => span.name === "llm_request")
+    const tool = spans.find((span) => span.name === "tool_call:read")
+
+    expect(interaction?.attrs["span.type"]).toBe("interaction")
+    expect(interaction?.attrs["user_prompt:gated"]).toBe("read package.json")
+    expect(llm?.parentSpanId).toBe(interaction?.spanId)
+    expect(llm?.attrs["span.type"]).toBe("llm_request")
+    expect(llm?.attrs["gen_ai.operation.name"]).toBe("chat")
+    expect(llm?.attrs["gen_ai.provider.name"]).toBe("anthropic")
+    expect(llm?.attrs["gen_ai.request.model"]).toBe("claude-sonnet-4-5")
+    expect(llm?.attrs["gen_ai.usage.input_tokens"]).toBe(120)
+    expect(llm?.attrs["gen_ai.usage.output_tokens"]).toBe(14)
+    expect(llm?.attrs["gen_ai.system_instructions:gated"]).toEqual([{ type: "text", content: "You are pi." }])
+    expect(llm?.attrs["gen_ai.input.messages:gated"]).toEqual([
+      { role: "user", parts: [{ type: "text", content: "read package.json" }] },
+    ])
+    expect(llm?.attrs["gen_ai.output.messages:gated"]).toEqual([
+      {
+        role: "assistant",
+        parts: [{ type: "tool_call", id: "tool-1", name: "read", arguments: { path: "package.json" } }],
+      },
+    ])
+
+    expect(tool?.parentSpanId).toBe(interaction?.spanId)
+    expect(tool?.attrs["span.type"]).toBe("tool_execution")
+    expect(tool?.attrs["gen_ai.operation.name"]).toBe("execute_tool")
+    expect(tool?.attrs["gen_ai.tool.name"]).toBe("read")
+    expect(tool?.attrs["gen_ai.tool.call.arguments:gated"]).toEqual({ path: "package.json" })
+    expect(tool?.attrs["gen_ai.tool.call.result:gated"]).toEqual({
+      content: '{"name":"app"}',
+      details: { path: "package.json" },
+    })
+  })
+
+  it("uses context messages for later tool-loop model calls", () => {
+    const builder = new PiSpanBuilder(config, identity)
+    builder.onBeforeAgentStart({ prompt: "run a command" }, ctx())
+
+    builder.onTurnStart({ turnIndex: 0 }, ctx())
+    builder.onContext({ messages: [{ role: "user", content: "run a command" }] })
+    builder.onMessageEnd({
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "pwd" } }],
+        usage: {},
+        stopReason: "toolUse",
+      },
+    })
+    builder.onToolExecutionStart({ toolCallId: "bash-1", toolName: "bash", args: { command: "pwd" } }, ctx())
+    builder.onToolExecutionEnd({
+      toolCallId: "bash-1",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "/repo/app" }] },
+      isError: false,
+    })
+
+    builder.onTurnStart({ turnIndex: 1 }, ctx())
+    builder.onContext({
+      messages: [
+        { role: "user", content: "run a command" },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "bash-1", name: "bash", arguments: { command: "pwd" } }],
+        },
+        { role: "toolResult", toolCallId: "bash-1", toolName: "bash", content: [{ type: "text", text: "/repo/app" }] },
+      ],
+    })
+    builder.onMessageEnd({
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        content: [{ type: "text", text: "You are in /repo/app." }],
+        usage: {},
+        stopReason: "stop",
+      },
+    })
+
+    const result = builder.onAgentEnd({ messages: [] }, ctx())
+    const calls = result?.spans.filter((span) => span.name === "llm_request") ?? []
+    expect(calls).toHaveLength(2)
+    expect(calls[1]?.attrs["gen_ai.input.messages:gated"]).toEqual([
+      { role: "user", parts: [{ type: "text", content: "run a command" }] },
+      { role: "assistant", parts: [{ type: "tool_call", id: "bash-1", name: "bash", arguments: { command: "pwd" } }] },
+      { role: "tool", parts: [{ type: "tool_call_response", id: "bash-1", response: "/repo/app" }] },
+    ])
+  })
+})

--- a/packages/telemetry/pi/src/span-builder.ts
+++ b/packages/telemetry/pi/src/span-builder.ts
@@ -1,0 +1,446 @@
+import { createHash, randomUUID } from "node:crypto"
+import { basename } from "node:path"
+import {
+  normalizeMessage,
+  normalizeMessages,
+  safeJson,
+  systemInstructionsParts,
+  toolResultValue,
+  userMessageFromPrompt,
+} from "./messages.ts"
+import type { AttrValue, BuildResult, PiContext, RuntimeConfig, SpanRecord, UserIdentity } from "./types.ts"
+
+interface RunState {
+  traceId: string
+  interaction: SpanRecord
+  activeLlm: SpanRecord | undefined
+  closed: SpanRecord[]
+  openTools: Map<string, SpanRecord>
+  systemPrompt: string | undefined
+  sessionId: string
+  sessionFile: string
+  cwd: string
+  turnNumber: number
+}
+
+export class PiSpanBuilder {
+  private run: RunState | undefined
+
+  constructor(
+    private readonly config: RuntimeConfig,
+    private readonly identity: UserIdentity,
+  ) {}
+
+  reset(): void {
+    this.run = undefined
+  }
+
+  onBeforeAgentStart(event: unknown, ctx: PiContext): void {
+    const ev = asRecord(event)
+    const prompt = typeof ev.prompt === "string" ? ev.prompt : ""
+    const images = Array.isArray(ev.images) ? ev.images : undefined
+    const systemPrompt = typeof ev.systemPrompt === "string" ? ev.systemPrompt : undefined
+    const session = sessionInfo(ctx)
+    const traceId = hashHex(`${session.id}:${Date.now()}:${randomUUID()}`, 32)
+    const spanId = hashHex(`${traceId}:interaction`, 16)
+    const contextAttrs = this.contextAttrs(ctx, session)
+
+    const interaction: SpanRecord = {
+      traceId,
+      spanId,
+      parentSpanId: "",
+      name: "interaction",
+      startMs: Date.now(),
+      endMs: undefined,
+      attrs: {
+        ...contextAttrs,
+        "span.type": "interaction",
+        "interaction.kind": "user",
+        "session.id": session.id,
+        "gen_ai.session.id": session.id,
+        "user.id": this.identity.userId,
+        "user.email": this.identity.email || undefined,
+        "user.name": this.identity.userName,
+        "user.full_name": this.identity.fullName || undefined,
+        "user_prompt:gated": prompt,
+        user_prompt_length: prompt.length,
+        "gen_ai.input.messages:gated": [userMessageFromPrompt(prompt, images)],
+      },
+      outcome: "ok",
+    }
+
+    this.run = {
+      traceId,
+      interaction,
+      activeLlm: undefined,
+      closed: [],
+      openTools: new Map(),
+      systemPrompt,
+      sessionId: session.id,
+      sessionFile: session.file,
+      cwd: session.cwd,
+      turnNumber: 0,
+    }
+  }
+
+  onTurnStart(event: unknown, ctx: PiContext): void {
+    const run = this.ensureRun(ctx)
+    this.closeAbandonedLlm(run)
+
+    const ev = asRecord(event)
+    const turnIndex = typeof ev.turnIndex === "number" ? ev.turnIndex : run.turnNumber
+    run.turnNumber += 1
+    const spanId = hashHex(`${run.traceId}:llm:${run.turnNumber}:${turnIndex}`, 16)
+    run.activeLlm = {
+      traceId: run.traceId,
+      spanId,
+      parentSpanId: run.interaction.spanId,
+      name: "llm_request",
+      startMs: typeof ev.timestamp === "number" ? ev.timestamp : Date.now(),
+      endMs: undefined,
+      attrs: {
+        ...this.contextAttrs(ctx, { id: run.sessionId, file: run.sessionFile, cwd: run.cwd }),
+        "span.type": "llm_request",
+        "gen_ai.operation.name": "chat",
+        "session.id": run.sessionId,
+        "gen_ai.session.id": run.sessionId,
+        "user.id": this.identity.userId,
+        "llm_request.call_index": turnIndex,
+        "turn.index": turnIndex,
+        "turn.number": run.turnNumber,
+        "gen_ai.system_instructions:gated": systemInstructionsParts(run.systemPrompt),
+      },
+      outcome: "ok",
+    }
+  }
+
+  onContext(event: unknown): void {
+    const run = this.run
+    if (!run?.activeLlm) return
+    const ev = asRecord(event)
+    run.activeLlm.attrs["gen_ai.input.messages:gated"] = normalizeMessages(
+      Array.isArray(ev.messages) ? ev.messages : [],
+    )
+  }
+
+  onBeforeProviderRequest(event: unknown): void {
+    const run = this.run
+    if (!run?.activeLlm) return
+    const payload = asRecord(asRecord(event).payload)
+    const payloadText = safeJson(payload)
+    run.activeLlm.attrs["pi.provider.payload_bytes"] = payloadText.length
+    copyIfString(payload, "model", run.activeLlm.attrs, "gen_ai.request.model")
+    copyIfBoolean(payload, "stream", run.activeLlm.attrs, "gen_ai.request.stream")
+    copyIfNumber(payload, "max_tokens", run.activeLlm.attrs, "gen_ai.request.max_tokens")
+    copyIfNumber(payload, "maxTokens", run.activeLlm.attrs, "gen_ai.request.max_tokens")
+    copyIfNumber(payload, "temperature", run.activeLlm.attrs, "gen_ai.request.temperature")
+    copyIfNumber(payload, "top_p", run.activeLlm.attrs, "gen_ai.request.top_p")
+    copyIfNumber(payload, "topP", run.activeLlm.attrs, "gen_ai.request.top_p")
+    if (Array.isArray(payload.tools)) run.activeLlm.attrs["gen_ai.tool.definitions:gated"] = payload.tools
+  }
+
+  onMessageEnd(event: unknown): void {
+    const message = asRecord(asRecord(event).message)
+    if (message.role !== "assistant") return
+    const run = this.run
+    if (!run?.activeLlm) return
+    this.finalizeLlm(run, message, Date.now())
+  }
+
+  onTurnEnd(event: unknown): void {
+    const run = this.run
+    if (!run?.activeLlm) return
+    const ev = asRecord(event)
+    const message = asRecord(ev.message)
+    const toolResults = Array.isArray(ev.toolResults) ? ev.toolResults : []
+    run.activeLlm.attrs["turn.tool_results"] = toolResults.length
+    if (message.role === "assistant") {
+      this.finalizeLlm(run, message, Date.now())
+      return
+    }
+    this.closeAbandonedLlm(run)
+  }
+
+  onToolExecutionStart(event: unknown, ctx: PiContext): void {
+    const run = this.ensureRun(ctx)
+    const ev = asRecord(event)
+    const toolCallId = typeof ev.toolCallId === "string" ? ev.toolCallId : randomUUID()
+    const toolName = typeof ev.toolName === "string" ? ev.toolName : "unknown"
+    const args = ev.args
+    const spanId = hashHex(`${run.traceId}:tool:${toolCallId}:${run.openTools.size}`, 16)
+    const span: SpanRecord = {
+      traceId: run.traceId,
+      spanId,
+      parentSpanId: run.interaction.spanId,
+      name: `tool_call:${toolName}`,
+      startMs: Date.now(),
+      endMs: undefined,
+      attrs: {
+        ...this.contextAttrs(ctx, { id: run.sessionId, file: run.sessionFile, cwd: run.cwd }),
+        "span.type": "tool_execution",
+        "gen_ai.operation.name": "execute_tool",
+        "session.id": run.sessionId,
+        "gen_ai.session.id": run.sessionId,
+        "user.id": this.identity.userId,
+        "gen_ai.tool.name": toolName,
+        "gen_ai.tool.call.id": toolCallId,
+        "gen_ai.tool.call.arguments:gated": attrValue(args),
+      },
+      outcome: "ok",
+    }
+    run.openTools.set(toolCallId, span)
+  }
+
+  onToolExecutionEnd(event: unknown): void {
+    const run = this.run
+    if (!run) return
+    const ev = asRecord(event)
+    const toolCallId = typeof ev.toolCallId === "string" ? ev.toolCallId : undefined
+    const span = (toolCallId ? run.openTools.get(toolCallId) : undefined) ?? this.findLatestToolByName(run, ev.toolName)
+    if (!span) return
+
+    span.endMs = Date.now()
+    const isError = ev.isError === true
+    span.outcome = isError ? "error" : "ok"
+    span.errorMessage = isError ? "Tool execution failed" : undefined
+    span.attrs["tool.is_error"] = isError
+    span.attrs.success = isError ? "false" : "true"
+    const resultValue = attrValue(toolResultValue(ev.result))
+    span.attrs["gen_ai.tool.call.result:gated"] = resultValue
+    if (isError) {
+      span.attrs["error.type"] = "tool_error"
+      span.attrs["error.message:gated"] = resultValue
+    }
+    span.attrs["pi.tool.duration_ms"] = Math.max(0, span.endMs - span.startMs)
+
+    if (toolCallId) run.openTools.delete(toolCallId)
+    else this.deleteToolSpan(run, span)
+    run.closed.push(span)
+  }
+
+  onSessionCompact(event: unknown): void {
+    const run = this.run
+    if (!run) return
+    const ev = asRecord(event)
+    run.interaction.attrs["pi.session.compacted"] = true
+    run.interaction.attrs["pi.session.compaction.from_extension"] = ev.fromExtension === true
+  }
+
+  onAgentEnd(event: unknown, ctx: PiContext): BuildResult | undefined {
+    const run = this.run
+    if (!run) return undefined
+    const ev = asRecord(event)
+    const messages = Array.isArray(ev.messages) ? ev.messages : []
+    const outputMessages = normalizeMessages(messages).filter((message) => message.role === "assistant")
+    if (outputMessages.length > 0) run.interaction.attrs["gen_ai.output.messages:gated"] = outputMessages
+    if (messages.length > 0) run.interaction.attrs["pi.agent.messages:gated"] = normalizeMessages(messages)
+    run.interaction.attrs["pi.turns"] = run.turnNumber
+    run.interaction.attrs["pi.tool_calls"] = run.closed.filter(
+      (span) => span.attrs["span.type"] === "tool_execution",
+    ).length
+
+    this.closeAbandonedLlm(run)
+    this.closeAbandonedTools(run)
+
+    run.interaction.endMs = Date.now()
+    run.interaction.outcome = "ok"
+    Object.assign(
+      run.interaction.attrs,
+      this.contextAttrs(ctx, { id: run.sessionId, file: run.sessionFile, cwd: run.cwd }),
+    )
+
+    const result = { traceId: run.traceId, spans: [run.interaction, ...run.closed] }
+    this.run = undefined
+    return result
+  }
+
+  private ensureRun(ctx: PiContext): RunState {
+    if (this.run) return this.run
+    this.onBeforeAgentStart({ prompt: "" }, ctx)
+    if (!this.run) throw new Error("Latitude pi telemetry failed to create a run")
+    return this.run
+  }
+
+  private finalizeLlm(run: RunState, message: Record<string, unknown>, fallbackEndMs: number): void {
+    const span = run.activeLlm
+    if (!span) return
+    span.endMs = typeof message.timestamp === "number" ? message.timestamp : fallbackEndMs
+    const normalized = normalizeMessage(message)
+    if (normalized) span.attrs["gen_ai.output.messages:gated"] = [normalized]
+
+    const provider = typeof message.provider === "string" ? message.provider : undefined
+    const model = typeof message.model === "string" ? message.model : undefined
+    if (provider) {
+      span.attrs["gen_ai.provider.name"] = provider
+      span.attrs["gen_ai.system"] = provider
+    }
+    if (model) {
+      span.attrs.model = model
+      if (span.attrs["gen_ai.request.model"] === undefined) span.attrs["gen_ai.request.model"] = model
+      span.attrs["gen_ai.response.model"] = model
+    }
+
+    const usage = asRecord(message.usage)
+    const input = numberValue(usage.input)
+    const output = numberValue(usage.output)
+    const cacheRead = numberValue(usage.cacheRead)
+    const cacheWrite = numberValue(usage.cacheWrite)
+    const total = numberValue(usage.totalTokens)
+    if (input !== undefined) {
+      span.attrs.input_tokens = input
+      span.attrs["gen_ai.usage.input_tokens"] = input
+    }
+    if (output !== undefined) {
+      span.attrs.output_tokens = output
+      span.attrs["gen_ai.usage.output_tokens"] = output
+    }
+    if (cacheRead !== undefined) {
+      span.attrs.cache_read_tokens = cacheRead
+      span.attrs["gen_ai.usage.cache_read.input_tokens"] = cacheRead
+    }
+    if (cacheWrite !== undefined) {
+      span.attrs.cache_creation_tokens = cacheWrite
+      span.attrs["gen_ai.usage.cache_creation.input_tokens"] = cacheWrite
+    }
+    if (total !== undefined) span.attrs["gen_ai.usage.total_tokens"] = total
+
+    const stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined
+    if (stopReason) span.attrs["gen_ai.response.finish_reasons"] = [stopReason]
+    if (stopReason === "error" || stopReason === "aborted") {
+      span.outcome = "error"
+      span.errorMessage = typeof message.errorMessage === "string" ? message.errorMessage : stopReason
+      span.attrs["error.type"] = stopReason
+      span.attrs["error.message:gated"] = span.errorMessage
+    } else {
+      span.outcome = "ok"
+    }
+
+    span.attrs["llm_request.duration_ms"] = Math.max(0, span.endMs - span.startMs)
+    run.closed.push(span)
+    run.activeLlm = undefined
+  }
+
+  private closeAbandonedLlm(run: RunState): void {
+    const span = run.activeLlm
+    if (!span) return
+    span.endMs = Date.now()
+    span.outcome = "error"
+    span.errorMessage = "llm_request abandoned before assistant message_end"
+    span.attrs["error.type"] = "abandoned"
+    span.attrs["error.message"] = span.errorMessage
+    run.closed.push(span)
+    run.activeLlm = undefined
+  }
+
+  private closeAbandonedTools(run: RunState): void {
+    for (const [id, span] of run.openTools) {
+      span.endMs = Date.now()
+      span.outcome = "error"
+      span.errorMessage = "tool_execution abandoned before tool_execution_end"
+      span.attrs["error.type"] = "abandoned"
+      span.attrs["error.message"] = span.errorMessage
+      span.attrs["tool.is_error"] = true
+      run.closed.push(span)
+      run.openTools.delete(id)
+    }
+  }
+
+  private findLatestToolByName(run: RunState, rawToolName: unknown): SpanRecord | undefined {
+    const toolName = typeof rawToolName === "string" ? rawToolName : undefined
+    const entries = Array.from(run.openTools.values())
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const span = entries[i]
+      if (!span) continue
+      if (!toolName || span.attrs["gen_ai.tool.name"] === toolName) return span
+    }
+    return undefined
+  }
+
+  private deleteToolSpan(run: RunState, span: SpanRecord): void {
+    for (const [id, candidate] of run.openTools) {
+      if (candidate === span) {
+        run.openTools.delete(id)
+        return
+      }
+    }
+  }
+
+  private contextAttrs(ctx: PiContext, session: { id: string; file: string; cwd: string }): Record<string, AttrValue> {
+    const metadata: Record<string, string> = {
+      ...this.config.metadata,
+      "pi.cwd": session.cwd,
+      "pi.session.id": session.id,
+    }
+    if (session.file) metadata["pi.session.file"] = session.file
+    const sessionName = ctx.sessionManager?.getSessionName?.()
+    if (sessionName) metadata["pi.session.name"] = sessionName
+
+    return {
+      "latitude.tags": this.config.tags,
+      "latitude.metadata": metadata,
+      "pi.cwd": session.cwd,
+      "pi.cwd.basename": basename(session.cwd),
+      "pi.session.file": session.file || undefined,
+      "pi.session.id": session.id,
+      "service.instance.id": session.id,
+    }
+  }
+}
+
+function sessionInfo(ctx: PiContext): { id: string; file: string; cwd: string } {
+  const cwd = ctx.cwd ?? process.cwd()
+  const file = ctx.sessionManager?.getSessionFile?.() ?? ""
+  const id = ctx.sessionManager?.getSessionId?.() ?? fileOrEphemeral(file)
+  return { id, file, cwd }
+}
+
+function fileOrEphemeral(file: string): string {
+  return file || `ephemeral:${randomUUID()}`
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {}
+}
+
+function attrValue(value: unknown): AttrValue {
+  if (value === undefined) return undefined
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value
+  if (Array.isArray(value)) return value
+  if (value && typeof value === "object") return value as Record<string, unknown>
+  return String(value)
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function copyIfString(
+  source: Record<string, unknown>,
+  from: string,
+  target: Record<string, AttrValue>,
+  to: string,
+): void {
+  if (typeof source[from] === "string") target[to] = source[from]
+}
+
+function copyIfNumber(
+  source: Record<string, unknown>,
+  from: string,
+  target: Record<string, AttrValue>,
+  to: string,
+): void {
+  if (typeof source[from] === "number") target[to] = source[from]
+}
+
+function copyIfBoolean(
+  source: Record<string, unknown>,
+  from: string,
+  target: Record<string, AttrValue>,
+  to: string,
+): void {
+  if (typeof source[from] === "boolean") target[to] = source[from]
+}
+
+function hashHex(input: string, length: number): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, length)
+}

--- a/packages/telemetry/pi/src/types.ts
+++ b/packages/telemetry/pi/src/types.ts
@@ -1,0 +1,122 @@
+// OTLP wire types. We hand-roll the small JSON subset Latitude needs instead
+// of depending on the OpenTelemetry SDK inside the pi extension runtime.
+
+export interface OtlpAnyValue {
+  stringValue?: string
+  intValue?: string
+  boolValue?: boolean
+  doubleValue?: number
+  arrayValue?: { values: OtlpAnyValue[] }
+}
+
+export interface OtlpKeyValue {
+  key: string
+  value: OtlpAnyValue
+}
+
+export interface OtlpSpan {
+  traceId: string
+  spanId: string
+  parentSpanId: string
+  name: string
+  kind: number
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  attributes: OtlpKeyValue[]
+  status: { code: number; message?: string | undefined }
+}
+
+export interface OtlpResourceSpans {
+  resource: { attributes: OtlpKeyValue[] }
+  scopeSpans: Array<{
+    scope: { name: string; version: string }
+    spans: OtlpSpan[]
+  }>
+}
+
+export interface OtlpExportRequest {
+  resourceSpans: OtlpResourceSpans[]
+}
+
+export interface MessagePart {
+  type: string
+  content?: string
+  id?: string
+  name?: string
+  arguments?: unknown
+  response?: unknown
+  modality?: string
+  uri?: string
+  [key: string]: unknown
+}
+
+export type MessageRole = "system" | "user" | "assistant" | "tool"
+
+export interface GenAIMessage {
+  role: MessageRole
+  parts: MessagePart[]
+}
+
+export type AttrValue = string | number | boolean | unknown[] | Record<string, unknown> | undefined
+
+export interface SpanRecord {
+  spanId: string
+  traceId: string
+  parentSpanId: string
+  name: string
+  startMs: number
+  endMs: number | undefined
+  attrs: Record<string, AttrValue>
+  outcome?: "ok" | "error" | undefined
+  errorMessage?: string | undefined
+}
+
+export interface BuildResult {
+  traceId: string
+  spans: SpanRecord[]
+}
+
+export interface PiExtensionAPI {
+  on(eventName: string, handler: (event: unknown, ctx: PiContext) => unknown | Promise<unknown>): void
+}
+
+export interface PiContext {
+  cwd?: string | undefined
+  hasUI?: boolean | undefined
+  ui?: {
+    notify?: (message: string, level?: "info" | "warning" | "error") => void
+    setStatus?: (key: string, value: string | undefined) => void
+    theme?: {
+      fg?: (name: string, value: string) => string
+    }
+  }
+  sessionManager?: {
+    getSessionId?: () => string
+    getSessionFile?: () => string | undefined
+    getSessionName?: () => string | undefined
+  }
+  model?: {
+    provider?: string
+    id?: string
+  }
+}
+
+export interface RuntimeConfig {
+  apiKey: string
+  project: string
+  baseUrl: string
+  enabled: boolean
+  debug: boolean
+  allowConversationAccess: boolean
+  tags: string[]
+  metadata: Record<string, string>
+  configSource: "env" | "file" | "none"
+}
+
+export interface UserIdentity {
+  userId: string
+  userName: string
+  fullName: string
+  email: string
+  hostName: string
+}

--- a/packages/telemetry/pi/src/version.ts
+++ b/packages/telemetry/pi/src/version.ts
@@ -1,0 +1,3 @@
+declare const __PACKAGE_VERSION__: string
+
+export const packageVersion = typeof __PACKAGE_VERSION__ === "string" ? __PACKAGE_VERSION__ : "0.0.0-dev"

--- a/packages/telemetry/pi/tsconfig.json
+++ b/packages/telemetry/pi/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "incremental": false,
+    "composite": false
+  }
+}

--- a/packages/telemetry/pi/tsdown.config.ts
+++ b/packages/telemetry/pi/tsdown.config.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "tsdown"
+
+const pkgJsonPath = fileURLToPath(new URL("./package.json", import.meta.url))
+const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { version: string }
+
+const define = {
+  __PACKAGE_VERSION__: JSON.stringify(pkg.version),
+}
+
+export default defineConfig([
+  {
+    entry: ["src/extension.ts"],
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    target: "node20",
+    fixedExtension: false,
+    define,
+  },
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "node20",
+    fixedExtension: false,
+    banner: { js: "#!/usr/bin/env node" },
+    define,
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2319,6 +2319,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/telemetry/pi:
+    dependencies:
+      '@clack/prompts':
+        specifier: 1.2.0
+        version: 1.2.0
+      picocolors:
+        specifier: 1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.4.6
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/telemetry/typescript:
     dependencies:
       '@opentelemetry/api':


### PR DESCRIPTION
Adds a first-party pi coding agent telemetry package, `@latitude-data/pi-telemetry`, so pi sessions can be sent to Latitude with the same trace reconstruction quality as the Claude Code and OpenClaw integrations.

The package includes a `latitude-pi` installer (`npx -y @latitude-data/pi-telemetry install`) that writes the pi package entry into `~/.pi/agent/settings.json` and stores Latitude config in `~/.pi/agent/latitude-telemetry.json` with `0600` permissions. It supports non-interactive installs, staging/dev/custom ingest URLs, env overrides, and `--no-content` structural-only telemetry.

The pi extension listens to pi lifecycle events and emits one OTLP trace per user prompt. Spans use Latitude's existing resolver contract:

- `interaction` root spans with `span.type=interaction`
- `llm_request` spans with `gen_ai.operation.name=chat`, model/provider metadata, token usage, and GenAI input/output messages
- `tool_call:<name>` spans with `gen_ai.operation.name=execute_tool`, full tool arguments, and tool results
- `latitude.captured.content` plus gated content attributes so `--no-content` keeps timing/model/tool structure while omitting prompts, responses, system prompts, and tool I/O

Docs now describe the first-party install path and the internal trace shape in `docs/telemetry/pi-coding-agent.md` and `dev-docs/pi-telemetry.md`.

Validation:

- `pnpm --filter @latitude-data/pi-telemetry check`
- `pnpm --filter @latitude-data/pi-telemetry typecheck`
- `pnpm --filter @latitude-data/pi-telemetry test`
- `pnpm --filter @latitude-data/pi-telemetry build`
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"`
- CLI dry-run install redacts the API key

Note: `pnpm knip` currently reports the existing `tsx` issue in `packages/platform/slack/package.json`; no pi telemetry files are reported after removing unused exported types.
