### PR TITLE
fix(clickhouse): drop IF NOT EXISTS on 00016 duration_ns re-add

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00016_session_parity.sql
@@ -41,9 +41,24 @@
 --   max_end_time, max_start_time, duration_ns,
 --   time_of_first_token, time_to_first_token_ns, ...
 --
--- Retry safety: every sub-action uses IF EXISTS / IF NOT EXISTS,
--- so re-running after a partial application is a no-op on
--- already-applied changes.
+-- Why duration_ns is the one sub-action without `IF NOT EXISTS`:
+-- on multi-replica CH Cloud the distributed DDL validator
+-- evaluates IF NOT EXISTS qualifiers against the *pre-ALTER*
+-- metadata snapshot, not the rolling working schema. Since
+-- duration_ns existed pre-ALTER (as the 00007 alias), an
+-- `ADD COLUMN IF NOT EXISTS duration_ns` next to a same-ALTER
+-- `DROP COLUMN duration_ns` was silently skipped — the alias
+-- got dropped and the SAF was never added, leaving sessions
+-- without a duration_ns column and breaking the sessions_mv
+-- CREATE that follows. The plain `ADD COLUMN duration_ns`
+-- (no IF qualifier) is kept by the validator and applied
+-- against the rolling schema, where the DROP has already
+-- removed the alias. Retry-safe because the leading DROP IF
+-- EXISTS guarantees the column is absent before the ADD runs.
+--
+-- Retry safety: every other sub-action uses IF EXISTS / IF NOT
+-- EXISTS, so re-running after a partial application is a no-op
+-- on already-applied changes.
 -- ═══════════════════════════════════════════════════════════
 
 ALTER TABLE sessions ON CLUSTER default
@@ -57,7 +72,7 @@ ALTER TABLE sessions ON CLUSTER default
         reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
         0
     ) AFTER time_of_first_token,
-    ADD COLUMN IF NOT EXISTS duration_ns
+    ADD COLUMN duration_ns
         SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS root_span_id
         AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql
@@ -49,6 +49,17 @@
 -- shifts time_of_first_token / time_to_first_token_ns down, giving
 -- the intended final order: max_end_time, max_start_time,
 -- duration_ns, time_of_first_token, time_to_first_token_ns, ...
+--
+-- Why duration_ns is the one sub-action without `IF NOT EXISTS`:
+-- on multi-replica CH Cloud the distributed DDL validator
+-- evaluates IF NOT EXISTS against the pre-ALTER metadata snapshot,
+-- not the rolling schema. Since duration_ns existed pre-ALTER (as
+-- the alias), `ADD COLUMN IF NOT EXISTS duration_ns` was silently
+-- skipped next to the same-ALTER `DROP COLUMN duration_ns` —
+-- alias dropped, SAF never added. Plain `ADD COLUMN duration_ns`
+-- (no IF qualifier) is kept and applied against the rolling
+-- schema after the DROP. Retry-safe because the leading DROP IF
+-- EXISTS guarantees the column is absent before the ADD runs.
 ALTER TABLE sessions
     DROP COLUMN IF EXISTS duration_ns,
     ADD COLUMN IF NOT EXISTS max_start_time
@@ -60,7 +71,7 @@ ALTER TABLE sessions
         reinterpretAsInt64(time_of_first_token) - reinterpretAsInt64(min_start_time),
         0
     ) AFTER time_of_first_token,
-    ADD COLUMN IF NOT EXISTS duration_ns
+    ADD COLUMN duration_ns
         SimpleAggregateFunction(sum, Int64) DEFAULT 0 CODEC(T64, ZSTD(1)) AFTER max_start_time,
     ADD COLUMN IF NOT EXISTS root_span_id
         AggregateFunction(argMinIf, FixedString(16), DateTime64(9, 'UTC'), UInt8) CODEC(ZSTD(1)) AFTER simulation_id,


### PR DESCRIPTION
## Summary

- Remove `IF NOT EXISTS` from the `duration_ns` ADD inside the single `00016` ALTER. The leading `DROP COLUMN IF EXISTS duration_ns` already guarantees the column is absent before the ADD runs, so the qualifier was redundant — and it was actively breaking the migration on prod's multi-replica cluster.
- Unblocks the prod CI deploy that's now failing one step later, on `CREATE MATERIALIZED VIEW sessions_mv`.

## What CI surfaced

The error visible in CI was on the MV creation:

```
ERROR 00016_session_parity.sql: failed to run SQL migration:
failed to execute SQL query "CREATE MATERIALIZED VIEW IF NOT EXISTS sessions_mv TO sessions
AS SELECT ..."
```

That's a downstream symptom. The MV's SELECT emits a `duration_ns` column — but on prod's `sessions` table there is no `duration_ns` column to write into:

```sql
SHOW CREATE TABLE sessions; -- duration_ns is absent;
                            -- max_start_time, time_of_first_token,
                            -- time_to_first_token_ns are all present
```

So the MV creation failed because the destination column the previous migration was supposed to add never materialized.

## Root cause: pre-ALTER snapshot validation of `IF NOT EXISTS`

