### PR TITLE
Add flagger selection to onboarding

### DIFF
--- a/apps/web/src/domains/flaggers/flaggers.collection.ts
+++ b/apps/web/src/domains/flaggers/flaggers.collection.ts
@@ -22,6 +22,7 @@ const makeProjectFlaggersCollection = (projectId: string) =>
                 projectId: mutation.modified.projectId,
                 slug: mutation.modified.slug,
                 enabled: mutation.modified.enabled,
+                sampling: mutation.modified.sampling,
               },
             }),
           ),
@@ -67,10 +68,16 @@ export function updateFlaggerMutation(input: {
   readonly projectId: string
   readonly id: string
   readonly slug: string
-  readonly enabled: boolean
+  readonly enabled?: boolean
+  readonly sampling?: number
 }) {
   const collection = getProjectFlaggersCollection(input.projectId)
   return collection.update(input.id, (draft) => {
-    draft.enabled = input.enabled
+    if (input.enabled !== undefined) draft.enabled = input.enabled
+    if (input.sampling !== undefined) draft.sampling = input.sampling
   })
+}
+
+export async function invalidateProjectFlaggers(projectId: string) {
+  await queryClient.invalidateQueries({ queryKey: flaggersQueryKey(projectId) })
 }

--- a/apps/web/src/domains/flaggers/flaggers.functions.ts
+++ b/apps/web/src/domains/flaggers/flaggers.functions.ts
@@ -1,4 +1,5 @@
 import {
+  configureProjectFlaggersForOnboardingUseCase,
   FLAGGER_STRATEGY_SLUGS,
   FlaggerRepository,
   type FlaggerSlug,
@@ -53,6 +54,27 @@ const toFlaggerRecord = (flagger: {
 
 export type FlaggerRecord = ReturnType<typeof toFlaggerRecord>
 
+const toAvailableFlaggerRecord = (slug: FlaggerSlug) => {
+  const strategy = getFlaggerStrategy(slug)
+  const details = strategy && isLlmCapableStrategy(strategy) ? strategy.annotator : strategy?.details
+
+  return {
+    slug,
+    name: details?.name ?? humanizeSlug(slug),
+    description: details?.description ?? "Flags matching trace behavior for review.",
+    mode: strategy && isLlmCapableStrategy(strategy) ? "llm" : "deterministic",
+  }
+}
+
+type AvailableFlaggerRecord = ReturnType<typeof toAvailableFlaggerRecord>
+
+export const listAvailableFlaggers = createServerFn({ method: "GET" }).handler(
+  async (): Promise<readonly AvailableFlaggerRecord[]> => {
+    await requireSession()
+    return FLAGGER_STRATEGY_SLUGS.map(toAvailableFlaggerRecord)
+  },
+)
+
 export const listFlaggersByProject = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string() }))
   .handler(async ({ data }): Promise<readonly FlaggerRecord[]> => {
@@ -71,12 +93,40 @@ export const listFlaggersByProject = createServerFn({ method: "GET" })
     return flaggers.map(toFlaggerRecord)
   })
 
+export const configureProjectFlaggersForOnboarding = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      enabledSlugs: z.array(z.enum(FLAGGER_STRATEGY_SLUGS)),
+    }),
+  )
+  .handler(async ({ data }): Promise<void> => {
+    const { organizationId, userId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const client = getPostgresClient()
+
+    await Effect.runPromise(
+      configureProjectFlaggersForOnboardingUseCase({
+        organizationId,
+        projectId,
+        enabledSlugs: data.enabledSlugs,
+        actorUserId: userId,
+      }).pipe(
+        withPostgres(Layer.mergeAll(FlaggerRepositoryLive, OutboxEventWriterLive), client, orgId),
+        Effect.provide(RedisCacheStoreLive(getRedisClient())),
+        withTracing,
+      ),
+    )
+  })
+
 export const updateFlagger = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),
       slug: z.enum(FLAGGER_STRATEGY_SLUGS),
       enabled: z.boolean(),
