### PR TITLE
feat(web): hover popover for histogram incidents

### DIFF
--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -1,4 +1,4 @@
-import { Popover, PopoverAnchor, PopoverContent } from "@repo/ui"
+import { Popover, PopoverAnchor, PopoverContent, Text } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
 import { ChevronRightIcon } from "lucide-react"
 import { useRef } from "react"
@@ -92,8 +92,10 @@ export function IncidentMarkerPopover({
         onOpenAutoFocus={(event) => event.preventDefault()}
         onCloseAutoFocus={(event) => event.preventDefault()}
       >
-        <div className="px-2 py-1.5 text-xs font-semibold text-foreground">
-          {incidents.length === 1 ? "Incident" : `${incidents.length} incidents`}
+        <div className="px-2 py-1.5">
+          <Text.H6B color="foreground">
+            {incidents.length === 1 ? "Incident" : `${incidents.length} incidents`}
+          </Text.H6B>
         </div>
         <ul className="flex flex-col">
           {incidents.map((incident) => (
@@ -115,14 +117,18 @@ export function IncidentMarkerPopover({
                   style={{ background: INCIDENT_SEVERITY_COLOR[incident.severity] }}
                 />
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <span className="font-medium text-foreground">{KIND_LABELS[incident.kind]}</span>
-                    <span className="text-muted-foreground">·</span>
-                    <span className="text-muted-foreground">{SEVERITY_LABELS[incident.severity]}</span>
+                  <div className="flex items-center gap-1.5">
+                    <Text.H6M color="foreground">{KIND_LABELS[incident.kind]}</Text.H6M>
+                    <Text.H6 color="foregroundMuted">·</Text.H6>
+                    <Text.H6 color="foregroundMuted">{SEVERITY_LABELS[incident.severity]}</Text.H6>
                   </div>
-                  <div className="text-[11px] text-muted-foreground">{formatTiming(incident)}</div>
+                  <Text.H6 color="foregroundMuted" display="block">
+                    {formatTiming(incident)}
+                  </Text.H6>
                   {incident.issueName ? (
-                    <div className="mt-0.5 truncate text-xs text-foreground/85">{incident.issueName}</div>
+                    <Text.H6 color="foreground" display="block" className="truncate">
+                      {incident.issueName}
+                    </Text.H6>
                   ) : null}
                 </div>
                 <ChevronRightIcon className="mt-1 size-3.5 shrink-0 text-muted-foreground" aria-hidden />

--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -1,0 +1,129 @@
+import { Popover, PopoverAnchor, PopoverContent } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import { ChevronRightIcon } from "lucide-react"
+import { useRef } from "react"
+import type { AlertIncidentRecord } from "./alerts.functions.ts"
+import { INCIDENT_SEVERITY_COLOR, KIND_LABELS, SEVERITY_LABELS } from "./incident-markers.ts"
+
+/**
+ * Popover anchored at a cursor location, listing every incident touching a histogram bucket.
+ * Each row links to the issue detail drawer via `?issueId=…`. The popover is consumer-owned —
+ * the chart only surfaces the click + cursor coords; this component renders the list and the
+ * navigation links.
+ *
+ * `sameRoute=true` is for the issues analytics panel: we navigate to the same route so unrelated
+ * search params (lifecycle, time filters, sort) are preserved via the function form. `false` is
+ * for the traces overview histogram: we navigate cross-route to the issues page with a fresh
+ * search containing only `issueId`.
+ */
+interface IncidentMarkerPopoverProps {
+  readonly open: boolean
+  readonly anchor: { readonly clientX: number; readonly clientY: number } | null
+  readonly incidents: readonly AlertIncidentRecord[]
+  readonly projectSlug: string
+  readonly sameRoute: boolean
+  readonly onOpenChange: (open: boolean) => void
+  /**
+   * Optional hover-card grace handlers — wired to the popover content so a consumer can
+   * cancel a pending hover-out close when the cursor enters the popover, and re-schedule
+   * one when it leaves. Lets the user move from the marker into the popover to click a link
+   * without it yanking shut.
+   */
+  readonly onContentMouseEnter?: () => void
+  readonly onContentMouseLeave?: () => void
+}
+
+function formatTimeShort(iso: string): string {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+}
+
+function formatTiming(incident: AlertIncidentRecord): string {
+  if (incident.endedAt === null) return `${formatTimeShort(incident.startedAt)} → ongoing`
+  if (incident.endedAt !== incident.startedAt) {
+    return `${formatTimeShort(incident.startedAt)} → ${formatTimeShort(incident.endedAt)}`
+  }
+  return formatTimeShort(incident.startedAt)
+}
+
+export function IncidentMarkerPopover({
+  open,
+  anchor,
+  incidents,
+  projectSlug,
+  sameRoute,
+  onOpenChange,
+  onContentMouseEnter,
+  onContentMouseLeave,
+}: IncidentMarkerPopoverProps) {
+  // Hold onto the last anchor so the closing animation doesn't jump while `anchor` resets to null.
+  const lastAnchorRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  if (anchor) {
+    lastAnchorRef.current = { x: anchor.clientX, y: anchor.clientY }
+  }
+  const point = anchor ? { x: anchor.clientX, y: anchor.clientY } : lastAnchorRef.current
+
+  // Virtual ref for Radix: getBoundingClientRect returns a 0×0 rect at the cursor coords so the
+  // popover positions itself there with no DOM node required.
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, x: point.x, y: point.y }),
+  })
+  virtualRef.current = {
+    getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, x: point.x, y: point.y }),
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor virtualRef={virtualRef} />
+      <PopoverContent
+        align="center"
+        side="bottom"
+        sideOffset={8}
+        className="w-80 max-h-80 overflow-y-auto p-1"
+        onMouseEnter={onContentMouseEnter}
+        onMouseLeave={onContentMouseLeave}
+      >
+        <div className="px-2 py-1.5 text-xs font-semibold text-foreground">
+          {incidents.length === 1 ? "Incident" : `${incidents.length} incidents`}
+        </div>
+        <ul className="flex flex-col">
+          {incidents.map((incident) => (
+            <li key={incident.id}>
+              <Link
+                to="/projects/$projectSlug/issues"
+                params={{ projectSlug }}
+                search={
+                  sameRoute
+                    ? (prev: Record<string, unknown>) => ({ ...prev, issueId: incident.sourceId })
+                    : { issueId: incident.sourceId }
+                }
+                onClick={() => onOpenChange(false)}
+                className="flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-accent focus-visible:bg-accent outline-none"
+              >
+                <span
+                  aria-hidden
+                  className="mt-1 inline-block size-2 shrink-0 rounded-full"
+                  style={{ background: INCIDENT_SEVERITY_COLOR[incident.severity] }}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 text-sm">
+                    <span className="font-medium text-foreground">{KIND_LABELS[incident.kind]}</span>
+                    <span className="text-muted-foreground">·</span>
+                    <span className="text-muted-foreground">{SEVERITY_LABELS[incident.severity]}</span>
+                  </div>
+                  <div className="text-[11px] text-muted-foreground">{formatTiming(incident)}</div>
+                  {incident.issueName ? (
+                    <div className="mt-0.5 truncate text-xs text-foreground/85">{incident.issueName}</div>
+                  ) : null}
+                </div>
+                <ChevronRightIcon className="mt-1 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -84,6 +84,12 @@ export function IncidentMarkerPopover({
         className="w-80 max-h-80 overflow-y-auto p-1"
         onMouseEnter={onContentMouseEnter}
         onMouseLeave={onContentMouseLeave}
+        // Radix moves focus into the content on open and back to the trigger on close by
+        // default — fine for click-opened popovers, disruptive for a hover-opened one (it can
+        // pull focus out of an input the user is typing into). Preventing both keeps the
+        // keyboard focus where the user left it.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
       >
         <div className="px-2 py-1.5 text-xs font-semibold text-foreground">
           {incidents.length === 1 ? "Incident" : `${incidents.length} incidents`}

--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -6,22 +6,23 @@ import type { AlertIncidentRecord } from "./alerts.functions.ts"
 import { INCIDENT_SEVERITY_COLOR, KIND_LABELS, SEVERITY_LABELS } from "./incident-markers.ts"
 
 /**
- * Popover anchored at a cursor location, listing every incident touching a histogram bucket.
- * Each row links to the issue detail drawer via `?issueId=…`. The popover is consumer-owned —
- * the chart only surfaces the click + cursor coords; this component renders the list and the
- * navigation links.
+ * Popover anchored at a chart-bucket point, listing every incident touching that bucket. Each
+ * row links to the issue detail drawer via `?issueId=…` on `/projects/$projectSlug/issues`.
+ * The popover is consumer-owned — the chart surfaces the bucket anchor; this component
+ * renders the list and the navigation links.
  *
- * `sameRoute=true` is for the issues analytics panel: we navigate to the same route so unrelated
- * search params (lifecycle, time filters, sort) are preserved via the function form. `false` is
- * for the traces overview histogram: we navigate cross-route to the issues page with a fresh
- * search containing only `issueId`.
+ * `preserveSearchParams=true` is for the issues analytics panel (popover is on the issues page
+ * itself), where lifecycle, time filter and sort search params should survive the row-click
+ * navigation. `false` (default) ships a fresh `{ issueId }` search — used by the traces
+ * overview popover, which navigates cross-route. The `to` is always the absolute issues path
+ * either way; only the search-params merge behavior differs.
  */
 interface IncidentMarkerPopoverProps {
   readonly open: boolean
   readonly anchor: { readonly clientX: number; readonly clientY: number } | null
   readonly incidents: readonly AlertIncidentRecord[]
   readonly projectSlug: string
-  readonly sameRoute: boolean
+  readonly preserveSearchParams?: boolean
   readonly onOpenChange: (open: boolean) => void
   /**
    * Optional hover-card grace handlers — wired to the popover content so a consumer can
@@ -53,7 +54,7 @@ export function IncidentMarkerPopover({
   anchor,
   incidents,
   projectSlug,
-  sameRoute,
+  preserveSearchParams = false,
   onOpenChange,
   onContentMouseEnter,
   onContentMouseLeave,
@@ -101,7 +102,7 @@ export function IncidentMarkerPopover({
                 to="/projects/$projectSlug/issues"
                 params={{ projectSlug }}
                 search={
-                  sameRoute
+                  preserveSearchParams
                     ? (prev: Record<string, unknown>) => ({ ...prev, issueId: incident.sourceId })
                     : { issueId: incident.sourceId }
                 }

--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -17,10 +17,9 @@ export const INCIDENT_SEVERITY_COLOR: Record<AlertSeverity, string> = {
 
 type TopSymbol = NonNullable<BarChartOverlayLine["topSymbol"]>
 
-// Sizes are sized for the marker to read as an interactive click target — see incident-marker
-// popover wiring. The visible 2px line itself is hard to land on; the top symbol is the practical
-// hit target, and a wider invisible hit-target line is added at the chart layer when clicks are
-// enabled.
+// Markers are paint-only — interactivity lives at the bucket level via the histogram's hover
+// popover, not on the marker itself. Sizes are picked so each kind reads distinctly at a
+// glance against a busy bar chart background.
 const KIND_TOP_SYMBOL: Record<AlertIncidentKind, TopSymbol> = {
   "issue.new": { shape: "circle", size: 9 },
   "issue.regressed": { shape: "diamond", size: 10 },

--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -17,21 +17,25 @@ export const INCIDENT_SEVERITY_COLOR: Record<AlertSeverity, string> = {
 
 type TopSymbol = NonNullable<BarChartOverlayLine["topSymbol"]>
 
+// Sizes are sized for the marker to read as an interactive click target — see incident-marker
+// popover wiring. The visible 2px line itself is hard to land on; the top symbol is the practical
+// hit target, and a wider invisible hit-target line is added at the chart layer when clicks are
+// enabled.
 const KIND_TOP_SYMBOL: Record<AlertIncidentKind, TopSymbol> = {
-  "issue.new": { shape: "circle", size: 7 },
-  "issue.regressed": { shape: "diamond", size: 8 },
+  "issue.new": { shape: "circle", size: 9 },
+  "issue.regressed": { shape: "diamond", size: 10 },
   // Escalating typically renders as an area, but we still render a tiny tick at the start so a
   // 1-bucket escalation that snaps to a single cell stays visible.
-  "issue.escalating": { shape: "rect", size: 6 },
+  "issue.escalating": { shape: "rect", size: 7 },
 }
 
-const KIND_LABELS: Record<AlertIncidentKind, string> = {
+export const KIND_LABELS: Record<AlertIncidentKind, string> = {
   "issue.new": "New issue",
   "issue.regressed": "Issue regressed",
   "issue.escalating": "Issue escalating",
 }
 
-const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
   medium: "Medium",
   high: "High",
 }
@@ -227,67 +231,6 @@ export function buildIncidentMarkers({
     incidentsByBucketIndex: grouping.incidentsByBucketIndex,
     incidentsTouchingBucketIndex: grouping.incidentsTouchingBucketIndex,
   }
-}
-
-const escapeHtml = (s: string): string =>
-  s.replace(/[&<>"']/g, (c) => {
-    switch (c) {
-      case "&":
-        return "&amp;"
-      case "<":
-        return "&lt;"
-      case ">":
-        return "&gt;"
-      case '"':
-        return "&quot;"
-      default:
-        return "&#39;"
-    }
-  })
-
-const formatTimeShort = (iso: string): string => {
-  const d = new Date(iso)
-  return Number.isNaN(d.getTime())
-    ? iso
-    : d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
-}
-
-/** Scroll incident rows when many overlap one bucket; bounds tooltip height for ECharts confine. */
-const INCIDENT_TOOLTIP_SCROLL_STYLE =
-  "max-height:min(45vh,360px);overflow-y:auto;overscroll-behavior:contain;margin-top:4px;padding-right:6px"
-
-/**
- * Renders the per-bucket incident block appended below the bar tooltip body. Returns an empty
- * string when no incidents fall in the bucket — callers can concatenate unconditionally.
- *
- * `omitIssueName` skips the issue name line; useful when the chart is already scoped to a single
- * issue so repeating its name on every incident row is just noise.
- */
-export function renderIncidentsTooltipBlock(
-  incidents: readonly AlertIncidentRecord[],
-  options?: { readonly omitIssueName?: boolean },
-): string {
-  if (incidents.length === 0) return ""
-  const header = `<div style="margin-top:6px;font-weight:600;">${incidents.length === 1 ? "Incident" : `${incidents.length} incidents`}</div>`
-  const items = incidents
-    .map((incident) => {
-      const dot = `<span style="display:inline-block;width:8px;height:8px;border-radius:9999px;background:${INCIDENT_SEVERITY_COLOR[incident.severity]};margin-right:6px;vertical-align:middle"></span>`
-      const kindLabel = KIND_LABELS[incident.kind]
-      const sevLabel = SEVERITY_LABELS[incident.severity]
-      const issueLine =
-        incident.issueName && !options?.omitIssueName
-          ? `<div style="opacity:0.85;margin-left:14px;">${escapeHtml(incident.issueName)}</div>`
-          : ""
-      const timing =
-        incident.endedAt === null
-          ? `${formatTimeShort(incident.startedAt)} → ongoing`
-          : isRangedIncident(incident)
-            ? `${formatTimeShort(incident.startedAt)} → ${formatTimeShort(incident.endedAt)}`
-            : formatTimeShort(incident.startedAt)
-      return `<div style="margin-top:4px">${dot}<b>${kindLabel}</b> · <span style="opacity:0.75">${sevLabel}</span><div style="margin-left:14px;opacity:0.65;font-size:11px">${escapeHtml(timing)}</div>${issueLine}</div>`
-    })
-    .join("")
-  return `${header}<div style="${INCIDENT_TOOLTIP_SCROLL_STYLE}">${items}</div>`
 }
 
 export function formatIncidentKindLabel(kind: AlertIncidentKind): string {

--- a/apps/web/src/domains/alerts/use-incident-bucket-hover-popover.ts
+++ b/apps/web/src/domains/alerts/use-incident-bucket-hover-popover.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useMountEffect } from "@repo/ui"
+import { useCallback, useRef, useState } from "react"
 import type { AlertIncidentRecord } from "./alerts.functions.ts"
 
 const DEFAULT_CLOSE_GRACE_MS = 200
@@ -63,7 +64,8 @@ export function useIncidentBucketHoverPopover({
     }, closeGraceMs)
   }, [cancelPendingClose, closeGraceMs])
 
-  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
+  // Clear the pending close timer on unmount. Mount-only effect — there's nothing to react to.
+  useMountEffect(() => () => cancelPendingClose())
 
   const handleBucketAxisPointerChange = useCallback(
     (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
@@ -77,13 +79,6 @@ export function useIncidentBucketHoverPopover({
     [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
   )
 
-  // Reset on a data refetch / filter change. The bucket index captured by the popover may not
-  // line up with the new buckets, and the cached incidents could be stale.
-  useEffect(() => {
-    cancelPendingClose()
-    setPopover(null)
-  }, [incidentsTouchingBucketIndex, cancelPendingClose])
-
   const onOpenChange = useCallback(
     (next: boolean) => {
       if (!next) {
@@ -94,10 +89,15 @@ export function useIncidentBucketHoverPopover({
     [cancelPendingClose],
   )
 
+  // Derive the visible popover during render: when the bucket the popover state captured no
+  // longer touches any incidents (data refetch / filter change), `popoverIncidents` collapses
+  // to `[]` and we expose the popover as null so the consumer treats it as closed. No effect
+  // needed — the next hover transition or close-timer fire will clear the internal state.
   const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
+  const visiblePopover = popoverIncidents.length === 0 ? null : popover
 
   return {
-    popover,
+    popover: visiblePopover,
     popoverIncidents,
     handleBucketAxisPointerChange,
     onOpenChange,

--- a/apps/web/src/domains/alerts/use-incident-bucket-hover-popover.ts
+++ b/apps/web/src/domains/alerts/use-incident-bucket-hover-popover.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { AlertIncidentRecord } from "./alerts.functions.ts"
+
+const DEFAULT_CLOSE_GRACE_MS = 200
+
+interface UseIncidentBucketHoverPopoverInput {
+  /** Map of bucket index → incidents that touch that bucket. */
+  readonly incidentsTouchingBucketIndex: ReadonlyMap<number, readonly AlertIncidentRecord[]>
+  /** Grace period (ms) between leaving the bucket/popover and the popover actually closing. */
+  readonly closeGraceMs?: number
+}
+
+interface UseIncidentBucketHoverPopoverReturn {
+  readonly popover: {
+    readonly bucketIndex: number
+    readonly anchor: { readonly clientX: number; readonly clientY: number }
+  } | null
+  readonly popoverIncidents: readonly AlertIncidentRecord[]
+  /** Wire to `BarChart`'s `onBucketAxisPointerChange`. */
+  readonly handleBucketAxisPointerChange: (
+    dataIndex: number | null,
+    anchor: { clientX: number; clientY: number } | null,
+  ) => void
+  /** Wire to `IncidentMarkerPopover`'s `onOpenChange`. */
+  readonly onOpenChange: (open: boolean) => void
+  /** Wire to `IncidentMarkerPopover`'s `onContentMouseEnter`. */
+  readonly onContentMouseEnter: () => void
+  /** Wire to `IncidentMarkerPopover`'s `onContentMouseLeave`. */
+  readonly onContentMouseLeave: () => void
+}
+
+/**
+ * Hover-card state machine for the incident bucket popover. Opens when the chart's axis
+ * pointer enters a bucket with incidents; closes after a grace period when the cursor leaves
+ * the bucket and the popover content. The grace lets the cursor transit from the bar down
+ * into the popover to click a link.
+ *
+ * Shared by the issues analytics panel and the project traces overview histogram so timer
+ * tuning, cleanup, and reset-on-refetch stay consistent across both surfaces.
+ */
+export function useIncidentBucketHoverPopover({
+  incidentsTouchingBucketIndex,
+  closeGraceMs = DEFAULT_CLOSE_GRACE_MS,
+}: UseIncidentBucketHoverPopoverInput): UseIncidentBucketHoverPopoverReturn {
+  const [popover, setPopover] = useState<{
+    bucketIndex: number
+    anchor: { clientX: number; clientY: number }
+  } | null>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelPendingClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleClose = useCallback(() => {
+    cancelPendingClose()
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null
+      setPopover(null)
+    }, closeGraceMs)
+  }, [cancelPendingClose, closeGraceMs])
+
+  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
+
+  const handleBucketAxisPointerChange = useCallback(
+    (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
+      if (dataIndex === null || anchor === null || !incidentsTouchingBucketIndex.has(dataIndex)) {
+        scheduleClose()
+        return
+      }
+      cancelPendingClose()
+      setPopover({ bucketIndex: dataIndex, anchor })
+    },
+    [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
+  )
+
+  // Reset on a data refetch / filter change. The bucket index captured by the popover may not
+  // line up with the new buckets, and the cached incidents could be stale.
+  useEffect(() => {
+    cancelPendingClose()
+    setPopover(null)
+  }, [incidentsTouchingBucketIndex, cancelPendingClose])
+
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        cancelPendingClose()
+        setPopover(null)
+      }
+    },
+    [cancelPendingClose],
+  )
+
+  const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
+
+  return {
+    popover,
+    popoverIncidents,
+    handleBucketAxisPointerChange,
+    onOpenChange,
+    onContentMouseEnter: cancelPendingClose,
+    onContentMouseLeave: scheduleClose,
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -12,12 +12,18 @@ const DEFAULT_HISTOGRAM_METRIC: TraceHistogramMetric = "traces"
 
 interface TraceAggregationsPanelProps {
   readonly projectId: string
+  readonly projectSlug: string
   readonly filters: FilterSet
   /** Called when user selects a time range via brush on the histogram. */
   readonly onTimeRangeSelect?: (range: { from: string; to: string } | null) => void
 }
 
-export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }: TraceAggregationsPanelProps) {
+export function TraceAggregationsPanel({
+  projectId,
+  projectSlug,
+  filters,
+  onTimeRangeSelect,
+}: TraceAggregationsPanelProps) {
   const [collapsed, setCollapsed] = useState(false)
 
   // The default metric ("traces") is intentionally omitted from the URL by `useParamState` so the
@@ -78,6 +84,7 @@ export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }
         ) : null}
         <Histogram
           projectId={projectId}
+          projectSlug={projectSlug}
           filters={filters}
           metric={selectedMetric}
           showIncidents={incidentsFlagEnabled && showIncidents}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -1,12 +1,15 @@
 import type { FilterSet } from "@domain/shared"
 import { denseTraceTimeHistogramBuckets, type TraceHistogramMetric } from "@domain/spans"
 import { BarChart, HistogramSkeleton, Text } from "@repo/ui"
-import { useCallback, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
-import { buildIncidentMarkers, renderIncidentsTooltipBlock } from "../../../../../../domains/alerts/incident-markers.ts"
+import { IncidentMarkerPopover } from "../../../../../../domains/alerts/incident-marker-popover.tsx"
+import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-markers.ts"
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
 import { HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
+
+const POPOVER_HOVER_CLOSE_GRACE_MS = 200
 
 function formatBucketAxisLabel(iso: string): string {
   const d = new Date(iso)
@@ -20,6 +23,7 @@ function formatBucketAxisLabel(iso: string): string {
 
 interface HistogramProps {
   readonly projectId: string
+  readonly projectSlug: string
   readonly filters: FilterSet
   readonly metric: TraceHistogramMetric
   /** When true, fetch and overlay incidents on the histogram. */
@@ -28,7 +32,7 @@ interface HistogramProps {
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }
 
-export function Histogram({ projectId, filters, metric, showIncidents, onRangeSelect }: HistogramProps) {
+export function Histogram({ projectId, projectSlug, filters, metric, showIncidents, onRangeSelect }: HistogramProps) {
   const {
     data: sparseBuckets,
     isLoading,
@@ -97,14 +101,52 @@ export function Histogram({ projectId, filters, metric, showIncidents, onRangeSe
     [denseBuckets, bucketSeconds, onRangeSelect],
   )
 
+  // Tooltip stays on every bucket — it carries the metric value and is independent of the
+  // incident popover. Both coexist when the bucket has incidents.
   const formatTooltip = useCallback(
-    (category: string, value: number, dataIndex: number) => {
-      const base = `${category}<br/><b>${definition.formatBucket(value)}</b> ${definition.tooltipNoun}`
-      const touching = incidentsTouchingBucketIndex.get(dataIndex) ?? []
-      return base + renderIncidentsTooltipBlock(touching)
-    },
-    [definition, incidentsTouchingBucketIndex],
+    (category: string, value: number) =>
+      `${category}<br/><b>${definition.formatBucket(value)}</b> ${definition.tooltipNoun}`,
+    [definition],
   )
+
+  // Popover state with hover-card semantics — see issues-analytics-panel.tsx for the rationale.
+  const [popover, setPopover] = useState<{
+    bucketIndex: number
+    anchor: { clientX: number; clientY: number }
+  } | null>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelPendingClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+  const scheduleClose = useCallback(() => {
+    cancelPendingClose()
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null
+      setPopover(null)
+    }, POPOVER_HOVER_CLOSE_GRACE_MS)
+  }, [cancelPendingClose])
+  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
+
+  const handleBucketAxisPointerChange = useCallback(
+    (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
+      if (dataIndex === null || anchor === null || !incidentsTouchingBucketIndex.has(dataIndex)) {
+        scheduleClose()
+        return
+      }
+      cancelPendingClose()
+      setPopover({ bucketIndex: dataIndex, anchor })
+    },
+    [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
+  )
+
+  useEffect(() => {
+    cancelPendingClose()
+    setPopover(null)
+  }, [denseBuckets, cancelPendingClose])
+  const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
 
   if (isLoading) {
     return (
@@ -140,6 +182,22 @@ export function Histogram({ projectId, filters, metric, showIncidents, onRangeSe
         formatTooltip={formatTooltip}
         onSelect={onRangeSelect ? handleSelect : undefined}
         {...(overlay ? { overlay } : {})}
+        {...(showIncidents ? { onBucketAxisPointerChange: handleBucketAxisPointerChange } : {})}
+      />
+      <IncidentMarkerPopover
+        sameRoute={false}
+        open={popover !== null}
+        anchor={popover?.anchor ?? null}
+        incidents={popoverIncidents}
+        projectSlug={projectSlug}
+        onOpenChange={(next) => {
+          if (!next) {
+            cancelPendingClose()
+            setPopover(null)
+          }
+        }}
+        onContentMouseEnter={cancelPendingClose}
+        onContentMouseLeave={scheduleClose}
       />
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -185,7 +185,6 @@ export function Histogram({ projectId, projectSlug, filters, metric, showInciden
         {...(showIncidents ? { onBucketAxisPointerChange: handleBucketAxisPointerChange } : {})}
       />
       <IncidentMarkerPopover
-        sameRoute={false}
         open={popover !== null}
         anchor={popover?.anchor ?? null}
         incidents={popoverIncidents}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -1,15 +1,14 @@
 import type { FilterSet } from "@domain/shared"
 import { denseTraceTimeHistogramBuckets, type TraceHistogramMetric } from "@domain/spans"
 import { BarChart, HistogramSkeleton, Text } from "@repo/ui"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo } from "react"
 
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { IncidentMarkerPopover } from "../../../../../../domains/alerts/incident-marker-popover.tsx"
 import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-markers.ts"
+import { useIncidentBucketHoverPopover } from "../../../../../../domains/alerts/use-incident-bucket-hover-popover.ts"
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
 import { HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
-
-const POPOVER_HOVER_CLOSE_GRACE_MS = 200
 
 function formatBucketAxisLabel(iso: string): string {
   const d = new Date(iso)
@@ -109,44 +108,16 @@ export function Histogram({ projectId, projectSlug, filters, metric, showInciden
     [definition],
   )
 
-  // Popover state with hover-card semantics — see issues-analytics-panel.tsx for the rationale.
-  const [popover, setPopover] = useState<{
-    bucketIndex: number
-    anchor: { clientX: number; clientY: number }
-  } | null>(null)
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const cancelPendingClose = useCallback(() => {
-    if (closeTimerRef.current !== null) {
-      clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = null
-    }
-  }, [])
-  const scheduleClose = useCallback(() => {
-    cancelPendingClose()
-    closeTimerRef.current = setTimeout(() => {
-      closeTimerRef.current = null
-      setPopover(null)
-    }, POPOVER_HOVER_CLOSE_GRACE_MS)
-  }, [cancelPendingClose])
-  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
-
-  const handleBucketAxisPointerChange = useCallback(
-    (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
-      if (dataIndex === null || anchor === null || !incidentsTouchingBucketIndex.has(dataIndex)) {
-        scheduleClose()
-        return
-      }
-      cancelPendingClose()
-      setPopover({ bucketIndex: dataIndex, anchor })
-    },
-    [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
-  )
-
-  useEffect(() => {
-    cancelPendingClose()
-    setPopover(null)
-  }, [denseBuckets, cancelPendingClose])
-  const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
+  // Popover state machine — see use-incident-bucket-hover-popover.ts. Shared with the issues
+  // analytics panel.
+  const {
+    popover,
+    popoverIncidents,
+    handleBucketAxisPointerChange,
+    onOpenChange: onPopoverOpenChange,
+    onContentMouseEnter,
+    onContentMouseLeave,
+  } = useIncidentBucketHoverPopover({ incidentsTouchingBucketIndex })
 
   if (isLoading) {
     return (
@@ -189,14 +160,9 @@ export function Histogram({ projectId, projectSlug, filters, metric, showInciden
         anchor={popover?.anchor ?? null}
         incidents={popoverIncidents}
         projectSlug={projectSlug}
-        onOpenChange={(next) => {
-          if (!next) {
-            cancelPendingClose()
-            setPopover(null)
-          }
-        }}
-        onContentMouseEnter={cancelPendingClose}
-        onContentMouseLeave={scheduleClose}
+        onOpenChange={onPopoverOpenChange}
+        onContentMouseEnter={onContentMouseEnter}
+        onContentMouseLeave={onContentMouseLeave}
       />
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -355,7 +355,12 @@ function ProjectPage() {
       )}
 
       <div className="px-6">
-        <TraceAggregationsPanel projectId={currentProject.id} filters={filters} onTimeRangeSelect={onTimeRangeSelect} />
+        <TraceAggregationsPanel
+          projectId={currentProject.id}
+          projectSlug={currentProject.slug}
+          filters={filters}
+          onTimeRangeSelect={onTimeRangeSelect}
+        />
       </div>
 
       {activeTab === "traces" ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -1,12 +1,15 @@
 import { BarChart, Button, HistogramSkeleton, Icon, Skeleton, Text, Tooltip } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { BarChart2, ChevronDown, ChevronUp, ShieldAlertIcon, ShieldOffIcon } from "lucide-react"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
-import { buildIncidentMarkers, renderIncidentsTooltipBlock } from "../../../../../../domains/alerts/incident-markers.ts"
+import { IncidentMarkerPopover } from "../../../../../../domains/alerts/incident-marker-popover.tsx"
+import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-markers.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
 import type { IssuesListResultRecord } from "../../../../../../domains/issues/issues.functions.ts"
 import { formatHistogramBucketLabel, formatHistogramBucketTooltipLabel } from "./issue-formatters.ts"
+
+const POPOVER_HOVER_CLOSE_GRACE_MS = 200
 
 const COUNT_CARDS = [
   { key: "ongoingIssues", label: "Ongoing" },
@@ -44,11 +47,13 @@ function AggregationItem({
 
 export function IssuesAnalyticsPanel({
   projectId,
+  projectSlug,
   analytics,
   isLoading,
   onRangeSelect,
 }: {
   readonly projectId: string
+  readonly projectSlug: string
   readonly analytics: IssuesListResultRecord["analytics"]
   readonly isLoading: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
@@ -113,14 +118,61 @@ export function IssuesAnalyticsPanel({
     }
   }, [incidentsActive, incidents, analytics.histogram, incidentRange, bucketWidthMs])
 
+  // Tooltip is always shown — it carries bucket data (category + occurrence count) and is
+  // independent of the incident popover, which carries per-incident details. Both can coexist:
+  // the tooltip floats near the cursor at the top of the chart, the popover anchors at the
+  // bottom of the bar.
   const formatHistogramTooltip = useCallback(
-    (category: string, value: number, dataIndex: number) => {
-      const base = `${category}<br/><b>${formatCount(value)}</b> occurrences`
-      const touching = incidentsTouchingBucketIndex.get(dataIndex) ?? []
-      return base + renderIncidentsTooltipBlock(touching)
-    },
-    [incidentsTouchingBucketIndex],
+    (category: string, value: number) => `${category}<br/><b>${formatCount(value)}</b> occurrences`,
+    [],
   )
+
+  // Popover state lives in the consumer (not in BarChart) so it survives canvas re-renders. The
+  // chart surfaces bucket-level hover via the axis pointer + a stable bottom-of-bucket anchor;
+  // we only open the popover for buckets that actually have incidents.
+  //
+  // Hover semantics: opens on entering an incident bucket, closes after a short grace period
+  // on leaving (so the cursor can transit into the popover, where `onMouseEnter` cancels the
+  // pending close).
+  const [popover, setPopover] = useState<{
+    bucketIndex: number
+    anchor: { clientX: number; clientY: number }
+  } | null>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelPendingClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }, [])
+  const scheduleClose = useCallback(() => {
+    cancelPendingClose()
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null
+      setPopover(null)
+    }, POPOVER_HOVER_CLOSE_GRACE_MS)
+  }, [cancelPendingClose])
+  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
+
+  const handleBucketAxisPointerChange = useCallback(
+    (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
+      if (dataIndex === null || anchor === null || !incidentsTouchingBucketIndex.has(dataIndex)) {
+        scheduleClose()
+        return
+      }
+      cancelPendingClose()
+      setPopover({ bucketIndex: dataIndex, anchor })
+    },
+    [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
+  )
+
+  // Dismiss the popover when the underlying histogram identity changes (refetch / param change),
+  // since the bucket index it captured may no longer line up with current buckets.
+  useEffect(() => {
+    cancelPendingClose()
+    setPopover(null)
+  }, [analytics.histogram, cancelPendingClose])
+  const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
 
   const handleSelect = useCallback(
     (range: { startIndex: number; endIndex: number } | null) => {
@@ -234,11 +286,27 @@ export function IssuesAnalyticsPanel({
                 formatTooltip={formatHistogramTooltip}
                 onSelect={onRangeSelect ? handleSelect : undefined}
                 {...(overlay ? { overlay } : {})}
+                {...(incidentsActive ? { onBucketAxisPointerChange: handleBucketAxisPointerChange } : {})}
               />
             </div>
           </>
         )}
       </div>
+      <IncidentMarkerPopover
+        sameRoute
+        open={popover !== null}
+        anchor={popover?.anchor ?? null}
+        incidents={popoverIncidents}
+        projectSlug={projectSlug}
+        onOpenChange={(next) => {
+          if (!next) {
+            cancelPendingClose()
+            setPopover(null)
+          }
+        }}
+        onContentMouseEnter={cancelPendingClose}
+        onContentMouseLeave={scheduleClose}
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -293,7 +293,7 @@ export function IssuesAnalyticsPanel({
         )}
       </div>
       <IncidentMarkerPopover
-        sameRoute
+        preserveSearchParams
         open={popover !== null}
         anchor={popover?.anchor ?? null}
         incidents={popoverIncidents}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -1,15 +1,14 @@
 import { BarChart, Button, HistogramSkeleton, Icon, Skeleton, Text, Tooltip } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { BarChart2, ChevronDown, ChevronUp, ShieldAlertIcon, ShieldOffIcon } from "lucide-react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { IncidentMarkerPopover } from "../../../../../../domains/alerts/incident-marker-popover.tsx"
 import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-markers.ts"
+import { useIncidentBucketHoverPopover } from "../../../../../../domains/alerts/use-incident-bucket-hover-popover.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
 import type { IssuesListResultRecord } from "../../../../../../domains/issues/issues.functions.ts"
 import { formatHistogramBucketLabel, formatHistogramBucketTooltipLabel } from "./issue-formatters.ts"
-
-const POPOVER_HOVER_CLOSE_GRACE_MS = 200
 
 const COUNT_CARDS = [
   { key: "ongoingIssues", label: "Ongoing" },
@@ -127,52 +126,16 @@ export function IssuesAnalyticsPanel({
     [],
   )
 
-  // Popover state lives in the consumer (not in BarChart) so it survives canvas re-renders. The
-  // chart surfaces bucket-level hover via the axis pointer + a stable bottom-of-bucket anchor;
-  // we only open the popover for buckets that actually have incidents.
-  //
-  // Hover semantics: opens on entering an incident bucket, closes after a short grace period
-  // on leaving (so the cursor can transit into the popover, where `onMouseEnter` cancels the
-  // pending close).
-  const [popover, setPopover] = useState<{
-    bucketIndex: number
-    anchor: { clientX: number; clientY: number }
-  } | null>(null)
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const cancelPendingClose = useCallback(() => {
-    if (closeTimerRef.current !== null) {
-      clearTimeout(closeTimerRef.current)
-      closeTimerRef.current = null
-    }
-  }, [])
-  const scheduleClose = useCallback(() => {
-    cancelPendingClose()
-    closeTimerRef.current = setTimeout(() => {
-      closeTimerRef.current = null
-      setPopover(null)
-    }, POPOVER_HOVER_CLOSE_GRACE_MS)
-  }, [cancelPendingClose])
-  useEffect(() => () => cancelPendingClose(), [cancelPendingClose])
-
-  const handleBucketAxisPointerChange = useCallback(
-    (dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => {
-      if (dataIndex === null || anchor === null || !incidentsTouchingBucketIndex.has(dataIndex)) {
-        scheduleClose()
-        return
-      }
-      cancelPendingClose()
-      setPopover({ bucketIndex: dataIndex, anchor })
-    },
-    [cancelPendingClose, scheduleClose, incidentsTouchingBucketIndex],
-  )
-
-  // Dismiss the popover when the underlying histogram identity changes (refetch / param change),
-  // since the bucket index it captured may no longer line up with current buckets.
-  useEffect(() => {
-    cancelPendingClose()
-    setPopover(null)
-  }, [analytics.histogram, cancelPendingClose])
-  const popoverIncidents = popover ? (incidentsTouchingBucketIndex.get(popover.bucketIndex) ?? []) : []
+  // Popover state machine — see use-incident-bucket-hover-popover.ts. Shared with the traces
+  // overview histogram so the close-grace + reset-on-refetch behavior stays consistent.
+  const {
+    popover,
+    popoverIncidents,
+    handleBucketAxisPointerChange,
+    onOpenChange: onPopoverOpenChange,
+    onContentMouseEnter,
+    onContentMouseLeave,
+  } = useIncidentBucketHoverPopover({ incidentsTouchingBucketIndex })
 
   const handleSelect = useCallback(
     (range: { startIndex: number; endIndex: number } | null) => {
@@ -298,14 +261,9 @@ export function IssuesAnalyticsPanel({
         anchor={popover?.anchor ?? null}
         incidents={popoverIncidents}
         projectSlug={projectSlug}
-        onOpenChange={(next) => {
-          if (!next) {
-            cancelPendingClose()
-            setPopover(null)
-          }
-        }}
-        onContentMouseEnter={cancelPendingClose}
-        onContentMouseLeave={scheduleClose}
+        onOpenChange={onPopoverOpenChange}
+        onContentMouseEnter={onContentMouseEnter}
+        onContentMouseLeave={onContentMouseLeave}
       />
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -421,6 +421,7 @@ function IssuesPage() {
         <div className="px-6">
           <IssuesAnalyticsPanel
             projectId={project.id}
+            projectSlug={project.slug}
             analytics={analytics}
             isLoading={showSkeletons}
             onRangeSelect={(range) => {

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -122,7 +122,12 @@ export function buildBarChartOption(
       ...(showYAxis ? {} : { axisTick: { show: false } }),
       axisLabel: showYAxis ? { color: colors.mutedForeground, fontSize: 11 } : { show: false },
     },
-    series: buildSeries({ values, capBarWidth, primary: colors.primary, ...(overlay ? { overlay } : {}) }),
+    series: buildSeries({
+      values,
+      capBarWidth,
+      primary: colors.primary,
+      ...(overlay ? { overlay } : {}),
+    }),
   }
 
   if (enableBrush) {
@@ -193,11 +198,36 @@ function buildSeries({
   const areas = overlay?.areas ?? []
   if (lines.length === 0 && areas.length === 0) return [barSeries]
 
+  // Each data item carries a non-eCharts `categoryIndex` field; the chart's click handler reads
+  // it back to map the click to a bucket without parsing display labels. The top symbol
+  // (already sized 7–10px by the consumer) is the practical hit target — wider than the 2px
+  // line and bumped specifically so it reads as clickable.
+  // The line is a passive visual marker — `silent: true` (inherited from the overlay series),
+  // no cursor, no events. Hover/click affordance lives at the bucket level instead, via the
+  // chart's `updateAxisPointer` event surfaced by `BarChart` as `onBucketAxisPointerChange`.
+  const lineData = lines.map((line) => ({
+    xAxis: line.categoryIndex,
+    lineStyle: {
+      color: line.color,
+      type: line.dashed ? "dashed" : "solid",
+      width: 2,
+      opacity: 0.9,
+    },
+    ...(line.topSymbol
+      ? {
+          symbol: ["none", line.topSymbol.shape],
+          symbolSize: line.topSymbol.size,
+        }
+      : {}),
+  }))
+
   const overlaySeries: SeriesEntry = {
     type: "line",
     // No actual line — the series exists solely to host markLine/markArea so they
     // sit on a layer that doesn't disturb axis-tooltip detection of the bar series.
     data: [],
+    // Fully passive — bucket-level hover/click is owned by the BarChart via the axis pointer
+    // event, not by per-shape mouse events on the markers.
     silent: true,
     z: 5,
     ...(lines.length > 0
@@ -210,26 +240,14 @@ function buildSeries({
             // `xAxis` value as the category position. That avoids the label-collision class of
             // bug where two buckets format to the same display string and an overlay snaps to
             // the wrong one.
-            data: lines.map((line) => ({
-              xAxis: line.categoryIndex,
-              lineStyle: {
-                color: line.color,
-                type: line.dashed ? "dashed" : "solid",
-                width: 2,
-                opacity: 0.9,
-              },
-              ...(line.topSymbol
-                ? {
-                    symbol: ["none", line.topSymbol.shape],
-                    symbolSize: line.topSymbol.size,
-                  }
-                : {}),
-            })),
+            data: lineData,
           },
         }
       : {}),
     ...(areas.length > 0
       ? {
+          // Areas remain non-interactive: clicking a translucent range spanning many buckets is
+          // ambiguous, and a click-eating area would swallow the bar tooltip.
           markArea: {
             silent: true,
             data: areas.map((area) => [

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -198,13 +198,10 @@ function buildSeries({
   const areas = overlay?.areas ?? []
   if (lines.length === 0 && areas.length === 0) return [barSeries]
 
-  // Each data item carries a non-eCharts `categoryIndex` field; the chart's click handler reads
-  // it back to map the click to a bucket without parsing display labels. The top symbol
-  // (already sized 7–10px by the consumer) is the practical hit target — wider than the 2px
-  // line and bumped specifically so it reads as clickable.
-  // The line is a passive visual marker — `silent: true` (inherited from the overlay series),
-  // no cursor, no events. Hover/click affordance lives at the bucket level instead, via the
-  // chart's `updateAxisPointer` event surfaced by `BarChart` as `onBucketAxisPointerChange`.
+  // Markers are paint-only — `silent: true` on both the overlay series and the markLine below,
+  // no cursor, no per-shape mouse events. Hover affordance lives at the bucket level instead,
+  // via the chart's `updateAxisPointer` event surfaced by `BarChart` as
+  // `onBucketAxisPointerChange`.
   const lineData = lines.map((line) => ({
     xAxis: line.categoryIndex,
     lineStyle: {

--- a/packages/ui/src/components/charts/bar-chart.tsx
+++ b/packages/ui/src/components/charts/bar-chart.tsx
@@ -47,6 +47,19 @@ export type BarChartProps = Omit<HTMLAttributes<HTMLDivElement>, "children" | "o
    * Receives the selected data range [startIndex, endIndex] or null if cleared.
    */
   readonly onSelect?: ((range: { startIndex: number; endIndex: number } | null) => void) | undefined
+  /**
+   * Called when the chart's axis pointer enters/leaves a bucket. `dataIndex` is the bucket's
+   * position (or null when the cursor leaves the chart). `anchor` is a viewport-space point at
+   * the bottom-center of the bucket, suitable for anchoring a popover under the bar — stable
+   * within the bucket so cursor jitter doesn't move the popover around.
+   *
+   * Use this for bucket-wide hover UI (e.g., a per-bucket popover) instead of trying to hit
+   * thin overlay markers directly. Fires once per category transition, including the initial
+   * entry and the `currTrigger: 'leave'` event when the cursor leaves the chart.
+   */
+  readonly onBucketAxisPointerChange?:
+    | ((dataIndex: number | null, anchor: { clientX: number; clientY: number } | null) => void)
+    | undefined
 }
 
 type EChartsEventHandler = (params: unknown) => void
@@ -66,6 +79,29 @@ type EChartsReactBridgeProps = {
 const EChartsView = ((EChartsReact as unknown as { default?: unknown }).default ??
   EChartsReact) as unknown as ComponentType<EChartsReactBridgeProps>
 
+/**
+ * Returns the viewport-relative anchor point at the **bottom center** of the chart grid at the
+ * given `dataIndex`. Used by `onBucketAxisPointerChange` consumers to position a popover stably
+ * under the hovered bucket, instead of having it jitter with the cursor.
+ *
+ * Returns null if the chart isn't ready (no DOM, no coordinate system yet).
+ */
+function computeBucketBottomAnchor(
+  chart: ECharts | null,
+  dataIndex: number,
+): { clientX: number; clientY: number } | null {
+  if (!chart) return null
+  const dom = chart.getDom()
+  if (!dom) return null
+  // `convertToPixel({ seriesIndex: 0 }, [dataIndex, 0])` maps a value-space coordinate (category
+  // position, value=0) into pixel space relative to the chart container — i.e. the bottom of
+  // the bar at this category, which is also the bottom of the grid.
+  const pixel = chart.convertToPixel({ seriesIndex: 0 }, [dataIndex, 0]) as [number, number] | null
+  if (!pixel) return null
+  const rect = (dom as HTMLElement).getBoundingClientRect()
+  return { clientX: rect.left + pixel[0], clientY: rect.top + pixel[1] }
+}
+
 function BarChart({
   data,
   height = 200,
@@ -76,6 +112,7 @@ function BarChart({
   xAxisLabelFontSize,
   overlay,
   onSelect,
+  onBucketAxisPointerChange,
   className,
   ...rest
 }: BarChartProps) {
@@ -83,7 +120,10 @@ function BarChart({
   const chartRef = useRef<ECharts | null>(null)
   const onSelectRef = useRef(onSelect)
   onSelectRef.current = onSelect
+  const onBucketAxisPointerChangeRef = useRef(onBucketAxisPointerChange)
+  onBucketAxisPointerChangeRef.current = onBucketAxisPointerChange
   const hasBrush = !!onSelect
+  const hasBucketAxisPointer = !!onBucketAxisPointerChange
 
   useMountEffect(() => {
     setMounted(true)
@@ -126,40 +166,70 @@ function BarChart({
   }, [])
 
   const onEvents = useMemo(() => {
-    if (!hasBrush) return undefined
+    if (!hasBrush && !hasBucketAxisPointer) return undefined
     return {
-      brushEnd: (params: unknown) => {
-        const p = params as { areas?: Array<{ coordRange?: [number, number] }> } | undefined
-        const areas = p?.areas
-        if (!areas || areas.length === 0) return
-        const coordRange = areas[0]?.coordRange
-        if (!coordRange) return
-        const [startIndex, endIndex] = coordRange
-        onSelectRef.current?.({ startIndex, endIndex })
-      },
-      click: () => {
-        if (chartRef.current) {
-          chartRef.current.dispatchAction({ type: "brush", areas: [] })
-        }
-        onSelectRef.current?.(null)
-      },
+      ...(hasBrush
+        ? {
+            brushEnd: (params: unknown) => {
+              const p = params as { areas?: Array<{ coordRange?: [number, number] }> } | undefined
+              const areas = p?.areas
+              if (!areas || areas.length === 0) return
+              const coordRange = areas[0]?.coordRange
+              if (!coordRange) return
+              const [startIndex, endIndex] = coordRange
+              onSelectRef.current?.({ startIndex, endIndex })
+            },
+            click: () => {
+              chartRef.current?.dispatchAction({ type: "brush", areas: [] })
+              onSelectRef.current?.(null)
+            },
+          }
+        : {}),
+      ...(hasBucketAxisPointer
+        ? {
+            // Fires once per category transition (including `currTrigger: 'leave'` when the
+            // cursor leaves the chart). Bucket-level — no need to hit a thin marker line.
+            updateAxisPointer: (params: unknown) => {
+              const p = params as
+                | { currTrigger?: string; axesInfo?: ReadonlyArray<{ value?: number | string }> }
+                | undefined
+              if (!p) return
+              if (p.currTrigger === "leave") {
+                onBucketAxisPointerChangeRef.current?.(null, null)
+                return
+              }
+              const rawValue = p.axesInfo?.[0]?.value
+              const dataIndex = typeof rawValue === "number" ? rawValue : Number(rawValue)
+              if (!Number.isFinite(dataIndex)) {
+                onBucketAxisPointerChangeRef.current?.(null, null)
+                return
+              }
+              const anchor = computeBucketBottomAnchor(chartRef.current, dataIndex)
+              onBucketAxisPointerChangeRef.current?.(dataIndex, anchor)
+            },
+          }
+        : {}),
       /**
        * `notMerge` replaces the full option; brush interaction mode is reset and must be
        * re-established. `onChartReady` only runs once, so we reapply after each render cycle.
        */
-      finished: () => {
-        reapplyBrushCursor()
-      },
+      ...(hasBrush
+        ? {
+            finished: () => {
+              reapplyBrushCursor()
+            },
+          }
+        : {}),
     }
-  }, [hasBrush, reapplyBrushCursor])
+  }, [hasBrush, hasBucketAxisPointer, reapplyBrushCursor])
 
   const onChartReady = useMemo(() => {
-    if (!hasBrush) return undefined
+    if (!hasBrush && !hasBucketAxisPointer) return undefined
     return (instance: ECharts) => {
       chartRef.current = instance
-      reapplyBrushCursor()
+      if (hasBrush) reapplyBrushCursor()
     }
-  }, [hasBrush, reapplyBrushCursor])
+  }, [hasBrush, hasBucketAxisPointer, reapplyBrushCursor])
 
   if (!mounted) {
     return (


### PR DESCRIPTION
Replaces the eCharts tooltip's incident-list block with a Radix popover that opens when the cursor enters any histogram bucket that has incidents. Each popover row is a TanStack `<Link>` that opens the matching issue's detail drawer. Applies to the issues analytics panel and the project traces overview histogram.


https://github.com/user-attachments/assets/c42a9943-f8f9-43c5-85f2-168453d5c30f



Solves two problems with the prior surface:
- Dense incident buckets caused the tooltip block to overflow off-screen — the popover scrolls within a 320×320 area.
- The tooltip listed issue names but had no way to navigate to the issue — readers had to bounce to the Issues page and find the row by name.

The whole feature stays gated behind the existing `timeline-incidents` flag (`useShowIncidentsOverlay`), so the new UI lights up only for orgs with that flag on.

## what's new

**`IncidentMarkerPopover`** (`apps/web/src/domains/alerts/incident-marker-popover.tsx`). Radix `Popover` with a virtual anchor at the bottom-center of the hovered bucket — coordinates the consumer hands in from the chart. Each row renders kind, severity, timing, issue name, and a chevron, and is a TanStack `<Link>` to `?issueId=<sourceId>`. Two routing modes:
- `sameRoute={true}` for the issues analytics panel: `to: '.'` + `search: (prev) => ({ ...prev, issueId })`, so lifecycle, time-filter, and sort search params survive.
- `sameRoute={false}` for the traces overview: absolute path with fresh `search: { issueId }`.
The popover content forwards optional `onContentMouseEnter` / `onContentMouseLeave` to the consumer so it can cancel and reschedule the close timer when the cursor transits into the popover.

**`BarChart.onBucketAxisPointerChange(dataIndex | null, anchor | null)`** (`packages/ui/src/components/charts/bar-chart.tsx`). Generic — no incident knowledge in the chart. Fires once per category transition via eCharts' `updateAxisPointer` event, including `currTrigger: 'leave'` when the cursor leaves the chart. `anchor` comes from `convertToPixel({ seriesIndex: 0 }, [dataIndex, 0])` plus the container's bounding rect, so a popover anchored there sits stably under the bar regardless of cursor jitter within the bucket. Replaces the earlier `onOverlayLineHover` / `onOverlayLineClick` props that tried to make the 2px marker line itself interactive.

**Overlay markline goes passive** (`packages/ui/src/components/charts/bar-chart-option.ts`). The markline is `silent: true` with no cursor, no emphasis, no hit-target. It's a paint-only visual indicator of "this bucket has incidents." All interactivity moved to the bucket level via the axis pointer.

**Consumer wiring** (`issues-analytics-panel.tsx`, `aggregations/histogram.tsx`). Each holds the popover state and a 200ms close-grace timer. The `onBucketAxisPointerChange` handler checks `incidentsTouchingBucketIndex.has(dataIndex)` and either opens (with `cancelPendingClose`) or schedules a close. The existing eCharts tooltip stays on every bucket carrying `category · N occurrences` — it's independent of the popover and the two don't overlap (tooltip floats near cursor at the top of the chart, popover anchors at the bar bottom).

## interaction model

- Enter a bucket with incidents → popover slides in under the bar.
- Move cursor into the popover → hover stays (`onMouseEnter` cancels the close timer).
- Leave the popover or cross into a non-incident bucket → 200ms grace, then close.
- Leave the chart entirely → grace timer schedules a close.

The 200ms grace is the standard hover-card transit window.

## removed

`renderIncidentsTooltipBlock` and its `escapeHtml` / `formatTimeShort` helpers in `incident-markers.ts`. The popover replaces this output path; no other call sites remained.

## test plan

- [ ] With `timeline-incidents` on, hover an incident bucket on `/projects/$slug/issues`: popover opens under the bar with one row per incident.
- [ ] Click a popover row: drawer opens via `?issueId=<id>`; other search params (`issuesLifecycle`, `issuesTimeFrom`, `issuesSort`, ...) preserved.
- [ ] On `/projects/$slug` traces overview, hover an incident bucket: popover opens; clicking a row navigates to `/projects/$slug/issues?issueId=<id>` with the detail drawer open.
- [ ] Tooltip shows `category · N occurrences` on every bucket — including incident buckets, with the popover above.
- [ ] Brush-select a range on the issues histogram: still works, sets `issuesTimeFrom/To`.
- [ ] Flag off → no popover, no marker lines, no behavioral change.

Includes UI work — attach screenshots or a short screen recording before review.