### PR TITLE
feat(ui): media states and file cards for chat conversation rendering

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/
 import { Route as WrappedIdRouteImport } from './routes/wrapped/$id'
 import { Route as DownloadsExportRouteImport } from './routes/downloads/export'
 import { Route as DesignSystemColorsRouteImport } from './routes/design-system/colors'
+import { Route as DesignSystemChatRouteImport } from './routes/design-system/chat'
 import { Route as DesignSystemButtonRouteImport } from './routes/design-system/button'
 import { Route as CcWrappedIdRouteImport } from './routes/cc-wrapped/$id'
 import { Route as BackofficeWrappedRouteImport } from './routes/backoffice/wrapped'
@@ -119,6 +120,11 @@ const DownloadsExportRoute = DownloadsExportRouteImport.update({
 const DesignSystemColorsRoute = DesignSystemColorsRouteImport.update({
   id: '/colors',
   path: '/colors',
+  getParentRoute: () => DesignSystemRouteRoute,
+} as any)
+const DesignSystemChatRoute = DesignSystemChatRouteImport.update({
+  id: '/chat',
+  path: '/chat',
   getParentRoute: () => DesignSystemRouteRoute,
 } as any)
 const DesignSystemButtonRoute = DesignSystemButtonRouteImport.update({
@@ -399,6 +405,7 @@ export interface FileRoutesByFullPath {
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
   '/design-system/button': typeof DesignSystemButtonRoute
+  '/design-system/chat': typeof DesignSystemChatRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/wrapped/$id': typeof WrappedIdRouteWithChildren
@@ -454,6 +461,7 @@ export interface FileRoutesByTo {
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
   '/design-system/button': typeof DesignSystemButtonRoute
+  '/design-system/chat': typeof DesignSystemChatRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/wrapped/$id': typeof WrappedIdRouteWithChildren
@@ -512,6 +520,7 @@ export interface FileRoutesById {
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
   '/design-system/button': typeof DesignSystemButtonRoute
+  '/design-system/chat': typeof DesignSystemChatRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/wrapped/$id': typeof WrappedIdRouteWithChildren
@@ -573,6 +582,7 @@ export interface FileRouteTypes {
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
     | '/design-system/button'
+    | '/design-system/chat'
     | '/design-system/colors'
     | '/downloads/export'
     | '/wrapped/$id'
@@ -628,6 +638,7 @@ export interface FileRouteTypes {
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
     | '/design-system/button'
+    | '/design-system/chat'
     | '/design-system/colors'
     | '/downloads/export'
     | '/wrapped/$id'
@@ -685,6 +696,7 @@ export interface FileRouteTypes {
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
     | '/design-system/button'
+    | '/design-system/chat'
     | '/design-system/colors'
     | '/downloads/export'
     | '/wrapped/$id'
@@ -832,6 +844,13 @@ declare module '@tanstack/react-router' {
       path: '/colors'
       fullPath: '/design-system/colors'
       preLoaderRoute: typeof DesignSystemColorsRouteImport
+      parentRoute: typeof DesignSystemRouteRoute
+    }
+    '/design-system/chat': {
+      id: '/design-system/chat'
+      path: '/chat'
+      fullPath: '/design-system/chat'
+      preLoaderRoute: typeof DesignSystemChatRouteImport
       parentRoute: typeof DesignSystemRouteRoute
     }
     '/design-system/button': {
@@ -1188,12 +1207,14 @@ const BackofficeRouteRouteWithChildren = BackofficeRouteRoute._addFileChildren(
 
 interface DesignSystemRouteRouteChildren {
   DesignSystemButtonRoute: typeof DesignSystemButtonRoute
+  DesignSystemChatRoute: typeof DesignSystemChatRoute
   DesignSystemColorsRoute: typeof DesignSystemColorsRoute
   DesignSystemIndexRoute: typeof DesignSystemIndexRoute
 }
 
 const DesignSystemRouteRouteChildren: DesignSystemRouteRouteChildren = {
   DesignSystemButtonRoute: DesignSystemButtonRoute,
+  DesignSystemChatRoute: DesignSystemChatRoute,
   DesignSystemColorsRoute: DesignSystemColorsRoute,
   DesignSystemIndexRoute: DesignSystemIndexRoute,
 }

--- a/apps/web/src/routes/design-system/chat.tsx
+++ b/apps/web/src/routes/design-system/chat.tsx
@@ -1,6 +1,7 @@
 import { Button, Conversation, Icon, Text, useMountEffect } from "@repo/ui"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { Moon, Sun } from "lucide-react"
+import type { ReactNode } from "react"
 import { useState } from "react"
 import type { GenAIMessage } from "rosetta-ai"
 
@@ -11,6 +12,8 @@ export const Route = createFileRoute("/design-system/chat")({
 // A tiny inline SVG (base64) so the "working image" case renders without any network access.
 const IMAGE_BLOB_B64 =
   "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNDAiIGhlaWdodD0iMTQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIxIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NmYxIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjZWM0ODk5Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3Qgd2lkdGg9IjI0MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0idXJsKCNnKSIvPjx0ZXh0IHg9IjEyMCIgeT0iNzgiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjIwIiBmaWxsPSJ3aGl0ZSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+aW1hZ2UgYmxvYjwvdGV4dD48L3N2Zz4="
+// A small CSV (base64) used to demonstrate downloading an inline blob document.
+const CSV_BLOB_B64 = "bmFtZSxzY29yZQpBbGljZSw5CkJvYiw3CkNhcm9sLDgK"
 
 // Remote sample media (renders when online; the broken URLs below show the
 // fallback behavior when a source is missing / inaccessible).
@@ -39,11 +42,23 @@ function greet(name: string) {
 
 > And a blockquote for good measure.`
 
-// `as GenAIMessage[]` — the schema is permissive (z.core.$loose) and we want
-// to exercise edge cases (unknown part types, refusals) that aren't in the
-// strict TS unions. Fields use the wire-format snake_case shape the renderer expects.
-const DEMO_MESSAGES = [
-  // 1. System instructions
+const JSON_SAMPLE = JSON.stringify(
+  { status: "ok", model: "claude-opus-4-7", usage: { input_tokens: 1240, output_tokens: 318 }, items: [1, 2, 3] },
+  null,
+  2,
+)
+
+// Long enough (> ~3000 chars) to trigger the large-markdown "show more" split.
+const LONG_TEXT = Array.from(
+  { length: 14 },
+  (_, i) =>
+    `Paragraph ${i + 1}. This is a long assistant response used to demonstrate how the renderer collapses oversized content behind a "show more" affordance, snapping to paragraph boundaries so the head and tail stay readable while the middle is hidden until expanded.`,
+).join("\n\n")
+
+// `as GenAIMessage[]` — the schema is permissive (z.core.$loose) and we want to exercise
+// edge cases (unknown part types/roles, refusals) that aren't in the strict TS unions.
+// Fields use the wire-format snake_case shape the renderer expects.
+const TEXT_MESSAGES = [
   {
     role: "system",
     parts: [
@@ -53,73 +68,73 @@ const DEMO_MESSAGES = [
       },
     ],
   },
+  { role: "user", parts: [{ type: "text", content: "Can you summarize the provider latencies?" }] },
+  { role: "assistant", parts: [{ type: "text", content: MARKDOWN_SAMPLE }] },
+  // JSON-block text part — renders via JsonContent (syntax-highlighted).
+  { role: "assistant", parts: [{ type: "text", content: JSON_SAMPLE }] },
+  // Long content — renders with the "show more" middle collapse.
+  { role: "assistant", parts: [{ type: "text", content: LONG_TEXT }] },
+] as GenAIMessage[]
 
-  // 2. Plain user text
-  {
-    role: "user",
-    parts: [{ type: "text", content: "Hey! Can you analyze the attached media and document?" }],
-  },
-
-  // 3. User with text + inline image blob + working remote image + broken image
+const MEDIA_MESSAGES = [
   {
     role: "user",
     parts: [
-      { type: "text", content: "Here are a few images:" },
+      { type: "text", content: "Images — inline blob, working remote URL, and a broken URL:" },
       { type: "blob", modality: "image", mime_type: "image/svg+xml", content: IMAGE_BLOB_B64 },
       { type: "uri", modality: "image", mime_type: "image/jpeg", uri: SAMPLE_IMAGE_URI },
-      // Source missing / inaccessible — shows the browser's broken-image fallback today.
       { type: "uri", modality: "image", mime_type: "image/png", uri: BROKEN_IMAGE_URI },
     ],
   },
-
-  // 4. User with audio, video, a file reference, an unknown-modality blob, and a plain link
   {
     role: "user",
     parts: [
-      { type: "text", content: "And some other attachments:" },
+      { type: "text", content: "Audio — working and broken:" },
       { type: "uri", modality: "audio", mime_type: "audio/mpeg", uri: SAMPLE_AUDIO_URI },
-      // Audio source we can't reach — bar-shaped fallback.
       { type: "uri", modality: "audio", mime_type: "audio/mpeg", uri: BROKEN_AUDIO_URI },
-      { type: "uri", modality: "video", mime_type: "video/mp4", uri: SAMPLE_VIDEO_URI },
-      // Video source we can't reach — fallback behavior.
-      { type: "uri", modality: "video", mime_type: "video/mp4", uri: BROKEN_VIDEO_URI },
-      // File reference — rendered as an id chip (not resolved to media in the UI).
-      { type: "file", modality: "image", mime_type: "application/pdf", file_id: "file_abc123report" },
-      // Unknown modality blob — falls through to the MediaFallback badge.
-      { type: "blob", modality: "document", mime_type: "application/pdf", content: "JVBERi0xLjcK" },
-      // Non-media URI — rendered as a clickable link.
-      { type: "uri", modality: "document", mime_type: "text/html", uri: "https://docs.latitude.so/guides" },
     ],
   },
-
-  // 5. Assistant with reasoning (thinking) + rich markdown text
   {
-    role: "assistant",
+    role: "user",
     parts: [
-      {
-        type: "reasoning",
-        content:
-          "The user attached an image and a PDF. I should describe the image and offer to extract the document text.",
-      },
-      { type: "text", content: MARKDOWN_SAMPLE },
+      { type: "text", content: "Video — working and broken:" },
+      { type: "uri", modality: "video", mime_type: "video/mp4", uri: SAMPLE_VIDEO_URI },
+      { type: "uri", modality: "video", mime_type: "video/mp4", uri: BROKEN_VIDEO_URI },
     ],
   },
+] as GenAIMessage[]
 
-  // 6. Assistant emitting a tool call (response is absorbed from the tool message below)
+const FILE_MESSAGES = [
+  {
+    role: "user",
+    parts: [
+      { type: "text", content: "File references (file_id, no resolvable source → no action):" },
+      { type: "file", modality: "document", mime_type: "application/pdf", file_id: "file_q3_report_abc123" },
+      { type: "file", modality: "document", mime_type: "text/csv", file_id: "file_metrics_def456" },
+      { type: "file", modality: "document", mime_type: "application/zip", file_id: "file_export_ghi789" },
+      { type: "file", modality: "document", mime_type: "text/x-python", file_id: "file_script_jkl012" },
+      { type: "file", modality: "image", mime_type: "image/png", file_id: "file_diagram_mno345" },
+    ],
+  },
+  {
+    role: "user",
+    parts: [
+      { type: "text", content: "A linked document (uri → Open) and an inline one (blob → Download):" },
+      { type: "uri", modality: "document", mime_type: "application/pdf", uri: "https://docs.latitude.so/guide.pdf" },
+      { type: "blob", modality: "document", mime_type: "text/csv", content: CSV_BLOB_B64 },
+    ],
+  },
+] as GenAIMessage[]
+
+const TOOL_MESSAGES = [
   {
     role: "assistant",
     parts: [
       { type: "text", content: "Let me look up the latest metrics for you." },
-      {
-        type: "tool_call",
-        id: "call_metrics_1",
-        name: "get_metrics",
-        arguments: { range: "7d", metric: "p95_latency" },
-      },
+      { type: "tool_call", id: "call_metrics_1", name: "get_metrics", arguments: { range: "7d", metric: "p95" } },
     ],
   },
-
-  // 7. Tool result that gets absorbed into the tool_call above (matched by id)
+  // Success result — absorbed into the tool_call above (matched by id).
   {
     role: "tool",
     parts: [
@@ -131,21 +146,50 @@ const DEMO_MESSAGES = [
       },
     ],
   },
-
-  // 8. Standalone tool error result (no matching call id → renders on its own, error styling)
+  {
+    role: "assistant",
+    parts: [
+      { type: "text", content: "Now fetching invoices…" },
+      { type: "tool_call", id: "call_inv_1", name: "fetch_invoices", arguments: { customerId: "cus_123" } },
+    ],
+  },
+  // Error result — absorbed, destructive styling.
   {
     role: "tool",
     parts: [
       {
         type: "tool_call_response",
-        id: "call_orphan_err",
+        id: "call_inv_1",
         response: { error: "Upstream provider timed out after 30s" },
         _provider_metadata: { _known_fields: { toolName: "fetch_invoices", isError: true } },
       },
     ],
   },
+  // Multiple tool calls in a single assistant message.
+  {
+    role: "assistant",
+    parts: [
+      { type: "text", content: "Running a couple of lookups in parallel:" },
+      { type: "tool_call", id: "call_a", name: "search_docs", arguments: { q: "rate limits" } },
+      { type: "tool_call", id: "call_b", name: "get_user", arguments: { id: "u_42" } },
+    ],
+  },
+  // Standalone tool error (no matching call → renders on its own).
+  {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "call_orphan",
+        response: { error: "Tool execution was cancelled" },
+        _provider_metadata: { _known_fields: { toolName: "run_export", isError: true } },
+      },
+    ],
+  },
+] as GenAIMessage[]
 
-  // 9. Assistant refusal (isRefusal known field → refusal badge)
+const EDGE_CASE_MESSAGES = [
+  // Refusal (isRefusal known field → refusal badge).
   {
     role: "assistant",
     parts: [
@@ -156,16 +200,76 @@ const DEMO_MESSAGES = [
       },
     ],
   },
-
-  // 10. Assistant with an unknown part type (default JSON fallback block)
+  // Multiple reasoning (thinking) parts.
   {
     role: "assistant",
     parts: [
-      { type: "text", content: "And here's a part type the renderer doesn't know about:" },
+      { type: "reasoning", content: "First, I should restate the problem to make sure I understand it." },
+      { type: "reasoning", content: "Then I'll outline the steps before answering." },
+      { type: "text", content: "Here's my answer after thinking it through." },
+    ],
+  },
+  // Unknown part type → default JSON fallback block.
+  {
+    role: "assistant",
+    parts: [
+      { type: "text", content: "And a part type the renderer doesn't know about:" },
       { type: "custom_widget", payload: { kind: "chart", series: [1, 2, 3] } } as never,
     ],
   },
+  // Unknown message role → default styling.
+  { role: "developer", parts: [{ type: "text", content: "A message with an unrecognized role." }] },
 ] as GenAIMessage[]
+
+const SECTIONS: { title: string; description: string; messages: GenAIMessage[] }[] = [
+  {
+    title: "Text & markdown",
+    description: "System, plain text, rich markdown, JSON blocks, long-content collapse.",
+    messages: TEXT_MESSAGES,
+  },
+  {
+    title: "Media",
+    description: "Image / audio / video, each with working and broken sources.",
+    messages: MEDIA_MESSAGES,
+  },
+  {
+    title: "Files & documents",
+    description: "file_id references, a linked document (Open), and an inline one (Download).",
+    messages: FILE_MESSAGES,
+  },
+  {
+    title: "Tool calls",
+    description: "Success and error results (absorbed), multiple calls, and a standalone error.",
+    messages: TOOL_MESSAGES,
+  },
+  {
+    title: "Roles & states",
+    description: "Refusal badge, multiple reasoning parts, unknown part type, unknown role.",
+    messages: EDGE_CASE_MESSAGES,
+  },
+]
+
+function Section({
+  title,
+  description,
+  surfaceClass,
+  children,
+}: {
+  title: string
+  description: string
+  surfaceClass: string
+  children: ReactNode
+}) {
+  return (
+    <section className={`flex flex-col gap-4 rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${surfaceClass}`}>
+      <div className="flex flex-col gap-1">
+        <Text.H4>{title}</Text.H4>
+        <Text.H6 color="foregroundMuted">{description}</Text.H6>
+      </div>
+      {children}
+    </section>
+  )
+}
 
 function ChatPage() {
   const [theme, setTheme] = useState<"light" | "dark">("light")
@@ -211,9 +315,8 @@ function ChatPage() {
             <Text.H2 className="text-balance">Chat / Conversation</Text.H2>
           </div>
           <Text.H6 color="foregroundMuted">
-            A full conversation exercising every message role and content part: system instructions, user and assistant
-            messages, text, reasoning, media (image / audio / video as blob and uri), file references, tool calls and
-            results, refusals, and unknown part types. Broken media sources are included to show fallback behavior.
+            Every message role and content part the renderer supports, grouped by theme: text & markdown, media (with
+            broken sources), files & documents, tool calls, and edge-case roles/states.
           </Text.H6>
           <div className="flex flex-wrap items-center justify-between gap-3">
             <Button
@@ -236,9 +339,16 @@ function ChatPage() {
           </div>
         </header>
 
-        <div className={`rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${pageSurfaceClass}`}>
-          <Conversation messages={DEMO_MESSAGES} />
-        </div>
+        {SECTIONS.map((section) => (
+          <Section
+            key={section.title}
+            title={section.title}
+            description={section.description}
+            surfaceClass={pageSurfaceClass}
+          >
+            <Conversation messages={section.messages} />
+          </Section>
+        ))}
       </div>
     </main>
   )

--- a/apps/web/src/routes/design-system/chat.tsx
+++ b/apps/web/src/routes/design-system/chat.tsx
@@ -19,6 +19,7 @@ const SAMPLE_AUDIO_URI = "https://www.w3schools.com/html/horse.mp3"
 const SAMPLE_VIDEO_URI = "https://www.w3schools.com/html/mov_bbb.mp4"
 const BROKEN_IMAGE_URI = "https://example.com/this-image-does-not-exist.png"
 const BROKEN_VIDEO_URI = "https://invalid.invalid/private-clip.mp4"
+const BROKEN_AUDIO_URI = "https://invalid.invalid/voice-note.mp3"
 
 const MARKDOWN_SAMPLE = `Here's a breakdown with **rich markdown**:
 
@@ -77,6 +78,8 @@ const DEMO_MESSAGES = [
     parts: [
       { type: "text", content: "And some other attachments:" },
       { type: "uri", modality: "audio", mime_type: "audio/mpeg", uri: SAMPLE_AUDIO_URI },
+      // Audio source we can't reach — bar-shaped fallback.
+      { type: "uri", modality: "audio", mime_type: "audio/mpeg", uri: BROKEN_AUDIO_URI },
       { type: "uri", modality: "video", mime_type: "video/mp4", uri: SAMPLE_VIDEO_URI },
       // Video source we can't reach — fallback behavior.
       { type: "uri", modality: "video", mime_type: "video/mp4", uri: BROKEN_VIDEO_URI },

--- a/apps/web/src/routes/design-system/chat.tsx
+++ b/apps/web/src/routes/design-system/chat.tsx
@@ -1,0 +1,242 @@
+import { Button, Conversation, Icon, Text, useMountEffect } from "@repo/ui"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Moon, Sun } from "lucide-react"
+import { useState } from "react"
+import type { GenAIMessage } from "rosetta-ai"
+
+export const Route = createFileRoute("/design-system/chat")({
+  component: ChatPage,
+})
+
+// A tiny inline SVG (base64) so the "working image" case renders without any network access.
+const IMAGE_BLOB_B64 =
+  "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNDAiIGhlaWdodD0iMTQwIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIxIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NmYxIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjZWM0ODk5Ii8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3Qgd2lkdGg9IjI0MCIgaGVpZ2h0PSIxNDAiIHJ4PSIxMiIgZmlsbD0idXJsKCNnKSIvPjx0ZXh0IHg9IjEyMCIgeT0iNzgiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjIwIiBmaWxsPSJ3aGl0ZSIgdGV4dC1hbmNob3I9Im1pZGRsZSI+aW1hZ2UgYmxvYjwvdGV4dD48L3N2Zz4="
+
+// Remote sample media (renders when online; the broken URLs below show the
+// fallback behavior when a source is missing / inaccessible).
+const SAMPLE_IMAGE_URI = "https://picsum.photos/id/237/240/140"
+const SAMPLE_AUDIO_URI = "https://www.w3schools.com/html/horse.mp3"
+const SAMPLE_VIDEO_URI = "https://www.w3schools.com/html/mov_bbb.mp4"
+const BROKEN_IMAGE_URI = "https://example.com/this-image-does-not-exist.png"
+const BROKEN_VIDEO_URI = "https://invalid.invalid/private-clip.mp4"
+
+const MARKDOWN_SAMPLE = `Here's a breakdown with **rich markdown**:
+
+1. A numbered list item
+2. Another with \`inline code\`
+
+\`\`\`ts
+function greet(name: string) {
+  return \`Hello, \${name}!\`
+}
+\`\`\`
+
+| Provider | Latency |
+| --- | --- |
+| OpenAI | 420ms |
+| Anthropic | 380ms |
+
+> And a blockquote for good measure.`
+
+// `as GenAIMessage[]` — the schema is permissive (z.core.$loose) and we want
+// to exercise edge cases (unknown part types, refusals) that aren't in the
+// strict TS unions. Fields use the wire-format snake_case shape the renderer expects.
+const DEMO_MESSAGES = [
+  // 1. System instructions
+  {
+    role: "system",
+    parts: [
+      {
+        type: "text",
+        content: "You are Latitude's helpful assistant. Be concise, cite sources, and refuse unsafe requests.",
+      },
+    ],
+  },
+
+  // 2. Plain user text
+  {
+    role: "user",
+    parts: [{ type: "text", content: "Hey! Can you analyze the attached media and document?" }],
+  },
+
+  // 3. User with text + inline image blob + working remote image + broken image
+  {
+    role: "user",
+    parts: [
+      { type: "text", content: "Here are a few images:" },
+      { type: "blob", modality: "image", mime_type: "image/svg+xml", content: IMAGE_BLOB_B64 },
+      { type: "uri", modality: "image", mime_type: "image/jpeg", uri: SAMPLE_IMAGE_URI },
+      // Source missing / inaccessible — shows the browser's broken-image fallback today.
+      { type: "uri", modality: "image", mime_type: "image/png", uri: BROKEN_IMAGE_URI },
+    ],
+  },
+
+  // 4. User with audio, video, a file reference, an unknown-modality blob, and a plain link
+  {
+    role: "user",
+    parts: [
+      { type: "text", content: "And some other attachments:" },
+      { type: "uri", modality: "audio", mime_type: "audio/mpeg", uri: SAMPLE_AUDIO_URI },
+      { type: "uri", modality: "video", mime_type: "video/mp4", uri: SAMPLE_VIDEO_URI },
+      // Video source we can't reach — fallback behavior.
+      { type: "uri", modality: "video", mime_type: "video/mp4", uri: BROKEN_VIDEO_URI },
+      // File reference — rendered as an id chip (not resolved to media in the UI).
+      { type: "file", modality: "image", mime_type: "application/pdf", file_id: "file_abc123report" },
+      // Unknown modality blob — falls through to the MediaFallback badge.
+      { type: "blob", modality: "document", mime_type: "application/pdf", content: "JVBERi0xLjcK" },
+      // Non-media URI — rendered as a clickable link.
+      { type: "uri", modality: "document", mime_type: "text/html", uri: "https://docs.latitude.so/guides" },
+    ],
+  },
+
+  // 5. Assistant with reasoning (thinking) + rich markdown text
+  {
+    role: "assistant",
+    parts: [
+      {
+        type: "reasoning",
+        content:
+          "The user attached an image and a PDF. I should describe the image and offer to extract the document text.",
+      },
+      { type: "text", content: MARKDOWN_SAMPLE },
+    ],
+  },
+
+  // 6. Assistant emitting a tool call (response is absorbed from the tool message below)
+  {
+    role: "assistant",
+    parts: [
+      { type: "text", content: "Let me look up the latest metrics for you." },
+      {
+        type: "tool_call",
+        id: "call_metrics_1",
+        name: "get_metrics",
+        arguments: { range: "7d", metric: "p95_latency" },
+      },
+    ],
+  },
+
+  // 7. Tool result that gets absorbed into the tool_call above (matched by id)
+  {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "call_metrics_1",
+        response: { p95_latency_ms: 412, samples: 18234, region: "us-east-1" },
+        _provider_metadata: { _known_fields: { toolName: "get_metrics" } },
+      },
+    ],
+  },
+
+  // 8. Standalone tool error result (no matching call id → renders on its own, error styling)
+  {
+    role: "tool",
+    parts: [
+      {
+        type: "tool_call_response",
+        id: "call_orphan_err",
+        response: { error: "Upstream provider timed out after 30s" },
+        _provider_metadata: { _known_fields: { toolName: "fetch_invoices", isError: true } },
+      },
+    ],
+  },
+
+  // 9. Assistant refusal (isRefusal known field → refusal badge)
+  {
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        content: "I can't help with that request.",
+        _provider_metadata: { _known_fields: { isRefusal: true } },
+      },
+    ],
+  },
+
+  // 10. Assistant with an unknown part type (default JSON fallback block)
+  {
+    role: "assistant",
+    parts: [
+      { type: "text", content: "And here's a part type the renderer doesn't know about:" },
+      { type: "custom_widget", payload: { kind: "chart", series: [1, 2, 3] } } as never,
+    ],
+  },
+] as GenAIMessage[]
+
+function ChatPage() {
+  const [theme, setTheme] = useState<"light" | "dark">("light")
+  const pageSurfaceClass = theme === "dark" ? "bg-black" : "bg-white"
+
+  const applyTheme = (nextTheme: "light" | "dark") => {
+    const root = document.documentElement
+    root.classList.toggle("dark", nextTheme === "dark")
+    root.style.colorScheme = nextTheme
+  }
+
+  const restoreHostTheme = () => {
+    const root = document.documentElement
+    const hostTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    root.classList.toggle("dark", hostTheme === "dark")
+    root.style.colorScheme = hostTheme
+  }
+
+  useMountEffect(() => {
+    applyTheme(theme)
+    return () => {
+      restoreHostTheme()
+    }
+  })
+
+  return (
+    <main className={`flex min-h-screen flex-col gap-6 p-4 text-foreground sm:p-6 lg:p-8 ${pageSurfaceClass}`}>
+      <div className="flex w-full max-w-3xl flex-col gap-6 self-center">
+        <header
+          className={`flex flex-col gap-4 rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${pageSurfaceClass}`}
+        >
+          <Link
+            to="/design-system"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            <span aria-hidden="true">←</span>
+            Design system
+          </Link>
+          <div className="flex flex-col gap-2">
+            <Text.H6 color="accentForeground" weight="semibold">
+              Showcase
+            </Text.H6>
+            <Text.H2 className="text-balance">Chat / Conversation</Text.H2>
+          </div>
+          <Text.H6 color="foregroundMuted">
+            A full conversation exercising every message role and content part: system instructions, user and assistant
+            messages, text, reasoning, media (image / audio / video as blob and uri), file references, tool calls and
+            results, refusals, and unknown part types. Broken media sources are included to show fallback behavior.
+          </Text.H6>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTheme((currentTheme) => {
+                  const nextTheme = currentTheme === "light" ? "dark" : "light"
+                  applyTheme(nextTheme)
+                  return nextTheme
+                })
+              }}
+            >
+              <Icon icon={theme === "light" ? Moon : Sun} size="sm" />
+              {theme === "light" ? "Switch to Dark" : "Switch to Light"}
+            </Button>
+            <div className={`flex items-center gap-2 rounded-lg border border-border/60 p-2 ${pageSurfaceClass}`}>
+              <Text.H6 color="foregroundMuted">Theme</Text.H6>
+              <Text.Mono>{theme}</Text.Mono>
+            </div>
+          </div>
+        </header>
+
+        <div className={`rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${pageSurfaceClass}`}>
+          <Conversation messages={DEMO_MESSAGES} />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/routes/design-system/index.tsx
+++ b/apps/web/src/routes/design-system/index.tsx
@@ -705,6 +705,12 @@ function DesignSystemPage() {
               >
                 Colors
               </Link>
+              <Link
+                to="/design-system/chat"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Chat
+              </Link>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/packages/ui/src/components/genai-conversation/part.tsx
+++ b/packages/ui/src/components/genai-conversation/part.tsx
@@ -1,4 +1,5 @@
-import { CheckIcon, FileIcon, LinkIcon, TerminalIcon, TriangleAlertIcon, XIcon } from "lucide-react"
+import { base64ByteLength } from "@repo/utils"
+import { CheckIcon, FileIcon, TerminalIcon, TriangleAlertIcon, XIcon } from "lucide-react"
 import { type ReactNode, use } from "react"
 import type { GenAIPart } from "rosetta-ai"
 import { cn } from "../../utils/cn.ts"
@@ -6,7 +7,8 @@ import { CodeBlockControls } from "../code-block/code-block-controls.tsx"
 import { Text } from "../text/text.tsx"
 import { Tooltip } from "../tooltip/tooltip.tsx"
 import { CollapsibleBlock } from "./parts/collapsible-block.tsx"
-import { formatJson, getKnownField, MediaFallback, renderMediaByModality } from "./parts/helpers.tsx"
+import { FileCard } from "./parts/file-card.tsx"
+import { formatJson, getKnownField, renderMediaByModality } from "./parts/helpers.tsx"
 import { isLexicalSearchHighlight } from "./parts/highlight-segments.ts"
 import { MarkdownContent } from "./parts/lazy-markdown-content.tsx"
 import { ToolCallBlock } from "./parts/tool-call-block.tsx"
@@ -24,6 +26,18 @@ import { TextSelectionContext } from "./text-selection.tsx"
 
 export { ReasoningGroup } from "./parts/reasoning-group.tsx"
 export type { ToolCallResult } from "./parts/types.ts"
+
+/** Last non-empty path segment of a URI, used as a file card's display name (undefined if none). */
+function fileNameFromUri(uri: string): string | undefined {
+  try {
+    const path = new URL(uri).pathname
+    const segment = path.split("/").filter(Boolean).pop()
+    return segment ? decodeURIComponent(segment) : undefined
+  } catch {
+    const segment = uri.split(/[?#]/)[0]?.split("/").filter(Boolean).pop()
+    return segment || undefined
+  }
+}
 
 // Blue ring + ::before "Search result inside" label for parts whose
 // rendered shape can't carry inline chips (tool_call_response). Spans the
@@ -98,20 +112,20 @@ export function Part({
       const dataUri = `data:${mimeType};base64,${p.content}`
       const media = renderMediaByModality({ modality: p.modality, src: dataUri, mimeType })
       if (media) return media
-      return <MediaFallback modality={p.modality} mimeType={p.mime_type} />
+      // Non-media blob (e.g. a document): show a file card with a download from the inline data.
+      return (
+        <FileCard
+          mimeType={p.mime_type ?? undefined}
+          modality={p.modality}
+          sizeBytes={base64ByteLength(p.content)}
+          downloadDataUri={dataUri}
+        />
+      )
     }
 
     case "file": {
       const p = part as FilePart
-      return (
-        <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
-          <FileIcon className="w-3.5 h-3.5 text-muted-foreground" />
-          <Text.Mono size="h6" color="foregroundMuted" ellipsis>
-            {p.file_id}
-          </Text.Mono>
-          <Text.H6 color="foregroundMuted">&middot; {p.modality}</Text.H6>
-        </span>
-      )
+      return <FileCard mimeType={p.mime_type ?? undefined} modality={p.modality} fileId={p.file_id} />
     }
 
     case "uri": {
@@ -124,16 +138,14 @@ export function Part({
       })
       if (media) return media
 
+      // Non-media URI (e.g. a linked document): show a file card that opens the original.
       return (
-        <a
+        <FileCard
+          fileName={fileNameFromUri(p.uri)}
+          mimeType={p.mime_type ?? undefined}
+          modality={p.modality}
           href={p.uri}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-primary hover:underline"
-        >
-          <LinkIcon className="w-3.5 h-3.5" />
-          <Text.H6 color="primary">{p.uri}</Text.H6>
-        </a>
+        />
       )
     }
 

--- a/packages/ui/src/components/genai-conversation/part.tsx
+++ b/packages/ui/src/components/genai-conversation/part.tsx
@@ -108,7 +108,9 @@ export function Part({
 
     case "blob": {
       const p = part as BlobPart
-      const mimeType = p.mime_type ?? (p.modality === "image" ? "image/png" : `${p.modality}/*`)
+      // Fall back to a valid concrete MIME — `${modality}/*` (e.g. "document/*") is not a real
+      // type and would produce an invalid data URI, breaking the FileCard download below.
+      const mimeType = p.mime_type ?? (p.modality === "image" ? "image/png" : "application/octet-stream")
       const dataUri = `data:${mimeType};base64,${p.content}`
       const media = renderMediaByModality({ modality: p.modality, src: dataUri, mimeType })
       if (media) return media

--- a/packages/ui/src/components/genai-conversation/part.tsx
+++ b/packages/ui/src/components/genai-conversation/part.tsx
@@ -120,6 +120,7 @@ export function Part({
         modality: p.modality,
         src: p.uri,
         mimeType: p.mime_type ?? undefined,
+        href: p.uri,
       })
       if (media) return media
 

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -13,7 +13,9 @@ import {
   FileVideoIcon,
   type LucideIcon,
 } from "lucide-react"
+import { cn } from "../../../utils/cn.ts"
 import { Text } from "../../text/text.tsx"
+import { Tooltip } from "../../tooltip/tooltip.tsx"
 
 const ACTION_CLASS =
   "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:text-foreground"
@@ -121,7 +123,25 @@ export function FileCard({
     <a href={downloadDataUri} download={downloadName} aria-label="Download file" className={ACTION_CLASS}>
       <DownloadIcon className="h-3.5 w-3.5" />
     </a>
-  ) : null
+  ) : (
+    // No resolvable source — keep the affordance but disable it and explain why on hover.
+    // `aria-disabled` (not the native `disabled` attr) so the tooltip still fires.
+    <Tooltip
+      asChild
+      trigger={
+        <button
+          type="button"
+          aria-disabled="true"
+          aria-label="No downloadable source"
+          className={cn(ACTION_CLASS, "cursor-not-allowed opacity-50")}
+        >
+          <DownloadIcon className="h-3.5 w-3.5" />
+        </button>
+      }
+    >
+      This attachment has no downloadable source.
+    </Tooltip>
+  )
 
   return (
     <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -47,7 +47,7 @@ const MIME_EXTENSIONS: Record<string, string> = {
 
 /** Picks a type-aware (monochrome) lucide icon from the mime type, falling back to modality then generic. */
 function fileIconForMime(mimeType?: string | null, modality?: string): LucideIcon {
-  const mime = (mimeType ?? "").toLowerCase()
+  const mime = (mimeType ?? "").toLowerCase().split(";")[0] ?? ""
   if (mime === "application/pdf") return FileTextIcon
   if (mime === "application/json") return FileJsonIcon
   if (mime.includes("csv") || mime.includes("spreadsheet") || mime.includes("excel")) return FileSpreadsheetIcon

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -124,7 +124,7 @@ export function FileCard({
   ) : null
 
   return (
-    <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-card px-3 py-2 shadow-sm">
+    <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
         <FileTypeIcon className="h-5 w-5 text-muted-foreground" />
       </div>

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -124,7 +124,7 @@ export function FileCard({
   ) : null
 
   return (
-    <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-muted/30 px-3 py-2">
+    <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-card px-3 py-2 shadow-sm">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
         <FileTypeIcon className="h-5 w-5 text-muted-foreground" />
       </div>

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -85,7 +85,8 @@ function fileExtensionForMime(mimeType?: string | null): string | undefined {
 /**
  * Renders a non-previewable attachment (document/file) as a card: type-aware icon + label + optional size.
  * The action depends on the source — `href` (uri) opens in a new tab, `downloadDataUri` (blob) downloads,
- * and a bare `fileId` (no resolvable source) shows no action and surfaces the id as the secondary line.
+ * and a bare `fileId` (no resolvable source) renders a disabled action with an explanatory tooltip while
+ * surfacing the id as the secondary line.
  */
 export function FileCard({
   fileName,

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -1,0 +1,147 @@
+import { formatBytes } from "@repo/utils"
+import {
+  DownloadIcon,
+  ExternalLinkIcon,
+  FileArchiveIcon,
+  FileAudioIcon,
+  FileCodeIcon,
+  FileIcon,
+  FileImageIcon,
+  FileJsonIcon,
+  FileSpreadsheetIcon,
+  FileTextIcon,
+  FileVideoIcon,
+  type LucideIcon,
+} from "lucide-react"
+import { Text } from "../../text/text.tsx"
+
+const ACTION_CLASS =
+  "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
+
+const MIME_LABELS: Record<string, string> = {
+  "application/pdf": "PDF document",
+  "application/json": "JSON",
+  "text/csv": "CSV",
+  "text/plain": "Text",
+  "text/html": "HTML",
+  "text/markdown": "Markdown",
+  "application/zip": "Archive",
+  "application/msword": "Word document",
+  "application/vnd.ms-excel": "Excel spreadsheet",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "Word document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "Excel spreadsheet",
+}
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  "application/pdf": "pdf",
+  "application/json": "json",
+  "text/csv": "csv",
+  "text/plain": "txt",
+  "text/html": "html",
+  "text/markdown": "md",
+  "application/zip": "zip",
+}
+
+/** Picks a type-aware (monochrome) lucide icon from the mime type, falling back to modality then generic. */
+function fileIconForMime(mimeType?: string | null, modality?: string): LucideIcon {
+  const mime = (mimeType ?? "").toLowerCase()
+  if (mime === "application/pdf") return FileTextIcon
+  if (mime === "application/json") return FileJsonIcon
+  if (mime.includes("csv") || mime.includes("spreadsheet") || mime.includes("excel")) return FileSpreadsheetIcon
+  if (mime.includes("zip") || mime.includes("tar") || mime.includes("gzip") || mime.includes("compressed")) {
+    return FileArchiveIcon
+  }
+  if (mime.includes("xml") || mime.includes("javascript") || mime.includes("html") || mime.startsWith("text/x-")) {
+    return FileCodeIcon
+  }
+  if (mime.startsWith("image/") || modality === "image") return FileImageIcon
+  if (mime.startsWith("audio/") || modality === "audio") return FileAudioIcon
+  if (mime.startsWith("video/") || modality === "video") return FileVideoIcon
+  if (mime.startsWith("text/")) return FileTextIcon
+  return FileIcon
+}
+
+/** Human-readable type label, e.g. "PDF document"; derives from the mime subtype, then modality. */
+function fileTypeLabel(mimeType?: string | null, modality?: string): string {
+  const mime = (mimeType ?? "").toLowerCase().split(";")[0] ?? ""
+  if (MIME_LABELS[mime]) return MIME_LABELS[mime]
+  const subtype = mime.includes("/") ? mime.split("/")[1] : undefined
+  if (subtype) return subtype.replace(/^x-/, "").replace(/[-.]/g, " ").toUpperCase()
+  if (modality) return modality.charAt(0).toUpperCase() + modality.slice(1)
+  return "File"
+}
+
+/** File extension for the download filename, e.g. "application/pdf" -> "pdf". */
+function fileExtensionForMime(mimeType?: string | null): string | undefined {
+  const mime = (mimeType ?? "").toLowerCase().split(";")[0] ?? ""
+  if (MIME_EXTENSIONS[mime]) return MIME_EXTENSIONS[mime]
+  const subtype = mime.includes("/") ? mime.split("/")[1] : undefined
+  return subtype && /^[a-z0-9]+$/.test(subtype) ? subtype : undefined
+}
+
+/**
+ * Renders a non-previewable attachment (document/file) as a card: type-aware icon + label + optional size.
+ * The action depends on the source — `href` (uri) opens in a new tab, `downloadDataUri` (blob) downloads,
+ * and a bare `fileId` (no resolvable source) shows no action and surfaces the id as the secondary line.
+ */
+export function FileCard({
+  fileName,
+  mimeType,
+  modality,
+  fileId,
+  sizeBytes,
+  href,
+  downloadDataUri,
+}: {
+  readonly fileName?: string | undefined
+  readonly mimeType?: string | null | undefined
+  readonly modality?: string | undefined
+  readonly fileId?: string | undefined
+  readonly sizeBytes?: number | undefined
+  readonly href?: string | undefined
+  readonly downloadDataUri?: string | undefined
+}) {
+  const FileTypeIcon = fileIconForMime(mimeType, modality)
+  const typeLabel = fileTypeLabel(mimeType, modality)
+  const primary = fileName ?? typeLabel
+
+  const secondaryBits: string[] = []
+  if (fileName) secondaryBits.push(typeLabel)
+  if (sizeBytes != null) secondaryBits.push(formatBytes(sizeBytes))
+  const secondary = secondaryBits.join(" · ")
+
+  const extension = fileExtensionForMime(mimeType)
+  const downloadName = fileName ?? `attachment${extension ? `.${extension}` : ""}`
+
+  const action = href ? (
+    <a href={href} target="_blank" rel="noopener noreferrer" aria-label="Open file in new tab" className={ACTION_CLASS}>
+      <ExternalLinkIcon className="h-3.5 w-3.5" />
+    </a>
+  ) : downloadDataUri ? (
+    <a href={downloadDataUri} download={downloadName} aria-label="Download file" className={ACTION_CLASS}>
+      <DownloadIcon className="h-3.5 w-3.5" />
+    </a>
+  ) : null
+
+  return (
+    <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-muted/30 px-3 py-2">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+        <FileTypeIcon className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text.H6 ellipsis>{primary}</Text.H6>
+        {secondary ? (
+          <Text.H6 color="foregroundMuted" ellipsis>
+            {secondary}
+          </Text.H6>
+        ) : null}
+        {fileId ? (
+          <Text.Mono size="h6" color="foregroundMuted" ellipsis>
+            {fileId}
+          </Text.Mono>
+        ) : null}
+      </div>
+      {action}
+    </div>
+  )
+}

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -14,6 +14,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { cn } from "../../../utils/cn.ts"
+import { Icon } from "../../icons/icons.tsx"
 import { Text } from "../../text/text.tsx"
 import { Tooltip } from "../../tooltip/tooltip.tsx"
 
@@ -117,11 +118,11 @@ export function FileCard({
 
   const action = href ? (
     <a href={href} target="_blank" rel="noopener noreferrer" aria-label="Open file in new tab" className={ACTION_CLASS}>
-      <ExternalLinkIcon className="h-3.5 w-3.5" />
+      <Icon icon={ExternalLinkIcon} size="sm" />
     </a>
   ) : downloadDataUri ? (
     <a href={downloadDataUri} download={downloadName} aria-label="Download file" className={ACTION_CLASS}>
-      <DownloadIcon className="h-3.5 w-3.5" />
+      <Icon icon={DownloadIcon} size="sm" />
     </a>
   ) : (
     // No resolvable source — keep the affordance but disable it and explain why on hover.
@@ -135,7 +136,7 @@ export function FileCard({
           aria-label="No downloadable source"
           className={cn(ACTION_CLASS, "cursor-not-allowed opacity-50")}
         >
-          <DownloadIcon className="h-3.5 w-3.5" />
+          <Icon icon={DownloadIcon} size="sm" />
         </button>
       }
     >
@@ -146,7 +147,7 @@ export function FileCard({
   return (
     <div className="flex max-w-md items-center gap-3 rounded-lg border border-border bg-card px-3 py-2">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
-        <FileTypeIcon className="h-5 w-5 text-muted-foreground" />
+        <Icon icon={FileTypeIcon} size="default" color="foregroundMuted" />
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
         <Text.H6 ellipsis>{primary}</Text.H6>

--- a/packages/ui/src/components/genai-conversation/parts/file-card.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/file-card.tsx
@@ -16,7 +16,7 @@ import {
 import { Text } from "../../text/text.tsx"
 
 const ACTION_CLASS =
-  "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
+  "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:text-foreground"
 
 const MIME_LABELS: Record<string, string> = {
   "application/pdf": "PDF document",

--- a/packages/ui/src/components/genai-conversation/parts/helpers.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/helpers.tsx
@@ -1,6 +1,4 @@
 import { isJsonBlock } from "@repo/utils"
-import { FileIcon } from "lucide-react"
-import { Text } from "../../text/text.tsx"
 import { AudioContent, ImageContent, VideoContent } from "./media-content.tsx"
 
 export function getKnownField<T>(metadata: Record<string, unknown> | undefined, field: string): T | undefined {
@@ -54,21 +52,4 @@ export function renderMediaByModality({
   }
 
   return null
-}
-
-export function MediaFallback({
-  modality,
-  mimeType,
-}: {
-  readonly modality: string
-  readonly mimeType?: string | null | undefined
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
-      <FileIcon className="w-3.5 h-3.5 text-muted-foreground" />
-      <Text.H6 color="foregroundMuted">
-        {modality} &middot; {mimeType ?? "binary data"}
-      </Text.H6>
-    </span>
-  )
 }

--- a/packages/ui/src/components/genai-conversation/parts/helpers.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/helpers.tsx
@@ -1,7 +1,7 @@
 import { isJsonBlock } from "@repo/utils"
 import { FileIcon } from "lucide-react"
 import { Text } from "../../text/text.tsx"
-import { ImageContent, VideoContent } from "./media-content.tsx"
+import { AudioContent, ImageContent, VideoContent } from "./media-content.tsx"
 
 export function getKnownField<T>(metadata: Record<string, unknown> | undefined, field: string): T | undefined {
   const known = (metadata?._known_fields ?? metadata?._knownFields) as Record<string, unknown> | undefined
@@ -46,12 +46,7 @@ export function renderMediaByModality({
   }
 
   if (modality === "audio") {
-    return (
-      <audio controls className="max-w-md">
-        <source src={src} type={mimeType} />
-        <track kind="captions" />
-      </audio>
-    )
+    return <AudioContent src={src} mimeType={mimeType} href={href} />
   }
 
   if (modality === "video") {

--- a/packages/ui/src/components/genai-conversation/parts/helpers.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/helpers.tsx
@@ -1,7 +1,7 @@
 import { isJsonBlock } from "@repo/utils"
 import { FileIcon } from "lucide-react"
 import { Text } from "../../text/text.tsx"
-import { ImageContent } from "./media-content.tsx"
+import { ImageContent, VideoContent } from "./media-content.tsx"
 
 export function getKnownField<T>(metadata: Record<string, unknown> | undefined, field: string): T | undefined {
   const known = (metadata?._known_fields ?? metadata?._knownFields) as Record<string, unknown> | undefined
@@ -55,12 +55,7 @@ export function renderMediaByModality({
   }
 
   if (modality === "video") {
-    return (
-      <video controls className="max-w-md max-h-64 rounded-lg">
-        <source src={src} type={mimeType} />
-        <track kind="captions" />
-      </video>
-    )
+    return <VideoContent src={src} mimeType={mimeType} href={href} />
   }
 
   return null

--- a/packages/ui/src/components/genai-conversation/parts/helpers.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/helpers.tsx
@@ -1,6 +1,7 @@
 import { isJsonBlock } from "@repo/utils"
 import { FileIcon } from "lucide-react"
 import { Text } from "../../text/text.tsx"
+import { ImageContent } from "./media-content.tsx"
 
 export function getKnownField<T>(metadata: Record<string, unknown> | undefined, field: string): T | undefined {
   const known = (metadata?._known_fields ?? metadata?._knownFields) as Record<string, unknown> | undefined
@@ -32,13 +33,16 @@ export function renderMediaByModality({
   modality,
   src,
   mimeType,
+  href,
 }: {
   modality: string
   src: string
   mimeType: string | undefined
+  /** Original openable URL (uri parts). When set, media renders an "open in new tab" affordance. */
+  href?: string | undefined
 }) {
   if (modality === "image") {
-    return <img src={src} alt="Attached content" className="max-w-md max-h-64 rounded-lg object-contain" />
+    return <ImageContent src={src} mimeType={mimeType} href={href} />
   }
 
   if (modality === "audio") {

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -71,7 +71,7 @@ function MediaErrorPlaceholder({
       <div
         className={cn(
           PLACEHOLDER_BAR,
-          "flex items-center gap-2 border border-dashed border-border bg-muted/30 px-3 py-2",
+          "flex items-center gap-2 border border-dashed border-border bg-card px-3 py-2",
         )}
       >
         <ErrorIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -85,7 +85,7 @@ function MediaErrorPlaceholder({
     <div
       className={cn(
         PLACEHOLDER_BOX,
-        "flex flex-col items-center justify-center gap-1.5 border border-dashed border-border bg-muted/30 p-4 text-center",
+        "flex flex-col items-center justify-center gap-1.5 border border-dashed border-border bg-card p-4 text-center",
       )}
     >
       <ErrorIcon className="h-6 w-6 text-muted-foreground" />

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -1,0 +1,97 @@
+import { ExternalLinkIcon, ImageOffIcon } from "lucide-react"
+import { useState } from "react"
+import { cn } from "../../../utils/cn.ts"
+import { Text } from "../../text/text.tsx"
+
+type MediaStatus = "loading" | "loaded" | "error"
+
+// Shared footprint for the loading skeleton and the error placeholder so the
+// layout doesn't jump before the real image dimensions are known.
+const PLACEHOLDER_BOX = "h-40 w-64 max-w-md rounded-lg"
+
+/** Hover-revealed (keyboard-focusable) action pinned to the top-right of a loaded image. */
+function OpenOriginalButton({ href }: { readonly href: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Open image in new tab"
+      className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/media:opacity-100"
+    >
+      <ExternalLinkIcon className="h-3.5 w-3.5" />
+    </a>
+  )
+}
+
+/** Shown when the image source can't be loaded (missing, expired, blocked, or corrupt). */
+function ImageErrorPlaceholder({
+  mimeType,
+  href,
+}: {
+  readonly mimeType?: string | undefined
+  readonly href?: string | undefined
+}) {
+  return (
+    <div
+      className={cn(
+        PLACEHOLDER_BOX,
+        "flex flex-col items-center justify-center gap-1.5 border border-dashed border-border bg-muted/30 p-4 text-center",
+      )}
+    >
+      <ImageOffIcon className="h-6 w-6 text-muted-foreground" />
+      <Text.H6 color="foregroundMuted">Image unavailable</Text.H6>
+      {mimeType ? <Text.H6 color="foregroundMuted">{mimeType}</Text.H6> : null}
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 inline-flex items-center gap-1 hover:underline"
+        >
+          <ExternalLinkIcon className="h-3.5 w-3.5 text-primary" />
+          <Text.H6 color="primary">Open original</Text.H6>
+        </a>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Renders an image content part with loading and error states.
+ * `href` is the original openable URL (present for `uri` parts, omitted for inline `blob`
+ * data URIs); when set, an "open in new tab" affordance is shown.
+ */
+export function ImageContent({
+  src,
+  mimeType,
+  href,
+}: {
+  readonly src: string
+  readonly mimeType?: string | undefined
+  readonly href?: string | undefined
+}) {
+  const [status, setStatus] = useState<MediaStatus>("loading")
+
+  if (status === "error") {
+    return <ImageErrorPlaceholder mimeType={mimeType} href={href} />
+  }
+
+  return (
+    <div className="group/media relative inline-flex">
+      {status === "loading" ? <div className={cn(PLACEHOLDER_BOX, "animate-pulse bg-muted")} /> : null}
+      <img
+        src={src}
+        alt="Attached content"
+        onLoad={() => setStatus("loaded")}
+        onError={() => setStatus("error")}
+        // Kept in the DOM (but collapsed) while loading so the request fires under the skeleton.
+        className={cn(
+          "max-w-md max-h-64 rounded-lg object-contain",
+          status === "loading" && "absolute h-0 w-0 opacity-0",
+        )}
+      />
+      {status === "loaded" && href ? <OpenOriginalButton href={href} /> : null}
+    </div>
+  )
+}

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, ImageOffIcon } from "lucide-react"
+import { ExternalLinkIcon, ImageOffIcon, type LucideIcon, VideoOffIcon } from "lucide-react"
 import { useState } from "react"
 import { cn } from "../../../utils/cn.ts"
 import { Text } from "../../text/text.tsx"
@@ -6,29 +6,33 @@ import { Text } from "../../text/text.tsx"
 type MediaStatus = "loading" | "loaded" | "error"
 
 // Shared footprint for the loading skeleton and the error placeholder so the
-// layout doesn't jump before the real image dimensions are known.
+// layout doesn't jump before the real media dimensions are known.
 const PLACEHOLDER_BOX = "h-40 w-64 max-w-md rounded-lg"
 
-/** Hover-revealed (keyboard-focusable) action pinned to the top-right of a loaded image. */
-function OpenOriginalButton({ href }: { readonly href: string }) {
+/** Hover-revealed (keyboard-focusable) action pinned to the top-right of loaded media. */
+function OpenOriginalButton({ href, label }: { readonly href: string; readonly label: string }) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label="Open image in new tab"
-      className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/media:opacity-100"
+      aria-label={label}
+      className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/media:opacity-100"
     >
       <ExternalLinkIcon className="h-3.5 w-3.5" />
     </a>
   )
 }
 
-/** Shown when the image source can't be loaded (missing, expired, blocked, or corrupt). */
-function ImageErrorPlaceholder({
+/** Shown when a media source can't be loaded (missing, expired, blocked, or corrupt). */
+function MediaErrorPlaceholder({
+  icon: ErrorIcon,
+  label,
   mimeType,
   href,
 }: {
+  readonly icon: LucideIcon
+  readonly label: string
   readonly mimeType?: string | undefined
   readonly href?: string | undefined
 }) {
@@ -39,8 +43,8 @@ function ImageErrorPlaceholder({
         "flex flex-col items-center justify-center gap-1.5 border border-dashed border-border bg-muted/30 p-4 text-center",
       )}
     >
-      <ImageOffIcon className="h-6 w-6 text-muted-foreground" />
-      <Text.H6 color="foregroundMuted">Image unavailable</Text.H6>
+      <ErrorIcon className="h-6 w-6 text-muted-foreground" />
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
       {mimeType ? <Text.H6 color="foregroundMuted">{mimeType}</Text.H6> : null}
       {href ? (
         <a
@@ -74,7 +78,7 @@ export function ImageContent({
   const [status, setStatus] = useState<MediaStatus>("loading")
 
   if (status === "error") {
-    return <ImageErrorPlaceholder mimeType={mimeType} href={href} />
+    return <MediaErrorPlaceholder icon={ImageOffIcon} label="Image unavailable" mimeType={mimeType} href={href} />
   }
 
   return (
@@ -91,7 +95,37 @@ export function ImageContent({
           status === "loading" && "absolute h-0 w-0 opacity-0",
         )}
       />
-      {status === "loaded" && href ? <OpenOriginalButton href={href} /> : null}
+      {status === "loaded" && href ? <OpenOriginalButton href={href} label="Open image in new tab" /> : null}
+    </div>
+  )
+}
+
+/**
+ * Renders a video content part using the native player. No loading skeleton — the
+ * native controls handle their own buffering/poster UX. `src` is set directly on the
+ * `<video>` element (not a child `<source>`) so its `onError` fires reliably on a failed
+ * load; detection is still best-effort. `href` enables the open-in-new-tab affordance.
+ */
+export function VideoContent({
+  src,
+  mimeType,
+  href,
+}: {
+  readonly src: string
+  readonly mimeType?: string | undefined
+  readonly href?: string | undefined
+}) {
+  const [hasError, setHasError] = useState(false)
+
+  if (hasError) {
+    return <MediaErrorPlaceholder icon={VideoOffIcon} label="Video unavailable" mimeType={mimeType} href={href} />
+  }
+
+  return (
+    <div className="group/media relative inline-flex">
+      {/* biome-ignore lint/a11y/useMediaCaption: attachment playback; no caption track is available for arbitrary media */}
+      <video src={src} controls onError={() => setHasError(true)} className="max-w-md max-h-64 rounded-lg" />
+      {href ? <OpenOriginalButton href={href} label="Open video in new tab" /> : null}
     </div>
   )
 }

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -1,23 +1,44 @@
-import { ExternalLinkIcon, ImageOffIcon, type LucideIcon, VideoOffIcon } from "lucide-react"
+import { ExternalLinkIcon, ImageOffIcon, type LucideIcon, VideoOffIcon, VolumeXIcon } from "lucide-react"
 import { useState } from "react"
 import { cn } from "../../../utils/cn.ts"
 import { Text } from "../../text/text.tsx"
 
 type MediaStatus = "loading" | "loaded" | "error"
 
-// Shared footprint for the loading skeleton and the error placeholder so the
+// Shared footprint for the loading skeleton and the (box) error placeholder so the
 // layout doesn't jump before the real media dimensions are known.
 const PLACEHOLDER_BOX = "h-40 w-64 max-w-md rounded-lg"
+// Bar footprint for thin, horizontal media (audio) where a square box would look wrong.
+const PLACEHOLDER_BAR = "w-72 max-w-md rounded-lg"
 
-/** Hover-revealed (keyboard-focusable) action pinned to the top-right of loaded media. */
-function OpenOriginalButton({ href, label }: { readonly href: string; readonly label: string }) {
+/**
+ * "Open in new tab" action for media backed by a real URL.
+ * - `overlay`: pinned top-right, hover-revealed — for box media (image/video) where it
+ *   would otherwise obscure the content.
+ * - `inline`: a persistent button sitting beside the media — for the audio bar, which has
+ *   no surface to overlay without covering the native controls.
+ */
+function OpenOriginalButton({
+  href,
+  label,
+  variant = "overlay",
+}: {
+  readonly href: string
+  readonly label: string
+  readonly variant?: "overlay" | "inline"
+}) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={label}
-      className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background/90 text-muted-foreground opacity-0 shadow-sm backdrop-blur transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/media:opacity-100"
+      className={cn(
+        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground shadow-sm transition-opacity hover:text-foreground",
+        variant === "overlay"
+          ? "absolute right-2 top-2 z-10 bg-background/90 opacity-0 backdrop-blur focus-visible:opacity-100 group-hover/media:opacity-100"
+          : "bg-background",
+      )}
     >
       <ExternalLinkIcon className="h-3.5 w-3.5" />
     </a>
@@ -30,12 +51,36 @@ function MediaErrorPlaceholder({
   label,
   mimeType,
   href,
+  layout = "box",
 }: {
   readonly icon: LucideIcon
   readonly label: string
   readonly mimeType?: string | undefined
   readonly href?: string | undefined
+  readonly layout?: "box" | "bar"
 }) {
+  const openLink = href ? (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:underline">
+      <ExternalLinkIcon className="h-3.5 w-3.5 text-primary" />
+      <Text.H6 color="primary">Open original</Text.H6>
+    </a>
+  ) : null
+
+  if (layout === "bar") {
+    return (
+      <div
+        className={cn(
+          PLACEHOLDER_BAR,
+          "flex items-center gap-2 border border-dashed border-border bg-muted/30 px-3 py-2",
+        )}
+      >
+        <ErrorIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Text.H6 color="foregroundMuted">{label}</Text.H6>
+        {openLink ? <div className="ml-auto shrink-0">{openLink}</div> : null}
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn(
@@ -46,17 +91,7 @@ function MediaErrorPlaceholder({
       <ErrorIcon className="h-6 w-6 text-muted-foreground" />
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
       {mimeType ? <Text.H6 color="foregroundMuted">{mimeType}</Text.H6> : null}
-      {href ? (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-1 inline-flex items-center gap-1 hover:underline"
-        >
-          <ExternalLinkIcon className="h-3.5 w-3.5 text-primary" />
-          <Text.H6 color="primary">Open original</Text.H6>
-        </a>
-      ) : null}
+      {openLink ? <div className="mt-1">{openLink}</div> : null}
     </div>
   )
 }
@@ -126,6 +161,43 @@ export function VideoContent({
       {/* biome-ignore lint/a11y/useMediaCaption: attachment playback; no caption track is available for arbitrary media */}
       <video src={src} controls onError={() => setHasError(true)} className="max-w-md max-h-64 rounded-lg" />
       {href ? <OpenOriginalButton href={href} label="Open video in new tab" /> : null}
+    </div>
+  )
+}
+
+/**
+ * Renders an audio content part using the native player. The player is a thin bar, so the
+ * open-original action sits inline beside it (persistent, not a hover overlay) and the error
+ * state is a bar-shaped placeholder rather than the square box used for image/video.
+ */
+export function AudioContent({
+  src,
+  mimeType,
+  href,
+}: {
+  readonly src: string
+  readonly mimeType?: string | undefined
+  readonly href?: string | undefined
+}) {
+  const [hasError, setHasError] = useState(false)
+
+  if (hasError) {
+    return (
+      <MediaErrorPlaceholder
+        icon={VolumeXIcon}
+        label="Audio unavailable"
+        mimeType={mimeType}
+        href={href}
+        layout="bar"
+      />
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* biome-ignore lint/a11y/useMediaCaption: attachment playback; no caption track is available for arbitrary media */}
+      <audio src={src} controls onError={() => setHasError(true)} className="max-w-md" />
+      {href ? <OpenOriginalButton href={href} label="Open audio in new tab" variant="inline" /> : null}
     </div>
   )
 }

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -70,10 +70,7 @@ function MediaErrorPlaceholder({
   if (layout === "bar") {
     return (
       <div
-        className={cn(
-          PLACEHOLDER_BAR,
-          "flex items-center gap-2 border border-dashed border-border bg-card px-3 py-2",
-        )}
+        className={cn(PLACEHOLDER_BAR, "flex items-center gap-2 border border-dashed border-border bg-card px-3 py-2")}
       >
         <Icon icon={ErrorIcon} size="sm" color="foregroundMuted" className="shrink-0" />
         <Text.H6 color="foregroundMuted">{label}</Text.H6>
@@ -112,6 +109,12 @@ export function ImageContent({
   readonly href?: string | undefined
 }) {
   const [status, setStatus] = useState<MediaStatus>("loading")
+  // Reset on src change (e.g. a refreshed signed URL) so a prior error doesn't stick.
+  const [lastSrc, setLastSrc] = useState(src)
+  if (src !== lastSrc) {
+    setLastSrc(src)
+    setStatus("loading")
+  }
 
   if (status === "error") {
     return <MediaErrorPlaceholder icon={ImageOffIcon} label="Image unavailable" mimeType={mimeType} href={href} />
@@ -152,6 +155,12 @@ export function VideoContent({
   readonly href?: string | undefined
 }) {
   const [hasError, setHasError] = useState(false)
+  // Reset on src change (e.g. a refreshed signed URL) so a prior error doesn't stick.
+  const [lastSrc, setLastSrc] = useState(src)
+  if (src !== lastSrc) {
+    setLastSrc(src)
+    setHasError(false)
+  }
 
   if (hasError) {
     return <MediaErrorPlaceholder icon={VideoOffIcon} label="Video unavailable" mimeType={mimeType} href={href} />
@@ -181,6 +190,12 @@ export function AudioContent({
   readonly href?: string | undefined
 }) {
   const [hasError, setHasError] = useState(false)
+  // Reset on src change (e.g. a refreshed signed URL) so a prior error doesn't stick.
+  const [lastSrc, setLastSrc] = useState(src)
+  if (src !== lastSrc) {
+    setLastSrc(src)
+    setHasError(false)
+  }
 
   if (hasError) {
     return (

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -1,6 +1,7 @@
 import { ExternalLinkIcon, ImageOffIcon, type LucideIcon, VideoOffIcon, VolumeXIcon } from "lucide-react"
 import { useState } from "react"
 import { cn } from "../../../utils/cn.ts"
+import { Icon } from "../../icons/icons.tsx"
 import { Text } from "../../text/text.tsx"
 
 type MediaStatus = "loading" | "loaded" | "error"
@@ -40,7 +41,7 @@ function OpenOriginalButton({
           : "bg-background",
       )}
     >
-      <ExternalLinkIcon className="h-3.5 w-3.5" />
+      <Icon icon={ExternalLinkIcon} size="sm" />
     </a>
   )
 }
@@ -61,7 +62,7 @@ function MediaErrorPlaceholder({
 }) {
   const openLink = href ? (
     <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:underline">
-      <ExternalLinkIcon className="h-3.5 w-3.5 text-primary" />
+      <Icon icon={ExternalLinkIcon} size="sm" color="primary" />
       <Text.H6 color="primary">Open original</Text.H6>
     </a>
   ) : null
@@ -74,7 +75,7 @@ function MediaErrorPlaceholder({
           "flex items-center gap-2 border border-dashed border-border bg-card px-3 py-2",
         )}
       >
-        <ErrorIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Icon icon={ErrorIcon} size="sm" color="foregroundMuted" className="shrink-0" />
         <Text.H6 color="foregroundMuted">{label}</Text.H6>
         {openLink ? <div className="ml-auto shrink-0">{openLink}</div> : null}
       </div>
@@ -88,7 +89,7 @@ function MediaErrorPlaceholder({
         "flex flex-col items-center justify-center gap-1.5 border border-dashed border-border bg-card p-4 text-center",
       )}
     >
-      <ErrorIcon className="h-6 w-6 text-muted-foreground" />
+      <Icon icon={ErrorIcon} size="md" color="foregroundMuted" />
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
       {mimeType ? <Text.H6 color="foregroundMuted">{mimeType}</Text.H6> : null}
       {openLink ? <div className="mt-1">{openLink}</div> : null}

--- a/packages/ui/src/components/genai-conversation/parts/media-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/media-content.tsx
@@ -34,9 +34,9 @@ function OpenOriginalButton({
       rel="noopener noreferrer"
       aria-label={label}
       className={cn(
-        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground shadow-sm transition-opacity hover:text-foreground",
+        "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground transition-opacity hover:text-foreground",
         variant === "overlay"
-          ? "absolute right-2 top-2 z-10 bg-background/90 opacity-0 backdrop-blur focus-visible:opacity-100 group-hover/media:opacity-100"
+          ? "absolute right-2 top-2 z-10 bg-background/90 opacity-0 shadow-sm backdrop-blur focus-visible:opacity-100 group-hover/media:opacity-100"
           : "bg-background",
       )}
     >

--- a/packages/ui/src/components/genai-conversation/parts/types.ts
+++ b/packages/ui/src/components/genai-conversation/parts/types.ts
@@ -15,6 +15,7 @@ export interface FilePart {
   readonly type: "file"
   readonly file_id: string
   readonly modality: string
+  readonly mime_type?: string | null | undefined
 }
 
 export interface UriPart {

--- a/packages/utils/src/base64.test.ts
+++ b/packages/utils/src/base64.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest"
-import { base64Decode, base64Encode, base64urlDecode, base64urlEncode, hexDecode, hexEncode } from "./base64.ts"
+import {
+  base64ByteLength,
+  base64Decode,
+  base64Encode,
+  base64urlDecode,
+  base64urlEncode,
+  hexDecode,
+  hexEncode,
+} from "./base64.ts"
+
+describe("base64ByteLength", () => {
+  it("returns the decoded byte length without decoding", () => {
+    for (const bytes of [new Uint8Array([]), new Uint8Array([1]), new Uint8Array([1, 2]), new Uint8Array([1, 2, 3])]) {
+      expect(base64ByteLength(base64Encode(bytes))).toBe(bytes.length)
+    }
+  })
+
+  it("accounts for padding", () => {
+    expect(base64ByteLength("")).toBe(0)
+    expect(base64ByteLength("QQ==")).toBe(1)
+    expect(base64ByteLength("QUI=")).toBe(2)
+    expect(base64ByteLength("QUJD")).toBe(3)
+  })
+})
 
 describe("base64Encode / base64Decode", () => {
   it("round-trips binary bytes", () => {

--- a/packages/utils/src/base64.ts
+++ b/packages/utils/src/base64.ts
@@ -63,3 +63,14 @@ export function base64Encode(data: Uint8Array | string): string {
 export function base64Decode(str: string): Uint8Array {
   return Uint8Array.fromBase64(str)
 }
+
+/**
+ * Decoded byte length of a (standard) base64 string, computed from its length without decoding.
+ * Useful for showing an attachment size from inline base64 content.
+ */
+export function base64ByteLength(base64: string): number {
+  const len = base64.length
+  if (len === 0) return 0
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0
+  return Math.floor((len * 3) / 4) - padding
+}

--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest"
-import { formatCount, formatPrice, isBlankCHString, normalizeCHString, parseCHDate } from "./format.ts"
+import { formatBytes, formatCount, formatPrice, isBlankCHString, normalizeCHString, parseCHDate } from "./format.ts"
+
+describe("formatBytes", () => {
+  it("formats whole bytes without decimals", () => {
+    expect(formatBytes(0)).toBe("0 B")
+    expect(formatBytes(512)).toBe("512 B")
+    expect(formatBytes(1023)).toBe("1023 B")
+  })
+
+  it("formats KB/MB/GB with one decimal", () => {
+    expect(formatBytes(1024)).toBe("1 KB")
+    expect(formatBytes(1536)).toBe("1.5 KB")
+    expect(formatBytes(2_400_000)).toBe("2.3 MB")
+    expect(formatBytes(1024 ** 3)).toBe("1 GB")
+  })
+
+  it("handles negative values", () => {
+    expect(formatBytes(-1536)).toBe("-1.5 KB")
+  })
+})
 
 describe("formatCount", () => {
   it("returns small numbers as-is", () => {

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -46,6 +46,28 @@ export function formatPrice(price: number): string {
   return `$${s}`
 }
 
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"]
+
+/**
+ * Format a byte count into a human-readable string (base 1024).
+ *
+ * Examples: `0` -> `"0 B"`, `1536` -> `"1.5 KB"`, `2_400_000` -> `"2.3 MB"`
+ * Whole bytes show no decimals; KB and above show one decimal place.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 0) return `-${formatBytes(-bytes)}`
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+
+  let unitIndex = 0
+  let value = bytes
+  while (value >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    value /= 1024
+    unitIndex++
+  }
+
+  return `${value.toFixed(1).replace(/\.0$/, "")} ${BYTE_UNITS[unitIndex]}`
+}
+
 /**
  * Format a nanosecond duration into a human-readable string.
  *

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,16 @@
-export { base64Decode, base64Encode, base64urlDecode, base64urlEncode, hexDecode, hexEncode } from "./base64.ts"
+export {
+  base64ByteLength,
+  base64Decode,
+  base64Encode,
+  base64urlDecode,
+  base64urlEncode,
+  hexDecode,
+  hexEncode,
+} from "./base64.ts"
 export { CryptoError, decrypt, encodeUtf8, encrypt, hash, toBuffer } from "./crypto.ts"
 export { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
 export {
+  formatBytes,
   formatCount,
   formatDuration,
   formatPrice,


### PR DESCRIPTION
Revises how the chat `Conversation` renderer displays message content. Images, video, audio, and file/document attachments previously rendered with no loading or failure handling — a broken image showed the browser's broken-image glyph, a failed video showed a dead player, and files/documents fell back to a bare badge, a translucent chip, or a plain link depending on which part type carried them. This makes each content type render predictably, with explicit loading and error states and a consistent way to reach the original source.

Part of an ongoing pass over message rendering; this PR covers media and files.

Media             |  Files
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/aa98c099-3168-4498-95e0-9b5e1c7537d3)  |  ![](https://github.com/user-attachments/assets/a5ad3bb9-9ea8-46c9-baf2-1292b1f09e56)


## media

`renderMediaByModality` now delegates each modality to a dedicated stateful component:

- **Images** (`ImageContent`): a loading skeleton, then the image; a hover-revealed "open in new tab" button (top-right) for `uri` sources. On failure, an image-sized "Image unavailable" placeholder.
- **Video** (`VideoContent`): native player with `src` on the `<video>` element (not a child `<source>`) so `onError` fires reliably; "Video unavailable" placeholder on failure. No skeleton — the native controls own their buffering UX.
- **Audio** (`AudioContent`): native player. The player is a thin bar, so the open-original action sits inline beside it (persistent, not an overlay) and the error state is a bar-shaped "Audio unavailable" placeholder.

The open-original affordance appears only when there's a real URL — `uri` parts get it, inline `blob` data URIs don't.

The browser collapses 404 / 403 / CORS into a single error event on `<img>`/`<video>`, so the copy stays neutral ("unavailable") rather than implying a cause.

## files & documents

A single `FileCard` replaces the three inconsistent renderings of non-previewable attachments (the `file_id` badge, the non-media `blob` chip, and the non-media `uri` link). It shows a type-aware monochrome icon (from mime/extension), a label, and an optional size, with a source-appropriate action:

- `uri` → **Open** in a new tab
- `blob` → **Download** (native `<a download>` on the inline data URL; size computed from the base64 length)
- bare `file_id` → a **disabled** action with a tooltip explaining there's no downloadable source, since a `file_id` isn't resolvable client-side

The card uses the opaque `bg-card` surface so it keeps consistent contrast inside user (accent) bubbles as well as assistant/system messages, in both themes.

## design-system showcase

Adds `/design-system/chat` (linked from the design-system index), which renders a full `GenAIMessage[]` conversation through the shared `Conversation` component, grouped into sections: text & markdown (including JSON blocks and long-content collapse), media (working and broken sources per modality), files & documents, tool calls (absorbed success/error results, multiple calls, a standalone error), and edge-case roles/states (refusal, reasoning, unknown part type, unknown role).

## utils

Adds `formatBytes` and `base64ByteLength` to `@repo/utils`, both unit-tested. `base64ByteLength` derives an attachment's size from its base64 string without decoding.

## scope

Rendered media (a visible image/video/audio) keeps no disabled affordance — the content is there and savable through the browser. Media error placeholders without an `href` don't yet show the disabled-action treatment; that's a possible follow-up for consistency with `FileCard`.
