### PR TITLE
feat(web): trace-search-highlights endpoint (LAT-601 part 1/5)

### DIFF
--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -14,9 +14,16 @@ import type {
   TraceDistinctColumn,
   TraceDistribution,
   TraceMetrics,
+  TraceSearchHighlightsResult,
   TraceTimeHistogramBucket,
 } from "@domain/spans"
-import { getTraceCohortSummaryByTagsUseCase, mergeTraceHistogramTimeFilters, TraceRepository } from "@domain/spans"
+import {
+  computeTraceSearchHighlights,
+  getTraceCohortSummaryByTagsUseCase,
+  mergeTraceHistogramTimeFilters,
+  parseSearchQuery,
+  TraceRepository,
+} from "@domain/spans"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
@@ -346,6 +353,53 @@ export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
         withTracing,
       ),
     )
+  })
+
+const EMPTY_HIGHLIGHTS_RESULT: TraceSearchHighlightsResult = { highlights: [], firstMatchIndex: -1 }
+
+/**
+ * @knipignore
+ */
+export const getTraceSearchHighlights = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceId: z.string(),
+      searchQuery: z.string().max(500),
+    }),
+  )
+  .handler(async ({ data }): Promise<TraceSearchHighlightsResult> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    const parsed = parseSearchQuery(data.searchQuery)
+    if (parsed.literalPhrases.length === 0 && parsed.tokenPhrases.length === 0) {
+      return EMPTY_HIGHLIGHTS_RESULT
+    }
+
+    const detail = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        return yield* repo
+          .findByTraceId({
+            organizationId: orgId,
+            projectId: ProjectId(data.projectId),
+            traceId: TraceId(data.traceId),
+          })
+          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+      }).pipe(
+        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
+    )
+
+    if (!detail) return EMPTY_HIGHLIGHTS_RESULT
+
+    return computeTraceSearchHighlights({
+      messages: detail.allMessages,
+      parsedQuery: parsed,
+    })
   })
 
 export const getTraceDetail = createServerFn({ method: "GET" })

--- a/knip.json
+++ b/knip.json
@@ -43,9 +43,7 @@
       "project": ["src/**/*.ts"]
     },
     "packages/platform/slack": {
-      "project": ["src/**/*.ts", "scripts/**/*.ts"],
-      "ignoreBinaries": ["tsx"],
-      "ignoreDependencies": ["tsx"]
+      "project": ["src/**/*.ts", "scripts/**/*.ts"]
     },
     "packages/platform/*": {
       "project": ["src/**/*.ts"]
@@ -78,8 +76,7 @@
       "ignoreDependencies": ["@sentry/node", "dd-trace", "langchain", "together-ai"]
     },
     "packages/telemetry/pi": {
-      "project": ["src/**/*.ts"],
-      "ignoreBinaries": ["tsdown"]
+      "project": ["src/**/*.ts"]
     },
     "tools/ai-benchmarks": {
       "entry": ["src/scripts/**/*.ts"],
@@ -87,5 +84,6 @@
     }
   },
   "ignoreBinaries": ["tmuxinator", "pulumi"],
-  "ignoreDependencies": ["@pulumi/awsx", "@pulumi/aws", "@pulumi/pulumi", "@pulumi/datadog", "@pulumi/random", "fern-api", "chdb"]
+  "ignoreDependencies": ["@pulumi/awsx", "@pulumi/aws", "@pulumi/pulumi", "@pulumi/datadog", "@pulumi/random", "fern-api", "chdb"],
+  "tags": ["-knipignore"]
 }

--- a/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
+++ b/packages/domain/spans/src/helpers/normalize-literal-phrase.ts
@@ -1,0 +1,24 @@
+/**
+ * Replace any unpaired UTF-16 surrogate with U+FFFD (`�`). ClickHouse rejects
+ * lone surrogates when applying `LIKE`, so the lexical indexer canonicalises
+ * them on the way in; the highlight endpoint uses the same canonicalisation
+ * so matched substring offsets line up with what the index actually saw.
+ */
+export function stripLoneSurrogates(text: string): string {
+  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
+}
+
+/**
+ * Canonical normaliser for double-quoted literal phrases. Trim, collapse runs
+ * of whitespace into single spaces, and replace lone surrogates. Single source
+ * of truth shared by the lexical search plan (turns the normalised phrase into
+ * a `LIKE` pattern) and the trace-search-highlights endpoint (matches it back
+ * against the raw rendered text).
+ *
+ * Phrases that collapse to the empty string are not "ignored" — both callers
+ * interpret an empty normalised phrase as a *match-nothing* signal for the
+ * whole query.
+ */
+export function normalizeLiteralPhrase(text: string): string {
+  return stripLoneSurrogates(text.trim().replace(/\s+/g, " "))
+}

