### PR TITLE
feat(search): semantic-region highlights pipeline (LAT-601 part 2/5)

### DIFF
--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -18,19 +18,18 @@ import type {
   TraceTimeHistogramBucket,
 } from "@domain/spans"
 import {
-  computeTraceSearchHighlights,
   getTraceCohortSummaryByTagsUseCase,
+  getTraceSearchHighlightsUseCase,
   mergeTraceHistogramTimeFilters,
-  parseSearchQuery,
   TraceRepository,
 } from "@domain/spans"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
-import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { TraceRepositoryLive, TraceSearchRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
 import { z } from "zod"
 import { enforceExportRequestRateLimit } from "../../domains/exports/export-rate-limit.ts"
@@ -355,8 +354,6 @@ export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
     )
   })
 
-const EMPTY_HIGHLIGHTS_RESULT: TraceSearchHighlightsResult = { highlights: [], firstMatchIndex: -1 }
-
 /**
  * @knipignore
  */
@@ -372,34 +369,19 @@ export const getTraceSearchHighlights = createServerFn({ method: "GET" })
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
 
-    const parsed = parseSearchQuery(data.searchQuery)
-    if (parsed.literalPhrases.length === 0 && parsed.tokenPhrases.length === 0) {
-      return EMPTY_HIGHLIGHTS_RESULT
-    }
-
-    const detail = await Effect.runPromise(
-      Effect.gen(function* () {
-        const repo = yield* TraceRepository
-        return yield* repo
-          .findByTraceId({
-            organizationId: orgId,
-            projectId: ProjectId(data.projectId),
-            traceId: TraceId(data.traceId),
-          })
-          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    return Effect.runPromise(
+      getTraceSearchHighlightsUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        traceId: TraceId(data.traceId),
+        searchQuery: data.searchQuery,
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withClickHouse(Layer.merge(TraceRepositoryLive, TraceSearchRepositoryLive), getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
+        Effect.orElseSucceed((): TraceSearchHighlightsResult => ({ highlights: [], firstMatchIndex: -1 })),
       ),
     )
-
-    if (!detail) return EMPTY_HIGHLIGHTS_RESULT
-
-    return computeTraceSearchHighlights({
-      messages: detail.allMessages,
-      parsedQuery: parsed,
-    })
   })
 
 export const getTraceDetail = createServerFn({ method: "GET" })

--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -42,9 +42,21 @@ import { prioritizeChunksForEmbedding, resolveTraceSearchRetentionDays } from ".
 describe("prioritizeChunksForEmbedding", () => {
   it("prioritizes tail chunks first and skips chunks below the embedding floor", () => {
     const chunks: TraceSearchChunk[] = [
-      { chunkIndex: 0, text: "a".repeat(TRACE_SEARCH_EMBEDDING_MIN_LENGTH), contentHash: "0" },
-      { chunkIndex: 2, text: "c".repeat(TRACE_SEARCH_EMBEDDING_MIN_LENGTH), contentHash: "2" },
-      { chunkIndex: 1, text: "short", contentHash: "1" },
+      {
+        chunkIndex: 0,
+        text: "a".repeat(TRACE_SEARCH_EMBEDDING_MIN_LENGTH),
+        contentHash: "0",
+        firstMessageIndex: 0,
+        lastMessageIndex: 0,
+      },
+      {
+        chunkIndex: 2,
+        text: "c".repeat(TRACE_SEARCH_EMBEDDING_MIN_LENGTH),
+        contentHash: "2",
+        firstMessageIndex: 4,
+        lastMessageIndex: 5,
+      },
+      { chunkIndex: 1, text: "short", contentHash: "1", firstMessageIndex: 2, lastMessageIndex: 3 },
     ]
 
     expect(prioritizeChunksForEmbedding(chunks).map((chunk) => chunk.chunkIndex)).toEqual([2, 0])

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -214,6 +214,8 @@ const processRefreshTrace = (payload: RefreshTracePayload) =>
         embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
         embedding,
         retentionDays,
+        firstMessageIndex: chunk.firstMessageIndex,
+        lastMessageIndex: chunk.lastMessageIndex,
       })
       embeddedCount++
     }

--- a/packages/domain/spans/package.json
+++ b/packages/domain/spans/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@domain/ai": "workspace:*",
     "@domain/billing": "workspace:*",
     "@repo/utils": "workspace:*",
     "@domain/events": "workspace:*",

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -106,6 +106,7 @@ export type {
   TraceSearchDocumentRow,
   TraceSearchEmbeddingRow,
   TraceSearchRepositoryShape,
+  TraceSemanticHighlightMatch,
 } from "./ports/trace-search-repository.ts"
 export { TraceSearchRepository } from "./ports/trace-search-repository.ts"
 export {
@@ -167,6 +168,7 @@ export type {
 export { getTraceAnalyticsUseCase } from "./use-cases/get-trace-analytics.ts"
 export type { GetTraceCohortSummaryByTagsInput } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
 export { getTraceCohortSummaryByTagsUseCase } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
+export { getTraceSearchHighlightsUseCase } from "./use-cases/get-trace-search-highlights.ts"
 export type { IngestSpansInput } from "./use-cases/ingest-spans.ts"
 export { ingestSpansUseCase } from "./use-cases/ingest-spans.ts"
 export { ingestSpansWithBillingUseCase } from "./use-cases/ingest-spans-with-billing.ts"

--- a/packages/domain/spans/src/ports/trace-search-repository.ts
+++ b/packages/domain/spans/src/ports/trace-search-repository.ts
@@ -1,6 +1,13 @@
 import type { OrganizationId, ProjectId, RepositoryError, TraceId } from "@domain/shared"
 import { Context, type Effect } from "effect"
 
+export interface TraceSemanticHighlightMatch {
+  readonly chunkIndex: number
+  readonly firstMessageIndex: number | null
+  readonly lastMessageIndex: number | null
+  readonly relevanceScore: number
+}
+
 export interface TraceSearchDocumentRow {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
@@ -23,6 +30,8 @@ export interface TraceSearchEmbeddingRow {
   readonly embeddingModel: string
   readonly embedding: readonly number[]
   readonly retentionDays?: number
+  readonly firstMessageIndex?: number
+  readonly lastMessageIndex?: number
 }
 
 /**
@@ -60,6 +69,23 @@ export interface TraceSearchRepositoryShape {
     chunkIndex: number,
     contentHash: string,
   ): Effect.Effect<boolean, RepositoryError>
+
+  /**
+   * Cosine-scan the chunks of a single trace against `queryEmbedding` and
+   * return the winning chunk's metadata. Used by `getTraceSearchHighlights`
+   * to paint the semantic-region highlight (LAT-601).
+   *
+   * Returns `null` when the trace has no chunk rows (TTL'd, never indexed,
+   * or pre-PR-2 in flight). When the winning chunk predates migration 00017,
+   * `firstMessageIndex` / `lastMessageIndex` come back NULL — caller falls
+   * back to literal/token highlights only.
+   */
+  findSemanticHighlightForTrace(args: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceId: TraceId
+    readonly queryEmbedding: readonly number[]
+  }): Effect.Effect<TraceSemanticHighlightMatch | null, RepositoryError>
 }
 
 export class TraceSearchRepository extends Context.Service<TraceSearchRepository, TraceSearchRepositoryShape>()(

--- a/packages/domain/spans/src/use-cases/build-trace-search-document.test.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-search-document.test.ts
@@ -272,6 +272,65 @@ describe("buildTraceSearchDocument", () => {
       const uniqueHashes = new Set(a.chunks.map((c) => c.contentHash))
       expect(uniqueHashes.size).toBe(a.chunks.length)
     })
+
+    describe("message-range threading (LAT-601)", () => {
+      it("emits firstMessageIndex/lastMessageIndex covering the turn's message range", async () => {
+        const document = await build([
+          textMessage("user", "first user message"),
+          textMessage("assistant", "first assistant response"),
+        ])
+
+        expect(document.chunks).toHaveLength(1)
+        expect(document.chunks[0]).toMatchObject({ firstMessageIndex: 0, lastMessageIndex: 1 })
+      })
+
+      it("indexes against the original allMessages array (system rows included)", async () => {
+        const document = await build([
+          textMessage("system", "system prompt"),
+          textMessage("user", "user q"),
+          textMessage("assistant", "assistant a"),
+        ])
+
+        expect(document.chunks).toHaveLength(1)
+        expect(document.chunks[0]).toMatchObject({ firstMessageIndex: 1, lastMessageIndex: 2 })
+      })
+
+      it("packs multiple turns into one chunk with a union message range", async () => {
+        const document = await build([
+          textMessage("user", "u0"),
+          textMessage("assistant", "a0"),
+          textMessage("user", "u1"),
+          textMessage("assistant", "a1"),
+        ])
+
+        expect(document.chunks).toHaveLength(1)
+        expect(document.chunks[0]).toMatchObject({ firstMessageIndex: 0, lastMessageIndex: 3 })
+      })
+
+      it("inherits the full turn range for every sub-chunk of an oversized turn", async () => {
+        const huge = "y".repeat(TRACE_SEARCH_CHUNK_MAX_CHARS * 3)
+        const document = await build([textMessage("user", "u"), textMessage("assistant", huge)])
+
+        expect(document.chunks.length).toBeGreaterThanOrEqual(2)
+        for (const chunk of document.chunks) {
+          expect(chunk.firstMessageIndex).toBe(0)
+          expect(chunk.lastMessageIndex).toBe(1)
+        }
+      })
+
+      it("preserves original allMessages indices on chunks that survived head/tail selection", async () => {
+        const messages: GenAIMessage[] = []
+        for (let i = 0; i < 22; i++) {
+          messages.push(textMessage("user", `marker-${i.toString().padStart(2, "0")} ${"x".repeat(900)}`))
+          messages.push(textMessage("assistant", `reply-${i.toString().padStart(2, "0")}`))
+        }
+
+        const document = await build(messages)
+
+        const lastChunk = document.chunks.at(-1)!
+        expect(lastChunk.lastMessageIndex).toBeGreaterThanOrEqual(40)
+      })
+    })
   })
 })
 

