### PR TITLE
Seed demo project derived data

### DIFF
--- a/apps/workflows/src/activities/index.ts
+++ b/apps/workflows/src/activities/index.ts
@@ -33,6 +33,8 @@ export {
   type SeedDemoProjectActivityInput,
   seedDemoProjectClickHouseActivity,
   seedDemoProjectPostgresActivity,
+  seedDemoProjectTaxonomyActivity,
+  seedDemoProjectTraceSearchActivity,
 } from "./seed-demo-project-activities.ts"
 export {
   type NameTaxonomyCategoryActivityInput,

--- a/apps/workflows/src/activities/seed-demo-project-activities.ts
+++ b/apps/workflows/src/activities/seed-demo-project-activities.ts
@@ -1,5 +1,5 @@
 import { AI } from "@domain/ai"
-import { ApiKeyId, OrganizationId, type OrganizationId as OrganizationIdType, ProjectId, TraceId } from "@domain/shared"
+import { ApiKeyId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { createSeedScope, type SeedScope } from "@domain/shared/seeding"
 import {
   buildTraceSearchDocument,
@@ -97,6 +97,7 @@ type DemoTraceRow = {
   readonly root_span_name: string
 }
 
+// Hardcoded rather than resolved from org settings so demo rows never expire per-tenant config.
 const DEMO_PROJECT_RETENTION_DAYS = 30
 const DEMO_PROJECT_TAXONOMY_SESSION_LIMIT = 10_000
 
@@ -160,6 +161,8 @@ export const seedDemoProjectTraceSearchActivity = (input: SeedDemoProjectActivit
           retentionDays: DEMO_PROJECT_RETENTION_DAYS,
         })
 
+        // NOTE: mirrors `prioritizeChunksForEmbedding` in apps/workers/src/workers/trace-search.ts.
+        // Not imported directly because extracting it to @domain/spans is a larger refactor.
         const eligibleChunks = document.chunks
           .filter((item) => item.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
           .sort((a, b) => b.chunkIndex - a.chunkIndex)
@@ -174,16 +177,27 @@ export const seedDemoProjectTraceSearchActivity = (input: SeedDemoProjectActivit
           )
           if (hasExisting) continue
 
-          const embedding = yield* ai.embed({
-            text: chunk.text,
-            model: TRACE_SEARCH_EMBEDDING_MODEL,
-            dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
-            telemetry: {
-              spanName: "demo-project.trace-search.embed",
-              name: "demo-project-trace-search-embed",
-              tags: ["demo-project", "trace-search", "embedding"],
-            },
-          })
+          const embedding = yield* ai
+            .embed({
+              text: chunk.text,
+              model: TRACE_SEARCH_EMBEDDING_MODEL,
+              dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+              telemetry: {
+                spanName: "demo-project.trace-search.embed",
+                name: "demo-project-trace-search-embed",
+                tags: ["demo-project", "trace-search", "embedding"],
+              },
+            })
+            .pipe(
+              Effect.tapError((err) =>
+                Effect.logWarning("demo-project trace-search embed failed — skipping chunk", {
+                  chunkIndex: chunk.chunkIndex,
+                  error: err,
+                }),
+              ),
+              Effect.orElseSucceed(() => null),
+            )
+          if (embedding === null) continue
 
           yield* searchRepo.upsertEmbedding({
             organizationId,
@@ -225,10 +239,16 @@ export const seedDemoProjectTaxonomyActivity = (input: SeedDemoProjectActivityIn
       const sessions = yield* Effect.gen(function* () {
         const repository = yield* SessionRepository
         const page = yield* repository.listByProjectId({
-          organizationId: input.organizationId as OrganizationIdType,
+          organizationId,
           projectId,
           options: { limit: DEMO_PROJECT_TAXONOMY_SESSION_LIMIT, sortBy: "lastActivity", sortDirection: "asc" },
         })
+        if (page.hasMore) {
+          yield* Effect.logWarning(
+            "demo-project taxonomy seed: session list was truncated; some sessions will not be observed",
+            { projectId, limit: DEMO_PROJECT_TAXONOMY_SESSION_LIMIT },
+          )
+        }
         return page.items
       }).pipe(withClickHouse(SessionRepositoryLive, clickhouse, organizationId))
 

--- a/apps/workflows/src/activities/seed-demo-project-activities.ts
+++ b/apps/workflows/src/activities/seed-demo-project-activities.ts
@@ -1,8 +1,39 @@
-import { ApiKeyId, OrganizationId, ProjectId } from "@domain/shared"
+import { AI } from "@domain/ai"
+import { ApiKeyId, OrganizationId, type OrganizationId as OrganizationIdType, ProjectId, TraceId } from "@domain/shared"
 import { createSeedScope, type SeedScope } from "@domain/shared/seeding"
+import {
+  buildTraceSearchDocument,
+  SessionRepository,
+  TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+  TRACE_SEARCH_EMBEDDING_MIN_LENGTH,
+  TRACE_SEARCH_EMBEDDING_MODEL,
+  TraceRepository,
+  TraceSearchRepository,
+} from "@domain/spans"
+import { recordSessionObservationUseCase, runProjectGardeningUseCase } from "@domain/taxonomy"
+import { withAi } from "@platform/ai"
+import { AIGenerateLive } from "@platform/ai-vercel"
+import { AIEmbedLive } from "@platform/ai-voyage"
+import { RedisCacheStoreLive, RedisTaxonomyLockRepositoryLive } from "@platform/cache-redis"
+import {
+  BehaviorObservationRepositoryLive,
+  queryClickhouse,
+  SessionRepositoryLive,
+  TraceRepositoryLive,
+  TraceSearchRepositoryLive,
+  withClickHouse,
+} from "@platform/db-clickhouse"
 import { seedDemoProjectClickHouse } from "@platform/db-clickhouse/seeding"
+import {
+  TaxonomyCategoryRepositoryLive,
+  TaxonomyClusterRepositoryLive,
+  TaxonomyLineageRepositoryLive,
+  TaxonomyRunRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
 import { seedDemoProjectPostgres } from "@platform/db-postgres/seeding"
-import { getAdminPostgresClient, getClickhouseClient } from "../clients.ts"
+import { Effect, Layer } from "effect"
+import { getAdminPostgresClient, getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
 /**
  * Plain-data input that the workflow hands every activity. Workflow code
@@ -59,3 +90,177 @@ export const seedDemoProjectPostgresActivity = (input: SeedDemoProjectActivityIn
  */
 export const seedDemoProjectClickHouseActivity = (input: SeedDemoProjectActivityInput): Promise<void> =>
   seedDemoProjectClickHouse({ client: getClickhouseClient(), scope: buildScope(input) })
+
+type DemoTraceRow = {
+  readonly trace_id: string
+  readonly start_time_ms: number | string
+  readonly root_span_name: string
+}
+
+const DEMO_PROJECT_RETENTION_DAYS = 30
+const DEMO_PROJECT_TAXONOMY_SESSION_LIMIT = 10_000
+
+const listSeededTraceRows = (input: SeedDemoProjectActivityInput) =>
+  queryClickhouse<DemoTraceRow>(
+    getClickhouseClient(),
+    `SELECT
+       CAST(trace_id AS String) AS trace_id,
+       toUnixTimestamp64Milli(min(min_start_time)) AS start_time_ms,
+       argMinIfMerge(root_span_name) AS root_span_name
+     FROM traces
+     WHERE organization_id = {organizationId:String}
+       AND project_id = {projectId:String}
+     GROUP BY trace_id
+     ORDER BY start_time_ms ASC, trace_id ASC`,
+    { organizationId: input.organizationId, projectId: input.projectId },
+  )
+
+/**
+ * Derived trace-search seed: creates the lexical document and semantic
+ * embeddings that the behaviour/search page reads. This intentionally uses
+ * the same domain document builder, trace repository, and Voyage embedding
+ * provider as the trace-search worker so demo projects exercise the real
+ * search path instead of fixture-only rows.
+ */
+export const seedDemoProjectTraceSearchActivity = (input: SeedDemoProjectActivityInput): Promise<void> => {
+  const clickhouse = getClickhouseClient()
+  const redis = getRedisClient()
+  const organizationId = OrganizationId(input.organizationId)
+  const projectId = ProjectId(input.projectId)
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const traceRows = yield* listSeededTraceRows(input)
+      const traceRepo = yield* TraceRepository
+      const searchRepo = yield* TraceSearchRepository
+      const ai = yield* AI
+
+      for (const row of traceRows) {
+        const traceId = TraceId(row.trace_id)
+        const startTimeMs = typeof row.start_time_ms === "string" ? Number(row.start_time_ms) : row.start_time_ms
+        const startTime = new Date(startTimeMs)
+        const trace = yield* traceRepo.findByTraceId({ organizationId, projectId, traceId })
+        if (trace.allMessages.length === 0) continue
+
+        const document = yield* buildTraceSearchDocument({
+          traceId,
+          startTime,
+          rootSpanName: row.root_span_name,
+          messages: trace.allMessages,
+        })
+
+        yield* searchRepo.upsertDocument({
+          organizationId,
+          projectId,
+          traceId,
+          startTime,
+          rootSpanName: document.rootSpanName,
+          searchText: document.searchText,
+          contentHash: document.contentHash,
+          retentionDays: DEMO_PROJECT_RETENTION_DAYS,
+        })
+
+        const eligibleChunks = document.chunks
+          .filter((item) => item.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
+          .sort((a, b) => b.chunkIndex - a.chunkIndex)
+
+        for (const chunk of eligibleChunks) {
+          const hasExisting = yield* searchRepo.hasEmbeddingWithHash(
+            organizationId,
+            projectId,
+            traceId,
+            chunk.chunkIndex,
+            chunk.contentHash,
+          )
+          if (hasExisting) continue
+
+          const embedding = yield* ai.embed({
+            text: chunk.text,
+            model: TRACE_SEARCH_EMBEDDING_MODEL,
+            dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+            telemetry: {
+              spanName: "demo-project.trace-search.embed",
+              name: "demo-project-trace-search-embed",
+              tags: ["demo-project", "trace-search", "embedding"],
+            },
+          })
+
+          yield* searchRepo.upsertEmbedding({
+            organizationId,
+            projectId,
+            traceId,
+            chunkIndex: chunk.chunkIndex,
+            startTime,
+            contentHash: chunk.contentHash,
+            embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
+            embedding: embedding.embedding as readonly number[],
+            retentionDays: DEMO_PROJECT_RETENTION_DAYS,
+            firstMessageIndex: chunk.firstMessageIndex,
+            lastMessageIndex: chunk.lastMessageIndex,
+          })
+        }
+      }
+    }).pipe(
+      withClickHouse(Layer.mergeAll(TraceRepositoryLive, TraceSearchRepositoryLive), clickhouse, organizationId),
+      withAi(AIEmbedLive, redis),
+    ),
+  )
+}
+
+/**
+ * Derived taxonomy seed: records behaviour observations from the freshly
+ * inserted tau sessions, then runs gardening once so the demo project opens
+ * with named behaviours/categories instead of waiting for the periodic
+ * production sweep.
+ */
+export const seedDemoProjectTaxonomyActivity = (input: SeedDemoProjectActivityInput): Promise<void> => {
+  const clickhouse = getClickhouseClient()
+  const postgres = getPostgresClient()
+  const redis = getRedisClient()
+  const organizationId = OrganizationId(input.organizationId)
+  const projectId = ProjectId(input.projectId)
+
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const sessions = yield* Effect.gen(function* () {
+        const repository = yield* SessionRepository
+        const page = yield* repository.listByProjectId({
+          organizationId: input.organizationId as OrganizationIdType,
+          projectId,
+          options: { limit: DEMO_PROJECT_TAXONOMY_SESSION_LIMIT, sortBy: "lastActivity", sortDirection: "asc" },
+        })
+        return page.items
+      }).pipe(withClickHouse(SessionRepositoryLive, clickhouse, organizationId))
+
+      for (const session of sessions) {
+        yield* recordSessionObservationUseCase({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          sessionId: session.sessionId,
+          triggeringTraceId: session.traceIds[0] ?? session.sessionId,
+          triggeringStartTime: session.startTime.toISOString(),
+        })
+      }
+
+      yield* runProjectGardeningUseCase({ organizationId, projectId, trigger: "manual" })
+    }).pipe(
+      withPostgres(
+        Layer.mergeAll(
+          TaxonomyCategoryRepositoryLive,
+          TaxonomyClusterRepositoryLive,
+          TaxonomyLineageRepositoryLive,
+          TaxonomyRunRepositoryLive,
+        ),
+        postgres,
+        organizationId,
+      ),
+      withClickHouse(
+        Layer.mergeAll(BehaviorObservationRepositoryLive, SessionRepositoryLive, TraceRepositoryLive),
+        clickhouse,
+        organizationId,
+      ),
+      withAi(Layer.mergeAll(AIEmbedLive, AIGenerateLive), redis),
+      Effect.provide(Layer.mergeAll(RedisCacheStoreLive(redis), RedisTaxonomyLockRepositoryLive(redis))),
+    ),
+  )
+}

--- a/apps/workflows/src/workflows/seed-demo-project-workflow.test.ts
+++ b/apps/workflows/src/workflows/seed-demo-project-workflow.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { callOrder, mockActivities } = vi.hoisted(() => {
+const { callOrder, mockActivities, patchedState } = vi.hoisted(() => {
   const callOrder: string[] = []
+  const patchedState = { enabled: true }
   const mockActivities = {
     seedDemoProjectPostgresActivity: vi.fn(async () => {
       callOrder.push("postgres")
@@ -9,11 +10,18 @@ const { callOrder, mockActivities } = vi.hoisted(() => {
     seedDemoProjectClickHouseActivity: vi.fn(async () => {
       callOrder.push("clickhouse")
     }),
+    seedDemoProjectTraceSearchActivity: vi.fn(async () => {
+      callOrder.push("trace-search")
+    }),
+    seedDemoProjectTaxonomyActivity: vi.fn(async () => {
+      callOrder.push("taxonomy")
+    }),
   }
-  return { callOrder, mockActivities }
+  return { callOrder, mockActivities, patchedState }
 })
 
 vi.mock("@temporalio/workflow", () => ({
+  patched: () => patchedState.enabled,
   proxyActivities: () => mockActivities,
 }))
 
@@ -30,13 +38,14 @@ const baseInput = {
 describe("seedDemoProjectWorkflow", () => {
   beforeEach(() => {
     callOrder.length = 0
+    patchedState.enabled = true
     vi.clearAllMocks()
   })
 
-  it("runs Postgres → ClickHouse in dependency order", async () => {
+  it("runs Postgres → ClickHouse → trace search → taxonomy in dependency order", async () => {
     const result = await seedDemoProjectWorkflow(baseInput)
 
-    expect(callOrder).toEqual(["postgres", "clickhouse"])
+    expect(callOrder).toEqual(["postgres", "clickhouse", "trace-search", "taxonomy"])
     expect(result).toEqual({ action: "seeded", projectId: "proj-demo" })
   })
 
@@ -45,6 +54,19 @@ describe("seedDemoProjectWorkflow", () => {
 
     expect(mockActivities.seedDemoProjectPostgresActivity).toHaveBeenCalledWith(baseInput)
     expect(mockActivities.seedDemoProjectClickHouseActivity).toHaveBeenCalledWith(baseInput)
+    expect(mockActivities.seedDemoProjectTraceSearchActivity).toHaveBeenCalledWith(baseInput)
+    expect(mockActivities.seedDemoProjectTaxonomyActivity).toHaveBeenCalledWith(baseInput)
+  })
+
+  it("keeps replay compatibility for workflows started before derived data seeding", async () => {
+    patchedState.enabled = false
+
+    const result = await seedDemoProjectWorkflow(baseInput)
+
+    expect(callOrder).toEqual(["postgres", "clickhouse"])
+    expect(mockActivities.seedDemoProjectTraceSearchActivity).not.toHaveBeenCalled()
+    expect(mockActivities.seedDemoProjectTaxonomyActivity).not.toHaveBeenCalled()
+    expect(result).toEqual({ action: "seeded", projectId: "proj-demo" })
   })
 
   it("propagates failure from the Postgres activity and skips downstream activities", async () => {
@@ -54,5 +76,7 @@ describe("seedDemoProjectWorkflow", () => {
 
     await expect(seedDemoProjectWorkflow(baseInput)).rejects.toThrow("postgres seed failed")
     expect(mockActivities.seedDemoProjectClickHouseActivity).not.toHaveBeenCalled()
+    expect(mockActivities.seedDemoProjectTraceSearchActivity).not.toHaveBeenCalled()
+    expect(mockActivities.seedDemoProjectTaxonomyActivity).not.toHaveBeenCalled()
   })
 })

--- a/apps/workflows/src/workflows/seed-demo-project-workflow.test.ts
+++ b/apps/workflows/src/workflows/seed-demo-project-workflow.test.ts
@@ -79,4 +79,14 @@ describe("seedDemoProjectWorkflow", () => {
     expect(mockActivities.seedDemoProjectTraceSearchActivity).not.toHaveBeenCalled()
     expect(mockActivities.seedDemoProjectTaxonomyActivity).not.toHaveBeenCalled()
   })
+
+  it("propagates failure from the ClickHouse activity and skips derived-data activities", async () => {
+    mockActivities.seedDemoProjectClickHouseActivity.mockImplementationOnce(async () => {
+      throw new Error("clickhouse seed failed")
+    })
+
+    await expect(seedDemoProjectWorkflow(baseInput)).rejects.toThrow("clickhouse seed failed")
+    expect(mockActivities.seedDemoProjectTraceSearchActivity).not.toHaveBeenCalled()
+    expect(mockActivities.seedDemoProjectTaxonomyActivity).not.toHaveBeenCalled()
+  })
 })

--- a/apps/workflows/src/workflows/seed-demo-project-workflow.ts
+++ b/apps/workflows/src/workflows/seed-demo-project-workflow.ts
@@ -1,12 +1,15 @@
-import { proxyActivities } from "@temporalio/workflow"
+import { patched, proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 /**
- * Two sequential activities, one per datastore. Each writes a fresh
- * project's worth of seed content (datasets, evaluations, issues, queues,
- * scores, ~30 days of telemetry) under the supplied
- * `(organizationId, projectId)` pair.
+ * Seeds the base demo content and the derived read models that make the
+ * demo immediately usable. The first two activities write a fresh project's
+ * worth of seed content (datasets, evaluations, issues, queues, scores,
+ * tau telemetry) under the supplied `(organizationId, projectId)` pair.
+ * The derived activities then build trace-search documents/embeddings and
+ * run taxonomy observation + gardening so behaviours are visible without
+ * waiting for background workers.
  *
  * Postgres → ClickHouse is the dependency order. ClickHouse doesn't
  * strictly read from Postgres at write-time, but the row identity is shared
@@ -14,10 +17,10 @@ import { defaultActivityRetryPolicy } from "./retry-policy.ts"
  * first means the audit trail (and the org's project list) surfaces a
  * non-empty project before the longer telemetry insert kicks off.
  *
- * Activity timeouts: 15 minutes. The full ClickHouse insert (the long
- * pole) typically completes in under five minutes on a healthy cluster
- * but spikes are routine on shared infra; the cap is generous so a slow
- * insert doesn't trip the retry policy.
+ * Activity timeouts: 30 minutes. ClickHouse insertion and derived AI work
+ * (Voyage embeddings + taxonomy naming) are the long poles. The cap is
+ * generous so a slow provider or shared-infra spike doesn't trip the retry
+ * policy.
  *
  * Retry policy: spreads `defaultActivityRetryPolicy` and marks
  * `SeedError` non-retryable. The Postgres seed runner wraps every
@@ -37,8 +40,13 @@ import { defaultActivityRetryPolicy } from "./retry-policy.ts"
  * use-case created it) but its content is partial. Operators clean up
  * via the existing `softDeleteProject` admin server function.
  */
-const { seedDemoProjectPostgresActivity, seedDemoProjectClickHouseActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "15 minutes",
+const {
+  seedDemoProjectPostgresActivity,
+  seedDemoProjectClickHouseActivity,
+  seedDemoProjectTraceSearchActivity,
+  seedDemoProjectTaxonomyActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
   retry: { ...defaultActivityRetryPolicy, nonRetryableErrorTypes: ["SeedError"] },
 })
 
@@ -71,6 +79,13 @@ export interface SeedDemoProjectWorkflowInput {
 export const seedDemoProjectWorkflow = async (input: SeedDemoProjectWorkflowInput) => {
   await seedDemoProjectPostgresActivity(input)
   await seedDemoProjectClickHouseActivity(input)
+
+  // Version gate so workflows already running with the previous two-activity
+  // history can finish replaying without scheduling the derived-data steps.
+  if (patched("seed-demo-project-derived-search-taxonomy-v1")) {
+    await seedDemoProjectTraceSearchActivity(input)
+    await seedDemoProjectTaxonomyActivity(input)
+  }
 
   return { action: "seeded" as const, projectId: input.projectId }
 }


### PR DESCRIPTION
## what changed

Backoffice-created demo projects now seed the derived data that powers the behaviours/search surfaces after the base Postgres and ClickHouse fixtures are inserted.

The `seedDemoProjectWorkflow` now runs two additional activities for new workflow executions:

- trace search seeding: lists the seeded tau traces, builds the same lexical documents used by the trace-search worker, generates Voyage embeddings for eligible chunks, and writes `trace_search_documents` / `trace_search_embeddings`
- taxonomy seeding: records behaviour observations from the seeded sessions and runs project gardening once so behaviours and categories are available without waiting for the periodic worker sweep

The workflow activity timeout is increased to 30 minutes because ClickHouse insertion plus AI-derived data can be slower than the previous base seed path.

## temporal compatibility

The derived-data steps are behind a Temporal `patched()` gate so workflows that were already running with the previous two-activity history can replay and finish without scheduling new commands.

## validation

- `pnpm --filter @app/workflows typecheck`
- `pnpm --filter @app/workflows test -- seed-demo-project-workflow.test.ts`
- `pnpm knip`
