### PR TITLE
fix(telemetry): update stale installer links

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Installer links now point to the current Latitude docs and API key settings URLs.
+
 ## [0.0.7] - 2026-04-24
 
 ### Changed
@@ -31,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--staging` and `--dev` environment flags** replace `--base-url`. They target:
   - `--staging` → `https://staging.latitude.so` / `https://staging-ingest.latitude.so`
   - `--dev` → `http://localhost:3000` / `http://localhost:3002`
-  - no flag → `https://app.latitude.so` / `https://ingest.latitude.so` (production default)
+  - no flag → `https://console.latitude.so` / `https://ingest.latitude.so` (production default)
   Every URL shown or written during install (API-keys link, project-creation link, ingest endpoint, trace-view link, About banner) is derived from the selected environment. The two environments are mutually exclusive; passing both errors out.
 - **Per-prompt inline help** — the API key prompt's description line tells you where to generate one (with the env-correct URL); the project slug prompt tells you where to create a project. Both include the current value as "(Enter to keep …)" hints when re-running.
 - **`picocolors` dependency** for minimal ANSI styling (cyan links, dim hints, yellow warnings for non-production envs).

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -26,7 +26,7 @@ const STATE_FILE = join(STATE_DIR, "state.json")
 const PLIST_PATH = join(homedir(), "Library", "LaunchAgents", "so.latitude.claude-code-telemetry.plist")
 const PLIST_LABEL = "so.latitude.claude-code-telemetry"
 const DEFAULT_HOOK_COMMAND = "npx -y @latitude-data/claude-code-telemetry"
-const DOCS_URL = "https://docs.latitude.so/claude-code-telemetry"
+const DOCS_URL = "https://docs.latitude.so/telemetry/claude-code"
 
 // Environments pick the app + ingest domain pair. Every URL shown or written
 // during install is derived from these two — there's no other source of truth.
@@ -56,12 +56,12 @@ const DEV_ENV: EnvironmentConfig = {
   ingest: "http://localhost:3002",
 }
 function urlsFor(env: EnvironmentConfig): {
-  apiKeys: string
+  apiKeys: (slug: string) => string
   projects: string
   projectView: (slug: string) => string
 } {
   return {
-    apiKeys: `${env.app}/settings/api-keys`,
+    apiKeys: (slug: string) => `${env.app}/projects/${slug}/settings/keys`,
     projects: env.app,
     projectView: (slug: string) => `${env.app}/projects/${slug}`,
   }
@@ -116,8 +116,8 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
   }
   note(aboutLines.join("\n"), "About")
 
-  const apiKey = await promptApiKey(existingEnv.LATITUDE_API_KEY, flags.apiKey, urls.apiKeys)
   const project = await promptProject(existingEnv.LATITUDE_PROJECT, flags.project, urls.projects)
+  const apiKey = await promptApiKey(existingEnv.LATITUDE_API_KEY, flags.apiKey, urls.apiKeys(project))
 
   let useLaunchctl = false
   if (process.platform === "darwin" && !flags.noLaunchctl) {

--- a/packages/telemetry/openclaw-cli/CHANGELOG.md
+++ b/packages/telemetry/openclaw-cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `@latitude-data/openclaw-telemetry-cli` installer wil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Installer links now point to the current Latitude docs and API key settings URLs.
+
 ## [0.0.7] - 2026-04-29
 
 Initial release of the standalone installer CLI. The runtime split that landed in `@latitude-data/openclaw-telemetry` 0.0.6 ([PR #2920](https://github.com/latitude-dev/latitude-llm/pull/2920)) deleted the bundled CLI from the runtime package so that runtime would pass OpenClaw 2026.4.25+'s install-time `dangerous-exec` security scan. The 0.0.6 manual install flow asked operators to run six `openclaw config set` commands plus a hand-edited `plugins.allow` array; this package brings the one-shot `npx -y` UX back. By living in a separate npm package, this CLI is installed via `npx`/`npm install -g` rather than `openclaw plugins install`, so it never goes through OpenClaw's install-time scanner.

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -7,7 +7,7 @@ For details on the plugin runtime itself — what it sends, the span tree, and t
 ## Requirements
 
 - **OpenClaw 2026.4.25 or newer** on PATH.
-- A **Latitude API key** and **project slug** — both from [console.latitude.so/settings/api-keys](https://console.latitude.so/settings/api-keys).
+- A **Latitude API key** from `https://console.latitude.so/projects/<your-slug>/settings/keys` and the matching **project slug**.
 
 ## Install
 

--- a/packages/telemetry/openclaw-cli/src/setup.ts
+++ b/packages/telemetry/openclaw-cli/src/setup.ts
@@ -35,7 +35,7 @@ import { readCliVersion } from "./version.ts"
 const RUNTIME_PACKAGE_NAME = "@latitude-data/openclaw-telemetry"
 const RUNTIME_VERSION = "0.0.7"
 
-const DOCS_URL = "https://docs.latitude.so/openclaw-telemetry"
+const DOCS_URL = "https://docs.latitude.so/telemetry/openclaw"
 
 interface EnvironmentConfig {
   name: "production" | "staging" | "dev"
@@ -64,12 +64,12 @@ const DEV_ENV: EnvironmentConfig = {
 }
 
 function urlsFor(env: EnvironmentConfig): {
-  apiKeys: string
+  apiKeys: (slug: string) => string
   projects: string
   projectView: (slug: string) => string
 } {
   return {
-    apiKeys: `${env.app}/settings/api-keys`,
+    apiKeys: (slug: string) => `${env.app}/projects/${slug}/settings/keys`,
     projects: env.app,
     projectView: (slug: string) => `${env.app}/projects/${slug}`,
   }
@@ -242,11 +242,11 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
   }
   note(aboutLines.join("\n"), "About")
 
-  log.info(`Get an API key at ${pc.cyan(urls.apiKeys)}`)
   log.info(`Create a project at ${pc.cyan(urls.projects)}`)
 
-  const apiKey = await promptApiKey(existingConfig?.apiKey, flags.apiKey)
   const project = await promptProject(existingConfig?.project, flags.project)
+  log.info(`Get an API key at ${pc.cyan(urls.apiKeys(project))}`)
+  const apiKey = await promptApiKey(existingConfig?.apiKey, flags.apiKey)
 
   await applyChanges({
     apiKey,

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -5,7 +5,7 @@ OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) 
 ## Requirements
 
 - **OpenClaw 2026.4.25 or newer** on PATH.
-- A **Latitude API key** and **project slug** — both from [console.latitude.so/settings/api-keys](https://console.latitude.so/settings/api-keys).
+- A **Latitude API key** from `https://console.latitude.so/projects/<your-slug>/settings/keys` and the matching **project slug**.
 
 ## Install
 


### PR DESCRIPTION
Updates the Claude Code and OpenClaw telemetry installers so their help text points at current Latitude URLs.

The Claude installer was still linking to a removed docs page and a stale API key settings route. Both installers now point docs at the current telemetry pages and build project-scoped API key settings links under `/projects/<slug>/settings/keys`, which matches the current web app routing on `development`.

Also updates the OpenClaw README references and changelogs so package docs do not send users to the removed settings route.

Validation:
- `pnpm --filter @latitude-data/claude-code-telemetry typecheck`
- `pnpm --filter @latitude-data/openclaw-telemetry-cli typecheck`
