### PR TITLE
fix(core): destroy workspaces with provider logs, spans and events

### DIFF
--- a/packages/core/src/services/workspaces/destroy.test.ts
+++ b/packages/core/src/services/workspaces/destroy.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { faker } from '@faker-js/faker'
+import { LogSources, Providers } from '@latitude-data/constants'
+import { database } from '../../client'
+import { unsafelyFindWorkspace } from '../../data-access/workspaces'
+import { events } from '../../schema/models/events'
+import { documentLogs } from '../../schema/legacyModels/documentLogs'
+import { evaluationResults } from '../../schema/legacyModels/evaluationResults'
+import {
+  EvaluationMetadataType,
+  evaluations,
+} from '../../schema/legacyModels/evaluations'
+import { providerLogs } from '../../schema/legacyModels/providerLogs'
+import { type Commit } from '../../schema/models/types/Commit'
+import { type User } from '../../schema/models/types/User'
+import { type Workspace } from '../../schema/models/types/Workspace'
+import {
+  createApiKey,
+  createProject,
+  createProviderApiKey,
+  createSpan,
+} from '../../tests/factories'
+import { destroyWorkspace } from './destroy'
+
+describe('destroyWorkspace', () => {
+  let workspace: Workspace
+  let user: User
+  let commit: Commit
+
+  beforeEach(async () => {
+    const {
+      workspace: w,
+      user: u,
+      commit: c,
+    } = await createProject({ workspace: { name: 'workspace' } })
+    workspace = w
+    user = u
+    commit = c
+  })
+
+  it('destroys an empty workspace', async () => {
+    const result = await destroyWorkspace(workspace)
+
+    expect(result.ok).toBe(true)
+    expect(await unsafelyFindWorkspace(workspace.id)).toBeUndefined()
+  })
+
+  it('destroys a workspace with spans, provider logs and legacy evaluation results', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      user,
+      name: 'provider',
+      type: Providers.OpenAI,
+    })
+    const { apiKey } = await createApiKey({
+      workspace,
+      name: faker.string.alpha(),
+    })
+
+    // events.workspaceId -> workspaces.id has no onDelete (NO ACTION) and is
+    // not removed by cascade, so it blocks deleting the workspace row.
+    await database.insert(events).values({
+      workspaceId: workspace.id,
+      type: 'workspaceCreated',
+      data: {},
+    })
+
+    // spans.apiKeyId -> apiKeys.id is onDelete: 'restrict'
+    await createSpan({ workspaceId: workspace.id, apiKeyId: apiKey.id })
+
+    // provider_logs.providerId -> providerApiKeys.id and
+    // provider_logs.apiKeyId -> apiKeys.id are both onDelete: 'restrict'
+    const [providerLog] = await database
+      .insert(providerLogs)
+      .values({
+        uuid: faker.string.uuid(),
+        workspaceId: workspace.id,
+        providerId: provider.id,
+        apiKeyId: apiKey.id,
+        source: LogSources.API,
+      })
+      .returning()
+
+    // Legacy v1 chain: evaluation_results.providerLogId -> provider_logs.id has
+    // no onDelete (NO ACTION). evaluation_results has no workspaceId, so it is
+    // only reachable through evaluations and blocks deleting the provider log.
+    const [evaluation] = await database
+      .insert(evaluations)
+      .values({
+        workspaceId: workspace.id,
+        name: 'evaluation',
+        description: 'legacy evaluation',
+        metadataType: EvaluationMetadataType.LlmAsJudgeSimple,
+        metadataId: 1,
+      })
+      .returning()
+
+    const [documentLog] = await database
+      .insert(documentLogs)
+      .values({
+        uuid: faker.string.uuid(),
+        workspaceId: workspace.id,
+        documentUuid: faker.string.uuid(),
+        commitId: commit.id,
+        resolvedContent: 'content',
+        contentHash: 'hash',
+        parameters: {},
+        source: LogSources.API,
+      })
+      .returning()
+
+    await database.insert(evaluationResults).values({
+      uuid: faker.string.uuid(),
+      evaluationId: evaluation!.id,
+      documentLogId: documentLog!.id,
+      providerLogId: providerLog!.id,
+      evaluatedProviderLogId: providerLog!.id,
+      evaluationProviderLogId: providerLog!.id,
+      source: LogSources.API,
+    })
+
+    const result = await destroyWorkspace(workspace)
+
+    expect(result.ok).toBe(true)
+    expect(await unsafelyFindWorkspace(workspace.id)).toBeUndefined()
+  })
+})

