### PR TITLE
feat(web): block new signups on Latitude Cloud

### DIFF
--- a/apps/web/src/app/(public)/setup/_components/SetupForm/index.tsx
+++ b/apps/web/src/app/(public)/setup/_components/SetupForm/index.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react'
 import { setupAction } from '$/actions/user/setupAction'
 import { useFormAction } from '$/hooks/useFormAction'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { FormWrapper } from '@latitude-data/web-ui/atoms/FormWrapper'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
@@ -19,6 +20,7 @@ export default function SetupForm({
   footer,
   source,
   returnTo,
+  signupsDisabled = false,
 }: {
   footer: ReactNode
   email?: string
@@ -26,6 +28,7 @@ export default function SetupForm({
   companyName?: string
   source?: string
   returnTo?: string
+  signupsDisabled?: boolean
 }) {
   const { toast } = useToast()
   const { execute, isPending } = useLatitudeAction(setupAction)
@@ -46,6 +49,13 @@ export default function SetupForm({
       <input type='hidden' name='returnTo' value={returnTo} />
       <input type='hidden' name='source' value={source} />
       <FormWrapper>
+        {signupsDisabled && (
+          <Alert
+            variant='warning'
+            title='Signups are disabled'
+            description='Latitude is no longer accepting new signups. If you already have an account, log in.'
+          />
+        )}
         <Input
           autoFocus
           required
@@ -55,6 +65,7 @@ export default function SetupForm({
           placeholder='Jon Snow'
           errors={errors?.name}
           defaultValue={data?.name || name}
+          disabled={signupsDisabled}
         />
         <Input
           required
@@ -64,6 +75,7 @@ export default function SetupForm({
           placeholder='jon@winterfell.com'
           errors={errors?.email}
           defaultValue={data?.email || email}
+          disabled={signupsDisabled}
         />
         <Input
           required
@@ -72,9 +84,15 @@ export default function SetupForm({
           placeholder='Acme Inc.'
           errors={errors?.companyName}
           defaultValue={data?.companyName || companyName}
+          disabled={signupsDisabled}
         />
         <div className='flex flex-col gap-6'>
-          <Button fullWidth isLoading={isPending} fancy>
+          <Button
+            fullWidth
+            isLoading={isPending}
+            disabled={signupsDisabled}
+            fancy
+          >
             Create account
           </Button>
 
@@ -87,18 +105,30 @@ export default function SetupForm({
             </div>
           </div>
 
-          <Button variant='outline' fullWidth asChild>
-            <a
-              href={
-                '/api/auth/google/start' +
-                (returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : '')
-              }
+          {signupsDisabled ? (
+            <Button
+              variant='outline'
+              fullWidth
+              disabled
               className='flex items-center gap-2'
             >
               <Icon name='googleWorkspace' />
               <Text.H5>Continue with Google</Text.H5>
-            </a>
-          </Button>
+            </Button>
+          ) : (
+            <Button variant='outline' fullWidth asChild>
+              <a
+                href={
+                  '/api/auth/google/start' +
+                  (returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : '')
+                }
+                className='flex items-center gap-2'
+              >
+                <Icon name='googleWorkspace' />
+                <Text.H5>Continue with Google</Text.H5>
+              </a>
+            </Button>
+          )}
         </div>
 
         {footer}

--- a/apps/web/src/app/(public)/setup/page.tsx
+++ b/apps/web/src/app/(public)/setup/page.tsx
@@ -2,6 +2,7 @@ import AuthFooter from '$/app/(public)/_components/Footer'
 import buildMetatags from '$/app/_lib/buildMetatags'
 import { FocusLayout } from '$/components/layouts'
 import { GoogleTagManager } from '$/components/Providers/GoogleTagManager'
+import { env } from '@latitude-data/env'
 import { Card, CardContent } from '@latitude-data/web-ui/atoms/Card'
 import { FocusHeader } from '@latitude-data/web-ui/molecules/FocusHeader'
 
@@ -28,6 +29,7 @@ export default async function SetupPage({
   }>
 }) {
   const { email, name, companyName, source, returnTo } = await searchParams
+  const signupsDisabled = env.LATITUDE_CLOUD
 
   return (
     <>
@@ -50,6 +52,7 @@ export default async function SetupPage({
               footer={<AuthFooter />}
               source={source}
               returnTo={returnTo}
+              signupsDisabled={signupsDisabled}
             />
           </CardContent>
         </Card>

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -1,8 +1,10 @@
 import { googleProvider } from '$/services/auth'
 import { setSession } from '$/services/auth/setSession'
+import { ROUTES } from '$/services/routes'
 import { isLatitudeUrl } from '@latitude-data/constants'
 import { OAuthProvider } from '@latitude-data/core/schema/models/oauthAccounts'
 import { findOrCreateUserFromOAuth } from '@latitude-data/core/services/auth/findOrCreateUserFromOAuth'
+import { NEW_SIGNUPS_DISABLED_MESSAGE } from '@latitude-data/core/services/users/setupService'
 import { env } from '@latitude-data/env'
 import { ObjectParser } from '@pilcrowjs/object-parser'
 import { decodeIdToken, OAuth2RequestError, OAuth2Tokens } from 'arctic'
@@ -57,6 +59,10 @@ export async function GET(request: NextRequest): Promise<Response> {
     })
 
     if (userResult.error) {
+      if (userResult.error.message === NEW_SIGNUPS_DISABLED_MESSAGE) {
+        return NextResponse.redirect(env.APP_URL + ROUTES.auth.setup)
+      }
+
       console.error(
         'Failed to find or create user from OAuth:',
         userResult.error,

--- a/packages/core/src/services/auth/findOrCreateUserFromOAuth.test.ts
+++ b/packages/core/src/services/auth/findOrCreateUserFromOAuth.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { findOrCreateUserFromOAuth } from './findOrCreateUserFromOAuth'
 import { OAuthProvider } from '../../schema/models/oauthAccounts'
 import { createProject, createOAuthAccount } from '../../tests/factories'
+import { unsafelyFindUserByEmail } from '../../queries/users/findByEmail'
+import { NEW_SIGNUPS_DISABLED_MESSAGE } from '../users/setupService'
+import * as envModule from '@latitude-data/env'
 
 describe('Auth Service: findOrCreateUserFromOAuth', () => {
   const testProviderId: OAuthProvider = OAuthProvider.GOOGLE
   const testProviderUserId = 'google-user-123'
   const testEmail = 'test@example.com'
   const testName = 'Test User'
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   it('should return existing user and workspace if OAuth account exists', async () => {
     const { workspace: existingWorkspace, user: existingUser } =
@@ -55,5 +62,58 @@ describe('Auth Service: findOrCreateUserFromOAuth', () => {
 
     // Verify workspace details (created by setupService)
     expect(newWorkspace.name).toBe(`${testName}'s Workspace`)
+  })
+
+  describe('when LATITUDE_CLOUD is true', () => {
+    const mockCloudEnabled = () => {
+      vi.spyOn(envModule, 'env', 'get').mockReturnValue({
+        ...envModule.env,
+        LATITUDE_CLOUD: true,
+      } as typeof envModule.env)
+    }
+
+    it('still logs in an existing user', async () => {
+      const { workspace: existingWorkspace, user: existingUser } =
+        await createProject()
+
+      await createOAuthAccount({
+        providerId: testProviderId,
+        providerUserId: testProviderUserId,
+        userId: existingUser.id,
+      })
+
+      mockCloudEnabled()
+
+      const result = await findOrCreateUserFromOAuth({
+        providerId: testProviderId,
+        providerUserId: testProviderUserId,
+        email: testEmail,
+        name: testName,
+      })
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error('Expected success')
+
+      expect(result.value!.isNewUser).toBe(false)
+      expect(result.value!.user.id).toBe(existingUser.id)
+      expect(result.value!.workspace.id).toBe(existingWorkspace.id)
+    })
+
+    it('does not create a new user and returns an error', async () => {
+      mockCloudEnabled()
+
+      const result = await findOrCreateUserFromOAuth({
+        providerId: testProviderId,
+        providerUserId: testProviderUserId,
+        email: testEmail,
+        name: testName,
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.error!.message).toBe(NEW_SIGNUPS_DISABLED_MESSAGE)
+
+      const user = await unsafelyFindUserByEmail({ email: testEmail })
+      expect(user).toBeNull()
+    })
   })
 })

--- a/packages/core/src/services/auth/findOrCreateUserFromOAuth.ts
+++ b/packages/core/src/services/auth/findOrCreateUserFromOAuth.ts
@@ -9,7 +9,9 @@ import { oauthAccounts } from '../../schema/models/oauthAccounts'
 import { OAuthProvider } from '../../schema/models/oauthAccounts'
 import { users } from '../../schema/models/users'
 import { workspaces } from '../../schema/models/workspaces'
-import setupServiceFn from '../users/setupService'
+import setupServiceFn, {
+  NEW_SIGNUPS_DISABLED_MESSAGE,
+} from '../users/setupService'
 
 interface FindOrCreateUserFromOAuthInput {
   providerId: OAuthProvider
@@ -105,6 +107,10 @@ export function findOrCreateUserFromOAuth(
         )
       }
       return Result.ok({ ...found, isNewUser: false })
+    }
+
+    if (env.LATITUDE_CLOUD) {
+      return Result.error(new BadRequestError(NEW_SIGNUPS_DISABLED_MESSAGE))
     }
 
     const setupResult = await setupServiceFn(

--- a/packages/core/src/services/users/setupService.test.ts
+++ b/packages/core/src/services/users/setupService.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import setupService from './setupService'
+import setupService, { NEW_SIGNUPS_DISABLED_MESSAGE } from './setupService'
 import { SubscriptionPlan } from '../../plans'
+import { unsafelyFindUserByEmail } from '../../queries/users/findByEmail'
 import * as envModule from '@latitude-data/env'
 
 vi.mock('../../events/publisher', () => ({
@@ -51,6 +52,31 @@ describe('setupService', () => {
 
     expect(workspace.currentSubscription).toBeDefined()
     expect(workspace.currentSubscription.plan).toBeDefined()
+  })
+
+  describe('when LATITUDE_CLOUD is true', () => {
+    it('does not create a user and returns an error', async () => {
+      vi.spyOn(envModule, 'env', 'get').mockReturnValue({
+        ...envModule.env,
+        LATITUDE_CLOUD: true,
+      } as typeof envModule.env)
+
+      const result = await setupService({
+        email: 'cloud-blocked@example.com',
+        name: 'Blocked User',
+        companyName: 'Blocked Company',
+        defaultProviderName: 'OpenAI',
+        defaultProviderApiKey: 'test-api-key',
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.error!.message).toBe(NEW_SIGNUPS_DISABLED_MESSAGE)
+
+      const user = await unsafelyFindUserByEmail({
+        email: 'cloud-blocked@example.com',
+      })
+      expect(user).toBeNull()
+    })
   })
 
   describe('when LATITUDE_ENTERPRISE_MODE is false', () => {

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -3,6 +3,7 @@ import { type WorkspaceDto } from '../../schema/models/types/Workspace'
 import { Providers } from '@latitude-data/constants'
 import { env } from '@latitude-data/env'
 import { publisher } from '../../events/publisher'
+import { BadRequestError } from '../../lib/errors'
 import { Result } from '../../lib/Result'
 import Transaction, { PromisedResult } from '../../lib/Transaction'
 import { createApiKey } from '../apiKeys'
@@ -15,6 +16,9 @@ import { UserTitle } from '@latitude-data/constants/users'
 import { createDatasetOnboarding } from '../onboardingResources/createDatasetOnboarding'
 
 const DEFAULT_MODEL = 'gpt-4o-mini'
+
+export const NEW_SIGNUPS_DISABLED_MESSAGE =
+  'Latitude is no longer accepting new signups'
 
 export default async function setupService(
   {
@@ -38,6 +42,10 @@ export default async function setupService(
   },
   transaction = new Transaction(),
 ): PromisedResult<{ user: User; workspace: WorkspaceDto }> {
+  if (env.LATITUDE_CLOUD) {
+    return Result.error(new BadRequestError(NEW_SIGNUPS_DISABLED_MESSAGE))
+  }
+
   return transaction.call(async () => {
     const user = await createUser(
       {


### PR DESCRIPTION
Latitude Cloud is no longer accepting new users. Existing users keep full access and login is unchanged, but new account/workspace creation is blocked whenever the app runs in cloud mode (`LATITUDE_CLOUD=true`). Self-hosted and enterprise deployments (`LATITUDE_CLOUD=false`) are unaffected and can still create their first account.

## what's blocked, and where

There are three paths that create a brand-new user + workspace. Two of them funnel through `setupService`, so the gate lives in core and the app layers inherit it:

- **Email signup** → `setupAction` → `setupService`. Guarded.
- **Google OAuth, new account only** → `findOrCreateUserFromOAuth` → `setupService`. Guarded in the new-user branch, *after* the existing-OAuth-account and existing-email lookups, so existing users keep logging in.
- **Workspace invitations** (an existing workspace adding a teammate) are intentionally left working.

The guard returns `Result.error(new BadRequestError(NEW_SIGNUPS_DISABLED_MESSAGE))`. `NEW_SIGNUPS_DISABLED_MESSAGE` is exported from `setupService` so the OAuth callback can recognize this specific error and branch on it. For the email-signup action the error flows through `result.unwrap()` and surfaces as a toast.

## oauth callback

`/api/auth/google/callback` shares one start route between login and signup, so a new user can reach it from the login page. When `findOrCreateUserFromOAuth` returns the signups-disabled error, the callback redirects to `/setup` (which renders the disabled state and a "log in if you have an account" message) instead of the previous raw `500`. Any other error keeps the old behavior. Existing-user login returns before the guard and is untouched.

## /setup ui

The `/setup` page reads `env.LATITUDE_CLOUD` server-side and passes `signupsDisabled` to the form. When disabled, the form shows a warning `Alert`, disables the three inputs and the "Create account" button, and renders "Continue with Google" as a plain disabled button (the active Google button is an `<a>` via `asChild`, so it's swapped rather than just styled). The "Log in" footer link stays active.

## why redirect to /setup instead of /login

Honoring "login keeps working exactly the same" meant not touching the login form. `LoginForm` only surfaces errors from `loginAction` via toast — it doesn't read an error query param — so adding a login-side message would have changed login. Redirecting blocked new-OAuth users to the already-disabled `/setup` page reuses the warning UI and leaves login alone.

## tests

- `setupService.test.ts`: when `LATITUDE_CLOUD` is true, returns an error and creates no user.
- `findOrCreateUserFromOAuth.test.ts`: with `LATITUDE_CLOUD` true, an existing user still logs in; a new email returns the error and inserts no user.

Env is toggled with the existing `vi.spyOn(env, 'env', 'get')` pattern. Core tests pass (9/9); `tc` clean on `@latitude-data/core` and `@latitude-data/web`.
