### PR TITLE
Add Bedrock GPT OSS fallback and bound flagger prompts

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger-annotator.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger-annotator.test.ts
@@ -226,6 +226,63 @@ describe("runFlaggerAnnotatorUseCase", () => {
     expect(generateCall.prompt).not.toContain("redacted")
   })
 
+  it("bounds oversized transcript text while preserving message edges and compact tool signals", async () => {
+    const longUserText = `${"start ".repeat(200)}${"middle ".repeat(60_000)}${"end ".repeat(200)}`
+
+    const { repository: traceRepo } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: longUserText }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: longUserText }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "tool_call", id: "call-search", name: "search_docs", arguments: { q: "needle" } }],
+            },
+            {
+              role: "tool",
+              parts: [{ type: "tool_call_response", id: "call-search", response: { ok: false } }],
+            },
+          ]),
+        ),
+    })
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>() =>
+        Effect.succeed({
+          object: { feedback: "oversized prompt was bounded" } as T,
+          tokens: 80,
+          duration: 150_000_000,
+        }),
+    })
+
+    await Effect.runPromise(
+      runFlaggerAnnotatorUseCase(INPUT).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, traceRepo),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            aiLayer,
+          ),
+        ),
+      ),
+    )
+
+    const generateCall = calls.generate[0]
+    expect(generateCall.prompt.length).toBeLessThan(25_000)
+    expect(generateCall.prompt).toContain("[m0 user]: start start")
+    expect(generateCall.prompt).toContain("end end")
+    expect(generateCall.prompt).toContain("chars from this message omitted")
+    expect(generateCall.prompt).toContain("[m2 toolcall]: search_docs")
+    expect(generateCall.prompt).toContain("[m3 toolresult]: error")
+  })
+
   it("handles empty conversation gracefully", async () => {
     const expectedFeedback = "No conversation content to analyze."
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger-annotator.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger-annotator.ts
@@ -76,6 +76,8 @@ Respond with structured data containing a "feedback" field with your annotation 
 
 const SYSTEM_PROMPT_PREVIEW_MAX_LINES = 4
 const SYSTEM_PROMPT_PREVIEW_MAX_CHARS = 600
+const ANNOTATOR_TEXT_PART_MAX_CHARS = 8_000
+const ANNOTATOR_TRANSCRIPT_MAX_CHARS = 120_000
 const TOOL_RESULT_ERROR_TEXT = /(^error\b|error:\s*|\bfailed\b|\bfailure\b|\bexception\b|\btimeout\b|\bunavailable\b)/i
 const TOOL_RESULT_ERROR_STATUSES = new Set(["error", "failed", "failure"])
 
@@ -100,6 +102,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function toNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() !== "" ? value.trim() : null
+}
+
+function truncateMiddle(text: string, maxChars: number, label: string): string {
+  if (text.length <= maxChars) return text
+
+  const omitted = text.length - maxChars
+  const marker = `\n[... ${omitted} ${label} omitted ...]\n`
+  const available = Math.max(0, maxChars - marker.length)
+  const headLength = Math.ceil(available / 2)
+  const tailLength = available - headLength
+
+  return `${text.slice(0, headLength).trimEnd()}${marker}${text.slice(text.length - tailLength).trimStart()}`
 }
 
 function cropSystemPromptPreview(text: string): string {
@@ -197,7 +211,7 @@ const formatConversationForAnnotator = (messages: readonly { role: string; parts
       if (part.type === "text") {
         const content = toNonEmptyString(part.content)
         if (content && (message.role === "user" || message.role === "assistant")) {
-          textParts.push(content)
+          textParts.push(truncateMiddle(content, ANNOTATOR_TEXT_PART_MAX_CHARS, "chars from this message"))
         }
         continue
       }
@@ -222,7 +236,9 @@ const formatConversationForAnnotator = (messages: readonly { role: string; parts
     flushText()
   }
 
-  return lines.length > 0 ? lines.join("\n") : "<no conversation messages available>"
+  if (lines.length === 0) return "<no conversation messages available>"
+
+  return truncateMiddle(lines.join("\n"), ANNOTATOR_TRANSCRIPT_MAX_CHARS, "chars from the middle of the transcript")
 }
 
 const loadTraceDetail = (input: RunFlaggerAnnotatorInput) =>

--- a/packages/platform/ai-vercel/src/ai.test.ts
+++ b/packages/platform/ai-vercel/src/ai.test.ts
@@ -1,8 +1,14 @@
-import { AICredentialError } from "@domain/ai"
+import { AICredentialError, AIGenerate } from "@domain/ai"
 import { Effect, Result } from "effect"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { bedrockModelFactoryMock, createAmazonBedrockMock, fromNodeProviderChainMock } = vi.hoisted(() => {
+const {
+  bedrockModelFactoryMock,
+  createAmazonBedrockMock,
+  fromNodeProviderChainMock,
+  generateTextMock,
+  outputObjectMock,
+} = vi.hoisted(() => {
   const bedrockModelFactoryMock = vi.fn((modelId: string) => ({ modelId }))
 
   return {
@@ -14,6 +20,8 @@ const { bedrockModelFactoryMock, createAmazonBedrockMock, fromNodeProviderChainM
         secretAccessKey: "provider-chain-secret-key",
       }),
     ),
+    generateTextMock: vi.fn(),
+    outputObjectMock: vi.fn((value: unknown) => value),
   }
 })
 
@@ -25,7 +33,14 @@ vi.mock("@aws-sdk/credential-providers", () => ({
   fromNodeProviderChain: fromNodeProviderChainMock,
 }))
 
-import { createProviderModel } from "./ai.ts"
+vi.mock("ai", () => ({
+  generateText: generateTextMock,
+  Output: {
+    object: outputObjectMock,
+  },
+}))
+
+import { AIGenerateLive, createProviderModel } from "./ai.ts"
 
 const originalAwsRegion = process.env.LAT_AWS_REGION
 const originalAwsAccessKeyId = process.env.LAT_AWS_ACCESS_KEY_ID
@@ -42,6 +57,8 @@ beforeEach(() => {
   bedrockModelFactoryMock.mockClear()
   createAmazonBedrockMock.mockClear()
   fromNodeProviderChainMock.mockClear()
+  generateTextMock.mockReset()
+  outputObjectMock.mockClear()
 })
 
 afterEach(() => {
@@ -119,5 +136,41 @@ describe("createProviderModel", () => {
     await Effect.runPromise(createProviderModel("amazon-bedrock", "us.minimax.minimax-m2.5"))
 
     expect(bedrockModelFactoryMock).toHaveBeenCalledWith("minimax.minimax-m2.5")
+  })
+})
+
+describe("AIGenerateLive", () => {
+  it("falls back from MiniMax M2.5 to Claude Haiku 4.5", async () => {
+    generateTextMock
+      .mockRejectedValueOnce(new Error("Bedrock is unable to process your request."))
+      .mockResolvedValueOnce({
+        output: { ok: true },
+        usage: {
+          totalTokens: 3,
+          inputTokens: 2,
+          outputTokens: 1,
+        },
+      })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ai = yield* AIGenerate
+
+        return yield* ai.generate({
+          provider: "amazon-bedrock",
+          model: "minimax.minimax-m2.5",
+          system: "Return JSON.",
+          prompt: "Say ok.",
+          schema: { parse: (value: unknown) => value } as never,
+        })
+      }).pipe(Effect.provide(AIGenerateLive)),
+    )
+
+    expect(result.object).toEqual({ ok: true })
+    expect(generateTextMock).toHaveBeenCalledTimes(2)
+    expect(generateTextMock.mock.calls[0]?.[0].model).toEqual({ modelId: "minimax.minimax-m2.5" })
+    expect(generateTextMock.mock.calls[1]?.[0].model).toEqual({
+      modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    })
   })
 })

--- a/packages/platform/ai-vercel/src/ai.test.ts
+++ b/packages/platform/ai-vercel/src/ai.test.ts
@@ -137,10 +137,26 @@ describe("createProviderModel", () => {
 
     expect(bedrockModelFactoryMock).toHaveBeenCalledWith("minimax.minimax-m2.5")
   })
+
+  it("passes GPT OSS 120B through as an on-demand foundation model", async () => {
+    process.env.LAT_AWS_REGION = "eu-central-1"
+
+    await Effect.runPromise(createProviderModel("amazon-bedrock", "openai.gpt-oss-120b-1:0"))
+
+    expect(bedrockModelFactoryMock).toHaveBeenCalledWith("openai.gpt-oss-120b-1:0")
+  })
+
+  it("strips a bogus geography prefix from GPT OSS 120B", async () => {
+    process.env.LAT_AWS_REGION = "eu-central-1"
+
+    await Effect.runPromise(createProviderModel("amazon-bedrock", "eu.openai.gpt-oss-120b-1:0"))
+
+    expect(bedrockModelFactoryMock).toHaveBeenCalledWith("openai.gpt-oss-120b-1:0")
+  })
 })
 
 describe("AIGenerateLive", () => {
-  it("falls back from MiniMax M2.5 to Claude Haiku 4.5", async () => {
+  it("falls back from MiniMax M2.5 to GPT OSS 120B", async () => {
     generateTextMock
       .mockRejectedValueOnce(new Error("Bedrock is unable to process your request."))
       .mockResolvedValueOnce({
@@ -169,8 +185,6 @@ describe("AIGenerateLive", () => {
     expect(result.object).toEqual({ ok: true })
     expect(generateTextMock).toHaveBeenCalledTimes(2)
     expect(generateTextMock.mock.calls[0]?.[0].model).toEqual({ modelId: "minimax.minimax-m2.5" })
-    expect(generateTextMock.mock.calls[1]?.[0].model).toEqual({
-      modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    })
+    expect(generateTextMock.mock.calls[1]?.[0].model).toEqual({ modelId: "openai.gpt-oss-120b-1:0" })
   })
 })

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -26,7 +26,7 @@ const MAX_ERROR_TEXT_LENGTH = 4_000
 const BEDROCK_MINIMAX_M25_MODEL_ID = "minimax.minimax-m2.5"
 const BEDROCK_MINIMAX_M25_FALLBACK_MODEL = {
   provider: "amazon-bedrock",
-  model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+  model: "openai.gpt-oss-120b-1:0",
 } as const
 const bedrockScopedModelIdPattern = /^(?:(?:eu|us|apac)\.)?([a-z0-9-]+\..+)$/
 

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -23,6 +23,11 @@ type BedrockGeographyPrefix = "eu" | "us" | "apac"
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 8192
 const MAX_ERROR_TEXT_LENGTH = 4_000
+const BEDROCK_MINIMAX_M25_MODEL_ID = "minimax.minimax-m2.5"
+const BEDROCK_MINIMAX_M25_FALLBACK_MODEL = {
+  provider: "amazon-bedrock",
+  model: "anthropic.claude-haiku-4-5-20251001-v1:0",
+} as const
 const bedrockScopedModelIdPattern = /^(?:(?:eu|us|apac)\.)?([a-z0-9-]+\..+)$/
 
 /**
@@ -82,6 +87,28 @@ const resolveBedrockModelId = (model: string, region: string): string => {
   }
 
   return `${bedrockGeographyPrefixForAwsRegion(region)}.${match[1]}`
+}
+
+const stripBedrockGeographyPrefix = (model: string): string => {
+  if (model.startsWith("global.")) {
+    return model
+  }
+
+  return model.match(bedrockScopedModelIdPattern)?.[1] ?? model
+}
+
+const resolveGenerateFallback = (
+  input: GenerateInput<unknown>,
+): { readonly provider: string; readonly model: string } | undefined => {
+  if (input.provider !== "amazon-bedrock") {
+    return undefined
+  }
+
+  if (stripBedrockGeographyPrefix(input.model) !== BEDROCK_MINIMAX_M25_MODEL_ID) {
+    return undefined
+  }
+
+  return BEDROCK_MINIMAX_M25_FALLBACK_MODEL
 }
 
 const normalizeProviderOptions = (
@@ -249,15 +276,17 @@ export const AIGenerateLive = Layer.effect(
       }
 
       const providerModel = yield* createProviderModel(input.provider, input.model)
+      const fallback = resolveGenerateFallback(input)
+      const fallbackProviderModel = fallback ? yield* createProviderModel(fallback.provider, fallback.model) : undefined
 
       return yield* Effect.tryPromise({
         try: async () => {
-          const execute = async () => {
+          const generateWithModel = async (model: ProviderModel) => {
             const startTime = performance.now()
             const providerOptions = normalizeProviderOptions(input.providerOptions)
 
             const call: GenerateTextCall = {
-              model: providerModel,
+              model,
               system: input.system,
               prompt: input.prompt,
               output: Output.object({ schema: input.schema }),
@@ -291,6 +320,25 @@ export const AIGenerateLive = Layer.effect(
               },
               duration: Math.round((performance.now() - startTime) * 1_000_000),
             } satisfies GenerateResult<T>
+          }
+
+          const execute = async () => {
+            try {
+              return await generateWithModel(providerModel)
+            } catch (primaryError) {
+              if (!fallback || fallbackProviderModel === undefined) {
+                throw primaryError
+              }
+
+              try {
+                return await generateWithModel(fallbackProviderModel)
+              } catch (fallbackError) {
+                throw new Error(
+                  `Primary model ${input.provider}/${input.model} failed: ${formatGenerateError(primaryError)}; ` +
+                    `fallback model ${fallback.provider}/${fallback.model} failed: ${formatGenerateError(fallbackError)}`,
+                )
+              }
+            }
           }
 
           return await runWithAiTelemetry(input.telemetry, execute)


### PR DESCRIPTION
## What changed

Adds a Bedrock generation fallback for `amazon-bedrock/minimax.minimax-m2.5`. When the MiniMax request fails, the Vercel AI adapter retries the same structured generation request with `amazon-bedrock/openai.gpt-oss-120b-1:0`.

`gpt-oss-120b` is an on-demand Bedrock foundation model in eu-central-1, not a regional inference-profile model. The resolver now has tests covering that it passes `openai.gpt-oss-120b-1:0` through unchanged and strips an accidental `eu.` geography prefix back to the valid foundation-model ID.

Also bounds flagger annotator transcript prompts before they are sent to the model. Long text parts are middle-truncated while preserving the beginning and end of each message, and the full rendered transcript has an additional cap. Tool call and tool result signals stay compact so oversized conversations do not push the annotator into very large prompts.

## Why

MiniMax M2.5 has been returning frequent Bedrock server-side failures in eu-central-1 despite usage staying well below AWS service quotas. GPT OSS 120B gives us a cheap same-region fallback path while keeping MiniMax as the primary model.

The flagger annotator prompt bound reduces another source of Bedrock instability: very large transcripts with long user/assistant text parts.

## Validation

Passed:

- `pnpm --filter @platform/ai-vercel check`
- `pnpm --filter @platform/ai-vercel test`
- `pnpm --filter @platform/ai-vercel typecheck`
- `pnpm --filter @domain/flaggers check`
- pre-commit `turbo format` / `knip`

Attempted but currently blocked by existing package-resolution/type errors in `@domain/spans` importing `@domain/ai` through the flaggers test/typecheck graph:

- `pnpm --filter @domain/flaggers test -- run-flagger-annotator.test.ts`
- `pnpm --filter @domain/flaggers typecheck`
