### PR TITLE
fix(flaggers): bind classifier feedback to annotations

### DIFF
--- a/apps/workflows/src/activities/flagger-activities.ts
+++ b/apps/workflows/src/activities/flagger-activities.ts
@@ -83,6 +83,8 @@ export const draftAnnotate = async (input: {
   readonly projectId: string
   readonly traceId: string
   readonly flaggerSlug: string
+  readonly feedback?: string | undefined
+  readonly messageIndex?: number | undefined
 }): Promise<DraftAnnotateOutput> => {
   return Effect.runPromise(
     draftFlaggerAnnotationWithBillingUseCase(input).pipe(

--- a/apps/workflows/src/workflows/flagger-workflow.test.ts
+++ b/apps/workflows/src/workflows/flagger-workflow.test.ts
@@ -4,18 +4,26 @@ const TEST_TRACE_CREATED_AT = "2024-01-15T10:00:00.000Z"
 
 const { mockActivities } = vi.hoisted(() => {
   const mockActivities = {
-    runFlagger: vi.fn(async (): Promise<{ matched: boolean }> => ({ matched: false })),
+    runFlagger: vi.fn(
+      async (): Promise<{ matched: boolean; feedback?: string | undefined; messageIndex?: number | undefined }> => ({
+        matched: false,
+      }),
+    ),
     draftAnnotate: vi.fn(
       async (): Promise<{
         traceId: string
         feedback: string
         traceCreatedAt: string
+        sessionId: string | null
+        simulationId: string | null
         scoreId: string
         messageIndex?: number | undefined
       }> => ({
         traceId: "trace-1",
         feedback: "Test feedback",
         traceCreatedAt: "2024-01-15T10:00:00.000Z",
+        sessionId: null,
+        simulationId: null,
         scoreId: "score-default",
       }),
     ),
@@ -73,13 +81,20 @@ describe("flaggerWorkflow", () => {
     expect(mockActivities.saveAnnotation).not.toHaveBeenCalled()
   })
 
-  it("calls draftAnnotate and saveAnnotation when flagger returns matched=true", async () => {
-    mockActivities.runFlagger.mockResolvedValueOnce({ matched: true })
+  it("passes classifier feedback through draftAnnotate and saveAnnotation when matched", async () => {
+    mockActivities.runFlagger.mockResolvedValueOnce({
+      matched: true,
+      feedback: "Classifier feedback",
+      messageIndex: 2,
+    })
     mockActivities.draftAnnotate.mockResolvedValueOnce({
       traceId: "trace-1",
-      feedback: "Generated feedback",
+      feedback: "Classifier feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: "session-1",
+      simulationId: null,
       scoreId: "score-from-draft",
+      messageIndex: 2,
     })
     mockActivities.saveAnnotation.mockResolvedValueOnce({
       flaggerId: FLAGGER_ID,
@@ -117,20 +132,22 @@ describe("flaggerWorkflow", () => {
       projectId: "proj-1",
       traceId: "trace-1",
       flaggerSlug: "refusal",
+      feedback: "Classifier feedback",
+      messageIndex: 2,
     })
     expect(mockActivities.saveAnnotation).toHaveBeenCalledTimes(1)
-    // The scoreId emitted by draftAnnotate must flow verbatim into
-    // saveAnnotation so the LLM telemetry span and the persisted score row
-    // share the same id (see PRD: "Identity strategy").
     expect(mockActivities.saveAnnotation).toHaveBeenCalledWith({
       organizationId: "org-1",
       projectId: "proj-1",
       traceId: "trace-1",
       flaggerId: FLAGGER_ID,
       flaggerSlug: "refusal",
-      feedback: "Generated feedback",
+      feedback: "Classifier feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: "session-1",
+      simulationId: null,
       scoreId: "score-from-draft",
+      messageIndex: 2,
     })
   })
 
@@ -140,6 +157,8 @@ describe("flaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: null,
+      simulationId: "simulation-1",
       scoreId: "score-msg-idx",
       messageIndex: 5,
     })
@@ -161,6 +180,7 @@ describe("flaggerWorkflow", () => {
       expect.objectContaining({
         messageIndex: 5,
         scoreId: "score-msg-idx",
+        simulationId: "simulation-1",
       }),
     )
   })
@@ -190,6 +210,8 @@ describe("flaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: null,
+      simulationId: null,
       scoreId: "score-save-failure",
     })
     mockActivities.saveAnnotation.mockRejectedValueOnce(new Error("Save failed"))
@@ -215,6 +237,8 @@ describe("flaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Tool call error feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: null,
+      simulationId: null,
       scoreId: "score-tool",
     })
     mockActivities.saveAnnotation.mockResolvedValueOnce({
@@ -251,6 +275,8 @@ describe("flaggerWorkflow", () => {
       flaggerSlug: "tool-call-errors",
       feedback: "Tool call error feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      sessionId: null,
+      simulationId: null,
       scoreId: "score-tool",
     })
   })

--- a/apps/workflows/src/workflows/flagger-workflow.ts
+++ b/apps/workflows/src/workflows/flagger-workflow.ts
@@ -49,6 +49,8 @@ export const flaggerWorkflow = async (input: {
       projectId: input.projectId,
       traceId: input.traceId,
       flaggerSlug: input.flaggerSlug,
+      ...(result.feedback !== undefined ? { feedback: result.feedback } : {}),
+      ...(result.messageIndex !== undefined ? { messageIndex: result.messageIndex } : {}),
     })
 
     log.info("Flagger draft annotate completed, starting save", {
@@ -67,6 +69,8 @@ export const flaggerWorkflow = async (input: {
       flaggerSlug: input.flaggerSlug,
       feedback: draftResult.feedback,
       traceCreatedAt: draftResult.traceCreatedAt,
+      sessionId: draftResult.sessionId,
+      simulationId: draftResult.simulationId,
       scoreId: draftResult.scoreId,
       messageIndex: draftResult.messageIndex,
     })

--- a/packages/domain/flaggers/src/use-cases/draft-flagger-annotation-with-billing.ts
+++ b/packages/domain/flaggers/src/use-cases/draft-flagger-annotation-with-billing.ts
@@ -13,6 +13,8 @@ export interface DraftFlaggerAnnotationWithBillingInput {
   readonly projectId: string
   readonly traceId: string
   readonly flaggerSlug: string
+  readonly feedback?: string | undefined
+  readonly messageIndex?: number | undefined
 }
 
 export const draftFlaggerAnnotationWithBillingUseCase = Effect.fn("flaggers.draftFlaggerAnnotationWithBilling")(

--- a/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.test.ts
+++ b/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.test.ts
@@ -57,6 +57,40 @@ const makeTraceDetail = (): TraceDetail => ({
 })
 
 describe("draftFlaggerAnnotationUseCase", () => {
+  it("uses classifier feedback directly and skips the second annotator LLM call", async () => {
+    const { repository: traceRepo } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+    })
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: () => Effect.die("AI should not be called when classifier feedback is provided"),
+    })
+
+    const result = await Effect.runPromise(
+      draftFlaggerAnnotationUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        flaggerSlug: "jailbreaking",
+        traceId: TRACE_ID,
+        feedback: "User attempted to override the assistant's system instructions.",
+        messageIndex: 0,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, traceRepo),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(ORG_ID) })),
+            aiLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.feedback).toBe("User attempted to override the assistant's system instructions.")
+    expect(result.sessionId).toBe("session")
+    expect(result.simulationId).toBeNull()
+    expect(result.messageIndex).toBe(0)
+    expect(calls.generate).toHaveLength(0)
+  })
+
   it("generates a scoreId, returns messageIndex and other fields in the output, and forwards them to the annotator's telemetry", async () => {
     const { repository: traceRepo } = createFakeTraceRepository({
       findByTraceId: () => Effect.succeed(makeTraceDetail()),

--- a/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.ts
+++ b/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.ts
@@ -1,4 +1,13 @@
-import { BadRequestError, generateId, type RepositoryError, type ScoreId } from "@domain/shared"
+import {
+  BadRequestError,
+  generateId,
+  OrganizationId,
+  ProjectId,
+  type RepositoryError,
+  type ScoreId,
+  TraceId,
+} from "@domain/shared"
+import { TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import { z } from "zod"
 import { type RunFlaggerAnnotatorError, runFlaggerAnnotatorUseCase } from "./run-flagger-annotator.ts"
@@ -10,6 +19,8 @@ const draftFlaggerAnnotationInputSchema = z.object({
   projectId: z.string().min(1),
   flaggerSlug: z.string().min(1),
   traceId: z.string().min(1),
+  feedback: z.string().min(1).optional(),
+  messageIndex: z.number().int().nonnegative().optional(),
 })
 
 const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, message: string) =>
@@ -36,6 +47,8 @@ interface DraftFlaggerAnnotationInput {
   readonly projectId: string
   readonly flaggerSlug: string
   readonly traceId: string
+  readonly feedback?: string | undefined
+  readonly messageIndex?: number | undefined
 }
 
 export type DraftFlaggerAnnotationError = BadRequestError | RepositoryError | RunFlaggerAnnotatorError
@@ -56,6 +69,25 @@ export const draftFlaggerAnnotationUseCase = Effect.fn("flaggers.draftFlaggerAnn
     "Invalid flagger annotate input",
   )
 
+  if (parsedInput.feedback !== undefined) {
+    const traceRepository = yield* TraceRepository
+    const trace = yield* traceRepository.findByTraceId({
+      organizationId: OrganizationId(parsedInput.organizationId),
+      projectId: ProjectId(parsedInput.projectId),
+      traceId: TraceId(parsedInput.traceId),
+    })
+
+    return {
+      traceId: parsedInput.traceId,
+      feedback: parsedInput.feedback,
+      traceCreatedAt: trace.startTime.toISOString(),
+      sessionId: trace.sessionId,
+      simulationId: trace.simulationId === "" ? null : trace.simulationId,
+      scoreId,
+      messageIndex: parsedInput.messageIndex,
+    } satisfies DraftFlaggerAnnotationOutput
+  }
+
   const annotatorResult = yield* runFlaggerAnnotatorUseCase({
     organizationId: parsedInput.organizationId,
     projectId: parsedInput.projectId,
@@ -72,5 +104,5 @@ export const draftFlaggerAnnotationUseCase = Effect.fn("flaggers.draftFlaggerAnn
     simulationId: annotatorResult.simulationId,
     scoreId,
     messageIndex: annotatorResult.messageIndex,
-  } as DraftFlaggerAnnotationOutput
+  } satisfies DraftFlaggerAnnotationOutput
 })

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1,4 +1,4 @@
-import { AI_GENERATE_TELEMETRY_TAGS, AIError } from "@domain/ai"
+import { AI_GENERATE_TELEMETRY_TAGS, AIError, type GenerateInput } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import {
   ChSqlClient,
@@ -62,6 +62,20 @@ const flaggerOutputSchema = z
     }
   })
 
+const createClassifyAndApproveAI = (
+  classification = { matched: true, feedback: "Flagger matched with concrete evidence." },
+) =>
+  createFakeAI({
+    generate: <T>(input: { readonly system?: string }) => {
+      const isAnnotationReview = input.system?.includes("adversarial quality reviewer") ?? false
+      return Effect.succeed({
+        object: (isAnnotationReview ? { annotationMakesSense: true } : classification) as T,
+        tokens: 20,
+        duration: 90_000_000,
+      })
+    },
+  })
+
 function makeTraceDetail(allMessages: TraceDetail["allMessages"]): TraceDetail {
   return {
     organizationId: OrganizationId(INPUT.organizationId),
@@ -117,14 +131,7 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    const { calls, layer: aiLayer } = createFakeAI({
-      generate: <T>() =>
-        Effect.succeed({
-          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
-          tokens: 22,
-          duration: 123_000_000,
-        }),
-    })
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
 
     const result = await Effect.runPromise(
       runFlaggerUseCase({ ...INPUT, flaggerSlug: "jailbreaking" }).pipe(
@@ -141,7 +148,7 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
-    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0]).toMatchObject({
       ...FLAGGER_MODEL,
       maxTokens: FLAGGER_MAX_TOKENS,
@@ -215,14 +222,7 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    const { calls, layer: aiLayer } = createFakeAI({
-      generate: <T>() =>
-        Effect.succeed({
-          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
-          tokens: 18,
-          duration: 80_000_000,
-        }),
-    })
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
 
     const result = await Effect.runPromise(
       runFlaggerUseCase({ ...INPUT, flaggerSlug: "refusal" }).pipe(
@@ -239,7 +239,7 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
-    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0].system).toContain("Refusal")
     expect(calls.generate[0].system).toContain("declines, deflects, or over-restricts")
     expect(calls.generate[0].system).not.toContain("Jailbreaking")
@@ -269,14 +269,7 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    const { calls, layer: aiLayer } = createFakeAI({
-      generate: <T>() =>
-        Effect.succeed({
-          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
-          tokens: 16,
-          duration: 60_000_000,
-        }),
-    })
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
 
     const result = await Effect.runPromise(
       runFlaggerUseCase({ ...INPUT, flaggerSlug: "frustration" }).pipe(
@@ -293,7 +286,7 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
-    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0].system).toContain("USER'S OWN WORDING")
     expect(calls.generate[0].system).toContain("Judge only the user-authored messages")
     expect(calls.generate[0].prompt).toContain("USER MESSAGES")
@@ -531,7 +524,7 @@ describe("runFlaggerUseCase", () => {
     expect(result).toEqual({ matched: false })
   })
 
-  it("recovers to matched=false when the AI returns matched=true without usable feedback", async () => {
+  it("drops matched annotations when the adversarial reviewer rejects the feedback", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>
         Effect.succeed(
@@ -548,13 +541,17 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    const { layer: aiLayer } = createFakeAI({
-      generate: <T>() =>
-        Effect.succeed({
-          object: { matched: true, feedback: "No jailbreaking behavior detected; this was legitimate." } as T,
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        const isAnnotationReview = input.system?.includes("adversarial quality reviewer") ?? false
+        return Effect.succeed({
+          object: (isAnnotationReview
+            ? { annotationMakesSense: false, reason: "The annotation contradicts the match." }
+            : { matched: true, feedback: "No jailbreaking behavior detected; this was legitimate." }) as T,
           tokens: 20,
           duration: 90_000_000,
-        }),
+        })
+      },
     })
 
     const result = await Effect.runPromise(
@@ -572,6 +569,8 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(2)
+    expect(calls.generate[1].prompt).toContain("No jailbreaking behavior detected")
   })
 
   it("recovers to matched=false when the SDK cause has no AI_NoObjectGeneratedError name but the message indicates a schema mismatch", async () => {
@@ -635,14 +634,7 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    const { calls, layer: aiLayer } = createFakeAI({
-      generate: <T>() =>
-        Effect.succeed({
-          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
-          tokens: 20,
-          duration: 90_000_000,
-        }),
-    })
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
 
     const result = await Effect.runPromise(
       runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
@@ -659,7 +651,7 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
-    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0].system).toContain("Laziness")
     expect(calls.generate[0].system).toContain("AVOIDS doing the work")
     // Laziness prompt includes work signals

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -46,10 +46,21 @@ const { repository: defaultFlaggerRepo } = createFakeFlaggerRepository([], {
     } as Flagger),
 })
 
-// Schema from the implementation - for testing default behavior
-const flaggerOutputSchema = z.object({
-  matched: z.boolean().optional().default(false),
-})
+// Schema shape from the implementation - for testing default behavior
+const flaggerOutputSchema = z
+  .object({
+    matched: z.boolean().optional().default(false),
+    feedback: z.string().min(1).nullable().optional(),
+    messageIndex: z.number().int().nonnegative().optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.matched && !value.feedback?.trim()) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["feedback"], message: "feedback required" })
+    }
+    if (!value.matched && value.feedback?.trim()) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["feedback"], message: "feedback not allowed" })
+    }
+  })
 
 function makeTraceDetail(allMessages: TraceDetail["allMessages"]): TraceDetail {
   return {
@@ -109,7 +120,7 @@ describe("runFlaggerUseCase", () => {
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { matched: true } as T,
+          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
           tokens: 22,
           duration: 123_000_000,
         }),
@@ -129,7 +140,7 @@ describe("runFlaggerUseCase", () => {
       ),
     )
 
-    expect(result).toEqual({ matched: true })
+    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0]).toMatchObject({
       ...FLAGGER_MODEL,
@@ -207,7 +218,7 @@ describe("runFlaggerUseCase", () => {
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { matched: true } as T,
+          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
           tokens: 18,
           duration: 80_000_000,
         }),
@@ -227,7 +238,7 @@ describe("runFlaggerUseCase", () => {
       ),
     )
 
-    expect(result).toEqual({ matched: true })
+    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].system).toContain("Refusal")
     expect(calls.generate[0].system).toContain("declines, deflects, or over-restricts")
@@ -261,7 +272,7 @@ describe("runFlaggerUseCase", () => {
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { matched: true } as T,
+          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
           tokens: 16,
           duration: 60_000_000,
         }),
@@ -281,7 +292,7 @@ describe("runFlaggerUseCase", () => {
       ),
     )
 
-    expect(result).toEqual({ matched: true })
+    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].system).toContain("USER'S OWN WORDING")
     expect(calls.generate[0].system).toContain("Judge only the user-authored messages")
