### PR TITLE
fix(security): harden OAuth key and magic-link auth

### DIFF
--- a/apps/api/src/routes/oauth-keys.test.ts
+++ b/apps/api/src/routes/oauth-keys.test.ts
@@ -1,5 +1,6 @@
+import { generateId } from "@domain/shared"
 import { eq } from "@platform/db-postgres"
-import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { members, oauthAccessTokens, oauthApplications, users } from "@platform/db-postgres/schema/better-auth"
 import { createApiKeyAuthHeaders } from "@platform/testkit"
 import { describe, expect, it } from "vitest"
 import {
@@ -29,6 +30,51 @@ const listOAuthKeysJson = async (
   const res = await app.fetch(new Request("http://localhost/v1/oauth-keys", { headers }))
   expect(res.status).toBe(200)
   return (await res.json()) as ListResponse
+}
+
+const seedOAuthKeyInOrganization = async (
+  database: ApiTestContext["database"],
+  input: { readonly organizationId: string },
+) => {
+  const userId = generateId()
+  const clientId = `lct_${generateId()}`
+  const oauthAccessToken = `loa_${crypto.randomUUID()}`
+  const oneHour = 60 * 60 * 1000
+
+  await database.db.insert(users).values({
+    id: userId,
+    email: `${userId}@example.com`,
+    name: "Second User",
+    emailVerified: true,
+    role: "user",
+  })
+
+  await database.db.insert(members).values({
+    id: generateId(),
+    organizationId: input.organizationId,
+    userId,
+    role: "member",
+  })
+
+  await database.db.insert(oauthApplications).values({
+    id: generateId(),
+    name: "Second MCP Client",
+    clientId,
+    userId,
+    organizationId: input.organizationId,
+    disabled: false,
+  })
+
+  await database.db.insert(oauthAccessTokens).values({
+    id: generateId(),
+    accessToken: oauthAccessToken,
+    clientId,
+    userId,
+    accessTokenExpiresAt: new Date(Date.now() + oneHour),
+    scopes: "openid profile email",
+  })
+
+  return { userId, clientId, oauthAccessToken }
 }
 
 describe("OAuth keys routes — list", () => {
@@ -65,10 +111,26 @@ describe("OAuth keys routes — list", () => {
     expect(bodyB.oauthKeys.map((k) => k.clientId)).toEqual([tenantB.oauthClientId])
   })
 
+  it<ApiTestContext>("GET /v1/oauth-keys returns only the caller's keys for OAuth callers", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const other = await seedOAuthKeyInOrganization(database, { organizationId: tenant.organizationId })
+
+    const body = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenant.oauthAccessToken))
+
+    expect(body.oauthKeys.map((k) => k.clientId)).toEqual([tenant.oauthClientId])
+    expect(body.oauthKeys.map((k) => k.clientId)).not.toContain(other.clientId)
+  })
+
   it<ApiTestContext>("GET /v1/oauth-keys works for API-key callers too (read-only)", async ({ app, database }) => {
     const tenant = await createOAuthTenantSetup(database)
+    const other = await seedOAuthKeyInOrganization(database, { organizationId: tenant.organizationId })
+
     const body = await listOAuthKeysJson(app, createApiKeyAuthHeaders(tenant.apiKeyToken))
-    expect(body.oauthKeys.map((k) => k.clientId)).toContain(tenant.oauthClientId)
+
+    expect(body.oauthKeys.map((k) => k.clientId).sort()).toEqual([tenant.oauthClientId, other.clientId].sort())
   })
 })
 
