### PR TITLE
Add live taxonomy search recommendations

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
+    "@domain/taxonomy": "workspace:*",
     "@domain/users": "workspace:*",
     "@intercom/messenger-js-sdk": "0.0.14",
     "@lottiefiles/dotlottie-wc": "0.9.12",

--- a/apps/web/src/domains/taxonomy/taxonomy.collection.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.collection.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query"
+import { getTaxonomyOverview } from "./taxonomy.functions.ts"
+
+const taxonomyOverviewQueryKey = (projectId: string) => ["taxonomyOverview", projectId] as const
+
+export function useTaxonomyOverview(projectId: string) {
+  return useQuery({
+    queryKey: taxonomyOverviewQueryKey(projectId),
+    queryFn: () => getTaxonomyOverview({ data: { projectId } }),
+    staleTime: 30_000,
+    enabled: projectId.length > 0,
+  })
+}

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -1,0 +1,210 @@
+import { OrganizationId, ProjectId } from "@domain/shared"
+import {
+  getLastRunUseCase,
+  getTaxonomyAnalyticsUseCase,
+  listCategoriesUseCase,
+  type TaxonomyCategory,
+  type TaxonomyCluster,
+  type TaxonomyClusterLineage,
+  TaxonomyClusterRepository,
+  type TaxonomyClusterTrendSummary,
+  type TaxonomyRun,
+} from "@domain/taxonomy"
+import { BehaviorObservationRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import {
+  TaxonomyCategoryRepositoryLive,
+  TaxonomyClusterRepositoryLive,
+  TaxonomyLineageRepositoryLive,
+  TaxonomyRunRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect, Layer } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+
+export interface TaxonomyClusterRecord {
+  readonly id: string
+  readonly organizationId: string
+  readonly projectId: string
+  readonly parentCategoryId: string | null
+  readonly name: string
+  readonly description: string
+  readonly observationCount: number
+  readonly state: TaxonomyCluster["state"]
+  readonly firstObservedAt: string
+  readonly lastObservedAt: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface TaxonomyCategoryRecord {
+  readonly id: string
+  readonly organizationId: string
+  readonly projectId: string
+  readonly name: string
+  readonly description: string
+  readonly clusterCount: number
+  readonly observationCount: number
+  readonly state: TaxonomyCategory["state"]
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface TaxonomyRunRecord {
+  readonly id: string
+  readonly trigger: TaxonomyRun["trigger"]
+  readonly status: TaxonomyRun["status"]
+  readonly startedAt: string
+  readonly completedAt: string | null
+  readonly observationsScanned: number
+  readonly noiseScanned: number
+  readonly clustersBorn: number
+  readonly clustersMerged: number
+  readonly clustersDeprecated: number
+  readonly categoriesRebuilt: number
+  readonly error: string | null
+}
+
+export interface TaxonomyLineageRecord {
+  readonly id: string
+  readonly transitionType: TaxonomyClusterLineage["transitionType"]
+  readonly fromClusterIds: readonly string[]
+  readonly toClusterIds: readonly string[]
+  readonly similarity: number | null
+  readonly createdAt: string
+}
+
+export interface TaxonomyCategoryWithClustersRecord {
+  readonly category: TaxonomyCategoryRecord
+  readonly clusters: readonly TaxonomyClusterRecord[]
+}
+
+export interface TaxonomyOverviewRecord {
+  readonly totalActiveCategories: number
+  readonly totalActiveClusters: number
+  readonly totalObservations: number
+  readonly topClusters: readonly (TaxonomyClusterRecord & {
+    readonly occurrences: number
+    readonly trend: TaxonomyClusterTrendSummary
+  })[]
+  readonly categories: readonly TaxonomyCategoryWithClustersRecord[]
+  readonly lastRun: TaxonomyRunRecord | null
+  readonly recentLineage: readonly TaxonomyLineageRecord[]
+}
+
+const postgresTaxonomyReadLayer = Layer.mergeAll(
+  TaxonomyCategoryRepositoryLive,
+  TaxonomyClusterRepositoryLive,
+  TaxonomyLineageRepositoryLive,
+  TaxonomyRunRepositoryLive,
+)
+
+const toClusterRecord = (cluster: TaxonomyCluster): TaxonomyClusterRecord => ({
+  id: cluster.id,
+  organizationId: cluster.organizationId,
+  projectId: cluster.projectId,
+  parentCategoryId: cluster.parentCategoryId,
+  name: cluster.name,
+  description: cluster.description,
+  observationCount: cluster.observationCount,
+  state: cluster.state,
+  firstObservedAt: cluster.firstObservedAt.toISOString(),
+  lastObservedAt: cluster.lastObservedAt.toISOString(),
+  createdAt: cluster.createdAt.toISOString(),
+  updatedAt: cluster.updatedAt.toISOString(),
+})
+
+const toCategoryRecord = (category: TaxonomyCategory): TaxonomyCategoryRecord => ({
+  id: category.id,
+  organizationId: category.organizationId,
+  projectId: category.projectId,
+  name: category.name,
+  description: category.description,
+  clusterCount: category.clusterCount,
+  observationCount: category.observationCount,
+  state: category.state,
+  createdAt: category.createdAt.toISOString(),
+  updatedAt: category.updatedAt.toISOString(),
+})
+
+const toRunRecord = (run: TaxonomyRun): TaxonomyRunRecord => ({
+  id: run.id,
+  trigger: run.trigger,
+  status: run.status,
+  startedAt: run.startedAt.toISOString(),
+  completedAt: run.completedAt?.toISOString() ?? null,
+  observationsScanned: run.observationsScanned,
+  noiseScanned: run.noiseScanned,
+  clustersBorn: run.clustersBorn,
+  clustersMerged: run.clustersMerged,
+  clustersDeprecated: run.clustersDeprecated,
+  categoriesRebuilt: run.categoriesRebuilt,
+  error: run.error,
+})
+
+const toLineageRecord = (lineage: TaxonomyClusterLineage): TaxonomyLineageRecord => ({
+  id: lineage.id,
+  transitionType: lineage.transitionType,
+  fromClusterIds: lineage.fromClusterIds,
+  toClusterIds: lineage.toClusterIds,
+  similarity: lineage.similarity,
+  createdAt: lineage.createdAt.toISOString(),
+})
+
+export const getTaxonomyOverview = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }): Promise<TaxonomyOverviewRecord> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const analytics = yield* getTaxonomyAnalyticsUseCase({ organizationId: orgId, projectId })
+        const categoryResult = yield* listCategoriesUseCase({ organizationId: orgId, projectId, includeEmpty: false })
+        const clusters = yield* TaxonomyClusterRepository
+        const categories = yield* Effect.forEach(
+          categoryResult.categories,
+          (category) =>
+            clusters
+              .list({
+                projectId,
+                state: "active",
+                parentCategoryId: category.id,
+                sort: "observation_count_desc",
+                limit: 100,
+                offset: 0,
+              })
+              .pipe(
+                Effect.map((page) => ({
+                  category: toCategoryRecord(category),
+                  clusters: page.items.map(toClusterRecord),
+                })),
+              ),
+          { concurrency: 4 },
+        )
+        const lastRun = yield* getLastRunUseCase({ organizationId: orgId, projectId })
+
+        return {
+          totalActiveCategories: analytics.totalActiveCategories,
+          totalActiveClusters: analytics.totalActiveClusters,
+          totalObservations: analytics.totalObservations,
+          topClusters: analytics.topClusters.map((row) => ({
+            ...toClusterRecord(row.cluster),
+            occurrences: row.occurrences,
+            trend: row.trend,
+          })),
+          categories,
+          lastRun: lastRun.run ? toRunRecord(lastRun.run) : null,
+          recentLineage: lastRun.lineage.map(toLineageRecord),
+        } satisfies TaxonomyOverviewRecord
+      }).pipe(
+        withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withClickHouse(BehaviorObservationRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
@@ -1,0 +1,302 @@
+import { Button, Card, CardContent, Icon, Skeleton } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ArrowUpRightIcon,
+  ChevronDownIcon,
+  FlameIcon,
+  MinusIcon,
+  SearchIcon,
+  SparklesIcon,
+  TagIcon,
+} from "lucide-react"
+import { useMemo, useState } from "react"
+import { useTaxonomyOverview } from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
+import type { TaxonomyOverviewRecord } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
+
+const numberFormatter = new Intl.NumberFormat()
+const formatCount = (value: number): string => numberFormatter.format(value)
+
+function shuffle<T>(items: readonly T[]): T[] {
+  const shuffled = [...items]
+  for (let index = shuffled.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(Math.random() * (index + 1))
+    const current = shuffled[index]
+    shuffled[index] = shuffled[swapIndex] as T
+    shuffled[swapIndex] = current as T
+  }
+  return shuffled
+}
+
+export function LiveTaxonomyPanel({
+  projectId,
+  projectSlug,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+}) {
+  const { data, isLoading } = useTaxonomyOverview(projectId)
+  const [showAllBehaviors, setShowAllBehaviors] = useState(false)
+  const namedTopClusters = useMemo(
+    () => (data?.topClusters ?? []).filter((cluster) => cluster.name !== "Pending"),
+    [data?.topClusters],
+  )
+  const recommendations = useMemo(() => shuffle(namedTopClusters).slice(0, 4), [namedTopClusters])
+  const trendByClusterId = useMemo(
+    () => new Map(namedTopClusters.map((cluster) => [cluster.id, cluster.trend] as const)),
+    [namedTopClusters],
+  )
+  const categoryNameById = useMemo(
+    () => new Map((data?.categories ?? []).map((item) => [item.category.id, item.category.name])),
+    [data?.categories],
+  )
+
+  if (isLoading) return <LiveTaxonomySkeleton />
+  if (!data || recommendations.length === 0) return null
+
+  return (
+    <section className="mx-auto grid w-full max-w-4xl px-6 pb-8">
+      <div
+        className={`col-start-1 row-start-1 transition-all duration-200 ease-out ${
+          showAllBehaviors ? "pointer-events-none scale-[0.99] opacity-0" : "scale-100 opacity-100"
+        }`}
+        aria-hidden={showAllBehaviors}
+      >
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {recommendations.map((cluster) => (
+            <RecommendationCard
+              key={cluster.id}
+              cluster={cluster}
+              projectSlug={projectSlug}
+              categoryName={cluster.parentCategoryId ? categoryNameById.get(cluster.parentCategoryId) : undefined}
+            />
+          ))}
+        </div>
+        {data.totalActiveClusters > recommendations.length ? (
+          <div className="mt-4 flex justify-center">
+            <Button variant="ghost" size="sm" onClick={() => setShowAllBehaviors(true)}>
+              See all behaviors & categories
+            </Button>
+          </div>
+        ) : null}
+      </div>
+      <div
+        className={`col-start-1 row-start-1 transition-all duration-200 ease-out ${
+          showAllBehaviors ? "scale-100 opacity-100" : "pointer-events-none scale-[0.99] opacity-0"
+        }`}
+        aria-hidden={!showAllBehaviors}
+      >
+        {showAllBehaviors ? (
+          <AllBehaviorsList
+            data={data}
+            projectSlug={projectSlug}
+            trendByClusterId={trendByClusterId}
+            onShowRecommendations={() => setShowAllBehaviors(false)}
+          />
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function AllBehaviorsList({
+  data,
+  projectSlug,
+  trendByClusterId,
+  onShowRecommendations,
+}: {
+  readonly data: TaxonomyOverviewRecord
+  readonly projectSlug: string
+  readonly trendByClusterId: ReadonlyMap<string, RecommendationCluster["trend"]>
+  readonly onShowRecommendations: () => void
+}) {
+  const [expandedCategoryIds, setExpandedCategoryIds] = useState<ReadonlySet<string>>(
+    () => new Set(data.categories.map((item) => item.category.id)),
+  )
+
+  const toggleCategory = (categoryId: string) => {
+    setExpandedCategoryIds((previous) => {
+      const next = new Set(previous)
+      if (next.has(categoryId)) next.delete(categoryId)
+      else next.add(categoryId)
+      return next
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex justify-center pb-1">
+        <Button variant="ghost" size="sm" onClick={onShowRecommendations}>
+          Show recommendations
+        </Button>
+      </div>
+      <div className="flex flex-col gap-2">
+        {data.categories.map((item) => {
+          const isExpanded = expandedCategoryIds.has(item.category.id)
+          return (
+            <div key={item.category.id} className="overflow-hidden rounded-xl bg-muted/25 transition-colors">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between gap-3 p-3 text-left transition-colors hover:bg-muted/50"
+                onClick={() => toggleCategory(item.category.id)}
+                aria-expanded={isExpanded}
+              >
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Icon
+                      icon={ChevronDownIcon}
+                      size="xs"
+                      color="foregroundMuted"
+                      className={`shrink-0 transition-transform ${isExpanded ? "rotate-0" : "-rotate-90"}`}
+                    />
+                    <div className="truncate text-sm font-medium text-foreground">{item.category.name}</div>
+                  </div>
+                  {item.category.description ? (
+                    <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">{item.category.description}</p>
+                  ) : null}
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatCount(item.category.observationCount)} sessions
+                </span>
+              </button>
+              {isExpanded ? (
+                <div className="grid grid-cols-1 gap-2 px-3 pb-3 md:grid-cols-2">
+                  {item.clusters.map((cluster) => (
+                    <Link
+                      key={cluster.id}
+                      to="/projects/$projectSlug/search"
+                      params={{ projectSlug }}
+                      search={{ q: cluster.name }}
+                      className="group min-w-0 rounded-lg bg-background/80 p-3 transition-colors hover:bg-muted/60"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="line-clamp-2 text-sm font-medium leading-5 text-foreground">
+                            {cluster.name}
+                          </div>
+                          <p className="mt-1 line-clamp-2 text-xs leading-4 text-muted-foreground">
+                            {cluster.description || `${formatCount(cluster.observationCount)} sessions`}
+                          </p>
+                          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                            {trendByClusterId.get(cluster.id) ? (
+                              <ClusterTag
+                                icon={trendMeta(trendByClusterId.get(cluster.id)?.status ?? "steady").icon}
+                                label={trendMeta(trendByClusterId.get(cluster.id)?.status ?? "steady").label}
+                              />
+                            ) : null}
+                            <span className="text-xs text-muted-foreground">
+                              {formatCount(cluster.observationCount)} sessions
+                            </span>
+                          </div>
+                        </div>
+                        <Icon
+                          icon={ArrowUpRightIcon}
+                          size="xs"
+                          color="foregroundMuted"
+                          className="shrink-0 opacity-60 transition-opacity group-hover:opacity-100"
+                        />
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function LiveTaxonomySkeleton() {
+  return (
+    <section className="mx-auto flex w-full max-w-4xl flex-col px-6 pb-8">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Skeleton className="h-36 rounded-2xl" />
+        <Skeleton className="h-36 rounded-2xl" />
+        <Skeleton className="h-36 rounded-2xl" />
+        <Skeleton className="h-36 rounded-2xl" />
+      </div>
+    </section>
+  )
+}
+
+type RecommendationCluster = TaxonomyOverviewRecord["topClusters"][number]
+
+type TagIconType = typeof TagIcon
+
+const trendMeta = (
+  status: RecommendationCluster["trend"]["status"],
+): { readonly label: string; readonly icon: TagIconType } => {
+  switch (status) {
+    case "new":
+      return { label: "new", icon: SparklesIcon }
+    case "spike":
+      return { label: "spiking", icon: FlameIcon }
+    case "rising":
+      return { label: "rising", icon: ArrowUpIcon }
+    case "steady":
+      return { label: "steady", icon: MinusIcon }
+    case "cooling":
+      return { label: "cooling", icon: ArrowDownIcon }
+    case "fading":
+      return { label: "fading", icon: ArrowDownIcon }
+  }
+}
+
+function ClusterTag({ icon, label }: { readonly icon: TagIconType; readonly label: string }) {
+  return (
+    <span className="inline-flex max-w-full items-center gap-1 rounded-full border border-border/60 bg-background/70 px-2 py-0.5 text-xs leading-5 text-muted-foreground">
+      <Icon icon={icon} size="xs" color="foregroundMuted" />
+      <span className="truncate">{label}</span>
+    </span>
+  )
+}
+
+function RecommendationCard({
+  cluster,
+  projectSlug,
+  categoryName,
+}: {
+  readonly cluster: RecommendationCluster
+  readonly projectSlug: string
+  readonly categoryName: string | undefined
+}) {
+  return (
+    <Link
+      to="/projects/$projectSlug/search"
+      params={{ projectSlug }}
+      search={{ q: cluster.name }}
+      className="group block min-w-0 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={`Search traces for ${cluster.name}`}
+    >
+      <Card className="h-full min-h-36 min-w-0 border-transparent bg-muted/30 shadow-none transition-colors hover:bg-muted/50">
+        <CardContent className="flex h-full flex-col gap-3 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background/70">
+                <Icon icon={SearchIcon} size="xs" color="foregroundMuted" />
+              </span>
+              <div className="line-clamp-2 text-sm font-medium leading-5 text-foreground">{cluster.name}</div>
+            </div>
+            <Icon
+              icon={ArrowUpRightIcon}
+              size="xs"
+              color="foregroundMuted"
+              className="shrink-0 opacity-60 transition-opacity group-hover:opacity-100"
+            />
+          </div>
+          <p className="line-clamp-3 min-h-12 text-xs leading-4 text-muted-foreground">
+            {cluster.description || `${formatCount(cluster.observationCount)} matching sessions`}
+          </p>
+          <div className="mt-auto flex flex-wrap items-center gap-1.5">
+            <ClusterTag icon={trendMeta(cluster.trend.status).icon} label={trendMeta(cluster.trend.status).label} />
+            {categoryName ? <ClusterTag icon={TagIcon} label={categoryName} /> : null}
+            <span className="text-xs text-muted-foreground">{formatCount(cluster.observationCount)} sessions</span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
@@ -36,9 +36,11 @@ const filtersCount = (filterSet: SavedSearchRecord["filterSet"]): number => Obje
 export function SavedSearchesList({
   projectId,
   projectSlug,
+  hasRecommendedSearches,
 }: {
   readonly projectId: string
   readonly projectSlug: string
+  readonly hasRecommendedSearches: boolean
 }) {
   const router = useRouter()
   const { data, isLoading } = useSavedSearchesList(projectId)
@@ -48,7 +50,7 @@ export function SavedSearchesList({
   const [assignOpenForId, setAssignOpenForId] = useState<string | null>(null)
 
   if (!isLoading && data.length === 0) {
-    return <SavedSearchesEmpty />
+    return <SavedSearchesEmpty hasRecommendedSearches={hasRecommendedSearches} />
   }
 
   const columns: InfiniteTableColumn<SavedSearchRecord>[] = [
@@ -223,22 +225,37 @@ function DeleteSavedSearchModal({
   )
 }
 
-function SavedSearchesEmpty() {
+function SavedSearchesEmpty({ hasRecommendedSearches }: { readonly hasRecommendedSearches: boolean }) {
   return (
-    <div className="flex h-full w-full items-center justify-center p-8 opacity-75">
+    <div
+      className={
+        hasRecommendedSearches
+          ? "flex w-full items-center justify-center px-8 pt-16 pb-16 opacity-75"
+          : "flex h-full w-full items-center justify-center p-8 opacity-75"
+      }
+    >
       <div className="flex max-w-lg flex-col items-center gap-6">
         <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-muted">
           <Icon icon={SparklesIcon} size="lg" color="foregroundMuted" />
         </div>
         <div className="flex flex-col items-center gap-2">
           <Text.H3 centered>Search your traces</Text.H3>
-          <Text.H5 centered color="foregroundMuted">
-            Describe what you're looking for in plain language. Search blends keywords with meaning, so phrases like
-            "failed payments" or "long latency on signup" work as well as exact matches.
-          </Text.H5>
-          <Text.H5 centered color="foregroundMuted">
-            Once you've built a useful search, save it from the action bar to come back to it later.
-          </Text.H5>
+          {hasRecommendedSearches ? (
+            <Text.H5 centered color="foregroundMuted">
+              Describe what you're looking for in plain language, or start from one of the recommended behavior searches
+              below.
+            </Text.H5>
+          ) : (
+            <>
+              <Text.H5 centered color="foregroundMuted">
+                Describe what you're looking for in plain language. Search blends keywords with meaning, so phrases like
+                "failed payments" or "long latency on signup" work as well as exact matches.
+              </Text.H5>
+              <Text.H5 centered color="foregroundMuted">
+                Once you've built a useful search, save it from the action bar to come back to it later.
+              </Text.H5>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -4,10 +4,12 @@ import { useHotkeys } from "@tanstack/react-hotkeys"
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
 import { ArrowLeftIcon, DatabaseIcon, DownloadIcon, FilterIcon, PinIcon, SearchIcon, XIcon } from "lucide-react"
 import { useRef, useState } from "react"
+import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import {
   useSavedSearchBySlug,
   useUpdateSavedSearch,
 } from "../../../../../domains/saved-searches/saved-searches.collection.ts"
+import { useTaxonomyOverview } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import { useTracesCount } from "../../../../../domains/traces/traces.collection.ts"
 import { enqueueTracesExport } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
@@ -36,6 +38,7 @@ import {
 } from "../-components/trace-page-state.ts"
 import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
+import { LiveTaxonomyPanel } from "./-components/live-taxonomy-panel.tsx"
 import { SaveSearchModal } from "./-components/save-search-modal.tsx"
 import { SavedSearchesList } from "./-components/saved-searches-list.tsx"
 import { SearchSyntaxLegend } from "./-components/search-syntax-legend.tsx"
@@ -97,6 +100,11 @@ function SearchPage() {
 
   const { data: loadedSavedSearch } = useSavedSearchBySlug(projectId, savedSearchSlug || null)
   const updateSavedSearchMutation = useUpdateSavedSearch(projectId)
+  const liveTaxonomyRecommendationsEnabled = useHasFeatureFlag("live-taxonomy-search-recommendations")
+  const { data: taxonomyOverview } = useTaxonomyOverview(liveTaxonomyRecommendationsEnabled ? projectId : "")
+  const hasRecommendedSearches =
+    liveTaxonomyRecommendationsEnabled &&
+    (taxonomyOverview?.topClusters.some((cluster) => cluster.name !== "Pending") ?? false)
 
   // Compare canonical serializations of both filter sets. `rawFilters` is whatever TanStack Router
   // wrote to the URL (potentially JSON-stringified twice depending on encoding), so going through
@@ -223,7 +231,18 @@ function SearchPage() {
         </Layout.ActionsRow>
       </Layout.Actions>
 
-      {!hasContent ? <SavedSearchesList projectId={projectId} projectSlug={projectSlug} /> : null}
+      {!hasContent ? (
+        <div className="flex min-h-0 grow flex-col">
+          <SavedSearchesList
+            projectId={projectId}
+            projectSlug={projectSlug}
+            hasRecommendedSearches={hasRecommendedSearches}
+          />
+          {liveTaxonomyRecommendationsEnabled ? (
+            <LiveTaxonomyPanel projectId={projectId} projectSlug={projectSlug} />
+          ) : null}
+        </div>
+      ) : null}
 
       {hasContent ? (
         <Layout.Actions className="pt-0">

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -10,6 +10,8 @@
     "format": "biome format --write src && biome check --fix src",
     "trace-search:backfill": "tsx src/scripts/backfill-trace-search.ts",
     "trace-search:backfill:dist": "node --enable-source-maps dist/scripts/backfill-trace-search.cjs",
+    "taxonomy:backfill": "tsx src/scripts/backfill-taxonomy.ts",
+    "taxonomy:backfill:dist": "node --enable-source-maps dist/scripts/backfill-taxonomy.cjs",
     "test-emails:incidents": "tsx src/scripts/send-test-incident-emails.ts",
     "test-slack:notifications": "tsx src/scripts/send-test-slack-notifications.ts",
     "typecheck": "tsgo -p tsconfig.json --noEmit",

--- a/apps/workers/src/scripts/backfill-taxonomy.ts
+++ b/apps/workers/src/scripts/backfill-taxonomy.ts
@@ -68,7 +68,7 @@ async function listProjects(filters: { readonly organizationId?: string; readonl
   }
 
   const result = await adminPostgres.pool.query<ProjectRow>(
-    `SELECT organization_id, id AS project_id FROM projects WHERE ${clauses.join(" AND ")} ORDER BY organization_id, id`,
+    `SELECT organization_id, id AS project_id FROM latitude.projects WHERE ${clauses.join(" AND ")} ORDER BY organization_id, id`,
     values,
   )
   return result.rows

--- a/apps/workers/src/scripts/backfill-taxonomy.ts
+++ b/apps/workers/src/scripts/backfill-taxonomy.ts
@@ -1,0 +1,253 @@
+import { parseArgs } from "node:util"
+import { type OrganizationId as OrganizationIdType, ProjectId } from "@domain/shared"
+import { SessionRepository } from "@domain/spans"
+import type { RedisClient } from "@platform/cache-redis"
+import { closeClickhouse, SessionRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { loadDevelopmentEnvironments } from "@repo/utils/env"
+import { Effect } from "effect"
+import {
+  getAdminPostgresClient,
+  getClickhouseClient,
+  getPostgresClient,
+  getRedisClient,
+  getWorkflowStarter,
+} from "../clients.ts"
+import { runGardenProjectJob, runObserveSessionJob } from "../workers/taxonomy.ts"
+
+const DEFAULT_LIMIT_PER_PROJECT = 250
+
+type ProjectRow = {
+  readonly organization_id: string
+  readonly project_id: string
+}
+
+const USAGE = `
+Usage: pnpm --filter @app/workers taxonomy:backfill [options]
+
+Backfills behavior observations from materialized ClickHouse sessions and optionally gardens projects.
+
+Options:
+  --organization-id <id>   Restrict backfill to one organization
+  --project-id <id>        Restrict backfill to one project
+  --limit <n>              Process at most this many sessions per project (default: ${DEFAULT_LIMIT_PER_PROJECT})
+  --concurrency <n>        Number of sessions to process in parallel (default: 4)
+  --reset                  Clear existing taxonomy rows/observations for selected projects first
+  --rebase-observations-to-now
+                           Rewrite observation timestamps into the current gardening lookback window
+  --skip-garden            Only record observations; do not run gardening after backfill
+  --help                   Show this help
+`.trim()
+
+function parsePositiveInteger(value: string, flagName: string): number {
+  const parsed = Number(value)
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} must be a positive integer, received "${value}"`)
+  }
+
+  return parsed
+}
+
+async function closeRedisClient(redis: RedisClient): Promise<void> {
+  await redis.quit().catch(() => undefined)
+}
+
+async function listProjects(filters: { readonly organizationId?: string; readonly projectId?: string }) {
+  const adminPostgres = getAdminPostgresClient()
+  const clauses = ["deleted_at IS NULL"]
+  const values: string[] = []
+
+  if (filters.organizationId) {
+    values.push(filters.organizationId)
+    clauses.push(`organization_id = $${values.length}`)
+  }
+
+  if (filters.projectId) {
+    values.push(filters.projectId)
+    clauses.push(`id = $${values.length}`)
+  }
+
+  const result = await adminPostgres.pool.query<ProjectRow>(
+    `SELECT organization_id, id AS project_id FROM projects WHERE ${clauses.join(" AND ")} ORDER BY organization_id, id`,
+    values,
+  )
+  return result.rows
+}
+
+async function rebaseObservationsToNow(project: ProjectRow) {
+  const clickhouse = getClickhouseClient()
+  await clickhouse.command({
+    query: `INSERT INTO behavior_observations
+            SELECT
+              organization_id,
+              project_id,
+              session_id,
+              now64(9) - toIntervalSecond(rowNumberInAllBlocks()),
+              now64(9) - toIntervalSecond(rowNumberInAllBlocks()) + toIntervalSecond(60),
+              trace_ids,
+              summary,
+              summary_hash,
+              embedding,
+              embedding_model,
+              assigned_cluster_id,
+              assignment_confidence,
+              assignment_method,
+              reassignment_run_id,
+              retention_days,
+              now64(3)
+            FROM behavior_observations FINAL
+            WHERE organization_id = {organizationId:String}
+              AND project_id = {projectId:String}`,
+    query_params: { organizationId: project.organization_id, projectId: project.project_id },
+  })
+  await clickhouse.command({ query: "OPTIMIZE TABLE behavior_observations FINAL" })
+}
+
+async function resetProjectTaxonomy(project: ProjectRow) {
+  const adminPostgres = getAdminPostgresClient()
+  const clickhouse = getClickhouseClient()
+  const params = [project.organization_id, project.project_id]
+
+  await adminPostgres.pool.query(
+    `DELETE FROM latitude.taxonomy_cluster_lineage WHERE organization_id = $1 AND project_id = $2`,
+    params,
+  )
+  await adminPostgres.pool.query(
+    `DELETE FROM latitude.taxonomy_clusters WHERE organization_id = $1 AND project_id = $2`,
+    params,
+  )
+  await adminPostgres.pool.query(
+    `DELETE FROM latitude.taxonomy_categories WHERE organization_id = $1 AND project_id = $2`,
+    params,
+  )
+  await adminPostgres.pool.query(
+    `DELETE FROM latitude.taxonomy_runs WHERE organization_id = $1 AND project_id = $2`,
+    params,
+  )
+  await clickhouse.command({
+    query:
+      "ALTER TABLE behavior_observations DELETE WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}",
+    query_params: { organizationId: project.organization_id, projectId: project.project_id },
+    clickhouse_settings: { mutations_sync: "2" },
+  })
+  await clickhouse.command({ query: "OPTIMIZE TABLE behavior_observations FINAL" })
+}
+
+loadDevelopmentEnvironments(new URL("../server.ts", import.meta.url).href)
+
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  options: {
+    "organization-id": { type: "string" },
+    "project-id": { type: "string" },
+    limit: { type: "string", default: String(DEFAULT_LIMIT_PER_PROJECT) },
+    concurrency: { type: "string", default: "4" },
+    reset: { type: "boolean", default: false },
+    "rebase-observations-to-now": { type: "boolean", default: false },
+    "skip-garden": { type: "boolean", default: false },
+    help: { type: "boolean", default: false },
+  },
+})
+
+if (values.help) {
+  console.log(USAGE)
+  process.exit(0)
+}
+
+if (positionals.length > 0) {
+  console.error(`Unexpected positional arguments: ${positionals.join(" ")}`)
+  console.log(USAGE)
+  process.exit(1)
+}
+
+const concurrency = parsePositiveInteger(values.concurrency ?? "4", "--concurrency")
+const limit = parsePositiveInteger(values.limit ?? String(DEFAULT_LIMIT_PER_PROJECT), "--limit")
+
+const clickhouse = getClickhouseClient()
+const postgres = getPostgresClient()
+const redis = getRedisClient()
+
+void Effect.runPromise(
+  Effect.gen(function* () {
+    const projects = yield* Effect.promise(() =>
+      listProjects({
+        ...(values["organization-id"] ? { organizationId: values["organization-id"] } : {}),
+        ...(values["project-id"] ? { projectId: values["project-id"] } : {}),
+      }),
+    )
+
+    console.log(`Found ${projects.length.toString()} project(s) to backfill`)
+
+    for (const project of projects) {
+      if (values.reset) {
+        console.log(`Resetting taxonomy for project ${project.project_id}`)
+        yield* Effect.promise(() => resetProjectTaxonomy(project))
+      }
+
+      const sessions = yield* Effect.gen(function* () {
+        const repository = yield* SessionRepository
+        const page = yield* repository.listByProjectId({
+          organizationId: project.organization_id as OrganizationIdType,
+          projectId: ProjectId(project.project_id),
+          options: { limit, sortBy: "lastActivity", sortDirection: "asc" },
+        })
+        return page.items
+      }).pipe(withClickHouse(SessionRepositoryLive, clickhouse, project.organization_id as OrganizationIdType))
+
+      console.log(`Backfilling ${sessions.length.toString()} sessions for project ${project.project_id}`)
+
+      yield* Effect.forEach(
+        sessions,
+        (session, index) =>
+          runObserveSessionJob(
+            {
+              organizationId: project.organization_id,
+              projectId: project.project_id,
+              sessionId: session.sessionId,
+              triggeringTraceId: session.traceIds[0] ?? session.sessionId,
+              triggeringStartTime: session.startTime.toISOString(),
+            },
+            { clickhouseClient: clickhouse, postgresClient: postgres, redisClient: redis },
+          ).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                console.log(`Observed ${index + 1}/${sessions.length}: ${session.sessionId}`)
+              }),
+            ),
+          ),
+        { concurrency, discard: true },
+      )
+
+      if (values["rebase-observations-to-now"]) {
+        console.log(`Rebasing observations to now for project ${project.project_id}`)
+        yield* Effect.promise(() => rebaseObservationsToNow(project))
+      }
+
+      if (!values["skip-garden"]) {
+        console.log(`Gardening taxonomy for project ${project.project_id}`)
+        const workflowStarter = yield* Effect.promise(() => getWorkflowStarter())
+        yield* runGardenProjectJob(
+          { organizationId: project.organization_id, projectId: project.project_id, reason: "manual" },
+          { clickhouseClient: clickhouse, postgresClient: postgres, redisClient: redis, workflowStarter },
+        )
+        console.log(`Started Temporal naming workflows for pending taxonomy labels in project ${project.project_id}`)
+      }
+    }
+  }).pipe(
+    Effect.ensuring(
+      Effect.promise(async () => {
+        const adminPostgres = getAdminPostgresClient()
+        await Promise.allSettled([
+          closeClickhouse(clickhouse),
+          closeRedisClient(redis),
+          postgres.pool.end(),
+          adminPostgres.pool.end(),
+        ])
+      }),
+    ),
+  ),
+).catch((error: unknown) => {
+  console.error("Taxonomy backfill failed")
+  console.error(error)
+  process.exitCode = 1
+})

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -214,6 +214,7 @@ const bootstrap = async () => {
     createTaxonomyWorker({
       consumer: ctx.consumer,
       publisher: ctx.publisher,
+      workflowStarter: ctx.workflowStarter,
       clickhouseClient: ctx.clickhouseClient,
       postgresClient: ctx.postgresClient,
       adminPostgresClient: getAdminPostgresClient(),

--- a/apps/workers/src/workers/taxonomy-read-use-cases.test.ts
+++ b/apps/workers/src/workers/taxonomy-read-use-cases.test.ts
@@ -14,7 +14,6 @@ import {
   createTaxonomyCentroid,
   getCategoryDetailsUseCase,
   getClusterDetailsUseCase,
-  getClusterTrendUseCase,
   getLastRunUseCase,
   getTaxonomyAnalyticsUseCase,
   listCategoriesUseCase,
@@ -201,7 +200,6 @@ describe("taxonomy read use-cases integration", () => {
           clusterDetails: yield* getClusterDetailsUseCase({ organizationId, projectId, clusterId }),
           categoryDetails: yield* getCategoryDetailsUseCase({ organizationId, projectId, categoryId }),
           observations: yield* listObservationsInClusterUseCase({ organizationId, projectId, clusterId, pageSize: 1 }),
-          trend: yield* getClusterTrendUseCase({ organizationId, projectId, clusterId, windowDays: 1, now }),
           analytics: yield* getTaxonomyAnalyticsUseCase({ organizationId, projectId, windowDays: 1, now }),
           lastRun: yield* getLastRunUseCase({ organizationId, projectId }),
         }
@@ -222,7 +220,6 @@ describe("taxonomy read use-cases integration", () => {
     expect(result.categoryDetails.clusters.map((row) => row.id)).toContain(clusterId)
     expect(result.observations.observations).toHaveLength(1)
     expect(result.observations.hasMore).toBe(true)
-    expect(result.trend.buckets.at(-1)?.count).toBe(2)
     expect(result.analytics.totalActiveCategories).toBeGreaterThanOrEqual(1)
     expect(result.analytics.topClusters[0]?.cluster.id).toBe(clusterId)
     expect(result.lastRun.run?.id).toBe(runId)

--- a/apps/workers/src/workers/taxonomy.ts
+++ b/apps/workers/src/workers/taxonomy.ts
@@ -257,7 +257,7 @@ export const runGardenProjectJob = (payload: GardenProjectPayload, deps: Taxonom
                     }),
                   ),
                 ),
-                Effect.catch((error) =>
+                Effect.catchTag("WorkflowAlreadyStartedError", (error) =>
                   Effect.sync(() =>
                     logger.info("Taxonomy cluster naming workflow already active", { workflowId, error }),
                   ),
@@ -288,7 +288,7 @@ export const runGardenProjectJob = (payload: GardenProjectPayload, deps: Taxonom
                     }),
                   ),
                 ),
-                Effect.catch((error) =>
+                Effect.catchTag("WorkflowAlreadyStartedError", (error) =>
                   Effect.sync(() =>
                     logger.info("Taxonomy category naming workflow already active", { workflowId, error }),
                   ),

--- a/apps/workers/src/workers/taxonomy.ts
+++ b/apps/workers/src/workers/taxonomy.ts
@@ -1,4 +1,4 @@
-import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
+import type { QueueConsumer, QueuePublisherShape, WorkflowStarterShape } from "@domain/queue"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import {
   BehaviorObservationRepository,
@@ -7,6 +7,7 @@ import {
   TAXONOMY_GARDENING_MIN_OBSERVATIONS,
   TAXONOMY_GARDENING_THROTTLE_MS,
   TAXONOMY_NOISE_LOOKBACK_DAYS,
+  TaxonomyCategoryRepository,
   TaxonomyClusterRepository,
   TaxonomyRunRepository,
   taxonomyGardenProjectDedupeKey,
@@ -38,6 +39,7 @@ const logger = createLogger("taxonomy")
 interface TaxonomyDeps {
   readonly consumer: QueueConsumer
   readonly publisher: QueuePublisherShape
+  readonly workflowStarter: WorkflowStarterShape
   readonly clickhouseClient: ClickHouseClient
   readonly postgresClient: PostgresClient
   readonly adminPostgresClient: PostgresClient
@@ -60,6 +62,14 @@ interface ObserveSessionPayload {
   readonly sessionId: string
   readonly triggeringTraceId: string
   readonly triggeringStartTime: string
+}
+
+interface TaxonomyRuntimeDeps {
+  readonly clickhouseClient: ClickHouseClient
+  readonly postgresClient: PostgresClient
+  readonly redisClient: RedisClient
+  readonly publisher?: QueuePublisherShape
+  readonly workflowStarter?: WorkflowStarterShape
 }
 
 export const runObserveSessionJob = (payload: ObserveSessionPayload, deps: TaxonomyRuntimeDeps) => {
@@ -123,12 +133,6 @@ export const runObserveSessionJob = (payload: ObserveSessionPayload, deps: Taxon
     Effect.withSpan("taxonomy.observeSession"),
     Effect.asVoid,
   )
-}
-
-interface TaxonomyRuntimeDeps {
-  readonly clickhouseClient: ClickHouseClient
-  readonly postgresClient: PostgresClient
-  readonly redisClient: RedisClient
 }
 
 interface TaxonomySweepDeps {
@@ -210,6 +214,7 @@ export const runGardenProjectJob = (payload: GardenProjectPayload, deps: Taxonom
       Effect.gen(function* () {
         const runs = yield* TaxonomyRunRepository
         const clusters = yield* TaxonomyClusterRepository
+        const categories = yield* TaxonomyCategoryRepository
         const recent = yield* runs.listRecentCompleted({
           projectId: ProjectId(payload.projectId),
           limit: 3,
@@ -227,6 +232,74 @@ export const runGardenProjectJob = (payload: GardenProjectPayload, deps: Taxonom
         const activeClusters = yield* clusters.listActiveByProject({
           projectId: ProjectId(payload.projectId),
         })
+        const activeCategories = yield* categories.listByProject({
+          projectId: ProjectId(payload.projectId),
+          state: "active",
+        })
+        if (deps.workflowStarter) {
+          for (const cluster of activeClusters) {
+            if (cluster.name !== "Pending") continue
+            const workflowId = `org:${payload.organizationId}:taxonomy:nameCluster:${payload.projectId}:${cluster.id}`
+            yield* deps.workflowStarter
+              .start(
+                "taxonomyNameClusterWorkflow",
+                { organizationId: payload.organizationId, projectId: payload.projectId, clusterId: cluster.id },
+                { workflowId },
+              )
+              .pipe(
+                Effect.tap(() =>
+                  Effect.sync(() =>
+                    logger.info("Started taxonomy cluster naming workflow", {
+                      organizationId: payload.organizationId,
+                      projectId: payload.projectId,
+                      clusterId: cluster.id,
+                      workflowId,
+                    }),
+                  ),
+                ),
+                Effect.catch((error) =>
+                  Effect.sync(() =>
+                    logger.info("Taxonomy cluster naming workflow already active", { workflowId, error }),
+                  ),
+                ),
+                Effect.catchDefect((defect) => {
+                  logger.warn("Taxonomy cluster naming workflow start failed", { workflowId, defect })
+                  return Effect.void
+                }),
+              )
+          }
+          for (const category of activeCategories) {
+            if (category.name !== "Pending") continue
+            const workflowId = `org:${payload.organizationId}:taxonomy:nameCategory:${payload.projectId}:${category.id}`
+            yield* deps.workflowStarter
+              .start(
+                "taxonomyNameCategoryWorkflow",
+                { organizationId: payload.organizationId, projectId: payload.projectId, categoryId: category.id },
+                { workflowId },
+              )
+              .pipe(
+                Effect.tap(() =>
+                  Effect.sync(() =>
+                    logger.info("Started taxonomy category naming workflow", {
+                      organizationId: payload.organizationId,
+                      projectId: payload.projectId,
+                      categoryId: category.id,
+                      workflowId,
+                    }),
+                  ),
+                ),
+                Effect.catch((error) =>
+                  Effect.sync(() =>
+                    logger.info("Taxonomy category naming workflow already active", { workflowId, error }),
+                  ),
+                ),
+                Effect.catchDefect((defect) => {
+                  logger.warn("Taxonomy category naming workflow start failed", { workflowId, defect })
+                  return Effect.void
+                }),
+              )
+          }
+        }
         const deprecatedClusters = yield* clusters.list({
           projectId: ProjectId(payload.projectId),
           state: "deprecated",
@@ -253,6 +326,8 @@ export const runGardenProjectJob = (payload: GardenProjectPayload, deps: Taxonom
           projectId: payload.projectId,
           countActive: activeClusters.length,
           countDeprecated: deprecatedClusters.items.length,
+          pendingClusterNames: activeClusters.filter((cluster) => cluster.name === "Pending").length,
+          pendingCategoryNames: activeCategories.filter((category) => category.name === "Pending").length,
         })
         if (zeroBirthsStreak) {
           logger.warn("Taxonomy zero births streak", {
@@ -317,6 +392,7 @@ export const createTaxonomyWorker = ({
   postgresClient,
   adminPostgresClient,
   redisClient,
+  workflowStarter,
 }: TaxonomyDeps) => {
   consumer.subscribe("taxonomy", {
     gardenProject: (payload) =>
@@ -324,6 +400,8 @@ export const createTaxonomyWorker = ({
         clickhouseClient,
         postgresClient,
         redisClient,
+        publisher,
+        workflowStarter,
       }),
     gardenSweep: (payload) =>
       runGardenSweepJob(payload as GardenSweepPayload, {

--- a/apps/workflows/package.json
+++ b/apps/workflows/package.json
@@ -24,6 +24,7 @@
     "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
+    "@domain/taxonomy": "workspace:*",
     "@platform/ai": "workspace:*",
     "@platform/ai-vercel": "workspace:*",
     "@platform/ai-voyage": "workspace:*",

--- a/apps/workflows/src/activities/index.ts
+++ b/apps/workflows/src/activities/index.ts
@@ -34,3 +34,9 @@ export {
   seedDemoProjectClickHouseActivity,
   seedDemoProjectPostgresActivity,
 } from "./seed-demo-project-activities.ts"
+export {
+  type NameTaxonomyCategoryActivityInput,
+  type NameTaxonomyClusterActivityInput,
+  nameTaxonomyCategoryActivity,
+  nameTaxonomyClusterActivity,
+} from "./taxonomy-naming-activities.ts"

--- a/apps/workflows/src/activities/taxonomy-naming-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-naming-activities.ts
@@ -1,0 +1,57 @@
+import { OrganizationId, ProjectId, TaxonomyCategoryId, TaxonomyClusterId } from "@domain/shared"
+import { nameCategoryUseCase, nameClusterUseCase } from "@domain/taxonomy"
+import { withAi } from "@platform/ai"
+import { AIGenerateLive } from "@platform/ai-vercel"
+import { AIEmbedLive } from "@platform/ai-voyage"
+import { RedisCacheStoreLive, RedisTaxonomyLockRepositoryLive } from "@platform/cache-redis"
+import { BehaviorObservationRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { TaxonomyCategoryRepositoryLive, TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { Effect, Layer } from "effect"
+import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
+
+export interface NameTaxonomyClusterActivityInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly clusterId: string
+}
+
+export interface NameTaxonomyCategoryActivityInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly categoryId: string
+}
+
+export const nameTaxonomyClusterActivity = (input: NameTaxonomyClusterActivityInput) =>
+  Effect.runPromise(
+    nameClusterUseCase({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      clusterId: TaxonomyClusterId(input.clusterId),
+    }).pipe(
+      withPostgres(TaxonomyClusterRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
+      withClickHouse(BehaviorObservationRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId)),
+      withAi(Layer.mergeAll(AIEmbedLive, AIGenerateLive), getRedisClient()),
+      Effect.provide(
+        Layer.mergeAll(RedisCacheStoreLive(getRedisClient()), RedisTaxonomyLockRepositoryLive(getRedisClient())),
+      ),
+    ),
+  )
+
+export const nameTaxonomyCategoryActivity = (input: NameTaxonomyCategoryActivityInput) =>
+  Effect.runPromise(
+    nameCategoryUseCase({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      categoryId: TaxonomyCategoryId(input.categoryId),
+    }).pipe(
+      withPostgres(
+        Layer.mergeAll(TaxonomyCategoryRepositoryLive, TaxonomyClusterRepositoryLive),
+        getPostgresClient(),
+        OrganizationId(input.organizationId),
+      ),
+      withAi(Layer.mergeAll(AIEmbedLive, AIGenerateLive), getRedisClient()),
+      Effect.provide(
+        Layer.mergeAll(RedisCacheStoreLive(getRedisClient()), RedisTaxonomyLockRepositoryLive(getRedisClient())),
+      ),
+    ),
+  )

--- a/apps/workflows/src/workflows/index.ts
+++ b/apps/workflows/src/workflows/index.ts
@@ -12,3 +12,11 @@ export {
   refreshEvaluationAlignmentWorkflow,
 } from "./refresh-evaluation-alignment-workflow.ts"
 export { type SeedDemoProjectWorkflowInput, seedDemoProjectWorkflow } from "./seed-demo-project-workflow.ts"
+export {
+  type TaxonomyNameCategoryWorkflowInput,
+  type TaxonomyNameCategoryWorkflowResult,
+  type TaxonomyNameClusterWorkflowInput,
+  type TaxonomyNameClusterWorkflowResult,
+  taxonomyNameCategoryWorkflow,
+  taxonomyNameClusterWorkflow,
+} from "./taxonomy-naming-workflow.ts"

--- a/apps/workflows/src/workflows/taxonomy-naming-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-naming-workflow.ts
@@ -9,7 +9,7 @@ export type TaxonomyNameClusterWorkflowResult = Awaited<ReturnType<typeof activi
 export type TaxonomyNameCategoryWorkflowResult = Awaited<ReturnType<typeof activities.nameTaxonomyCategoryActivity>>
 
 const { nameTaxonomyClusterActivity, nameTaxonomyCategoryActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "1 minute",
+  startToCloseTimeout: "2 minutes",
   retry: {
     ...defaultActivityRetryPolicy,
     initialInterval: "1 minute",

--- a/apps/workflows/src/workflows/taxonomy-naming-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-naming-workflow.ts
@@ -1,0 +1,26 @@
+import { proxyActivities } from "@temporalio/workflow"
+import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
+
+export type TaxonomyNameClusterWorkflowInput = activities.NameTaxonomyClusterActivityInput
+export type TaxonomyNameCategoryWorkflowInput = activities.NameTaxonomyCategoryActivityInput
+
+export type TaxonomyNameClusterWorkflowResult = Awaited<ReturnType<typeof activities.nameTaxonomyClusterActivity>>
+export type TaxonomyNameCategoryWorkflowResult = Awaited<ReturnType<typeof activities.nameTaxonomyCategoryActivity>>
+
+const { nameTaxonomyClusterActivity, nameTaxonomyCategoryActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minute",
+  retry: {
+    ...defaultActivityRetryPolicy,
+    initialInterval: "1 minute",
+    maximumInterval: "30 minutes",
+  },
+})
+
+export const taxonomyNameClusterWorkflow = async (
+  input: TaxonomyNameClusterWorkflowInput,
+): Promise<TaxonomyNameClusterWorkflowResult> => nameTaxonomyClusterActivity(input)
+
+export const taxonomyNameCategoryWorkflow = async (
+  input: TaxonomyNameCategoryWorkflowInput,
+): Promise<TaxonomyNameCategoryWorkflowResult> => nameTaxonomyCategoryActivity(input)

--- a/dev-docs/taxonomy.md
+++ b/dev-docs/taxonomy.md
@@ -58,8 +58,7 @@ The worker emits structured gardening counters, cluster counts, and a `taxonomy.
 - `getClusterDetailsUseCase`: project-scoped cluster row plus a small recent ClickHouse observation sample.
 - `getCategoryDetailsUseCase`: project-scoped category row plus active member clusters.
 - `listObservationsInClusterUseCase`: ClickHouse observations ordered by `(start_time DESC, session_id ASC)` and paged by a compound cursor so same-timestamp observations are not skipped.
-- `getClusterTrendUseCase`: daily observation counts for a cluster over a window, default 14 days.
-- `getTaxonomyAnalyticsUseCase`: active category/cluster counts, total observations in the window, and top clusters by windowed ClickHouse occurrence count.
+- `getTaxonomyAnalyticsUseCase`: active category/cluster counts, total observations in the window, top clusters by windowed ClickHouse occurrence count, and ClickHouse-side current-vs-baseline trend summaries for those top clusters.
 - `getLastRunUseCase`: latest taxonomy run plus the last 10 birth/merge lineage transitions for the activity panel.
 
 ## Operational controls

--- a/packages/domain/feature-flags/src/registry.ts
+++ b/packages/domain/feature-flags/src/registry.ts
@@ -36,6 +36,11 @@ export const FEATURE_FLAGS = {
     name: "Session search v2",
     description: "Routes users to the new session-rollup search at /session-search instead of the legacy /search.",
   },
+  "live-taxonomy-search-recommendations": {
+    emoji: "🌱",
+    name: "Live taxonomy search recommendations",
+    description: "Shows behavior taxonomy recommendations and category browsing on the search blank slate.",
+  },
   "timeline-incidents": {
     emoji: "📊",
     name: "Timeline incidents overlay",

--- a/packages/domain/queue/src/workflow-registry.ts
+++ b/packages/domain/queue/src/workflow-registry.ts
@@ -54,6 +54,16 @@ const _registry = {
     readonly apiKeyId: string
     readonly timelineAnchorIso: string
   }>(),
+  taxonomyNameClusterWorkflow: input<{
+    readonly organizationId: string
+    readonly projectId: string
+    readonly clusterId: string
+  }>(),
+  taxonomyNameCategoryWorkflow: input<{
+    readonly organizationId: string
+    readonly projectId: string
+    readonly categoryId: string
+  }>(),
 }
 
 export type WorkflowRegistry = typeof _registry

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -171,8 +171,12 @@ export const TAXONOMY_CATEGORY_CONTINUATION_THRESHOLD = 0.8
 export const TAXONOMY_SEARCH_MIN_SCORE = 0.2
 export const TAXONOMY_SEARCH_MIN_VECTOR_SIMILARITY = 0.5
 
-export const TAXONOMY_NAMING_MODEL = { provider: "anthropic", model: "claude-haiku-4-5" } as const
+export const TAXONOMY_NAMING_MODEL = {
+  provider: "amazon-bedrock",
+  model: "minimax.minimax-m2.5",
+} as const
 export const TAXONOMY_NAMING_REFRESH_OBSERVATIONS = 25
+export const TAXONOMY_NAMING_TIMEOUT_MS = 60_000
 
 export const TAXONOMY_FPS_SAMPLE_BUDGET_MIN = 4
 export const TAXONOMY_FPS_SAMPLE_BUDGET_MAX = 12

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -169,6 +169,8 @@ export {
   getClusterTrendUseCase,
   getLastRunUseCase,
   getTaxonomyAnalyticsUseCase,
+  type TaxonomyClusterTrendStatus,
+  type TaxonomyClusterTrendSummary,
   type TopTaxonomyCluster,
 } from "./use-cases/analytics.ts"
 export {

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -160,13 +160,10 @@ export {
   type TaxonomyRunRepositoryShape,
 } from "./ports/taxonomy-run-repository.ts"
 export {
-  type GetClusterTrendInput,
-  type GetClusterTrendResult,
   type GetLastRunInput,
   type GetLastRunResult,
   type GetTaxonomyAnalyticsInput,
   type GetTaxonomyAnalyticsResult,
-  getClusterTrendUseCase,
   getLastRunUseCase,
   getTaxonomyAnalyticsUseCase,
   type TaxonomyClusterTrendStatus,

--- a/packages/domain/taxonomy/src/ports/behavior-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/behavior-observation-repository.ts
@@ -45,6 +45,13 @@ export interface BehaviorObservationClusterOccurrence {
   readonly count: number
 }
 
+export interface BehaviorObservationClusterTrendCounts {
+  readonly clusterId: TaxonomyClusterId
+  readonly currentCount: number
+  readonly baselineCount: number
+  readonly baselineDays: number
+}
+
 export interface ReassignObservationInput {
   readonly observation: TaxonomyObservation
   readonly assignedClusterId: TaxonomyClusterId
@@ -96,6 +103,14 @@ export interface BehaviorObservationRepositoryShape {
     readonly since: Date
     readonly limit: number
   }): Effect.Effect<readonly BehaviorObservationClusterOccurrence[], RepositoryError, ChSqlClient>
+  getClusterTrendCounts(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly clusterIds: readonly TaxonomyClusterId[]
+    readonly currentSince: Date
+    readonly baselineSince: Date
+    readonly baselineDays: number
+  }): Effect.Effect<readonly BehaviorObservationClusterTrendCounts[], RepositoryError, ChSqlClient>
 }
 
 export class BehaviorObservationRepository extends Context.Service<

--- a/packages/domain/taxonomy/src/testing/fake-behavior-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-behavior-observation-repository.ts
@@ -140,6 +140,26 @@ export const createFakeBehaviorObservationRepository = (
           .map(([clusterId, count]) => ({ clusterId: clusterId as never, count }))
       }),
 
+    getClusterTrendCounts: ({ organizationId, projectId, clusterIds, currentSince, baselineSince, baselineDays }) =>
+      Effect.sync(() =>
+        clusterIds.map((clusterId) => {
+          let currentCount = 0
+          let baselineCount = 0
+          for (const observation of rows.values()) {
+            if (
+              observation.organizationId !== organizationId ||
+              observation.projectId !== projectId ||
+              observation.assignedClusterId !== clusterId ||
+              observation.startTime < baselineSince
+            )
+              continue
+            if (observation.startTime >= currentSince) currentCount++
+            else baselineCount++
+          }
+          return { clusterId, currentCount, baselineCount, baselineDays }
+        }),
+      ),
+
     ...overrides,
   }
 

--- a/packages/domain/taxonomy/src/use-cases/analytics.ts
+++ b/packages/domain/taxonomy/src/use-cases/analytics.ts
@@ -33,9 +33,20 @@ export interface GetTaxonomyAnalyticsInput {
   readonly now?: Date
 }
 
+export type TaxonomyClusterTrendStatus = "new" | "spike" | "rising" | "steady" | "cooling" | "fading"
+
+export interface TaxonomyClusterTrendSummary {
+  readonly status: TaxonomyClusterTrendStatus
+  readonly currentCount: number
+  readonly baselineCount: number
+  readonly baselineDailyAverage: number
+  readonly ratio: number | null
+}
+
 export interface TopTaxonomyCluster {
   readonly cluster: TaxonomyCluster
   readonly occurrences: number
+  readonly trend: TaxonomyClusterTrendSummary
 }
 
 export interface GetTaxonomyAnalyticsResult {
@@ -57,12 +68,64 @@ export interface GetLastRunResult {
 }
 
 const MS_PER_DAY = 24 * 60 * 60_000
+const TREND_CURRENT_DAYS = 1
+const TREND_BASELINE_DAYS = 7
 
 const startOfUtcDay = (date: Date): Date =>
   new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
 const dayKey = (date: Date): string => startOfUtcDay(date).toISOString().slice(0, 10)
 const windowStart = (now: Date, windowDays: number): Date =>
   startOfUtcDay(new Date(now.getTime() - (windowDays - 1) * MS_PER_DAY))
+
+const classifyClusterTrend = (input: {
+  readonly currentCount: number
+  readonly baselineCount: number
+  readonly baselineDays: number
+}): TaxonomyClusterTrendSummary => {
+  const baselineDailyAverage = input.baselineDays > 0 ? input.baselineCount / input.baselineDays : 0
+  const ratio = baselineDailyAverage > 0 ? input.currentCount / baselineDailyAverage : null
+
+  if (input.baselineCount === 0 && input.currentCount > 0) {
+    return { status: "new", currentCount: input.currentCount, baselineCount: 0, baselineDailyAverage, ratio: null }
+  }
+  if (input.currentCount === 0 && input.baselineCount >= 3) {
+    return { status: "fading", currentCount: 0, baselineCount: input.baselineCount, baselineDailyAverage, ratio }
+  }
+  if (input.currentCount >= 5 && ratio !== null && ratio >= 3) {
+    return {
+      status: "spike",
+      currentCount: input.currentCount,
+      baselineCount: input.baselineCount,
+      baselineDailyAverage,
+      ratio,
+    }
+  }
+  if (input.currentCount >= 2 && ratio !== null && ratio >= 1.5) {
+    return {
+      status: "rising",
+      currentCount: input.currentCount,
+      baselineCount: input.baselineCount,
+      baselineDailyAverage,
+      ratio,
+    }
+  }
+  if (ratio !== null && ratio <= 0.5) {
+    return {
+      status: "cooling",
+      currentCount: input.currentCount,
+      baselineCount: input.baselineCount,
+      baselineDailyAverage,
+      ratio,
+    }
+  }
+  return {
+    status: "steady",
+    currentCount: input.currentCount,
+    baselineCount: input.baselineCount,
+    baselineDailyAverage,
+    ratio,
+  }
+}
 
 export const getClusterTrendUseCase = (input: GetClusterTrendInput) =>
   Effect.gen(function* () {
@@ -109,11 +172,24 @@ export const getTaxonomyAnalyticsUseCase = (input: GetTaxonomyAnalyticsInput) =>
       since,
       limit: 5,
     })
-    const topClusterRows = yield* clusters.listByIds(topOccurrences.map((row) => row.clusterId))
+    const topClusterIds = topOccurrences.map((row) => row.clusterId)
+    const topClusterRows = yield* clusters.listByIds(topClusterIds)
+    const trendCounts = yield* observations.getClusterTrendCounts({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      clusterIds: topClusterIds,
+      currentSince: new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY),
+      baselineSince: new Date(now.getTime() - (TREND_CURRENT_DAYS + TREND_BASELINE_DAYS) * MS_PER_DAY),
+      baselineDays: TREND_BASELINE_DAYS,
+    })
     const clusterById = new Map(topClusterRows.map((cluster) => [cluster.id, cluster] as const))
+    const trendByClusterId = new Map(trendCounts.map((trend) => [trend.clusterId, trend] as const))
     const topClusters = topOccurrences.flatMap((row) => {
       const cluster = clusterById.get(row.clusterId)
-      return cluster && cluster.state === "active" ? [{ cluster, occurrences: row.count }] : []
+      const trend = trendByClusterId.get(row.clusterId)
+      return cluster && cluster.state === "active" && trend
+        ? [{ cluster, occurrences: row.count, trend: classifyClusterTrend(trend) }]
+        : []
     })
     const allActiveClusters = yield* clusters.listActiveByProject({
       projectId: input.projectId,

--- a/packages/domain/taxonomy/src/use-cases/analytics.ts
+++ b/packages/domain/taxonomy/src/use-cases/analytics.ts
@@ -1,6 +1,5 @@
-import type { OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import type { OrganizationId, ProjectId } from "@domain/shared"
 import { Effect } from "effect"
-import { TAXONOMY_LIST_ALL_BY_CLUSTER_MAX } from "../constants.ts"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
 import type { TaxonomyClusterLineage, TaxonomyRun } from "../entities/lineage.ts"
 import { BehaviorObservationRepository } from "../ports/behavior-observation-repository.ts"
@@ -8,23 +7,6 @@ import { TaxonomyCategoryRepository } from "../ports/taxonomy-category-repositor
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import { TaxonomyLineageRepository } from "../ports/taxonomy-lineage-repository.ts"
 import { TaxonomyRunRepository } from "../ports/taxonomy-run-repository.ts"
-
-export interface GetClusterTrendInput {
-  readonly organizationId: OrganizationId
-  readonly projectId: ProjectId
-  readonly clusterId: TaxonomyClusterId
-  readonly windowDays?: number
-  readonly now?: Date
-}
-
-interface ClusterTrendBucket {
-  readonly date: string
-  readonly count: number
-}
-
-export interface GetClusterTrendResult {
-  readonly buckets: readonly ClusterTrendBucket[]
-}
 
 export interface GetTaxonomyAnalyticsInput {
   readonly organizationId: OrganizationId
@@ -73,7 +55,6 @@ const TREND_BASELINE_DAYS = 7
 
 const startOfUtcDay = (date: Date): Date =>
   new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
-const dayKey = (date: Date): string => startOfUtcDay(date).toISOString().slice(0, 10)
 const windowStart = (now: Date, windowDays: number): Date =>
   startOfUtcDay(new Date(now.getTime() - (windowDays - 1) * MS_PER_DAY))
 
@@ -126,32 +107,6 @@ const classifyClusterTrend = (input: {
     ratio,
   }
 }
-
-export const getClusterTrendUseCase = (input: GetClusterTrendInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("taxonomy.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("taxonomy.clusterId", input.clusterId)
-    const observations = yield* BehaviorObservationRepository
-    const now = input.now ?? new Date()
-    const days = Math.max(input.windowDays ?? 14, 1)
-    const since = windowStart(now, days)
-    const counts = new Map<string, number>()
-    for (let index = 0; index < days; index++) {
-      counts.set(dayKey(new Date(since.getTime() + index * MS_PER_DAY)), 0)
-    }
-    const rows = yield* observations.listAllByCluster({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      clusterId: input.clusterId,
-      limit: TAXONOMY_LIST_ALL_BY_CLUSTER_MAX,
-    })
-    for (const row of rows) {
-      if (row.startTime < since || row.startTime > now) continue
-      const key = dayKey(row.startTime)
-      counts.set(key, (counts.get(key) ?? 0) + 1)
-    }
-    return { buckets: [...counts.entries()].map(([date, count]) => ({ date, count })) } satisfies GetClusterTrendResult
-  }).pipe(Effect.withSpan("taxonomy.getClusterTrend"))
 
 export const getTaxonomyAnalyticsUseCase = (input: GetTaxonomyAnalyticsInput) =>
   Effect.gen(function* () {

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -7,6 +7,7 @@ import {
   TAXONOMY_FPS_SAMPLE_BUDGET_MIN,
   TAXONOMY_LIST_ALL_BY_CLUSTER_MAX,
   TAXONOMY_NAMING_MODEL,
+  TAXONOMY_NAMING_TIMEOUT_MS,
 } from "../constants.ts"
 import type { TaxonomyCategory } from "../entities/category.ts"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
@@ -47,30 +48,61 @@ const sampleBudget = (count: number): number =>
     clamp(Math.round(Math.log2(count + 1)) * 2, TAXONOMY_FPS_SAMPLE_BUDGET_MIN, TAXONOMY_FPS_SAMPLE_BUDGET_MAX),
   )
 
-const generateName = (input: { readonly subject: "cluster" | "category"; readonly samples: readonly string[] }) =>
-  Effect.gen(function* () {
-    const ai = yield* AI
-    const sampleLines = input.samples.map((sample, index) => `${index}: ${sample}`).join("\n")
-    const map = yield* ai.generate({
-      provider: TAXONOMY_NAMING_MODEL.provider,
-      model: TAXONOMY_NAMING_MODEL.model,
-      system: `proposeCandidateThemes: propose concise candidate themes for this behavior taxonomy ${input.subject}. Return only schema-valid JSON.`,
-      prompt: `Samples:\n${sampleLines}`,
-      schema: candidateThemesSchema,
-      temperature: 0.2,
-      maxTokens: 800,
-    })
-    const reduced = yield* ai.generate({
-      provider: TAXONOMY_NAMING_MODEL.provider,
-      model: TAXONOMY_NAMING_MODEL.model,
-      system: `Collapse candidate themes into one clear behavior taxonomy ${input.subject} name and description. Return only schema-valid JSON.`,
-      prompt: `Samples:\n${sampleLines}\n\nCandidates:\n${JSON.stringify(map.object.candidates)}`,
-      schema: finalNameSchema,
-      temperature: 0.2,
-      maxTokens: 500,
-    })
-    return reduced.object
-  })
+const withNamingTimeout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.timeoutOrElse({
+      duration: TAXONOMY_NAMING_TIMEOUT_MS,
+      orElse: () => Effect.fail(new Error("Taxonomy naming timed out")),
+    }),
+  )
+
+const generateClusterName = (input: { readonly samples: readonly string[] }) =>
+  withNamingTimeout(
+    Effect.gen(function* () {
+      const ai = yield* AI
+      const sampleLines = input.samples.map((sample, index) => `${index}: ${sample}`).join("\n")
+      const map = yield* ai.generate({
+        provider: TAXONOMY_NAMING_MODEL.provider,
+        model: TAXONOMY_NAMING_MODEL.model,
+        system:
+          "proposeCandidateThemes: propose concise candidate themes for this behavior taxonomy cluster. Return only schema-valid JSON.",
+        prompt: `Samples:\n${sampleLines}`,
+        schema: candidateThemesSchema,
+        temperature: 0.2,
+        maxTokens: 800,
+      })
+      const reduced = yield* ai.generate({
+        provider: TAXONOMY_NAMING_MODEL.provider,
+        model: TAXONOMY_NAMING_MODEL.model,
+        system:
+          "Collapse candidate themes into one clear behavior taxonomy cluster name and description. Return only schema-valid JSON with BOTH required string keys: name and description.",
+        prompt: `Samples:\n${sampleLines}\n\nCandidates:\n${JSON.stringify(map.object.candidates)}\n\nReturn JSON exactly like {"name":"Short behavior label","description":"One sentence describing the repeated behavior."}`,
+        schema: finalNameSchema,
+        temperature: 0.2,
+        maxTokens: 1600,
+      })
+      return reduced.object
+    }),
+  )
+
+const generateCategoryName = (input: { readonly samples: readonly string[] }) =>
+  withNamingTimeout(
+    Effect.gen(function* () {
+      const ai = yield* AI
+      const sampleLines = input.samples.map((sample, index) => `${index}: ${sample}`).join("\n")
+      const generated = yield* ai.generate({
+        provider: TAXONOMY_NAMING_MODEL.provider,
+        model: TAXONOMY_NAMING_MODEL.model,
+        system:
+          "Name this customer-support behavior taxonomy category from its member clusters. Use business/domain language from the cluster names and descriptions. Do not mention taxonomy mechanics, pending states, uncategorized behaviors, clustering, or assignment. Return only schema-valid JSON with BOTH required string keys: name and description.",
+        prompt: `Member clusters:\n${sampleLines}\n\nWrite a user-facing category label that summarizes what these behaviors are about. Bad labels: Pending States, Uncategorized Behaviors, Miscellaneous, Other. Good labels: Order Management Requests, Flight Booking Support, Customer Information Gathering.\n\nReturn JSON exactly like {"name":"Short customer-support category label","description":"One sentence describing what these related customer behaviors have in common."}`,
+        schema: finalNameSchema,
+        temperature: 0.2,
+        maxTokens: 800,
+      })
+      return generated.object
+    }),
+  )
 
 export const nameClusterUseCase = (input: NameClusterInput) =>
   Effect.gen(function* () {
@@ -92,7 +124,7 @@ export const nameClusterUseCase = (input: NameClusterInput) =>
       sampleBudget(cluster.observationCount),
     )
     const samples = selected.map((index) => ranked[index]?.summary).filter((summary) => summary !== undefined)
-    const generated = yield* generateName({ subject: "cluster", samples })
+    const generated = yield* generateClusterName({ samples })
     yield* clusters.save({
       ...cluster,
       name: generated.name,
@@ -117,6 +149,17 @@ export const nameCategoryUseCase = (input: NameCategoryInput) =>
       (cluster) =>
         cluster.parentCategoryId === input.categoryId && normalizeTaxonomyCentroid(cluster.centroid).length > 0,
     )
+    const unnamedMemberClusters = memberClusters.filter(
+      (cluster) => cluster.name === "Pending" || cluster.description.trim().length === 0,
+    )
+    if (unnamedMemberClusters.length > 0) {
+      return yield* Effect.fail(
+        new Error(
+          `Cannot name taxonomy category until member clusters are named (${unnamedMemberClusters.length.toString()} pending)`,
+        ),
+      )
+    }
+
     const selected = farthestPointSample(
       memberClusters.map((cluster) => normalizeTaxonomyCentroid(cluster.centroid)),
       sampleBudget(memberClusters.length),
@@ -125,7 +168,10 @@ export const nameCategoryUseCase = (input: NameCategoryInput) =>
       .map((index) => memberClusters[index])
       .filter((cluster) => cluster !== undefined)
       .map((cluster) => `${cluster.name}: ${cluster.description}`)
-    const generated = yield* generateName({ subject: "category", samples })
+    const generated = yield* generateCategoryName({ samples })
+    if (/pending|uncategorized|miscellaneous|other behaviors/i.test(generated.name)) {
+      return yield* Effect.fail(new Error(`Generated unusable taxonomy category name: ${generated.name}`))
+    }
     yield* categories.save({
       ...category,
       name: generated.name,

--- a/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/name-taxonomy.ts
@@ -169,7 +169,7 @@ export const nameCategoryUseCase = (input: NameCategoryInput) =>
       .filter((cluster) => cluster !== undefined)
       .map((cluster) => `${cluster.name}: ${cluster.description}`)
     const generated = yield* generateCategoryName({ samples })
-    if (/pending|uncategorized|miscellaneous|other behaviors/i.test(generated.name)) {
+    if (/\bpending\s+states?\b|\buncategorized\b|\bmiscellaneous\b|\bother\s+behaviors?\b/i.test(generated.name)) {
       return yield* Effect.fail(new Error(`Generated unusable taxonomy category name: ${generated.name}`))
     }
     yield* categories.save({

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -28,7 +28,7 @@ import { createFakeTaxonomyCategoryRepository } from "../testing/fake-taxonomy-c
 import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
 import { createFakeTaxonomyLineageRepository } from "../testing/fake-taxonomy-lineage-repository.ts"
 import { createFakeTaxonomyRunRepository } from "../testing/fake-taxonomy-run-repository.ts"
-import { getClusterTrendUseCase, getLastRunUseCase, getTaxonomyAnalyticsUseCase } from "./analytics.ts"
+import { getLastRunUseCase, getTaxonomyAnalyticsUseCase } from "./analytics.ts"
 import { getCategoryDetailsUseCase, getClusterDetailsUseCase } from "./get-details.ts"
 import { listCategoriesUseCase } from "./list-categories.ts"
 import { listClustersInCategoryUseCase, listClustersUseCase } from "./list-clusters.ts"
@@ -410,33 +410,6 @@ describe("listObservationsInClusterUseCase", () => {
 })
 
 describe("analytics read use-cases", () => {
-  it("gets a cluster trend for the requested window", async () => {
-    const clusterId = TaxonomyClusterId("t".repeat(24))
-    const observations = createFakeBehaviorObservationRepository([
-      { ...makeObservation(1, clusterId), startTime: new Date("2026-05-23T10:00:00.000Z") },
-      { ...makeObservation(2, clusterId), startTime: new Date("2026-05-24T10:00:00.000Z") },
-      { ...makeObservation(3, clusterId), startTime: new Date("2026-05-24T11:00:00.000Z") },
-    ])
-
-    const result = await Effect.runPromise(
-      getClusterTrendUseCase({
-        organizationId,
-        projectId,
-        clusterId,
-        windowDays: 2,
-        now: new Date("2026-05-24T12:00:00.000Z"),
-      }).pipe(
-        Effect.provide(Layer.succeed(BehaviorObservationRepository, observations.repository)),
-        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
-      ),
-    )
-
-    expect(result.buckets).toEqual([
-      { date: "2026-05-23", count: 1 },
-      { date: "2026-05-24", count: 2 },
-    ])
-  })
-
   it("gets taxonomy analytics counts and top clusters", async () => {
     const categories = createFakeTaxonomyCategoryRepository([
       makeCategory({ id: TaxonomyCategoryId("a".repeat(24)) }),

--- a/packages/domain/taxonomy/src/use-cases/run-project-gardening.ts
+++ b/packages/domain/taxonomy/src/use-cases/run-project-gardening.ts
@@ -8,14 +8,11 @@ import {
 import type { TaxonomyClusterLineage, TaxonomyRunTrigger } from "../entities/lineage.ts"
 import { TaxonomyGardeningTimeoutError } from "../errors.ts"
 import { BehaviorObservationRepository } from "../ports/behavior-observation-repository.ts"
-import { TaxonomyCategoryRepository } from "../ports/taxonomy-category-repository.ts"
-import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import { TaxonomyLockRepository } from "../ports/taxonomy-lock-repository.ts"
 import { TaxonomyRunRepository } from "../ports/taxonomy-run-repository.ts"
 import { deprecateInactiveClustersUseCase } from "./deprecate-inactive-clusters.ts"
 import { emitLineageUseCase } from "./emit-lineage.ts"
 import { mergeNearDuplicateClustersUseCase } from "./merge-near-duplicate-clusters.ts"
-import { nameCategoryUseCase, nameClusterUseCase } from "./name-taxonomy.ts"
 import { reassignNoiseToCurrentClustersUseCase } from "./reassign-noise-to-current-clusters.ts"
 import { rebuildCategoryHierarchyUseCase } from "./rebuild-category-hierarchy.ts"
 import { sweepNoiseAndBirthClustersUseCase } from "./sweep-noise-and-birth-clusters.ts"
@@ -50,8 +47,6 @@ export const runProjectGardeningUseCase = (input: RunProjectGardeningInput) =>
     yield* Effect.annotateCurrentSpan("taxonomy.projectId", input.projectId)
     const locks = yield* TaxonomyLockRepository
     const runs = yield* TaxonomyRunRepository
-    const clusters = yield* TaxonomyClusterRepository
-    const categories = yield* TaxonomyCategoryRepository
     const observations = yield* BehaviorObservationRepository
     const startedAt = input.now ?? new Date()
     const runId = TaxonomyRunId(generateId())
@@ -126,38 +121,6 @@ export const runProjectGardeningUseCase = (input: RunProjectGardeningInput) =>
             projectId: input.projectId,
             now,
           })
-
-          const bornClusterIds = new Set(
-            lineage.flatMap((row) => (row.transitionType === "birth" ? row.toClusterIds : [])),
-          )
-          const activeClusters = yield* clusters.listActiveByProject({
-            projectId: input.projectId,
-          })
-          for (const cluster of activeClusters) {
-            if (bornClusterIds.has(cluster.id) || cluster.name === "Pending") {
-              yield* nameClusterUseCase({
-                organizationId: input.organizationId,
-                projectId: input.projectId,
-                clusterId: cluster.id,
-                now,
-              })
-            }
-          }
-
-          const activeCategories = yield* categories.listByProject({
-            projectId: input.projectId,
-            state: "active",
-          })
-          for (const category of activeCategories) {
-            if (category.name === "Pending") {
-              yield* nameCategoryUseCase({
-                organizationId: input.organizationId,
-                projectId: input.projectId,
-                categoryId: category.id,
-                now,
-              })
-            }
-          }
 
           yield* emitLineageUseCase({ transitions: lineage })
 

--- a/packages/platform/db-clickhouse/src/repositories/behavior-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/behavior-observation-repository.ts
@@ -324,6 +324,55 @@ export const BehaviorObservationRepositoryLive = Layer.effect(
               ),
             )
         }),
+
+      getClusterTrendCounts: ({ organizationId, projectId, clusterIds, currentSince, baselineSince, baselineDays }) =>
+        Effect.gen(function* () {
+          if (clusterIds.length === 0) return []
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                          assigned_cluster_id AS cluster_id,
+                          countIf(start_time >= {currentSince:DateTime64(9, 'UTC')}) AS current_count,
+                          countIf(start_time >= {baselineSince:DateTime64(9, 'UTC')} AND start_time < {currentSince:DateTime64(9, 'UTC')}) AS baseline_count
+                        FROM behavior_observations FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND assigned_cluster_id IN {clusterIds:Array(String)}
+                          AND start_time >= {baselineSince:DateTime64(9, 'UTC')}
+                        GROUP BY assigned_cluster_id`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  clusterIds: clusterIds as readonly string[],
+                  currentSince: toClickhouseDateTime(currentSince),
+                  baselineSince: toClickhouseDateTime(baselineSince),
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<{
+                cluster_id: string
+                current_count: string | number
+                baseline_count: string | number
+              }>()
+              const rowByClusterId = new Map(rows.map((row) => [row.cluster_id, row]))
+              return clusterIds.map((clusterId) => {
+                const row = rowByClusterId.get(clusterId as string)
+                return {
+                  clusterId,
+                  currentCount: Number(row?.current_count ?? 0),
+                  baselineCount: Number(row?.baseline_count ?? 0),
+                  baselineDays,
+                }
+              })
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "BehaviorObservationRepository.getClusterTrendCounts"),
+              ),
+            )
+        }),
     }
   }),
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@domain/spans':
         specifier: workspace:*
         version: link:../../packages/domain/spans
+      '@domain/taxonomy':
+        specifier: workspace:*
+        version: link:../../packages/domain/taxonomy
       '@domain/users':
         specifier: workspace:*
         version: link:../../packages/domain/users
@@ -785,6 +788,9 @@ importers:
       '@domain/spans':
         specifier: workspace:*
         version: link:../../packages/domain/spans
+      '@domain/taxonomy':
+        specifier: workspace:*
+        version: link:../../packages/domain/taxonomy
       '@platform/ai':
         specifier: workspace:*
         version: link:../../packages/platform/ai

--- a/specs/live-taxonomy.md
+++ b/specs/live-taxonomy.md
@@ -1,0 +1,994 @@
+# Live Behavior Taxonomy
+
+> **Documentation**: `dev-docs/taxonomy.md` (to be created), `dev-docs/spans.md`, `dev-docs/issues.md`
+
+A dynamic, project-scoped 2-level taxonomy of behaviors (user + agent) extracted from ingested traces. The taxonomy evolves as new traffic arrives: new behavior types are born from a noise bucket, existing categories absorb similar incoming sessions, and labels are LLM-named from cluster contents. The MVP is **TypeScript-orchestrated with a single Python sidecar** for the births step (UMAP + HDBSCAN), reusing the patterns proven by `@domain/issues` (running decayed centroid math, pgvector hybrid retrieval), `@platform/db-clickhouse` trace-search (org-scoped append-only embedding rows with TTL), and `@platform/op-gepa` (Python RPC engine with a TS client wrapping it).
+
+The product surface (out of scope for the MVP backend, but worth fixing in mind) is a single project-scoped page showing categories and their member clusters, with example sessions per cluster:
+
+```
+Billing
+  ├─ User requested cancellation                     1,243 sessions   ↑12%
+  ├─ Agent failed to comply with cancellation         347 sessions   ↑45%
+  └─ User asked about refund policy                   512 sessions    →
+Product feedback
+  ├─ User complained about not finding settings        88 sessions   new
+  ├─ User reported broken integration                  41 sessions   new
+  └─ User praised the assistant                       219 sessions    →
+Onboarding
+  └─ User stuck on signup flow                        163 sessions   ↑8%
+```
+
+## Shape of the MVP
+
+The pipeline has a small number of moving parts and they sit at deliberate scales:
+
+- **One observation per session.** Sessions are the durable conversational boundary in this product (see `specs/session-problems/`). In-session segmentation by cosine drift is reasonable Future Work.
+- **2-level hierarchy: Category → Cluster.** Matches the product mockup. 3+ levels are reasonable Future Work.
+- **Online assignment via pgvector exact cosine.** Per-project cluster counts are hundreds to low-thousands; brute-force exact cosine over the `(organization_id, project_id)` partition is sub-ms. Same pattern as `@domain/issues`.
+- **Two-gate assignment (absolute + relative).** Either gate alone runs at ~5% false-assignment in published baselines; combined drops to ~2–3%. Cheap to implement, matches user intuition ("assign only if there's a clearly best match and it's actually close").
+- **Periodic gardening pass per project.** Births new clusters from noise, merges near-duplicates, deprecates dead clusters, rebuilds the category hierarchy, and LLM-names changed clusters.
+- **Births use UMAP + HDBSCAN via a Python sidecar** (`@platform/op-taxonomy-engine`, mirrors `@platform/op-gepa`). This is the one place we don't compromise: launching with medium+ tenants on day 1, the variable-density quality gap between fixed-threshold single-linkage and HDBSCAN is observable in the product surface (chained mega-clusters and over-split niches), so we take the Python sidecar cost on day 1.
+- **Category roll-up uses pure-TS agglomerative average-linkage** over leaf-cluster centroids. Sub-millisecond at the 5–15 category count this targets; engine RPC would be artificial overhead.
+- **Cluster labeling via Farthest-Point Sampling** over each cluster's member observation summaries, then map+reduce LLM calls to produce the final name + description.
+- **Lineage** is recorded inline as births/merges happen (simple `Birth | Death | Continuation | Split | Merge` transition rows). A fuller Hungarian + secondary-link lineage matcher is documented under Future Work.
+- **Named constants for every threshold**, seeded from a benchmark corpus and a tuning pass on the seeded Acme corpus. Bayesian / automated retuning is Future Work.
+
+The architectural bet is that for the **per-tenant** scale this product actually runs at, a careful online-assignment + scheduled-gardening loop on top of pgvector + ClickHouse is sufficient to ship the product, with the Python engine carrying the one piece where quality matters most. If a tenant ever crosses the scale where exact pgvector cosine stops being instant on the online path, the existing trace-search HNSW/vector-similarity work is the natural upgrade path; nothing in this MVP design forecloses it.
+
+## Scope
+
+- **Per-session unit.** The clustered entity is one *behavior observation* per `(organizationId, projectId, sessionId)`. Multi-trace sessions are clustered once across all their traces.
+- **Forward-only.** Sessions that complete after rollout are clustered. There is no first-class customer backfill in the product UI. Re-enqueueing past sessions through the worker works mechanically but is operational, not productized.
+- **Project-scoped.** Every query, every centroid, every Redis key is `(organizationId, projectId)`-keyed. No cross-project, no cross-organization clustering.
+- **2-level hierarchy.** Top-level Categories (`"Billing"`, `"Product feedback"`) own leaf Clusters (`"User requested cancellation"`). Sub-leaf or category-of-category structure is Future Work.
+- **One canonical assignment per session.** An observation lands in exactly one leaf cluster (or in the noise bucket). Multi-label assignment is Future Work; in-session segmentation is Future Work.
+- **Backend MVP only.** The PRD-level product surface in the opening illustration drives the data shape and the read endpoints, but no frontend work is part of this spec. Read use-cases ship as plain `@domain/taxonomy` use-cases consumable by `apps/web` server functions when the UI lands.
+
+## Glossary
+
+The vocabulary below is canonical. Code, dev-docs, and the product surface use these exact terms.
+
+- **Observation** — one clustered behavior unit per session. Carries `summary`, `embedding`, `assignedClusterId`, `assignmentConfidence`, `assignmentMethod`. Stored append-only in ClickHouse `behavior_observations`.
+- **Cluster** — a leaf taxonomy node. Carries a running weighted-decayed centroid, derived pgvector column, LLM-generated `name` and `description`, lifecycle state, and an optional `parentCategoryId`. Stored canonically in Postgres `taxonomy_clusters`.
+- **Category** — a top-level grouping over clusters (e.g. `"Billing"`). Derived during gardening from the centroids of its member clusters. Stored canonically in Postgres `taxonomy_categories`.
+- **Centroid** — the same running weighted-decayed-sum shape as `@domain/issues` (`{ base, mass, model, decay, weights }`), with a derived normalized `vector(2048)` column materialized inside the repository `save`. Decay anchor is a dedicated `clusteredAt`, not `updatedAt`. See `dev-docs/issues.md#centroids`.
+- **Assignment** — the act of attaching a fresh observation to an existing cluster. Decided by the two-gate rule (absolute cosine ≥ `TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD` *and* softmax relative-margin ≥ `TAXONOMY_ASSIGN_RELATIVE_MARGIN`).
+- **Noise bucket** — observations that fail to assign live in the noise bucket. The bucket is a ClickHouse predicate (`assigned_cluster_id = ''`), not a separate table.
+- **Gardening** — the offline pass per project that births clusters from the noise bucket, merges near-duplicates, rebuilds the category hierarchy, and renames changed clusters. Runs at most once per `TAXONOMY_GARDENING_THROTTLE_MS` per project, plus a periodic cron sweep.
+- **Lineage** — the typed transition record between two gardening runs: `Continuation`, `Birth`, `Death`, `Split`, `Merge`. Stored append-only in Postgres `taxonomy_cluster_lineage`.
+- **Confidence** — the cosine similarity of an observation to its assigned cluster's centroid at assignment time. Persisted on the observation row.
+
+## Dependencies & preconditions
+
+- **Session materialization parity** (`specs/session-problems/1-parity-traces-sessions.md`). The taxonomy clusters at session granularity using the canonical synthesized `session_id` (`coalesce(nullIf(session_id, ''), toString(trace_id))`) so orphan traces become 1-trace sessions and every trace is covered exactly once. Until that lands, the taxonomy worker reads `traces.session_id` directly and applies the same coalesce inline; the canonical column from session-materialization should be substituted on landing.
+- **Voyage embedding + Redis cache layer** (`@platform/ai`, `@platform/ai-voyage`). Already in place; the taxonomy worker reuses `withAi(AIEmbedLive, redisClient)` exactly as trace-search does.
+- **LLM structured generation via `@platform/ai-vercel`** (`AIGenerateLive`). Already in place; the taxonomy worker uses `AI.generate({ schema, system, prompt, ... })` for summarization and naming.
+- **`trace-end:run` debounce boundary** (`apps/workers/src/workers/trace-end.ts`). The taxonomy worker hooks the same dispatch point trace-search already uses.
+- **Python clustering engine sidecar** (`@platform/op-taxonomy-engine`, new). Single-purpose RPC service exposing `noiseSweep({ embeddings, minClusterSize, minSamples, umapNComponents, umapNNeighbors, randomSeed }) → { assignments, outlierScores }`. Mirrors the `@platform/op-gepa` shape exactly: Python `op_taxonomy_engine` package using `uv` + `pyproject.toml` + the same RPC protocol as op-gepa; TS client `@platform/op-taxonomy-engine` wrapping it. Dependencies: `numpy`, `scikit-learn-contrib hdbscan`, `umap-learn`. The engine is stateless — embeddings in, assignments out, no DB access.
+
+## Data model
+
+### Postgres — `taxonomy_clusters`
+
+Canonical leaf-cluster row. Mirrors the `issues` shape: JSONB centroid + derived `vector(2048)` + GIN-indexed `tsvector`.
+
+```text
+taxonomy_clusters
+├─ id                       cuid          PRIMARY KEY
+├─ organization_id          cuid          NOT NULL
+├─ project_id               cuid          NOT NULL
+├─ parent_category_id       cuid          NULL    -- nullable while uncategorized
+├─ name                     text          NOT NULL
+├─ description              text          NOT NULL
+├─ centroid                 jsonb         NOT NULL  -- TaxonomyCentroid (see Helpers)
+├─ centroid_embedding       vector(2048)  NULL     -- derived from centroid on save
+├─ search_document          tsvector      GENERATED ALWAYS AS (
+│                             setweight(to_tsvector('english', name),        'A') ||
+│                             setweight(to_tsvector('english', description), 'B')
+│                           ) STORED
+├─ observation_count        bigint        NOT NULL DEFAULT 0
+├─ state                    text          NOT NULL DEFAULT 'active'
+│                                          -- 'active' | 'merged' | 'deprecated'
+├─ merged_into_cluster_id   cuid          NULL    -- set when state = 'merged'
+├─ first_observed_at        timestamptz   NOT NULL
+├─ last_observed_at         timestamptz   NOT NULL
+├─ clustered_at             timestamptz   NOT NULL  -- decay anchor, NOT updated_at
+├─ created_at, updated_at   timestamptz   NOT NULL
+└─ INDEXES
+   ├─ btree (organization_id, project_id, state, last_observed_at)
+   ├─ btree (organization_id, project_id, parent_category_id)
+   └─ GIN   (search_document)
+```
+
+**No IVFFlat/HNSW index on `centroid_embedding`.** Per-project cluster count is expected in the hundreds, low thousands at worst; exact sequential scan under the `(organization_id, project_id)` prefix outperforms any approximate index at that scale. Same rule as `@domain/issues`.
+
+### Postgres — `taxonomy_categories`
+
+Top-level grouping. The MVP keeps categories as their own table (rather than a `parent_cluster_id` self-link on `taxonomy_clusters`) so that:
+
+- a category can carry its own LLM-generated name/description independent of any single leaf,
+- a category can survive its members being merged/split,
+- the derived `centroid_embedding` over member clusters can be persisted for fast read.
+
+```text
+taxonomy_categories
+├─ id                       cuid          PRIMARY KEY
+├─ organization_id          cuid          NOT NULL
+├─ project_id               cuid          NOT NULL
+├─ name                     text          NOT NULL
+├─ description              text          NOT NULL
+├─ centroid_embedding       vector(2048)  NULL     -- mean-of-member-cluster-centroids, normalized
+├─ search_document          tsvector      GENERATED ALWAYS AS (...)
+├─ cluster_count            integer       NOT NULL DEFAULT 0
+├─ observation_count        bigint        NOT NULL DEFAULT 0
+├─ state                    text          NOT NULL DEFAULT 'active'  -- 'active' | 'deprecated'
+├─ clustered_at             timestamptz   NOT NULL
+├─ created_at, updated_at   timestamptz   NOT NULL
+└─ INDEXES
+   ├─ btree (organization_id, project_id, state)
+   └─ GIN   (search_document)
+```
+
+### Postgres — `taxonomy_cluster_lineage`
+
+Append-only transition log. One row per detected transition per gardening run.
+
+```text
+taxonomy_cluster_lineage
+├─ id                  cuid          PRIMARY KEY
+├─ organization_id     cuid          NOT NULL
+├─ project_id          cuid          NOT NULL
+├─ run_id              cuid          NOT NULL          -- one per gardening run
+├─ transition_type     text          NOT NULL          -- 'birth' | 'death' | 'continuation' | 'split' | 'merge'
+├─ from_cluster_ids    cuid[]        NOT NULL DEFAULT '{}'
+├─ to_cluster_ids      cuid[]        NOT NULL DEFAULT '{}'
+├─ similarity          double precision NULL           -- evidence for the transition
+├─ created_at          timestamptz   NOT NULL
+└─ INDEXES
+   └─ btree (organization_id, project_id, created_at DESC)
+```
+
+Lineage is **derived state**; it lets the UI explain "this cluster was born from noise on May 14th" or "two clusters merged into this one." It is not used on the hot online assignment path.
+
+### ClickHouse — `behavior_observations`
+
+Append-only observation rows. Mirrors `trace_search_embeddings` exactly — `ReplacingMergeTree(indexed_at)`, org-first sort, monthly partitions, per-row `retention_days` with a grace buffer. **Created via `pnpm --filter @platform/db-clickhouse ch:create`; both the `clustered/` and `unclustered/` variants are filled in.**
+
+```sql
+CREATE TABLE IF NOT EXISTS behavior_observations ON CLUSTER default (
+  organization_id           LowCardinality(String) CODEC(ZSTD(1)),
+  project_id                LowCardinality(String) CODEC(ZSTD(1)),
+  session_id                String                 CODEC(ZSTD(1)),
+  start_time                DateTime64(9, 'UTC')   CODEC(Delta(8), ZSTD(1)),
+  end_time                  DateTime64(9, 'UTC')   CODEC(Delta(8), ZSTD(1)),
+  trace_ids                 Array(FixedString(32)) CODEC(ZSTD(1)),
+  summary                   String                 CODEC(ZSTD(3)),
+  summary_hash              FixedString(64)        CODEC(ZSTD(1)),
+  embedding                 Array(Float32)         CODEC(ZSTD(1)),
+  embedding_model           LowCardinality(String) CODEC(ZSTD(1)),
+  assigned_cluster_id       String                 DEFAULT '' CODEC(ZSTD(1)),
+  assignment_confidence     Float32                DEFAULT 0.0 CODEC(ZSTD(1)),
+  assignment_method         LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+  -- 'centroid_online' | 'gardening_birth' | 'gardening_reassign' | 'noise'
+  reassignment_run_id       String                 DEFAULT '' CODEC(ZSTD(1)),
+  retention_days            UInt16                 DEFAULT 90 CODEC(T64, ZSTD(1)),
+  indexed_at                DateTime64(3, 'UTC')   DEFAULT now64(3) CODEC(Delta(8), LZ4)
+)
+ENGINE = ReplicatedReplacingMergeTree(indexed_at)
+PARTITION BY toYYYYMM(start_time)
+PRIMARY KEY (organization_id, project_id, session_id)
+ORDER BY (organization_id, project_id, session_id)
+TTL toDateTime(start_time) + toIntervalDay(retention_days + 30) DELETE;
+```
+
+**Why one row per session, versioned by `indexed_at`.** When gardening reassigns an observation (after a merge or a birth), the worker writes a fresh row with a newer `indexed_at`; `ReplacingMergeTree` collapses to the latest version. The same row also gets rewritten if the upstream session adds new traces and the worker resummarizes — see [Online observation pipeline](#online-observation-pipeline).
+
+**Embedding column is `Array(Float32)` with no fixed dimension.** Matches the proven trace-search shape; a future model swap rewrites rows without a table rebuild.
+
+**Why no separate noise table.** The noise bucket is `assigned_cluster_id = ''` — a single index-friendly predicate on the existing observations table. No second storage surface to keep consistent.
+
+### Postgres — `taxonomy_runs`
+
+One row per gardening run per project. Used for monitoring and for joining lineage rows.
+
+```text
+taxonomy_runs
+├─ id                       cuid          PRIMARY KEY
+├─ organization_id          cuid          NOT NULL
+├─ project_id               cuid          NOT NULL
+├─ trigger                  text          NOT NULL    -- 'cron' | 'manual' | 'threshold'
+├─ status                   text          NOT NULL    -- 'pending' | 'running' | 'completed' | 'failed'
+├─ started_at               timestamptz   NOT NULL
+├─ completed_at             timestamptz   NULL
+├─ observations_scanned     integer       NOT NULL DEFAULT 0
+├─ noise_scanned            integer       NOT NULL DEFAULT 0
+├─ clusters_born            integer       NOT NULL DEFAULT 0
+├─ clusters_merged          integer       NOT NULL DEFAULT 0
+├─ clusters_deprecated      integer       NOT NULL DEFAULT 0
+├─ categories_rebuilt       integer       NOT NULL DEFAULT 0
+├─ error                    text          NULL
+└─ INDEXES
+   └─ btree (organization_id, project_id, started_at DESC)
+```
+
+## Architecture
+
+Two pipelines, sharing the same data model and the same centroid helpers.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Online (per session, near-real-time)                                    │
+│                                                                         │
+│   TracesIngested → trace-end:run (existing, debounced)                  │
+│       │                                                                 │
+│       ├── publish trace-search:refreshTrace (existing)                  │
+│       └── publish taxonomy:observe-session  (new, debounced per session)│
+│                                                                         │
+│   taxonomy:observe-session worker                                       │
+│     1. Load session messages from ClickHouse (TraceRepository)          │
+│     2. Build session document (buildSessionDocument)                    │
+│     3. Summarize via AI.generate (cached by summary_hash)               │
+│     4. Embed summary via AI.embed (cached, 24h TTL)                     │
+│     5. Project-scoped pgvector top-K cluster lookup                     │
+│     6. Two-gate assignment decision (absolute + relative)               │
+│     7. On match → IssueLike centroid update inside per-cluster lock     │
+│     8. Write observation row to ClickHouse (assigned or noise)          │
+└─────────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  │ noise accumulates; clusters drift
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Offline gardening (per project, scheduled)                              │
+│                                                                         │
+│   taxonomy:garden-sweep cron (hourly)                                   │
+│     fans out one taxonomy:garden-project per active project             │
+│                                                                         │
+│   taxonomy:garden-project worker (throttled per project)                │
+│     1. Open taxonomy_runs row                                           │
+│     2. Noise sweep: RPC → op-taxonomy-engine (UMAP + HDBSCAN)           │
+│        → emit Births                                                    │
+│     3. Merge pass: pairwise cosine over active clusters                 │
+│        → emit Merges; reassign observations                             │
+│     4. Death pass: clusters with mass < floor → 'deprecated'            │
+│     5. Reassignment pass: re-run two-gate over recent noise             │
+│        observations against current cluster set                         │
+│     6. Hierarchy rebuild: agglomerative cluster centroids → categories  │
+│     7. Naming pass: LLM-name changed clusters and rebuilt categories    │
+│        from FPS-sampled observation summaries                           │
+│     8. Lineage write: emit transition rows                              │
+│     9. Close taxonomy_runs row                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The online pipeline lands assignment decisions within seconds of session settle; the offline pipeline catches up the rest (births, merges, hierarchy) at the configured cadence (default 1h throttle, 6h cron sweep). Both pipelines are best-effort: failures log and swallow at the worker level (`Effect.orElseSucceed(() => undefined)`), and the next pass picks up from canonical state.
+
+## Online observation pipeline
+
+### Trigger
+
+When `runTraceEndJob` finishes a trace successfully (`apps/workers/src/workers/trace-end.ts`), it publishes a new sibling task right next to the existing `trace-search:refreshTrace` publish:
+
+```ts
+yield* publisher.publish("taxonomy", "observeSession", {
+  organizationId: payload.organizationId,
+  projectId: payload.projectId,
+  sessionId: canonicalSessionId, // coalesce(nullIf(traceSessionId, ''), toString(traceId))
+  triggeringTraceId: payload.traceId,
+  triggeringStartTime: traceDetail.startTime.toISOString(),
+}, {
+  dedupeKey: `org:${payload.organizationId}:taxonomy:observeSession:${payload.projectId}:${canonicalSessionId}`,
+  debounceMs: TAXONOMY_OBSERVATION_DEBOUNCE_MS, // 5 min default
+})
+```
+
+**Why `debounceMs` not `throttleMs`.** Active sessions keep producing traces. We want the worker to wait until the session settles — the same shape `trace-end:run` itself uses with respect to `TracesIngested`. Each new trace in the same session pushes the firing time forward; the worker only runs once the session is quiet.
+
+**Why the `org:${organizationId}:…` prefix on the dedupe key.** Project ids are globally unique cuids, so org-prefixing isn't required for collision avoidance — but every other org-scoped Redis/queue key in the codebase leads with `org:${organizationId}:` (see the repo-wide convention in `CLAUDE.md`). Matching that shape keeps the keyspace consistently partitioned and makes tenancy obvious at a glance.
+
+**Why fire-and-forget (no error coupling).** Wrap the publish in `Effect.map(() => true).catch(...)` like the `deterministic-flaggers:run` sibling, so a taxonomy failure cannot stall trace-end. This mirrors what trace-search would do if it weren't already swallowing in-handler.
+
+### Worker
+
+A new file `apps/workers/src/workers/taxonomy.ts` follows `trace-search.ts` line-for-line for composition:
+
+- subscribes to topic `"taxonomy"` with task `"observeSession"` (and later `"gardenSweep"`, `"gardenProject"`),
+- runs `withPostgres`, `withClickHouse(Layer.mergeAll(TraceRepositoryLive, BehaviorObservationRepositoryLive, ...))`, `withAi(AIEmbedLive ⊕ AIGenerateLive, redisClient)`,
+- wraps the per-session handler in `Effect.withSpan("taxonomy.observeSession")` and `Effect.orElseSucceed(() => undefined)` so a single failing session never re-enters the job queue forever.
+
+### `observeSession` handler (step by step)
+
+1. **Load the session.** Read all traces for `(orgId, projectId, sessionId)` since the start of the session via a use-case `loadSessionForTaxonomyUseCase` in `@domain/spans` (or a co-located helper in `@domain/taxonomy` that delegates to `TraceRepository`). Empty session → no-op.
+
+2. **Build the session document.** A pure helper `buildSessionDocument({ traces, messages })` in `@domain/taxonomy/src/helpers.ts` produces:
+   - a flat normalized conversation text (same role gate as trace-search: only `user` + `assistant`; tool calls preserved as `[TOOL CALL: <name>]`; tool results dropped),
+   - the canonical `summary_hash` over `(sessionId + "\0" + conversationText)` for caching/dedup,
+   - lightweight metadata (`primaryActor`, `traceCount`, `firstTraceId`, `lastTraceId`).
+
+   Conversation text is hard-capped at `TAXONOMY_SESSION_DOCUMENT_MAX_LENGTH` (initial: 30,000 chars; sessions tend to be longer than single traces). Middle-truncation when over budget, matching trace-search.
+
+3. **Skip floor.** If conversation text length is below `TAXONOMY_SESSION_MIN_LENGTH` (initial: 200 chars), record an observation row with `assigned_cluster_id = ''`, `assignment_method = 'noise'`, and **no embedding** (empty array). These rows are visible to the noise sweep but cheap. Reason: a session whose entire conversation is "hi" is not signal worth embedding.
+
+4. **Decide what text to embed.** Two-branch decision based on `TAXONOMY_SUMMARY_STRATEGY` and conversation length:
+
+   - **LLM-summary branch** — when `TAXONOMY_SUMMARY_STRATEGY === "llm"` *and* conversation tokens ≥ `TAXONOMY_SUMMARY_MIN_SESSION_TOKENS`. Call `summarizeBehaviorUseCase` in `@domain/taxonomy`:
+     - port: `@domain/ai` `AI.generate`,
+     - Zod output schema:
+       ```ts
+       z.object({
+         summary: z.string().min(20).max(280)
+           .describe("One sentence capturing what the user was trying to do and what the agent did. Generic, not memorizing facts."),
+         primaryActor: z.enum(["user", "agent", "both"])
+           .describe("Whose behavior the summary primarily describes."),
+         intentTags: z.array(z.string()).max(4)
+           .describe("Up to four short topical tags (lowercase, kebab-case)."),
+       })
+       ```
+     - model: `TAXONOMY_SUMMARY_MODEL` (initial: a cheap-fast non-reasoning model, e.g. Haiku 4.5). Reasoning is intentionally off — a 1-sentence intent label doesn't need it. Subscription-plan model resolution is Future Work.
+     - **Cache on `summary_hash`.** The use-case checks ClickHouse for an existing observation with the same `(orgId, projectId, sessionId, summary_hash, strategy)` and skips the LLM call if found. Appending new traces to a session whose conversation hash didn't change does not re-pay the summary cost. Including `strategy` in the key prevents stale `embed_direct` rows from masking a switch to `"llm"`.
+     - The text-to-embed for step 5 is the returned `summary` string.
+
+   - **Embed-direct branch** — when `TAXONOMY_SUMMARY_STRATEGY === "embed_direct"` *or* conversation tokens < `TAXONOMY_SUMMARY_MIN_SESSION_TOKENS`. No LLM call. The text-to-embed for step 5 is the normalized conversation text already produced in step 2, capped at the same `TAXONOMY_SESSION_DOCUMENT_MAX_LENGTH`. The `summary` column on the observation row stores the first 280 chars of that conversation (so FPS sampling and inspection still work); `assignment_method` is unchanged by this branch.
+
+   This is the single biggest cost knob in the MVP. See [Cost & performance](#cost--performance) for the ceilings each branch produces at XL.
+
+5. **Embed.** Call `embedBehaviorSummaryUseCase` in `@domain/taxonomy` → `AI.embed({ text: textToEmbed, model: TAXONOMY_EMBEDDING_MODEL, dimensions: TAXONOMY_EMBEDDING_DIMENSIONS, inputType: "document" })`. **The cache wrap inside `withAi` keys on `(text, model, dimensions, inputType)`**, so identical embed inputs across sessions hit the same cached embedding without re-paying.
+
+6. **Top-K cluster lookup.** Call `findNearestClustersUseCase`. The repository method is `TaxonomyClusterRepository.listNearestActive(orgId, projectId, queryVector, k = TAXONOMY_ASSIGN_TOPK)` — exact pgvector cosine over `WHERE organization_id AND project_id AND state = 'active' AND centroid_embedding IS NOT NULL`, ordered by `1 - (centroid_embedding <=> $vector)` DESC, LIMIT K. Vector inlined as `sql.raw` literal as in `issue-repository.hybridSearch` (node-postgres can't bind JS arrays to `vector`).
+
+7. **Two-gate decision.** `decideAssignmentInGardening` helper:
+   ```ts
+   if (topK.length === 0) return { method: "noise", clusterId: null, confidence: 0 }
+   const sims = topK.map(c => c.cosine)               // already 0..1
+   const probs = softmax(sims, TAXONOMY_ASSIGN_TEMPERATURE)
+   const absoluteOk = sims[0] >= TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD
+   const relativeOk = (probs[0] - (probs[1] ?? 0)) >= TAXONOMY_ASSIGN_RELATIVE_MARGIN
+   if (absoluteOk && relativeOk) {
+     return { method: "centroid_online", clusterId: topK[0].id, confidence: sims[0] }
+   }
+   return { method: "noise", clusterId: null, confidence: sims[0] }
+   ```
+   Both gates apply. Published baselines put either gate alone at ~5% false-assignment and the combined rate at ~2–3%. The same ratio is expected to hold here at this scale, and is the calibration target for the benchmark corpus described under [Tuning](#tuning-and-the-benchmark-corpus).
+
+8. **Update the cluster centroid (only on assignment).** `assignObservationToClusterUseCase` mirrors `assignScoreToIssueUseCase`:
+   - acquire a per-cluster Redis lock keyed `org:${organizationId}:taxonomy:cluster:${clusterId}` with token + `SET NX EX` (so concurrent observations into the same cluster don't lose centroid contributions),
+   - re-read the cluster row,
+   - `updateTaxonomyCentroid({ centroid, embedding, weight: 1.0, timestamp: observation.startTime })` — the same running-decayed-sum math as `updateIssueCentroid`, exported from `@domain/taxonomy/src/helpers.ts`,
+   - persist; `TaxonomyClusterRepository.save` materializes the derived `centroid_embedding` via `normalizeTaxonomyCentroid(centroid)` exactly as `IssueRepository.save` does,
+   - release lock.
+
+9. **Write the observation row.** `BehaviorObservationRepository.upsert(...)` writes one row to ClickHouse `behavior_observations` with `assigned_cluster_id` set (or empty if noise), `assignment_method` per step 7, `assignment_confidence = sims[0]` when matched and the bare top-1 cosine when noise (for visibility into how close we came), `indexed_at = now`.
+
+10. **Bump cluster counters.** On assignment, `+1 observation_count` and `last_observed_at = now` on the cluster row. Async-batchable, but keeping it in the same transaction is fine at this scale.
+
+11. **Bump the noise counter (noise path only).** When the observation lands as noise, `INCR org:${organizationId}:taxonomy:noise-count:${projectId}` (Redis). If the post-INCR value crosses `TAXONOMY_NOISE_GARDENING_TRIGGER`, publish the noise-pressure `gardenProject` per [Trigger model §3](#trigger-model). The counter is best-effort (re-synced from CH at gardening start/end — see [§A](#a-noise-sweep-cluster-births)); a missed INCR just delays the trigger by one observation. Counter key carries a 7-day idle TTL refreshed on each INCR.
+
+12. **Span and finally.** `Effect.withSpan("taxonomy.observeSession")` + `withTracing` per worker tracing rules. Failure paths fall through to `Effect.orElseSucceed(() => undefined)`; the next session ingest reattempts naturally.
+
+### Shared centroid math
+
+`@domain/taxonomy/src/helpers.ts` exports an analog of every centroid function in `@domain/issues/src/helpers.ts`:
+
+```ts
+export const createTaxonomyCentroid = (): TaxonomyCentroid => ({
+  base: new Array(TAXONOMY_EMBEDDING_DIMENSIONS).fill(0),
+  mass: 0,
+  model: TAXONOMY_EMBEDDING_MODEL,
+  decay: TAXONOMY_CENTROID_HALF_LIFE_SECONDS,
+  weights: TAXONOMY_OBSERVATION_WEIGHT_SCHEME, // { default: 1.0 }
+})
+
+export const updateTaxonomyCentroid = (input: {
+  centroid: TaxonomyCentroid
+  embedding: number[]
+  weight: number      // observation-specific; 1.0 in MVP
+  timestamp: Date     // assignment time, used as new clusteredAt
+  operation: "add" | "remove"
+  previousClusteredAt: Date
+}): TaxonomyCentroid => { ... }
+
+export const normalizeTaxonomyCentroid = (centroid: TaxonomyCentroid): number[] => { ... }
+```
+
+The **only** changes from `@domain/issues` helpers are:
+
+- the weight scheme is `Record<"default", number>` for MVP (single bucket; multi-source weighting like annotations vs evaluations is Future Work),
+- the model/dimensions constants come from `@domain/taxonomy/src/constants.ts`, not `@domain/issues`,
+- `decay` half-life default is `TAXONOMY_CENTROID_HALF_LIFE_SECONDS = 30 days` (longer than issues' 14d, since taxonomy categories are slower-moving than failure patterns).
+
+The math is otherwise byte-for-byte the issues helpers, which is exactly the point — the centroid engine is the proven, tested part. **The two helpers should share an underlying utility once both are stable; see [Future Work — Extract shared centroid core](#future-work). For the MVP, they are duplicated (with tests) inside `@domain/taxonomy`.**
+
+## Offline gardening pipeline
+
+### Trigger model
+
+Three complementary triggers, each via the existing `@domain/queue` rails:
+
+1. **Cron sweep.** Registered once at worker boot in `apps/workers/src/server.ts` with `queuePublisher.scheduleRepeatable("taxonomy", "gardenSweep", {}, { key: TAXONOMY_GARDENING_CRON_KEY, pattern: TAXONOMY_GARDENING_CRON_PATTERN, tz: "UTC" })`. Initial pattern: `"0 */6 * * *"` (every 6 hours). The handler enumerates eligible projects (admin Postgres / RLS-bypass path, same as `sweepEscalating`) and publishes one `taxonomy:gardenProject` per project with the throttle key below.
+
+2. **Activity-driven throttled publish.** The online `observeSession` handler also publishes `taxonomy:gardenProject` opportunistically when a noise observation lands, throttled to one fire per project per `TAXONOMY_GARDENING_THROTTLE_MS` (initial: 1h):
+
+   ```ts
+   yield* publisher.publish("taxonomy", "gardenProject", { organizationId, projectId }, {
+     dedupeKey: `org:${organizationId}:taxonomy:gardenProject:${projectId}`,
+     throttleMs: TAXONOMY_GARDENING_THROTTLE_MS,
+   })
+   ```
+
+   This means an idle project still gets the 6-hour sweep; an active project with noise accumulating gets gardening every hour at most; a quiet project incurs no gardening cost.
+
+3. **Noise-pressure publish.** The online handler also maintains a per-project Redis counter (`org:${organizationId}:taxonomy:noise-count:${projectId}`, INCR on every noise-bound observation write in step 9 of the online pipeline). When the counter crosses `TAXONOMY_NOISE_GARDENING_TRIGGER` (initial: 30,000 — sized for first-taxonomy latency and RPC payload, not engine compute; see [§A](#a-noise-sweep-cluster-births) and the [config table](#configuration-reference) for the rationale), the handler publishes `taxonomy:gardenProject` with a *tighter* throttle than path (2):
+
+   ```ts
+   yield* publisher.publish("taxonomy", "gardenProject", { organizationId, projectId }, {
+     dedupeKey: `org:${organizationId}:taxonomy:gardenProject:${projectId}`,
+     throttleMs: TAXONOMY_NOISE_PRESSURE_THROTTLE_MS, // 5 min
+   })
+   ```
+
+   This is the safety valve for cold-starting high-volume tenants. At ~7k/hr noise inflow (XL cold-start), path (2)'s 1h throttle is the binding constraint at first; the pressure trigger fires at ~4.3 hours when the counter crosses 30k, producing the first taxonomy. At ~20k/hr noise inflow (hyper-whale), the pressure trigger crosses 30k every ~90 minutes and the 5-minute throttle floor is never binding; the pool peaks near 30–40k between fires.
+
+The three triggers share the same dedupe key, so a publish from any path is dropped if another is already scheduled inside the *shorter* of the two throttles. Same semantics as the `issues:refresh` throttle pattern.
+
+### Eligibility & cold-start gate
+
+The gardening handler short-circuits when:
+
+- the project's observation count in the gardening lookback window (default 30 days) is below `TAXONOMY_GARDENING_MIN_OBSERVATIONS` (initial: 50). A handful of sessions is not enough signal to build a taxonomy; we wait. This is the cold-start gate. The next sweep will pick it up.
+- another `taxonomy_runs` row for the same `(orgId, projectId)` is in `'running'` state. Defensive against stuck runs; combined with the lock, prevents concurrent gardening for one project.
+
+### Per-project gardening (step by step)
+
+The worker acquires a per-project Redis lock (`org:${organizationId}:taxonomy:garden:${projectId}`), inserts a `taxonomy_runs` row, then runs the activities below in order. Every step is idempotent; a crashed run is picked up by the next sweep with no double-counting.
+
+#### A. Noise sweep (cluster births)
+
+The most important step — this is how new behavior types enter the taxonomy.
+
+1. **Re-sync the noise counter from CH** and load the noise pool in one shot: `SELECT session_id, embedding FROM behavior_observations WHERE organization_id = ? AND project_id = ? AND assigned_cluster_id = '' AND length(embedding) > 0 AND start_time >= now() - INTERVAL TAXONOMY_NOISE_LOOKBACK_DAYS DAY`. (Default lookback: 7 days. Empty-embedding noise rows from step 3 of online are excluded.) Use `count(rows)` to `SET` the Redis counter `org:${organizationId}:taxonomy:noise-count:${projectId}` to ground truth; this corrects any drift accumulated by the best-effort INCR path during online ingest.
+2. If the noise count is below `TAXONOMY_NOISE_BIRTH_MIN_OBSERVATIONS` (initial: 8), skip — not enough density for a birth.
+3. **Cluster the noise embeddings via the Python engine.** Compute the per-run `minClusterSize` (see step 4), then RPC out to `@platform/op-taxonomy-engine`:
+
+   ```ts
+   const { assignments, outlierScores } = yield* TaxonomyEngineClient.noiseSweep({
+     embeddings,                     // Array<number[]>, 2048-dim
+     minClusterSize,                 // see step 4
+     minSamples: TAXONOMY_HDBSCAN_MIN_SAMPLES,
+     umapNComponents: TAXONOMY_UMAP_N_COMPONENTS,
+     umapNNeighbors: TAXONOMY_UMAP_N_NEIGHBORS,
+     umapMinDist: TAXONOMY_UMAP_MIN_DIST,
+     randomSeed: TAXONOMY_UMAP_RANDOM_SEED,
+   })
+   ```
+
+   The engine's pipeline is `UMAP(2048 → TAXONOMY_UMAP_N_COMPONENTS)` → `HDBSCAN(metric="euclidean", min_cluster_size, min_samples, cluster_selection_method="eom")`. UMAP gives HDBSCAN a sharper density signal than raw 2048-dim cosines provide; HDBSCAN handles variable-density clusters natively (dense and sparse topics in the same pool both work), produces a first-class noise label (`assignment = -1`) for points that don't fit anywhere, and returns a per-point `outlier_score ∈ [0, 1]`.
+
+   `randomSeed` is pinned in constants so reproducibility holds across runs (lineage continuity depends on this). The engine's library versions are pinned in `pyproject.toml` for the same reason.
+
+   At MVP scale (≤30,000 noise observations bounded by [Trigger model §3](#trigger-model)), the engine returns in ~30–60s end-to-end including RPC overhead and ~80–120MB compressed payload, comfortably inside `TAXONOMY_GARDENING_MAX_RUNTIME_MS = 5 min`. The pool can briefly overshoot the trigger under bursty inflow — HDBSCAN scales fine to ~100k points; the trigger threshold is set well below where the engine starts to slow, and the bound is RPC payload + first-taxonomy UX, not engine compute.
+
+4. **Birth eligibility per candidate cluster.** HDBSCAN's `min_cluster_size` is the proportional-floor knob:
+
+   ```ts
+   const minClusterSize = clamp(
+     round(noisePoolSize * TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_RATIO),
+     TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_FLOOR,
+     TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_CEILING,
+   )
+   ```
+
+   Computed once per run from `noisePoolSize` (the count read in step 1) and passed to the engine in step 3. Initial values: floor `4`, ratio `0.005` (0.5%), ceiling `30`. At small scale the floor binds (a 4-member micro-pattern in a 250-noise pool is real signal); at whale scale the ratio binds (~30 members required when the pool is in the tens of thousands) so the UI isn't cluttered with low-count artifacts. See [Why a proportional `min_members`](#why-a-proportional-min_members).
+
+   HDBSCAN already enforces this floor by construction (clusters below `min_cluster_size` are emitted as noise), so the post-engine eligibility check is reduced to:
+
+   - **absorption check**: build the candidate centroid (normalized mean of member embeddings); if its top-1 cosine against an existing active cluster ≥ `TAXONOMY_ABSORPTION_THRESHOLD` (initial: 0.85), do not birth — instead reassign all members to that absorbing cluster. This catches "we already have a cluster for this, the gate just barely rejected each member individually."
+
+   The intra-cluster diameter check from the previous spec design is dropped — HDBSCAN's density criterion is a stronger filter than a single-number diameter cap (it adapts to local density rather than imposing a fixed bound).
+
+5. **Birth.** For each eligible candidate that survives the absorption check, create a `taxonomy_clusters` row with:
+   - `centroid = createTaxonomyCentroid()` then folded with each member observation via `updateTaxonomyCentroid` (so the running-sum invariant matches the online path),
+   - `name = "Pending"`, `description = ""` (the naming pass below fills these in),
+   - `observation_count = members.length`, `first_observed_at = min(member start times)`, `last_observed_at = max(member start times)`, `clustered_at = now`,
+   - `state = "active"`, `parent_category_id = NULL` (filled by the hierarchy step),
+   - reassign each member observation in ClickHouse with `assignment_method = "gardening_birth"`, `reassignment_run_id = run.id`, `assigned_cluster_id = newCluster.id`, fresh `indexed_at`.
+
+6. Emit a `taxonomy_cluster_lineage` row per birth with `transition_type = "birth"`, `from_cluster_ids = []`, `to_cluster_ids = [newCluster.id]`.
+
+#### B. Merge pass
+
+Detect and consolidate near-duplicate active clusters.
+
+1. List all active clusters with non-null `centroid_embedding`.
+2. Compute pairwise cosine between every pair (project-scoped only; per-project N is small enough that `O(n²)` is trivial). Threshold at `TAXONOMY_MERGE_THRESHOLD` (initial: 0.92 cosine).
+3. Build connected components over the threshold-passing edges. Each component with ≥2 members triggers a merge.
+4. **Choose the survivor.** Per component, the survivor is the cluster with the highest `observation_count` (tiebreak: lowest `id` for determinism).
+5. **Reassign observations.** For each non-survivor, reassign all of its observations in ClickHouse to the survivor with `assignment_method = "gardening_reassign"`, fold their normalized embeddings into the survivor's centroid via repeated `updateTaxonomyCentroid` (under the survivor's Redis lock), mark the non-survivor's `state = "merged"`, set `merged_into_cluster_id = survivor.id`.
+6. Emit lineage `transition_type = "merge"` with `from_cluster_ids = [losers...]`, `to_cluster_ids = [survivor]`, `similarity = min pairwise cosine in component`.
+
+#### C. Death pass
+
+A cluster whose centroid mass has decayed below `TAXONOMY_DEAD_CLUSTER_MASS_FLOOR` (initial: 0.5) without new observations in the last `TAXONOMY_DEAD_CLUSTER_INACTIVITY_DAYS` (initial: 30 days) is transitioned to `state = "deprecated"`. Observations stay attached (we don't orphan them), but the cluster is no longer a candidate for online assignment and is hidden from the default UI.
+
+Emit lineage `transition_type = "death"` per deprecated cluster.
+
+#### D. Reassignment pass (catch-up for the noise floor)
+
+Run after births: re-evaluate the two-gate decision for each noise observation in the lookback window against the **current** active cluster set (which now includes any births from step A). This catches observations that landed in noise because the matching cluster didn't exist yet at observation time.
+
+For each reassigned observation, fold its embedding into the target cluster's centroid (same Redis-locked update path as online) and rewrite its ClickHouse row with `assignment_method = "gardening_reassign"`.
+
+#### E. Hierarchy rebuild (categories)
+
+The taxonomy's 2nd level. Rebuilt from scratch each gardening run.
+
+1. List all active clusters with non-null `centroid_embedding` and `observation_count > 0`.
+2. **Choose K.** `K = clamp(round(sqrt(activeClusters.length)), 3, TAXONOMY_HIERARCHY_MAX_CATEGORIES)` (initial cap: 15). A square-root heuristic that matches typical UI navigation breadth.
+3. Run **pure-TS agglomerative clustering with average linkage** over the cluster centroids until K components remain. Stays in TS (not the engine) on purpose: category roll-up is sub-millisecond at this count, the input is already-clean cluster centroids (not raw noise), and a category isn't a density region — it's a navigation grouping. See [Why HDBSCAN for births and TS agglomerative average-linkage for the category roll-up](#why-hdbscan-for-births-and-ts-agglomerative-average-linkage-for-the-category-roll-up).
+4. **Match against existing categories.** For each new candidate category, compute the centroid (mean of member cluster centroids, normalized) and find the best-matching existing category by cosine. If similarity ≥ `TAXONOMY_CATEGORY_CONTINUATION_THRESHOLD` (initial: 0.80), keep the existing category id, update its `centroid_embedding`, `cluster_count`, `observation_count`. Otherwise, create a new category row with `name = "Pending"`, `description = ""`.
+5. **Update `parent_category_id` on every member cluster.** Set in one batch update.
+6. **Deprecate orphan categories.** Any prior active category that wasn't matched is `state = 'deprecated'`.
+7. Emit lineage rows for each rebuilt category? **No** — lineage is leaf-level only in the MVP. Categories are derived/rebuilt; their evolution is observable via the `taxonomy_runs` `categories_rebuilt` counter.
+
+#### F. Naming pass
+
+For each cluster that:
+
+- is newly born, **or**
+- has had ≥ `TAXONOMY_NAMING_REFRESH_OBSERVATIONS` (initial: 25) observations attached since its last naming, **or**
+- is `name = "Pending"`,
+
+run `nameClusterUseCase`:
+
+1. Sample observation summaries via **Farthest-Point Sampling** over the cluster's member observations (read from CH, ranked by recency). Budget: `clamp(round(log2(observation_count + 1)) * 2, TAXONOMY_FPS_SAMPLE_BUDGET_MIN, TAXONOMY_FPS_SAMPLE_BUDGET_MAX)` (initial bounds: 4, 12). FPS implementation in helpers: start from the observation closest to the centroid (the canonical example), iteratively add the observation furthest from the already-selected set by cosine distance.
+2. Map step: call `AI.generate` once with the K sampled summaries and a `proposeCandidateThemes` system prompt; output schema is `z.object({ candidates: z.array(z.object({ theme: z.string(), examples: z.array(z.number()) })).min(1).max(5) })`.
+3. Reduce step: a second `AI.generate` call that takes the candidate themes plus the original samples and outputs the final `z.object({ name: z.string().min(3).max(80), description: z.string().min(20).max(280) })`.
+4. Save to the cluster row; update `clustered_at = now`.
+
+The map-reduce shape (propose candidate themes, then collapse to a single name + description) is a standard cluster-labeling pattern. At per-cluster scale (K ≤ 12 samples), both calls fit comfortably in a single model context; the indirection is mostly about quality, not size.
+
+Same flow applies for renaming a newly-created category, with the input being the names+descriptions of its member clusters (not raw observation summaries — categories summarize over clusters).
+
+#### G. Close the run
+
+Update the `taxonomy_runs` row with `status = 'completed'`, `completed_at`, the counters, release the per-project Redis lock. Re-sync `org:${organizationId}:taxonomy:noise-count:${projectId}` from ClickHouse one more time (`SELECT count(*) ... WHERE assigned_cluster_id = ''` over the lookback window) — births and reassignments during the run drained most of the pool, and the counter must reflect post-drain reality so the next noise-pressure trigger fires at the right point.
+
+### Backpressure & long-running gardening
+
+- Per-project gardening should complete in under a minute at expected MVP scale (≤10k active observations, ≤500 active clusters per project). The hard cap is `TAXONOMY_GARDENING_MAX_RUNTIME_MS` (initial: 5 min); past that the worker writes `status = 'failed'`, `error = 'timeout'`, releases the lock, and lets the next sweep retry.
+- The cron sweep enumerates projects in batches of `TAXONOMY_GARDENING_SWEEP_BATCH` (initial: 25) with a small delay between batches to avoid thundering-herding the queue.
+- The per-project work is a single BullMQ task, not a Temporal workflow. Failures replay from scratch; there's no in-flight state worth resuming.
+
+## Read paths
+
+`@domain/taxonomy` exposes the use-cases below. All are project-scoped at the boundary. The MVP ships them as plain use-cases; the web composition adds `apps/web` server functions on top when the UI lands.
+
+- `listCategoriesUseCase(orgId, projectId, { state?, includeEmpty? })` — list categories, default `state = 'active'`, default omit categories with zero member clusters.
+- `listClustersInCategoryUseCase(orgId, projectId, categoryId, { state?, sort? })` — list leaf clusters, sorted by `observation_count` desc by default.
+- `listClustersUseCase(orgId, projectId, { state?, search?, parentCategoryId?, sort?, cursor?, pageSize? })` — flat-list with hybrid search (pgvector + tsvector) on `(name, description)` exactly as `IssueRepository.hybridSearch`. `search` runs the same dual lexical+semantic plan, with the search embedding cached via `withAICache` (24h TTL).
+- `listObservationsInClusterUseCase(orgId, projectId, clusterId, { cursor?, pageSize? })` — paginated ClickHouse list of observations attached to a cluster, ordered by `start_time DESC`.
+- `getClusterDetailsUseCase(orgId, projectId, clusterId)` — cluster row + a small sample of recent observation summaries for the details drawer.
+- `getCategoryDetailsUseCase(orgId, projectId, categoryId)` — category row + its member clusters.
+- `getClusterTrendUseCase(orgId, projectId, clusterId, { window? })` — observation count per day for the window (default 14 days), for the histogram in the cluster details drawer. Read from CH; mirror `getIssueTrendUseCase`.
+- `getTaxonomyAnalyticsUseCase(orgId, projectId, { window? })` — top-line counts (total active categories, total active clusters, total observations in window, top-5 clusters by occurrence). For the page-level summary panel.
+- `getLastRunUseCase(orgId, projectId)` — the most recent `taxonomy_runs` row plus a small slice of lineage transitions (last 10 births/merges) for an "Activity" panel.
+
+Operational use-cases (not user-surfaced):
+
+- `triggerProjectGardeningUseCase(orgId, projectId, { reason })` — admin-only manual trigger that publishes a `taxonomy:gardenProject` with the throttle key, so it coalesces with any pending scheduled run.
+- `recordObservationUseCase` — the use-case the worker calls; exposed for tests and admin manual ingest.
+
+## Configuration reference
+
+All constants live in `packages/domain/taxonomy/src/constants.ts`.
+
+| Constant | Initial value | Purpose |
+|---|---|---|
+| `TAXONOMY_EMBEDDING_MODEL` | `"voyage-4-large"` | Same family as issues + trace-search, single embedding-account surface. |
+| `TAXONOMY_EMBEDDING_DIMENSIONS` | `2048` | Matches stored centroid column shape. |
+| `TAXONOMY_SUMMARY_MODEL` | `{ provider: "anthropic", model: "claude-haiku-4-5" }` (or any equivalent cheap-fast non-reasoning model) | Summaries are 1-sentence intent labels; reasoning tokens buy nothing here. Per-tier resolution is Future Work — XL tenants will likely want an even cheaper option. Intentionally different from `ISSUE_DETAILS_GENERATION_MODEL`, which carries reasoning because issue details summarize over many examples. |
+| `TAXONOMY_SUMMARY_STRATEGY` | `"llm"` | Global text-to-embed switch. `"llm"` (default) summarizes then embeds the summary; `"embed_direct"` skips the LLM call and embeds normalized conversation text directly. Quality/cost tradeoff in [Decisions & tradeoffs](#why-llm-summary-is-the-default-not-embed_direct). |
+| `TAXONOMY_SUMMARY_MIN_SESSION_TOKENS` | `500` | Below this conversation-token count, skip the LLM summary even under `"llm"` strategy and embed conversation text directly. Short sessions are usually single-intent already; the LLM call buys little. Estimated 40–60% summary-call reduction on chat-heavy mixes. |
+| `TAXONOMY_CENTROID_HALF_LIFE_SECONDS` | `30 * 24 * 60 * 60` (30d) | Slower decay than issues (14d); behavior categories move slower than failures. |
+| `TAXONOMY_OBSERVATION_WEIGHT_SCHEME` | `{ default: 1.0 }` | Single weight bucket in MVP; multi-source weighting is Future Work. |
+| `TAXONOMY_SESSION_DOCUMENT_MAX_LENGTH` | `30_000` chars | Hard cap before middle-truncation. |
+| `TAXONOMY_SESSION_MIN_LENGTH` | `200` chars | Skip floor below this; observation row written without embedding. |
+| `TAXONOMY_OBSERVATION_DEBOUNCE_MS` | `5 * 60_000` (5 min) | Per-session debounce on `observeSession`. |
+| `TAXONOMY_ASSIGN_TOPK` | `10` | Top-K cluster lookup. |
+| `TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD` | `0.65` | Absolute cosine floor. |
+| `TAXONOMY_ASSIGN_RELATIVE_MARGIN` | `0.06` | Softmax margin between top-1 and top-2 probabilities. |
+| `TAXONOMY_ASSIGN_TEMPERATURE` | `0.08` | Softmax temperature; smaller → sharper. |
+| `TAXONOMY_GARDENING_CRON_KEY` | `"taxonomy:garden-sweep"` | Idempotent repeatable-job key. |
+| `TAXONOMY_GARDENING_CRON_PATTERN` | `"0 */6 * * *"` (every 6h) | Sweep cadence. |
+| `TAXONOMY_GARDENING_THROTTLE_MS` | `60 * 60_000` (1h) | Per-project activity-driven gardening throttle. |
+| `TAXONOMY_NOISE_GARDENING_TRIGGER` | `30_000` | Noise-counter threshold above which the online handler publishes a `gardenProject` via the pressure path (see [Trigger model §3](#trigger-model)). Bound is **first-taxonomy latency + RPC payload**, not engine compute: HDBSCAN handles 100k+ comfortably, but at 30k the RPC payload is ~80–120MB compressed and a new whale tenant sees its first taxonomy after ~4.3 hours of ingest — both acceptable. Higher values improve HDBSCAN quality (sharper density estimates, less re-birth/re-merge churn) at the cost of longer cold-start UX. |
+| `TAXONOMY_NOISE_PRESSURE_THROTTLE_MS` | `5 * 60_000` (5 min) | Floor on the noise-pressure publish path. Bypasses `TAXONOMY_GARDENING_THROTTLE_MS` so cold-starting high-volume tenants can garden faster than hourly. |
+| `TAXONOMY_GARDENING_MIN_OBSERVATIONS` | `50` | Cold-start gate. |
+| `TAXONOMY_GARDENING_MAX_RUNTIME_MS` | `5 * 60_000` (5 min) | Per-run safety cap. |
+| `TAXONOMY_GARDENING_SWEEP_BATCH` | `25` | Cron sweep enumeration batch size. |
+| `TAXONOMY_NOISE_LOOKBACK_DAYS` | `7` | Noise sweep / reassignment window. |
+| `TAXONOMY_NOISE_BIRTH_MIN_OBSERVATIONS` | `8` | Minimum noise size to attempt birthing. |
+| `TAXONOMY_UMAP_N_COMPONENTS` | `15` | UMAP target dimensionality before HDBSCAN. Reduces 2048-dim Voyage embeddings to a density-friendlier space. |
+| `TAXONOMY_UMAP_N_NEIGHBORS` | `15` | UMAP neighborhood size. Lower → preserves more local structure; higher → preserves more global structure. 15 is the standard default. |
+| `TAXONOMY_UMAP_MIN_DIST` | `0.0` | UMAP minimum distance between projected points. 0.0 packs tightly for downstream HDBSCAN. |
+| `TAXONOMY_UMAP_RANDOM_SEED` | `42` | Pinned for reproducibility — lineage continuity across runs depends on stable UMAP projections. Bump only when intentionally re-evaluating the taxonomy. |
+| `TAXONOMY_HDBSCAN_MIN_SAMPLES` | `5` | HDBSCAN's outlier sensitivity. Higher → more conservative (more points labeled noise), lower → more permissive. |
+| `TAXONOMY_HDBSCAN_CLUSTER_SELECTION_METHOD` | `"eom"` | Excess-of-mass cluster selection. Produces fewer, more stable clusters than `"leaf"`; the right choice when the noise sweep is one input to a fuller pipeline (we don't want every micro-pattern). |
+| `TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_FLOOR` | `4` | Minimum members per born cluster at small scale — preserves sensitivity for projects where 4 members is genuinely meaningful signal. |
+| `TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_RATIO` | `0.005` (0.5%) | Proportional floor: a born cluster needs at least this share of the current noise pool. Binds at whale scale to filter birthday-paradox artifacts. |
+| `TAXONOMY_NOISE_BIRTH_MIN_MEMBERS_CEILING` | `30` | Hard cap so a 30-session real pattern in a 1M-noise pool still births. |
+| `TAXONOMY_ABSORPTION_THRESHOLD` | `0.85` cosine | Re-absorb a candidate birth into an existing cluster instead of birthing. |
+| `TAXONOMY_MERGE_THRESHOLD` | `0.92` cosine | Pairwise merge threshold. |
+| `TAXONOMY_DEAD_CLUSTER_MASS_FLOOR` | `0.5` | Mass below which a cluster can be deprecated. |
+| `TAXONOMY_DEAD_CLUSTER_INACTIVITY_DAYS` | `30` | Inactivity window required alongside mass floor. |
+| `TAXONOMY_HIERARCHY_MAX_CATEGORIES` | `15` | Upper bound on K for the category layer. |
+| `TAXONOMY_CATEGORY_CONTINUATION_THRESHOLD` | `0.80` cosine | Match a candidate category against an existing one. |
+| `TAXONOMY_NAMING_REFRESH_OBSERVATIONS` | `25` | Re-name a cluster after this many new observations. |
+| `TAXONOMY_FPS_SAMPLE_BUDGET_MIN` | `4` | FPS sample floor. |
+| `TAXONOMY_FPS_SAMPLE_BUDGET_MAX` | `12` | FPS sample ceiling. |
+| `TAXONOMY_OBSERVATION_RETENTION_DAYS` | `90` | ClickHouse TTL on `behavior_observations`. |
+
+All thresholds are initial seeds chosen by analogy to the issues system and to published cluster-labeling baselines. They are explicitly **MVP defaults**, not optimal values. See [Tuning](#tuning-and-the-benchmark-corpus).
+
+## Tuning and the benchmark corpus
+
+The MVP ships with the constants above. The seeded **Acme** corpus (already used to tune `TRACE_SEARCH_MIN_RELEVANCE_SCORE`) is the natural smoke-test set: run the worker against it, eyeball the resulting categories and a sample of cluster contents, and adjust the absolute/relative gates if the false-assignment rate is materially above the ~2–3% target. The procedure:
+
+1. Seed: `pnpm db:up && pnpm db:seed` (existing).
+2. Re-enqueue every seeded session through `taxonomy:observeSession` via a one-off admin script.
+3. Trigger `taxonomy:gardenProject` once per seeded project.
+4. Manually inspect: are obviously-different sessions in the same cluster (false positives)? Are obviously-same sessions split (false negatives)?
+5. Adjust `TAXONOMY_ASSIGN_*` constants; re-run.
+
+Bayesian / automated tuning is Future Work; the MVP's expectation is that the seeded corpus + a human eyeball pass picks defaults that hold for the first cohort of real customers, and that production observability (next item) tells us when to retune.
+
+## Observability
+
+The MVP includes the following metrics, all surfaced as structured logs via `@repo/observability`'s `createLogger("taxonomy")` and as Effect spans (`Effect.withSpan`) for OTel:
+
+- `taxonomy.observeSession.duration` and `.outcome` (`assigned` / `noise` / `skip_too_short` / `error`).
+- `taxonomy.observeSession.confidence` (histogram).
+- `taxonomy.gardenProject.duration`, `.observations_scanned`, `.noise_scanned`, `.clusters_born`, `.clusters_merged`, `.clusters_deprecated`, `.categories_rebuilt`.
+- `taxonomy.assign.topk.cosine` histogram (top-1, top-2 spread).
+- `taxonomy.embed.cache_hit_rate` (derived from existing `withAICache` instrumentation).
+- `taxonomy.cluster.count_active`, `.count_deprecated` per project (gauge, refreshed by gardening).
+
+Dashboards are not part of the MVP; the metrics ship and the observability epic owns the dashboards.
+
+## Cost & performance
+
+The trace-search tenant brackets (Small 5k / Medium 50k / Large 500k / XL 5M **traces** per month) are the volume reference. The taxonomy adds at most one LLM call and one Voyage embed call per **session**, both cached, with the LLM call gated by [the strategy + min-session-tokens decision in step 4](#observesession-handler-step-by-step).
+
+### From traces to sessions
+
+The taxonomy clusters per-session, so per-trace tenant volume has to be translated through a traces:sessions ratio. The product has no measured ratio yet; the table below uses **2:1 as a blended assumption** and surfaces the bounds explicitly:
+
+| Workload | Ratio | Why |
+|---|---|---|
+| One-shot completions / API-only | **1:1** | Every trace becomes its own session via the orphan→1-trace-session synthesis (`specs/session-problems/0-problems.md`). |
+| Chat / agent (typical) | **3:1 to 10:1** | Multi-turn conversations group several traces into one session. |
+| **Blended default** | **2:1** | Used in the ceiling table below. |
+
+Real tenant mix swings the per-session cost by roughly 3× from these numbers (one-shot tenants pay more per trace; chat-heavy tenants pay less).
+
+### Per-session cost components
+
+- **LLM summary** (LLM-summary branch only — `"llm"` strategy *and* conversation ≥ `TAXONOMY_SUMMARY_MIN_SESSION_TOKENS`):
+  - Input: ~3,000 conversation tokens + ~500 static system prompt + schema (the static half is prompt-cached).
+  - Output: ~150 tokens (1-sentence summary + small Zod object).
+  - At **Claude Haiku 4.5** (~$1 / $5 per MTok): **~$0.004/session**.
+  - At a cheap MoE-class model without reasoning (~$0.30 / $1.20 per MTok ballpark): **~$0.001/session**.
+  - `summary_hash` cache hit (same conversation seen for this session before): **$0**.
+- **Voyage embedding** (`voyage-4-large`, 2048 dims, $0.12 / MTok, 200M-token monthly account allowance shared with trace-search):
+  - LLM branch: ~80 input tokens (the summary). Embed-direct branch: ~3,000 input tokens (the conversation).
+  - Embed-cache hit on identical `(text, model, dims, inputType)`: **$0**.
+- **Gardening LLM** (per project per run): bounded by cluster count, not session count. ≤24 LLM calls/run × a few runs/day per active project. Trivial at every tier.
+
+### Cost ceiling per tier
+
+**Monthly worst case** for a single tenant, assuming no cache hits and every session crossing the LLM threshold. Real costs sit below this thanks to `summary_hash` caching, short-session skipping, and dormancy.
+
+| Tier | Traces/mo | Sessions/mo (2:1) | LLM summary @ Haiku 4.5 | LLM summary @ cheap MoE | Voyage embed | Gardening LLM |
+|---|---|---|---|---|---|---|
+| Small | 5k | 2.5k | **~$10** | **~$3** | free | <$1 |
+| Medium | 50k | 25k | **~$100** | **~$28** | free | <$1 |
+| Large | 500k | 250k | **~$1,000** | **~$275** | free | <$1 |
+| XL | 5M | 2.5M | **~$10,000** | **~$2,750** | ~$24 marginal | ~$1 |
+
+The LLM summary call dominates and **only the XL number is meaningful**. Three knobs in MVP scope curb it:
+
+1. **Default to a cheap non-reasoning model.** `TAXONOMY_SUMMARY_MODEL` is initialized to a Haiku-class model with reasoning off. A 1-sentence intent label doesn't need reasoning tokens, and reasoning bills as output (the expensive side).
+2. **`TAXONOMY_SUMMARY_MIN_SESSION_TOKENS = 500`.** Short sessions bypass the LLM entirely and embed conversation text directly. In chat-heavy mixes this cuts summary calls by an estimated 40–60% with negligible quality loss (short sessions are usually already single-intent).
+3. **`TAXONOMY_SUMMARY_STRATEGY = "embed_direct"`.** Documented escape hatch for tenants where the XL ceiling is intolerable. Never pays the per-session LLM cost; worst-case XL drops to **~$880/mo** (Voyage overflow only: 7.5B embed tokens − 0.2B free × $0.12/MTok). Quality tradeoff documented in [Decisions & tradeoffs](#why-llm-summary-is-the-default-not-embed_direct).
+
+Subscription-plan model/strategy resolution (per-tier `TAXONOMY_SUMMARY_MODEL` and `TAXONOMY_SUMMARY_STRATEGY` overrides) is the right answer once a customer crosses the XL bracket. Documented as Future Work and not in MVP scope.
+
+### Storage
+
+- Postgres `taxonomy_clusters`: few KB/row × low-thousands of clusters per project. Negligible.
+- ClickHouse `behavior_observations`: 2048 × 4 bytes = 8 KB/row uncompressed, ~6 KB with ZSTD. At XL (2.5M sessions/mo × 90-day TTL) ≈ ~45 GB/project for embeddings, plus tens of MB for summary text. Same order of magnitude as the trace-search XL embedding footprint.
+
+### Latency
+
+- `observeSession`: dominated by the summary LLM call (~1–3s) when the LLM branch fires, or by the embed call (~100ms cached, ~300ms uncached) when the embed-direct branch fires. Per-cluster Redis lock + Postgres write + ClickHouse insert: ~30ms. Total p95 ~3s end-to-end on the LLM branch, ~400ms on embed-direct. Runs out-of-band so the user never waits.
+- Online assignment query (Postgres pgvector scan): instant up to ~10k clusters per project; multi-ms beyond. Same scaling profile as `IssueRepository.hybridSearch`.
+- `gardenProject`: dominated by the `op-taxonomy-engine.noiseSweep` RPC at ~30–60s for a 30k noise pool (UMAP fit_transform on 30k × 2048 → 30k × 15: ~15–35s; HDBSCAN: ~5–15s; serialization + ~80–120MB compressed payload + RPC: ~10s). Capped at 5 min by `TAXONOMY_GARDENING_MAX_RUNTIME_MS`. The remaining gardening activities (merge, death, reassignment, hierarchy, naming) are sub-second each at MVP scale.
+
+## Decisions & tradeoffs
+
+### Why UMAP + HDBSCAN for births (and not the full BIRCH/UMAP/HDBSCAN/FAISS stack)
+
+We adopt the part of the published clustering stack where the quality gap matters at our scale, and skip the parts that exist only to scale it to hundreds-of-millions-of-segment corpora.
+
+**Adopted: UMAP + HDBSCAN for the noise-sweep births step.** Launching with medium+ tenants on day 1, the single-density-threshold limitation of agglomerative single-linkage is observably worse than HDBSCAN. Concretely: a noise pool that contains both a dense, dominant intent (e.g. "user asked about pricing", thousands of tight neighbors) and a sparse-but-real one (e.g. "user reported a niche Stripe webhook edge case", a dozen members) cannot be served by a single fixed link threshold — single-linkage chains the dense topic into a mega-cluster *and* over-splits the sparse one. HDBSCAN's per-point mutual-reachability distance adapts to local density and handles both correctly. UMAP-15 before HDBSCAN sharpens the density signal (raw 2048-dim cosines compress in the uninteresting range).
+
+**Skipped: BIRCH coreset.** BIRCH is a scale technique for global multi-tenant corpora at the hundreds-of-millions of segments range. The per-project noise pool here is bounded by [Trigger model §3](#trigger-model) at ~30k observations; HDBSCAN runs on this comfortably in tens of seconds. Add BIRCH only if a hyper-whale project crosses the threshold where HDBSCAN itself starts to slow (>100k noise observations per run).
+
+**Skipped: FAISS IVF for online assignment.** Per-tenant cluster count is hundreds to low-thousands of leaves. Pgvector exact cosine over `(organization_id, project_id)` is sub-ms and already proven by `@domain/issues`. FAISS-class ANN matters at five-figure+ cluster counts per project.
+
+**Operational cost of going Python.** Mitigated by `@platform/op-gepa` setting the precedent — the engine, RPC protocol, TS client, and deploy lane are already a solved shape. The new sidecar `@platform/op-taxonomy-engine` mirrors it.
+
+If a tenant ever crosses the scale where pgvector exact cosine stops being instant on the online path, the upgrade path is the same one trace-search documents: ClickHouse `vector_similarity` HNSW under the `(org, project)` sort prefix. The taxonomy MVP's data layout (org-first sort, append-only embeddings) does not foreclose that path.
+
+### Why per-session and not per-trace
+
+Multi-trace sessions ("user requested cancellation → agent failed to comply") are the unit users care about, per the product mockup. Per-trace clustering would treat each trace independently and lose the cross-trace arc. The cost is one dependency: the canonical synthesized `session_id` from `specs/session-problems/1-parity-traces-sessions.md`. Until that lands, the worker derives the same coalesce inline.
+
+### Why per-session and not per-segment (intra-session)
+
+An alternative design segments conversations by cosine drift between adjacent message windows and clusters each segment separately. That produces more clusters with finer intent resolution but requires a tunable drift threshold and adds storage. The MVP picks **one observation per session** to keep the data model and the trigger boundary simple. Segmentation is Future Work; it can layer on top of the existing observation row by emitting multiple observations per session and continuing to use the same `(sessionId, segmentIndex)` versioning key.
+
+### Why LLM summary is the default (not `embed_direct`)
+
+The core argument for summary-first is that embedding raw conversation text collapses multi-intent sessions into one diluted vector — a conversation spanning pricing, feature questions, bugs, and refund requests becomes one undifferentiated cluster. LLM summaries focus on intent, which is the thing the product is clustering on.
+
+The MVP keeps `"llm"` as the default because the product mockup is dominated by intent-shaped clusters ("user requested cancellation", "agent failed to comply") — precisely where summaries pay back. `"embed_direct"` exists as:
+
+- the **mandatory short-session branch** (sessions below `TAXONOMY_SUMMARY_MIN_SESSION_TOKENS`, where the conversation is already short and usually single-intent — the LLM call's quality gain is negligible), and
+- an **explicit knob** for tenants where the XL cost ceiling outweighs the quality gap. Cost-conscious customers can opt in via per-tier overrides once subscription-plan resolution lands.
+
+Switching strategies in production affects future observations only — existing rows keep their original assignment and `assignment_method`. The next gardening run re-evaluates the noise bucket and any boundary observations against the current cluster set, so the system converges to the new strategy without a forced rebuild.
+
+### Why two gates (absolute + relative)
+
+Published baselines put either gate alone at ~5% false-assignment, dropping to ~2.3% combined. The two gates are cheap to implement (one extra softmax over the top-K returned set) and the combined behavior matches user intuition: "assign only if there's a clearly best match and it's actually close." The taxonomy adopts this verbatim.
+
+### Why a new `@domain/taxonomy` package, not refactor `@domain/issues`
+
+`@domain/issues` is live, complex, and orchestrated via Temporal workflows. The taxonomy is a new product surface with its own lifecycle (births/merges/categories), its own cron+throttle cadence, and a different consumer model (browsing, not alerting). Generalizing the shared centroid math into a `@domain/shared` clustering core is the right *eventual* design, but doing it as a refactor during MVP couples taxonomy delivery to risk in a live failure-detection system. Duplicated helpers with tests are the cheaper path for now; the extraction is explicit Future Work.
+
+### Why pgvector for centroids and ClickHouse for observations
+
+Same reasoning as the rest of the codebase. Centroids are the small, mutable, hybrid-searched set (project-scoped low-thousands) — that's pgvector + tsvector territory. Observations are the high-volume, append-only, retention-bounded stream — that's ClickHouse's home. Mixing them produces the worst of both stores; splitting them is what the existing reliability system already does (canonical issues in PG, score analytics in CH).
+
+### Why a proportional `min_members` (HDBSCAN's `min_cluster_size`)
+
+A fixed `min_members = 4` (the small-N default) does not scale across the size range this product targets. At small-project scale (a 250-noise-obs pool), 4 members is ~1.6% of the pool — genuinely meaningful signal. At whale scale (60k noise obs), 4 members is ~0.007% of the pool. Two failure modes compound at that size:
+
+- **Density-artifact clusters.** Even with HDBSCAN's robust density criterion, the lower bound on cluster size determines how many low-count "shapes" the algorithm is willing to emit. At a fixed floor of 4 in a 60k pool, the resulting cluster list contains a long tail of tight-but-irrelevant micro-groupings.
+- **UX clutter.** A "User stuck on signup flow — 4 sessions" cluster is not a product insight in a project that does 2.5M sessions/mo. The UI gets flooded with low-count born clusters that drown out the patterns that actually matter, and the naming pass burns LLM cost on each one.
+
+The proportional floor `min_cluster_size = clamp(round(pool * 0.005), 4, 30)` resolves both: small projects keep the `4` floor (preserving sensitivity to micro-patterns); whale projects float up to the `30` ceiling (filtering chance and clutter). The ceiling is intentionally generous — a 30-session pattern in a 1M-noise pool is still a real product insight, and we don't want the scaling rule to silently lose it.
+
+This is the same shape as the rest of the taxonomy's "use absolute thresholds with proportional bounds" pattern (see [Trigger model](#trigger-model)): a single static threshold can't span 3 orders of magnitude of project size without becoming wrong at one end or both.
+
+### Why HDBSCAN for births and TS agglomerative average-linkage for the category roll-up
+
+Different goals at different stages, different tools:
+
+- **Births** need to handle variable-density topic populations and produce a first-class noise label for points that don't fit anywhere. HDBSCAN does both natively (see [Why UMAP + HDBSCAN for births](#why-umap--hdbscan-for-births-and-not-the-full-birchumaphdbscanfaiss-stack)). UMAP-15 reduces dimensionality before HDBSCAN so the density estimates are sharp.
+- **Category roll-up** wants spherical-ish groupings of ~hundreds of leaf centroids into 5–15 categories. Pure-TS agglomerative average-linkage on the cluster centroids is sub-millisecond at that count and gives clean results. Pushing it through HDBSCAN would force an artificial second engine RPC for a problem the engine isn't shaped for (a category isn't a density region; it's a navigation grouping over already-cleaned centroids).
+
+This keeps the engine boundary narrow: one RPC, one purpose, one place to swap.
+
+### Why a square-root-K heuristic for the category layer
+
+The category layer is a navigation aid, not a statistical claim. `K ≈ sqrt(active_cluster_count)` (capped at 15) gives the user a reasonable navigation breadth at any scale: 9 clusters → 3 categories, 100 clusters → 10 categories, 1000 clusters → 15 categories (clamped). Information-criterion-based K selection (BIC, gap statistic) is Future Work and only worth the complexity if the heuristic produces noticeably wrong groupings on real data.
+
+### Why no Hungarian lineage at the category layer
+
+Leaf clusters carry identity across runs (they exist persistently in PG with stable ids). Categories are rebuilt from scratch each run and matched against prior categories via cosine continuation. Hungarian-style 1:1 + secondary scans for splits/merges is overkill for the K≤15 category layer and would obscure the simpler "rebuild + match" mental model the user sees in the UI. Leaf-level Hungarian + secondary scans is the right tool for the leaf layer and is explicit Future Work — the MVP records simple Birth/Death/Continuation/Merge transitions inline as gardening runs, without the global optimization step.
+
+## Constraints & limitations
+
+### Forward-only rollout
+
+There is no first-class historical backfill. Sessions completed before the worker started running are invisible. Re-enqueuing `taxonomy:observeSession` for historical sessions works mechanically (admin script) but is operational, not productized.
+
+### Cold-start window
+
+Until a project has accumulated `TAXONOMY_GARDENING_MIN_OBSERVATIONS` observations (initial: 50) within the gardening lookback (initial: 7d), no clusters exist and every session lands in noise. The product surface shows an empty state ("Not enough observations yet") for cold-start projects. The next gardening sweep after the threshold is crossed produces the first taxonomy.
+
+### Single-assignment
+
+An observation belongs to exactly one leaf cluster (or noise). A session that legitimately spans multiple behaviors ("user asked about pricing, then changed topic to feature requests") is forced into one assignment. Multi-label and in-session segmentation are Future Work.
+
+### One global summary model
+
+`TAXONOMY_SUMMARY_MODEL` is one constant. Tenants with very different content distributions may want different models. Subscription-plan knobs (per-tier model resolution, same shape as the trace-search Future Work) cover this; not in MVP.
+
+### Python engine availability is a hard dependency
+
+The noise-sweep births step calls out to `@platform/op-taxonomy-engine` over RPC. If the engine is unreachable, that step fails — the rest of the gardening run (merge, death, reassignment, hierarchy, naming) still has no useful work to do without fresh births, so the whole run writes `status = 'failed'` and the next sweep retries. This is the same fate-sharing op-gepa already accepts. Worth flagging because it adds one new SPOF compared to the rest of the worker stack, which is pure TS + Postgres + ClickHouse + Redis.
+
+### Per-project gardening is sequential
+
+Each project's gardening run is a single BullMQ task and runs to completion before the next sweep enqueue lands inside its throttle window. Two thousand projects with hourly throttles and 6h sweeps means at most ~333 active gardening runs per hour per worker pod, easy at the sweep batch size. No parallel intra-project gardening because cluster state is mutated globally per project.
+
+### Naming model determinism
+
+LLM-generated names drift across runs even when the underlying cluster contents change negligibly. We cap the renaming frequency via `TAXONOMY_NAMING_REFRESH_OBSERVATIONS` (initial: 25 new observations between renames), but a small linguistic re-roll per refresh is expected and intended — the cluster name is a label, not a stable identifier. The stable identifier is the cluster id.
+
+### No Temporal workflow
+
+Both online and offline pipelines run as BullMQ tasks. Temporal would buy retry semantics and visibility but adds workflow-versioning headache (see `temporal-developer` skill). The MVP picks BullMQ for the same reason `issues:refresh` and `trace-search:refreshTrace` do.
+
+## Future work
+
+In rough priority order. None on the near-term roadmap; documented here so the MVP design doesn't accidentally foreclose them.
+
+### Extract shared centroid core
+
+`@domain/issues` and `@domain/taxonomy` duplicate `createCentroid` / `updateCentroid` / `normalizeCentroid` byte-for-byte modulo the constants. Once both surfaces are stable, hoist the math into `@domain/shared` (or a thin `@domain/clustering`) and have both packages re-export shaped helpers. This is the right design; it's deferred because the cost of duplicating ~120 lines of well-tested math is lower than the cost of breaking issue discovery during taxonomy MVP delivery.
+
+### Hungarian + secondary-link lineage
+
+The MVP records lineage rows inline as births/merges happen during gardening. The fuller version is a 3-pass match against the old-vs-new centroid cosine matrix: Hungarian 1:1 matching for continuations, row scan for splits, column scan for merges. This produces a globally optimal continuation graph and surfaces splits (one old cluster → two new) cleanly. Worth implementing once we have a benchmark corpus of human-labeled transitions to tune the secondary-link threshold against.
+
+### Intra-session segmentation
+
+Multi-behavior sessions ("billing question → feature request → praise") produce one diluted observation today. Segmenting by cosine drift between adjacent message-window embeddings gives finer-grained taxonomy resolution. Implementation: emit multiple observation rows per session with `segment_index` as part of the ReplacingMergeTree dedup key, otherwise identical to the current shape.
+
+### Per-tier model + threshold knobs
+
+`TAXONOMY_SUMMARY_MODEL`, `TAXONOMY_EMBEDDING_MODEL`, the absolute/relative gates, and the centroid half-life are good candidates for per-subscription-tier resolution (same shape as the trace-search subscription-plan knobs Future Work). The MVP keeps them as single constants until customer scale demands tiering.
+
+### Bayesian threshold tuning loop
+
+A held-out human-labeled set (or a richer human-confirmed transition log) supports automated retuning of every threshold via Optuna or Effect-friendly equivalent. The MVP relies on the seeded Acme corpus + manual inspection; the production loop materializes once the metric set and the human-labeled pool are large enough.
+
+### Adaptive gardening cadence
+
+The MVP uses three fixed triggers — the 6h cron sweep, the 1h activity throttle, and the 5-min noise-pressure throttle. This bounds the noise pool correctly and is materially fine for the seeded Acme corpus and small/medium customer scale, but two inefficiencies remain at the edges:
+
+- **Mature/dormant projects** keep getting swept every 6h by the cron path even when nothing has changed — wasted gardening cycles for a no-op outcome.
+- **Cold-starting whales** fire the noise-pressure path every ~4 hours during the first ~week of convergence (the 30k trigger gives HDBSCAN enough data per pass that re-birth churn is much reduced versus the previous 8k design, but it's still not zero — clusters born early may still merge or rename in subsequent passes during convergence, churning the lineage table and burning some LLM naming cost on short-lived clusters).
+
+A neat self-tuning answer is to replace the fixed activity throttle with a **per-project adaptive interval** that reacts to each run's observed productivity (`clusters_born + clusters_merged + clusters_deprecated + noise_reassignment_rate`):
+
+- **Productive run** (≥ N structural changes *or* ≥ X% of clusters touched): halve the interval (or snap to floor).
+- **Quiet run** (0 structural changes): double the interval, up to a ceiling.
+- Floor ≈ 1h, ceiling ≈ 24h. State persisted as `next_eligible_at` on the project's taxonomy state row; the cron sweep picks projects whose timer has expired instead of fanning out unconditionally. The noise-pressure path keeps its own short throttle independent of the adaptive interval — it remains the correctness valve against overshooting the noise-sweep working ceiling.
+
+The behavior falls out naturally for the mature/dormant case: a mature project drifts toward the ceiling and only snaps back when a new behavior burst produces a productive run.
+
+The companion fix on the cost side is **deferred naming** — don't pay LLM naming cost on a cluster until it has survived one gardening pass without being merged (or has accumulated ≥ N observations). Short-lived clusters from the convergence phase (whether driven by the noise-pressure path or by the adaptive activity path) never pay the naming bill. The data model already supports this via `name = "Pending"`; the change is only in the naming-pass selection criteria.
+
+Both are deferred because the MVP triggers are correct and adequate; this only becomes a real efficiency lever once XL-scale onboarding is a regular occurrence (deferred naming) or once dormant-project sweep waste shows up in real cost reporting (adaptive interval).
+
+### N-level hierarchy
+
+The MVP hard-codes a 2-level hierarchy because the product mockup shows 2 levels and recursive depth-aware schedules are real complexity. Once 2 levels show their limits in real customer data (broad categories like "Billing" containing hundreds of leaves), recursive Category → Subcategory → Cluster hierarchy is the next step. The data model carries `parent_category_id` already; extending requires `parent_subcategory_id` or a self-referential model on a single node table.
+
+### Cross-project taxonomy (templates)
+
+Today's taxonomies are project-scoped and independent. There's a real product wish for "this customer's taxonomy looks like a generic customer-support taxonomy; let me prefill it." That's a templating layer over the existing data model: an org-scoped (or globally-shared) "starter taxonomy" that seeds cluster names + centroids, with the live pipeline doing assignment from sentence one. Out of scope for MVP; the data model accommodates it.
+
+### Observability dashboards
+
+The MVP ships metrics but not dashboards. A "Taxonomy Health" page (gardening run times, observations-to-noise ratio, top-1 confidence histogram, cluster churn rate) lives in the observability epic.
+
+### HNSW for whale projects
+
+Same reasoning as trace-search Future Work. Mirror the size-gated planner once a project crosses the threshold where exact pgvector scan over `taxonomy_clusters` stops being instant.
+
+---
+
+## Tasks
+
+> **Status legend**: `[ ] pending`, `[~] in progress`, `[x] complete`
+
+### Phase 1 — Foundations (data model, package skeleton)
+
+Lays the storage and the bounded-context skeleton. Nothing user-visible. Single PR.
+
+- [ ] **P1-1**: Create `packages/domain/taxonomy/` with the standard layout (`entities/`, `ports/`, `use-cases/`, `testing/`, `helpers.ts`, `helpers.test.ts`, `errors.ts`, `constants.ts`, `index.ts`). Mirror `packages/domain/issues/src/` file naming exactly.
+- [ ] **P1-2**: Define entity schemas in `entities/`: `cluster.ts` (`taxonomyClusterSchema`, `taxonomyCentroidSchema`), `category.ts` (`taxonomyCategorySchema`), `observation.ts` (`taxonomyObservationSchema`), `lineage.ts` (`taxonomyClusterLineageSchema`, `taxonomyRunSchema`). Zod-first per `0001-domain-entity-schema-style.md`.
+- [ ] **P1-3**: Define ports in `ports/`: `taxonomy-cluster-repository.ts`, `taxonomy-category-repository.ts`, `taxonomy-lineage-repository.ts`, `taxonomy-run-repository.ts`, `behavior-observation-repository.ts`, `taxonomy-lock-repository.ts`.
+- [ ] **P1-4**: Centralize every tunable from this spec's [Configuration reference](#configuration-reference) in `constants.ts`, with the documented seed values. No inline literals in use-cases or repository code.
+- [ ] **P1-5**: Define `errors.ts` with `Data.TaggedError` classes per the issues reference pattern (`TaxonomyClusterNotFoundError`, `TaxonomyClusterLockUnavailableError`, `TaxonomyEmbeddingDimensionMismatchError`, `TaxonomyCentroidModelMismatchError`, etc.).
+- [ ] **P1-6**: Implement the centroid helpers in `helpers.ts` (`createTaxonomyCentroid`, `updateTaxonomyCentroid`, `applyDecay`, `normalizeTaxonomyCentroid`, `validateVector`). Port from `@domain/issues/src/helpers.ts` line-for-line with the constants substitution. Co-locate exhaustive `helpers.test.ts`.
+- [ ] **P1-7**: Postgres migration (Drizzle Kit) for `taxonomy_clusters`, `taxonomy_categories`, `taxonomy_cluster_lineage`, `taxonomy_runs`. Generated `search_document` columns + indexes per [Data model](#data-model). No FK constraints per repo rule.
+- [ ] **P1-8**: ClickHouse migration via `pnpm --filter @platform/db-clickhouse ch:create behavior_observations`. Fill both the `unclustered/` and `clustered/` variants per the DDL in [Data model](#data-model).
+- [ ] **P1-9**: Pure-TS helpers in `helpers.ts`: `agglomerativeCluster(centroids, { metric: "cosine", linkage: "average", k })` (used **only** for the 5–15-category roll-up; not for the noise sweep — that's the Python engine in Phase 4), `farthestPointSample(embeddings, budget)`, `softmax(values, temperature)`. Each with co-located tests.
+- [ ] **P1-10**: `testing/fake-*-repository.ts` in-memory adapters per the `@domain/issues/testing/` shape. Export through `testing/index.ts`.
+
+**Exit gate:** All taxonomy types, constants, helpers, ports, errors, and migrations compile and tests pass. No worker yet; no repository impls yet. `pnpm --filter @domain/taxonomy test` and `pnpm --filter @domain/taxonomy typecheck` are green.
+
+### Phase 2 — Platform adapters (Postgres + ClickHouse repositories)
+
+Implements the ports against real storage. Still no online pipeline. Single PR.
+
+- [ ] **P2-1**: Drizzle schema in `packages/platform/db-postgres/src/schema/` for the four PG tables. Mirror `issues.ts` shape (jsonb + vector + generated tsvector + indexes).
+- [ ] **P2-2**: `TaxonomyClusterRepositoryLive` in `packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts`. Implements `findById`, `listByIds`, `listActiveByProject`, `listNearestActive(orgId, projectId, queryVector, k)` (inlined `vector` literal per node-postgres limitation), `hybridSearch(orgId, projectId, queryVector, queryText, ...)`, `save` (materializes `centroid_embedding` from JSONB centroid), `bulkUpdateParentCategory`, `markMerged`, `markDeprecated`.
+- [ ] **P2-3**: `TaxonomyCategoryRepositoryLive` similarly. Includes `listByProject`, `findBestMatchByVector`, `save`, `markDeprecated`.
+- [ ] **P2-4**: `TaxonomyLineageRepositoryLive` (append-only) + `TaxonomyRunRepositoryLive` (CRUD).
+- [ ] **P2-5**: `TaxonomyLockRepositoryLive` — Redis `SET NX EX` + token comparison on release. Project-scoped keys `org:${organizationId}:taxonomy:cluster:${clusterId}` and `org:${organizationId}:taxonomy:garden:${projectId}`. Mirror `IssueDiscoveryLockRepository`.
+- [ ] **P2-6**: `BehaviorObservationRepositoryLive` in `packages/platform/db-clickhouse/src/repositories/`. Implements `upsert`, `listNoiseByProject(orgId, projectId, sinceTs)`, `listByCluster(orgId, projectId, clusterId, { cursor, pageSize })`, `getCounts(orgId, projectId)`, `findBySessionAndSummaryHash`. JSONEachRow inserts, parameterized SELECTs per CH skill rules.
+- [ ] **P2-7**: Composition wiring in `apps/workers/src/server.ts` is deferred to Phase 3; this phase ships only the live layers and their unit tests against the testkit PGlite / chdb fakes.
+
+**Exit gate:** All repository tests pass against the testkit fakes; integration tests against PGlite/chdb green; `pnpm --filter @platform/db-postgres test` and `pnpm --filter @platform/db-clickhouse test` green for taxonomy paths.
+
+### Phase 3 — Online observation pipeline
+
+The user-visible "live" half. Single PR; adds the `taxonomy:observeSession` worker and the trace-end hook.
+
+- [ ] **P3-1**: Use-case `summarizeBehaviorUseCase` in `@domain/taxonomy/src/use-cases/summarize-behavior.ts`. Builds the prompt + schema described in [Online observation pipeline §4](#observesession-handler-step-by-step), calls `AI.generate`, returns the parsed object. Per-organization telemetry metadata.
+- [ ] **P3-2**: Use-case `embedBehaviorSummaryUseCase`. Mirrors `embedScoreFeedbackUseCase` exactly.
+- [ ] **P3-3**: Use-case `findNearestClustersUseCase`. Wraps `TaxonomyClusterRepository.listNearestActive`.
+- [ ] **P3-4**: Use-case `decideClusterAssignmentUseCase`. Pure function over the top-K result, returns `{ method, clusterId, confidence }`. Tests cover both gates passing/failing in every combination.
+- [ ] **P3-5**: Use-case `assignObservationToClusterUseCase`. Acquires per-cluster lock, re-reads cluster, folds embedding into centroid, persists via `TaxonomyClusterRepository.save`, increments `observation_count` and `last_observed_at`, releases lock. Mirror `assignScoreToIssueUseCase`.
+- [ ] **P3-6**: Orchestration use-case `recordSessionObservationUseCase`. End-to-end: load session, build document, summarize, embed, find nearest, decide, assign-or-noise, write observation row. Co-located test against testkit fakes covers every branch.
+- [ ] **P3-7**: Worker module `apps/workers/src/workers/taxonomy.ts`. `createTaxonomyWorker(deps)` subscribes to topic `"taxonomy"` with `observeSession` task (later tasks added in P4). `runObserveSessionJob` composes the layers exactly as `trace-search.ts` does; `Effect.withSpan("taxonomy.observeSession")` + `Effect.orElseSucceed(() => undefined)` at the boundary.
+- [ ] **P3-8**: Hook into `runTraceEndJob`: after the existing `trace-search:refreshTrace` publish, add a sibling `publisher.publish("taxonomy", "observeSession", payload, { dedupeKey, debounceMs: TAXONOMY_OBSERVATION_DEBOUNCE_MS })`. Wrap in the same `.map(() => true).catch(...)` shape as `deterministic-flaggers:run` so failures only log.
+- [ ] **P3-9**: Wire the new worker into `apps/workers/src/server.ts` alongside existing worker registrations.
+- [ ] **P3-10**: End-to-end test: feed a seeded session through the worker (testkit), verify observation row appears in chdb with the expected `assignment_method`. Cover both cold-start (no clusters → noise) and assignment-against-existing-cluster paths.
+
+**Exit gate:** Live worker runs end-to-end against a seeded Acme project: new sessions produce observation rows; observations match an existing cluster when one exists, otherwise fall to noise. `pnpm --filter @apps/workers typecheck` and the worker integration tests pass.
+
+### Phase 4 — Python clustering engine (`@platform/op-taxonomy-engine`)
+
+The sidecar that runs UMAP + HDBSCAN for the noise-sweep births step. Mirrors `@platform/op-gepa` end-to-end: Python `op_taxonomy_engine` package + TS client + RPC protocol + container. Single PR; lands before Phase 5 because the gardening worker depends on it.
+
+- [ ] **P4-1**: Scaffold `packages/platform/op-taxonomy-engine/python/` with `pyproject.toml` (uv-managed), `op_taxonomy_engine` package layout copied from `op_gepa_engine`. Pin `numpy`, `umap-learn`, `hdbscan`, `scikit-learn`. Reuse the existing `rpc/server.py` + `rpc/protocol.py` patterns; no need to invent a new transport.
+- [ ] **P4-2**: Implement the `noiseSweep` handler in `op_taxonomy_engine/core/`. Inputs: `embeddings: list[list[float]]`, `minClusterSize: int`, `minSamples: int`, `umapNComponents: int`, `umapNNeighbors: int`, `umapMinDist: float`, `randomSeed: int`. Pipeline: `UMAP(n_components, n_neighbors, min_dist, random_state=randomSeed).fit_transform(embeddings)` → `HDBSCAN(min_cluster_size, min_samples, metric="euclidean", cluster_selection_method="eom").fit(reduced)`. Outputs: `assignments: list[int]` (HDBSCAN labels, -1 for noise) and `outlierScores: list[float]`. Deterministic given the same input + seed; assert this in a test.
+- [ ] **P4-3**: TS client `packages/platform/op-taxonomy-engine/src/`: `client.ts`, `protocol.ts`, `constants.ts`, `index.ts`. Mirror `@platform/op-gepa` shape exactly. Single exported port `TaxonomyEngineClient` with `noiseSweep(request)` method. Co-located protocol tests.
+- [ ] **P4-4**: Container + deploy lane: Dockerfile, container image, pin to op-gepa's deployment shape. Health check + ready endpoint per the existing RPC server pattern.
+- [ ] **P4-5**: Integration test against the running container: synthetic 2-cluster embeddings (two Gaussian blobs in 2048-dim space) → assert two cluster labels emerge with the right member counts and the expected handful of noise points.
+
+**Exit gate:** Engine container starts, RPC client connects, deterministic synthetic-data test passes against the engine.
+
+### Phase 5 — Offline gardening pipeline
+
+The "live" half. Multiple PRs possible (one per major activity), but the easier path is one PR landing all gardening activities behind the same worker. Each activity is independently testable.
+
+- [ ] **P5-1**: Cron-sweep handler `taxonomy:gardenSweep`. Admin Postgres path, enumerates projects with ≥`TAXONOMY_GARDENING_MIN_OBSERVATIONS` observations in the lookback, publishes one `taxonomy:gardenProject` per project with the throttle key. Mirror `sweep-escalating-issues.ts` shape.
+- [ ] **P5-2**: `queuePublisher.scheduleRepeatable` registration in `apps/workers/src/server.ts` for the cron. Idempotent by `TAXONOMY_GARDENING_CRON_KEY`.
+- [ ] **P5-3**: Per-project orchestrator `runGardenProjectJob` in the taxonomy worker. Acquires per-project lock, inserts `taxonomy_runs` row, runs activities A→G in order, closes the run, releases the lock. Time-capped at `TAXONOMY_GARDENING_MAX_RUNTIME_MS`.
+- [ ] **P5-4**: Activity A — `sweepNoiseAndBirthClustersUseCase` per [§A](#a-noise-sweep-cluster-births). Computes `minClusterSize`, calls `TaxonomyEngineClient.noiseSweep`, runs the absorption check on each engine-returned cluster, writes births. Failure on the engine RPC propagates and fails the run (see [Python engine availability is a hard dependency](#python-engine-availability-is-a-hard-dependency)).
+- [ ] **P5-5**: Activity B — `mergeNearDuplicateClustersUseCase` per [§B](#b-merge-pass).
+- [ ] **P5-6**: Activity C — `deprecateInactiveClustersUseCase` per [§C](#c-death-pass).
+- [ ] **P5-7**: Activity D — `reassignNoiseToCurrentClustersUseCase` per [§D](#d-reassignment-pass-catch-up-for-the-noise-floor).
+- [ ] **P5-8**: Activity E — `rebuildCategoryHierarchyUseCase` per [§E](#e-hierarchy-rebuild-categories). TS agglomerative average-linkage on cluster centroids (helper from P1-9), K selection, continuation matching, `parent_category_id` batch update.
+- [ ] **P5-9**: Activity F — `nameClusterUseCase` and `nameCategoryUseCase` per [§F](#f-naming-pass). FPS sampling helper, map+reduce LLM calls, Zod schemas inline. Tests use a stubbed `AI` adapter that returns deterministic names.
+- [ ] **P5-10**: Activity G — `emitLineageUseCase`. Pure-PG writes; one row per transition emitted by activities A/B/C.
+- [ ] **P5-11**: Manual-trigger use-case `triggerProjectGardeningUseCase` (admin-only) that publishes a `taxonomy:gardenProject` with the throttle key. Wired into the `backoffice` skill convention if applicable; otherwise lives as a domain use-case for now.
+- [ ] **P5-12**: End-to-end test: seed a project with synthetic noise; run gardening against the running engine container; assert births, names, lineage rows, category assignments. Cover a follow-up run that produces a merge (two near-duplicate clusters in seed).
+
+**Exit gate:** Gardening produces a coherent 2-level taxonomy from a seeded project. Lineage rows match the visible transitions. Re-running gardening with no new data is a no-op (idempotency). `pnpm --filter @apps/workers test` covers the worker; the seeded Acme corpus produces hand-recognizable categories.
+
+### Phase 6 — Read use-cases
+
+Domain read paths consumed later by `apps/web`. No frontend; just the domain surface plus tests.
+
+- [ ] **P6-1**: `listCategoriesUseCase`.
+- [ ] **P6-2**: `listClustersInCategoryUseCase`, `listClustersUseCase`.
+- [ ] **P6-3**: `getClusterDetailsUseCase`, `getCategoryDetailsUseCase`.
+- [ ] **P6-4**: `listObservationsInClusterUseCase`.
+- [ ] **P6-5**: `getClusterTrendUseCase`, `getTaxonomyAnalyticsUseCase`, `getLastRunUseCase`.
+- [ ] **P6-6**: Hybrid search inside `listClustersUseCase` — `IssueRepository.hybridSearch`-equivalent over `taxonomy_clusters`. Reuses the same Voyage embed (cached) for `inputType: "query"`.
+- [ ] **P6-7**: Integration tests against PGlite + chdb fakes for every read use-case.
+
+**Exit gate:** Read use-cases return the right shape against seeded data. `apps/web` can call them through composed server functions when the frontend lands; no `apps/web` changes are part of this phase.
+
+### Phase 7 — Observability, ops, docs
+
+Polish + the durable knowledge handoff. Single PR.
+
+- [ ] **P7-1**: Structured logging tags and metrics enumerated in [Observability](#observability), including engine RPC latency + error-rate metrics on the new `@platform/op-taxonomy-engine` boundary. Effect spans on every use-case via `withTracing`.
+- [ ] **P7-2**: Admin script `scripts/taxonomy/rerun-project.ts` to re-enqueue all sessions in a project through `taxonomy:observeSession` (for ops / corpus tuning).
+- [ ] **P7-3**: `dev-docs/taxonomy.md`. Promote durable knowledge from this spec: data model, lifecycle, online + offline pipelines, engine boundary, configuration reference, decisions. Trim spec-only or task-tracking sections. Cross-link from `dev-docs/spans.md` (trace-end hook) and `dev-docs/issues.md` (shared centroid lineage).
+- [ ] **P7-4**: Update the skill glossary in `CLAUDE.md` if a new taxonomy-specific skill emerges from implementation; otherwise no AGENTS.md change.
+- [ ] **P7-5**: Manual tuning pass against seeded Acme corpus per [Tuning](#tuning-and-the-benchmark-corpus). Document any threshold adjustments back into `constants.ts` with a short comment per change.
+- [ ] **P7-6**: Delete this spec (`specs/live-taxonomy.md`) once `dev-docs/taxonomy.md` is authoritative and the MVP has shipped to staging.
+
+**Exit gate:** Documentation captures the durable design; metrics + logs are present; the seeded corpus produces a hand-recognizable, sensible taxonomy; this spec can be deleted.

--- a/specs/live-taxonomy.md
+++ b/specs/live-taxonomy.md
@@ -568,8 +568,7 @@ Update the `taxonomy_runs` row with `status = 'completed'`, `completed_at`, the 
 - `listObservationsInClusterUseCase(orgId, projectId, clusterId, { cursor?, pageSize? })` — paginated ClickHouse list of observations attached to a cluster, ordered by `start_time DESC`.
 - `getClusterDetailsUseCase(orgId, projectId, clusterId)` — cluster row + a small sample of recent observation summaries for the details drawer.
 - `getCategoryDetailsUseCase(orgId, projectId, categoryId)` — category row + its member clusters.
-- `getClusterTrendUseCase(orgId, projectId, clusterId, { window? })` — observation count per day for the window (default 14 days), for the histogram in the cluster details drawer. Read from CH; mirror `getIssueTrendUseCase`.
-- `getTaxonomyAnalyticsUseCase(orgId, projectId, { window? })` — top-line counts (total active categories, total active clusters, total observations in window, top-5 clusters by occurrence). For the page-level summary panel.
+- `getTaxonomyAnalyticsUseCase(orgId, projectId, { window? })` — top-line counts (total active categories, total active clusters, total observations in window, top-5 clusters by occurrence) plus ClickHouse-side current-vs-baseline trend summaries for those top clusters. For the page-level summary panel.
 - `getLastRunUseCase(orgId, projectId)` — the most recent `taxonomy_runs` row plus a small slice of lineage transitions (last 10 births/merges) for an "Activity" panel.
 
 Operational use-cases (not user-surfaced):
@@ -974,7 +973,7 @@ Domain read paths consumed later by `apps/web`. No frontend; just the domain sur
 - [ ] **P6-2**: `listClustersInCategoryUseCase`, `listClustersUseCase`.
 - [ ] **P6-3**: `getClusterDetailsUseCase`, `getCategoryDetailsUseCase`.
 - [ ] **P6-4**: `listObservationsInClusterUseCase`.
-- [ ] **P6-5**: `getClusterTrendUseCase`, `getTaxonomyAnalyticsUseCase`, `getLastRunUseCase`.
+- [ ] **P6-5**: `getTaxonomyAnalyticsUseCase`, `getLastRunUseCase`.
 - [ ] **P6-6**: Hybrid search inside `listClustersUseCase` — `IssueRepository.hybridSearch`-equivalent over `taxonomy_clusters`. Reuses the same Voyage embed (cached) for `inputType: "query"`.
 - [ ] **P6-7**: Integration tests against PGlite + chdb fakes for every read use-case.
 


### PR DESCRIPTION
Adds a feature-flagged live taxonomy recommendation surface to the search empty state. When `live-taxonomy-search-recommendations` is enabled, the blank slate shows randomized behavior search cards, trend/category pills, and an inline expandable category browser that links each behavior back into trace search.

Moves taxonomy naming out of the gardening job and into Temporal workflows. Gardening now completes the structural taxonomy update, then starts durable naming workflows for pending clusters/categories. Category naming waits for member clusters to have names, and the prompt rejects taxonomy-mechanics labels like “Pending States” or “Uncategorized Behaviors”.

Adds read-time trend analytics for top clusters using ClickHouse observation counts over the current 24h window vs a 7d baseline. The UI maps those statuses to user-facing labels such as new, spiking, rising, steady, cooling, and fading.

Also adds an ops backfill script for local/corpus taxonomy seeding and renumbers the behavior-observations ClickHouse migration to avoid the branch conflict with trace search.

Validation run:
- `pnpm --filter @domain/feature-flags typecheck && pnpm --filter @domain/queue typecheck && pnpm --filter @domain/taxonomy typecheck && pnpm --filter @platform/db-clickhouse typecheck && pnpm --filter @app/workflows typecheck && pnpm --filter @app/workers typecheck && pnpm --filter @app/web typecheck`
- `pnpm --filter @domain/feature-flags check && pnpm --filter @domain/queue check && pnpm --filter @domain/taxonomy check && pnpm --filter @platform/db-clickhouse check && pnpm --filter @app/workflows check && pnpm --filter @app/workers check && pnpm --filter @app/web check`
- commit hook (`turbo format` + `knip`)

UI note: attach screenshots or a short recording of the search blank slate with the feature flag enabled.