### PR TITLE
fix(wrapped): use absolute URL for og:image

### DIFF
--- a/apps/web/src/routes/wrapped/$id.tsx
+++ b/apps/web/src/routes/wrapped/$id.tsx
@@ -1,6 +1,7 @@
 import type { ReportVersion, WrappedReportRecord, WrappedReportType } from "@domain/spans"
 import { createFileRoute, notFound } from "@tanstack/react-router"
 import { getWrappedPageData } from "../../domains/wrapped/wrapped.functions.ts"
+import { WEB_BASE_URL } from "../../lib/auth-config.ts"
 import { TITLE_FOR_KIND } from "./-components/claude-code/v1/personality-copy.ts"
 import { WrappedReportV1 } from "./-components/claude-code/v1/WrappedReportV1.tsx"
 
@@ -37,7 +38,9 @@ export const Route = createFileRoute("/wrapped/$id")({
     const archetype = TITLE_FOR_KIND[record.report.personality.kind] ?? "The Wrapped"
     const title = `${record.ownerName}'s Claude Code Wrapped`
     const description = `${record.ownerName} is ${archetype} this week. See the full Wrapped.`
-    const ogImage = `/wrapped/${params.id}/og/png`
+    // og:image must be an absolute URL — crawlers (Slack, Twitter, etc.)
+    // fetch it without a page-relative base, so a relative path 404s.
+    const ogImage = `${WEB_BASE_URL}/wrapped/${params.id}/og/png`
     return {
       meta: [
         { title },


### PR DESCRIPTION
The Wrapped page route set `og:image` (and `twitter:image`) to a page-relative path, `/wrapped/${id}/og/png`. Social crawlers — Slack, Twitter, Facebook — fetch the `og:image` value with no page-relative base, so a relative path resolves incorrectly and the preview card image fails to load.

The path now gets prefixed with `WEB_BASE_URL` (from `lib/auth-config.ts`, sourced from `VITE_LAT_WEB_URL`, already trailing-slash-trimmed and available isomorphically inside the route `head`):

```ts
const ogImage = `${WEB_BASE_URL}/wrapped/${params.id}/og/png`
```

`ogImage` feeds both `og:image` and `twitter:image`, so both are now absolute.
