### PR TITLE
fix(flaggers): sanitize truncated snippets

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/shared.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/shared.ts
@@ -24,9 +24,16 @@ export interface SuspiciousSnippet {
 /**
  * Truncate text to maximum excerpt length.
  */
+const loneSurrogatePattern = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g
+
+function replaceLoneSurrogates(text: string): string {
+  return text.replace(loneSurrogatePattern, "�")
+}
+
 export function truncateExcerpt(text: string, maxLength: number = 500): string {
-  if (text.length <= maxLength) return text
-  return `${text.slice(0, maxLength)}...`
+  const wellFormedText = replaceLoneSurrogates(text)
+  if (wellFormedText.length <= maxLength) return wellFormedText
+  return `${replaceLoneSurrogates(wellFormedText.slice(0, maxLength))}...`
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
@@ -6,6 +6,7 @@ import { emptyResponseStrategy } from "./empty-response.ts"
 import { frustrationStrategy } from "./frustration.ts"
 import { lazinessStrategy } from "./laziness.ts"
 import { refusalStrategy } from "./refusal.ts"
+import { truncateExcerpt } from "./shared.ts"
 import { trashingStrategy } from "./trashing.ts"
 
 const ORG_ID = "a".repeat(24)
@@ -57,6 +58,26 @@ const user = (text: string): TraceMessage => ({
 const assistant = (text: string): TraceMessage => ({
   role: "assistant",
   parts: [{ type: "text", content: text }],
+})
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+describe("truncateExcerpt", () => {
+  it("does not emit lone UTF-16 surrogates when truncation splits an emoji", () => {
+    const excerpt = truncateExcerpt(`prefix ${"🎯"} suffix`, 8)
+
+    expect(excerpt).toBe("prefix �...")
+    expect(excerpt).not.toMatch(/[\uD800-\uDFFF]/)
+  })
+
+  it("replaces malformed surrogates in untruncated text", () => {
+    const excerpt = truncateExcerpt("bad \uD83D input")
+
+    expect(excerpt).toBe("bad � input")
+    expect(excerpt).not.toMatch(/[\uD800-\uDFFF]/)
+  })
 })
 
 let toolCallCounter = 0


### PR DESCRIPTION
Fixes malformed Bedrock prompt payloads from flagger classification prompts when a suspicious-snippet excerpt contains a lone UTF-16 surrogate.

The jailbreak flagger truncates suspicious trace snippets before sending them to the model. If truncation splits an emoji surrogate pair, or if the original trace text already contains malformed surrogate code units, the generated prompt can serialize into a payload Bedrock rejects with errors like `Invalid 'messages': unexpected end of hex escape`.

This PR sanitizes flagger excerpts by replacing lone surrogates with `�` before and after truncation. It also adds coverage for both split-emoji truncation and malformed input.

Validated with:

- `pnpm --filter @domain/flaggers test -- src/flagger-strategies/strategies.test.ts`
- `pnpm --filter @domain/flaggers typecheck`