### PR TITLE
Polish taxonomy recommendations

### DIFF
--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -239,7 +239,8 @@ export const getTaxonomyOverview = createServerFn({ method: "GET" })
           return {
             category: item.category,
             trend:
-              item.clusters.length > 0
+              item.clusters.length > 0 &&
+              (categoryTrendCounts.currentCount > 0 || categoryTrendCounts.baselineCount > 0)
                 ? classifyClusterTrend({
                     ...categoryTrendCounts,
                     baselineDays: TAXONOMY_TREND_BASELINE_DAYS,

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -1,8 +1,13 @@
-import { OrganizationId, ProjectId } from "@domain/shared"
+import { OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import {
+  BehaviorObservationRepository,
+  classifyClusterTrend,
   getLastRunUseCase,
   getTaxonomyAnalyticsUseCase,
   listCategoriesUseCase,
+  TAXONOMY_TREND_BASELINE_DAYS,
+  TAXONOMY_TREND_CURRENT_DAYS,
+  TAXONOMY_TREND_MS_PER_DAY,
   type TaxonomyCategory,
   type TaxonomyCluster,
   type TaxonomyClusterLineage,
@@ -77,18 +82,22 @@ export interface TaxonomyLineageRecord {
   readonly createdAt: string
 }
 
+export type TaxonomyClusterWithTrendRecord = TaxonomyClusterRecord & {
+  readonly trend: TaxonomyClusterTrendSummary
+}
+
 export interface TaxonomyCategoryWithClustersRecord {
   readonly category: TaxonomyCategoryRecord
-  readonly clusters: readonly TaxonomyClusterRecord[]
+  readonly trend: TaxonomyClusterTrendSummary | null
+  readonly clusters: readonly TaxonomyClusterWithTrendRecord[]
 }
 
 export interface TaxonomyOverviewRecord {
   readonly totalActiveCategories: number
   readonly totalActiveClusters: number
   readonly totalObservations: number
-  readonly topClusters: readonly (TaxonomyClusterRecord & {
+  readonly topClusters: readonly (TaxonomyClusterWithTrendRecord & {
     readonly occurrences: number
-    readonly trend: TaxonomyClusterTrendSummary
   })[]
   readonly categories: readonly TaxonomyCategoryWithClustersRecord[]
   readonly lastRun: TaxonomyRunRecord | null
@@ -163,7 +172,8 @@ export const getTaxonomyOverview = createServerFn({ method: "GET" })
 
     return Effect.runPromise(
       Effect.gen(function* () {
-        const analytics = yield* getTaxonomyAnalyticsUseCase({ organizationId: orgId, projectId })
+        const now = new Date()
+        const analytics = yield* getTaxonomyAnalyticsUseCase({ organizationId: orgId, projectId, now })
         const categoryResult = yield* listCategoriesUseCase({ organizationId: orgId, projectId, includeEmpty: false })
         const clusters = yield* TaxonomyClusterRepository
         const categories = yield* Effect.forEach(
@@ -186,6 +196,61 @@ export const getTaxonomyOverview = createServerFn({ method: "GET" })
               ),
           { concurrency: 4 },
         )
+        const categoryClusterIds = categories.flatMap((item) =>
+          item.clusters.map((cluster) => TaxonomyClusterId(cluster.id)),
+        )
+        const observations = yield* BehaviorObservationRepository
+        const trendCounts =
+          categoryClusterIds.length > 0
+            ? yield* observations.getClusterTrendCounts({
+                organizationId: orgId,
+                projectId,
+                clusterIds: categoryClusterIds,
+                currentSince: new Date(now.getTime() - TAXONOMY_TREND_CURRENT_DAYS * TAXONOMY_TREND_MS_PER_DAY),
+                baselineSince: new Date(
+                  now.getTime() -
+                    (TAXONOMY_TREND_CURRENT_DAYS + TAXONOMY_TREND_BASELINE_DAYS) * TAXONOMY_TREND_MS_PER_DAY,
+                ),
+                baselineDays: TAXONOMY_TREND_BASELINE_DAYS,
+              })
+            : []
+        const trendCountByClusterId = new Map(trendCounts.map((trend) => [trend.clusterId, trend] as const))
+        const trendByClusterId = new Map(
+          trendCounts.map((trend) => [trend.clusterId, classifyClusterTrend(trend)] as const),
+        )
+        const emptyTrend = classifyClusterTrend({
+          currentCount: 0,
+          baselineCount: 0,
+          baselineDays: TAXONOMY_TREND_BASELINE_DAYS,
+        })
+        const categoriesWithTrends = categories.map((item) => {
+          const categoryTrendCounts = item.clusters.reduce(
+            (totals, cluster) => {
+              const trend = trendCountByClusterId.get(TaxonomyClusterId(cluster.id))
+              if (!trend) return totals
+              return {
+                currentCount: totals.currentCount + trend.currentCount,
+                baselineCount: totals.baselineCount + trend.baselineCount,
+              }
+            },
+            { currentCount: 0, baselineCount: 0 },
+          )
+
+          return {
+            category: item.category,
+            trend:
+              item.clusters.length > 0
+                ? classifyClusterTrend({
+                    ...categoryTrendCounts,
+                    baselineDays: TAXONOMY_TREND_BASELINE_DAYS,
+                  })
+                : null,
+            clusters: item.clusters.map((cluster) => ({
+              ...cluster,
+              trend: trendByClusterId.get(TaxonomyClusterId(cluster.id)) ?? emptyTrend,
+            })),
+          }
+        })
         const lastRun = yield* getLastRunUseCase({ organizationId: orgId, projectId })
 
         return {
@@ -197,7 +262,7 @@ export const getTaxonomyOverview = createServerFn({ method: "GET" })
             occurrences: row.occurrences,
             trend: row.trend,
           })),
-          categories,
+          categories: categoriesWithTrends,
           lastRun: lastRun.run ? toRunRecord(lastRun.run) : null,
           recentLineage: lastRun.lineage.map(toLineageRecord),
         } satisfies TaxonomyOverviewRecord

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, Icon, Skeleton } from "@repo/ui"
+import { Button, Card, CardContent, Icon, useMountEffect } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
 import {
   ArrowDownIcon,
@@ -11,12 +11,25 @@ import {
   SparklesIcon,
   TagIcon,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { useTaxonomyOverview } from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
 import type { TaxonomyOverviewRecord } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
 
-const numberFormatter = new Intl.NumberFormat()
+const numberFormatter = new Intl.NumberFormat("en-US")
+const compactNumberFormatter = new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 })
+const COMPACT_SESSION_COUNT_THRESHOLD = 100_000
+const RECOMMENDATION_ROTATION_INITIAL_DELAY_MS = 10_000
+const RECOMMENDATION_ROTATION_INTERVAL_MS = 5_000
+const RECOMMENDATION_FADE_MS = 500
+const RECOMMENDATION_COUNT = 4
+
 const formatCount = (value: number): string => numberFormatter.format(value)
+const formatDisplayCount = (value: number): string =>
+  value >= COMPACT_SESSION_COUNT_THRESHOLD ? compactNumberFormatter.format(value) : formatCount(value)
+const formatSessionLabel = (value: number, display: "compact" | "full" = "compact"): string => {
+  const count = display === "compact" ? formatDisplayCount(value) : formatCount(value)
+  return `${count} session${value === 1 ? "" : "s"}`
+}
 
 function shuffle<T>(items: readonly T[]): T[] {
   const shuffled = [...items]
@@ -42,18 +55,13 @@ export function LiveTaxonomyPanel({
     () => (data?.topClusters ?? []).filter((cluster) => cluster.name !== "Pending"),
     [data?.topClusters],
   )
-  const recommendations = useMemo(() => shuffle(namedTopClusters).slice(0, 4), [namedTopClusters])
-  const trendByClusterId = useMemo(
-    () => new Map(namedTopClusters.map((cluster) => [cluster.id, cluster.trend] as const)),
-    [namedTopClusters],
-  )
+  const shuffledTopClusters = useMemo(() => shuffle(namedTopClusters), [namedTopClusters])
   const categoryNameById = useMemo(
     () => new Map((data?.categories ?? []).map((item) => [item.category.id, item.category.name])),
     [data?.categories],
   )
 
-  if (isLoading) return <LiveTaxonomySkeleton />
-  if (!data || recommendations.length === 0) return null
+  if (isLoading || !data || shuffledTopClusters.length === 0) return null
 
   return (
     <section className="mx-auto grid w-full max-w-4xl px-6 pb-8">
@@ -63,17 +71,13 @@ export function LiveTaxonomyPanel({
         }`}
         aria-hidden={showAllBehaviors}
       >
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-          {recommendations.map((cluster) => (
-            <RecommendationCard
-              key={cluster.id}
-              cluster={cluster}
-              projectSlug={projectSlug}
-              categoryName={cluster.parentCategoryId ? categoryNameById.get(cluster.parentCategoryId) : undefined}
-            />
-          ))}
-        </div>
-        {data.totalActiveClusters > recommendations.length ? (
+        <RotatingRecommendationGrid
+          key={shuffledTopClusters.map((cluster) => cluster.id).join(":")}
+          clusters={shuffledTopClusters}
+          projectSlug={projectSlug}
+          categoryNameById={categoryNameById}
+        />
+        {data.totalActiveClusters > RECOMMENDATION_COUNT ? (
           <div className="mt-4 flex justify-center">
             <Button variant="ghost" size="sm" onClick={() => setShowAllBehaviors(true)}>
               See all behaviors & categories
@@ -91,7 +95,6 @@ export function LiveTaxonomyPanel({
           <AllBehaviorsList
             data={data}
             projectSlug={projectSlug}
-            trendByClusterId={trendByClusterId}
             onShowRecommendations={() => setShowAllBehaviors(false)}
           />
         ) : null}
@@ -100,15 +103,99 @@ export function LiveTaxonomyPanel({
   )
 }
 
+function RotatingRecommendationGrid({
+  clusters,
+  projectSlug,
+  categoryNameById,
+}: {
+  readonly clusters: readonly RecommendationCluster[]
+  readonly projectSlug: string
+  readonly categoryNameById: ReadonlyMap<string, string>
+}) {
+  const slotCount = Math.min(RECOMMENDATION_COUNT, clusters.length)
+  const [slots, setSlots] = useState(() =>
+    Array.from({ length: slotCount }, (_, index) => ({ clusterIndex: index, visible: true })),
+  )
+  const nextClusterIndex = useRef(slotCount)
+  const lastRotatedSlotIndex = useRef<number | null>(null)
+
+  useMountEffect(() => {
+    if (clusters.length <= slotCount) return
+
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+    const chooseSlotIndex = () => {
+      if (slotCount <= 1) return 0
+
+      let slotIndex = Math.floor(Math.random() * slotCount)
+      while (slotIndex === lastRotatedSlotIndex.current) {
+        slotIndex = Math.floor(Math.random() * slotCount)
+      }
+      lastRotatedSlotIndex.current = slotIndex
+      return slotIndex
+    }
+    const rotateOneSlot = () => {
+      const slotIndex = chooseSlotIndex()
+      setSlots((previous) => previous.map((slot, index) => (index === slotIndex ? { ...slot, visible: false } : slot)))
+
+      const fadeTimeout = setTimeout(() => {
+        setSlots((previous) => {
+          const visibleClusterIndexes = new Set(previous.map((slot) => slot.clusterIndex))
+          visibleClusterIndexes.delete(previous[slotIndex]?.clusterIndex)
+
+          let candidateIndex = nextClusterIndex.current % clusters.length
+          while (visibleClusterIndexes.has(candidateIndex)) {
+            nextClusterIndex.current += 1
+            candidateIndex = nextClusterIndex.current % clusters.length
+          }
+          nextClusterIndex.current += 1
+
+          return previous.map((slot, index) =>
+            index === slotIndex ? { clusterIndex: candidateIndex, visible: true } : slot,
+          )
+        })
+      }, RECOMMENDATION_FADE_MS)
+      timeouts.push(fadeTimeout)
+    }
+
+    const initialTimeout = setTimeout(() => {
+      rotateOneSlot()
+      const interval = setInterval(rotateOneSlot, RECOMMENDATION_ROTATION_INTERVAL_MS)
+      timeouts.push(interval)
+    }, RECOMMENDATION_ROTATION_INITIAL_DELAY_MS)
+    timeouts.push(initialTimeout)
+
+    return () => {
+      for (const timeout of timeouts) clearTimeout(timeout)
+    }
+  })
+
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      {slots.map((slot, index) => {
+        const cluster = clusters[slot.clusterIndex]
+        if (!cluster) return null
+
+        return (
+          <div key={index} className={`transition-opacity duration-500 ${slot.visible ? "opacity-100" : "opacity-0"}`}>
+            <RecommendationCard
+              cluster={cluster}
+              projectSlug={projectSlug}
+              categoryName={cluster.parentCategoryId ? categoryNameById.get(cluster.parentCategoryId) : undefined}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 function AllBehaviorsList({
   data,
   projectSlug,
-  trendByClusterId,
   onShowRecommendations,
 }: {
   readonly data: TaxonomyOverviewRecord
   readonly projectSlug: string
-  readonly trendByClusterId: ReadonlyMap<string, RecommendationCluster["trend"]>
   readonly onShowRecommendations: () => void
 }) {
   const [expandedCategoryIds, setExpandedCategoryIds] = useState<ReadonlySet<string>>(
@@ -156,9 +243,12 @@ function AllBehaviorsList({
                     <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">{item.category.description}</p>
                   ) : null}
                 </div>
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {formatCount(item.category.observationCount)} sessions
-                </span>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  {item.trend ? (
+                    <ClusterTag icon={trendMeta(item.trend.status).icon} label={trendMeta(item.trend.status).label} />
+                  ) : null}
+                  <SessionCount value={item.category.observationCount} />
+                </div>
               </button>
               {isExpanded ? (
                 <div className="grid grid-cols-1 gap-2 px-3 pb-3 md:grid-cols-2">
@@ -176,18 +266,14 @@ function AllBehaviorsList({
                             {cluster.name}
                           </div>
                           <p className="mt-1 line-clamp-2 text-xs leading-4 text-muted-foreground">
-                            {cluster.description || `${formatCount(cluster.observationCount)} sessions`}
+                            {cluster.description || formatSessionLabel(cluster.observationCount, "full")}
                           </p>
                           <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                            {trendByClusterId.get(cluster.id) ? (
-                              <ClusterTag
-                                icon={trendMeta(trendByClusterId.get(cluster.id)?.status ?? "steady").icon}
-                                label={trendMeta(trendByClusterId.get(cluster.id)?.status ?? "steady").label}
-                              />
-                            ) : null}
-                            <span className="text-xs text-muted-foreground">
-                              {formatCount(cluster.observationCount)} sessions
-                            </span>
+                            <ClusterTag
+                              icon={trendMeta(cluster.trend.status).icon}
+                              label={trendMeta(cluster.trend.status).label}
+                            />
+                            <SessionCount value={cluster.observationCount} />
                           </div>
                         </div>
                         <Icon
@@ -206,19 +292,6 @@ function AllBehaviorsList({
         })}
       </div>
     </div>
-  )
-}
-
-function LiveTaxonomySkeleton() {
-  return (
-    <section className="mx-auto flex w-full max-w-4xl flex-col px-6 pb-8">
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <Skeleton className="h-36 rounded-2xl" />
-        <Skeleton className="h-36 rounded-2xl" />
-        <Skeleton className="h-36 rounded-2xl" />
-        <Skeleton className="h-36 rounded-2xl" />
-      </div>
-    </section>
   )
 }
 
@@ -243,6 +316,16 @@ const trendMeta = (
     case "fading":
       return { label: "fading", icon: ArrowDownIcon }
   }
+}
+
+function SessionCount({ value }: { readonly value: number }) {
+  const exactLabel = formatSessionLabel(value, "full")
+
+  return (
+    <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground" title={exactLabel}>
+      {formatSessionLabel(value)}
+    </span>
+  )
 }
 
 function ClusterTag({ icon, label }: { readonly icon: TagIconType; readonly label: string }) {
@@ -288,12 +371,12 @@ function RecommendationCard({
             />
           </div>
           <p className="line-clamp-3 min-h-12 text-xs leading-4 text-muted-foreground">
-            {cluster.description || `${formatCount(cluster.observationCount)} matching sessions`}
+            {cluster.description || `${formatSessionLabel(cluster.observationCount, "full")} matching`}
           </p>
           <div className="mt-auto flex flex-wrap items-center gap-1.5">
             <ClusterTag icon={trendMeta(cluster.trend.status).icon} label={trendMeta(cluster.trend.status).label} />
             {categoryName ? <ClusterTag icon={TagIcon} label={categoryName} /> : null}
-            <span className="text-xs text-muted-foreground">{formatCount(cluster.observationCount)} sessions</span>
+            <SessionCount value={cluster.observationCount} />
           </div>
         </CardContent>
       </Card>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/live-taxonomy-panel.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, Icon, useMountEffect } from "@repo/ui"
+import { Button, Card, CardContent, Icon, Tooltip, useMountEffect } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
 import {
   ArrowDownIcon,
@@ -70,6 +70,7 @@ export function LiveTaxonomyPanel({
           showAllBehaviors ? "pointer-events-none scale-[0.99] opacity-0" : "scale-100 opacity-100"
         }`}
         aria-hidden={showAllBehaviors}
+        inert={showAllBehaviors || undefined}
       >
         <RotatingRecommendationGrid
           key={shuffledTopClusters.map((cluster) => cluster.id).join(":")}
@@ -90,6 +91,7 @@ export function LiveTaxonomyPanel({
           showAllBehaviors ? "scale-100 opacity-100" : "pointer-events-none scale-[0.99] opacity-0"
         }`}
         aria-hidden={!showAllBehaviors}
+        inert={!showAllBehaviors || undefined}
       >
         {showAllBehaviors ? (
           <AllBehaviorsList
@@ -315,6 +317,10 @@ const trendMeta = (
       return { label: "cooling", icon: ArrowDownIcon }
     case "fading":
       return { label: "fading", icon: ArrowDownIcon }
+    default: {
+      const _exhaustiveCheck: never = status
+      throw new Error(`Unhandled trend status: ${_exhaustiveCheck}`)
+    }
   }
 }
 
@@ -322,9 +328,15 @@ function SessionCount({ value }: { readonly value: number }) {
   const exactLabel = formatSessionLabel(value, "full")
 
   return (
-    <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground" title={exactLabel}>
-      {formatSessionLabel(value)}
-    </span>
+    <Tooltip
+      trigger={
+        <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+          {formatSessionLabel(value)}
+        </span>
+      }
+    >
+      {exactLabel}
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
@@ -245,7 +245,7 @@ function SavedSearchesEmpty({ behaviorEmptyState }: { readonly behaviorEmptyStat
         <div className="flex flex-col items-center gap-2">
           {behaviorEmptyState === "detecting" ? (
             <>
-              <Text.H3 centered>Detecting behaviors</Text.H3>
+              <Text.H3 centered>Detecting behaviours</Text.H3>
               <Text.H5 centered color="foregroundMuted">
                 Latitude is reading incoming traces to find repeated user and agent behaviors. The first behaviors
                 usually appear after enough similar sessions arrive, which can take a few minutes on active projects.

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/saved-searches-list.tsx
@@ -33,14 +33,16 @@ const formatDate = (iso: string): string => dateFormatter.format(new Date(iso))
 
 const filtersCount = (filterSet: SavedSearchRecord["filterSet"]): number => Object.keys(filterSet).length
 
+type BehaviorEmptyState = "default" | "detecting" | "recommendations"
+
 export function SavedSearchesList({
   projectId,
   projectSlug,
-  hasRecommendedSearches,
+  behaviorEmptyState,
 }: {
   readonly projectId: string
   readonly projectSlug: string
-  readonly hasRecommendedSearches: boolean
+  readonly behaviorEmptyState: BehaviorEmptyState
 }) {
   const router = useRouter()
   const { data, isLoading } = useSavedSearchesList(projectId)
@@ -50,7 +52,7 @@ export function SavedSearchesList({
   const [assignOpenForId, setAssignOpenForId] = useState<string | null>(null)
 
   if (!isLoading && data.length === 0) {
-    return <SavedSearchesEmpty hasRecommendedSearches={hasRecommendedSearches} />
+    return <SavedSearchesEmpty behaviorEmptyState={behaviorEmptyState} />
   }
 
   const columns: InfiniteTableColumn<SavedSearchRecord>[] = [
@@ -225,7 +227,9 @@ function DeleteSavedSearchModal({
   )
 }
 
-function SavedSearchesEmpty({ hasRecommendedSearches }: { readonly hasRecommendedSearches: boolean }) {
+function SavedSearchesEmpty({ behaviorEmptyState }: { readonly behaviorEmptyState: BehaviorEmptyState }) {
+  const hasRecommendedSearches = behaviorEmptyState === "recommendations"
+
   return (
     <div
       className={
@@ -239,20 +243,20 @@ function SavedSearchesEmpty({ hasRecommendedSearches }: { readonly hasRecommende
           <Icon icon={SparklesIcon} size="lg" color="foregroundMuted" />
         </div>
         <div className="flex flex-col items-center gap-2">
-          <Text.H3 centered>Search your traces</Text.H3>
-          {hasRecommendedSearches ? (
-            <Text.H5 centered color="foregroundMuted">
-              Describe what you're looking for in plain language, or start from one of the recommended behavior searches
-              below.
-            </Text.H5>
+          {behaviorEmptyState === "detecting" ? (
+            <>
+              <Text.H3 centered>Detecting behaviors</Text.H3>
+              <Text.H5 centered color="foregroundMuted">
+                Latitude is reading incoming traces to find repeated user and agent behaviors. The first behaviors
+                usually appear after enough similar sessions arrive, which can take a few minutes on active projects.
+              </Text.H5>
+            </>
           ) : (
             <>
+              <Text.H3 centered>Explore behaviours</Text.H3>
               <Text.H5 centered color="foregroundMuted">
-                Describe what you're looking for in plain language. Search blends keywords with meaning, so phrases like
-                "failed payments" or "long latency on signup" work as well as exact matches.
-              </Text.H5>
-              <Text.H5 centered color="foregroundMuted">
-                Once you've built a useful search, save it from the action bar to come back to it later.
+                Explore behaviours Latitude detected from user and agent interactions, or describe the behavior you want
+                to investigate. Latitude keeps them up to date as new data comes in.
               </Text.H5>
             </>
           )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -106,7 +106,9 @@ function SearchPage() {
     liveTaxonomyRecommendationsEnabled &&
     (taxonomyOverview?.topClusters.some((cluster) => cluster.name !== "Pending") ?? false)
   const behaviorEmptyState =
-    liveTaxonomyRecommendationsEnabled && taxonomyOverview?.totalActiveClusters === 0
+    liveTaxonomyRecommendationsEnabled &&
+    taxonomyOverview !== undefined &&
+    taxonomyOverview.totalActiveClusters === 0
       ? "detecting"
       : hasRecommendedSearches
         ? "recommendations"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -105,6 +105,12 @@ function SearchPage() {
   const hasRecommendedSearches =
     liveTaxonomyRecommendationsEnabled &&
     (taxonomyOverview?.topClusters.some((cluster) => cluster.name !== "Pending") ?? false)
+  const behaviorEmptyState =
+    liveTaxonomyRecommendationsEnabled && taxonomyOverview?.totalActiveClusters === 0
+      ? "detecting"
+      : hasRecommendedSearches
+        ? "recommendations"
+        : "default"
 
   // Compare canonical serializations of both filter sets. `rawFilters` is whatever TanStack Router
   // wrote to the URL (potentially JSON-stringified twice depending on encoding), so going through
@@ -233,11 +239,7 @@ function SearchPage() {
 
       {!hasContent ? (
         <div className="flex min-h-0 grow flex-col">
-          <SavedSearchesList
-            projectId={projectId}
-            projectSlug={projectSlug}
-            hasRecommendedSearches={hasRecommendedSearches}
-          />
+          <SavedSearchesList projectId={projectId} projectSlug={projectSlug} behaviorEmptyState={behaviorEmptyState} />
           {liveTaxonomyRecommendationsEnabled ? (
             <LiveTaxonomyPanel projectId={projectId} projectSlug={projectSlug} />
           ) : null}

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -160,12 +160,16 @@ export {
   type TaxonomyRunRepositoryShape,
 } from "./ports/taxonomy-run-repository.ts"
 export {
+  classifyClusterTrend,
   type GetLastRunInput,
   type GetLastRunResult,
   type GetTaxonomyAnalyticsInput,
   type GetTaxonomyAnalyticsResult,
   getLastRunUseCase,
   getTaxonomyAnalyticsUseCase,
+  TAXONOMY_TREND_BASELINE_DAYS,
+  TAXONOMY_TREND_CURRENT_DAYS,
+  TAXONOMY_TREND_MS_PER_DAY,
   type TaxonomyClusterTrendStatus,
   type TaxonomyClusterTrendSummary,
   type TopTaxonomyCluster,

--- a/packages/domain/taxonomy/src/use-cases/analytics.ts
+++ b/packages/domain/taxonomy/src/use-cases/analytics.ts
@@ -49,16 +49,16 @@ export interface GetLastRunResult {
   readonly lineage: readonly TaxonomyClusterLineage[]
 }
 
-const MS_PER_DAY = 24 * 60 * 60_000
-const TREND_CURRENT_DAYS = 1
-const TREND_BASELINE_DAYS = 7
+export const TAXONOMY_TREND_MS_PER_DAY = 24 * 60 * 60_000
+export const TAXONOMY_TREND_CURRENT_DAYS = 1
+export const TAXONOMY_TREND_BASELINE_DAYS = 7
 
 const startOfUtcDay = (date: Date): Date =>
   new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
 const windowStart = (now: Date, windowDays: number): Date =>
-  startOfUtcDay(new Date(now.getTime() - (windowDays - 1) * MS_PER_DAY))
+  startOfUtcDay(new Date(now.getTime() - (windowDays - 1) * TAXONOMY_TREND_MS_PER_DAY))
 
-const classifyClusterTrend = (input: {
+export const classifyClusterTrend = (input: {
   readonly currentCount: number
   readonly baselineCount: number
   readonly baselineDays: number
@@ -133,9 +133,11 @@ export const getTaxonomyAnalyticsUseCase = (input: GetTaxonomyAnalyticsInput) =>
       organizationId: input.organizationId,
       projectId: input.projectId,
       clusterIds: topClusterIds,
-      currentSince: new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY),
-      baselineSince: new Date(now.getTime() - (TREND_CURRENT_DAYS + TREND_BASELINE_DAYS) * MS_PER_DAY),
-      baselineDays: TREND_BASELINE_DAYS,
+      currentSince: new Date(now.getTime() - TAXONOMY_TREND_CURRENT_DAYS * TAXONOMY_TREND_MS_PER_DAY),
+      baselineSince: new Date(
+        now.getTime() - (TAXONOMY_TREND_CURRENT_DAYS + TAXONOMY_TREND_BASELINE_DAYS) * TAXONOMY_TREND_MS_PER_DAY,
+      ),
+      baselineDays: TAXONOMY_TREND_BASELINE_DAYS,
     })
     const clusterById = new Map(topClusterRows.map((cluster) => [cluster.id, cluster] as const))
     const trendByClusterId = new Map(trendCounts.map((trend) => [trend.clusterId, trend] as const))


### PR DESCRIPTION
## what changed

Polishes the live taxonomy recommendation surface on the search page.

The recommendation panel now waits for loaded taxonomy data before rendering, so empty projects do not briefly flash recommendation placeholders. When more than four behaviours exist, it shows four cards and rotates one card at a time: the first rotation waits 10 seconds, then a different card fades every 5 seconds.

The all-behaviours view now shows trend pills on categories as well as individual behaviours. Category trends are calculated by summing the current/baseline observation counts for the category's behaviours and reusing the same trend classifier as behaviour cards.

Large session counts now use compact labels in the UI while keeping the exact value available in the tooltip.

## copy updates

The blank state now frames the page around behaviours instead of trace search:

- projects with detected behaviours: “Explore behaviours”
- projects still waiting for behaviour discovery: “Detecting behaviors”

## validation

- `pnpm --filter @domain/taxonomy format`
- `pnpm --filter @app/web format`
- `pnpm --filter @domain/taxonomy typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm knip`

Please attach screenshots or a short screen recording for reviewer context.