The earlier PR (#3242) folded everything into one ALTER and reordered the sub-actions to avoid `AFTER duration_ns`. That unblocked the original `code: 16` failure on the ALTER. But the retry then exposed a second multi-replica behavior:

On 4-replica ClickHouse Cloud, the distributed DDL validator evaluates `IF NOT EXISTS` qualifiers against the **pre-ALTER metadata snapshot**, *not* the rolling working schema. Since `duration_ns` existed pre-ALTER (as the `00007` `Int64 ALIAS`), the validator saw the column already present and silently dropped `ADD COLUMN IF NOT EXISTS duration_ns` from the kept sub-action list — even though the same ALTER's earlier `DROP COLUMN duration_ns` would have removed it by the time the ADD actually ran.

Net result on prod:

- `DROP duration_ns` (alias) → applied.
- `ADD COLUMN IF NOT EXISTS duration_ns` (SAF) → **skipped**.
- Every other `ADD COLUMN IF NOT EXISTS …` → applied (those columns didn't exist pre-ALTER, so the qualifier kept them).
- `MODIFY TTL` → applied.
- `DROP VIEW sessions_mv` → applied.
- `CREATE MATERIALIZED VIEW sessions_mv` → failed because `duration_ns` is missing on the destination.

Single-replica staging didn't reproduce this because it evaluates the qualifier against the rolling working schema (where the leading DROP has already removed `duration_ns` before the ADD is checked), so the ADD survives and applies.

This is the same family of asymmetry we saw in #3242 — multi-replica validates against pre-ALTER metadata while single-replica validates against the rolling schema. There the asymmetry hit `AFTER` resolution; here it hits `IF NOT EXISTS` evaluation. Pattern to remember for future migrations: **a DROP+ADD of the same column name inside one ALTER cannot rely on `IF NOT EXISTS` for the ADD half on a multi-replica cluster**.

## Fix

Write the `duration_ns` re-add as a plain `ADD COLUMN` (no `IF NOT EXISTS`):

```sql
ALTER TABLE sessions ON CLUSTER default
    DROP COLUMN IF EXISTS duration_ns,
    ADD COLUMN IF NOT EXISTS max_start_time         ...,
    ADD COLUMN IF NOT EXISTS time_of_first_token    ...,
    ADD COLUMN IF NOT EXISTS time_to_first_token_ns ... ALIAS ...,
    ADD COLUMN              duration_ns             ... AFTER max_start_time,   -- no IF qualifier
    ADD COLUMN IF NOT EXISTS root_span_id           ...,
    ...
```

Without the qualifier the validator does not pre-skip the sub-action. It then applies against the rolling schema, where the leading `DROP COLUMN IF EXISTS duration_ns` has already removed the alias — so the ADD succeeds. Retry safety is preserved by the leading DROP: the column is guaranteed absent the moment the ADD runs, on a fresh schema *or* on the half-migrated prod state.

Same change in `clustered/` and `unclustered/`, with an extra comment block in both explaining why `duration_ns` is the single sub-action without `IF NOT EXISTS`.

## Behaviour on the current half-migrated prod state

Prod is at goose `version_id = 15` (the failed 00016 was never marked applied). Re-running `00016_session_parity.sql` end-to-end:

| sub-action | effect on retry |
| --- | --- |
| `DROP COLUMN IF EXISTS duration_ns` | no-op (already absent) |
| `ADD COLUMN IF NOT EXISTS max_start_time / time_of_first_token / time_to_first_token_ns / root_span_id / root_span_name / input_messages / last_input_messages / output_messages / system_instructions / retention_days` | each skipped — the columns are already present from the previous partial run |
| `ADD COLUMN duration_ns ...` | **kept and applied** — adds the SAF in the intended slot |
| `MODIFY TTL ...` | no-op (TTL already at the target expression) |
| `DROP VIEW IF EXISTS sessions_mv` | no-op (already dropped) |
| `CREATE MATERIALIZED VIEW sessions_mv ...` | succeeds — destination now has `duration_ns` |

No need to manually patch prod beforehand. The migration is idempotent against both fresh and half-migrated states.

## Operational note

`sessions_mv` is currently absent on prod, so new spans are not being aggregated into `sessions` until this PR ships. Existing rows are untouched. The dropped pre-migration `duration_ns` was an `ALIAS` (a computed expression on `max_end_time`, not stored data) — no on-disk data was lost.

## Test plan

- [ ] CI prod deploy completes the ClickHouse migration step end-to-end (no `code: 16`, no MV creation error).
- [ ] On prod, after deploy:
  ```sql
  SELECT
    (SELECT count() FROM system.columns
     WHERE database=currentDatabase() AND table='sessions' AND name='duration_ns') AS duration_ns_present,
    (SELECT count() FROM system.tables
     WHERE database=currentDatabase() AND name='sessions_mv')                       AS mv_present,
    (SELECT max(version_id) FROM latitude.goose_db_version
     WHERE is_applied = 1)                                                          AS goose_version;
  ```
  expects `(1, 1, 16)`.
- [ ] `SHOW CREATE TABLE sessions FORMAT Vertical` shows `duration_ns SimpleAggregateFunction(sum, Int64) DEFAULT 0` immediately after `max_start_time`, and `time_of_first_token` / `time_to_first_token_ns` in their intended positions after `duration_ns`.
- [ ] After traffic resumes, confirm `sessions` rows are advancing — e.g. `SELECT max(min_start_time) FROM sessions` increasing over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)