### PR TITLE
feat(notifications): add unsubscribe footer to notification emails

### DIFF
--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -4,14 +4,40 @@ import { isValidId, ProjectId, projectSettingsSchema } from "@domain/shared"
 import { OutboxEventWriterLive, ProjectRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { setCookie } from "@tanstack/react-start/server"
+import { getCookies, setCookie } from "@tanstack/react-start/server"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getOutboxWriter, getPostgresClient } from "../../server/clients.ts"
 
-export const LAST_PROJECT_COOKIE_NAME = "latitude-last-project-slug"
+const LAST_PROJECT_COOKIE_NAME = "latitude-last-project-slug"
 const LAST_PROJECT_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
+/**
+ * Resolves the slug of the user's "current" project: the last-viewed slug
+ * from `LAST_PROJECT_COOKIE_NAME` if it still names a project the user has
+ * access to, else the first project in `listProjects()`, else `null` when
+ * the user has no projects at all.
+ *
+ * Used by `/_authenticated/` and by `/_authenticated/settings/$section` to
+ * land users on a project-scoped page without needing a slug in the URL.
+ */
+export const resolveDefaultProjectSlug = createServerFn({ method: "GET" }).handler(async (): Promise<string | null> => {
+  const cookieSlug = getCookies()[LAST_PROJECT_COOKIE_NAME]
+  const { organizationId } = await requireSession()
+  const client = getPostgresClient()
+
+  const projects = await Effect.runPromise(
+    Effect.gen(function* () {
+      const repo = yield* ProjectRepository
+      return yield* repo.list()
+    }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId), withTracing),
+  )
+
+  const cookieMatch = cookieSlug ? projects.find((p) => p.slug === cookieSlug) : undefined
+  const target = cookieMatch ?? projects[0]
+  return target?.slug ?? null
+})
 
 // Persist the currently visited slug so `/_authenticated/` can redirect back
 // to it. Called from the project layout's mount effect — using a server fn

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as BackofficeProjectsProjectIdRouteImport } from './routes/backof
 import { Route as BackofficeOrganizationsOrganizationIdRouteImport } from './routes/backoffice/organizations/$organizationId'
 import { Route as ApiObservabilityTestErrorRouteImport } from './routes/api/observability-test/error'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as AuthenticatedSettingsSectionRouteImport } from './routes/_authenticated/settings/$section'
 import { Route as AuthenticatedProjectsProjectSlugRouteImport } from './routes/_authenticated/projects/$projectSlug'
 import { Route as Char91DotwellKnownChar93OpenidConfigurationSplatRouteImport } from './routes/[.well-known]/openid-configuration/$'
 import { Route as Char91DotwellKnownChar93OauthAuthorizationServerSplatRouteImport } from './routes/[.well-known]/oauth-authorization-server/$'