+      sampling: z.number().int().min(0).max(100),
     }),
   )
   .handler(async ({ data }): Promise<FlaggerRecord | null> => {
@@ -91,6 +141,7 @@ export const updateFlagger = createServerFn({ method: "POST" })
         projectId,
         slug: data.slug,
         enabled: data.enabled,
+        sampling: data.sampling,
         actorUserId: userId,
       }).pipe(
         withPostgres(Layer.mergeAll(FlaggerRepositoryLive, OutboxEventWriterLive), client, orgId),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
+import type { FLAGGER_STRATEGY_SLUGS } from "@domain/flaggers"
 import {
   Button,
   CodeBlock,
@@ -14,6 +15,7 @@ import {
 } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { useForm } from "@tanstack/react-form"
+import { useQuery } from "@tanstack/react-query"
 import type { LucideIcon } from "lucide-react"
 import {
   Bot,
@@ -28,6 +30,11 @@ import {
 } from "lucide-react"
 import { lazy, type ReactNode, Suspense, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useApiKeysCollection } from "../../../../../domains/api-keys/api-keys.collection.ts"
+import { invalidateProjectFlaggers, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
+import {
+  configureProjectFlaggersForOnboarding,
+  listAvailableFlaggers,
+} from "../../../../../domains/flaggers/flaggers.functions.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
@@ -57,10 +64,11 @@ import {
   type TsPackageManager,
 } from "./onboarding-integration-snippets.ts"
 
-type OnboardingStep = "role" | "stack" | "telemetry"
+type OnboardingStep = "role" | "stack" | "flaggers" | "telemetry"
 type StackChoice = "coding-agent-machine" | "production-agent"
 type TelemetrySetupMode = "coding-agent" | "manual"
 type IntegrationPanel = "typescript" | "python" | "opentelemetry"
+type FlaggerPresetSlug = (typeof FLAGGER_STRATEGY_SLUGS)[number]
 
 const SETUP_MODE_TAB_OPTIONS = [
   { id: "coding-agent" as const, label: "Coding agent", icon: <Bot className="h-4 w-4" /> },
@@ -96,6 +104,98 @@ const CODING_MACHINE_AGENT_TAB_OPTIONS = [
     icon: <OnboardingCodingAgentTabIcon src={ONBOARDING_OPENCLAW_LOGO_SRC} />,
   },
 ] as const satisfies ReadonlyArray<{ id: CodingMachineAgentId; label: string; icon: ReactNode }>
+
+const FLAGGER_USE_CASE_PRESETS = [
+  {
+    id: "support-agent",
+    label: "Support agent",
+    description: "Customer-facing assistants handling questions, escalations, and account workflows.",
+    enabledSlugs: [
+      "frustration",
+      "refusal",
+      "forgetting",
+      "tool-call-errors",
+      "empty-response",
+      "jailbreaking",
+      "nsfw",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "coding-agent",
+    label: "Coding agent",
+    description: "Agents that edit files, call tools, and work through multi-step implementation tasks.",
+    enabledSlugs: [
+      "laziness",
+      "trashing",
+      "tool-call-errors",
+      "empty-response",
+      "refusal",
+      "forgetting",
+      "output-schema-validation",
+      "frustration",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "sales-agent",
+    label: "Sales agent",
+    description: "Lead qualification and buyer-facing assistants where tone and follow-through matter.",
+    enabledSlugs: [
+      "frustration",
+      "refusal",
+      "forgetting",
+      "empty-response",
+      "jailbreaking",
+      "nsfw",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "tool-workflow-agent",
+    label: "Tool workflow agent",
+    description: "Agents that coordinate tools, APIs, and structured workflows.",
+    enabledSlugs: [
+      "tool-call-errors",
+      "trashing",
+      "output-schema-validation",
+      "empty-response",
+      "laziness",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "knowledge-base-agent",
+    label: "Knowledge-base agent",
+    description: "RAG and documentation assistants that need to preserve context and answer directly.",
+    enabledSlugs: [
+      "forgetting",
+      "refusal",
+      "empty-response",
+      "frustration",
+      "laziness",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "structured-extraction-agent",
+    label: "Structured extraction",
+    description: "Extraction and classification agents that return machine-readable output.",
+    enabledSlugs: [
+      "output-schema-validation",
+      "empty-response",
+      "tool-call-errors",
+      "laziness",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+  {
+    id: "safety-agent",
+    label: "Safety agent",
+    description: "Moderation and policy-sensitive assistants exposed to adversarial or unsafe inputs.",
+    enabledSlugs: [
+      "nsfw",
+      "jailbreaking",
+      "refusal",
+      "frustration",
+      "empty-response",
+    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
+  },
+] as const
 
 const STACK_CHOICE_OPTIONS: ReadonlyArray<{
   readonly id: StackChoice
@@ -392,6 +492,8 @@ export function OnboardingFlow({
   const [telemetrySetupMode, setTelemetrySetupMode] = useState<TelemetrySetupMode>("coding-agent")
   const [integrationPanel, setIntegrationPanel] = useState<IntegrationPanel>("typescript")
   const [otelExporterLanguage, setOtelExporterLanguage] = useState<OtelExporterLanguageId>("go")
+  const [selectedFlaggerSlugs, setSelectedFlaggerSlugs] = useState<ReadonlySet<string> | null>(null)
+  const [isSavingFlaggers, setIsSavingFlaggers] = useState(false)
 
   const form = useForm({
     defaultValues: {
@@ -404,7 +506,7 @@ export function OnboardingFlow({
         await submitOnboarding({ data: { jobTitle, phoneNumber, stackChoice: stack } })
       },
       {
-        onSuccess: () => setStep("telemetry"),
+        onSuccess: () => setStep("flaggers"),
         onError: (error) => {
           toast({ variant: "destructive", description: toUserMessage(error) })
         },
@@ -424,6 +526,52 @@ export function OnboardingFlow({
     [projectId],
   )
   const { data: apiKeysList } = useApiKeysCollection()
+  const { data: projectFlaggers = [], isLoading: isLoadingProjectFlaggers } = useProjectFlaggers(projectId)
+  const { data: availableFlaggers = [], isLoading: isLoadingAvailableFlaggers } = useQuery({
+    queryKey: ["availableFlaggers"],
+    queryFn: () => listAvailableFlaggers(),
+  })
+
+  const availableFlaggerSlugs = availableFlaggers.map((flagger) => flagger.slug)
+  const currentEnabledFlaggerSlugs = new Set(
+    projectFlaggers.filter((flagger) => flagger.enabled).map((flagger) => flagger.slug),
+  )
+  const enabledFlaggerSlugs =
+    selectedFlaggerSlugs ?? (projectFlaggers.length > 0 ? currentEnabledFlaggerSlugs : new Set(availableFlaggerSlugs))
+
+  const toggleFlaggerSelection = (slug: string) => {
+    setSelectedFlaggerSlugs((current) => {
+      const next = new Set(current ?? enabledFlaggerSlugs)
+      if (next.has(slug)) {
+        next.delete(slug)
+      } else {
+        next.add(slug)
+      }
+      return next
+    })
+  }
+
+  const applyFlaggerPreset = (enabledSlugs: readonly string[]) => {
+    setSelectedFlaggerSlugs(new Set(enabledSlugs))
+  }
+
+  const handleConfigureFlaggers = async () => {
+    setIsSavingFlaggers(true)
+    try {
+      await configureProjectFlaggersForOnboarding({
+        data: {
+          projectId,
+          enabledSlugs: availableFlaggerSlugs.filter((slug) => enabledFlaggerSlugs.has(slug)),
+        },
+      })
+      await invalidateProjectFlaggers(projectId)
+      setStep("telemetry")
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setIsSavingFlaggers(false)
+    }
+  }
 
   const resolvedProjectSlug = project?.slug?.trim() || projectSlug.trim()
   const slugForSnippets = resolvedProjectSlug || "your-project-slug"
@@ -650,6 +798,96 @@ export function OnboardingFlow({
               </div>
             </div>
           </div>
+        ) : step === "flaggers" ? (
+          <div className="flex w-full max-w-[880px] self-center">
+            <div className="flex w-full flex-col gap-8">
+              <div className="flex flex-col gap-4">
+                <div className="h-8 w-8">
+                  <img src="/favicon.svg" alt="Latitude" className="h-8 w-8" />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Text.H2 weight="medium">Choose automatic flaggers</Text.H2>
+                  <Text.H4 color="foregroundMuted">
+                    Latitude inspects all incoming traces and creates issues when they detect common failure patterns.
+                    Choose the patterns you want to monitor.
+                  </Text.H4>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-6">
+                <div className="flex flex-row flex-wrap gap-2">
+                  {FLAGGER_USE_CASE_PRESETS.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => applyFlaggerPreset(preset.enabledSlugs)}
+                      className="inline-flex cursor-pointer rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:border-primary/40 hover:bg-accent/10"
+                      title={preset.description}
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+
+                {isLoadingAvailableFlaggers || isLoadingProjectFlaggers ? (
+                  <Text.H5 color="foregroundMuted">Loading flaggers…</Text.H5>
+                ) : (
+                  <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3">
+                    {availableFlaggers.map((flagger) => {
+                      const selected = enabledFlaggerSlugs.has(flagger.slug)
+                      return (
+                        <button
+                          key={flagger.slug}
+                          type="button"
+                          aria-pressed={selected}
+                          onClick={() => toggleFlaggerSelection(flagger.slug)}
+                          className={cn(
+                            "group flex min-h-[132px] w-full cursor-pointer flex-col justify-between gap-4 rounded-xl border p-4 text-left shadow-sm transition-colors hover:border-primary/40 hover:bg-accent/10",
+                            {
+                              "border-primary bg-primary-muted/40 ring-1 ring-primary/20": selected,
+                              "border-border bg-card": !selected,
+                            },
+                          )}
+                        >
+                          <div className="flex min-w-0 flex-col gap-1.5">
+                            <Text.H5M>{flagger.name}</Text.H5M>
+                            <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
+                          </div>
+                          <div className="flex flex-row justify-end">
+                            <span
+                              aria-hidden
+                              className={cn(
+                                "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-colors",
+                                {
+                                  "border-primary bg-primary text-primary-foreground": selected,
+                                  "border-border bg-background text-transparent group-hover:border-primary/40":
+                                    !selected,
+                                },
+                              )}
+                            >
+                              <Icon icon={Check} size="sm" />
+                            </span>
+                          </div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-row flex-wrap items-center gap-3">
+                <Button variant="outline" onClick={() => setStep("stack")}>
+                  Back
+                </Button>
+                <Button
+                  disabled={isLoadingAvailableFlaggers || availableFlaggers.length === 0 || isSavingFlaggers}
+                  onClick={() => void handleConfigureFlaggers()}
+                >
+                  {isSavingFlaggers ? "Saving…" : "Continue"}
+                </Button>
+              </div>
+            </div>
+          </div>
         ) : stackChoice === "production-agent" ? (
           <div className="mx-auto w-full max-w-[560px]">
             <div className="flex w-full flex-col gap-6">
@@ -814,7 +1052,7 @@ export function OnboardingFlow({
               )}
 
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("stack")}>
+                <Button variant="outline" onClick={() => setStep("flaggers")}>
                   Back
                 </Button>
                 <Button variant="ghost" onClick={() => void onOpenProjectTraces(projectId)}>
@@ -893,7 +1131,7 @@ export function OnboardingFlow({
               </div>
 
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("stack")}>
+                <Button variant="outline" onClick={() => setStep("flaggers")}>
                   Back
                 </Button>
                 <Button variant="ghost" onClick={() => void onOpenProjectTraces(projectId)}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -1,7 +1,25 @@
-import { cn, Label, Switch, Text, useToast } from "@repo/ui"
+import {
+  Button,
+  CloseTrigger,
+  cn,
+  Icon,
+  Modal,
+  Slider,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+  Tooltip,
+  useToast,
+} from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute } from "@tanstack/react-router"
-import { useRef } from "react"
+import { Pencil } from "lucide-react"
+import { useRef, useState } from "react"
 import { updateFlaggerMutation, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
 import type { FlaggerRecord } from "../../../../../domains/flaggers/flaggers.functions.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
@@ -18,6 +36,7 @@ function ProjectFlaggersSettingsPage() {
   const { projectSlug } = Route.useParams()
   const { toast } = useToast()
   const routeProject = useRouteProject()
+  const [editingFlagger, setEditingFlagger] = useState<FlaggerRecord | null>(null)
 
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),
@@ -31,23 +50,39 @@ function ProjectFlaggersSettingsPage() {
   // flagger that authored them; scroll it into view once and keep it highlighted.
   const [targetFlaggerSlug] = useParamState("flagger", "")
   const hasScrolledToTargetRef = useRef(false)
-  const scrollTargetRef = (node: HTMLDivElement | null) => {
+  const scrollTargetRef = (node: HTMLTableRowElement | null) => {
     if (node && !hasScrolledToTargetRef.current) {
       hasScrolledToTargetRef.current = true
       node.scrollIntoView({ block: "center", behavior: "smooth" })
     }
   }
 
-  const handleFlaggerEnabledChange = async (flagger: FlaggerRecord, checked: boolean) => {
+  const handleFlaggerEnabledChange = async (flagger: FlaggerRecord, enabled: boolean) => {
     try {
       const transaction = updateFlaggerMutation({
         projectId: currentProject.id,
         id: flagger.id,
         slug: flagger.slug,
-        enabled: checked,
+        enabled,
       })
       await transaction.isPersisted.promise
-      toast({ description: checked ? "Flagger enabled" : "Flagger disabled" })
+      toast({ description: "Flagger settings updated" })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  const handleFlaggerSamplingUpdate = async (flagger: FlaggerRecord, sampling: number) => {
+    try {
+      const transaction = updateFlaggerMutation({
+        projectId: currentProject.id,
+        id: flagger.id,
+        slug: flagger.slug,
+        sampling,
+      })
+      await transaction.isPersisted.promise
+      toast({ description: "Flagger settings updated" })
+      setEditingFlagger(null)
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
     }
@@ -62,32 +97,130 @@ function ProjectFlaggersSettingsPage() {
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (
           <Text.H5 color="foregroundMuted">No flaggers have been provisioned for this project yet</Text.H5>
         ) : (
-          flaggers.map((flagger) => {
-            const inputId = `flagger-${flagger.id}`
-            const isTarget = targetFlaggerSlug !== "" && flagger.slug === targetFlaggerSlug
-            return (
-              <div
-                key={flagger.id}
-                ref={isTarget ? scrollTargetRef : undefined}
-                className={cn("flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4", {
-                  "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget,
-                })}
-              >
-                <div className="flex flex-col gap-1">
-                  <Label htmlFor={inputId}>{flagger.name}</Label>
-                  <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
-                </div>
-                <Switch
-                  id={inputId}
-                  checked={flagger.enabled}
-                  onCheckedChange={(checked) => void handleFlaggerEnabledChange(flagger, checked)}
-                  aria-label={`Toggle ${flagger.name}`}
-                />
-              </div>
-            )
-          })
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Flagger</TableHead>
+                <TableHead className="w-10">Enabled</TableHead>
+                <TableHead>Sampling</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {flaggers.map((flagger) => {
+                const isTarget = targetFlaggerSlug !== "" && flagger.slug === targetFlaggerSlug
+                return (
+                  <TableRow
+                    key={flagger.id}
+                    ref={isTarget ? scrollTargetRef : undefined}
+                    verticalPadding
+                    hoverable={false}
+                    className={cn({ "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget })}
+                  >
+                    <TableCell className="max-w-[28rem]">
+                      <div className="flex flex-col gap-1">
+                        <Text.H5M>{flagger.name}</Text.H5M>
+                        <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Switch
+                        checked={flagger.enabled}
+                        onCheckedChange={(checked) => void handleFlaggerEnabledChange(flagger, checked)}
+                        aria-label={`${flagger.enabled ? "Disable" : "Enable"} ${flagger.name}`}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-row items-center gap-1">
+                        <Text.H5>{flagger.sampling}%</Text.H5>
+                        <Tooltip
+                          asChild
+                          trigger={
+                            <Button variant="ghost" size="icon" onClick={() => setEditingFlagger(flagger)}>
+                              <Icon icon={Pencil} size="sm" />
+                            </Button>
+                          }
+                        >
+                          Edit sampling rate
+                        </Tooltip>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
         )}
       </div>
+
+      {editingFlagger ? (
+        <EditFlaggerModal
+          flagger={editingFlagger}
+          onClose={() => setEditingFlagger(null)}
+          onSave={handleFlaggerSamplingUpdate}
+        />
+      ) : null}
     </SettingsPage>
+  )
+}
+
+function EditFlaggerModal({
+  flagger,
+  onClose,
+  onSave,
+}: {
+  readonly flagger: FlaggerRecord
+  readonly onClose: () => void
+  readonly onSave: (flagger: FlaggerRecord, sampling: number) => Promise<void>
+}) {
+  const [sampling, setSampling] = useState(flagger.sampling)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      await onSave(flagger, sampling)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      scrollable={false}
+      onOpenChange={(open) => (!open ? onClose() : undefined)}
+      title={`Edit ${flagger.name} sampling`}
+      description="Configure what percentage of eligible traces this flagger samples."
+      footer={
+        <>
+          <CloseTrigger />
+          <Button onClick={() => void handleSave()} isLoading={isSaving}>
+            Save
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-6 pb-6">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-row items-baseline justify-between gap-4">
+            <Text.H6 color="foregroundMuted">Sampling rate</Text.H6>
+            <Text.H4M color="foreground">{sampling}%</Text.H4M>
+          </div>
+          <Slider
+            min={0}
+            max={100}
+            step={1}
+            value={[sampling]}
+            onValueChange={(values) => setSampling(values[0] ?? 0)}
+          />
+          <Text.H6 color="foregroundMuted">
+            {sampling === 0
+              ? "0% pauses sampling for this flagger."
+              : `Runs on ${sampling}% of eligible incoming traces.`}
+          </Text.H6>
+        </div>
+      </div>
+    </Modal>
   )
 }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -251,6 +251,7 @@ export interface EventPayloads {
     readonly projectId: string
     readonly flaggerSlug: string
     readonly enabled: boolean
+    readonly sampling: number
   }
   SavedSearchCreated: {
     readonly organizationId: string

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -55,8 +55,14 @@ export {
   type FlaggerRepositoryShape,
   type ListFlaggersByProjectInput,
   type SaveFlaggersForProjectInput,
+  type UpdateFlaggerEnabledForProjectInput,
   type UpdateFlaggerInput as RepositoryUpdateFlaggerInput,
 } from "./ports/flagger-repository.ts"
+export {
+  type ConfigureProjectFlaggersForOnboardingError,
+  type ConfigureProjectFlaggersForOnboardingInput,
+  configureProjectFlaggersForOnboardingUseCase,
+} from "./use-cases/configure-project-flaggers-for-onboarding.ts"
 export {
   type DraftFlaggerAnnotationError,
   type DraftFlaggerAnnotationOutput,

--- a/packages/domain/flaggers/src/ports/flagger-repository.ts
+++ b/packages/domain/flaggers/src/ports/flagger-repository.ts
@@ -20,7 +20,14 @@ export interface SaveFlaggersForProjectInput {
 export interface UpdateFlaggerInput {
   readonly projectId: ProjectId
   readonly slug: FlaggerSlug
-  readonly enabled: boolean
+  readonly enabled?: boolean
+  readonly sampling?: number
+}
+
+export interface UpdateFlaggerEnabledForProjectInput {
+  readonly projectId: ProjectId
+  readonly enabledSlugs: readonly FlaggerSlug[]
+  readonly slugs: readonly FlaggerSlug[]
 }
 
 export interface FlaggerRepositoryShape {
@@ -39,6 +46,14 @@ export interface FlaggerRepositoryShape {
    * second run).
    */
   saveManyForProject(input: SaveFlaggersForProjectInput): Effect.Effect<readonly Flagger[], RepositoryError, SqlClient>
+  /**
+   * Sets `enabled` for all `slugs` in one project in a single database update:
+   * slugs included in `enabledSlugs` become enabled, the rest become disabled.
+   * Returns only rows whose enabled state changed.
+   */
+  updateEnabledForProject(
+    input: UpdateFlaggerEnabledForProjectInput,
+  ): Effect.Effect<readonly Flagger[], RepositoryError, SqlClient>
   update(input: UpdateFlaggerInput): Effect.Effect<Flagger | null, RepositoryError, SqlClient>
 }
 

--- a/packages/domain/flaggers/src/testing/fake-flagger-repository.ts
+++ b/packages/domain/flaggers/src/testing/fake-flagger-repository.ts
@@ -60,13 +60,40 @@ export const createFakeFlaggerRepository = (
         return inserted.sort((a, b) => a.slug.localeCompare(b.slug))
       }),
 
-    update: ({ projectId, slug, enabled }) =>
+    updateEnabledForProject: ({ projectId, enabledSlugs, slugs }) =>
+      Effect.sync(() => {
+        const enabledSet = new Set(enabledSlugs)
+        const updatedFlaggers: Flagger[] = []
+
+        for (const slug of slugs) {
+          const id = indexByProjectSlug.get(keyFor(projectId, slug))
+          if (!id) continue
+          const existing = flaggers.get(id)
+          if (!existing) continue
+
+          const enabled = enabledSet.has(slug)
+          if (existing.enabled === enabled) continue
+
+          const updated = { ...existing, enabled, updatedAt: new Date() }
+          flaggers.set(id, updated)
+          updatedFlaggers.push(updated)
+        }
+
+        return updatedFlaggers.sort((a, b) => a.slug.localeCompare(b.slug))
+      }),
+
+    update: ({ projectId, slug, enabled, sampling }) =>
       Effect.sync(() => {
         const id = indexByProjectSlug.get(keyFor(projectId, slug))
         if (!id) return null
         const existing = flaggers.get(id)
         if (!existing) return null
-        const updated = { ...existing, enabled, updatedAt: new Date() }
+        const updated = {
+          ...existing,
+          ...(enabled !== undefined ? { enabled } : {}),
+          ...(sampling !== undefined ? { sampling } : {}),
+          updatedAt: new Date(),
+        }
         flaggers.set(id, updated)
         return updated
       }),

--- a/packages/domain/flaggers/src/use-cases/configure-project-flaggers-for-onboarding.ts
+++ b/packages/domain/flaggers/src/use-cases/configure-project-flaggers-for-onboarding.ts
@@ -1,0 +1,67 @@
+import { OutboxEventWriter } from "@domain/events"
+import { type ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { FlaggerSlug } from "../flagger-strategies/types.ts"
+import { FLAGGER_STRATEGY_SLUGS } from "../flagger-strategies/types.ts"
+import { FlaggerRepository } from "../ports/flagger-repository.ts"
+import { evictProjectFlaggersUseCase } from "./get-project-flaggers.ts"
+import { provisionFlaggersUseCase } from "./provision-flaggers.ts"
+
+export interface ConfigureProjectFlaggersForOnboardingInput {
+  readonly organizationId: string
+  readonly projectId: ProjectId
+  readonly enabledSlugs: readonly FlaggerSlug[]
+  readonly actorUserId: string
+}
+
+export type ConfigureProjectFlaggersForOnboardingError = RepositoryError
+
+/**
+ * Defensively provisions project flaggers and applies the onboarding enabled
+ * selection in one transaction. Provisioning is idempotent, so racing with the
+ * background ProjectCreated worker cannot create duplicates; the bulk update
+ * runs after provisioning so the user's onboarding choices win.
+ */
+export const configureProjectFlaggersForOnboardingUseCase = Effect.fn("flaggers.configureProjectFlaggersForOnboarding")(
+  function* (input: ConfigureProjectFlaggersForOnboardingInput) {
+    yield* Effect.annotateCurrentSpan("flaggers.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("flaggers.projectId", input.projectId)
+
+    const sqlClient = yield* SqlClient
+
+    yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        yield* provisionFlaggersUseCase({ organizationId: input.organizationId, projectId: input.projectId })
+
+        const repository = yield* FlaggerRepository
+        const updatedRows = yield* repository.updateEnabledForProject({
+          projectId: input.projectId,
+          slugs: FLAGGER_STRATEGY_SLUGS,
+          enabledSlugs: input.enabledSlugs,
+        })
+
+        const outboxEventWriter = yield* OutboxEventWriter
+        for (const row of updatedRows) {
+          yield* outboxEventWriter.write({
+            eventName: "FlaggerToggled",
+            aggregateType: "flagger",
+            aggregateId: row.id,
+            organizationId: input.organizationId,
+            payload: {
+              organizationId: input.organizationId,
+              actorUserId: input.actorUserId,
+              projectId: input.projectId,
+              flaggerSlug: row.slug,
+              enabled: row.enabled,
+              sampling: row.sampling,
+            },
+          })
+        }
+      }),
+    )
+
+    // Evict after commit so a concurrent reader cannot repopulate the cache with
+    // stale values between eviction and commit.
+    yield* evictProjectFlaggersUseCase({ organizationId: input.organizationId, projectId: input.projectId })
+  },
+)

--- a/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
@@ -75,6 +75,31 @@ describe("updateFlaggerUseCase", () => {
     expect(updated?.id).toBe(seed.id)
   })
 
+  it("updates sampling and returns the updated flagger", async () => {
+    const seed = makeFlagger("jailbreaking", FLAGGER_DEFAULT_ENABLED)
+    const { repository } = createFakeFlaggerRepository([seed])
+    const { layer: cacheLayer } = createCacheLayer()
+
+    const layer = Layer.mergeAll(
+      Layer.succeed(FlaggerRepository, repository),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
+      cacheLayer,
+    )
+
+    const updated = await Effect.runPromise(
+      updateFlaggerUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        slug: "jailbreaking",
+        sampling: 42,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(updated?.sampling).toBe(42)
+    expect(updated?.enabled).toBe(seed.enabled)
+  })
+
   it("evicts the project's flagger cache so the next read picks up the new value before TTL", async () => {
     // Cache eviction is the load-bearing behavior here: without it, callers
     // of `getProjectFlaggersUseCase` would see the stale `enabled` value for
@@ -164,6 +189,7 @@ describe("updateFlaggerUseCase", () => {
       projectId: PROJECT_ID,
       flaggerSlug: "jailbreaking",
       enabled: false,
+      sampling: FLAGGER_DEFAULT_SAMPLING,
     })
   })
 

--- a/packages/domain/flaggers/src/use-cases/update-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.ts
@@ -10,7 +10,8 @@ export interface UpdateFlaggerInput {
   readonly organizationId: string
   readonly projectId: ProjectId
   readonly slug: FlaggerSlug
-  readonly enabled: boolean
+  readonly enabled?: boolean
+  readonly sampling?: number
   readonly actorUserId?: string
 }
 
@@ -18,10 +19,11 @@ export type UpdateFlaggerError = RepositoryError
 
 /**
  * Updates a flagger row and evicts the project's flagger cache entry so
- * `processFlaggersUseCase` picks up the new `enabled` value on the next run
- * (otherwise the 5-minute cache TTL would gate the change). Eviction is
- * folded in here so callers can't forget — `evictProjectFlaggersUseCase` is
- * permissive (no-op when `CacheStore` isn't in the layer).
+ * `processFlaggersUseCase` picks up the new `enabled` or `sampling` value on
+ * the next run (otherwise the 5-minute cache TTL would gate the change).
+ * Eviction is folded in here so callers can't forget —
+ * `evictProjectFlaggersUseCase` is permissive (no-op when `CacheStore` isn't
+ * in the layer).
  */
 export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function* (input: UpdateFlaggerInput) {
   yield* Effect.annotateCurrentSpan("flagger.organizationId", input.organizationId)
@@ -35,7 +37,8 @@ export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function
       const row = yield* repository.update({
         projectId: input.projectId,
         slug: input.slug,
-        enabled: input.enabled,
+        ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+        ...(input.sampling !== undefined ? { sampling: input.sampling } : {}),
       })
 
       if (row) {
@@ -50,7 +53,8 @@ export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function
             actorUserId: input.actorUserId ?? "",
             projectId: input.projectId,
             flaggerSlug: input.slug,
-            enabled: input.enabled,
+            enabled: row.enabled,
+            sampling: row.sampling,
           },
         })
       }

--- a/packages/platform/db-postgres/src/repositories/flagger-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/flagger-repository.ts
@@ -7,7 +7,7 @@ import {
   flaggerSchema,
 } from "@domain/flaggers"
 import { RepositoryError, SqlClient, type SqlClientShape } from "@domain/shared"
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { flaggers } from "../schema/flaggers.ts"
@@ -107,7 +107,52 @@ export const FlaggerRepositoryLive = Layer.effect(
             )
         }),
 
-      update: ({ projectId, slug, enabled }) =>
+      updateEnabledForProject: ({ projectId, enabledSlugs, slugs }) =>
+        Effect.gen(function* () {
+          if (slugs.length === 0) {
+            return [] as readonly Flagger[]
+          }
+
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const now = new Date()
+          const enabledExpression =
+            enabledSlugs.length === 0
+              ? sql<boolean>`false`
+              : sql<boolean>`case when ${flaggers.slug} in (${sql.join(
+                  enabledSlugs.map((slug) => sql`${slug}`),
+                  sql`, `,
+                )}) then true else false end`
+
+          return yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .update(flaggers)
+                .set({
+                  enabled: enabledExpression,
+                  updatedAt: now,
+                })
+                .where(
+                  and(
+                    eq(flaggers.organizationId, organizationId),
+                    eq(flaggers.projectId, projectId),
+                    inArray(flaggers.slug, slugs),
+                    sql`${flaggers.enabled} is distinct from ${enabledExpression}`,
+                  ),
+                )
+                .returning(),
+            )
+            .pipe(
+              Effect.map((rows) =>
+                rows
+                  .map(toDomainFlagger)
+                  .slice()
+                  .sort((a, b) => a.slug.localeCompare(b.slug)),
+              ),
+              Effect.mapError((cause) => new RepositoryError({ operation: "updateEnabledForProject", cause })),
+            )
+        }),
+
+      update: ({ projectId, slug, enabled, sampling }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const now = new Date()
@@ -116,7 +161,11 @@ export const FlaggerRepositoryLive = Layer.effect(
             .query((db, organizationId) =>
               db
                 .update(flaggers)
-                .set({ enabled, updatedAt: now })
+                .set({
+                  ...(enabled !== undefined ? { enabled } : {}),
+                  ...(sampling !== undefined ? { sampling } : {}),
+                  updatedAt: now,
+                })
                 .where(
                   and(
                     eq(flaggers.organizationId, organizationId),


### PR DESCRIPTION
## Summary

Adds a flagger selection step to project onboarding before telemetry setup. New users can choose which automatic monitors are enabled for the default project instead of starting with every flagger enabled by default.

The onboarding save path defensively provisions missing flagger rows before applying the selected enabled state. That keeps the flow safe when the background `ProjectCreated` provisioning worker has not run yet, and the existing `(organization_id, project_id, slug)` conflict handling prevents duplicate rows if both paths race. Provisioning remains insert-only on conflict, so later worker retries do not overwrite the user's choices.

https://www.loom.com/share/73635f10a1e14efa996a984de7287305

## Validation

- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web test -- src/domains/flaggers/flaggers.functions.ts`

Please attach a screenshot or short screen recording of the new onboarding step for reviewer context.