@@ -97,6 +159,23 @@ describe("OAuth keys routes — get", () => {
 
     const res = await app.fetch(
       new Request("http://localhost/v1/oauth-keys/not-a-composite", {
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns 404 for another user's key in the same org", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const other = await seedOAuthKeyInOrganization(database, { organizationId: tenant.organizationId })
+    const otherCompositeId = `${other.clientId}:${other.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${otherCompositeId}`, {
         headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
       }),
     )
@@ -152,6 +231,48 @@ describe("OAuth keys routes — revoke", () => {
       .from(oauthApplications)
       .where(eq(oauthApplications.clientId, tenant.oauthClientId))
     expect(apps[0]?.disabled).toBe(true)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} lets OAuth callers revoke their own key", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${tenant.oauthClientId}:${tenant.userId}`, {
+        method: "DELETE",
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+    expect(res.status).toBe(204)
+
+    const after = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenant.oauthClientId))
+    expect(after).toHaveLength(0)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} rejects same-org cross-user revocation by OAuth callers", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const other = await seedOAuthKeyInOrganization(database, { organizationId: tenant.organizationId })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${other.clientId}:${other.userId}`, {
+        method: "DELETE",
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+    expect(res.status).toBe(403)
+
+    const tokens = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, other.clientId))
+    expect(tokens).toHaveLength(1)
   })
 
   it<ApiTestContext>("DELETE /v1/oauth-keys/{id} is idempotent — second call still returns 204", async ({

--- a/apps/api/src/routes/oauth-keys.ts
+++ b/apps/api/src/routes/oauth-keys.ts
@@ -165,7 +165,7 @@ const revokeOAuthKey = oauthKeyEndpoint({
     await Effect.runPromise(
       revokeOAuthKeyUseCase({
         ...parsed,
-        actor: c.var.auth.method === "oauth" ? { kind: "user", userId: c.var.auth.userId } : { kind: "api-key" },
+        actor: c.var.auth.method === "oauth" ? { kind: "user", userId: c.var.auth.userId } : { kind: "organization" },
       }).pipe(
         Effect.provide(OAuthTokenCacheInvalidatorLive(c.var.redis)),
         withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),

--- a/apps/api/src/routes/oauth-keys.ts
+++ b/apps/api/src/routes/oauth-keys.ts
@@ -103,7 +103,8 @@ const listOAuthKeys = oauthKeyEndpoint({
         withTracing,
       ),
     )
-    return c.json({ oauthKeys: keys.map(toResponse) }, 200)
+    const visibleKeys = c.var.auth.method === "oauth" ? keys.filter((key) => key.userId === c.var.auth.userId) : keys
+    return c.json({ oauthKeys: visibleKeys.map(toResponse) }, 200)
   },
 })
 
@@ -125,6 +126,10 @@ const getOAuthKey = oauthKeyEndpoint({
     const parsed = parseCompositeId(oauthKeyId)
     if (!parsed) {
       throw new OAuthKeyNotFoundError({ clientId: oauthKeyId, userId: "" })
+    }
+
+    if (c.var.auth.method === "oauth" && parsed.userId !== c.var.auth.userId) {
+      throw new OAuthKeyNotFoundError(parsed)
     }
 
     const key = await Effect.runPromise(
@@ -158,7 +163,10 @@ const revokeOAuthKey = oauthKeyEndpoint({
     }
 
     await Effect.runPromise(
-      revokeOAuthKeyUseCase(parsed).pipe(
+      revokeOAuthKeyUseCase({
+        ...parsed,
+        actor: c.var.auth.method === "oauth" ? { kind: "user", userId: c.var.auth.userId } : { kind: "api-key" },
+      }).pipe(
         Effect.provide(OAuthTokenCacheInvalidatorLive(c.var.redis)),
         withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
         withTracing,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,7 +71,6 @@
     "posthog-js": "1.371.3",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-use": "17.6.0",
     "rosetta-ai": "catalog:",
     "satori": "0.18.4",
     "ua-parser-js": "2.0.9",

--- a/apps/web/src/components/filters-builder/multi-select-filter.tsx
+++ b/apps/web/src/components/filters-builder/multi-select-filter.tsx
@@ -12,9 +12,9 @@ import {
 } from "@repo/ui"
 import { Loader2 } from "lucide-react"
 import { type RefObject, useMemo, useRef, useState } from "react"
-import { useDebounce } from "react-use"
 import { useSessionDistinctValues } from "../../domains/sessions/sessions.collection.ts"
 import { useTraceDistinctValues } from "../../domains/traces/traces.collection.ts"
+import { useDebounce } from "../../lib/hooks/useDebounce.ts"
 import type { DistinctColumn } from "./types.ts"
 
 export type FilterMode = "traces" | "sessions"

--- a/apps/web/src/domains/oauth/oauth-keys.functions.ts
+++ b/apps/web/src/domains/oauth/oauth-keys.functions.ts
@@ -74,7 +74,7 @@ export const revokeOAuthKey = createServerFn({ method: "POST" })
     const redis = getRedisClient()
 
     await Effect.runPromise(
-      revokeOAuthKeyUseCase({ clientId: data.clientId, userId: data.userId }).pipe(
+      revokeOAuthKeyUseCase({ clientId: data.clientId, userId: data.userId, actor: { kind: "organization" } }).pipe(
         Effect.provide(OAuthTokenCacheInvalidatorLive(redis)),
         withPostgres(OAuthKeyRepositoryLive, client, organizationId),
         withTracing,

--- a/apps/web/src/lib/hooks/useDebounce.ts
+++ b/apps/web/src/lib/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+import { type DependencyList, useEffect, useRef } from "react"
+
+/**
+ * Runs `callback` after `delayMs` once `dependencies` stop changing.
+ *
+ * This intentionally mirrors the small subset of `react-use`'s `useDebounce`
+ * API that the web app used, without pulling in its vulnerable js-cookie
+ * transitive dependency.
+ */
+export function useDebounce(callback: () => void, delayMs: number, dependencies: DependencyList): void {
+  const callbackRef = useRef(callback)
+
+  // TODO(frontend-use-effect-policy): keep the latest callback available to the timer without resetting it every render.
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  // TODO(frontend-use-effect-policy): debounce side effect with explicit caller-controlled dependencies.
+  useEffect(() => {
+    const timeout = window.setTimeout(() => callbackRef.current(), delayMs)
+    return () => window.clearTimeout(timeout)
+  }, [delayMs, ...dependencies])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
@@ -1,9 +1,9 @@
 import { Button, cn, Icon, Select, type SelectOption, Text, Textarea, ThumbButton, Tooltip } from "@repo/ui"
 import { InfoIcon, SparklesIcon } from "lucide-react"
 import { memo, useRef, useState } from "react"
-import { useDebounce } from "react-use"
 import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { useIssue, useIssues } from "../../../../../../domains/issues/issues.collection.ts"
+import { useDebounce } from "../../../../../../lib/hooks/useDebounce.ts"
 
 const SAVE_HOTKEY = "Mod+Enter"
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -2,7 +2,6 @@ import type { FilterCondition, FilterSet, PercentileTraceFilterField } from "@do
 import { Button, Icon, Input, Tabs, Text, Tooltip } from "@repo/ui"
 import { ChevronDown, ChevronUp, InfoIcon, XIcon } from "lucide-react"
 import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
-import { useDebounce } from "react-use"
 import {
   getTextFieldsForMode,
   MULTI_SELECT_FIELDS,
@@ -12,6 +11,7 @@ import { MetadataFilter } from "../../../../../components/filters-builder/metada
 import { type FilterMode, MultiSelectFilter } from "../../../../../components/filters-builder/multi-select-filter.tsx"
 import { PercentileFilter } from "../../../../../components/filters-builder/percentile-filter.tsx"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 
 export type { FilterMode }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -50,7 +50,6 @@ function IssuesBreadcrumb() {
 
 import { ActivityIcon, ArchiveIcon, CheckIcon, DownloadIcon, PauseIcon, SearchIcon } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
-import { useDebounce } from "react-use"
 import { invalidateIssueQueries, useIssues } from "../../../../../domains/issues/issues.collection.ts"
 import {
   applyBulkIssueLifecycleAction,
@@ -59,6 +58,7 @@ import {
 } from "../../../../../domains/issues/issues.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
+import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { EMPTY_SELECTION, type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { ColumnsSelector } from "../-components/columns-selector.tsx"

--- a/apps/workers/src/workers/domain-events/magic-link-email-copy.test.ts
+++ b/apps/workers/src/workers/domain-events/magic-link-email-copy.test.ts
@@ -1,0 +1,18 @@
+import { magicLinkTemplate } from "@domain/email"
+import { describe, expect, it } from "vitest"
+
+describe("magic link email copy", () => {
+  it("uses neutral account-existence copy", async () => {
+    const rendered = await magicLinkTemplate({
+      userName: "there",
+      magicLinkUrl: "https://console.latitude.so/api/auth/magic-link/verify?token=test",
+    })
+
+    expect(rendered.subject).toBe("Continue to Latitude")
+    expect(rendered.text).toContain("use this link to continue to Latitude")
+    expect(rendered.html).toContain("Continue to Latitude")
+    expect(rendered.html).not.toContain("Welcome back")
+    expect(rendered.html).not.toContain("signing up")
+    expect(rendered.html).not.toContain("Sign In to Latitude")
+  })
+})

--- a/apps/workers/src/workers/domain-events/magic-link-email.ts
+++ b/apps/workers/src/workers/domain-events/magic-link-email.ts
@@ -1,11 +1,8 @@
-import { magicLinkTemplate, type RenderedEmail, sendEmail, signupMagicLinkTemplate } from "@domain/email"
+import { magicLinkTemplate, sendEmail } from "@domain/email"
 import type { QueueConsumer } from "@domain/queue"
-import { UserRepository } from "@domain/users"
-import { SqlClientLive, UserRepositoryLive } from "@platform/db-postgres"
 import { createEmailTransportSender } from "@platform/email-transport"
 import { createLogger, withTracing } from "@repo/observability"
-import { Effect, Layer } from "effect"
-import { getPostgresClient } from "../../clients.ts"
+import { Effect } from "effect"
 
 const logger = createLogger("magic-link-email")
 const normalizeEmail = (email: string) => email.trim().toLowerCase()
@@ -17,31 +14,14 @@ interface MagicLinkEmailDeps {
 export const createMagicLinkEmailWorker = ({ consumer }: MagicLinkEmailDeps) => {
   consumer.subscribe("magic-link-email", {
     send: (payload) => {
-      const pgClient = getPostgresClient()
       const emailSender = createEmailTransportSender()
       const sendEmailUseCase = sendEmail({ emailSender })
 
-      const repoLayer = UserRepositoryLive.pipe(Layer.provideMerge(SqlClientLive(pgClient)))
-
       return Effect.gen(function* () {
         const normalizedEmail = normalizeEmail(payload.email)
-
-        const userRepo = yield* UserRepository
-        const user = yield* userRepo
-          .findByEmail(normalizedEmail)
-          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-
-        const userName = user?.name ?? "there"
-
-        let rendered: RenderedEmail
-
-        if (user === null) {
-          rendered = yield* Effect.tryPromise(() =>
-            signupMagicLinkTemplate({ userName, magicLinkUrl: payload.magicLinkUrl }),
-          )
-        } else {
-          rendered = yield* Effect.tryPromise(() => magicLinkTemplate({ userName, magicLinkUrl: payload.magicLinkUrl }))
-        }
+        const rendered = yield* Effect.tryPromise(() =>
+          magicLinkTemplate({ userName: "there", magicLinkUrl: payload.magicLinkUrl }),
+        )
 
         yield* sendEmailUseCase({
           to: normalizedEmail,
@@ -54,7 +34,6 @@ export const createMagicLinkEmailWorker = ({ consumer }: MagicLinkEmailDeps) => 
         Effect.tapError((error) =>
           Effect.sync(() => logger.error(`Magic link email failed for ${payload.email}`, error)),
         ),
-        Effect.provide(repoLayer),
         withTracing,
       )
     },

--- a/packages/domain/email/src/templates/magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/magic-link/EmailTemplate.tsx
@@ -14,17 +14,14 @@ interface MagicLinkEmailProps {
 
 export function MagicLinkEmail({ userName, magicLinkUrl }: MagicLinkEmailProps) {
   return (
-    <ContainerLayout previewText={`Hi ${userName}, sign in to Latitude`}>
-      <EmailText
-        variant="heading"
-        className={emailDesignTokens.spacing.headingGap}
-      >{`Welcome back, ${userName}`}</EmailText>
+    <ContainerLayout previewText={`Hi ${userName}, continue to Latitude`}>
+      <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>{`Continue to Latitude`}</EmailText>
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        We received a sign-in request for your account. Tap the button below to continue to your Latitude dashboard.
+        We received a request to access Latitude with this email address. Tap the button below to continue.
       </EmailText>
 
       <Section className={emailDesignTokens.spacing.buttonTop}>
-        <EmailButton href={magicLinkUrl} label="Sign In to Latitude" />
+        <EmailButton href={magicLinkUrl} label="Continue to Latitude" />
       </Section>
 
       <EmailText variant="bodySmall" className={`text-muted-foreground ${emailDesignTokens.spacing.footnoteTop}`}>

--- a/packages/domain/email/src/templates/magic-link/index.tsx
+++ b/packages/domain/email/src/templates/magic-link/index.tsx
@@ -13,8 +13,8 @@ export interface MagicLinkEmailData {
 export async function magicLinkTemplate(data: MagicLinkEmailData): Promise<RenderedEmail> {
   return {
     html: await renderEmail(<MagicLinkEmail userName={data.userName} magicLinkUrl={data.magicLinkUrl} />),
-    subject: `${data.userName}, here's your sign-in link for Latitude`,
-    text: `Hi ${data.userName}, use this link to sign in to Latitude: ${data.magicLinkUrl}`,
+    subject: "Continue to Latitude",
+    text: `Hi ${data.userName}, use this link to continue to Latitude: ${data.magicLinkUrl}`,
   }
 }
 

--- a/packages/domain/oauth-keys/src/index.ts
+++ b/packages/domain/oauth-keys/src/index.ts
@@ -3,4 +3,8 @@ export { OAuthApplicationNotFoundError, OAuthKeyNotFoundError } from "./errors.t
 export { OAuthKeyRepository, OAuthTokenCacheInvalidator } from "./ports/oauth-key-repository.ts"
 export { type GetOAuthKeyInput, getOAuthKeyUseCase } from "./use-cases/get-oauth-key.ts"
 export { listOAuthKeysUseCase } from "./use-cases/list-oauth-keys.ts"
-export { type RevokeOAuthKeyInput, revokeOAuthKeyUseCase } from "./use-cases/revoke-oauth-key.ts"
+export {
+  type RevokeOAuthKeyActor,
+  type RevokeOAuthKeyInput,
+  revokeOAuthKeyUseCase,
+} from "./use-cases/revoke-oauth-key.ts"

--- a/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
+++ b/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
@@ -27,9 +27,8 @@ export class OAuthTokenCacheInvalidator extends Context.Service<
  * accepts `organizationId`. The use-cases compose these primitives.
  *
  * `oauth_access_tokens` and `oauth_consents` have no RLS by design — the
- * tenant scope is enforced by the JOIN through `oauth_applications`. The
- * write methods on tokens reflect that: they take a `clientId` and assume
- * the caller has already verified ownership via `findApplicationInOrganization`.
+ * tenant scope is enforced by the JOIN through `oauth_applications`, including
+ * in write methods that mutate token rows.
  */
 export class OAuthKeyRepository extends Context.Service<
   OAuthKeyRepository,
@@ -63,9 +62,8 @@ export class OAuthKeyRepository extends Context.Service<
      * returns the plaintext `access_token` values that were removed.
      * Callers feed those back through `OAuthTokenCacheInvalidator` so
      * the Redis-cached positive validations don't keep a revoked token
-     * usable until its TTL expires. The tokens table has no RLS, so
-     * callers MUST verify org ownership via
-     * `applicationBelongsToOrganization` first.
+     * usable until its TTL expires. The implementation must scope the
+     * delete through `oauth_applications` because the tokens table has no RLS.
      */
     deleteTokensForPair: (input: {
       readonly clientId: string

--- a/packages/domain/oauth-keys/src/use-cases/revoke-oauth-key.ts
+++ b/packages/domain/oauth-keys/src/use-cases/revoke-oauth-key.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect"
 import { OAuthApplicationNotFoundError } from "../errors.ts"
 import { OAuthKeyRepository, OAuthTokenCacheInvalidator } from "../ports/oauth-key-repository.ts"
 
-export type RevokeOAuthKeyActor = { readonly kind: "api-key" } | { readonly kind: "user"; readonly userId: string }
+export type RevokeOAuthKeyActor = { readonly kind: "organization" } | { readonly kind: "user"; readonly userId: string }
 
 export interface RevokeOAuthKeyInput {
   readonly clientId: string

--- a/packages/domain/oauth-keys/src/use-cases/revoke-oauth-key.ts
+++ b/packages/domain/oauth-keys/src/use-cases/revoke-oauth-key.ts
@@ -1,11 +1,14 @@
-import { SqlClient } from "@domain/shared"
+import { ForbiddenError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { OAuthApplicationNotFoundError } from "../errors.ts"
 import { OAuthKeyRepository, OAuthTokenCacheInvalidator } from "../ports/oauth-key-repository.ts"
 
+export type RevokeOAuthKeyActor = { readonly kind: "api-key" } | { readonly kind: "user"; readonly userId: string }
+
 export interface RevokeOAuthKeyInput {
   readonly clientId: string
   readonly userId: string
+  readonly actor: RevokeOAuthKeyActor
 }
 
 /**
@@ -38,6 +41,11 @@ export interface RevokeOAuthKeyInput {
 export const revokeOAuthKeyUseCase = Effect.fn("oauthKeys.revokeOAuthKey")(function* (input: RevokeOAuthKeyInput) {
   yield* Effect.annotateCurrentSpan("oauthKey.clientId", input.clientId)
   yield* Effect.annotateCurrentSpan("oauthKey.userId", input.userId)
+  yield* Effect.annotateCurrentSpan("oauthKey.actorKind", input.actor.kind)
+
+  if (input.actor.kind === "user" && input.actor.userId !== input.userId) {
+    return yield* new ForbiddenError({ message: "You can only revoke your own OAuth keys" })
+  }
 
   const sqlClient = yield* SqlClient
 

--- a/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
@@ -1,6 +1,6 @@
 import { type OAuthKey, OAuthKeyRepository } from "@domain/oauth-keys"
 import { RepositoryError, SqlClient, type SqlClientShape } from "@domain/shared"
-import { and, desc, eq, max } from "drizzle-orm"
+import { and, desc, eq, inArray, max } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { oauthAccessTokens, oauthApplications, users } from "../schema/better-auth.ts"
@@ -134,11 +134,38 @@ export const OAuthKeyRepositoryLive = Layer.effect(
     deleteTokensForPair: (input) =>
       Effect.gen(function* () {
         const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+        const tokenRows = yield* sqlClient
+          .query((db, organizationId) =>
+            db
+              .select({ id: oauthAccessTokens.id, accessToken: oauthAccessTokens.accessToken })
+              .from(oauthAccessTokens)
+              .innerJoin(oauthApplications, eq(oauthApplications.clientId, oauthAccessTokens.clientId))
+              .where(
+                and(
+                  eq(oauthApplications.organizationId, organizationId),
+                  eq(oauthAccessTokens.clientId, input.clientId),
+                  eq(oauthAccessTokens.userId, input.userId),
+                ),
+              ),
+          )
+          .pipe(
+            Effect.mapError(
+              (cause): RepositoryError => new RepositoryError({ operation: "deleteTokensForPair", cause }),
+            ),
+          )
+
+        if (tokenRows.length === 0) return []
+
         const rows = yield* sqlClient
           .query((db) =>
             db
               .delete(oauthAccessTokens)
-              .where(and(eq(oauthAccessTokens.clientId, input.clientId), eq(oauthAccessTokens.userId, input.userId)))
+              .where(
+                inArray(
+                  oauthAccessTokens.id,
+                  tokenRows.map((row) => row.id),
+                ),
+              )
               .returning({ accessToken: oauthAccessTokens.accessToken }),
           )
           .pipe(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,9 +528,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
-      react-use:
-        specifier: 17.6.0
-        version: 17.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rosetta-ai:
         specifier: 'catalog:'
         version: 2.0.0
@@ -7673,9 +7670,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/js-cookie@2.2.7':
-    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
-
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
@@ -9785,9 +9779,6 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
-
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
@@ -11080,12 +11071,6 @@ packages:
     peerDependencies:
       react: '*'
       tslib: 2.8.1
-
-  react-use@17.6.0:
-    resolution: {integrity: sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -18758,8 +18743,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/js-cookie@2.2.7': {}
-
   '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
@@ -20908,8 +20891,6 @@ snapshots:
 
   jose@6.2.2: {}
 
-  js-cookie@2.2.1: {}
-
   js-md4@0.3.2: {}
 
   js-tiktoken@1.0.21:
@@ -22615,25 +22596,6 @@ snapshots:
   react-universal-interface@0.6.2(react@19.2.5)(tslib@2.8.1):
     dependencies:
       react: 19.2.5
-      tslib: 2.8.1
-
-  react-use@17.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@types/js-cookie': 2.2.7
-      '@xobotyi/scrollbar-width': 1.9.5
-      copy-to-clipboard: 3.3.3
-      fast-deep-equal: 3.1.3
-      fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-universal-interface: 0.6.2(react@19.2.5)(tslib@2.8.1)
-      resize-observer-polyfill: 1.5.1
-      screenfull: 5.2.0
-      set-harmonic-interval: 1.0.1
-      throttle-debounce: 3.0.1
-      ts-easing: 0.2.0
       tslib: 2.8.1
 
   react@18.3.1:


### PR DESCRIPTION
## Summary
- keep the existing Dependabot alert fix that removes the vulnerable react-use dependency
- restrict OAuth-authenticated callers to their own OAuth keys for list/get/revoke operations
- scope OAuth token deletion through the org-owned OAuth application before deleting token rows
- make magic-link email rendering account-existence neutral and add a regression test

## Testing
- pnpm --filter @domain/oauth-keys typecheck
- pnpm --filter @domain/oauth-keys check
- pnpm --filter @app/api typecheck
- pnpm --filter @app/api check
- pnpm --filter @app/workers typecheck
- pnpm --filter @app/workers check
- pnpm --filter @platform/db-postgres typecheck
- pnpm --filter @app/workers exec vitest run --dir src src/workers/domain-events/magic-link-email-copy.test.ts
- LAT_API_URL=http://localhost:3001 LAT_WEB_URL=http://localhost:3000 pnpm --filter @app/api exec vitest run --dir src src/routes/oauth-keys.test.ts