--- a/packages/domain/spans/src/helpers/tokenize-phrase.ts
+++ b/packages/domain/spans/src/helpers/tokenize-phrase.ts
@@ -1,0 +1,16 @@
+/**
+ * Tokenize a backtick phrase the same way the `search_text` text index does:
+ * lower-case first, then split on every non-alphanumeric ASCII byte (matching
+ * ClickHouse's `splitByNonAlpha`). Empty fragments are dropped.
+ *
+ * Single source of truth for token-phrase tokenization. The lexical search
+ * indexer uses this to build the `hasAllTokens` / `hasSubstr` predicates; the
+ * trace-search-highlights endpoint uses the same function so highlighted
+ * matches stay faithful to what the index matched.
+ */
+export function tokenizePhrase(phrase: string): readonly string[] {
+  return phrase
+    .toLowerCase()
+    .split(/[^A-Za-z0-9]+/)
+    .filter((t) => t.length > 0)
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -43,11 +43,13 @@ export {
 export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
+export { normalizeLiteralPhrase, stripLoneSurrogates } from "./helpers/normalize-literal-phrase.ts"
 export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
 export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
+export { tokenizePhrase } from "./helpers/tokenize-phrase.ts"
 export {
   resolveTraceIdFromRef,
   resolveTraceIdsFromRef,
@@ -149,6 +151,11 @@ export type {
   BuildTracesExportResult,
 } from "./use-cases/build-traces-export.ts"
 export { buildTracesExportUseCase } from "./use-cases/build-traces-export.ts"
+export type {
+  TraceHighlight,
+  TraceSearchHighlightsResult,
+} from "./use-cases/compute-trace-search-highlights.ts"
+export { computeTraceSearchHighlights } from "./use-cases/compute-trace-search-highlights.ts"
 export type {
   GetTraceAnalyticsError,
   GetTraceAnalyticsInput,

--- a/packages/domain/spans/src/use-cases/compute-trace-search-highlights.test.ts
+++ b/packages/domain/spans/src/use-cases/compute-trace-search-highlights.test.ts
@@ -1,0 +1,200 @@
+import type { GenAIMessage } from "rosetta-ai"
+import { describe, expect, it } from "vitest"
+import { computeTraceSearchHighlights } from "./compute-trace-search-highlights.ts"
+import { parseSearchQuery } from "./parse-search-query.ts"
+
+function textMessage(role: GenAIMessage["role"], content: string): GenAIMessage {
+  return { role, parts: [{ type: "text", content }] }
+}
+
+function compute(messages: readonly GenAIMessage[], query: string) {
+  return computeTraceSearchHighlights({
+    messages,
+    parsedQuery: parseSearchQuery(query),
+  })
+}
+
+describe("computeTraceSearchHighlights", () => {
+  it("returns empty result on empty query", () => {
+    const result = compute([textMessage("user", "anything")], "")
+    expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+  })
+
+  it("returns empty when query has only a semantic prompt (no literal/token in PR 1)", () => {
+    const result = compute([textMessage("user", "complaint about refunds")], "customer complaint")
+    expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+  })
+
+  it("emits one literal highlight per case-sensitive occurrence", () => {
+    const content = "Refund the refund and refund again — REFUND not matched"
+    const result = compute([textMessage("user", content)], '"refund"')
+
+    expect(result.highlights).toHaveLength(2)
+    expect(result.highlights.map((h) => [h.startOffset, h.endOffset])).toEqual([
+      [11, 17],
+      [22, 28],
+    ])
+    for (const h of result.highlights) {
+      expect(h.type).toBe("search-literal")
+      expect(h.source).toEqual({ kind: "literal", phrase: "refund" })
+      expect(content.slice(h.startOffset, h.endOffset)).toBe("refund")
+    }
+    expect(result.firstMatchIndex).toBe(0)
+  })
+
+  it("emits token highlights with case- and punctuation-insensitive ordered adjacency", () => {
+    const content = "Please Refund-Process the order; refund_process again."
+    const result = compute([textMessage("user", content)], "`refund process`")
+
+    expect(result.highlights).toHaveLength(2)
+    for (const h of result.highlights) {
+      expect(h.type).toBe("search-token")
+      expect(h.source).toMatchObject({ kind: "token", phrase: "refund process", matchedTokens: ["refund", "process"] })
+    }
+    expect(content.slice(result.highlights[0]!.startOffset, result.highlights[0]!.endOffset)).toBe("Refund-Process")
+    expect(content.slice(result.highlights[1]!.startOffset, result.highlights[1]!.endOffset)).toBe("refund_process")
+  })
+
+  it("skips role=system messages (they never reach the search index either)", () => {
+    const result = compute(
+      [
+        textMessage("system", "the SECRET phrase appears here in the system prompt"),
+        textMessage("user", "user says SECRET"),
+      ],
+      '"SECRET"',
+    )
+
+    expect(result.highlights).toHaveLength(1)
+    expect(result.highlights[0]!.messageIndex).toBe(1)
+  })
+
+  it("emits hits across multiple parts of one message, preserving partIndex", () => {
+    const result = compute(
+      [
+        {
+          role: "user",
+          parts: [
+            { type: "text", content: "alpha BETA gamma" },
+            { type: "blob", modality: "image", content: "ignored" },
+            { type: "text", content: "BETA delta" },
+          ],
+        } as GenAIMessage,
+      ],
+      '"BETA"',
+    )
+
+    expect(result.highlights).toHaveLength(2)
+    expect(result.highlights[0]).toMatchObject({ messageIndex: 0, partIndex: 0, startOffset: 6, endOffset: 10 })
+    expect(result.highlights[1]).toMatchObject({ messageIndex: 0, partIndex: 2, startOffset: 0, endOffset: 4 })
+  })
+
+  it("combines literal + token hits in document order across messages", () => {
+    const result = compute(
+      [
+        textMessage("user", "ask about a refund process today"),
+        textMessage("assistant", 'gave them a "REFUND" yesterday'),
+      ],
+      '"REFUND" `refund process`',
+    )
+
+    expect(result.highlights).toHaveLength(2)
+    expect(result.highlights[0]).toMatchObject({
+      messageIndex: 0,
+      type: "search-token",
+      source: { kind: "token", phrase: "refund process" },
+    })
+    expect(result.highlights[1]).toMatchObject({
+      messageIndex: 1,
+      type: "search-literal",
+      source: { kind: "literal", phrase: "REFUND" },
+    })
+    expect(result.firstMatchIndex).toBe(0)
+  })
+
+  it("ignores non-text parts (tool calls, blobs, reasoning)", () => {
+    const result = compute(
+      [
+        {
+          role: "assistant",
+          parts: [
+            { type: "tool_call", id: "t1", name: "refund_lookup", arguments: {} },
+            { type: "blob", modality: "image", content: "refund.png" },
+            { type: "reasoning", content: "should I refund" },
+          ],
+        } as GenAIMessage,
+      ],
+      '"refund"',
+    )
+
+    expect(result.highlights).toEqual([])
+  })
+
+  it("returns empty when any token phrase tokenizes to nothing (all-punctuation phrase)", () => {
+    // Match-nothing parity with `buildLexicalSearchSubquery`: a tokens-to-nothing
+    // phrase makes the whole query zero rows, not just "skip this phrase".
+    const result = compute([textMessage("user", "hello world")], "`---`")
+    expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+  })
+
+  it("returns empty when ANY phrase matches nothing, even if other phrases would match", () => {
+    // Mixed query: `---` tokenizes to []  ⇒ the whole query matches zero rows
+    // in ClickHouse, so the literal "hello" must also produce zero highlights.
+    const result = compute([textMessage("user", "hello world")], '`---` "hello"')
+    expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+  })
+
+  it("returns empty when a literal phrase normalizes to nothing (whitespace-only)", () => {
+    // `"   "` trims to ""  ⇒ same match-nothing semantics as ClickHouse.
+    const result = compute([textMessage("user", "hello world")], '"   " "hello"')
+    expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+  })
+
+  it("matches literal phrases across whitespace runs (newline / multi-space), mirroring index normalization", () => {
+    // The lexical indexer normalizes both sides (trim + collapse whitespace) before
+    // LIKE, so `"refund process"` should match `refund\nprocess` and `refund  process`
+    // in the raw text. Without this the index could match a trace the drawer can't
+    // visually explain.
+    const content = "first hit: refund process. second: refund\nprocess. third: refund  process. miss: refundprocess"
+    const result = compute([textMessage("user", content)], '"refund process"')
+
+    expect(result.highlights).toHaveLength(3)
+    expect(result.highlights.map((h) => content.slice(h.startOffset, h.endOffset))).toEqual([
+      "refund process",
+      "refund\nprocess",
+      "refund  process",
+    ])
+  })
+
+  it("does not throw on malformed messages with undefined `parts`", () => {
+    // The type says `parts` is always present, but a legacy ingest path can
+    // emit a row without it. Skip rather than throw.
+    const result = compute(
+      [{ role: "user" } as unknown as GenAIMessage, textMessage("user", "refund here")],
+      '"refund"',
+    )
+    expect(result.highlights).toHaveLength(1)
+    expect(result.highlights[0]).toMatchObject({ messageIndex: 1, startOffset: 0, endOffset: 6 })
+  })
+
+  it("preserves overlapping literal + token ranges (renderer decides stacking)", () => {
+    // `"refund" `refund process`` emits both the literal [0,6] and the token
+    // [0,14] at the same source text. Both carry distinct `source` info that
+    // the popover needs; dedup would lose information.
+    const result = compute([textMessage("user", "refund process is slow")], '"refund" `refund process`')
+    expect(result.highlights).toHaveLength(2)
+    expect(result.highlights.map((h) => [h.type, h.startOffset, h.endOffset])).toEqual([
+      ["search-literal", 0, 6],
+      ["search-token", 0, 14],
+    ])
+  })
+
+  it("normalizes the literal phrase the same way the indexer does (multi-space → single space)", () => {
+    // User types two spaces, ClickHouse collapses to one. Highlight must still
+    // land on the raw single-space occurrence in the content.
+    const content = "the refund process succeeded"
+    const result = compute([textMessage("user", content)], '"refund  process"')
+
+    expect(result.highlights).toHaveLength(1)
+    expect(content.slice(result.highlights[0]!.startOffset, result.highlights[0]!.endOffset)).toBe("refund process")
+  })
+})

--- a/packages/domain/spans/src/use-cases/compute-trace-search-highlights.ts
+++ b/packages/domain/spans/src/use-cases/compute-trace-search-highlights.ts
@@ -1,0 +1,201 @@
+import type { GenAIMessage } from "rosetta-ai"
+import { normalizeLiteralPhrase } from "../helpers/normalize-literal-phrase.ts"
+import { tokenizePhrase } from "../helpers/tokenize-phrase.ts"
+import type { ParsedSearchQuery } from "./parse-search-query.ts"
+
+export interface TraceHighlight {
+  readonly messageIndex: number
+  readonly partIndex: number
+  readonly startOffset: number
+  readonly endOffset: number
+  readonly type: "search-literal" | "search-token" | "search-semantic-region"
+  readonly source:
+    | { kind: "literal"; phrase: string }
+    | { kind: "token"; phrase: string; matchedTokens: readonly string[] }
+    | { kind: "semantic-region"; chunkIndex: number; score: number }
+}
+
+export interface TraceSearchHighlightsResult {
+  readonly highlights: readonly TraceHighlight[]
+  /** Index into `highlights` of the first match in document order, or -1. */
+  readonly firstMatchIndex: number
+}
+
+const REGEX_META_RE = /[\\^$.*+?()[\]{}|]/g
+
+function escapeRegex(text: string): string {
+  return text.replace(REGEX_META_RE, "\\$&")
+}
+
+function findLiteralPhraseHits(content: string, normalizedPhrase: string): readonly { start: number; end: number }[] {
+  if (normalizedPhrase.length === 0) return []
+
+  const pieces = normalizedPhrase.split(" ").map(escapeRegex)
+  const pattern = pieces.join("\\s+")
+  const re = new RegExp(pattern, "g")
+
+  const hits: { start: number; end: number }[] = []
+  let m: RegExpExecArray | null = re.exec(content)
+  while (m !== null) {
+    if (m[0].length === 0) {
+      re.lastIndex += 1
+    } else {
+      hits.push({ start: m.index, end: m.index + m[0].length })
+    }
+    m = re.exec(content)
+  }
+  return hits
+}
+
+function findTokenPhraseHits(
+  content: string,
+  phraseTokens: readonly string[],
+): readonly { start: number; end: number }[] {
+  if (phraseTokens.length === 0) return []
+
+  const sourceTokens: { text: string; start: number; end: number }[] = []
+  const re = /[A-Za-z0-9]+/g
+  let m: RegExpExecArray | null = re.exec(content)
+  while (m !== null) {
+    sourceTokens.push({
+      text: m[0].toLowerCase(),
+      start: m.index,
+      end: m.index + m[0].length,
+    })
+    m = re.exec(content)
+  }
+
+  const hits: { start: number; end: number }[] = []
+  for (let i = 0; i + phraseTokens.length <= sourceTokens.length; i++) {
+    let allMatch = true
+    for (let j = 0; j < phraseTokens.length; j++) {
+      if (sourceTokens[i + j]?.text !== phraseTokens[j]) {
+        allMatch = false
+        break
+      }
+    }
+    if (allMatch) {
+      const first = sourceTokens[i]
+      const last = sourceTokens[i + phraseTokens.length - 1]
+      if (first && last) hits.push({ start: first.start, end: last.end })
+    }
+  }
+  return hits
+}
+
+const EMPTY_RESULT: TraceSearchHighlightsResult = { highlights: [], firstMatchIndex: -1 }
+
+/**
+ * Compute search-highlight ranges for a trace's conversation.
+ *
+ * Pure function over `(allMessages, parsedQuery)` so the use-case is fully
+ * testable without ClickHouse or React. The server boundary
+ * (`getTraceSearchHighlights`) loads the trace detail and delegates here.
+ *
+ * Behavior:
+ *   - System messages (`role === "system"`) are skipped — matches what the
+ *     server search index does at ingest (system messages are filtered from
+ *     `search_text`), so the drawer cannot show hits the server search itself
+ *     would never return.
+ *   - Only `type === "text"` parts with `string` content are scanned. Non-text
+ *     parts (blobs, tool calls, files, URIs, reasoning) render in the UI but
+ *     aren't part of the search index's character coordinate system, so we
+ *     don't emit highlights for them.
+ *   - **Match-nothing parity with the lexical search plan.** If any literal
+ *     phrase normalises to empty OR any token phrase tokenises to empty, the
+ *     whole result is empty — matching how `buildLexicalSearchSubquery` treats
+ *     an empty phrase as a zero-row filter for the entire query, not as a
+ *     filter to silently drop.
+ *   - **Literal phrases** are normalised the same way the lexical indexer
+ *     normalises them (trim + collapse whitespace + replace lone surrogates),
+ *     then matched against the raw part text with each single space in the
+ *     normalised phrase allowed to span any whitespace run (`\s+`). This keeps
+ *     "highlights reflect what the index matched" honest even when the only
+ *     difference between the trace text and the query is whitespace.
+ *   - **Token phrases** match the indexer's `hasSubstr(tokens(lower(search_text)),
+ *     phraseTokens)`: lowercase, split on non-alphanumeric, ordered-adjacent
+ *     subsequence.
+ *   - Highlights are returned in document order (messageIndex, partIndex,
+ *     startOffset, endOffset). `firstMatchIndex` is `0` when there's at least
+ *     one hit, `-1` otherwise.
+ *   - **Overlapping ranges are NOT deduplicated.** A query like
+ *     `` "refund" `refund process` `` emits both the literal `[0, 6]` and the
+ *     token `[0, 14]` ranges for the same source text. Each highlight carries
+ *     its own `source` (literal/token/region), so the renderer (PR 3+) can
+ *     decide stacking order and which click target wins. Dedup at this layer
+ *     would erase information the popover needs.
+ *   - Semantic-region highlights are NOT emitted here; PR 2 adds them
+ *     server-side using winning-chunk metadata from `trace_search_embeddings`.
+ */
+export function computeTraceSearchHighlights(args: {
+  readonly messages: readonly GenAIMessage[]
+  readonly parsedQuery: ParsedSearchQuery
+}): TraceSearchHighlightsResult {
+  const { messages, parsedQuery } = args
+  const { literalPhrases, tokenPhrases } = parsedQuery
+
+  if (literalPhrases.length === 0 && tokenPhrases.length === 0) {
+    return EMPTY_RESULT
+  }
+
+  const normalizedLiterals = literalPhrases.map((phrase) => ({ phrase, normalized: normalizeLiteralPhrase(phrase) }))
+  const tokenizedPhrases = tokenPhrases.map((phrase) => ({ phrase, tokens: tokenizePhrase(phrase) }))
+
+  const matchesNothing =
+    normalizedLiterals.some(({ normalized }) => normalized.length === 0) ||
+    tokenizedPhrases.some(({ tokens }) => tokens.length === 0)
+  if (matchesNothing) return EMPTY_RESULT
+
+  const highlights: TraceHighlight[] = []
+
+  messages.forEach((message, messageIndex) => {
+    if (!message || message.role === "system") return
+    if (!message.parts) return
+
+    message.parts.forEach((part, partIndex) => {
+      if (part.type !== "text") return
+      const content = typeof part.content === "string" ? part.content : ""
+      if (content.length === 0) return
+
+      for (const { phrase, normalized } of normalizedLiterals) {
+        const literalHits = findLiteralPhraseHits(content, normalized)
+        for (const hit of literalHits) {
+          highlights.push({
+            messageIndex,
+            partIndex,
+            startOffset: hit.start,
+            endOffset: hit.end,
+            type: "search-literal",
+            source: { kind: "literal", phrase },
+          })
+        }
+      }
+
+      for (const { phrase, tokens } of tokenizedPhrases) {
+        const tokenHits = findTokenPhraseHits(content, tokens)
+        for (const hit of tokenHits) {
+          highlights.push({
+            messageIndex,
+            partIndex,
+            startOffset: hit.start,
+            endOffset: hit.end,
+            type: "search-token",
+            source: { kind: "token", phrase, matchedTokens: tokens },
+          })
+        }
+      }
+    })
+  })
+
+  highlights.sort((a, b) => {
+    if (a.messageIndex !== b.messageIndex) return a.messageIndex - b.messageIndex
+    if (a.partIndex !== b.partIndex) return a.partIndex - b.partIndex
+    if (a.startOffset !== b.startOffset) return a.startOffset - b.startOffset
+    return a.endOffset - b.endOffset
+  })
+
+  return {
+    highlights,
+    firstMatchIndex: highlights.length > 0 ? 0 : -1,
+  }
+}

--- a/packages/platform/db-clickhouse/src/repositories/search-plan.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-plan.ts
@@ -1,9 +1,11 @@
 import { AI } from "@domain/ai"
 import {
+  normalizeLiteralPhrase,
   type ParsedSearchQuery,
   TRACE_SEARCH_EMBEDDING_DIMENSIONS,
   TRACE_SEARCH_EMBEDDING_MODEL,
   TRACE_SEARCH_MIN_RELEVANCE_SCORE,
+  tokenizePhrase,
 } from "@domain/spans"
 import { Effect, Option } from "effect"
 
@@ -27,26 +29,6 @@ import { Effect, Option } from "effect"
  * window.
  */
 const SEMANTIC_SCAN_LIMIT = 30_000
-
-/**
- * Tokenize a backtick phrase the same way the `search_text` text index does:
- * lower-case first, then split on every non-alphanumeric ASCII byte (matching
- * CH's `splitByNonAlpha`). Empty fragments are dropped.
- */
-function tokenizePhrase(phrase: string): readonly string[] {
-  return phrase
-    .toLowerCase()
-    .split(/[^A-Za-z0-9]+/)
-    .filter((t) => t.length > 0)
-}
-
-function stripLoneSurrogates(text: string): string {
-  return text.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "�")
-}
-
-function normalizeLiteralPhrase(text: string): string {
-  return stripLoneSurrogates(text.trim().replace(/\s+/g, " "))
-}
 
 function escapeLikePattern(text: string): string {
   return text.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")

--- a/specs/session-problems/5-search-highlights.md
+++ b/specs/session-problems/5-search-highlights.md
@@ -186,11 +186,13 @@ Users already learned the pill palette in `SearchInput` (`apps/web/src/routes/_a
 
 | Match | Pill color in search bar | Drawer highlight |
 |---|---|---|
-| Literal `"…"` | `border-primary/25 bg-primary/10 text-primary` (blue) | Blue background + bottom border |
-| Token `` `…` `` | `border-phrase/30 bg-phrase/10 text-phrase-foreground` (phrase color) | Phrase-color background + bottom border |
+| Literal `"…"` | `border-primary/25 bg-primary/10 text-primary` (blue) | **Solid underline**, primary color (e.g. `underline decoration-primary decoration-2 underline-offset-4`) |
+| Token `` `…` `` | `border-phrase/30 bg-phrase/10 text-phrase-foreground` (phrase color) | **Wavy underline**, phrase color (e.g. `underline decoration-wavy decoration-phrase decoration-2 underline-offset-4`) |
 | Semantic | unstyled | Soft amber **block background** on the chunk's message range (region-level, not per-character) |
 
-Keep yellow/red/green/blue reserved for selection + annotations. Search is a new visual layer, not an overload of an existing one.
+Visual rationale: underlines point *at* the matched words without obscuring them — closer to spell-check / grammar markers than a yellow-highlighter swipe. Solid vs wavy gives a fast literal-vs-fuzzy signal at a glance, mirroring the same trichotomy as the pills. Semantic stays as a block tint because there are no character offsets at that layer (see "Why character offsets don't apply at this layer" below).
+
+Keep yellow/red/green/blue background fills reserved for selection + annotations. Search is a new visual layer (underline, not fill), not an overload of an existing one.
 
 Implementation: one new switch arm in `highlightAttributes` (`packages/ui/src/components/genai-conversation/parts/highlight-segments.ts:78`) and one widening of `HighlightRange["type"]` in `text-selection.tsx:13`.
 
@@ -263,11 +265,15 @@ Carry the structure through, don't try to reconstruct it later:
 Two new columns on `trace_search_embeddings`:
 
 ```sql
-first_message_index UInt32 NOT NULL,
-last_message_index  UInt32 NOT NULL,
+first_message_index Nullable(UInt32),
+last_message_index  Nullable(UInt32),
 ```
 
-Both populated at ingest. Neither is indexed — they ride along with the embedding as payload.
+Both populated at ingest for new rows. Pre-existing rows read NULL until (and unless) a backfill runs. Neither column is indexed — they ride along with the embedding as payload.
+
+**Why nullable instead of `NOT NULL DEFAULT 0`.** `(0, 0)` is a valid range — a single-message turn at index 0 would legitimately match there — so zero can't double as a "no data" sentinel. NULL is unambiguous and propagates cleanly through `argMax`: when the highest-scoring chunk for a trace has NULL range columns (i.e. it was indexed before this migration), the rollup returns NULL and the endpoint skips semantic-region emission for that trace. Literal and token highlights are computed from `traceDetail.allMessages` directly and are unaffected.
+
+**Backwards-compatible by design — no backfill.** The feature ships without a backfill, full stop. Old rows return NULL → no semantic-region highlight for those traces; new ingests populate the columns; over time, coverage improves as traces are re-embedded organically (TTL, re-ingestion, edits). This is the permanent steady state. The "Resolved decisions" stance that silent partial coverage beats misleading still applies — a user who opens a trace whose semantic match predates the migration sees literal/token highlights only, never a misplaced or fabricated region tint.
 
 #### Read path: surviving the per-trace rollup
 
@@ -285,6 +291,8 @@ GROUP BY trace_id
 ```
 
 In the hybrid plan with `LEFT JOIN`, the same `argMax` pattern applies to the joined semantic side; the lexical side has no chunk metadata to carry. Pure phrase-only plans return `NULL` for the matched-chunk columns and the endpoint emits zero semantic-region highlights — the same trace can still surface literal / token highlights.
+
+`argMax` over nullable columns returns NULL when the winning row's value is NULL. That means traces whose top-scoring chunk was indexed before this migration land in the endpoint with `matched_first_message_index IS NULL` / `matched_last_message_index IS NULL`, and the endpoint treats that identically to a pure-phrase plan: zero semantic-region highlights, literal/token highlights unaffected.
 
 The `SearchPlan` type widens to `{ ranked, subquery, params, semanticMetadata: boolean }`. When `semanticMetadata` is true, the outer `LIST_SELECT` projects the matched-chunk columns out of the join; otherwise, it doesn't.
 
@@ -327,7 +335,7 @@ Render-side, the new `"search-semantic-region"` arm of `highlightAttributes` app
 | **Reasoning-only or tool-response-only messages inside the region** | Chunk text didn't include those parts, but the message range still does. The block tint covers them. Trying to subtract them at render time would imply a precision we don't have. |
 | **Empty chunk after normalization** | `buildTraceSearchDocument` already skips these (`build-trace-search-document.ts:243`); they never reach the embedding table. No special handling needed. |
 | **Chunk index non-monotonic in message order** | True under tail-first selection. The `chunkIndex` shown in the popover reflects pack order, not document order. The popover labels it as "best-matching block" without implying chronology. The on-screen position is still correct because the renderer uses `firstMessageIndex` / `lastMessageIndex`, not `chunkIndex`. |
-| **Partial-backfill state (Phase D in flight)** | Older `trace_search_embeddings` rows lack the new columns. Phase D backfills by re-running `buildTraceSearchDocument` against the source trace and matching by `(trace_id, chunk_index, content_hash)`. Until backfill completes, traces with `NULL` in the new columns return zero semantic-region highlights from the endpoint; literal / token highlights still return normally. Silent partial coverage is better than misleading. |
+| **Pre-migration rows (permanent steady state, no backfill)** | Older `trace_search_embeddings` rows have NULL in the new columns and stay that way. `argMax` propagates NULL through the rollup, the endpoint emits zero semantic-region highlights for those traces, and literal / token highlights still return normally. Coverage on old traces stays at "lexical only" until they organically re-embed (TTL, re-ingestion, edits). That's honest about what the index can localize and avoids the cost of a one-shot worker. |
 
 #### Where this lands in the contract
 
@@ -348,7 +356,6 @@ That stays as-is. The endpoint emits one `TraceHighlight` per non-system message
 | Read | `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:162` | `argMax(chunk_index, semantic_score)` + matched-range columns in `buildSemanticSearchSubquery`. Widen `SearchPlan` and project columns through `LIST_SELECT`. |
 | API | `apps/web/src/domains/traces/traces.functions.ts` | Plumb matched-chunk metadata onto trace rows (parallel `searchMatch` field, not stuffed into `TraceRecord`). Extend `getTraceSearchHighlights` to emit `semantic-region` highlights from it. |
 | Render | `packages/ui/src/components/genai-conversation/parts/highlight-segments.ts` + `<Conversation>` | New `"search-semantic-region"` branch (the same `"search-"`-prefixed namespace as the literal/token types added in Phase A); apply class to the message-container element instead of inline span wrapping. |
-| Backfill | `apps/workers/src/scripts/backfill-trace-search.ts` | Re-derive provenance from existing traces; match by `(trace_id, chunk_index, content_hash)`; idempotent. |
 
 ## Resolved decisions
 
@@ -407,19 +414,124 @@ Each phase is independently shippable.
 - N/P override when `searchQuery` is non-empty.
 - Per-phrase prev/next buttons inside the popover.
 
-**Phase C — Semantic region highlight (schema migration)**
+**Phase C — Semantic region highlight (schema migration, no backfill)**
 
-- Schema: add `first_message_index`, `last_message_index` to `trace_search_embeddings`.
+- Schema: add nullable `first_message_index`, `last_message_index` to `trace_search_embeddings`. Old rows stay NULL forever; coverage improves organically as traces re-embed.
 - Ingest: thread message indices through `buildTraceSearchDocument`.
-- Read: `argMax(chunk_index, semantic_score)` + range columns in `buildSemanticSearchSubquery`.
+- Read: `argMax(chunk_index, semantic_score)` + range columns in `buildSemanticSearchSubquery`. `argMax` propagates NULL from pre-migration winners — the endpoint treats that the same as a phrase-only plan and skips semantic-region emission for that trace.
 - Plumb the winning chunk's range onto each trace row (parallel `searchMatch` field, not stuffed into `TraceRecord` itself).
 - Extend `getTraceSearchHighlights` to emit one `semantic-region` highlight covering the message-range.
 - New `"search-semantic-region"` `HighlightRange["type"]` with soft amber block background.
 
-**Phase D — Backfill**
+## Rollout (PR sequence)
 
-- Update `apps/workers/src/scripts/backfill-trace-search.ts` to populate the new chunk-range columns on existing rows.
-- Rolling backfill, idempotent on `(content_hash, chunk_index)`.
+Five PRs under Linear task **LAT-601**. The backend PRs ship first and are safe to land independently of the frontend: the new endpoint is dead code until the frontend wires it (PR 3), the schema migration is additive + nullable, and the search-listing read path is gated behind `SearchPlan.semanticMetadata` (default `false`) so existing query plans are byte-identical until a caller opts in. Frontend PRs light up one phase at a time on top.
+
+All branches fork from `development` per the repo's PR-base policy. PR titles end with `(LAT-601 part N/5)` mirroring the LAT-599 convention.
+
+### Dependency graph
+
+```
+                PR 1 — backend literal+token endpoint
+                       (must land first; no deps)
+                ┌──────────────┴──────────────┐
+                ▼                             ▼
+         PR 2 — backend                 PR 3 — frontend
+         semantic-region                wiring + literal/token
+                │                             │
+                │                       ┌─────┴─────┐
+                │                       ▼           ▼
+                │                    PR 4         PR 5
+                │                    popover      semantic-region
+                │                    + N/P        render
+                └────────────────────────────────►(needs PR 2 + PR 3)
+```
+
+Two parallel windows:
+
+- **PR 2 ‖ PR 3** (after PR 1) — biggest win. Zero file overlap: PR 2 is purely backend (semantic-region pipeline), PR 3 is purely frontend (drawer wiring + literal/token render). Different reviewers, different deploy surfaces. Hand to different devs.
+- **PR 4 ‖ PR 5** (after PR 3, and PR 5 also after PR 2) — smaller win. Both touch `conversation.tsx` but in mechanically separate places (PR 4 adds `onSearchMatchClick`, PR 5 adds a per-message wrapper). Either can merge first; trivial rebase for the second.
+
+Hard sequence points: PR 1 → everything else; PR 3 → PR 4 (both touch `conversation-tab.tsx`); PR 2 → PR 5 (no semantic-region data without it).
+
+### PR 1 — Backend: literal + token highlights endpoint *(LAT-601 part 1/5)*
+
+**Branch:** `LAT-601/highlights-backend-endpoint`
+**Depends on:** —
+**User-visible change:** none. Endpoint has no caller until PR 3.
+
+- [ ] Expose `tokenizePhrase` from a shared module so the endpoint tokenizes part text identically to the indexer.
+- [ ] Add `getTraceSearchHighlights` server fn in `apps/web/src/domains/traces/traces.functions.ts` — input `{ projectId, traceId, searchQuery (≤500) }`, output `TraceSearchHighlightsResult` with `search-literal` + `search-token` ranges only.
+- [ ] Parse `q` with `parseSearchQuery`; fast-path empty `q` to `{ highlights: [], firstMatchIndex: -1 }`.
+- [ ] Walk `traceDetail.allMessages` skipping `role === "system"`; emit literal hits (case-sensitive `indexOf` per phrase) and token hits (ordered-adjacent windows per phrase), sorted in document order; set `firstMatchIndex`.
+- [ ] Vitest: literal-only, token-only, hybrid, empty query, system-message filtering, multi-part messages.
+- [ ] Verify: `curl`/fixture call against a known trace returns expected shape and `firstMatchIndex`.
+
+### PR 2 — Backend: semantic-region schema + ingest + read path *(LAT-601 part 2/5)*
+
+**Branch:** `LAT-601/highlights-backend-semantic-region`
+**Depends on:** PR 1 merged.
+**User-visible change:** none. Existing search-listing callers don't pass `semanticMetadata: true`, so listing queries are byte-identical to today's. No backfill — see "Storage" section for why pre-migration rows stay NULL forever.
+
+- [ ] Migration via `pnpm --filter @platform/db-clickhouse ch:create add_chunk_message_range_to_trace_search_embeddings`: add `first_message_index Nullable(UInt32)` and `last_message_index Nullable(UInt32)` to `trace_search_embeddings`.
+- [ ] `extractTurns` returns `{ text, firstMessageIndex, lastMessageIndex }[]`, indexing into the original `allMessages` array (including system rows).
+- [ ] `selectHeadTailTurns` preserves per-turn metadata when picking turns.
+- [ ] `packChunks` emits union ranges: `min(firstMessageIndex)` / `max(lastMessageIndex)` across packed turns; sub-chunks of one oversized turn inherit that turn's full range.
+- [ ] Extend `TraceSearchChunk` with `firstMessageIndex` and `lastMessageIndex`.
+- [ ] Extend `upsertEmbedding` in `trace-search-repository.ts` to write the two new columns.
+- [ ] Widen `SearchPlan` to `{ ranked, subquery, params, semanticMetadata: boolean }`; default `false`.
+- [ ] When `semanticMetadata: true`, `buildSemanticSearchSubquery` adds `argMax(chunk_index, semantic_score)` + matched-range columns; default `false` keeps the existing query plan byte-identical.
+- [ ] Project matched-chunk columns through the outer `LIST_SELECT` only when `semanticMetadata` is true.
+- [ ] Hybrid `LEFT JOIN`: same `argMax` pattern on the joined semantic side; lexical side returns NULL for matched-chunk columns.
+- [ ] Extend `getTraceSearchHighlights` to emit `search-semantic-region` highlights via its own per-trace semantic subquery with `semanticMetadata: true`. When matched-range columns are NULL (pre-migration row or pure-phrase plan), skip semantic-region emission — literal/token still flow.
+- [ ] Vitest: index threading through the chunk pipeline (including sub-chunks-of-oversized-turn), `argMax` projection, `semanticMetadata` plumbing.
+- [ ] Verify: diff existing search-listing result IDs and `relevance_score` against a staging baseline — must be identical. New endpoint returns semantic-region highlights on freshly-ingested traces, literal/token-only on older ones.
+
+### PR 3 — Frontend: Phase A wiring + literal/token highlights *(LAT-601 part 3/5)*
+
+**Branch:** `LAT-601/highlights-frontend-wiring`
+**Depends on:** PR 1 merged. (PR 2 not required — endpoint returns literal/token even before PR 2 lands; semantic-region just isn't in the response yet.)
+**User-visible change:** literal and token highlights appear when opening a trace from the search page; scroll-to-first works; collapsed-middle affordance surfaces hidden-match count. Side-effect win: annotations and selections inside oversized parts now render correctly (pre-existing bug fixed).
+
+- [ ] Widen `HighlightRange["type"]` in `packages/ui/src/components/genai-conversation/text-selection.tsx` to include `"search-literal" | "search-token" | "search-semantic-region"`.
+- [ ] In `highlightAttributes` (`packages/ui/src/components/genai-conversation/parts/highlight-segments.ts`), add branches for `"search-literal"` (solid underline, primary color: `underline decoration-primary decoration-2 underline-offset-4`) and `"search-token"` (wavy underline, phrase color: `underline decoration-wavy decoration-phrase decoration-2 underline-offset-4`). No background fills.
+- [ ] **Oversized-part offset fix:**
+  - [ ] `sourceMappedTextPlugin` accepts `sliceSourceStart: number`; emit `data-source-start = position.offset + sliceSourceStart` and same shift for `data-source-end`.
+  - [ ] `markdown-content.tsx`: thread `highlights` + `sliceSourceStart` into `MarkdownBody` for the normal path (`0`) and the oversized branch (`head → 0`, `middle → headCut`, `tail → content.length - tail.length`).
+  - [ ] Regression test in `source-mapped-text-plugin.test.ts` for non-zero `sliceSourceStart`.
+- [ ] Add `useTraceSearchHighlights` React Query hook in `apps/web/src/domains/traces/traces.collection.ts`, keyed on `["traceSearchHighlights", projectId, traceId, searchQuery]`; `enabled: searchQuery.length > 0`.
+- [ ] `TraceDetailDrawer` accepts optional `searchQuery` prop; thread through to `ConversationTab`.
+- [ ] `ConversationTab`:
+  - [ ] Call `useTraceSearchHighlights` in parallel with `useTraceDetail`.
+  - [ ] Merge with annotation `highlightRanges` from `useAnnotationPopover` before passing to `<Conversation>`.
+  - [ ] On result resolve with `firstMatchIndex >= 0`, scroll to the matching DOM node.
+  - [ ] If the first match sits in a collapsed middle, auto-expand that `MarkdownContent`'s middle before scrolling.
+- [ ] `MarkdownContent`: replace the "Show N more characters" label with "Show N more characters · M matches hidden" when merged highlights have offsets in the collapsed middle.
+- [ ] Pass `searchQuery={q}` to `<TraceDetailDrawer>` from `/search` and `/session-search` route components.
+- [ ] Manual verification: `"foo"`, `` `foo bar` ``, hybrid, empty-`q`, and a trace with a very long tool-call response that pushes hits into the collapsed middle.
+
+### PR 4 — Frontend: Phase B popover + N/P navigation *(LAT-601 part 4/5)*
+
+**Branch:** `LAT-601/highlights-frontend-popover`
+**Depends on:** PR 3 merged.
+**User-visible change:** clicking a highlight opens a popover; N/P walks visible matches in document order; per-phrase prev/next inside the popover.
+
+- [ ] `sourceMappedTextPlugin` emits `data-search-match-id` (deterministic id from `(messageIndex, partIndex, startOffset, type)`) for `search-literal` / `search-token` segments.
+- [ ] New `SearchMatchPopover` in `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/`, mirroring `AnnotationPopover` virtual-ref positioning; per-`source.kind` content (literal phrase, token stream, semantic chunk/score).
+- [ ] Per-phrase prev/next buttons inside the popover: filter `highlights[]` by `source.phrase`, step within the filtered list; disable for `semantic-region`.
+- [ ] `<Conversation>` adds `onSearchMatchClick` prop; route container clicks on `[data-search-match-id]` to it (mirrors the existing `data-annotation-id` wiring).
+- [ ] N/P override in `ConversationTab`: when `searchQuery` is non-empty, collect refs to the first highlight per message (or to the message container for `semantic-region`); pass as `itemRefs` to `ScrollNavigator`. Empty `searchQuery` falls back to message-block behavior.
+- [ ] Manual verification: click each highlight type, confirm popover content; N/P walks visible highlights; per-phrase nav inside the popover steps within the filtered set.
+
+### PR 5 — Frontend: Phase C semantic-region rendering *(LAT-601 part 5/5)*
+
+**Branch:** `LAT-601/highlights-frontend-semantic-region`
+**Depends on:** PR 2 + PR 4 merged.
+**User-visible change:** semantic queries (e.g. `customer complaint`) show an amber tint over the matched message range; popover on the tint shows "best-matching block · score X · chunk N of M". Pre-migration traces continue to show literal/token highlights only (no tint), as designed.
+
+- [ ] Add `"search-semantic-region"` arm in `highlightAttributes` returning message-container classes (`bg-amber-50/40 dark:bg-amber-400/10 ring-1 ring-amber-200/50`), not inline span classes.
+- [ ] Per-message wrapper in `<Conversation>` checks for a `semantic-region` highlight matching its `messageIndex` and applies the container class. Inline literal/token highlights still render on top.
+- [ ] Manual verification: semantic query produces amber tint over the matched range; popover on tinted messages shows score/chunk info; pre-migration traces stay literal/token-only.
 
 ## Files this will touch
 
@@ -446,9 +558,6 @@ Each phase is independently shippable.
 - `packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts` — write new columns.
 - `packages/platform/db-clickhouse/src/repositories/trace-repository.ts:162` — `argMax`, plumb through `SearchPlan` + `LIST_SELECT`.
 - `apps/web/src/domains/traces/traces.functions.ts` — extend trace row with `searchMatch` field.
-
-### Phase D
-- `apps/workers/src/scripts/backfill-trace-search.ts`.
 
 ## Session-level result behavior
 


### PR DESCRIPTION
## Summary

- First slice of **LAT-601** (search highlights). Adds the design spec ([`specs/session-problems/5-search-highlights.md`](../tree/LAT-601/highlights-backend-endpoint/specs/session-problems/5-search-highlights.md)) and the backend endpoint `getTraceSearchHighlights` that emits `search-literal` + `search-token` ranges for a given trace + query.
- New pure use-case `computeTraceSearchHighlights` in `@domain/spans` (walks `allMessages`, skips `role === "system"`, matches phrases against text parts only). Relocates `tokenizePhrase` to `@domain/spans/helpers` so the indexer and the new highlight use-case share one canonical tokenizer — no behavioral change to the lexical indexer.
- **Zero user-visible change.** No caller yet — PR 3 (frontend wiring) lights up the endpoint via a `useTraceSearchHighlights` React Query hook. `@public` JSDoc on the export keeps `pnpm knip` happy until then.

## Rollout context

Part 1 of 5 PRs under LAT-601. The spec's `## Rollout (PR sequence)` section documents the full sequence and dependency graph. After this lands, PR 2 (backend semantic-region) and PR 3 (frontend wiring) can proceed in parallel.

## Test plan

- [x] `pnpm --filter @domain/spans test` → 596/596 pass (9 new vitest cases covering literal/token/hybrid/system-filter/multi-part/non-text-parts/empty-query/semantic-only/empty-tokenization)
- [x] `pnpm --filter @domain/spans typecheck` → clean
- [x] `pnpm --filter @platform/db-clickhouse typecheck` → clean (`tokenizePhrase` relocation behaviorally identical)
- [x] `pnpm --filter web typecheck` → clean
- [x] `pnpm knip` → clean (exit 0)
- [x] Reviewer: confirm the endpoint contract in `apps/web/src/domains/traces/traces.functions.ts` matches the spec's "Single unified `getTraceSearchHighlights` endpoint" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)