### PR TITLE
feat(sessions): freshness-weighted ordering for session search

### DIFF
--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -46,7 +46,10 @@ export function useSessionsInfiniteScroll({
       })
       return result ?? { sessions: [], hasMore: false }
     },
-    initialPageParam: undefined as { sortValue: string; sessionId: string } | undefined,
+    initialPageParam: undefined as
+      | { sortValue: string; sessionId: string }
+      | { relevanceBucket: number; lastActivityAt: string; sessionId: string }
+      | undefined,
     getNextPageParam: (lastPage) => lastPage?.nextCursor,
   })
 

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -56,18 +56,31 @@ const serializeSearchMatch = (match: SessionSearchMatch) => ({
 
 export type SessionSearchMatchRecord = ReturnType<typeof serializeSearchMatch>
 
-const sessionListCursorSchema = z.object({
-  sortValue: z.string(),
-  sessionId: z.string(),
-})
+// Two cursor shapes coexist on the wire: the original
+// `(sortValue, sessionId)` for the non-search list path and the
+// freshness-weighted `(relevanceBucket, lastActivityAt, sessionId)` for the
+// search list path. The repository discriminates by shape — a stale cursor
+// of the wrong kind is silently dropped (pagination restarts).
+const sessionListCursorSchema = z.union([
+  z.object({
+    sortValue: z.string(),
+    sessionId: z.string(),
+  }),
+  z.object({
+    relevanceBucket: z.number(),
+    lastActivityAt: z.string(),
+    sessionId: z.string(),
+  }),
+])
+
+type SessionListNextCursor =
+  | { readonly sortValue: string; readonly sessionId: string }
+  | { readonly relevanceBucket: number; readonly lastActivityAt: string; readonly sessionId: string }
 
 interface SessionListResult {
   readonly sessions: readonly SessionRecord[]
   readonly hasMore: boolean
-  readonly nextCursor?: {
-    readonly sortValue: string
-    readonly sessionId: string
-  }
+  readonly nextCursor?: SessionListNextCursor
   readonly searchMatches?: Readonly<Record<string, SessionSearchMatchRecord>>
 }
 

--- a/dev-docs/qa/session-search.md
+++ b/dev-docs/qa/session-search.md
@@ -69,12 +69,13 @@ expected behavior — tick the box once you've verified it.
 
 | # | Query (typed into the search bar) | Mode | Expected `matching_trace_count` per session (sorted) | Why |
 |---|---|---|---|---|
-| 1 | `"refund"` | literal | `qa-refund-4-1` = **4** (all traces), `qa-deep-20-1` = **16** (first mention at trace 5 → 5..20), `qa-mixed-6-1` = **4** (first mention at trace 3 → 3..6). Total **24**. | `bestScore = 0.0` for every match (no semantic component), so secondary ordering collapses to `session_id DESC`. `qa-code-3-1` and `qa-cancellation-5-1` are absent. |
+| 1 | `"refund"` | literal | `qa-refund-4-1` = **4** (all traces), `qa-deep-20-1` = **16** (first mention at trace 5 → 5..20), `qa-mixed-6-1` = **4** (first mention at trace 3 → 3..6). Total **24**. | `bestScore = 0.0` for every match (no semantic component), so every match shares the same relevance bucket. Secondary ordering is `last_activity_at DESC` (see Query 7 / spec [7-freshness-weighted-sort.md](../../specs/session-problems/7-freshness-weighted-sort.md)). `qa-code-3-1` and `qa-cancellation-5-1` are absent. |
 | 2 | `` `dispute team` `` | token phrase | `qa-refund-4-1` = **2** (first at trace 3 → 3..4), `qa-deep-20-1` = **9** (first at trace 12 → 12..20). Total **11**. | Adjacent tokens "dispute team" first appear in `qa-refund-4-1`'s trace 3 reply and `qa-deep-20-1`'s trace 12. Accumulated history carries the phrase forward into every later trace in each session. |
 | 3 | `customer wanted their money back` | semantic — **pure** | `qa-cancellation-5-1` first (engineered pure-semantic target — none of "refund", "money", "back" appear in any of its turns; cosine alone has to surface it). `qa-refund-4-1`, `qa-mixed-6-1`, and `qa-deep-20-1` also appear since they're refund-themed. Specific per-session counts depend on which chunks survive the semantic-scan cap; don't pin exact numbers. | Cosine ranks across all chunk embeddings; no literal filter narrows the candidate set. **This is the only query in the suite that is genuinely pure-semantic** — the others either are literal/hybrid or rely on accidental token overlap. |
 | 4 | `"refund" user complaint` | hybrid | Same per-session counts as query 1 (literal filter is the same), but ranked by the semantic prompt within each session: `qa-refund-4-1` likely first, then `qa-deep-20-1`, then `qa-mixed-6-1`. Total still **24**. | Literal `"refund"` filters the candidate set; the semantic prompt only reorders within. `qa-cancellation-5-1` drops out — no literal "refund" in any of its traces. |
 | 5 | `pizza dough` (literally appears in `qa-deep-20-1` trace 14) | semantic (parser-wise) — but with literal overlap, so behaves like a literal hit | `qa-deep-20-1` only — first occurrence at trace 14 → **7** matches via accumulated history (14..20). | Parser-wise this is a semantic query (no quotes/backticks), but a trace containing the exact words has cosine ≈ 1.0, so semantic search behaves indistinguishably from literal here. Useful sanity check that the embedding worker actually indexed the deep fixture. |
 | 6 | Empty search bar | n/a | Plain session listing, no "Matching traces" column, ordered by recency. | Non-search mode falls through to the regular sessions list — same as the project page's Sessions tab. |
+| 7 | `"refund"` (same as Query 1, but verifying sort order) | literal | The three matching sessions (`qa-refund-4-1`, `qa-deep-20-1`, `qa-mixed-6-1`) appear in **`last_activity_at DESC`** order — whichever session finished ingestion last appears first. Confirm by clicking each result; the "Last activity" timestamp in the panel header should be monotonically decreasing from top to bottom. | Spec [7-freshness-weighted-sort.md](../../specs/session-problems/7-freshness-weighted-sort.md): when every result shares the same relevance bucket (here, all `0.0` because the query is phrase-only), the sort tie-breaker is the session's most-recent activity — **not** `session_id DESC`. Pre-spec, the order would have been `qa-refund-4-1` → `qa-mixed-6-1` → `qa-deep-20-1` regardless of timing. |
 
 - [ ] Query 1 — literal (`"refund"`)
 - [ ] Query 2 — token phrase (`` `dispute team` ``)
@@ -82,6 +83,7 @@ expected behavior — tick the box once you've verified it.
 - [ ] Query 4 — hybrid (`"refund" user complaint`)
 - [ ] Query 5 — deep-only word (semantic with literal overlap)
 - [ ] Query 6 — empty bar
+- [ ] Query 7 — freshness-weighted ordering within a relevance bucket
 
 ## Behavioral checklist
 

--- a/packages/domain/spans/src/constants.ts
+++ b/packages/domain/spans/src/constants.ts
@@ -157,3 +157,25 @@ export const TRACE_SEARCH_MIN_RELEVANCE_SCORE = 0.3
  * id/score arrays.
  */
 export const SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW = 50
+
+/**
+ * Width of the relevance bucket used when sorting session search results.
+ *
+ * Sessions are sorted by `(relevance_bucket, last_activity_at, session_id)`
+ * where `relevance_bucket = floor(best_score / RELEVANCE_BUCKET_WIDTH) *
+ * RELEVANCE_BUCKET_WIDTH`. A wider bucket favors freshness (more sessions
+ * share a tier, recency dominates); a narrower bucket favors relevance.
+ *
+ * 0.1 is the default: with TRACE_SEARCH_MIN_RELEVANCE_SCORE = 0.3 the
+ * non-empty buckets are {0.3-0.4, 0.4-0.5, ..., 0.9-1.0}, giving seven
+ * recency-sorted tiers above the lexical-only floor.
+ */
+export const SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH = 0.1
+
+/**
+ * Maximum future skew (milliseconds) tolerated when reading max_end_time
+ * for the freshness sort. A span with end_time more than this far in the
+ * future is clamped to now() + this interval, preventing client-clock-skew
+ * junk from floating to the top of search results forever.
+ */
+export const SESSION_SEARCH_MAX_CLOCK_SKEW_MS = 60 * 60 * 1000

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -6,7 +6,9 @@
 
 export {
   SESSION_ID_MAX_LENGTH,
+  SESSION_SEARCH_MAX_CLOCK_SKEW_MS,
   SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+  SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH,
   SPAN_ID_LENGTH,
   TRACE_COHORT_SUMMARY_CACHE_TTL_SECONDS,
   TRACE_END_DEBOUNCE_MS,
@@ -76,6 +78,7 @@ export type {
   SessionListPage,
   SessionMetrics,
   SessionRepositoryShape,
+  SessionSearchCursor,
 } from "./ports/session-repository.ts"
 export { emptySessionMetrics, SessionRepository } from "./ports/session-repository.ts"
 export type { SpanListOptions, SpanMessagesData, SpanRepositoryShape } from "./ports/span-repository.ts"

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -60,17 +60,33 @@ export interface SessionListCursor {
   readonly sessionId: string
 }
 
+/**
+ * Cursor shape used by the search-active list path, which sorts by
+ * `(relevance_bucket, last_activity_at, session_id) DESC`. The bucket
+ * snaps `best_score` into fixed-width tiers (see
+ * `SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH`) so recently-active sessions
+ * float above stale ones of equivalent relevance. `lastActivityAt` is the
+ * session's `max_end_time` (clamped against client clock skew) serialized
+ * as an ISO-8601 string.
+ */
+export interface SessionSearchCursor {
+  readonly relevanceBucket: number
+  readonly lastActivityAt: string
+  readonly sessionId: string
+}
+
 export interface SessionListOptions {
   readonly limit?: number
-  readonly cursor?: SessionListCursor
+  readonly cursor?: SessionListCursor | SessionSearchCursor
   readonly sortBy?: string
   readonly sortDirection?: "asc" | "desc"
   readonly filters?: FilterSet
   /**
    * When present, the repository switches into the search code path: results
-   * are session-rollups of matching traces, ranking is forced to
-   * `bestScore DESC, sessionId DESC` regardless of `sortBy`, and the returned
-   * `SessionListPage` carries a parallel `searchMatches` map.
+   * are session-rollups of matching traces, ranking is forced to the
+   * freshness-weighted `(relevance_bucket, last_activity_at, sessionId) DESC`
+   * tuple regardless of `sortBy`, and the returned `SessionListPage` carries
+   * a parallel `searchMatches` map.
    */
   readonly searchQuery?: string
 }
@@ -78,7 +94,7 @@ export interface SessionListOptions {
 export interface SessionListPage {
   readonly items: readonly Session[]
   readonly hasMore: boolean
-  readonly nextCursor?: SessionListCursor
+  readonly nextCursor?: SessionListCursor | SessionSearchCursor
   /**
    * Per-result search match metadata, keyed by `sessionId`. Present only when
    * `SessionListOptions.searchQuery` was active for the request. Surfaced as

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -60,15 +60,6 @@ export interface SessionListCursor {
   readonly sessionId: string
 }
 
-/**
- * Cursor shape used by the search-active list path, which sorts by
- * `(relevance_bucket, last_activity_at, session_id) DESC`. The bucket
- * snaps `best_score` into fixed-width tiers (see
- * `SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH`) so recently-active sessions
- * float above stale ones of equivalent relevance. `lastActivityAt` is the
- * session's `max_end_time` (clamped against client clock skew) serialized
- * as an ISO-8601 string.
- */
 export interface SessionSearchCursor {
   readonly relevanceBucket: number
   readonly lastActivityAt: string
@@ -82,11 +73,9 @@ export interface SessionListOptions {
   readonly sortDirection?: "asc" | "desc"
   readonly filters?: FilterSet
   /**
-   * When present, the repository switches into the search code path: results
-   * are session-rollups of matching traces, ranking is forced to the
-   * freshness-weighted `(relevance_bucket, last_activity_at, sessionId) DESC`
-   * tuple regardless of `sortBy`, and the returned `SessionListPage` carries
-   * a parallel `searchMatches` map.
+   * When set, switches the repository into the search code path. `sortBy` /
+   * `sortDirection` are ignored and the page carries a parallel
+   * `searchMatches` map.
    */
   readonly searchQuery?: string
 }

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -278,32 +278,12 @@ export const listSessionsBySearchQuery = ({
     const plan = yield* planSearch(parsed)
     const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
 
-    // Bucket math: floor(score / width) * width snaps best_score into
-    // fixed-width tiers. Within a tier, recently-active sessions float to
-    // the top — the §2 pathology (an 18-month-old 0.87 beating a fresh
-    // 0.85) is gone for any pair inside the same bucket, while relevance
-    // still dominates across bucket boundaries.
-    const bucketExpr = `floor(max(relevance_score) / {bucketWidth:Float64}) * {bucketWidth:Float64}`
-
-    // `coalesce(any(sf.sess_max_end_time), max(end_time))` falls back to
-    // the matching traces' end_time for orphan rows (synthesized
-    // `session_id = toString(trace_id)` has no row in `sessions`). The
-    // outer `least(…, now + skew)` clamps client-clock-skewed futures so
-    // junk can't pin itself to the top forever.
-    const lastActivityExpr = `
-      least(
-        coalesce(any(sf.sess_max_end_time), max(end_time)),
-        addMilliseconds(now64(9, 'UTC'), {clockSkewMs:UInt32})
-      )
-    `.trim()
-
     const searchCursor = isSearchCursor(cursor) ? cursor : undefined
+    // HAVING references the SELECT aliases (CH lets it see them) so the
+    // bucket and last_activity expressions stay defined in exactly one
+    // place — the outer projection below.
     const sessionCursorClause = searchCursor
-      ? `HAVING (
-           ${bucketExpr},
-           ${lastActivityExpr},
-           session_id
-         ) < (
+      ? `HAVING (relevance_bucket, last_activity_at, session_id) < (
            {cursorBucket:Float64},
            {cursorLastActivityAt:DateTime64(9, 'UTC')},
            {cursorSessionId:String}
@@ -327,8 +307,8 @@ export const listSessionsBySearchQuery = ({
                   -- candidate set only. sessions.max_end_time is a
                   -- SimpleAggregateFunction(max, ...) so plain reads can
                   -- see a single unmerged part; max() finalizes across
-                  -- parts. Restricting the IN clause to trace_rollup's
-                  -- session_ids keeps the scan bounded to matched sessions.
+                  -- parts. The IN clause keeps the scan bounded to the
+                  -- session_ids that actually matched.
                   session_freshness AS (
                     SELECT
                       session_id,
@@ -336,9 +316,7 @@ export const listSessionsBySearchQuery = ({
                     FROM sessions
                     WHERE organization_id = {organizationId:String}
                       AND project_id = {projectId:String}
-                      AND session_id IN (
-                        SELECT session_id FROM trace_rollup WHERE session_id != ''
-                      )
+                      AND session_id IN (SELECT session_id FROM trace_rollup)
                     GROUP BY session_id
                   )
                   SELECT
@@ -347,8 +325,22 @@ export const listSessionsBySearchQuery = ({
                     session_id,
                     max(relevance_score)                                            AS best_score,
                     argMax(trace_id, relevance_score)                               AS best_trace_id,
-                    ${bucketExpr}                                                   AS relevance_bucket,
-                    ${lastActivityExpr}                                             AS last_activity_at,
+                    -- Bucket math: floor(score / width) * width snaps
+                    -- best_score into fixed-width tiers. Within a tier,
+                    -- recently-active sessions float to the top via
+                    -- last_activity_at; across tiers, relevance still wins.
+                    floor(max(relevance_score) / {bucketWidth:Float64})
+                      * {bucketWidth:Float64}                                       AS relevance_bucket,
+                    -- coalesce(any(sf.sess_max_end_time), max(end_time))
+                    -- falls back to the matching traces' end_time for orphan
+                    -- rows (synthesized session_id = toString(trace_id) has no
+                    -- row in sessions). The outer least(…, now + skew) clamps
+                    -- client-clock-skewed futures so junk can't pin itself to
+                    -- the top forever.
+                    least(
+                      coalesce(any(sf.sess_max_end_time), max(end_time)),
+                      addMilliseconds(now64(9, 'UTC'), {clockSkewMs:UInt32})
+                    )                                                               AS last_activity_at,
                     count()                                                         AS matching_trace_count,
                     -- Sort the (trace_id, score) tuples once, then slice the
                     -- top-K and split into parallel arrays. The cap bounds

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -18,9 +18,14 @@ import type {
   SessionCountResult,
   SessionListCursor,
   SessionListPage,
+  SessionSearchCursor,
   SessionSearchMatch,
 } from "@domain/spans"
-import { SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW } from "@domain/spans"
+import {
+  SESSION_SEARCH_MAX_CLOCK_SKEW_MS,
+  SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+  SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH,
+} from "@domain/spans"
 import { normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect } from "effect"
 import { buildClickHouseWhere } from "../filter-builder.ts"
@@ -60,6 +65,12 @@ type SessionSearchRow = {
   // search path.
   best_score: number
   best_trace_id: string
+  // Fixed-width snap of `best_score` (see SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH).
+  // Drives the freshness-weighted sort tuple alongside `last_activity_at`.
+  relevance_bucket: number
+  // Session-level `max_end_time`, clamped to `now() + SESSION_SEARCH_MAX_CLOCK_SKEW_MS`
+  // to neutralize bad client clocks. ISO-8601 string from JSONEachRow.
+  last_activity_at: string
   matching_trace_count: string
   matching_trace_ids: string[]
   matching_trace_scores: number[]
@@ -232,10 +243,20 @@ interface ListSearchInput {
   readonly projectId: ProjectId
   readonly parsed: ParsedSearchQuery
   readonly filters: FilterSet | undefined
-  readonly cursor: SessionListCursor | undefined
+  readonly cursor: SessionListCursor | SessionSearchCursor | undefined
   readonly limit: number
   readonly fetchFullSessions: FetchFullSessions
 }
+
+/**
+ * Search-path cursor carries the freshness-weighted sort tuple. Legacy
+ * `SessionListCursor` values (from clients on the prior cursor shape) are
+ * silently dropped — keyset pagination will restart from the top, which is
+ * the only safe behavior when the cursor's encoded sort key doesn't match
+ * the query's actual ORDER BY.
+ */
+const isSearchCursor = (cursor: SessionListCursor | SessionSearchCursor | undefined): cursor is SessionSearchCursor =>
+  cursor !== undefined && "relevanceBucket" in cursor && "lastActivityAt" in cursor
 
 /**
  * Search-active list path (spec §4.3). Runs the trace → session rollup
@@ -257,9 +278,36 @@ export const listSessionsBySearchQuery = ({
     const plan = yield* planSearch(parsed)
     const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
 
-    const sessionCursorClause = cursor
-      ? `HAVING (max(relevance_score), session_id) <
-           ({cursorSortValue:Float64}, {cursorSessionId:String})`
+    // Bucket math: floor(score / width) * width snaps best_score into
+    // fixed-width tiers. Within a tier, recently-active sessions float to
+    // the top — the §2 pathology (an 18-month-old 0.87 beating a fresh
+    // 0.85) is gone for any pair inside the same bucket, while relevance
+    // still dominates across bucket boundaries.
+    const bucketExpr = `floor(max(relevance_score) / {bucketWidth:Float64}) * {bucketWidth:Float64}`
+
+    // `coalesce(any(sf.sess_max_end_time), max(end_time))` falls back to
+    // the matching traces' end_time for orphan rows (synthesized
+    // `session_id = toString(trace_id)` has no row in `sessions`). The
+    // outer `least(…, now + skew)` clamps client-clock-skewed futures so
+    // junk can't pin itself to the top forever.
+    const lastActivityExpr = `
+      least(
+        coalesce(any(sf.sess_max_end_time), max(end_time)),
+        addMilliseconds(now64(9, 'UTC'), {clockSkewMs:UInt32})
+      )
+    `.trim()
+
+    const searchCursor = isSearchCursor(cursor) ? cursor : undefined
+    const sessionCursorClause = searchCursor
+      ? `HAVING (
+           ${bucketExpr},
+           ${lastActivityExpr},
+           session_id
+         ) < (
+           {cursorBucket:Float64},
+           {cursorLastActivityAt:DateTime64(9, 'UTC')},
+           {cursorSessionId:String}
+         )`
       : ""
 
     const rows = yield* chSqlClient
@@ -274,6 +322,24 @@ export const listSessionsBySearchQuery = ({
                       t.organization_id, t.project_id, t.trace_id,
                       search_results.relevance_score
                     ${finalHaving}
+                  ),
+                  -- Pre-aggregate the sessions table's max_end_time for the
+                  -- candidate set only. sessions.max_end_time is a
+                  -- SimpleAggregateFunction(max, ...) so plain reads can
+                  -- see a single unmerged part; max() finalizes across
+                  -- parts. Restricting the IN clause to trace_rollup's
+                  -- session_ids keeps the scan bounded to matched sessions.
+                  session_freshness AS (
+                    SELECT
+                      session_id,
+                      max(max_end_time) AS sess_max_end_time
+                    FROM sessions
+                    WHERE organization_id = {organizationId:String}
+                      AND project_id = {projectId:String}
+                      AND session_id IN (
+                        SELECT session_id FROM trace_rollup WHERE session_id != ''
+                      )
+                    GROUP BY session_id
                   )
                   SELECT
                     organization_id,
@@ -281,6 +347,8 @@ export const listSessionsBySearchQuery = ({
                     session_id,
                     max(relevance_score)                                            AS best_score,
                     argMax(trace_id, relevance_score)                               AS best_trace_id,
+                    ${bucketExpr}                                                   AS relevance_bucket,
+                    ${lastActivityExpr}                                             AS last_activity_at,
                     count()                                                         AS matching_trace_count,
                     -- Sort the (trace_id, score) tuples once, then slice the
                     -- top-K and split into parallel arrays. The cap bounds
@@ -311,22 +379,26 @@ export const listSessionsBySearchQuery = ({
                     sum(error_count)                                                AS error_count,
                     sum(tokens_total)                                               AS tokens_total
                   FROM trace_rollup
+                  LEFT JOIN session_freshness AS sf USING (session_id)
                   GROUP BY organization_id, project_id, session_id
                   ${sessionCursorClause}
-                  ORDER BY best_score DESC, session_id DESC
+                  ORDER BY relevance_bucket DESC, last_activity_at DESC, session_id DESC
                   LIMIT {limit:UInt32}`,
           query_params: {
             organizationId: organizationId as string,
             projectId: projectId as string,
             limit: limit + 1,
             matchingTracesCap: SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW,
+            bucketWidth: SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH,
+            clockSkewMs: SESSION_SEARCH_MAX_CLOCK_SKEW_MS,
             ...telemetryParams,
             ...scoreParams,
             ...plan.params,
-            ...(cursor
+            ...(searchCursor
               ? {
-                  cursorSortValue: cursor.sortValue,
-                  cursorSessionId: cursor.sessionId,
+                  cursorBucket: searchCursor.relevanceBucket,
+                  cursorLastActivityAt: searchCursor.lastActivityAt,
+                  cursorSessionId: searchCursor.sessionId,
                 }
               : {}),
           },
@@ -363,7 +435,12 @@ export const listSessionsBySearchQuery = ({
       items,
       hasMore,
       nextCursor: {
-        sortValue: String(Number(last.best_score)),
+        relevanceBucket: Number(last.relevance_bucket),
+        // Pass CH's DateTime64 string back unchanged: ClickHouse accepts the
+        // same ISO-8601 form it emits as `{x:DateTime64(9, 'UTC')}` input,
+        // so round-tripping through the wire as a string preserves the
+        // nanosecond precision the cursor predicate needs.
+        lastActivityAt: last.last_activity_at,
         sessionId: normalizeCHString(last.session_id),
       },
       searchMatches,

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -325,29 +325,13 @@ export const listSessionsBySearchQuery = ({
                     session_id,
                     max(relevance_score)                                            AS best_score,
                     argMax(trace_id, relevance_score)                               AS best_trace_id,
-                    -- Bucket math: floor(score / width) * width snaps
-                    -- best_score into fixed-width tiers. Within a tier,
-                    -- recently-active sessions float to the top via
-                    -- last_activity_at; across tiers, relevance still wins.
                     floor(max(relevance_score) / {bucketWidth:Float64})
                       * {bucketWidth:Float64}                                       AS relevance_bucket,
-                    -- coalesce(any(sf.sess_max_end_time), max(end_time))
-                    -- falls back to the matching traces' end_time for orphan
-                    -- rows (synthesized session_id = toString(trace_id) has no
-                    -- row in sessions). The outer least(…, now + skew) clamps
-                    -- client-clock-skewed futures so junk can't pin itself to
-                    -- the top forever.
                     least(
                       coalesce(any(sf.sess_max_end_time), max(end_time)),
                       addMilliseconds(now64(9, 'UTC'), {clockSkewMs:UInt32})
                     )                                                               AS last_activity_at,
                     count()                                                         AS matching_trace_count,
-                    -- Sort the (trace_id, score) tuples once, then slice the
-                    -- top-K and split into parallel arrays. The cap bounds
-                    -- per-row memory: an unbounded groupArray could otherwise
-                    -- materialize up to SEMANTIC_SCAN_LIMIT (30k) tuples per
-                    -- session in the pathological single-session case.
-                    -- matching_trace_count above keeps the true total.
                     arrayMap(
                       pair -> pair.1,
                       arraySlice(

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -1,6 +1,11 @@
 import { AI, AIError, type AIShape } from "@domain/ai"
 import { type ChSqlClient, isNotFoundError, OrganizationId, ProjectId, SessionId } from "@domain/shared"
-import { SessionRepository, type SessionRepositoryShape, TRACE_SEARCH_EMBEDDING_DIMENSIONS } from "@domain/spans"
+import {
+  type SessionListPage,
+  SessionRepository,
+  type SessionRepositoryShape,
+  TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+} from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect, Layer } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
@@ -1077,7 +1082,7 @@ describe("SessionRepository", () => {
 
       // Page through all matching sessions with a small limit.
       const collected: { sessionId: string; matchingTraceCount: number }[] = []
-      let cursor: { sortValue: string; sessionId: string } | undefined
+      let cursor: SessionListPage["nextCursor"]
       for (let i = 0; i < 10; i++) {
         const page = await runCh(
           repo.listByProjectId({
@@ -1162,10 +1167,530 @@ describe("SessionRepository", () => {
     })
 
     // Reference: spec §4.7 — when searchQuery is active the server forces
-    // ORDER BY best_score DESC, session_id DESC regardless of client sortBy.
+    // its own ordering (now the freshness-weighted tuple from
+    // 7-freshness-weighted-sort.md) regardless of client sortBy.
     // The use of buildAlignedAt is currently unused but kept for fixtures
     // that may want to inject specific cosine magnitudes; tagging via void
     // keeps the import noise minimal without producing an unused-warning.
     void buildAlignedAt
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Freshness-weighted ordering (spec 7-freshness-weighted-sort.md).
+    // Inside a relevance bucket, sessions sort by `last_activity_at DESC`,
+    // then `session_id DESC`. Across buckets relevance still dominates.
+    // ════════════════════════════════════════════════════════════════════════
+    describe("freshness-weighted ordering", () => {
+      // Build a vector whose cosine with the all-0.1 mock query embedding is
+      // exactly `(DIMS - 2N) / DIMS` — see test 6 above for the derivation.
+      // Picking the right N gives us a predictable bucket without touching
+      // floating-point boundaries.
+      const flippedVec = (flipped: number): readonly number[] => {
+        const v = new Array(DIMS).fill(0.1) as number[]
+        for (let i = 0; i < flipped; i++) v[i] = -0.1
+        return v as readonly number[]
+      }
+      // Cosine targets chosen to sit comfortably inside their buckets
+      // (avoids ambiguity from `floor(score / 0.1)` near boundaries).
+      const COSINE_087 = flippedVec(133) // ≈ 0.8701 → bucket 0.8
+      const COSINE_085 = flippedVec(154) // ≈ 0.8496 → bucket 0.8
+      const COSINE_081 = flippedVec(195) // ≈ 0.8096 → bucket 0.8
+      const COSINE_055 = flippedVec(461) // ≈ 0.5498 → bucket 0.5
+      const COSINE_065 = flippedVec(359) // ≈ 0.6494 → bucket 0.6
+
+      // §2 worked example: an 18-month-old 0.87 must not beat a fresh 0.85
+      // because they share bucket 0.8. Without the freshness sort, the old
+      // session wins on raw cosine; with it, freshness wins inside the tier.
+      it("within the same bucket, the more recently active session sorts first", async () => {
+        const oldStart = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+        const freshStart = new Date(Date.UTC(2026, 3, 1, 10, 0, 0))
+        const sessionStale = "frb-stale-087"
+        const sessionFresh = "frb-fresh-085"
+        const traceStale = padTrace("frb1")
+        const traceFresh = padTrace("frb2")
+
+        await insertSpans([
+          makeSpanRow({ traceId: traceStale, spanId: padSpan("frb1"), sessionId: sessionStale, startTime: oldStart }),
+          makeSpanRow({
+            traceId: traceFresh,
+            spanId: padSpan("frb2"),
+            sessionId: sessionFresh,
+            startTime: freshStart,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: traceStale, text: "freshmark stale conversation", startTime: oldStart, contentHashSuffix: "f1" },
+          {
+            traceId: traceFresh,
+            text: "freshmark recent conversation",
+            startTime: freshStart,
+            contentHashSuffix: "f2",
+          },
+        ])
+        await insertSearchEmbeddings([
+          { traceId: traceStale, chunkIndex: 0, embedding: COSINE_087, startTime: oldStart, contentHashSuffix: "f1" },
+          {
+            traceId: traceFresh,
+            chunkIndex: 0,
+            embedding: COSINE_085,
+            startTime: freshStart,
+            contentHashSuffix: "f2",
+          },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark" conversation', limit: 10 },
+          }),
+        )
+
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual([sessionFresh, sessionStale])
+        // Raw cosine is unchanged — the stale session still has the higher
+        // best_score, the freshness sort just reorders within the bucket.
+        expect(nonNull(page.searchMatches?.[sessionStale]).bestScore).toBeGreaterThan(
+          nonNull(page.searchMatches?.[sessionFresh]).bestScore,
+        )
+      })
+
+      // The other half of the calibration: a 0.42 from five minutes ago does
+      // NOT beat a 0.85 from this morning, because they sit in different
+      // buckets and relevance dominates across bucket boundaries.
+      it("across bucket boundaries, the higher-relevance bucket wins even if the lower bucket is fresher", async () => {
+        const oldStart = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+        const freshStart = new Date(Date.UTC(2026, 3, 1, 10, 0, 0))
+        const sessionStaleHi = "frx-stale-085"
+        const sessionFreshLo = "frx-fresh-055"
+        const traceStale = padTrace("frx1")
+        const traceFresh = padTrace("frx2")
+
+        await insertSpans([
+          makeSpanRow({
+            traceId: traceStale,
+            spanId: padSpan("frx1"),
+            sessionId: sessionStaleHi,
+            startTime: oldStart,
+          }),
+          makeSpanRow({
+            traceId: traceFresh,
+            spanId: padSpan("frx2"),
+            sessionId: sessionFreshLo,
+            startTime: freshStart,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: traceStale, text: "freshmark stale strong-match", startTime: oldStart, contentHashSuffix: "x1" },
+          { traceId: traceFresh, text: "freshmark recent weak-match", startTime: freshStart, contentHashSuffix: "x2" },
+        ])
+        await insertSearchEmbeddings([
+          { traceId: traceStale, chunkIndex: 0, embedding: COSINE_085, startTime: oldStart, contentHashSuffix: "x1" },
+          {
+            traceId: traceFresh,
+            chunkIndex: 0,
+            embedding: COSINE_055,
+            startTime: freshStart,
+            contentHashSuffix: "x2",
+          },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark" match', limit: 10 },
+          }),
+        )
+
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual([sessionStaleHi, sessionFreshLo])
+      })
+
+      // Lexical-only matches all collapse to bucket 0.0 (best_score = 0); the
+      // freshness sort is the only signal left, so they form a coherent
+      // "latest matches first" page (§6.5).
+      it("lexical-only sessions all share bucket 0.0 and sort by recency among themselves", async () => {
+        const base = new Date(Date.UTC(2026, 0, 10, 10, 0, 0))
+        const sessions = [
+          { id: "lex-newest", offsetSec: 200 },
+          { id: "lex-middle", offsetSec: 100 },
+          { id: "lex-oldest", offsetSec: 0 },
+        ] as const
+        const spans = sessions.map((s, i) =>
+          makeSpanRow({
+            traceId: padTrace(`lex${i}`),
+            spanId: padSpan(`lx${i}`),
+            sessionId: s.id,
+            startTime: new Date(base.getTime() + s.offsetSec * 1_000),
+          }),
+        )
+        await insertSpans(spans)
+        await insertSearchDocs(
+          sessions.map((s, i) => ({
+            traceId: padTrace(`lex${i}`),
+            text: `freshmark lexical-only ${s.id}`,
+            startTime: new Date(base.getTime() + s.offsetSec * 1_000),
+            contentHashSuffix: `lx${i}`,
+          })),
+        )
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark"', limit: 10 },
+          }),
+        )
+
+        // All three lexical-only → best_score = 0.0 → bucket 0.0 → sort by
+        // last_activity_at DESC. Newest fixture first, oldest last.
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual(["lex-newest", "lex-middle", "lex-oldest"])
+        for (const id of ids) {
+          expect(nonNull(page.searchMatches?.[id]).bestScore).toBe(0)
+        }
+      })
+
+      // §6.3: freshness is the SESSION's last activity, not the matching
+      // traces' last activity. A live conversation whose only matching turn
+      // is old must still rank as fresh; a dead conversation whose matching
+      // turns are equally old must rank stale.
+      it("freshness is session-level — a live session with an old matching trace still beats a fully-stale session", async () => {
+        const ancientMatch = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+        // The "live" session has a recent NON-matching span (so its
+        // sessions.max_end_time advances) but the only span that matches the
+        // search phrase is from January.
+        const liveActivity = new Date(Date.UTC(2026, 4, 1, 10, 0, 0))
+        const sessionLive = "frlive"
+        const sessionDead = "frdead"
+        const traceLiveMatch = padTrace("flm")
+        const traceLiveRecent = padTrace("flr")
+        const traceDead = padTrace("fld")
+
+        await insertSpans([
+          // Live session: one old matching trace + one recent non-matching
+          // trace. sessions.max_end_time = liveActivity + 1s.
+          makeSpanRow({
+            traceId: traceLiveMatch,
+            spanId: padSpan("flm"),
+            sessionId: sessionLive,
+            startTime: ancientMatch,
+          }),
+          makeSpanRow({
+            traceId: traceLiveRecent,
+            spanId: padSpan("flr"),
+            sessionId: sessionLive,
+            startTime: liveActivity,
+          }),
+          // Dead session: one old matching trace, nothing else.
+          // sessions.max_end_time = ancientMatch + 1s.
+          makeSpanRow({
+            traceId: traceDead,
+            spanId: padSpan("fld"),
+            sessionId: sessionDead,
+            startTime: ancientMatch,
+          }),
+        ])
+        // Only the two "match" traces carry the search phrase; the recent
+        // span on the live session is in the same session but invisible to
+        // the search candidate set.
+        await insertSearchDocs([
+          {
+            traceId: traceLiveMatch,
+            text: "freshmark old-matching-turn",
+            startTime: ancientMatch,
+            contentHashSuffix: "fl1",
+          },
+          {
+            traceId: traceDead,
+            text: "freshmark dead-session-match",
+            startTime: ancientMatch,
+            contentHashSuffix: "fl2",
+          },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark"', limit: 10 },
+          }),
+        )
+
+        // Both lexical-only → same bucket. The live session's
+        // last_activity_at is `liveActivity` (from the non-matching span),
+        // not `ancientMatch` — so it sorts ahead of the dead session.
+        // If the implementation used `max(trace_rollup.end_time)` instead
+        // (the matching-trace-only option in §5.1), both would tie at
+        // `ancientMatch` and this assertion would fail.
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual([sessionLive, sessionDead])
+      })
+
+      // The clock-skew clamp prevents future-dated spans from pinning
+      // themselves to the top forever. Two far-future sessions (with
+      // different future offsets) must NOT be distinguishable by their
+      // relative future-ness — both clamp to `now() +
+      // SESSION_SEARCH_MAX_CLOCK_SKEW_MS` and tie on last_activity_at,
+      // breaking on session_id DESC.
+      it("future-dated spans clamp to now+1h, so two skewed sessions tie on last_activity_at", async () => {
+        const sessionLater = "skew-z" // later session_id (alphabetically) — wins DESC tiebreak
+        const sessionEarlier = "skew-a"
+        const traceLater = padTrace("skl")
+        const traceEarlier = padTrace("ske")
+        // Both well past the 1h clamp window. DateTime64(9) tops out
+        // around 2262-04-11, so we stay below that with room to spare.
+        const farFuture = new Date(Date.UTC(2200, 0, 1, 10, 0, 0))
+        const nearerFuture = new Date(Date.UTC(2100, 0, 1, 10, 0, 0))
+
+        await insertSpans([
+          // The EARLIER session_id carries the FURTHER-future timestamp.
+          // Without the clamp, the far-future session would beat the
+          // nearer-future one on raw end_time, so the earlier session_id
+          // would win — the opposite of what we expect.
+          makeSpanRow({
+            traceId: traceEarlier,
+            spanId: padSpan("ske"),
+            sessionId: sessionEarlier,
+            startTime: farFuture,
+          }),
+          makeSpanRow({
+            traceId: traceLater,
+            spanId: padSpan("skl"),
+            sessionId: sessionLater,
+            startTime: nearerFuture,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: traceEarlier, text: "freshmark future-clamp a", startTime: farFuture, contentHashSuffix: "sk1" },
+          { traceId: traceLater, text: "freshmark future-clamp b", startTime: nearerFuture, contentHashSuffix: "sk2" },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark"', limit: 10 },
+          }),
+        )
+
+        // Both clamp to now()+1h, tied on last_activity_at.
+        // session_id DESC means "skew-z" beats "skew-a" — proves the clamp
+        // collapsed the two future timestamps into a tie.
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual([sessionLater, sessionEarlier])
+      })
+
+      // Future-dated bottom-bucket sessions must NOT leapfrog a present-day
+      // top-bucket session: bucket ordering takes precedence over freshness
+      // even when the freshness column has been pinned to its clamp.
+      it("a future-clamped lexical session does not promote across bucket boundaries", async () => {
+        const future = new Date(Date.UTC(2200, 0, 1, 10, 0, 0))
+        const past = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))
+        const sessionHighBucketStale = "clamp-hi"
+        const sessionLexFuture = "clamp-lo-future"
+        const traceHigh = padTrace("clh")
+        const traceFuture = padTrace("clf")
+
+        await insertSpans([
+          makeSpanRow({
+            traceId: traceHigh,
+            spanId: padSpan("clh"),
+            sessionId: sessionHighBucketStale,
+            startTime: past,
+          }),
+          makeSpanRow({
+            traceId: traceFuture,
+            spanId: padSpan("clf"),
+            sessionId: sessionLexFuture,
+            startTime: future,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: traceHigh, text: "freshmark strong-match relevance", startTime: past, contentHashSuffix: "cl1" },
+          { traceId: traceFuture, text: "freshmark future-clamp weak", startTime: future, contentHashSuffix: "cl2" },
+        ])
+        // Only the stale session is semantically strong (bucket 0.8). The
+        // future-dated one is lexical-only (bucket 0.0).
+        await insertSearchEmbeddings([
+          { traceId: traceHigh, chunkIndex: 0, embedding: COSINE_081, startTime: past, contentHashSuffix: "cl1" },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark" match', limit: 10 },
+          }),
+        )
+
+        const ids = page.items.map((s) => s.sessionId)
+        expect(ids).toEqual([sessionHighBucketStale, sessionLexFuture])
+      })
+
+      // The wire cursor is the three-field freshness tuple, not the legacy
+      // (sortValue, sessionId) shape — and the values must round-trip into
+      // the HAVING predicate on the next page without losing rows.
+      it("nextCursor exposes the freshness-weighted (relevanceBucket, lastActivityAt, sessionId) tuple", async () => {
+        const start = new Date(Date.UTC(2026, 1, 1, 10, 0, 0))
+        const sessions = ["cur-a", "cur-b", "cur-c"] as const
+        await insertSpans(
+          sessions.map((s, i) =>
+            makeSpanRow({
+              traceId: padTrace(`cur${i}`),
+              spanId: padSpan(`cu${i}`),
+              sessionId: s,
+              startTime: new Date(start.getTime() + i * 1_000),
+            }),
+          ),
+        )
+        await insertSearchDocs(
+          sessions.map((s, i) => ({
+            traceId: padTrace(`cur${i}`),
+            text: `freshmark cursor-shape ${s}`,
+            startTime: new Date(start.getTime() + i * 1_000),
+            contentHashSuffix: `cu${i}`,
+          })),
+        )
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark"', limit: 2 },
+          }),
+        )
+
+        const cursor = nonNull(page.nextCursor)
+        expect("relevanceBucket" in cursor).toBe(true)
+        expect("lastActivityAt" in cursor).toBe(true)
+        expect("sessionId" in cursor).toBe(true)
+        expect("sortValue" in cursor).toBe(false)
+        if (!("relevanceBucket" in cursor)) throw new Error("unreachable")
+        // All lexical-only → bucket 0.0. Cursor encodes the snapped bucket
+        // exactly so the HAVING predicate round-trips deterministically.
+        expect(cursor.relevanceBucket).toBe(0)
+        // ISO-8601 — CH `DateTime64(9, 'UTC')` JSON-serializes that way.
+        expect(typeof cursor.lastActivityAt).toBe("string")
+        expect(cursor.lastActivityAt.length).toBeGreaterThan(0)
+      })
+
+      // The full pagination contract under the new sort tuple: a mixed-bucket
+      // set walks (bucket DESC, last_activity_at DESC, session_id DESC) with
+      // no duplicates, no skips, and the final page reports hasMore = false.
+      it("pagination across mixed buckets walks the full sort tuple without duplicates", async () => {
+        const t = new Date(Date.UTC(2026, 1, 5, 10, 0, 0))
+        // Six sessions: 2 in bucket 0.8, 2 in bucket 0.6, 2 in bucket 0.0
+        // (lexical-only). Within each bucket the *-fresh suffix is newer.
+        const fixtures = [
+          { id: "pg-08-fresh", offset: 6_000, embed: COSINE_085 },
+          { id: "pg-08-stale", offset: 0, embed: COSINE_087 },
+          { id: "pg-06-fresh", offset: 7_000, embed: COSINE_065 },
+          { id: "pg-06-stale", offset: 1_000, embed: COSINE_065 },
+          { id: "pg-00-fresh", offset: 8_000, embed: undefined },
+          { id: "pg-00-stale", offset: 2_000, embed: undefined },
+        ] as const
+        await insertSpans(
+          fixtures.map((f, i) =>
+            makeSpanRow({
+              traceId: padTrace(`pg${i}`),
+              spanId: padSpan(`pg${i}`),
+              sessionId: f.id,
+              startTime: new Date(t.getTime() + f.offset),
+            }),
+          ),
+        )
+        await insertSearchDocs(
+          fixtures.map((f, i) => ({
+            traceId: padTrace(`pg${i}`),
+            text: `freshmark pagination ${f.id}`,
+            startTime: new Date(t.getTime() + f.offset),
+            contentHashSuffix: `pg${i}`,
+          })),
+        )
+        await insertSearchEmbeddings(
+          fixtures
+            .map((f, i) =>
+              f.embed
+                ? {
+                    traceId: padTrace(`pg${i}`),
+                    chunkIndex: 0,
+                    embedding: f.embed,
+                    startTime: new Date(t.getTime() + f.offset),
+                    contentHashSuffix: `pg${i}`,
+                  }
+                : null,
+            )
+            .filter((e): e is NonNullable<typeof e> => e !== null),
+        )
+
+        const expected = ["pg-08-fresh", "pg-08-stale", "pg-06-fresh", "pg-06-stale", "pg-00-fresh", "pg-00-stale"]
+
+        // The semantic-prompt half of the query (`relevance`) is what lifts
+        // `relevance_score` above 0 for the embedded fixtures — phrase-only
+        // mode collapses every match to `relevance_score = 0` (see
+        // `search-plan.ts`'s phrase-only branch), so the buckets only
+        // separate when a semantic prompt is present.
+        const collected: string[] = []
+        let cursor: SessionListPage["nextCursor"]
+        for (let i = 0; i < 5; i++) {
+          const page = await runCh(
+            repo.listByProjectId({
+              organizationId: ORG_ID,
+              projectId: PROJECT_ID,
+              options: { searchQuery: '"freshmark" relevance', limit: 2, ...(cursor ? { cursor } : {}) },
+            }),
+          )
+          for (const item of page.items) collected.push(item.sessionId)
+          if (!page.hasMore || !page.nextCursor) break
+          cursor = page.nextCursor
+        }
+
+        expect(collected).toEqual(expected)
+        expect(new Set(collected).size).toBe(collected.length)
+      })
+
+      // Orphan traces (no row in `sessions`) take the LEFT JOIN's NULL
+      // branch and fall back to `max(trace_rollup.end_time)`; multiple
+      // orphans must still order by recency among themselves.
+      it("orphan traces fall back to trace-level end_time for freshness ordering", async () => {
+        const base = new Date(Date.UTC(2026, 2, 1, 10, 0, 0))
+        const orphanOld = padTrace("oro")
+        const orphanNew = padTrace("orn")
+        // No sessionId on either span → both become orphan sessions keyed
+        // by `toString(trace_id)`. The sessions table has nothing for them.
+        await insertSpans([
+          makeSpanRow({ traceId: orphanOld, spanId: padSpan("oro"), startTime: base }),
+          makeSpanRow({
+            traceId: orphanNew,
+            spanId: padSpan("orn"),
+            startTime: new Date(base.getTime() + 60_000),
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: orphanOld, text: "freshmark orphan stale", startTime: base, contentHashSuffix: "or1" },
+          {
+            traceId: orphanNew,
+            text: "freshmark orphan recent",
+            startTime: new Date(base.getTime() + 60_000),
+            contentHashSuffix: "or2",
+          },
+        ])
+
+        const page = await runCh(
+          repo.listByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            options: { searchQuery: '"freshmark"', limit: 10 },
+          }),
+        )
+
+        const ids = page.items.map((s) => s.sessionId)
+        // Both lexical-only → bucket 0.0. Without the coalesce fallback,
+        // both would tie at NULL last_activity_at and the ordering would
+        // collapse to session_id DESC — the newer orphan must come first.
+        expect(ids).toEqual([orphanNew, orphanOld])
+      })
+    })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -356,8 +356,15 @@ export const SessionRepositoryLive = Layer.effect(
 
         const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(options.filters)
 
+        // Search-mode cursors (carrying `relevanceBucket` / `lastActivityAt`)
+        // don't match this query's ORDER BY tuple; drop them and restart
+        // pagination from the top. Same posture as the search path's reverse
+        // case in `listSessionsBySearchQuery`.
+        const listCursor =
+          options.cursor && "sortValue" in options.cursor && "sessionId" in options.cursor ? options.cursor : undefined
+
         const havingParts: string[] = [...havingClauses]
-        if (options.cursor) {
+        if (listCursor) {
           havingParts.push(
             `(${sort.expr} ${cmp} {cursorSortValue:${sort.chType}}
                 OR (${sort.expr} = {cursorSortValue:${sort.chType}}
@@ -384,10 +391,10 @@ export const SessionRepositoryLive = Layer.effect(
                 projectId: projectId as string,
                 limit: limit + 1,
                 ...filterParams,
-                ...(options.cursor
+                ...(listCursor
                   ? {
-                      cursorSortValue: options.cursor.sortValue,
-                      cursorSessionId: options.cursor.sessionId,
+                      cursorSortValue: listCursor.sortValue,
+                      cursorSessionId: listCursor.sessionId,
                     }
                   : {}),
               },

--- a/packages/platform/db-clickhouse/src/seeds/spans/freshness-sort-demo.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/freshness-sort-demo.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto"
+import type { SeedScope } from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { insertJsonEachRow } from "../../sql.ts"
+import { isSentinelPresent } from "../idempotency.ts"
+import type { Seeder } from "../types.ts"
+import type { SpanRow } from "./span-builders.ts"
+
+/**
+ * Manual-test seed for the freshness-weighted session sort
+ * (`specs/session-problems/7-freshness-weighted-sort.md`).
+ *
+ * Drops eight sessions into the bootstrap project, each containing the
+ * unique phrase `freshmark` so a phrase-only query at
+ * `/sessions?searchQuery="freshmark"` matches all of them. Half the
+ * sessions are dated 30-75 days ago (the "stale" cohort), half are
+ * within the last few days (the "fresh" cohort). Because phrase-only
+ * matches all collapse to `best_score = 0.0`, every result lands in
+ * `relevance_bucket = 0.0` and the freshness sort is the only signal —
+ * the fresh cohort must appear first under the new ordering, where
+ * previously the secondary sort was the meaningless `session_id DESC`.
+ */
+
+const formatClickhouseTimestamp = (date: Date): string => date.toISOString().replace("T", " ").replace("Z", "000")
+
+interface FixtureSpec {
+  readonly key: "fresh" | "stale"
+  readonly indexInCohort: number
+  readonly daysAgo: number
+  readonly sessionLabel: string
+  readonly userPrompt: string
+  readonly assistantResponse: string
+}
+
+/**
+ * Eight conversations all carrying the `freshmark` phrase. The cohort
+ * label is part of the session id so the user can read the ordering at
+ * a glance ("fresh-1 above stale-1 is correct"). Day offsets cover both
+ * sides of any plausible "live vs. idle" threshold.
+ */
+const FIXTURES: readonly FixtureSpec[] = [
+  {
+    key: "fresh",
+    indexInCohort: 0,
+    daysAgo: 0,
+    sessionLabel: "freshmark-fresh-today",
+    userPrompt: "Hey, I just hit the freshmark dashboard and the throughput chart looks flat. Is the agent stuck?",
+    assistantResponse:
+      "Let me check the freshmark agent health metrics for today and confirm whether the throughput dip is real or a render artifact.",
+  },
+  {
+    key: "fresh",
+    indexInCohort: 1,
+    daysAgo: 1,
+    sessionLabel: "freshmark-fresh-yesterday",
+    userPrompt: "Following up on yesterday's freshmark throughput issue — did the new worker pool roll out?",
+    assistantResponse:
+      "Yes, the freshmark worker pool was redeployed at 03:14 UTC and the throughput chart has been steady since.",
+  },
+  {
+    key: "fresh",
+    indexInCohort: 2,
+    daysAgo: 2,
+    sessionLabel: "freshmark-fresh-two-days",
+    userPrompt: "Why did the freshmark queue depth spike right after the deploy?",
+    assistantResponse:
+      "The deploy bounced the freshmark consumer; in-flight messages were redelivered, which produced the brief queue-depth spike before drain.",
+  },
+  {
+    key: "fresh",
+    indexInCohort: 3,
+    daysAgo: 3,
+    sessionLabel: "freshmark-fresh-three-days",
+    userPrompt: "Customer is asking about freshmark turnaround time for premium accounts. What should I tell them?",
+    assistantResponse:
+      "Freshmark premium SLA is currently a 4-hour p95 turnaround. I have the latest dashboard snapshot if you want to share it.",
+  },
+  {
+    key: "stale",
+    indexInCohort: 0,
+    daysAgo: 30,
+    sessionLabel: "freshmark-stale-30d",
+    userPrompt: "Old ticket re-opened: freshmark indexing failed for org 14228. Any updates?",
+    assistantResponse:
+      "Looking at the freshmark indexing logs for org 14228 from a month ago — the failure was traced to a transient embedding-service timeout.",
+  },
+  {
+    key: "stale",
+    indexInCohort: 1,
+    daysAgo: 45,
+    sessionLabel: "freshmark-stale-45d",
+    userPrompt: "Quarter-end audit: can you pull the freshmark cost breakdown for last sprint?",
+    assistantResponse:
+      "Pulling the freshmark cost breakdown for the audit window: compute, embedding, and storage line items attached in the next message.",
+  },
+  {
+    key: "stale",
+    indexInCohort: 2,
+    daysAgo: 60,
+    sessionLabel: "freshmark-stale-60d",
+    userPrompt: "Doing a postmortem on the freshmark outage from two months ago. Where are the traces?",
+    assistantResponse:
+      "Freshmark outage traces from that window are preserved under the incident-2025-q4 tag — I can link them inline if useful.",
+  },
+  {
+    key: "stale",
+    indexInCohort: 3,
+    daysAgo: 75,
+    sessionLabel: "freshmark-stale-75d",
+    userPrompt: "Historical question: when did we first ship the freshmark scoring pipeline?",
+    assistantResponse:
+      "The freshmark scoring pipeline first shipped in March; the original launch retro is in the eng-archive workspace.",
+  },
+] as const
+
+const contentHashFor = (...parts: readonly string[]): string =>
+  createHash("sha256").update(parts.join("\x00")).digest("hex")
+
+const FIXTURE_KEY = "freshmark-sort-demo"
+
+const buildFixtureSpan = (scope: SeedScope, spec: FixtureSpec): SpanRow => {
+  const cohortIndex = spec.key === "fresh" ? spec.indexInCohort : spec.indexInCohort + 100
+  const traceId = scope.traceHex(FIXTURE_KEY, cohortIndex)
+  const spanId = scope.spanHex(FIXTURE_KEY, cohortIndex)
+  // Anchor mid-morning UTC so business-hours filters don't suppress the
+  // fixtures and the spread of `daysAgo` values is the only differentiator.
+  const start = scope.dateDaysAgo(spec.daysAgo, 10, spec.indexInCohort)
+  const durationMs = 1_400
+  const end = new Date(start.getTime() + durationMs)
+  const inputMessages = [{ role: "user", parts: [{ type: "text", content: spec.userPrompt }] }]
+  const outputMessages = [{ role: "assistant", parts: [{ type: "text", content: spec.assistantResponse }] }]
+  const inputTokens = Math.max(12, Math.ceil(spec.userPrompt.length / 4))
+  const outputTokens = Math.max(12, Math.ceil(spec.assistantResponse.length / 4))
+
+  return {
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    session_id: spec.sessionLabel,
+    user_id: "",
+    trace_id: traceId,
+    span_id: spanId,
+    parent_span_id: "",
+    api_key_id: scope.apiKeyId,
+    simulation_id: "",
+    start_time: formatClickhouseTimestamp(start),
+    end_time: formatClickhouseTimestamp(end),
+    name: "chat gpt-4.1",
+    service_name: "freshmark-support-agent",
+    kind: 1,
+    status_code: 1,
+    status_message: "",
+    error_type: "",
+    tags: ["freshmark", "demo", spec.key],
+    metadata: { seed: FIXTURE_KEY, cohort: spec.key },
+    operation: "chat",
+    provider: "openai",
+    model: "gpt-4.1",
+    response_model: "gpt-4.1-2025-04-14",
+    tokens_input: inputTokens,
+    tokens_output: outputTokens,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: inputTokens * 25,
+    cost_output_microcents: outputTokens * 100,
+    cost_total_microcents: inputTokens * 25 + outputTokens * 100,
+    cost_is_estimated: 1,
+    time_to_first_token_ns: 180_000_000,
+    is_streaming: 1,
+    response_id: `seed-${spanId}`,
+    finish_reasons: ["stop"],
+    input_messages: JSON.stringify(inputMessages),
+    output_messages: JSON.stringify(outputMessages),
+    system_instructions: JSON.stringify([
+      { type: "text", content: "You are a Latitude support agent helping debug freshmark pipeline issues." },
+    ]),
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: {},
+    attr_int: {},
+    attr_float: { "gen_ai.request.temperature": 0 },
+    attr_bool: {},
+    resource_string: { "service.name": "freshmark-support-agent" },
+    scope_name: "openai-instrumentation",
+    scope_version: "1.0.0",
+  }
+}
+
+/**
+ * Lexical-search row mirroring what the `trace-search` worker would
+ * normally upsert from this span's canonical conversation text. Seeding
+ * it directly lets the demo work without waiting for the worker queue.
+ * `search_text` is just user + assistant text joined — that's the shape
+ * `buildTraceSearchDocument` produces in production (no system prompt).
+ */
+const buildSearchDocumentRow = (scope: SeedScope, spec: FixtureSpec, span: SpanRow) => {
+  const searchText = `${spec.userPrompt}\n${spec.assistantResponse}`
+  const contentHash = contentHashFor(span.trace_id, searchText)
+  return {
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    trace_id: span.trace_id,
+    start_time: span.start_time,
+    root_span_name: span.name,
+    search_text: searchText,
+    content_hash: contentHash,
+    indexed_at: formatClickhouseTimestamp(new Date()),
+  }
+}
+
+export const freshnessSortDemoSeeder: Seeder = {
+  name: "spans/freshness-sort-demo",
+  run: (ctx) =>
+    Effect.gen(function* () {
+      // Sentinel: the first deterministic trace_id in this fixture set.
+      const sentinel = ctx.scope.traceHex(FIXTURE_KEY, 0)
+      const present = yield* isSentinelPresent(ctx.client, "spans", "trace_id = {sentinel:String}", { sentinel })
+      if (present) {
+        if (!ctx.quiet) console.log("  -> spans/freshness-sort-demo: already seeded, skipping")
+        return
+      }
+
+      const spans: SpanRow[] = FIXTURES.map((spec) => buildFixtureSpan(ctx.scope, spec))
+      const docs = FIXTURES.map((spec, i) => buildSearchDocumentRow(ctx.scope, spec, spans[i] as SpanRow))
+
+      yield* insertJsonEachRow(ctx.client, "spans", spans)
+      yield* insertJsonEachRow(ctx.client, "trace_search_documents", docs)
+
+      if (!ctx.quiet) {
+        console.log(
+          `  -> spans/freshness-sort-demo: ${spans.length} sessions seeded (search "freshmark" to verify the freshness sort)`,
+        )
+      }
+    }),
+}

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
 import type { SeedContext, Seeder } from "../types.ts"
 import { fixedTraceSeeders } from "./fixed-traces.ts"
+import { freshnessSortDemoSeeder } from "./freshness-sort-demo.ts"
 import { generateAllSpans, type SpanRow, type TraceConfig } from "./generator.ts"
 
 const TRACE_COUNT = 2000
@@ -49,4 +50,4 @@ export const runSpansSeed = (
     return traceIds
   })
 
-export const spanSeeders: Seeder[] = [...fixedTraceSeeders]
+export const spanSeeders: Seeder[] = [...fixedTraceSeeders, freshnessSortDemoSeeder]


### PR DESCRIPTION
## Summary

When you search sessions, results are now sorted by **relevance bucket → recency → session_id** instead of pure relevance. Within a 0.1-wide score bucket, recently-active sessions float above equally-relevant stale ones; relevance still dominates across bucket boundaries.

This fixes the "ageing project" pathology described in [`specs/session-problems/7-freshness-weighted-sort.md`](specs/session-problems/7-freshness-weighted-sort.md): a long-lived project accumulates high-scoring historical matches that crowd out fresh, live conversations on every query.

Concrete example: a search for `"refund"` against a project with
- a 0.87-relevance support thread from 18 months ago, and
- a 0.85-relevance customer conversation from this morning

now puts the live conversation first (both share bucket 0.8; freshness wins). Before, the 18-month-old artifact won.

## What changes

- New outer `SELECT` columns in the search query:
  - `relevance_bucket = floor(max(relevance_score) / bucketWidth) * bucketWidth`
  - `last_activity_at = least(coalesce(any(sf.sess_max_end_time), max(end_time)), now() + clockSkewMs)`
- New `session_freshness` CTE pre-aggregates `sessions.max_end_time` per matched session and joins via `LEFT JOIN ... USING (session_id)`. Orphan traces fall back to `max(trace_rollup.end_time)`.
- `ORDER BY` becomes `(relevance_bucket, last_activity_at, session_id) DESC`.
- `HAVING` cursor predicate matches the new tuple.
- New cursor shape `SessionSearchCursor { relevanceBucket, lastActivityAt, sessionId }`; `SessionListPage.nextCursor` widened to `SessionListCursor | SessionSearchCursor`.
- Wire validator (`sessions.functions.ts`) accepts either shape via a Zod union; React Query `initialPageParam` widened.
- Stale cursors of the wrong shape are silently dropped — pagination restarts from the top instead of producing a broken keyset comparison.

## Why session-level `max_end_time`, not matching-trace `end_time`

A live conversation whose only matching turn is from six months ago should still rank as fresh — the session is alive, the query just happened to hit an old quote. Using `sessions.max_end_time` captures that; using `max(trace_rollup.end_time)` would penalize it. Test #4 in the new suite exercises this exact scenario.

## Knobs

Two new constants in `@domain/spans/constants.ts`:
- `SESSION_SEARCH_RELEVANCE_BUCKET_WIDTH = 0.1` — wider favors freshness, narrower favors relevance
- `SESSION_SEARCH_MAX_CLOCK_SKEW_MS = 60 * 60 * 1000` — clamps future-dated spans (bad client clocks) to `now() + 1h`