--- a/packages/domain/spans/src/use-cases/build-trace-search-document.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-search-document.ts
@@ -21,6 +21,8 @@ export interface TraceSearchChunk {
   readonly chunkIndex: number
   readonly text: string
   readonly contentHash: string
+  readonly firstMessageIndex: number
+  readonly lastMessageIndex: number
 }
 
 export interface TraceSearchDocument {
@@ -67,33 +69,49 @@ function formatGenAIMessage(message: GenAIMessage): string {
     .trim()
 }
 
+interface ExtractedTurn {
+  readonly text: string
+  readonly firstMessageIndex: number
+  readonly lastMessageIndex: number
+}
+
 /**
  * Group messages into "turns": each turn starts with a user message (or the
  * first non-system message if the conversation opens with the assistant), and
  * extends through the model's response and any tool-call/tool-response pairs
  * up to the next user message.
  *
- * System messages are filtered out entirely — they're prompts, not content.
+ * System messages are filtered out of the turn text but their positions are
+ * preserved in `allMessages`, so `firstMessageIndex` / `lastMessageIndex` may
+ * span over a system row (e.g. a `system,user,assistant` prefix yields one
+ * turn with `firstMessageIndex: 1` and `lastMessageIndex: 2`).
  */
-function extractTurns(messages: readonly GenAIMessage[]): string[] {
-  const turns: string[][] = []
-  let current: string[] | undefined
+function extractTurns(messages: readonly GenAIMessage[]): ExtractedTurn[] {
+  const turns: { texts: string[]; firstMessageIndex: number; lastMessageIndex: number }[] = []
+  let current: { texts: string[]; firstMessageIndex: number; lastMessageIndex: number } | undefined
 
-  for (const message of messages) {
-    if (!message) continue
-    if (message.role === "system") continue
+  messages.forEach((message, messageIndex) => {
+    if (!message) return
+    if (message.role === "system") return
     const text = formatGenAIMessage(message)
-    if (!text) continue
+    if (!text) return
 
     if (message.role === "user" || current === undefined) {
-      current = [text]
+      current = { texts: [text], firstMessageIndex: messageIndex, lastMessageIndex: messageIndex }
       turns.push(current)
     } else {
-      current.push(text)
+      current.texts.push(text)
+      current.lastMessageIndex = messageIndex
     }
-  }
+  })
 
-  return turns.map((turn) => turn.join("\n").trim()).filter((t) => t.length > 0)
+  return turns
+    .map((turn) => ({
+      text: turn.texts.join("\n").trim(),
+      firstMessageIndex: turn.firstMessageIndex,
+      lastMessageIndex: turn.lastMessageIndex,
+    }))
+    .filter((t) => t.text.length > 0)
 }
 
 /**
@@ -104,13 +122,13 @@ function extractTurns(messages: readonly GenAIMessage[]): string[] {
  * Both walks soft-cap on their boundary: the turn that crosses is still
  * included fully (atomic-turn rule), then the walk stops.
  */
-function selectHeadTailTurns(turns: readonly string[]): string[] {
+function selectHeadTailTurns(turns: readonly ExtractedTurn[]): ExtractedTurn[] {
   const tailIndices = new Set<number>()
   let tailAccum = 0
   for (let i = turns.length - 1; i >= 0; i--) {
     if (tailAccum >= TRACE_SEARCH_CHUNK_TAIL_BUDGET_CHARS) break
     tailIndices.add(i)
-    tailAccum += turns[i]!.length
+    tailAccum += turns[i]!.text.length
   }
 
   const headIndices: number[] = []
@@ -119,7 +137,7 @@ function selectHeadTailTurns(turns: readonly string[]): string[] {
     if (tailIndices.has(i)) break
     if (headAccum >= TRACE_SEARCH_CHUNK_HEAD_BUDGET_CHARS) break
     headIndices.push(i)
-    headAccum += turns[i]!.length
+    headAccum += turns[i]!.text.length
   }
 
   const sortedTail = [...tailIndices].sort((a, b) => a - b)
@@ -128,42 +146,65 @@ function selectHeadTailTurns(turns: readonly string[]): string[] {
 
 interface ChunkPayload {
   readonly text: string
+  readonly firstMessageIndex: number
+  readonly lastMessageIndex: number
 }
 
 /**
  * Greedy-pack turns into chunks. A turn larger than the per-chunk cap splits
  * into overlapping pieces; smaller turns accumulate into one chunk until the
  * next turn would push it over the cap.
+ *
+ * Each emitted chunk carries the **union** of the message ranges of every
+ * turn that contributed to it. Sub-chunks of one oversized turn inherit that
+ * turn's full range (turns are atomic for the mapping) so every sub-chunk
+ * maps to the same conversational region.
  */
-function packChunks(turns: readonly string[]): ChunkPayload[] {
+function packChunks(turns: readonly ExtractedTurn[]): ChunkPayload[] {
   const chunks: ChunkPayload[] = []
   const separator = "\n\n"
   let buffer = ""
+  let bufferFirst = -1
+  let bufferLast = -1
 
   const flush = () => {
     const trimmed = buffer.trim()
-    if (trimmed.length > 0) chunks.push({ text: trimmed })
+    if (trimmed.length > 0 && bufferFirst >= 0) {
+      chunks.push({ text: trimmed, firstMessageIndex: bufferFirst, lastMessageIndex: bufferLast })
+    }
     buffer = ""
+    bufferFirst = -1
+    bufferLast = -1
   }
 
   for (const turn of turns) {
-    if (turn.length > TRACE_SEARCH_CHUNK_MAX_CHARS) {
+    if (turn.text.length > TRACE_SEARCH_CHUNK_MAX_CHARS) {
       flush()
       const stride = Math.max(1, TRACE_SEARCH_CHUNK_MAX_CHARS - TRACE_SEARCH_CHUNK_OVERLAP_CHARS)
-      for (let i = 0; i < turn.length; i += stride) {
-        const piece = turn.slice(i, i + TRACE_SEARCH_CHUNK_MAX_CHARS).trim()
-        if (piece.length > 0) chunks.push({ text: piece })
-        if (i + TRACE_SEARCH_CHUNK_MAX_CHARS >= turn.length) break
+      for (let i = 0; i < turn.text.length; i += stride) {
+        const piece = turn.text.slice(i, i + TRACE_SEARCH_CHUNK_MAX_CHARS).trim()
+        if (piece.length > 0) {
+          chunks.push({
+            text: piece,
+            firstMessageIndex: turn.firstMessageIndex,
+            lastMessageIndex: turn.lastMessageIndex,
+          })
+        }
+        if (i + TRACE_SEARCH_CHUNK_MAX_CHARS >= turn.text.length) break
       }
       continue
     }
 
-    const candidate = buffer ? `${buffer}${separator}${turn}` : turn
+    const candidate = buffer ? `${buffer}${separator}${turn.text}` : turn.text
     if (candidate.length > TRACE_SEARCH_CHUNK_MAX_CHARS) {
       flush()
-      buffer = turn
+      buffer = turn.text
+      bufferFirst = turn.firstMessageIndex
+      bufferLast = turn.lastMessageIndex
     } else {
       buffer = candidate
+      bufferFirst = bufferFirst < 0 ? turn.firstMessageIndex : Math.min(bufferFirst, turn.firstMessageIndex)
+      bufferLast = Math.max(bufferLast, turn.lastMessageIndex)
     }
   }
   flush()
@@ -228,21 +269,28 @@ export const buildTraceSearchDocument = (
 ): Effect.Effect<TraceSearchDocument, CryptoError> =>
   Effect.gen(function* () {
     const turns = extractTurns(input.messages)
-    const totalLength = turns.reduce((sum, t) => sum + t.length, 0)
+    const totalLength = turns.reduce((sum, t) => sum + t.text.length, 0)
 
     const selectedTurns = totalLength <= TRACE_SEARCH_DOCUMENT_MAX_LENGTH ? [...turns] : selectHeadTailTurns(turns)
 
-    const wholeTraceText = turns.join("\n\n")
+    const wholeTraceText = turns.map((t) => t.text).join("\n\n")
     const searchText = normalizeSearchText(wholeTraceText)
     const contentHash = yield* hash(`${input.traceId}\0${searchText}`)
 
     const packed = packChunks(selectedTurns)
     const chunks: TraceSearchChunk[] = []
     for (let i = 0; i < packed.length; i++) {
-      const text = normalizeChunkText(packed[i]!.text)
+      const payload = packed[i]!
+      const text = normalizeChunkText(payload.text)
       if (text.length === 0) continue
       const chunkHash = yield* hash(`${input.traceId}\0${i}\0${text}`)
-      chunks.push({ chunkIndex: i, text, contentHash: chunkHash })
+      chunks.push({
+        chunkIndex: i,
+        text,
+        contentHash: chunkHash,
+        firstMessageIndex: payload.firstMessageIndex,
+        lastMessageIndex: payload.lastMessageIndex,
+      })
     }
 
     return {

--- a/packages/domain/spans/src/use-cases/compute-trace-search-highlights.test.ts
+++ b/packages/domain/spans/src/use-cases/compute-trace-search-highlights.test.ts
@@ -1,5 +1,6 @@
 import type { GenAIMessage } from "rosetta-ai"
 import { describe, expect, it } from "vitest"
+import type { TraceSemanticHighlightMatch } from "../ports/trace-search-repository.ts"
 import { computeTraceSearchHighlights } from "./compute-trace-search-highlights.ts"
 import { parseSearchQuery } from "./parse-search-query.ts"
 
@@ -186,6 +187,105 @@ describe("computeTraceSearchHighlights", () => {
       ["search-literal", 0, 6],
       ["search-token", 0, 14],
     ])
+  })
+
+  describe("semantic-region highlights", () => {
+    const userAsst = (i: number) => [textMessage("user", `q${i}`), textMessage("assistant", `a${i}`)]
+    const conversation = [...userAsst(0), ...userAsst(1), ...userAsst(2), ...userAsst(3)]
+
+    function withMatch(match: TraceSemanticHighlightMatch) {
+      return computeTraceSearchHighlights({
+        messages: conversation,
+        parsedQuery: parseSearchQuery("customer complaint"),
+        semanticMatch: match,
+      })
+    }
+
+    it("emits one block-level highlight per non-system message in the matched range", () => {
+      // matched range: messages 2..5 (4 messages). All highlights share the
+      // same source (chunkIndex + score), placeholder partIndex/startOffset/endOffset.
+      const result = withMatch({
+        chunkIndex: 3,
+        firstMessageIndex: 2,
+        lastMessageIndex: 5,
+        relevanceScore: 0.84,
+      })
+
+      expect(result.highlights).toHaveLength(4)
+      expect(result.highlights.map((h) => h.messageIndex)).toEqual([2, 3, 4, 5])
+      for (const h of result.highlights) {
+        expect(h.type).toBe("search-semantic-region")
+        expect(h.partIndex).toBe(0)
+        expect(h.startOffset).toBe(0)
+        expect(h.endOffset).toBe(0)
+        expect(h.source).toEqual({ kind: "semantic-region", chunkIndex: 3, score: 0.84 })
+      }
+    })
+
+    it("skips role=system messages inside the matched range (visual tint may visually span them)", () => {
+      // Insert a system message inside the matched range. The endpoint emits
+      // no highlight for it; the renderer may visually span the tint across.
+      const messages = [
+        textMessage("user", "q0"),
+        textMessage("system", "drifted-in system prompt"),
+        textMessage("assistant", "a0"),
+      ]
+      const result = computeTraceSearchHighlights({
+        messages,
+        parsedQuery: parseSearchQuery("complaint"),
+        semanticMatch: { chunkIndex: 0, firstMessageIndex: 0, lastMessageIndex: 2, relevanceScore: 0.7 },
+      })
+      expect(result.highlights.map((h) => h.messageIndex)).toEqual([0, 2])
+    })
+
+    it("skips emission when matched-range columns are NULL (pre-migration row)", () => {
+      // ArgMax over a NULL column yields NULL. The endpoint treats that as
+      // "no semantic-region data" and skips semantic-region; literal/token
+      // (none here) would still flow.
+      const result = withMatch({
+        chunkIndex: 0,
+        firstMessageIndex: null,
+        lastMessageIndex: null,
+        relevanceScore: 0.6,
+      })
+      expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+    })
+
+    it("composes with literal hits — literal underlines render on top of the block tint", () => {
+      const result = computeTraceSearchHighlights({
+        messages: conversation,
+        parsedQuery: parseSearchQuery('"q1"'),
+        semanticMatch: { chunkIndex: 0, firstMessageIndex: 2, lastMessageIndex: 3, relevanceScore: 0.5 },
+      })
+
+      // 2 semantic-region highlights (messages 2 and 3) + 1 literal at index 2
+      // (matching "q1" in message "q1"). messageIndex 0 has "q0" — no match.
+      const semanticRegionHighlights = result.highlights.filter((h) => h.type === "search-semantic-region")
+      const literalHighlights = result.highlights.filter((h) => h.type === "search-literal")
+      expect(semanticRegionHighlights).toHaveLength(2)
+      expect(literalHighlights).toHaveLength(1)
+      expect(literalHighlights[0]!.messageIndex).toBe(2)
+    })
+
+    it("ignores semanticMatch when a phrase match-nothing makes the whole query empty", () => {
+      // `---` tokenizes to []  ⇒ whole query is zero rows ⇒ no semantic-region
+      // either, because the trace itself wouldn't appear in search results.
+      const result = computeTraceSearchHighlights({
+        messages: conversation,
+        parsedQuery: parseSearchQuery("`---` customer complaint"),
+        semanticMatch: { chunkIndex: 0, firstMessageIndex: 0, lastMessageIndex: 7, relevanceScore: 0.9 },
+      })
+      expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+    })
+
+    it("returns empty when semanticMatch is null and there are no phrases (semantic-only with no match)", () => {
+      const result = computeTraceSearchHighlights({
+        messages: conversation,
+        parsedQuery: parseSearchQuery("customer complaint"),
+        semanticMatch: null,
+      })
+      expect(result).toEqual({ highlights: [], firstMatchIndex: -1 })
+    })
   })
 
   it("normalizes the literal phrase the same way the indexer does (multi-space → single space)", () => {

--- a/packages/domain/spans/src/use-cases/compute-trace-search-highlights.ts
+++ b/packages/domain/spans/src/use-cases/compute-trace-search-highlights.ts
@@ -1,6 +1,7 @@
 import type { GenAIMessage } from "rosetta-ai"
 import { normalizeLiteralPhrase } from "../helpers/normalize-literal-phrase.ts"
 import { tokenizePhrase } from "../helpers/tokenize-phrase.ts"
+import type { TraceSemanticHighlightMatch } from "../ports/trace-search-repository.ts"
 import type { ParsedSearchQuery } from "./parse-search-query.ts"
 
 export interface TraceHighlight {
@@ -130,27 +131,60 @@ const EMPTY_RESULT: TraceSearchHighlightsResult = { highlights: [], firstMatchIn
 export function computeTraceSearchHighlights(args: {
   readonly messages: readonly GenAIMessage[]
   readonly parsedQuery: ParsedSearchQuery
+  readonly semanticMatch?: TraceSemanticHighlightMatch | null
 }): TraceSearchHighlightsResult {
-  const { messages, parsedQuery } = args
+  const { messages, parsedQuery, semanticMatch } = args
   const { literalPhrases, tokenPhrases } = parsedQuery
 
-  if (literalPhrases.length === 0 && tokenPhrases.length === 0) {
+  const hasPhrases = literalPhrases.length > 0 || tokenPhrases.length > 0
+  const semanticRegion =
+    semanticMatch && semanticMatch.firstMessageIndex !== null && semanticMatch.lastMessageIndex !== null
+      ? {
+          chunkIndex: semanticMatch.chunkIndex,
+          firstMessageIndex: semanticMatch.firstMessageIndex,
+          lastMessageIndex: semanticMatch.lastMessageIndex,
+          score: semanticMatch.relevanceScore,
+        }
+      : null
+
+  if (!hasPhrases && semanticRegion === null) {
     return EMPTY_RESULT
   }
 
   const normalizedLiterals = literalPhrases.map((phrase) => ({ phrase, normalized: normalizeLiteralPhrase(phrase) }))
   const tokenizedPhrases = tokenPhrases.map((phrase) => ({ phrase, tokens: tokenizePhrase(phrase) }))
 
-  const matchesNothing =
-    normalizedLiterals.some(({ normalized }) => normalized.length === 0) ||
-    tokenizedPhrases.some(({ tokens }) => tokens.length === 0)
-  if (matchesNothing) return EMPTY_RESULT
+  if (hasPhrases) {
+    const matchesNothing =
+      normalizedLiterals.some(({ normalized }) => normalized.length === 0) ||
+      tokenizedPhrases.some(({ tokens }) => tokens.length === 0)
+    if (matchesNothing) return EMPTY_RESULT
+  }
 
   const highlights: TraceHighlight[] = []
 
   messages.forEach((message, messageIndex) => {
     if (!message || message.role === "system") return
     if (!message.parts) return
+
+    if (
+      semanticRegion !== null &&
+      messageIndex >= semanticRegion.firstMessageIndex &&
+      messageIndex <= semanticRegion.lastMessageIndex
+    ) {
+      highlights.push({
+        messageIndex,
+        partIndex: 0,
+        startOffset: 0,
+        endOffset: 0,
+        type: "search-semantic-region",
+        source: {
+          kind: "semantic-region",
+          chunkIndex: semanticRegion.chunkIndex,
+          score: semanticRegion.score,
+        },
+      })
+    }
 
     message.parts.forEach((part, partIndex) => {
       if (part.type !== "text") return

--- a/packages/domain/spans/src/use-cases/get-trace-search-highlights.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-search-highlights.ts
@@ -1,0 +1,125 @@
+import { AI } from "@domain/ai"
+import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError, TraceId } from "@domain/shared"
+import { Effect, Option } from "effect"
+import {
+  TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+  TRACE_SEARCH_EMBEDDING_MODEL,
+  TRACE_SEARCH_MIN_RELEVANCE_SCORE,
+} from "../constants.ts"
+import { TraceRepository } from "../ports/trace-repository.ts"
+import { TraceSearchRepository, type TraceSemanticHighlightMatch } from "../ports/trace-search-repository.ts"
+import { computeTraceSearchHighlights, type TraceSearchHighlightsResult } from "./compute-trace-search-highlights.ts"
+import { parseSearchQuery } from "./parse-search-query.ts"
+
+const EMPTY_RESULT: TraceSearchHighlightsResult = { highlights: [], firstMatchIndex: -1 }
+
+/**
+ * Server-side entry point for the LAT-601 search-highlights flow. Pure
+ * orchestration over domain ports — no HTTP / TanStack-specific concerns — so
+ * the same use-case can serve the web server function today and a future
+ * REST/MCP endpoint without duplication.
+ *
+ * Behaviour:
+ *   1. `parseSearchQuery` the raw input. An empty parsed query (no literals,
+ *      no token phrases, no semantic prompt) short-circuits to the empty
+ *      result before touching ClickHouse.
+ *   2. Fetch the trace detail and (when the parsed query has a semantic
+ *      prompt) the per-trace winning-chunk metadata in parallel.
+ *      `findByTraceId` not found → empty result.
+ *   3. The semantic branch embeds the prompt via Voyage and runs the focused
+ *      per-trace `argMax` query. AI unavailable or embed failure → semantic
+ *      match drops to `null` and the renderer falls back to literal/token
+ *      highlights only (same shape as a pre-migration `trace_search_embeddings`
+ *      row with NULL range columns).
+ *   4. Delegate to the pure `computeTraceSearchHighlights` use-case for the
+ *      actual highlight emission.
+ */
+export const getTraceSearchHighlightsUseCase = (args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly traceId: TraceId
+  readonly searchQuery: string
+}): Effect.Effect<
+  TraceSearchHighlightsResult,
+  RepositoryError,
+  ChSqlClient | TraceRepository | TraceSearchRepository
+> =>
+  Effect.gen(function* () {
+    const parsed = parseSearchQuery(args.searchQuery)
+    const hasPhrases = parsed.literalPhrases.length > 0 || parsed.tokenPhrases.length > 0
+    const hasSemantic = parsed.semanticPrompt.length > 0
+    if (!hasPhrases && !hasSemantic) return EMPTY_RESULT
+
+    const traceRepo = yield* TraceRepository
+    const detailEffect = traceRepo
+      .findByTraceId({
+        organizationId: args.organizationId,
+        projectId: args.projectId,
+        traceId: args.traceId,
+      })
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+
+    const semanticEffect = hasSemantic
+      ? findSemanticMatch({ ...args, semanticPrompt: parsed.semanticPrompt })
+      : Effect.succeed(null)
+
+    const [detail, semanticMatch] = yield* Effect.all([detailEffect, semanticEffect], { concurrency: 2 })
+    if (!detail) return EMPTY_RESULT
+
+    // Semantic-only parity with `buildSearchPlan`: the listing path filters
+    // out traces below `TRACE_SEARCH_MIN_RELEVANCE_SCORE` when there are no
+    // phrases, so the drawer must drop the semantic-region highlight at the
+    // same floor — otherwise a trace that wouldn't appear in search results
+    // could still get a tint. The hybrid path drops the floor on purpose
+    // (phrase precision is the gate), so we only enforce it when there are
+    // no phrases.
+    const effectiveSemanticMatch =
+      semanticMatch && !hasPhrases && semanticMatch.relevanceScore < TRACE_SEARCH_MIN_RELEVANCE_SCORE
+        ? null
+        : semanticMatch
+
+    return computeTraceSearchHighlights({
+      messages: detail.allMessages,
+      parsedQuery: parsed,
+      semanticMatch: effectiveSemanticMatch,
+    })
+  })
+
+/**
+ * Embed the semantic prompt and look up the winning-chunk metadata for the
+ * given trace. AI may be absent in dev/CI — treated identically to a chunk
+ * indexed before migration 00017 (no semantic-region highlight; literal /
+ * token still flow). Repository errors are also swallowed to `null` because
+ * the highlight layer is decorative — a backend hiccup on the semantic side
+ * shouldn't block literal/token highlights from rendering.
+ */
+const findSemanticMatch = (args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly traceId: TraceId
+  readonly semanticPrompt: string
+}): Effect.Effect<TraceSemanticHighlightMatch | null, never, ChSqlClient | TraceSearchRepository> =>
+  Effect.gen(function* () {
+    const aiOption = yield* Effect.serviceOption(AI)
+    if (Option.isNone(aiOption)) return null
+
+    const embedResult = yield* aiOption.value
+      .embed({
+        text: args.semanticPrompt,
+        model: TRACE_SEARCH_EMBEDDING_MODEL,
+        dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+        inputType: "query",
+      })
+      .pipe(Effect.orElseSucceed(() => undefined))
+    if (!embedResult || embedResult.embedding.length === 0) return null
+
+    const searchRepo = yield* TraceSearchRepository
+    return yield* searchRepo
+      .findSemanticHighlightForTrace({
+        organizationId: args.organizationId,
+        projectId: args.projectId,
+        traceId: args.traceId,
+        queryEmbedding: embedResult.embedding,
+      })
+      .pipe(Effect.orElseSucceed(() => null))
+  })

--- a/packages/platform/db-clickhouse/clickhouse/.migration-lock
+++ b/packages/platform/db-clickhouse/clickhouse/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-05-20T07:45:06.179Z
-# Hash: f2d24705-ca48-427a-bae7-6e3f0be43e7e
+# Generated: 2026-05-22T14:26:56.929Z
+# Hash: b7f69c4a-621b-4787-84b4-25b78d48218f
 # Do not manually edit this file.

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00017_add_chunk_message_range_to_trace_search_embeddings.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00017_add_chunk_message_range_to_trace_search_embeddings.sql
@@ -1,0 +1,12 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+ALTER TABLE trace_search_embeddings ON CLUSTER default
+    ADD COLUMN IF NOT EXISTS first_message_index Nullable(UInt32) CODEC(T64, ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS last_message_index  Nullable(UInt32) CODEC(T64, ZSTD(1));
+
+-- +goose Down
+
+ALTER TABLE trace_search_embeddings ON CLUSTER default
+    DROP COLUMN IF EXISTS last_message_index,
+    DROP COLUMN IF EXISTS first_message_index;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00017_add_chunk_message_range_to_trace_search_embeddings.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00017_add_chunk_message_range_to_trace_search_embeddings.sql
@@ -1,0 +1,12 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+ALTER TABLE trace_search_embeddings
+    ADD COLUMN IF NOT EXISTS first_message_index Nullable(UInt32) CODEC(T64, ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS last_message_index  Nullable(UInt32) CODEC(T64, ZSTD(1));
+
+-- +goose Down
+
+ALTER TABLE trace_search_embeddings
+    DROP COLUMN IF EXISTS last_message_index,
+    DROP COLUMN IF EXISTS first_message_index;

--- a/packages/platform/db-clickhouse/src/repositories/search-plan.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-plan.ts
@@ -104,19 +104,42 @@ function buildLexicalSearchSubquery(parsed: ParsedSearchQuery): {
  * the per-project cosine scan cost by keeping the nearest chunks first; the
  * outer rollup collapses surviving chunks back into one row per trace for the
  * downstream join.
+ *
+ * When `semanticMetadata` is `true`, the rollup also surfaces `argMax(...)`
+ * of `chunk_index`, `first_message_index`, `last_message_index` aligned to the
+ * winning `semantic_score` — used by `getTraceSearchHighlights` (LAT-601) to
+ * paint the matched conversational region as a semantic-region highlight.
+ * `false` keeps the SQL byte-identical to the pre-PR-2 listing query so
+ * existing callers see no change.
  */
-function buildSemanticSearchSubquery(queryEmbedding: readonly number[]): {
+function buildSemanticSearchSubquery(
+  queryEmbedding: readonly number[],
+  semanticMetadata: boolean,
+): {
   subquery: string
   params: Record<string, unknown>
 } {
+  const innerExtraCols = semanticMetadata
+    ? `,
+                  chunk_index,
+                  first_message_index,
+                  last_message_index`
+    : ""
+  const outerExtraCols = semanticMetadata
+    ? `,
+                argMax(chunk_index, semantic_score)         AS matched_chunk_index,
+                argMax(first_message_index, semantic_score) AS matched_first_message_index,
+                argMax(last_message_index, semantic_score)  AS matched_last_message_index`
+    : ""
+
   return {
     subquery: `SELECT
                 trace_id,
-                max(semantic_score) AS semantic_score
+                max(semantic_score) AS semantic_score${outerExtraCols}
               FROM (
                 SELECT
                   CAST(trace_id AS String) AS trace_id,
-                  (1 - cosineDistance(embedding, {queryEmbedding:Array(Float32)})) AS semantic_score
+                  (1 - cosineDistance(embedding, {queryEmbedding:Array(Float32)})) AS semantic_score${innerExtraCols}
                 FROM trace_search_embeddings
                 WHERE organization_id = {organizationId:String}
                   AND project_id = {projectId:String}
@@ -138,12 +161,20 @@ function buildSemanticSearchSubquery(queryEmbedding: readonly number[]): {
  *     sort so phrase matches surface in chronological order rather than by
  *     trace_id hash.
  *
+ * `semanticMetadata` (LAT-601): when true the subquery exposes the winning
+ * chunk's metadata alongside `relevance_score` —
+ * `matched_chunk_index`, `matched_first_message_index`,
+ * `matched_last_message_index`. NULL on traces that matched purely lexically
+ * or were indexed before migration 00017. Default `false` keeps the SQL
+ * byte-identical to before; the listing query plan is unchanged.
+ *
  * @public
  */
 export type SearchPlan = {
   readonly ranked: boolean
   readonly subquery: string
   readonly params: Record<string, unknown>
+  readonly semanticMetadata: boolean
 }
 
 /**
@@ -163,17 +194,33 @@ export type SearchPlan = {
  * or to a deliberate empty result when there are no phrases — same fallback
  * shape the previous design relied on.
  */
-function buildSearchPlan(parsed: ParsedSearchQuery, queryEmbedding: readonly number[] | undefined): SearchPlan {
+function buildSearchPlan(
+  parsed: ParsedSearchQuery,
+  queryEmbedding: readonly number[] | undefined,
+  semanticMetadata: boolean,
+): SearchPlan {
   const hasPhrases = parsed.literalPhrases.length > 0 || parsed.tokenPhrases.length > 0
   const hasSemantic = parsed.semanticPrompt.length > 0
   const hasEmbedding = !!queryEmbedding && queryEmbedding.length > 0
+
+  // Outer projection for plans that don't actually carry semantic metadata
+  // (phrase-only, semantic-without-embedding). The columns are present so
+  // every plan has the same shape when `semanticMetadata: true`; values are
+  // NULL because there's no winning chunk to point at.
+  const nullMetadataCols = semanticMetadata
+    ? `,
+                      CAST(NULL AS Nullable(UInt16))  AS matched_chunk_index,
+                      CAST(NULL AS Nullable(UInt32))  AS matched_first_message_index,
+                      CAST(NULL AS Nullable(UInt32))  AS matched_last_message_index`
+    : ""
 
   if (hasPhrases && !hasSemantic) {
     const lex = buildLexicalSearchSubquery(parsed)
     return {
       ranked: false,
-      subquery: `SELECT trace_id, 0.0 AS relevance_score FROM (${lex.subquery})`,
+      subquery: `SELECT trace_id, 0.0 AS relevance_score${nullMetadataCols} FROM (${lex.subquery})`,
       params: lex.params,
+      semanticMetadata,
     }
   }
 
@@ -181,21 +228,32 @@ function buildSearchPlan(parsed: ParsedSearchQuery, queryEmbedding: readonly num
     if (!hasEmbedding) {
       return {
         ranked: true,
-        subquery: `SELECT CAST(trace_id AS String) AS trace_id, 0.0 AS relevance_score
+        subquery: `SELECT CAST(trace_id AS String) AS trace_id, 0.0 AS relevance_score${nullMetadataCols}
                    FROM trace_search_documents
                    WHERE organization_id = {organizationId:String}
                      AND project_id = {projectId:String}
                      AND 0`,
         params: {},
+        semanticMetadata,
       }
     }
-    const sem = buildSemanticSearchSubquery(queryEmbedding)
+    const sem = buildSemanticSearchSubquery(queryEmbedding, semanticMetadata)
+    const semanticPassthrough = semanticMetadata
+      ? `,
+                 matched_chunk_index,
+                 matched_first_message_index,
+                 matched_last_message_index`
+      : ""
     return {
       ranked: true,
-      subquery: `SELECT trace_id, semantic_score AS relevance_score
+      subquery: `SELECT trace_id, semantic_score AS relevance_score${semanticPassthrough}
                  FROM (${sem.subquery})
                  WHERE semantic_score >= {minRelevanceScore:Float64}`,
-      params: { ...sem.params, minRelevanceScore: TRACE_SEARCH_MIN_RELEVANCE_SCORE },
+      params: {
+        ...sem.params,
+        minRelevanceScore: TRACE_SEARCH_MIN_RELEVANCE_SCORE,
+      },
+      semanticMetadata,
     }
   }
 
@@ -204,23 +262,37 @@ function buildSearchPlan(parsed: ParsedSearchQuery, queryEmbedding: readonly num
   if (!hasEmbedding) {
     return {
       ranked: false,
-      subquery: `SELECT trace_id, 0.0 AS relevance_score FROM (${lex.subquery})`,
+      subquery: `SELECT trace_id, 0.0 AS relevance_score${nullMetadataCols} FROM (${lex.subquery})`,
       params: lex.params,
+      semanticMetadata,
     }
   }
-  const sem = buildSemanticSearchSubquery(queryEmbedding)
+  const sem = buildSemanticSearchSubquery(queryEmbedding, semanticMetadata)
   // LEFT JOIN keeps phrase-matching traces without an embedding (semantic_score
   // defaults to 0.0 in CH for the missing side of an outer join). The lexical
   // filter is the precision gate, so no semantic floor here.
+  //
+  // Semantic-metadata pass-through: `sem.matched_*` columns are already
+  // 1-per-trace (the inner subquery rolls them up via argMax), so MAX over
+  // them in the outer GROUP BY is a no-op that just lets us forward them.
+  // On lexical-only matches the LEFT JOIN gives NULLs, which propagate
+  // through MAX — the read side treats NULL as "no semantic-region data".
+  const hybridMetadataCols = semanticMetadata
+    ? `,
+                      max(sem.matched_chunk_index)         AS matched_chunk_index,
+                      max(sem.matched_first_message_index) AS matched_first_message_index,
+                      max(sem.matched_last_message_index)  AS matched_last_message_index`
+    : ""
   return {
     ranked: true,
     subquery: `SELECT lex.trace_id AS trace_id,
-                      max(sem.semantic_score) AS relevance_score
+                      max(sem.semantic_score) AS relevance_score${hybridMetadataCols}
                FROM (${lex.subquery}) AS lex
                LEFT JOIN (${sem.subquery}) AS sem
                  ON lex.trace_id = sem.trace_id
                GROUP BY lex.trace_id`,
     params: { ...lex.params, ...sem.params },
+    semanticMetadata,
   }
 }
 
@@ -262,14 +334,21 @@ const generateQueryEmbedding = (semanticPrompt: string): Effect.Effect<readonly 
     return result?.embedding
   })
 
+interface PlanSearchOptions {
+  readonly semanticMetadata?: boolean
+}
+
 /**
  * Resolve a parsed search query into a `SearchPlan`. Skips the embedder
  * when the parsed query has no semantic prompt — phrase-only queries are
  * pure filters and don't need a Voyage round-trip.
  */
-export const planSearch = (parsed: ParsedSearchQuery): Effect.Effect<SearchPlan, never> =>
+export const planSearch = (
+  parsed: ParsedSearchQuery,
+  options: PlanSearchOptions = {},
+): Effect.Effect<SearchPlan, never> =>
   Effect.gen(function* () {
     const queryEmbedding =
       parsed.semanticPrompt.length > 0 ? yield* generateQueryEmbedding(parsed.semanticPrompt) : undefined
-    return buildSearchPlan(parsed, queryEmbedding)
+    return buildSearchPlan(parsed, queryEmbedding, options.semanticMetadata ?? false)
   })

--- a/packages/platform/db-clickhouse/src/repositories/trace-search-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-search-repository.test.ts
@@ -103,4 +103,107 @@ describe("TraceSearchRepository", () => {
       ).toBe(false)
     })
   })
+
+  describe("findSemanticHighlightForTrace", () => {
+    // Unit basis vectors → cosineDistance(e_i, e_j) = 1 for i!=j, 0 for i==j.
+    // So `semantic_score = 1 - cosineDistance` is 1.0 for the aligned chunk
+    // and 0.0 for any orthogonal chunk.
+    const basisVector = (oneAt: number): number[] => {
+      const v = new Array(TRACE_SEARCH_EMBEDDING_DIMENSIONS).fill(0)
+      v[oneAt] = 1
+      return v
+    }
+
+    it("returns null when the trace has no chunk rows", async () => {
+      const result = await Effect.runPromise(
+        repo.findSemanticHighlightForTrace({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          queryEmbedding: basisVector(0),
+        }),
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it("argMax selects the chunk with the highest cosine score and surfaces its message range", async () => {
+      const startTime = new Date()
+
+      // Two chunks against the SAME trace. Chunk 0's embedding is aligned
+      // with the query (score 1.0); chunk 1 is orthogonal (score 0.0).
+      await Effect.runPromise(
+        repo.upsertEmbedding({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          chunkIndex: 0,
+          startTime,
+          contentHash: "c0".repeat(32),
+          embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
+          embedding: basisVector(0),
+          firstMessageIndex: 4,
+          lastMessageIndex: 7,
+        }),
+      )
+      await Effect.runPromise(
+        repo.upsertEmbedding({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          chunkIndex: 1,
+          startTime,
+          contentHash: "c1".repeat(32),
+          embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
+          embedding: basisVector(1),
+          firstMessageIndex: 12,
+          lastMessageIndex: 14,
+        }),
+      )
+
+      const result = await Effect.runPromise(
+        repo.findSemanticHighlightForTrace({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          queryEmbedding: basisVector(0),
+        }),
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.chunkIndex).toBe(0)
+      expect(result?.firstMessageIndex).toBe(4)
+      expect(result?.lastMessageIndex).toBe(7)
+      expect(result?.relevanceScore).toBeCloseTo(1, 6)
+    })
+
+    it("returns NULL message-range columns for pre-migration chunks (rollout parity)", async () => {
+      await Effect.runPromise(
+        repo.upsertEmbedding({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          chunkIndex: 0,
+          startTime: new Date(),
+          contentHash: "legacy".repeat(8).slice(0, 64),
+          embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
+          embedding: basisVector(0),
+        }),
+      )
+
+      const result = await Effect.runPromise(
+        repo.findSemanticHighlightForTrace({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TEST_TRACE_ID,
+          queryEmbedding: basisVector(0),
+        }),
+      )
+
+      expect(result).not.toBeNull()
+      expect(result?.chunkIndex).toBe(0)
+      expect(result?.firstMessageIndex).toBeNull()
+      expect(result?.lastMessageIndex).toBeNull()
+    })
+  })
 })

--- a/packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts
@@ -50,6 +50,8 @@ export const TraceSearchRepositoryLive = Layer.effect(
                 embedding_model: row.embeddingModel,
                 embedding: [...row.embedding],
                 retention_days: row.retentionDays ?? 30,
+                first_message_index: row.firstMessageIndex ?? null,
+                last_message_index: row.lastMessageIndex ?? null,
                 indexed_at: toClickhouseDateTime(new Date()),
               },
             ],
@@ -89,10 +91,63 @@ export const TraceSearchRepositoryLive = Layer.effect(
         })
         .pipe(Effect.mapError((error) => toRepositoryError(error, "hasEmbeddingWithHash")))
 
+    const findSemanticHighlightForTrace: TraceSearchRepositoryShape["findSemanticHighlightForTrace"] = (args) =>
+      chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            query: `SELECT
+                      argMax(chunk_index, semantic_score)         AS chunk_index,
+                      argMax(first_message_index, semantic_score) AS first_message_index,
+                      argMax(last_message_index, semantic_score)  AS last_message_index,
+                      max(semantic_score)                         AS relevance_score,
+                      count() AS row_count
+                    FROM (
+                      SELECT
+                        chunk_index,
+                        first_message_index,
+                        last_message_index,
+                        (1 - cosineDistance(embedding, {queryEmbedding:Array(Float32)})) AS semantic_score
+                      FROM trace_search_embeddings
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND trace_id = {traceId:FixedString(32)}
+                    )`,
+            query_params: {
+              organizationId: args.organizationId as string,
+              projectId: args.projectId as string,
+              traceId: args.traceId,
+              queryEmbedding: [...args.queryEmbedding],
+            },
+            format: "JSONEachRow",
+          })
+
+          const [row] = await result.json<{
+            chunk_index: number
+            first_message_index: number | null
+            last_message_index: number | null
+            relevance_score: number
+            row_count: string | number
+          }>()
+
+          // `count()` is UInt64 — comes back as a String over JSONEachRow
+          // today, but Number() is defensive against driver/output-format
+          // changes (Copilot review on #3257).
+          if (!row || Number(row.row_count) === 0) return null
+
+          return {
+            chunkIndex: row.chunk_index,
+            firstMessageIndex: row.first_message_index,
+            lastMessageIndex: row.last_message_index,
+            relevanceScore: row.relevance_score,
+          }
+        })
+        .pipe(Effect.mapError((error) => toRepositoryError(error, "findSemanticHighlightForTrace")))
+
     return {
       upsertDocument,
       upsertEmbedding,
       hasEmbeddingWithHash,
+      findSemanticHighlightForTrace,
     } satisfies TraceSearchRepositoryShape
   }),
 )

--- a/packages/platform/testkit/src/clickhouse/schema.sql
+++ b/packages/platform/testkit/src/clickhouse/schema.sql
@@ -404,7 +404,9 @@ CREATE TABLE trace_search_embeddings
     `content_hash` FixedString(64) CODEC(ZSTD(1)),
     `embedding_model` LowCardinality(String) CODEC(ZSTD(1)),
     `embedding` Array(Float32) CODEC(ZSTD(1)),
-    `indexed_at` DateTime64(3, 'UTC') DEFAULT now64(3) CODEC(Delta(8), LZ4)
+    `indexed_at` DateTime64(3, 'UTC') DEFAULT now64(3) CODEC(Delta(8), LZ4),
+    `first_message_index` Nullable(UInt32) CODEC(T64, ZSTD(1)),
+    `last_message_index` Nullable(UInt32) CODEC(T64, ZSTD(1))
 )
 ENGINE = ReplacingMergeTree(indexed_at)
 PARTITION BY toYYYYMM(start_time)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 'catalog:'
-        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
+        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.8.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
       '@platform/testkit':
         specifier: workspace:*
         version: link:../../packages/platform/testkit
@@ -1497,6 +1497,9 @@ importers:
 
   packages/domain/spans:
     dependencies:
+      '@domain/ai':
+        specifier: workspace:*
+        version: link:../ai
       '@domain/billing':
         specifier: workspace:*
         version: link:../billing
@@ -7918,9 +7921,6 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@xobotyi/scrollbar-width@1.9.5':
-    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
-
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -8535,9 +8535,6 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  copy-to-clipboard@3.3.3:
-    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
-
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
@@ -8581,18 +8578,11 @@ packages:
     resolution: {integrity: sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==}
     engines: {node: '>=16'}
 
-  css-in-js-utils@3.1.0:
-    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
-
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -9014,9 +9004,6 @@ packages:
   error-causes@3.0.2:
     resolution: {integrity: sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw==}
 
-  error-stack-parser@2.1.4:
-    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
-
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -9158,9 +9145,6 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-shallow-equal@1.0.0:
-    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
 
@@ -9179,9 +9163,6 @@ packages:
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
-
-  fastest-stable-stringify@2.0.2:
-    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -9563,9 +9544,6 @@ packages:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
 
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -9629,9 +9607,6 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  inline-style-prefixer@7.0.1:
-    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
@@ -10167,9 +10142,6 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -10394,12 +10366,6 @@ packages:
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
-
-  nano-css@5.6.2:
-    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -11066,12 +11032,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-universal-interface@0.6.2:
-    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
-    peerDependencies:
-      react: '*'
-      tslib: 2.8.1
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -11164,9 +11124,6 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -11255,9 +11212,6 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rtl-css-js@1.16.1:
-    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
-
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -11288,10 +11242,6 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
-
-  screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -11337,10 +11287,6 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
-
-  set-harmonic-interval@1.0.1:
-    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
-    engines: {node: '>=6.9'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -11475,10 +11421,6 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
-  source-map@0.5.6:
-    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -11527,24 +11469,12 @@ packages:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  stack-generator@2.0.10:
-    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
-
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  stackframe@1.3.4:
-    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  stacktrace-gps@3.1.2:
-    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
-
-  stacktrace-js@2.0.2:
-    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -11654,9 +11584,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  stylis@4.4.0:
-    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -11750,10 +11677,6 @@ packages:
     peerDependencies:
       tslib: 2.8.1
 
-  throttle-debounce@3.0.1:
-    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
-    engines: {node: '>=10'}
-
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -11789,9 +11712,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toggle-selection@1.0.6:
-    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -11837,9 +11757,6 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
-  ts-easing@0.2.0:
-    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -14120,7 +14037,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -14589,7 +14506,7 @@ snapshots:
       '@modelcontextprotocol/ext-apps': 1.7.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -14602,7 +14519,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@modelcontextprotocol/inspector-cli@0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -14639,7 +14556,7 @@ snapshots:
       pkce-challenge: 4.1.0
       prismjs: 1.30.0
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-simple-code-editor: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       serve-handler: 6.1.7
       tailwind-merge: 2.6.1
@@ -14667,7 +14584,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.8.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@cfworker/json-schema@4.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -14678,7 +14595,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@25.8.0)(typescript@6.0.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -16263,7 +16180,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16288,7 +16205,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16316,7 +16233,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16373,7 +16290,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -16421,7 +16338,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16472,7 +16389,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16510,7 +16427,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16567,7 +16484,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -16609,7 +16526,7 @@ snapshots:
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/rect': 1.1.1
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16637,7 +16554,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16657,7 +16574,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16676,7 +16593,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16694,7 +16611,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16720,7 +16637,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16765,7 +16682,7 @@ snapshots:
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -16857,7 +16774,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16888,7 +16805,7 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16908,7 +16825,7 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16948,7 +16865,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17085,7 +17002,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18768,7 +18685,7 @@ snapshots:
 
   '@types/mssql@9.1.11(@azure/core-client@1.10.1)':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.19.17
       tarn: 3.0.2
       tedious: 19.2.1(@azure/core-client@1.10.1)
     transitivePeerDependencies:
@@ -18835,7 +18752,7 @@ snapshots:
 
   '@types/readable-stream@4.0.23':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 22.19.17
 
   '@types/request@2.48.13':
     dependencies:
@@ -19042,8 +18959,6 @@ snapshots:
       '@xtuc/long': 4.2.2
 
   '@workflow/serde@4.1.0': {}
-
-  '@xobotyi/scrollbar-width@1.9.5': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -19592,7 +19507,7 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -19686,10 +19601,6 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  copy-to-clipboard@3.3.3:
-    dependencies:
-      toggle-selection: 1.0.6
-
   core-js@3.49.0: {}
 
   cors@2.8.6:
@@ -19723,10 +19634,6 @@ snapshots:
 
   css-gradient-parser@0.0.17: {}
 
-  css-in-js-utils@3.1.0:
-    dependencies:
-      hyphenate-style-name: 1.1.0
-
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -19740,11 +19647,6 @@ snapshots:
       camelize: 1.0.1
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
 
   css-tree@3.2.1:
     dependencies:
@@ -20027,10 +19929,6 @@ snapshots:
 
   error-causes@3.0.2: {}
 
-  error-stack-parser@2.1.4:
-    dependencies:
-      stackframe: 1.3.4
-
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -20222,8 +20120,6 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-shallow-equal@1.0.0: {}
-
   fast-string-truncated-width@1.2.1: {}
 
   fast-string-width@1.1.0:
@@ -20247,8 +20143,6 @@ snapshots:
       fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
-
-  fastest-stable-stringify@2.0.2: {}
 
   fd-package-json@2.0.0:
     dependencies:
@@ -20690,8 +20584,6 @@ snapshots:
 
   hyperdyperid@1.2.0: {}
 
-  hyphenate-style-name@1.1.0: {}
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -20773,10 +20665,6 @@ snapshots:
       - utf-8-validate
 
   inline-style-parser@0.2.7: {}
-
-  inline-style-prefixer@7.0.1:
-    dependencies:
-      css-in-js-utils: 3.1.0
 
   interpret@1.4.0: {}
 
@@ -21399,8 +21287,6 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdn-data@2.0.14: {}
-
   mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
@@ -21736,19 +21622,6 @@ snapshots:
   multipasta@0.2.7: {}
 
   mustache@4.2.0: {}
-
-  nano-css@5.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      css-tree: 1.1.3
-      csstype: 3.2.3
-      fastest-stable-stringify: 2.0.2
-      inline-style-prefixer: 7.0.1
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      rtl-css-js: 1.16.1
-      stacktrace-js: 2.0.2
-      stylis: 4.4.0
 
   nanoid@3.3.12: {}
 
@@ -22465,10 +22338,10 @@ snapshots:
       date-fns: 3.6.0
       react: 19.2.5
 
-  react-dom@18.3.1(react@19.2.5):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
-      react: 19.2.5
+      react: 18.3.1
       scheduler: 0.23.2
 
   react-dom@19.2.5(react@19.2.5):
@@ -22566,7 +22439,7 @@ snapshots:
   react-simple-code-editor@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
@@ -22592,11 +22465,6 @@ snapshots:
       use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
       - '@types/react'
-
-  react-universal-interface@0.6.2(react@19.2.5)(tslib@2.8.1):
-    dependencies:
-      react: 19.2.5
-      tslib: 2.8.1
 
   react@18.3.1:
     dependencies:
@@ -22727,8 +22595,6 @@ snapshots:
       - supports-color
 
   reselect@5.1.1: {}
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -22893,10 +22759,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rtl-css-js@1.16.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-
   run-applescript@7.1.0: {}
 
   rxjs@7.8.2:
@@ -22937,8 +22799,6 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 2.1.1(ajv@8.18.0)
       ajv-keywords: 5.1.0(ajv@8.18.0)
-
-  screenfull@5.2.0: {}
 
   selderee@0.11.0:
     dependencies:
@@ -22994,8 +22854,6 @@ snapshots:
       - supports-color
 
   set-cookie-parser@3.1.0: {}
-
-  set-harmonic-interval@1.0.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -23189,8 +23047,6 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
-  source-map@0.5.6: {}
-
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
@@ -23235,28 +23091,11 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  stack-generator@2.0.10:
-    dependencies:
-      stackframe: 1.3.4
-
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
-
-  stackframe@1.3.4: {}
-
-  stacktrace-gps@3.1.2:
-    dependencies:
-      source-map: 0.5.6
-      stackframe: 1.3.4
-
-  stacktrace-js@2.0.2:
-    dependencies:
-      error-stack-parser: 2.1.4
-      stack-generator: 2.0.10
-      stacktrace-gps: 3.1.2
 
   standard-as-callback@2.1.0: {}
 
@@ -23348,8 +23187,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  stylis@4.4.0: {}
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -23409,7 +23246,7 @@ snapshots:
       '@azure/identity': 4.13.1
       '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
       '@js-joda/core': 5.7.0
-      '@types/node': 25.8.0
+      '@types/node': 22.19.17
       bl: 6.1.6
       iconv-lite: 0.6.3
       js-md4: 0.3.2
@@ -23425,7 +23262,7 @@ snapshots:
       '@azure/identity': 4.13.1
       '@azure/keyvault-keys': 4.10.0(@azure/core-client@1.10.1)
       '@js-joda/core': 5.7.0
-      '@types/node': 25.8.0
+      '@types/node': 22.19.17
       bl: 6.1.6
       iconv-lite: 0.7.2
       js-md4: 0.3.2
@@ -23481,8 +23318,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  throttle-debounce@3.0.1: {}
-
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
@@ -23509,8 +23344,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toggle-selection@1.0.6: {}
 
   toidentifier@1.0.1: {}
 
@@ -23545,28 +23378,6 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-easing@0.2.0: {}
-
-  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.14.1
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.30
-
   ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.19.17)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23587,6 +23398,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.30
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.8.0)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.8.0
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.30
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/specs/session-problems/5-search-highlights.md
+++ b/specs/session-problems/5-search-highlights.md
@@ -457,34 +457,41 @@ Hard sequence points: PR 1 → everything else; PR 3 → PR 4 (both touch `conve
 ### PR 1 — Backend: literal + token highlights endpoint *(LAT-601 part 1/5)*
 
 **Branch:** `LAT-601/highlights-backend-endpoint`
+**Status:** open as [#3255](https://github.com/latitude-dev/latitude-llm/pull/3255) — Copilot + Claude bot review comments addressed; awaiting human review.
 **Depends on:** —
 **User-visible change:** none. Endpoint has no caller until PR 3.
 
-- [ ] Expose `tokenizePhrase` from a shared module so the endpoint tokenizes part text identically to the indexer.
-- [ ] Add `getTraceSearchHighlights` server fn in `apps/web/src/domains/traces/traces.functions.ts` — input `{ projectId, traceId, searchQuery (≤500) }`, output `TraceSearchHighlightsResult` with `search-literal` + `search-token` ranges only.
-- [ ] Parse `q` with `parseSearchQuery`; fast-path empty `q` to `{ highlights: [], firstMatchIndex: -1 }`.
-- [ ] Walk `traceDetail.allMessages` skipping `role === "system"`; emit literal hits (case-sensitive `indexOf` per phrase) and token hits (ordered-adjacent windows per phrase), sorted in document order; set `firstMatchIndex`.
-- [ ] Vitest: literal-only, token-only, hybrid, empty query, system-message filtering, multi-part messages.
-- [ ] Verify: `curl`/fixture call against a known trace returns expected shape and `firstMatchIndex`.
+- [x] Relocated `tokenizePhrase` to `@domain/spans/helpers/tokenize-phrase.ts`; lexical indexer + highlights endpoint share one tokenizer.
+- [x] Added `getTraceSearchHighlights` server fn in `apps/web/src/domains/traces/traces.functions.ts` — input `{ projectId, traceId, searchQuery (≤500) }`, output `TraceSearchHighlightsResult` with `search-literal` + `search-token` ranges only. Auth (`requireSession()`) fires before the parsed-query early-exit so unauthenticated callers can't even see the empty fast-path.
+- [x] Parsed `q` with `parseSearchQuery`; fast-path empty `q` to `{ highlights: [], firstMatchIndex: -1 }`.
+- [x] Walked `traceDetail.allMessages` skipping `role === "system"` and guarding against `message.parts` being undefined; emitted literal hits (normalised phrase + flexible-whitespace regex) and token hits (ordered-adjacent windows), sorted in document order; set `firstMatchIndex`. Overlapping literal + token ranges are intentionally preserved (each carries distinct `source` info).
+- [x] Match-nothing parity with `buildLexicalSearchSubquery`: any literal that normalises to empty OR any token that tokenises to empty makes the whole result empty.
+- [x] Relocated `normalizeLiteralPhrase` + `stripLoneSurrogates` to `@domain/spans/helpers/normalize-literal-phrase.ts` so indexer and highlights share one canonical normaliser.
+- [x] Vitest: literal-only, token-only, hybrid, empty query, semantic-only, system-message filtering, multi-part messages, malformed `parts`, overlapping ranges, match-nothing combinations, whitespace-flexible literal matching (12+ cases).
+- [x] Verified: 602 / 602 vitest, 3 typechecks clean, `pnpm knip` exit 0 (export shielded by `@knipignore` JSDoc + `tags: ["-knipignore"]` in `knip.json`).
 
 ### PR 2 — Backend: semantic-region schema + ingest + read path *(LAT-601 part 2/5)*
 
 **Branch:** `LAT-601/highlights-backend-semantic-region`
+**Status:** all code on local branch; pending the staging-baseline diff verification.
 **Depends on:** PR 1 merged.
 **User-visible change:** none. Existing search-listing callers don't pass `semanticMetadata: true`, so listing queries are byte-identical to today's. No backfill — see "Storage" section for why pre-migration rows stay NULL forever.
 
-- [ ] Migration via `pnpm --filter @platform/db-clickhouse ch:create add_chunk_message_range_to_trace_search_embeddings`: add `first_message_index Nullable(UInt32)` and `last_message_index Nullable(UInt32)` to `trace_search_embeddings`.
-- [ ] `extractTurns` returns `{ text, firstMessageIndex, lastMessageIndex }[]`, indexing into the original `allMessages` array (including system rows).
-- [ ] `selectHeadTailTurns` preserves per-turn metadata when picking turns.
-- [ ] `packChunks` emits union ranges: `min(firstMessageIndex)` / `max(lastMessageIndex)` across packed turns; sub-chunks of one oversized turn inherit that turn's full range.
-- [ ] Extend `TraceSearchChunk` with `firstMessageIndex` and `lastMessageIndex`.
-- [ ] Extend `upsertEmbedding` in `trace-search-repository.ts` to write the two new columns.
-- [ ] Widen `SearchPlan` to `{ ranked, subquery, params, semanticMetadata: boolean }`; default `false`.
-- [ ] When `semanticMetadata: true`, `buildSemanticSearchSubquery` adds `argMax(chunk_index, semantic_score)` + matched-range columns; default `false` keeps the existing query plan byte-identical.
-- [ ] Project matched-chunk columns through the outer `LIST_SELECT` only when `semanticMetadata` is true.
-- [ ] Hybrid `LEFT JOIN`: same `argMax` pattern on the joined semantic side; lexical side returns NULL for matched-chunk columns.
-- [ ] Extend `getTraceSearchHighlights` to emit `search-semantic-region` highlights via its own per-trace semantic subquery with `semanticMetadata: true`. When matched-range columns are NULL (pre-migration row or pure-phrase plan), skip semantic-region emission — literal/token still flow.
-- [ ] Vitest: index threading through the chunk pipeline (including sub-chunks-of-oversized-turn), `argMax` projection, `semanticMetadata` plumbing.
+- [x] Migration `00017_add_chunk_message_range_to_trace_search_embeddings` (unclustered + clustered): `first_message_index Nullable(UInt32)` and `last_message_index Nullable(UInt32)` on `trace_search_embeddings` with `CODEC(T64, ZSTD(1))`.
+- [x] `extractTurns` returns `{ text, firstMessageIndex, lastMessageIndex }[]`, indexing into the original `allMessages` array (system rows included).
+- [x] `selectHeadTailTurns` preserves per-turn metadata when picking turns; type widening only.
+- [x] `packChunks` emits union ranges: `min(firstMessageIndex)` / `max(lastMessageIndex)` across packed turns; sub-chunks of one oversized turn inherit that turn's full range.
+- [x] Extended `TraceSearchChunk` with `firstMessageIndex` and `lastMessageIndex`.
+- [x] Extended `TraceSearchEmbeddingRow` (port) + `upsertEmbedding` (live) to write the two new columns; nullable in CH → `undefined` serialises to `null` in `JSONEachRow`. Worker (`apps/workers/src/workers/trace-search.ts`) passes them through from chunk to row.
+- [x] Widened `SearchPlan` to `{ ranked, subquery, params, semanticMetadata: boolean }`. `planSearch(parsed, opts?)` accepts an `opts.semanticMetadata?: boolean`; default `false`.
+- [x] `buildSemanticSearchSubquery(queryEmbedding, semanticMetadata)` conditionally adds `argMax(chunk_index, semantic_score)` + matched-range columns; default `false` keeps the existing query plan byte-identical.
+- [x] Outer subquery wrapping in `buildSearchPlan` projects `matched_chunk_index` / `matched_first_message_index` / `matched_last_message_index` through every branch when `semanticMetadata: true` (phrase-only / no-embedding plans cast NULL of the right type for shape parity).
+- [x] Hybrid `LEFT JOIN`: `max(sem.matched_*)` pass-through over the joined side; lexical-only matches return NULL (no semantic chunk).
+- [x] New `TraceSearchRepository.findSemanticHighlightForTrace(orgId, projectId, traceId, queryEmbedding)` runs the focused per-trace `argMax` query and returns `{ chunkIndex, firstMessageIndex, lastMessageIndex, relevanceScore } | null` (nullable on the message-range columns for pre-migration chunks).
+- [x] Extended `computeTraceSearchHighlights` use-case to accept an optional `semanticMatch`. When the matched-range columns are non-null, emits one `search-semantic-region` highlight per non-system message in `[first, last]`. NULL range columns → skip semantic-region emission; literal/token still flow.
+- [x] Extended `getTraceSearchHighlights` handler: when `parsedQuery.semanticPrompt` is non-empty, runs the Voyage embed + `findSemanticHighlightForTrace` in parallel with `findByTraceId` (both Effect-resolved via `withAi` + `withClickHouse`). AI unavailable → semantic-region skipped, literal/token continue to flow.
+- [x] Added `@domain/ai` to `apps/web/package.json` so the handler can take the `AI` service from context for embedding.
+- [x] Vitest: index threading through the chunk pipeline (single turn, system-row interleave, multi-turn packing, sub-chunks-of-oversized-turn, head/tail dropping the middle); semantic-region emission (block-per-message, system skipping, NULL-range skipping, composes with literal hits, suppressed by match-nothing phrase, semantic-only with no match). Total: 613 / 613 vitest in `@domain/spans`, 154 / 154 in `@platform/db-clickhouse`. All 4 typechecks clean. `pnpm knip` exit 0.
 - [ ] Verify: diff existing search-listing result IDs and `relevance_score` against a staging baseline — must be identical. New endpoint returns semantic-region highlights on freshly-ingested traces, literal/token-only on older ones.
 
 ### PR 3 — Frontend: Phase A wiring + literal/token highlights *(LAT-601 part 3/5)*


### PR DESCRIPTION
## Summary

Second slice of **LAT-601** (search highlights). Builds the backend half that unlocks `search-semantic-region` highlights in the trace drawer — schema, ingest, read path, per-trace lookup, and a reusable use-case all land together. Existing search-listing callers don't opt into the new shape, so listing SQL is byte-identical.

**Depends on [#3255](https://github.com/latitude-dev/latitude-llm/pull/3255)** (PR 1). Branched off it, so until PR 1 merges this diff includes its commits — review can focus on the `860402b3b`/`97c59a2c3` two-commit delta on top.

## What's in PR 2

### Schema — migration `00017`, unclustered + clustered

- `first_message_index Nullable(UInt32)`, `last_message_index Nullable(UInt32)` on `trace_search_embeddings`, `CODEC(T64, ZSTD(1))`.
- Nullable so pre-migration rows are distinguishable from rows that legitimately match at message 0 — no backfill needed; pre-migration coverage stays at "lexical only" until rows re-embed organically.

### Ingest — `@domain/spans/use-cases/build-trace-search-document.ts`

- `extractTurns` → `{ text, firstMessageIndex, lastMessageIndex }[]` indexed against the original `allMessages` (system rows included), so indices line up with the renderer.
- `selectHeadTailTurns` preserves the metadata when picking turns.
- `packChunks` emits union ranges across packed turns; sub-chunks of one oversized turn inherit that turn's full range — turns are atomic for the mapping.
- `TraceSearchChunk` + `TraceSearchEmbeddingRow` + live `upsertEmbedding` + the `trace-search` worker all carry the new fields.

### Read path — `@platform/db-clickhouse/repositories/search-plan.ts`

- `SearchPlan.semanticMetadata: boolean` (default `false`). When `true`, `buildSemanticSearchSubquery` adds `argMax(chunk_index/first_message_index/last_message_index, semantic_score)` rolled up alongside `max(semantic_score)`.
- All three plan branches (phrase-only / semantic-only / hybrid) project matched-* columns through with NULL-typed casts for shape parity. Hybrid `LEFT JOIN` uses `max(sem.matched_*)` — sem is already 1-per-trace so MAX is a no-op pass-through; lexical-only matches naturally return NULL.
- `planSearch(parsed, opts?)` accepts `opts.semanticMetadata?`. Default keeps the listing query plan byte-identical.

### Per-trace lookup — `TraceSearchRepository.findSemanticHighlightForTrace`

- Focused per-trace `argMax` query (no listing scan). Returns `{ chunkIndex, firstMessageIndex, lastMessageIndex, relevanceScore } | null` with nullable range columns on pre-migration chunks.

### Use-case — `@domain/spans/use-cases/get-trace-search-highlights.ts`

- `getTraceSearchHighlightsUseCase` owns the full orchestration: parse query → parallel `findByTraceId` + (embed via AI service + `findSemanticHighlightForTrace`) → `computeTraceSearchHighlights`.
- Pure Effect over domain ports, no HTTP/TanStack concerns. **Reusable by a future REST/MCP endpoint** with the same three layers — apps/web is a thin layer-providing wrapper.
- AI unavailable in dev/CI → semantic match drops to `null`, literal/token still flow.

### `computeTraceSearchHighlights` extended

- Optional `semanticMatch` input. Emits one `search-semantic-region` highlight per non-system message in `[firstMessageIndex, lastMessageIndex]`. NULL range columns → skip semantic-region. Match-nothing phrases suppress semantic-region too (the trace wouldn't be in search results).

### Handler — `apps/web/src/domains/traces/traces.functions.ts`

- Slimmed down to `requireSession()` + delegate to the use-case + provide layers. `Effect.orElseSucceed` to empty result for repository errors (decorative layer; shouldn't break the drawer).

## User-visible change

None. No caller of the search-listing path sets `semanticMetadata: true`, so listing SQL is byte-identical. The new endpoint sits unused until PR 3 / PR 5 wire it from the frontend.

## Test plan

- [x] `pnpm --filter @domain/spans test` → 613 / 613 (12 new cases: 5 chunk index threading + 7 semantic-region emission incl. block-per-message, system-row skipping, NULL-range fallback, literal composition, match-nothing suppression, semantic-only-no-match)
- [x] `pnpm --filter @platform/db-clickhouse test` → 154 / 154
- [x] `pnpm --filter @domain/spans typecheck` → clean
- [x] `pnpm --filter @platform/db-clickhouse typecheck` → clean
- [x] `pnpm --filter web typecheck` → clean
- [x] `pnpm --filter @app/workers typecheck` → clean
- [x] `pnpm knip` → exit 0
- [x] Reviewer: confirm the migration is safe — Nullable additive ALTER on `trace_search_embeddings`; no backfill needed.
- [ ] Manual on staging once merged: diff existing search-listing result IDs and `relevance_score` against a pre-PR baseline — must be identical (gated by the default-false flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)