@@ -219,6 +220,12 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedSettingsSectionRoute =
+  AuthenticatedSettingsSectionRouteImport.update({
+    id: '/settings/$section',
+    path: '/settings/$section',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugRoute =
   AuthenticatedProjectsProjectSlugRouteImport.update({
     id: '/projects/$projectSlug',
@@ -401,6 +408,7 @@ export interface FileRoutesByFullPath {
   '/.well-known/oauth-authorization-server/$': typeof Char91DotwellKnownChar93OauthAuthorizationServerSplatRoute
   '/.well-known/openid-configuration/$': typeof Char91DotwellKnownChar93OpenidConfigurationSplatRoute
   '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRouteWithChildren
+  '/settings/$section': typeof AuthenticatedSettingsSectionRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
@@ -455,6 +463,7 @@ export interface FileRoutesByTo {
   '/welcome': typeof WelcomeIndexRoute
   '/.well-known/oauth-authorization-server/$': typeof Char91DotwellKnownChar93OauthAuthorizationServerSplatRoute
   '/.well-known/openid-configuration/$': typeof Char91DotwellKnownChar93OpenidConfigurationSplatRoute
+  '/settings/$section': typeof AuthenticatedSettingsSectionRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
@@ -513,6 +522,7 @@ export interface FileRoutesById {
   '/.well-known/oauth-authorization-server/$': typeof Char91DotwellKnownChar93OauthAuthorizationServerSplatRoute
   '/.well-known/openid-configuration/$': typeof Char91DotwellKnownChar93OpenidConfigurationSplatRoute
   '/_authenticated/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugRouteWithChildren
+  '/_authenticated/settings/$section': typeof AuthenticatedSettingsSectionRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
@@ -572,6 +582,7 @@ export interface FileRouteTypes {
     | '/.well-known/oauth-authorization-server/$'
     | '/.well-known/openid-configuration/$'
     | '/projects/$projectSlug'
+    | '/settings/$section'
     | '/api/auth/$'
     | '/api/observability-test/error'
     | '/backoffice/organizations/$organizationId'
@@ -626,6 +637,7 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/.well-known/oauth-authorization-server/$'
     | '/.well-known/openid-configuration/$'
+    | '/settings/$section'
     | '/api/auth/$'
     | '/api/observability-test/error'
     | '/backoffice/organizations/$organizationId'
@@ -683,6 +695,7 @@ export interface FileRouteTypes {
     | '/.well-known/oauth-authorization-server/$'
     | '/.well-known/openid-configuration/$'
     | '/_authenticated/projects/$projectSlug'
+    | '/_authenticated/settings/$section'
     | '/api/auth/$'
     | '/api/observability-test/error'
     | '/backoffice/organizations/$organizationId'
@@ -946,6 +959,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/auth/$'
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/settings/$section': {
+      id: '/_authenticated/settings/$section'
+      path: '/settings/$section'
+      fullPath: '/settings/$section'
+      preLoaderRoute: typeof AuthenticatedSettingsSectionRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/projects/$projectSlug': {
       id: '/_authenticated/projects/$projectSlug'
@@ -1262,12 +1282,14 @@ const AuthenticatedProjectsProjectSlugRouteWithChildren =
 interface AuthenticatedRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedProjectsProjectSlugRoute: typeof AuthenticatedProjectsProjectSlugRouteWithChildren
+  AuthenticatedSettingsSectionRoute: typeof AuthenticatedSettingsSectionRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
   AuthenticatedProjectsProjectSlugRoute:
     AuthenticatedProjectsProjectSlugRouteWithChildren,
+  AuthenticatedSettingsSectionRoute: AuthenticatedSettingsSectionRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -1,13 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
-import { createServerFn } from "@tanstack/react-start"
-import { getCookies } from "@tanstack/react-start/server"
 import { z } from "zod"
-import { LAST_PROJECT_COOKIE_NAME, listProjects } from "../../domains/projects/projects.functions.ts"
-
-const getLastProjectSlug = createServerFn({ method: "GET" }).handler(async (): Promise<string | null> => {
-  const slug = getCookies()[LAST_PROJECT_COOKIE_NAME]
-  return typeof slug === "string" && slug.length > 0 ? slug : null
-})
+import { resolveDefaultProjectSlug } from "../../domains/projects/projects.functions.ts"
 
 /**
  * Landing route. Picks the user's current project (last-viewed cookie,
@@ -29,14 +22,13 @@ export const Route = createFileRoute("/_authenticated/")({
   validateSearch: searchSchema,
   loaderDeps: ({ search }) => ({ next: search.next, installed: search.installed, error: search.error }),
   loader: async ({ deps }) => {
-    const [lastSlug, projects] = await Promise.all([getLastProjectSlug(), listProjects()])
-    const target = (lastSlug && projects.find((p) => p.slug === lastSlug)) ?? projects[0]
-    if (!target) return null
+    const slug = await resolveDefaultProjectSlug()
+    if (!slug) return null
 
     if (deps.next === "integrations") {
       throw redirect({
         to: "/projects/$projectSlug/settings/integrations",
-        params: { projectSlug: target.slug },
+        params: { projectSlug: slug },
         search: {
           ...(deps.installed ? { installed: deps.installed } : {}),
           ...(deps.error ? { error: deps.error } : {}),
@@ -46,7 +38,7 @@ export const Route = createFileRoute("/_authenticated/")({
 
     throw redirect({
       to: "/projects/$projectSlug",
-      params: { projectSlug: target.slug },
+      params: { projectSlug: slug },
     })
   },
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -34,7 +34,7 @@ import {
   Tv,
   Watch,
 } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { hasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.functions.ts"
 import {
   getNotificationPreferences,
@@ -354,6 +354,19 @@ function NotificationsSection() {
     enabled: emailNotificationsEnabled,
   })
 
+  // Scroll the targeted toggle into view when the page is opened with a
+  // `#notifications-<group>` hash. Email unsubscribe links go through the
+  // `/settings/$section` redirect, which appends the hash so the user lands
+  // directly on the row they came to flip. Runs once `isLoading` flips false
+  // because the rows don't exist in the DOM until then.
+  useEffect(() => {
+    if (isLoading || !emailNotificationsEnabled) return
+    const hash = window.location.hash.slice(1)
+    if (!hash.startsWith("notifications-")) return
+    const el = document.getElementById(hash)
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [isLoading, emailNotificationsEnabled])
+
   // Local prefs mirror server prefs; saves run in the background per change.
   // Missing entries are treated as "email on" so a fresh user sees every
   // toggle in the on position (matches the opt-out default).
@@ -394,7 +407,8 @@ function NotificationsSection() {
           return (
             <div
               key={group}
-              className="flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4"
+              id={`notifications-${group}`}
+              className="flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4 scroll-mt-8"
             >
               <div className="flex flex-col gap-1">
                 <Label htmlFor={inputId}>{meta.label}</Label>

--- a/apps/web/src/routes/_authenticated/settings/$section.tsx
+++ b/apps/web/src/routes/_authenticated/settings/$section.tsx
@@ -1,0 +1,38 @@
+import { notificationGroupSchema } from "@domain/shared"
+import { createFileRoute, redirect } from "@tanstack/react-router"
+import { z } from "zod"
+import { resolveDefaultProjectSlug } from "../../../domains/projects/projects.functions.ts"
+
+/**
+ * Top-level settings redirect. Resolves the user's "current" project (last
+ * visited, else first available) and forwards to the project-scoped settings
+ * page for that section.
+ *
+ * Lets external links — email footers, bookmarks, support docs — point at
+ * `/settings/<section>` without knowing a project slug. Re-resolves at click
+ * time, so the link still works after the project the email referenced is
+ * deleted.
+ *
+ * The optional `?group=<NotificationGroup>` search param is forwarded as a
+ * URL hash so the destination page (today: `account`) can scroll to the
+ * matching toggle row. Hash fragments aren't sent server-side, so we carry
+ * the intent through an explicit query param instead.
+ */
+const searchSchema = z.object({
+  group: notificationGroupSchema.optional(),
+})
+
+export const Route = createFileRoute("/_authenticated/settings/$section")({
+  validateSearch: searchSchema,
+  loaderDeps: ({ search }) => ({ group: search.group }),
+  loader: async ({ params, deps }) => {
+    const slug = await resolveDefaultProjectSlug()
+    if (!slug) throw redirect({ to: "/" })
+
+    const hash = deps.group ? `notifications-${deps.group}` : ""
+    throw redirect({
+      href: `/projects/${slug}/settings/${params.section}${hash ? `#${hash}` : ""}`,
+    })
+  },
+  component: () => null,
+})

--- a/packages/domain/email/src/components/EmailFooter.tsx
+++ b/packages/domain/email/src/components/EmailFooter.tsx
@@ -1,0 +1,39 @@
+import { NOTIFICATION_GROUP_META, type NotificationGroup } from "@domain/shared"
+import { Link, Text } from "@react-email/components"
+// @ts-expect-error TS6133 - React required at runtime for JSX in workers
+// biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
+import React from "react"
+import { emailDesignTokens } from "../tokens/design-system.js"
+
+interface EmailFooterProps {
+  readonly unsubscribe?: {
+    readonly webAppUrl: string
+    readonly group: NotificationGroup
+  }
+}
+
+/**
+ * Shared, optional footer dropped into `ContainerLayout`'s `footer` slot.
+ * Renders an unsubscribe row when `unsubscribe` is set, nothing otherwise —
+ * safe to pass to any template, even transactional ones that should never
+ * carry an opt-out (magic links, invites, exports).
+ *
+ * The link goes through the generic `/settings/<section>` redirect, which
+ * resolves the user's current project at click time. That means the URL
+ * keeps working even after the project the email referenced is deleted,
+ * and we never need to embed a project slug in the email body.
+ */
+export function EmailFooter({ unsubscribe }: EmailFooterProps) {
+  if (!unsubscribe) return null
+  const base = unsubscribe.webAppUrl.replace(/\/$/, "")
+  const url = `${base}/settings/account?group=${unsubscribe.group}`
+  const label = NOTIFICATION_GROUP_META[unsubscribe.group].label
+  return (
+    <Text className={`${emailDesignTokens.typography.bodySmall} text-muted-foreground text-center m-0`}>
+      You're receiving this because you have <strong>{label}</strong> emails turned on.{" "}
+      <Link href={url} className="text-primary underline">
+        Unsubscribe
+      </Link>
+    </Text>
+  )
+}

--- a/packages/domain/email/src/templates/notifications/custom-message/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/custom-message/EmailTemplate.tsx
@@ -4,6 +4,7 @@ import { Section } from "@react-email/components"
 import React from "react"
 import { ContainerLayout } from "../../../components/ContainerLayout.tsx"
 import { EmailButton } from "../../../components/EmailButton.tsx"
+import { EmailFooter } from "../../../components/EmailFooter.tsx"
 import { EmailText } from "../../../components/EmailText.tsx"
 import { emailDesignTokens } from "../../../tokens/design-system.ts"
 
@@ -12,11 +13,12 @@ interface CustomMessageEmailProps {
   readonly title: string
   readonly content: string | undefined
   readonly linkUrl: string | undefined
+  readonly webAppUrl: string
 }
 
-export function CustomMessageEmail({ userName, title, content, linkUrl }: CustomMessageEmailProps) {
+export function CustomMessageEmail({ userName, title, content, linkUrl, webAppUrl }: CustomMessageEmailProps) {
   return (
-    <ContainerLayout previewText={title}>
+    <ContainerLayout previewText={title} footer={<EmailFooter unsubscribe={{ webAppUrl, group: "custom_messages" }} />}>
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
         {title}
       </EmailText>
@@ -38,5 +40,6 @@ CustomMessageEmail.PreviewProps = {
   title: "We've added new evaluation templates",
   content:
     "Hi Alex, we just shipped three new evaluation templates for tool-calling agents. Take a look at the templates page when you have a minute.",
-  linkUrl: "https://console.latitude.so/evaluations",
+  linkUrl: "http://localhost:3000/evaluations",
+  webAppUrl: "http://localhost:3000",
 } satisfies CustomMessageEmailProps

--- a/packages/domain/email/src/templates/notifications/custom-message/index.tsx
+++ b/packages/domain/email/src/templates/notifications/custom-message/index.tsx
@@ -23,7 +23,13 @@ const buildCustomMessageHtml = async (
   const userName = ctx.recipient.name ?? "there"
   const linkUrl = resolveLinkUrl(ctx, payload.link)
   const html = await renderEmail(
-    <CustomMessageEmail userName={userName} title={payload.title} content={payload.content} linkUrl={linkUrl} />,
+    <CustomMessageEmail
+      userName={userName}
+      title={payload.title}
+      content={payload.content}
+      linkUrl={linkUrl}
+      webAppUrl={ctx.webAppUrl}
+    />,
   )
   return {
     html,

--- a/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
@@ -6,6 +6,7 @@ import { Section } from "@react-email/components"
 import React from "react"
 import { ContainerLayout } from "../../../components/ContainerLayout.tsx"
 import { EmailButton } from "../../../components/EmailButton.tsx"
+import { EmailFooter } from "../../../components/EmailFooter.tsx"
 import { EmailText } from "../../../components/EmailText.tsx"
 import { emailDesignTokens } from "../../../tokens/design-system.ts"
 import {
@@ -30,6 +31,7 @@ interface IncidentClosedEmailProps {
   readonly organizationName: string
   readonly projectName: string | undefined
   readonly recovery: IncidentRecovery
+  readonly webAppUrl: string
 }
 
 export function IncidentClosedEmail({
@@ -43,6 +45,7 @@ export function IncidentClosedEmail({
   organizationName,
   projectName,
   recovery,
+  webAppUrl,
 }: IncidentClosedEmailProps) {
   const issueRef = issueName ?? "an issue"
   const scope = formatScope(organizationName, projectName)
@@ -54,7 +57,10 @@ export function IncidentClosedEmail({
   ]
 
   return (
-    <ContainerLayout previewText={`Resolved: escalation on ${issueRef}`}>
+    <ContainerLayout
+      previewText={`Resolved: escalation on ${issueRef}`}
+      footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
+    >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
         Resolved escalation
       </EmailText>
@@ -103,4 +109,5 @@ IncidentClosedEmail.PreviewProps = {
   organizationName: "Acme Inc.",
   projectName: "Support agent",
   recovery: { durationMs: 32 * 60 * 1000 },
+  webAppUrl: "http://localhost:3000",
 } satisfies IncidentClosedEmailProps

--- a/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
@@ -52,6 +52,7 @@ export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"
             organizationName={ctx.organization.name}
             projectName={ctx.project?.name}
             recovery={payload.recovery}
+            webAppUrl={ctx.webAppUrl}
           />,
         ),
       catch: (cause) => ({

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -6,6 +6,7 @@ import { Section } from "@react-email/components"
 import React from "react"
 import { ContainerLayout } from "../../../components/ContainerLayout.tsx"
 import { EmailButton } from "../../../components/EmailButton.tsx"
+import { EmailFooter } from "../../../components/EmailFooter.tsx"
 import { EmailText } from "../../../components/EmailText.tsx"
 import { emailDesignTokens } from "../../../tokens/design-system.ts"
 import {
@@ -44,6 +45,7 @@ interface IncidentEventEmailProps {
   readonly projectName: string | undefined
   readonly tags: readonly string[] | undefined
   readonly sampleExcerpt: IncidentSampleExcerpt | undefined
+  readonly webAppUrl: string
 }
 
 export function IncidentEventEmail({
@@ -58,6 +60,7 @@ export function IncidentEventEmail({
   projectName,
   tags,
   sampleExcerpt,
+  webAppUrl,
 }: IncidentEventEmailProps) {
   const heading = ALERT_KIND_TO_HEADING[incidentKind]
   const subtitle = ALERT_KIND_TO_SUBTITLE[incidentKind]
@@ -71,7 +74,10 @@ export function IncidentEventEmail({
   ]
 
   return (
-    <ContainerLayout previewText={`${heading}: ${issueRef}`}>
+    <ContainerLayout
+      previewText={`${heading}: ${issueRef}`}
+      footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
+    >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
         {heading}
       </EmailText>
@@ -119,4 +125,5 @@ IncidentEventEmail.PreviewProps = {
     truncated: false,
     author: { kind: "user", name: "Anna Bosch", imageUrl: null },
   },
+  webAppUrl: "http://localhost:3000",
 } satisfies IncidentEventEmailProps

--- a/packages/domain/email/src/templates/notifications/incident-event/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/index.tsx
@@ -54,6 +54,7 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
             projectName={ctx.project?.name}
             tags={payload.tags}
             sampleExcerpt={payload.sampleExcerpt}
+            webAppUrl={ctx.webAppUrl}
           />,
         ),
       catch: (cause) => ({

--- a/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
@@ -6,6 +6,7 @@ import { Section } from "@react-email/components"
 import React from "react"
 import { ContainerLayout } from "../../../components/ContainerLayout.tsx"
 import { EmailButton } from "../../../components/EmailButton.tsx"
+import { EmailFooter } from "../../../components/EmailFooter.tsx"
 import { EmailText } from "../../../components/EmailText.tsx"
 import { emailDesignTokens } from "../../../tokens/design-system.ts"
 import {
@@ -34,6 +35,7 @@ interface IncidentOpenedEmailProps {
   readonly tags: readonly string[] | undefined
   readonly breach: IncidentBreach | undefined
   readonly sampleExcerpt: IncidentSampleExcerpt | undefined
+  readonly webAppUrl: string
 }
 
 const buildBreachLine = (breach: IncidentBreach | undefined): string | null => {
@@ -61,6 +63,7 @@ export function IncidentOpenedEmail({
   tags,
   breach,
   sampleExcerpt,
+  webAppUrl,
 }: IncidentOpenedEmailProps) {
   const issueRef = issueName ?? "an issue"
   const scope = formatScope(organizationName, projectName)
@@ -73,7 +76,10 @@ export function IncidentOpenedEmail({
   ]
 
   return (
-    <ContainerLayout previewText={`Escalating: ${issueRef}`}>
+    <ContainerLayout
+      previewText={`Escalating: ${issueRef}`}
+      footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
+    >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
         Escalating issue
       </EmailText>
@@ -132,4 +138,5 @@ IncidentOpenedEmail.PreviewProps = {
     truncated: false,
     author: { kind: "evaluation", name: "warranty-judge" },
   },
+  webAppUrl: "http://localhost:3000",
 } satisfies IncidentOpenedEmailProps

--- a/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
@@ -54,6 +54,7 @@ export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"
             tags={payload.tags}
             breach={payload.breach}
             sampleExcerpt={payload.sampleExcerpt}
+            webAppUrl={ctx.webAppUrl}
           />,
         ),
       catch: (cause) => ({

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/EmailTemplateV1.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/EmailTemplateV1.tsx
@@ -254,7 +254,7 @@ export function ClaudeCodeWrappedEmailV1({ userName, report, webAppUrl, reportId
   const base = webAppUrl.replace(/\/$/, "")
   const imageBaseUrl = `${base}/email-branding/claude-code-wrapped/personalities`
   const projectUrl = `${base}/projects/${report.project.slug}`
-  const settingsUrl = `${base}/settings/account`
+  const settingsUrl = `${base}/settings/account?group=wrapped_reports`
   const logoUrl = `${base}/latitude-logo.png`
   const fullReportUrl = `${base}/wrapped/${reportId}`
 


### PR DESCRIPTION
## summary

Adds an opt-out link to the four notification email kinds — `incident.event`, `incident.opened`, `incident.closed`, `custom.message` — and fixes the broken settings URL in the Claude Code Wrapped email. To make the unsubscribe link survive after the project the email referenced is deleted, this also introduces a top-level `/settings/<section>` redirect that resolves the user's current project at click time.

Until now `wrapped.report` was the only notification template with any opt-out affordance, and its link pointed at a path that didn't exist (`/settings/account` — the real page is mounted under `/projects/<slug>/settings/account`). The other four kinds had no link at all, which is a CAN-SPAM / Gmail-bulk-sender exposure for `custom.message` in particular and a UX papercut for the incident kinds during a noisy outage.

Transactional emails (magic links, invites, exports) are deliberately untouched — a user can't meaningfully opt out of a sign-in email they just requested.

## the generic settings redirect

`/settings/<section>` lives at `apps/web/src/routes/_authenticated/settings/$section.tsx`. It re-uses the same cookie + fallback that `_authenticated/index.tsx` already does (now extracted into `resolveDefaultProjectSlug()` so both routes stay in lockstep) and redirects to `/projects/<resolvedSlug>/settings/<section>`. The redirect is dynamic over `<section>`, so every existing settings sub-page benefits — `general`, `members`, `billing`, etc. — not just `account`.

Two consequences worth calling out:

- The link in an email still resolves correctly after the source project is deleted, because the slug is recomputed at click time against `listProjects()`.
- An optional `?group=<NotificationGroup>` search param is converted into a `#notifications-<group>` URL hash on the final redirect so the account settings page can scroll the targeted toggle into view.

When the user has no projects at all, the redirect falls through to `/`, which already renders the empty-projects state.

## the unsubscribe footer

New shared component at `packages/domain/email/src/components/EmailFooter.tsx`. Takes an optional `unsubscribe: { webAppUrl, group }` prop — renders nothing when omitted, so it's safe to drop into any template. `ContainerLayout` already exposed a `footer` slot that no template was using; the four notification templates now pass `<EmailFooter unsubscribe={...} />` into it.

Each notification kind maps to a group via the existing `NOTIFICATION_KIND_META`: incidents → `incidents`, custom-message → `custom_messages`. The footer copy uses the human label from `NOTIFICATION_GROUP_META`.

`webAppUrl` is propagated through each renderer's `index.tsx` from `ctx.webAppUrl` (already in `NotificationEmailRenderContext`), which the email worker resolves from `LAT_WEB_URL`.

## scroll-to-toggle on the settings page

`NotificationsSection` in `account.tsx` gains a small mount-effect that scrolls `#notifications-<group>` into view once the preferences query has resolved. Each toggle row gets a matching `id` and `scroll-mt-8` so it lands below the page chrome.

## out of scope

- RFC 8058 one-click unsubscribe (`List-Unsubscribe` / `List-Unsubscribe-Post` headers + tokenized endpoint). Strictly additive; can layer on later if Gmail bulk-sender deliverability becomes a concern.
- Per-project notification preferences. Today preferences are user-scoped per group.

## test plan

- [ ] `pnpm --filter @domain/email typecheck` and `pnpm --filter @app/web typecheck` pass.
- [ ] Run `pnpm --filter @domain/email dev` (React Email preview on port 3001) and confirm the four notification templates render an "Unsubscribe" row, transactional templates render unchanged, and the Wrapped template footer URL now includes `?group=wrapped_reports`.
- [ ] Log in as a seeded user, visit `/settings/account` — should land on `/projects/<slug>/settings/account`. Same for `/settings/general`, `/settings/billing`, etc.
- [ ] Create two projects, visit one to set the `latitude-last-project-slug` cookie, delete that project, then visit `/settings/account` — should redirect to the other project.
- [ ] Navigate to `/projects/<slug>/settings/account#notifications-incidents` and confirm the incidents toggle scrolls into view.
- [ ] Trigger one notification of each of the four kinds, open the email in Mailpit, click Unsubscribe → lands on the right toggle scrolled into view.