--- a/packages/core/src/services/workspaces/destroy.ts
+++ b/packages/core/src/services/workspaces/destroy.ts
@@ -1,11 +1,16 @@
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 
 import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
+import { evaluationResults } from '../../schema/legacyModels/evaluationResults'
+import { evaluations } from '../../schema/legacyModels/evaluations'
+import { providerLogs } from '../../schema/legacyModels/providerLogs'
 import { apiKeys } from '../../schema/models/apiKeys'
 import { claimedRewards } from '../../schema/models/claimedRewards'
+import { events } from '../../schema/models/events'
 import { integrations } from '../../schema/models/integrations'
 import { providerApiKeys } from '../../schema/models/providerApiKeys'
+import { spans } from '../../schema/models/spans'
 import { subscriptions } from '../../schema/models/subscriptions'
 import { workspaces } from '../../schema/models/workspaces'
 import type { Workspace } from '../../schema/models/types/Workspace'
@@ -14,15 +19,23 @@ import type { Workspace } from '../../schema/models/types/Workspace'
  * Permanently destroys a workspace and all associated data.
  * This is a destructive operation that cannot be undone.
  *
- * Handles cleanup of tables that don't have cascade delete:
- * - providerApiKeys
- * - apiKeys
- * - claimedRewards
- * - integrations
- * - subscriptions
+ * The deletion order is forced by the foreign key graph and must not be
+ * reordered casually:
  *
