### PR TITLE
fix(core): reject merge when two documentUuids would share the same path

### DIFF
--- a/packages/core/src/services/commits/merge.test.ts
+++ b/packages/core/src/services/commits/merge.test.ts
@@ -404,6 +404,81 @@ describe('mergeCommit', () => {
       })
     })
 
+    it('rejects merge when two drafts add a document at the same path', async (ctx) => {
+      const { project, workspace, user, providers } =
+        await ctx.factories.createProject()
+
+      const { commit: draftA } = await ctx.factories.createDraft({
+        project,
+        user,
+      })
+      await createNewDocument({
+        user,
+        workspace,
+        commit: draftA,
+        path: 'shared/path',
+        content: ctx.factories.helpers.createPrompt({
+          provider: providers[0]!,
+          content: 'from-A',
+        }),
+      })
+      await mergeCommit(draftA).then((r) => r.unwrap())
+
+      const { commit: draftB } = await ctx.factories.createDraft({
+        project,
+        user,
+      })
+      await createNewDocument({
+        user,
+        workspace,
+        commit: draftB,
+        path: 'shared/path',
+        content: ctx.factories.helpers.createPrompt({
+          provider: providers[0]!,
+          content: 'from-B',
+        }),
+      })
+
+      const result = await mergeCommit(draftB)
+      expect(result.ok).toBe(false)
+      expect((result.error as Error).message).toContain('shared/path')
+      expect((result.error as Error).message).toContain(
+        'more than one active document',
+      )
+    })
+
+    it('allows merge when a draft deletes the existing document and adds a new one at the same path', async (ctx) => {
+      const { project, user, workspace, documents, providers } =
+        await ctx.factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            recycle: ctx.factories.helpers.createPrompt({ provider: 'openai' }),
+          },
+        })
+
+      const { commit } = await ctx.factories.createDraft({ project, user })
+
+      await destroyDocument({
+        document: documents.find((d) => d.path === 'recycle')!,
+        commit,
+        workspace,
+      })
+
+      await createNewDocument({
+        user,
+        workspace,
+        commit,
+        path: 'recycle',
+        content: ctx.factories.helpers.createPrompt({
+          provider: providers[0]!,
+          content: 'replacement',
+        }),
+      })
+
+      const result = await mergeCommit(commit)
+      expect(result.ok).toBe(true)
+    })
+
     it('publishes commitMerged event alongside commitPublished', async (ctx) => {
       const { project, workspace, user, providers } =
         await ctx.factories.createProject()

--- a/packages/core/src/services/commits/merge.ts
+++ b/packages/core/src/services/commits/merge.ts
@@ -31,6 +31,58 @@ type ValidationResult = {
   headDocuments: DocumentVersion[]
 }
 
+/**
+ * Projects the post-merge active state of the project's documents and rejects
+ * the merge when two distinct documentUuids would share the same path.
+ *
+ * Without this check, two drafts that each add a new document at the same path
+ * can both merge independently (the `(path, commit_id, deleted_at)` unique
+ * constraint only enforces uniqueness within a single commit), leaving LIVE
+ * with two active rows at the same path. Path-based lookups then become
+ * non-deterministic.
+ */
+function detectDuplicatePathConflicts({
+  headDocuments,
+  changedDocuments,
+  commitId,
+}: {
+  headDocuments: DocumentVersion[]
+  changedDocuments: DocumentVersion[]
+  commitId: number
+}) {
+  const changedUuids = new Set(changedDocuments.map((d) => d.documentUuid))
+  const projectedDocuments = [
+    ...headDocuments.filter((d) => !changedUuids.has(d.documentUuid)),
+    ...changedDocuments,
+  ]
+
+  const pathToUuids = new Map<string, Set<string>>()
+  for (const doc of projectedDocuments) {
+    if (doc.deletedAt) continue
+    const existing = pathToUuids.get(doc.path) ?? new Set<string>()
+    existing.add(doc.documentUuid)
+    pathToUuids.set(doc.path, existing)
+  }
+
+  const conflictingPaths = [...pathToUuids.entries()]
+    .filter(([, uuids]) => uuids.size > 1)
+    .map(([path]) => path)
+
+  if (conflictingPaths.length === 0) return Result.nil()
+
+  const message = `Cannot publish: the following paths would have more than one active document after merging: ${conflictingPaths
+    .map((p) => `'${p}'`)
+    .join(
+      ', ',
+    )}. Please rename or delete the conflicting documents before publishing.`
+
+  return Result.error(
+    new UnprocessableEntityError(message, {
+      [commitId]: [message],
+    }),
+  )
+}
+
 export async function mergeCommit(
   commit: Commit,
   transaction = new Transaction(),
@@ -83,6 +135,13 @@ export async function mergeCommit(
           ),
         )
       }
+
+      const pathConflictResult = detectDuplicatePathConflicts({
+        headDocuments,
+        changedDocuments,
+        commitId: commit.id,
+      })
+      if (!Result.isOk(pathConflictResult)) return pathConflictResult
 
       const evaluationsScope = new EvaluationsV2Repository(workspace.id, tx)
       const evaluationChangesResult =


### PR DESCRIPTION
## Summary

- Adds a path-conflict check to `mergeCommit` (Phase 1, after `recomputeChanges`) that projects the post-merge active state of the project's documents and rejects the merge if any path would end up with more than one active `documentUuid`.

## Background

Several customers have hit a bug where a prompt becomes silently duplicated in LIVE, and subsequent calls to `POST /api/v3/projects/X/versions/Y/documents/run` return `404 NotFoundError: No document with path …`. The root cause is in the merge path, not the read path that #3171 / #3173 fixed:

- Drafts are created from the current LIVE head and only contain deltas — documents themselves are not copied.
- A document added in a draft gets a freshly-generated `documentUuid`.
- The unique constraint `(path, commit_id, deleted_at)` only enforces uniqueness within a single commit.
- `recomputeChanges` and `getMergedAndDraftDocuments` compare draft vs head **by `documentUuid`**, not by path.
- `mergeCommit` has no cross-commit path-conflict check.

So if Draft A and Draft B are both branched from the same LIVE and each add `/foo` with different UUIDs, both merges succeed independently and LIVE ends up with two active rows at `/foo`. Path-based lookups then become order-dependent and can 404 when one of the duplicates has been renamed/deleted in a later commit.

## Fix

In `mergeCommit`'s validation phase, build the projected post-merge document set from `headDocuments` (minus any UUID the draft overrides) plus `changedDocuments`, then group active rows (`deletedAt IS NULL`) by `path`. If any path resolves to more than one UUID, return `UnprocessableEntityError` listing the conflicting paths so the user can rename/delete before publishing.

The existing in-draft check in `updateDocumentUnsafe` still catches conflicts within a single draft; this new check is the cross-draft backstop.

## Test plan

- [x] `packages/core` unit tests: `pnpm test src/services/commits/merge.test.ts` (15 tests pass, including 2 new ones)
- [x] Wider regression sweep: `pnpm test src/repositories/documentVersionsRepository/ src/services/commits/ src/services/documents/recomputeChanges/` (140 tests pass)
- [x] `pnpm tc` clean
- [x] `pnpm --filter @latitude-data/core lint` clean (no new warnings/errors)
- [ ] Manual: create two drafts from the same LIVE that each add the same path; verify the second merge fails with a helpful message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)