### PR TITLE
Fix Posthog emails sending as IDs

### DIFF
--- a/packages/platform/analytics-posthog/src/payload-mapping.test.ts
+++ b/packages/platform/analytics-posthog/src/payload-mapping.test.ts
@@ -60,6 +60,29 @@ describe("mapEventToPostHog", () => {
     expect(mapped?.distinctId).toBe("user-new")
   })
 
+  it("sets $set.email on the person profile for UserSignedUp", () => {
+    const mapped = mapEventToPostHog({
+      eventName: "UserSignedUp",
+      organizationId: "system",
+      payload: { userId: "user-new", email: "foo@bar.com" },
+      occurredAt,
+    })
+
+    expect(mapped?.properties?.$set).toEqual({ email: "foo@bar.com" })
+  })
+
+  it("does NOT set $set.email for MemberInvited (email belongs to invitee, not actor)", () => {
+    const mapped = mapEventToPostHog({
+      eventName: "MemberInvited",
+      organizationId: "org-1",
+      payload: { organizationId: "org-1", actorUserId: "actor-1", email: "invited@bar.com", role: "member" },
+      occurredAt,
+    })
+
+    expect(mapped?.distinctId).toBe("actor-1")
+    expect(mapped?.properties?.$set).toBeUndefined()
+  })
+
   it("maps ProjectCreated", () => {
     const mapped = mapEventToPostHog({
       eventName: "ProjectCreated",

--- a/packages/platform/analytics-posthog/src/payload-mapping.test.ts
+++ b/packages/platform/analytics-posthog/src/payload-mapping.test.ts
@@ -71,6 +71,18 @@ describe("mapEventToPostHog", () => {
     expect(mapped?.properties?.$set).toEqual({ email: "foo@bar.com" })
   })
 
+  it("does NOT set $set.email for org pseudo-id events even if email appears in payload", () => {
+    const mapped = mapEventToPostHog({
+      eventName: "FirstTraceReceived",
+      organizationId: "org-1",
+      payload: { organizationId: "org-1", projectId: "p-1", traceId: "t-1", email: "leaked@bar.com" },
+      occurredAt,
+    })
+
+    expect(mapped?.distinctId).toBe("org_org-1")
+    expect(mapped?.properties?.$set).toBeUndefined()
+  })
+
   it("does NOT set $set.email for MemberInvited (email belongs to invitee, not actor)", () => {
     const mapped = mapEventToPostHog({
       eventName: "MemberInvited",

--- a/packages/platform/analytics-posthog/src/payload-mapping.ts
+++ b/packages/platform/analytics-posthog/src/payload-mapping.ts
@@ -55,6 +55,23 @@ const resolveDistinctId = (input: TrackedEventInput): string => {
 export const orgDistinctId = (organizationId: string): string => `org_${organizationId}`
 
 /**
+ * When the distinctId is a real user (userId, not actorUserId) and the payload
+ * carries that user's email, set it as a PostHog person property so the person
+ * is immediately identifiable by email — without waiting for the frontend
+ * posthog.identify() call that only fires when the user loads the web app.
+ *
+ * We only do this when `actorUserId` is absent, because events that carry
+ * `actorUserId` (e.g. MemberInvited) may also have an `email` field that
+ * belongs to a *different* person (the invitee), not the actor.
+ */
+const getPersonEmailSet = (input: TrackedEventInput): Record<string, unknown> => {
+  if (typeof input.payload.actorUserId === "string" && input.payload.actorUserId.length > 0) return {}
+  const email = input.payload.email
+  if (typeof email !== "string" || email.length === 0) return {}
+  return { $set: { email } }
+}
+
+/**
  * Maps a tracked domain event to the PostHog capture shape.
  * Returns `null` when the event is not in the whitelist so the worker can skip
  * safely even if the upstream filter regresses.
@@ -74,6 +91,7 @@ export const mapEventToPostHog = (input: TrackedEventInput): PostHogCaptureInput
       // so PostHog doesn't create phantom person records for org pseudo-ids.
       // Also up to 4x cheaper per PostHog's pricing model.
       ...(!hasUserContext(input) ? { $process_person_profile: false } : {}),
+      ...getPersonEmailSet(input),
     },
     groups: { [POSTHOG_ORGANIZATION_GROUP]: input.organizationId },
     // CRITICAL: pass occurredAt through as `timestamp` so queue delays or

--- a/packages/platform/analytics-posthog/src/payload-mapping.ts
+++ b/packages/platform/analytics-posthog/src/payload-mapping.ts
@@ -66,6 +66,7 @@ export const orgDistinctId = (organizationId: string): string => `org_${organiza
  */
 const getPersonEmailSet = (input: TrackedEventInput): Record<string, unknown> => {
   if (typeof input.payload.actorUserId === "string" && input.payload.actorUserId.length > 0) return {}
+  if (typeof input.payload.userId !== "string" || input.payload.userId.length === 0) return {}
   const email = input.payload.email
   if (typeof email !== "string" || email.length === 0) return {}
   return { $set: { email } }


### PR DESCRIPTION
include $set.email in PostHog events so users show up by email instead of their CUID

--

Deeper explanation:

Backend events like UserSignedUp were sending email as a plain event property, not a person property. PostHog only uses a person's email (via $set) to display them by email address in its UI — without it, the person falls back to showing the raw distinctId, a CUID that looks like a random ID.

The frontend's posthog.identify() call is the existing fix for this, but it only fires when the user loads the authenticated web app. For the window between signup and first page load — or for users who never visit the web app — the person record had no email.

Added getPersonEmailSet in payload-mapping.ts: when the event's distinctId is a userId (not an actorUserId) and the payload includes an email field, a $set: { email } is merged into the PostHog capture properties. This covers UserSignedUp immediately. The guard on actorUserId prevents MemberInvited from incorrectly stamping the invitee's email onto the actor's person profile.