- * All other related tables (projects, memberships, etc.) are handled
- * by database cascade delete constraints.
+ * - `spans` and `provider_logs` reference `apiKeys`/`providerApiKeys` with
+ *   `onDelete: 'restrict'`, so they must be deleted before those keys.
+ * - `evaluation_results` (legacy v1) references `provider_logs` without a
+ *   cascade and has no `workspaceId` of its own, so it must be deleted (scoped
+ *   through its `evaluations`) before the provider logs.
+ * - `apiKeys`, `providerApiKeys`, `claimedRewards`, `integrations` and `events`
+ *   reference `workspaces` without a cascade, so they must be deleted before
+ *   the workspace row.
+ * - `workspaces.currentSubscriptionId` references `subscriptions`, so the
+ *   workspace must be deleted before its subscriptions.
+ *
+ * All other related tables (projects, memberships, document logs, evaluations,
+ * etc.) are removed by database cascade delete constraints when the workspace
+ * row is deleted.
  */
 export async function destroyWorkspace(
   workspace: Workspace,
@@ -30,6 +43,22 @@ export async function destroyWorkspace(
 ) {
   return transaction.call(async (tx) => {
     const workspaceId = workspace.id
+
+    await tx.delete(evaluationResults).where(
+      inArray(
+        evaluationResults.evaluationId,
+        tx
+          .select({ id: evaluations.id })
+          .from(evaluations)
+          .where(eq(evaluations.workspaceId, workspaceId)),
+      ),
+    )
+
+    await tx.delete(spans).where(eq(spans.workspaceId, workspaceId))
+
+    await tx
+      .delete(providerLogs)
+      .where(eq(providerLogs.workspaceId, workspaceId))
 
     await tx
       .delete(providerApiKeys)
@@ -44,6 +73,8 @@ export async function destroyWorkspace(
     await tx
       .delete(integrations)
       .where(eq(integrations.workspaceId, workspaceId))
+
+    await tx.delete(events).where(eq(events.workspaceId, workspaceId))
 
     await tx.delete(workspaces).where(eq(workspaces.id, workspaceId))
 

--- a/packages/core/src/services/workspaces/destroy.ts
+++ b/packages/core/src/services/workspaces/destroy.ts
@@ -44,15 +44,17 @@ export async function destroyWorkspace(
   return transaction.call(async (tx) => {
     const workspaceId = workspace.id
 
-    await tx.delete(evaluationResults).where(
-      inArray(
-        evaluationResults.evaluationId,
-        tx
-          .select({ id: evaluations.id })
-          .from(evaluations)
-          .where(eq(evaluations.workspaceId, workspaceId)),
-      ),
-    )
+    await tx
+      .delete(evaluationResults)
+      .where(
+        inArray(
+          evaluationResults.evaluationId,
+          tx
+            .select({ id: evaluations.id })
+            .from(evaluations)
+            .where(eq(evaluations.workspaceId, workspaceId)),
+        ),
+      )
 
     await tx.delete(spans).where(eq(spans.workspaceId, workspaceId))
 


### PR DESCRIPTION
Workspaces deleted from the Backoffice never disappeared. The button enqueues a background `destroyWorkspaceJob`, the toast reported success, and the job was marked completed in BullMQ — but the workspace stayed. The deletion was failing inside the `destroyWorkspace` service and the failure was being swallowed (the job returns a `Result.error` instead of throwing, so BullMQ records a completed job). This PR fixes the deletion itself; the swallowed-error problem is a separate follow-up.

## what was failing

`destroyWorkspace` deletes the workspace-scoped tables that have no `ON DELETE CASCADE`, then the workspace row (whose cascade clears everything else). The delete order and the table list were both wrong for any workspace that had actually been used:

- `spans` and `provider_logs` reference `apiKeys`/`providerApiKeys` with `onDelete: 'restrict'`. The service deleted the API keys first, so Postgres refused while the spans/logs still pointed at them.
- `evaluation_results` (legacy v1) references `provider_logs` with no cascade and has no `workspaceId` of its own — it's only reachable through `evaluations`. It was never deleted, so it blocked deleting the provider logs.
- `events` references `workspaces` with `NO ACTION` and is not cascade-deleted. It was missing from the cleanup list entirely, so `DELETE workspaces` failed at statement end for any workspace with event rows.

Each of these aborts the transaction with a foreign key violation. An empty workspace deleted fine, which is why this wasn't caught earlier.

## the fix

Reorder the deletes to follow the foreign key graph and add the missing `events` and legacy `evaluation_results` cleanup:

```
evaluation_results → spans → provider_logs
  → providerApiKeys → apiKeys → claimedRewards → integrations → events
  → workspaces → subscriptions
```

The order is forced by the constraint types, not preference, so it's documented in the service JSDoc to stop a future "tidy-up" from reintroducing the bug.

## how the table list was verified

The blockers were confirmed against the live FK graph (`pg_constraint`), not just the Drizzle schema files — the `events → workspaces` constraint is written across two lines and a single-line grep missed it. The DB query gives the authoritative set of tables that reference `workspaces` (or the no-cascade tables) with `RESTRICT`/`NO ACTION`, and all of them are now handled.

## tests

`destroy.test.ts` covers both paths: an empty workspace, and a workspace carrying spans, provider logs, an `events` row, and the full legacy `evaluation` → `documentLog` → `evaluation_result` chain. The second test reproduced the failure before the fix and passes after. Each missing delete was confirmed load-bearing by removing it individually and watching the test fail.

## follow-up

`destroyWorkspaceJob` returns the service `Result` instead of unwrapping it, so a failure is reported to BullMQ as success — no retry, no `captureException`. That's why this went unnoticed for so long. Fixing it (so future schema drift fails loudly) is a separate change.
