### PR TITLE
Fix Pi telemetry interactive run cleanup

### DIFF
--- a/packages/telemetry/pi/CHANGELOG.md
+++ b/packages/telemetry/pi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2026-05-21
+
+### Fixed
+
+- Telemetry export no longer blocks Pi's agent lifecycle at the end of a run. Trace uploads are dispatched asynchronously after span construction so the TUI can leave the working/loading state immediately.
+- Failed telemetry uploads are now silent unless debug logging is enabled, avoiding direct stderr writes that can disturb Pi's interactive terminal layout.
+
 ## [0.0.1] - 2026-05-21
 
 ### Added

--- a/packages/telemetry/pi/package.json
+++ b/packages/telemetry/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/pi-telemetry",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pi coding agent extension that streams sessions to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/pi/src/extension.ts
+++ b/packages/telemetry/pi/src/extension.ts
@@ -88,12 +88,19 @@ export default function latitudePiTelemetry(pi: PiExtensionAPI): void {
       allowConversationAccess: config.allowConversationAccess,
       identity,
     })
-    await postTraces({
+
+    const exportPromise = postTraces({
       baseUrl: config.baseUrl,
       apiKey: config.apiKey,
       project: config.project,
       payload,
       logger,
     })
+
+    if (ctx.hasUI) {
+      void exportPromise
+    } else {
+      await exportPromise
+    }
   })
 }

--- a/packages/telemetry/pi/src/logger.ts
+++ b/packages/telemetry/pi/src/logger.ts
@@ -9,7 +9,7 @@ export function createLogger(debugEnabled: boolean): Logger {
       if (debugEnabled) process.stderr.write(`[latitude-pi] ${message}\n`)
     },
     warn(message) {
-      process.stderr.write(`[latitude-pi] ${message}\n`)
+      if (debugEnabled) process.stderr.write(`[latitude-pi] ${message}\n`)
     },
   }
 }


### PR DESCRIPTION
Fixes the Pi telemetry extension leaving interactive runs in a stuck working/loading state after the assistant response completes. Interactive sessions now build the OTLP payload synchronously but dispatch the upload without awaiting it, so Pi can return to idle immediately. Non-interactive sessions still await export so print-mode runs do not exit before telemetry is sent.

Failed upload logs are debug-only to avoid writing directly to stderr during TUI rendering.

Bumps `@latitude-data/pi-telemetry` to `0.0.2` and adds the matching changelog entry so the existing package publish workflow releases the fix.

Validated with:
- `pnpm --filter @latitude-data/pi-telemetry check`
- `pnpm --filter @latitude-data/pi-telemetry typecheck`
- `pnpm --filter @latitude-data/pi-telemetry test`