@@ -520,6 +531,49 @@ describe("runFlaggerUseCase", () => {
     expect(result).toEqual({ matched: false })
   })
 
+  it("recovers to matched=false when the AI returns matched=true without usable feedback", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const { layer: aiLayer } = createFakeAI({
+      generate: <T>() =>
+        Effect.succeed({
+          object: { matched: true, feedback: "No jailbreaking behavior detected; this was legitimate." } as T,
+          tokens: 20,
+          duration: 90_000_000,
+        }),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "jailbreaking" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
   it("recovers to matched=false when the SDK cause has no AI_NoObjectGeneratedError name but the message indicates a schema mismatch", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>
@@ -584,7 +638,7 @@ describe("runFlaggerUseCase", () => {
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { matched: true } as T,
+          object: { matched: true, feedback: "Flagger matched with concrete evidence." } as T,
           tokens: 20,
           duration: 90_000_000,
         }),
@@ -604,7 +658,7 @@ describe("runFlaggerUseCase", () => {
       ),
     )
 
-    expect(result).toEqual({ matched: true })
+    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].system).toContain("Laziness")
     expect(calls.generate[0].system).toContain("AVOIDS doing the work")
@@ -669,13 +723,16 @@ describe("runFlaggerUseCase", () => {
     expect(parsed).toEqual({ matched: false })
   })
 
-  it("schema: explicit matched=true is preserved", () => {
-    const parsed = flaggerOutputSchema.parse({ matched: true })
-    expect(parsed).toEqual({ matched: true })
+  it("schema: matched=true requires positive feedback", () => {
+    expect(() => flaggerOutputSchema.parse({ matched: true })).toThrow()
+
+    const parsed = flaggerOutputSchema.parse({ matched: true, feedback: "Assistant refused a harmless request." })
+    expect(parsed).toEqual({ matched: true, feedback: "Assistant refused a harmless request." })
   })
 
-  it("schema: explicit matched=false is preserved", () => {
+  it("schema: matched=false rejects annotation feedback", () => {
     const parsed = flaggerOutputSchema.parse({ matched: false })
     expect(parsed).toEqual({ matched: false })
+    expect(() => flaggerOutputSchema.parse({ matched: false, feedback: "No issue detected." })).toThrow()
   })
 })

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -51,11 +51,6 @@ export interface ClassifyTraceForFlaggerInput {
   readonly strategyOverride?: FlaggerStrategy
 }
 
-const selfNegatingFeedbackPattern =
-  /\b(?:no\s+(?:[\w-]+\s+){0,6}(?:detected|found|present)|not\s+(?:a|an)?\s*(?:[\w-]+\s+){0,6}(?:issue|problem|violation|jailbreak|refusal|error)|does\s+not\s+(?:show|indicate|contain|demonstrate)|normal\s+(?:software\s+development\s+)?workflow|legitimate\s+(?:request|workflow|behavior)|correctly\s+(?:refused|handled))\b/i
-
-const isSelfNegatingFeedback = (feedback: string): boolean => selfNegatingFeedbackPattern.test(feedback)
-
 const baseFlaggerOutputSchema = z.object({
   matched: z.boolean().optional().default(false),
   feedback: z.string().min(1).nullable().optional(),
@@ -74,14 +69,6 @@ const flaggerOutputSchema = baseFlaggerOutputSchema
           message: "matched=true requires positive annotation feedback",
         })
         return
-      }
-
-      if (isSelfNegatingFeedback(feedback)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["feedback"],
-          message: "matched=true feedback must describe the issue, not explain that no issue was detected",
-        })
       }
     } else if (feedback) {
       ctx.addIssue({
@@ -102,9 +89,57 @@ Structured output contract:
 - Set matched=false when the trace does not belong to this flagger; in that case feedback must be null or omitted.
 - Set matched=true only when the trace belongs to this flagger; in that case feedback is required.
 - For matched=true, feedback must be the final human-readable annotation: one or two short sentences describing the issue and concrete evidence.
-- Never use matched=true with feedback that says no issue was detected, the workflow was legitimate, or the assistant behaved correctly.
 - Include messageIndex only when one transcript line is clearly the best evidence.
 `.trim()
+
+const ANNOTATION_REVIEWER_SYSTEM_PROMPT = `
+You are an adversarial quality reviewer for automated flagger annotations.
+
+Your job is to decide whether a proposed annotation should be saved for a flagger match. Be strict: approve only when the annotation clearly describes the same issue category and is supported by the provided evidence. Reject annotations that contradict the match, describe normal or allowed behavior, say no issue was found, switch to another issue category, or rely on facts not present in the evidence.
+
+Return only structured output.
+`.trim()
+
+const annotationReviewOutputSchema = z.object({
+  annotationMakesSense: z.boolean().optional().default(false),
+  reason: z.string().optional(),
+})
+
+const buildClassificationSystemPrompt = (strategy: FlaggerStrategy, trace: TraceDetail): string =>
+  `${strategy.buildSystemPrompt!(trace)}\n\n${FLAGGER_OUTPUT_CONTRACT}`
+
+const buildAnnotationReviewPrompt = (
+  strategy: FlaggerStrategy,
+  trace: TraceDetail,
+  decision: RunFlaggerResult,
+): string => {
+  const annotator = strategy.annotator
+  const flaggerDescription = annotator
+    ? [
+        `Name: ${annotator.name}`,
+        `Description: ${annotator.description}`,
+        "Reviewer guidance:",
+        annotator.instructions,
+      ].join("\n")
+    : "No flagger metadata available. Judge against the classification prompt and evidence."
+
+  return [
+    "Flagger being reviewed:",
+    flaggerDescription,
+    "",
+    "Evidence originally shown to the classifier:",
+    strategy.buildPrompt!(trace),
+    "",
+    "Proposed annotation:",
+    decision.feedback ?? "<missing>",
+    "",
+    decision.messageIndex !== undefined
+      ? `Proposed message index: ${decision.messageIndex}`
+      : "No message index proposed.",
+    "",
+    "Return annotationMakesSense=true only if the proposed annotation is a coherent positive annotation for this flagger and is supported by the evidence.",
+  ].join("\n")
+}
 
 const parseFlaggerOutput = (input: unknown): RunFlaggerResult => {
   const parsed = flaggerOutputSchema.safeParse(input)
@@ -157,7 +192,7 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
     .generate({
       ...FLAGGER_MODEL,
       maxTokens: FLAGGER_MAX_TOKENS,
-      system: `${strategy.buildSystemPrompt!(input.trace)}\n\n${FLAGGER_OUTPUT_CONTRACT}`,
+      system: buildClassificationSystemPrompt(strategy, input.trace),
       prompt: strategy.buildPrompt!(input.trace),
       schema: baseFlaggerOutputSchema,
       telemetry: {
@@ -180,6 +215,43 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
           }),
       ),
     )
+
+  if (!decisions.matched) {
+    return decisions satisfies RunFlaggerResult
+  }
+
+  const review = yield* ai
+    .generate({
+      ...FLAGGER_MODEL,
+      maxTokens: FLAGGER_MAX_TOKENS,
+      system: ANNOTATION_REVIEWER_SYSTEM_PROMPT,
+      prompt: buildAnnotationReviewPrompt(strategy, input.trace, decisions),
+      schema: annotationReviewOutputSchema,
+      telemetry: {
+        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+        metadata: buildProjectScopedAiMetadata(
+          { organizationId: input.organizationId, projectId: input.projectId },
+          { traceId: input.traceId, flaggerSlug: input.flaggerSlug, stage: "annotation-review" },
+        ),
+      },
+    })
+    .pipe(
+      Effect.map((result) => result.object),
+      Effect.catchIf(
+        (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
+        () =>
+          Effect.gen(function* () {
+            yield* Effect.annotateCurrentSpan("flagger.annotationReviewSchemaMismatch", true)
+            return { annotationMakesSense: false }
+          }),
+      ),
+    )
+
+  if (!review.annotationMakesSense) {
+    yield* Effect.annotateCurrentSpan("flagger.annotationReviewRejected", true)
+    return { matched: false } satisfies RunFlaggerResult
+  }
 
   return decisions satisfies RunFlaggerResult
 })

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -24,6 +24,8 @@ export interface RunFlaggerInput {
 
 export interface RunFlaggerResult {
   readonly matched: boolean
+  readonly feedback?: string | undefined
+  readonly messageIndex?: number | undefined
 }
 
 export type RunFlaggerError = NotFoundError | RepositoryError | AIError | AICredentialError
@@ -49,9 +51,66 @@ export interface ClassifyTraceForFlaggerInput {
   readonly strategyOverride?: FlaggerStrategy
 }
 
-const flaggerOutputSchema = z.object({
+const selfNegatingFeedbackPattern =
+  /\b(?:no\s+(?:[\w-]+\s+){0,6}(?:detected|found|present)|not\s+(?:a|an)?\s*(?:[\w-]+\s+){0,6}(?:issue|problem|violation|jailbreak|refusal|error)|does\s+not\s+(?:show|indicate|contain|demonstrate)|normal\s+(?:software\s+development\s+)?workflow|legitimate\s+(?:request|workflow|behavior)|correctly\s+(?:refused|handled))\b/i
+
+const isSelfNegatingFeedback = (feedback: string): boolean => selfNegatingFeedbackPattern.test(feedback)
+
+const baseFlaggerOutputSchema = z.object({
   matched: z.boolean().optional().default(false),
+  feedback: z.string().min(1).nullable().optional(),
+  messageIndex: z.number().int().nonnegative().optional(),
 })
+
+const flaggerOutputSchema = baseFlaggerOutputSchema
+  .superRefine((value, ctx) => {
+    const feedback = value.feedback?.trim()
+
+    if (value.matched) {
+      if (!feedback) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["feedback"],
+          message: "matched=true requires positive annotation feedback",
+        })
+        return
+      }
+
+      if (isSelfNegatingFeedback(feedback)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["feedback"],
+          message: "matched=true feedback must describe the issue, not explain that no issue was detected",
+        })
+      }
+    } else if (feedback) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["feedback"],
+        message: "matched=false must not include annotation feedback",
+      })
+    }
+  })
+  .transform((value) => ({
+    matched: value.matched,
+    ...(value.matched && value.feedback ? { feedback: value.feedback.trim() } : {}),
+    ...(value.matched && value.messageIndex !== undefined ? { messageIndex: value.messageIndex } : {}),
+  }))
+
+const FLAGGER_OUTPUT_CONTRACT = `
+Structured output contract:
+- Set matched=false when the trace does not belong to this flagger; in that case feedback must be null or omitted.
+- Set matched=true only when the trace belongs to this flagger; in that case feedback is required.
+- For matched=true, feedback must be the final human-readable annotation: one or two short sentences describing the issue and concrete evidence.
+- Never use matched=true with feedback that says no issue was detected, the workflow was legitimate, or the assistant behaved correctly.
+- Include messageIndex only when one transcript line is clearly the best evidence.
+`.trim()
+
+const parseFlaggerOutput = (input: unknown): RunFlaggerResult => {
+  const parsed = flaggerOutputSchema.safeParse(input)
+  if (!parsed.success) return { matched: false }
+  return parsed.data
+}
 
 const loadTraceDetail = (input: RunFlaggerInput) =>
   Effect.gen(function* () {
@@ -98,9 +157,9 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
     .generate({
       ...FLAGGER_MODEL,
       maxTokens: FLAGGER_MAX_TOKENS,
-      system: strategy.buildSystemPrompt!(input.trace),
+      system: `${strategy.buildSystemPrompt!(input.trace)}\n\n${FLAGGER_OUTPUT_CONTRACT}`,
       prompt: strategy.buildPrompt!(input.trace),
-      schema: flaggerOutputSchema,
+      schema: baseFlaggerOutputSchema,
       telemetry: {
         spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
         tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
@@ -111,18 +170,18 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
       },
     })
     .pipe(
-      Effect.map((result) => result.object),
+      Effect.map((result) => parseFlaggerOutput(result.object)),
       Effect.catchIf(
         (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
         () =>
           Effect.gen(function* () {
             yield* Effect.annotateCurrentSpan("flagger.flaggerSchemaMismatch", true)
-            return { matched: false }
+            return { matched: false } satisfies RunFlaggerResult
           }),
       ),
     )
 
-  return { matched: decisions.matched } satisfies RunFlaggerResult
+  return decisions satisfies RunFlaggerResult
 })
 
 /**


### PR DESCRIPTION
## What changed

LLM-backed flagger matches now carry the annotation feedback that should be saved for the matched trace. The classifier contract accepts `matched`, optional `feedback`, and optional `messageIndex`; `matched=true` is only accepted when feedback is present.

Before the workflow saves a matched annotation, a second adversarial AI reviewer checks the proposed annotation against the flagger guidance and the same evidence shown to the classifier. If the reviewer says the annotation does not make sense for the flagger/evidence, the match is dropped and no annotation is saved.

The flagger workflow passes approved classifier feedback into the existing draft annotation activity. When feedback is present, the draft step reuses it and only loads trace context for metadata instead of asking a second LLM to write a new annotation. This keeps the saved system annotation tied to the decision that triggered it.

## Why

The previous flow made one LLM call to classify a trace and a second call to draft the annotation. The second call could contradict the match decision, producing saved annotations like “No jailbreaking behavior detected...” for a matched jailbreaking score. That failure mode was cross-cutting for all LLM flaggers, not specific to jailbreak detection.

## Notes

The contradiction check is model-judged rather than phrase-matched in code, so it can catch category drift, unsupported annotations, and explicit contradictions without maintaining brittle string patterns.

The workflow still calls the draft activity after a match so billing, score id generation, and trace context loading stay in the existing activity boundary.

## Validation

- `pnpm --filter @domain/flaggers test -- run-flagger.test.ts draft-flagger-annotation.test.ts`
- `pnpm --filter @app/workflows test -- flagger-workflow.test.ts`
- `pnpm --filter @domain/flaggers typecheck`
- `pnpm --filter @app/workflows typecheck`
