### PR TITLE
fix(clickhouse): reorder 00016 ALTER to avoid AFTER duration_ns

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -26,6 +26,21 @@
 -- under staging load either. A single ALTER has no inter-ALTER
 -- race, so no SYSTEM SYNC REPLICA is needed.
 --
+-- Why we never write `AFTER duration_ns`: the original
+-- duration_ns (from 00007) is an ALIAS column. ALIAS columns
+-- have no storage position, so CH refuses to resolve them as
+-- AFTER targets — even when the same ALTER drops the alias and
+-- re-adds duration_ns as a stored column (some CH versions
+-- validate AFTER against the table's pre-ALTER metadata for
+-- columns that existed before the statement). Instead, we add
+-- duration_ns LAST among the four new columns that cluster
+-- after max_start_time, with `AFTER max_start_time`. That
+-- slots it into the slot right after max_start_time and shifts
+-- time_of_first_token / time_to_first_token_ns down by one, so
+-- the final column order matches the intended layout:
+--   max_end_time, max_start_time, duration_ns,
+--   time_of_first_token, time_to_first_token_ns, ...
+--
 -- Retry safety: every sub-action uses IF EXISTS / IF NOT EXISTS,
 -- so re-running after a partial application is a no-op on
 -- already-applied changes.
@@ -35,15 +50,15 @@ ALTER TABLE sessions ON CLUSTER default
     DROP COLUMN IF EXISTS duration_ns,
     ADD COLUMN IF NOT EXISTS max_start_time
         SimpleAggregateFunction(max, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER max_end_time,
-    ADD COLUMN IF NOT EXISTS duration_ns
-        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS time_of_first_token
-        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER duration_ns,
+        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS time_to_first_token_ns Int64 ALIAS if(
         time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'),
         reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
         0
     ) AFTER time_of_first_token,
+    ADD COLUMN IF NOT EXISTS duration_ns
+        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS root_span_id
         AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,
     ADD COLUMN IF NOT EXISTS root_span_name

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
@@ -37,19 +37,31 @@
 --     (CH doesn't allow MODIFY COLUMN to change a column's kind),
 --   - ADD COLUMN duration_ns re-adds it as a SimpleAggregateFunction,
 --   - MODIFY TTL references retention_days from the same ALTER.
+--
+-- Why we never write `AFTER duration_ns`: the original duration_ns
+-- (from 00007) is an ALIAS column, and ALIAS columns have no
+-- storage position, so CH refuses to resolve them as AFTER targets
+-- — even when this same ALTER drops the alias and re-adds it as a
+-- stored column (some CH versions validate AFTER against pre-ALTER
+-- metadata). Instead, we add duration_ns LAST among the four new
+-- columns that cluster after max_start_time, with `AFTER
+-- max_start_time`. That inserts it right after max_start_time and
+-- shifts time_of_first_token / time_to_first_token_ns down, giving
+-- the intended final order: max_end_time, max_start_time,
+-- duration_ns, time_of_first_token, time_to_first_token_ns, ...
 ALTER TABLE sessions
     DROP COLUMN IF EXISTS duration_ns,
     ADD COLUMN IF NOT EXISTS max_start_time
         SimpleAggregateFunction(max, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER max_end_time,
-    ADD COLUMN IF NOT EXISTS duration_ns
-        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS time_of_first_token
-        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER duration_ns,
+        SimpleAggregateFunction(min, DateTime64(9, 'UTC')) CODEC(Delta(8), ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS time_to_first_token_ns Int64 ALIAS if(
         time_of_first_token < toDateTime64('2261-01-01', 9, 'UTC'),
         reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
         0
     ) AFTER time_of_first_token,
+    ADD COLUMN IF NOT EXISTS duration_ns
+        SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS root_span_id
         AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,
     ADD COLUMN IF NOT EXISTS root_span_name


### PR DESCRIPTION
## Summary

- Reorder the folded ALTER in `00016_session_parity.sql` so `duration_ns` is added LAST among the four columns clustered after `max_start_time`, eliminating the only `AFTER duration_ns` reference in the statement.
- Unblocks the prod deploy that has been failing today with `code: 16, message: Wrong column name. Cannot find column duration_ns to insert after`.
- Final column order, single-ALTER structure, and idempotency are preserved.

## Root cause

The folded ALTER from #3233 drops `duration_ns` (the `Int64 ALIAS` from `00007_sessions.sql`) and re-adds it as `SimpleAggregateFunction(sum, Int64)` in the same statement, while another sub-action — `ADD time_of_first_token … AFTER duration_ns` — references that name as an insertion target.

That worked on **staging** because that ClickHouse Cloud project is a single replica: ALTER sub-actions are applied in declared order against a rolling in-memory schema, so by the time the validator checks `AFTER duration_ns` the column has been re-added as a stored SAF and the lookup resolves.

It does **not** work on **production**, which is a 4-replica ClickHouse Cloud project. ON CLUSTER ALTERs there are queued through Keeper and validated upfront by the distributed DDL worker on each replica, against the pre-ALTER metadata snapshot. In that snapshot:

- `duration_ns` is still the ALIAS from `00007`.
- ALIAS columns have no storage position, so they cannot be used as `AFTER` targets.
- The same-ALTER `DROP duration_ns` + `ADD duration_ns` makes the name ambiguous to the validator (which entry should `AFTER duration_ns` resolve against?).
- Validation fails with code 16 before any sub-action is applied. The whole ALTER rolls back atomically and CI fails.

Confirmed by direct inspection of both Cloud projects:

- Same CH version on both: `26.2.1.345`.
- Staging `SELECT * FROM system.clusters WHERE cluster = 'default'` returns 1 row; prod returns 4 (1 shard × 4 replicas).
- Prod `sessions` is clean — `duration_ns` is still `Int64 ALIAS` at the original position, none of the new columns are present, so atomic rollback held and the retry runs on a known-good state.

This is a ClickHouse Cloud topology asymmetry we should keep in mind for future migrations: anything verified only on the 1-replica staging project may slip past upfront DDL validation that the 4-replica prod project enforces. The two specific patterns to avoid going forward:

1. Using a column as an `AFTER` target when it is **also being DROPped** in the same ALTER (ambiguous to the multi-replica validator, even if re-added later in the statement).
2. Using an **ALIAS** column as an `AFTER` target (no storage position).

## Fix

Reorder the sub-actions inside the single ALTER:

```sql
DROP COLUMN IF EXISTS duration_ns,
ADD max_start_time           AFTER max_end_time,
ADD time_of_first_token      AFTER max_start_time,        -- was: AFTER duration_ns
ADD time_to_first_token_ns   AFTER time_of_first_token,   -- ALIAS, unchanged
ADD duration_ns              AFTER max_start_time,        -- moved to LAST of the group
...
```

`duration_ns` is now added *after* the columns that should logically follow it, with `AFTER max_start_time`. Because `AFTER X` inserts the new column immediately after X, this lands `duration_ns` between `max_start_time` and `time_of_first_token`, shifting `time_of_first_token` and `time_to_first_token_ns` down by one — exactly the final order intended by #3233:

```
…, max_end_time, max_start_time, duration_ns, time_of_first_token, time_to_first_token_ns, …
```

What's preserved:

- Still a single ALTER → no inter-statement 517 race (the issue #3233 was solving).
- Still idempotent via `IF EXISTS` / `IF NOT EXISTS` → safe to retry after any failure.
- Down migration untouched (it only uses `AFTER max_end_time`, which is the original 00007 stored column).
- No `AFTER` clause now references any column being DROPped in the same ALTER.

Same change applied to both `clustered/` and `unclustered/` variants, with a comment block documenting the constraint so future edits don't regress.

## Test plan

- [ ] Prod CI deploy completes the ClickHouse migration step (`ch:up` finishes `00016_session_parity.sql` without `code: 16`).
- [ ] After deploy, on the prod CH project: `SELECT name, type, default_kind, position FROM system.columns WHERE database = currentDatabase() AND table = 'sessions' ORDER BY position` shows `duration_ns` as `SimpleAggregateFunction(sum, Int64)` immediately after `max_start_time`, with `time_of_first_token`, `time_to_first_token_ns` (ALIAS), and the other new columns present.
- [ ] `sessions_mv` materialized view recreated: `SELECT name FROM system.tables WHERE name = 'sessions_mv'`.
- [ ] `goose_db_version` records `version_id = 16` as applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)