### PR TITLE
feat(web): use <Link> for click-triggered navigation

### DIFF
--- a/.agents/skills/web-frontend/SKILL.md
+++ b/.agents/skills/web-frontend/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: web-frontend
-description: apps/web UI — routes, @repo/ui, TanStack Start server functions and collections, forms (useForm + createFormSubmitHandler + fieldErrorsAsStrings for Zod field errors), Tailwind layout rules, design-system updates, and useEffect / useMountEffect policy.
+description: apps/web UI — routes, @repo/ui, TanStack Start server functions and collections, navigation (Link vs useNavigate), forms (useForm + createFormSubmitHandler + fieldErrorsAsStrings for Zod field errors), Tailwind layout rules, design-system updates, and useEffect / useMountEffect policy.
 ---
 
 # Web app frontend (`apps/web`)
 
-**When to use:** `apps/web` UI — routes, `@repo/ui`, TanStack Start server functions and collections, forms (**`useForm`** with **`createFormSubmitHandler`** + **`fieldErrorsAsStrings`** when Zod validation errors should appear on fields), Tailwind layout rules, design-system updates, and **`useEffect` / `useMountEffect` policy**.
+**When to use:** `apps/web` UI — routes, `@repo/ui`, TanStack Start server functions and collections, **navigation (`Link` vs `useNavigate`)**, forms (**`useForm`** with **`createFormSubmitHandler`** + **`fieldErrorsAsStrings`** when Zod validation errors should appear on fields), Tailwind layout rules, design-system updates, and **`useEffect` / `useMountEffect` policy**.
 
 ## Legacy UI reference
 
@@ -217,6 +217,84 @@ export function useAuthenticatedUser() {
 - Use `useState` for local UI state (modals, form visibility); no global stores
 - Invalidate query cache after mutations: `getQueryClient().invalidateQueries({ queryKey: [...] })`
 - Forms use TanStack React Form (`useForm` + `form.Field`)
+
+## Navigation: `<Link>` vs `useNavigate`
+
+**Rule:** if navigation is triggered by a user clicking something, render a **`<Link>`** (from `@tanstack/react-router`). Reserve **`useNavigate`** for *programmatic* redirects — work the user didn't directly click "go there" for.
+
+A real anchor (`<Link>` → `<a href>`) is the only way to get:
+
+- `href` (hover-preview the URL, right-click → copy/open, browser history correctness)
+- **cmd/ctrl-click and middle-click to open in a new tab**
+- Keyboard activation (Enter) and focus-visible handling for free, no manual `onKeyDown`
+- Works before client-side JS has hydrated
+
+| Trigger | Use |
+| --- | --- |
+| User clicks a button / badge / row / link-styled element to go to a different page | **`<Link>`** |
+| Same-route navigation that only flips a search param (drawer toggle, "apply saved search" on the page you're already on) | `useNavigate` is fine — there is no new document to link to |
+| After a mutation completes (`createX` → go to the new resource, `deleteX` → go back to the listing) | `useNavigate` |
+| Auth flows (sign in, sign out, OAuth callback, redirect-after-login) | `useNavigate` |
+
+### Anti-pattern to avoid
+
+Do **not** put `role="button"`, `onClick`, and a hand-rolled `onKeyDown` on a `Badge`/`div`/`span` to call `navigate(...)`. That re-implements (badly) what `<Link>` already provides, and silently breaks cmd-click / middle-click / right-click flows.
+
+```tsx
+// ❌ Bad — click-to-navigate via useNavigate
+const navigate = useNavigate()
+function open() {
+  navigate({ to: "/projects/$projectSlug/settings/flaggers", params: { projectSlug }, search: { flagger: slug } })
+}
+return (
+  <Badge
+    role="button"
+    tabIndex={0}
+    onClick={open}
+    onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && open()}
+  >
+    {label}
+  </Badge>
+)
+
+// ✅ Good — real anchor wraps the visual badge
+return (
+  <Link
+    to="/projects/$projectSlug/settings/flaggers"
+    params={{ projectSlug }}
+    search={{ flagger: slug }}
+    aria-label={`Open the ${name} flagger settings`}
+    className="inline-flex"
+  >
+    <Badge variant="secondary" size="small" className="cursor-pointer hover:bg-muted">
+      {label}
+    </Badge>
+  </Link>
+)
+```
+
+`Badge` (and other `@repo/ui` primitives that are plain `<div>`s without `asChild`) should be wrapped *inside* the `<Link>` as visual children — the `<Link>` is the interactive anchor.
+
+For `<Button>` (which **does** support `asChild`), use the Radix Slot pattern: `<Button asChild><Link to="…">…</Link></Button>`.
+
+When the clickable element sits inside a larger row-level click handler, add `data-no-navigate` to the `<Link>` (the parent handler skips elements under `[data-no-navigate]`) and `onClick={(e) => e.stopPropagation()}` for belt-and-suspenders.
+
+### Table rows that navigate
+
+If clicking an `InfiniteTable` row opens a different page, use the **`renderRowLink`** prop — not `onRowClick` + `useNavigate`. `renderRowLink` is router-agnostic: the table renders a stretched-link overlay, the app supplies the `<Link>` element.
+
+```tsx
+<InfiniteTable
+  data={items}
+  columns={columns}
+  getRowKey={(r) => r.id}
+  renderRowLink={(row, props) => (
+    <Link to="/items/$id" params={{ id: row.id }} aria-label={`Open ${row.name}`} {...props} />
+  )}
+/>
+```
+
+Keep `onRowClick` only for **same-route** row interactions: selecting a row to open a drawer, applying a saved filter on the same page, toggling expansion state, etc. — the cases where there is no new URL to navigate to.
 
 ## TanStack Form + Zod field errors (`createFormSubmitHandler` + `fieldErrorsAsStrings`)
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
@@ -1,7 +1,7 @@
 import { canUpdateAnnotation, getAnnotationProvenance } from "@domain/annotations"
 import { Avatar, Badge, Button, DropdownMenu, Icon, LatitudeLogo, type MenuOption, Text, Tooltip } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { Link, useParams } from "@tanstack/react-router"
 import { ArrowUpRightIcon, EllipsisIcon, GlobeIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useDeleteAnnotation } from "../../../../../../domains/annotations/annotations.collection.ts"
@@ -31,7 +31,6 @@ export function AnnotationCard({
   onUpdate,
   onDelete,
 }: AnnotationCardProps) {
-  const navigate = useNavigate()
   const { projectSlug } = useParams({ strict: false })
   const [isEditing, setIsEditing] = useState(false)
   const memberByUserId = useMemberByUserIdMap()
@@ -71,22 +70,6 @@ export function AnnotationCard({
   function handleSave(data: { passed: boolean; comment: string; issueId: string | null }) {
     onUpdate(data)
     setIsEditing(false)
-  }
-
-  function openLinkedIssue(event: { stopPropagation: () => void; preventDefault?: () => void }) {
-    if (!annotation.issueId || !projectSlug) {
-      return
-    }
-
-    event.stopPropagation()
-    event.preventDefault?.()
-    void navigate({
-      to: "/projects/$projectSlug/issues",
-      params: { projectSlug },
-      search: {
-        issueId: annotation.issueId,
-      },
-    })
   }
 
   if (isEditing) {
@@ -189,38 +172,45 @@ export function AnnotationCard({
         <div className="flex items-center gap-2 pt-1">
           {linkedIssueName &&
             (() => {
-              const issueLinkBadge = (
+              const isNavigable = Boolean(projectSlug && annotation.issueId)
+              const badge = (
                 <Badge
-                  data-no-navigate
                   variant="outline"
                   size="small"
                   ellipsis
-                  role="button"
-                  tabIndex={0}
-                  aria-label={`Open issue ${linkedIssueName}`}
-                  className="cursor-pointer hover:bg-muted"
+                  {...(isNavigable ? { className: "cursor-pointer hover:bg-muted" } : {})}
                   iconProps={{
                     icon: ShieldAlertIcon,
                     color: "foregroundMuted",
                     placement: "start",
                     className: "stroke-[2.5]",
                   }}
-                  onClick={openLinkedIssue}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      openLinkedIssue(event)
-                    }
-                  }}
                 >
                   {linkedIssueName}
                 </Badge>
               )
+              const trigger =
+                projectSlug && annotation.issueId ? (
+                  <Link
+                    data-no-navigate
+                    to="/projects/$projectSlug/issues"
+                    params={{ projectSlug }}
+                    search={{ issueId: annotation.issueId }}
+                    aria-label={`Open issue ${linkedIssueName}`}
+                    onClick={(event) => event.stopPropagation()}
+                    className="inline-flex min-w-0"
+                  >
+                    {badge}
+                  </Link>
+                ) : (
+                  badge
+                )
               return linkedIssueDescription ? (
-                <Tooltip asChild trigger={issueLinkBadge}>
+                <Tooltip asChild trigger={trigger}>
                   <span className="block max-w-xs whitespace-pre-wrap text-left">{linkedIssueDescription}</span>
                 </Tooltip>
               ) : (
-                issueLinkBadge
+                trigger
               )
             })()}
           {isAgentDraft && (
@@ -250,22 +240,10 @@ interface FlaggerBadgeProps {
  * (e.g. it was de-provisioned after the annotation was created).
  */
 function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
-  const navigate = useNavigate()
   const { data: flaggers = [] } = useProjectFlaggers(projectId)
   const flagger = flaggers.find((candidate) => candidate.slug === slug)
   const name = flagger?.name ?? humanizeFlaggerSlug(slug)
   const label = `${name} flagger`
-
-  function openFlaggerSettings(event: { stopPropagation: () => void; preventDefault?: () => void }) {
-    if (!projectSlug) return
-    event.stopPropagation()
-    event.preventDefault?.()
-    void navigate({
-      to: "/projects/$projectSlug/settings/flaggers",
-      params: { projectSlug },
-      search: { flagger: slug },
-    })
-  }
 
   if (!projectSlug) {
     return (
@@ -279,24 +257,24 @@ function FlaggerBadge({ projectId, projectSlug, slug }: FlaggerBadgeProps) {
     <Tooltip
       asChild
       trigger={
-        <Badge
+        <Link
           data-no-navigate
-          variant="secondary"
-          size="small"
-          role="button"
-          tabIndex={0}
+          to="/projects/$projectSlug/settings/flaggers"
+          params={{ projectSlug }}
+          search={{ flagger: slug }}
           aria-label={`Open the ${name} flagger settings`}
-          className="cursor-pointer hover:bg-muted"
-          iconProps={{ icon: ArrowUpRightIcon, color: "foregroundMuted", placement: "end" }}
-          onClick={openFlaggerSettings}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              openFlaggerSettings(event)
-            }
-          }}
+          onClick={(event) => event.stopPropagation()}
+          className="inline-flex"
         >
-          {label}
-        </Badge>
+          <Badge
+            variant="secondary"
+            size="small"
+            className="cursor-pointer hover:bg-muted"
+            iconProps={{ icon: ArrowUpRightIcon, color: "foregroundMuted", placement: "end" }}
+          >
+            {label}
+          </Badge>
+        </Link>
       }
     >
       Flagged automatically by the {name} flagger — open its settings

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -11,7 +11,7 @@ import {
   useToast,
 } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
-import { Link, createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { useCallback, useState } from "react"
 import { useDatasetsInfiniteScroll } from "../../../../../domains/datasets/datasets.collection.ts"
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -11,7 +11,7 @@ import {
   useToast,
 } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
-import { createFileRoute } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { useCallback, useState } from "react"
 import { useDatasetsInfiniteScroll } from "../../../../../domains/datasets/datasets.collection.ts"
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
@@ -85,16 +85,17 @@ function DatasetsPage() {
   })
 
   const getRowKey = useCallback((d: DatasetRecord) => d.id, [])
-  const onRowClick = useCallback(
-    (d: DatasetRecord) =>
-      navigate({
-        to: "/projects/$projectSlug/datasets/$datasetId",
-        params: { projectSlug, datasetId: d.id },
-      }),
-    [navigate, projectSlug],
+  const renderRowLink = useCallback(
+    (d: DatasetRecord, props: { className: string }) => (
+      <Link
+        to="/projects/$projectSlug/datasets/$datasetId"
+        params={{ projectSlug, datasetId: d.id }}
+        aria-label={`Open dataset ${d.name}`}
+        {...props}
+      />
+    ),
+    [projectSlug],
   )
-
-  const getRowAriaLabel = useCallback((d: DatasetRecord) => `Open dataset ${d.name}`, [])
 
   const hasNoDatasets = datasets.length === 0
   const showEmptyState = !isLoading && hasNoDatasets
@@ -154,9 +155,7 @@ function DatasetsPage() {
             isLoading={isLoading}
             columns={columns}
             getRowKey={getRowKey}
-            onRowClick={onRowClick}
-            rowInteractionRole="link"
-            getRowAriaLabel={getRowAriaLabel}
+            renderRowLink={renderRowLink}
             infiniteScroll={infiniteScroll}
             sorting={sorting}
             defaultSorting={DEFAULT_SORTING}

--- a/apps/web/src/routes/backoffice/organizations/index.tsx
+++ b/apps/web/src/routes/backoffice/organizations/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import { useInfiniteQuery } from "@tanstack/react-query"
-import { Link, createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { useCallback, useMemo } from "react"
 import {
   type AdminOrganizationUsageItemDto,

--- a/apps/web/src/routes/backoffice/organizations/index.tsx
+++ b/apps/web/src/routes/backoffice/organizations/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import { useInfiniteQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { useCallback, useMemo } from "react"
 import {
   type AdminOrganizationUsageItemDto,
@@ -22,8 +22,6 @@ export const Route = createFileRoute("/backoffice/organizations/")({
 })
 
 function BackofficeOrganizationsByUsagePage() {
-  const navigate = useNavigate()
-
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ["backoffice", "organizations-by-usage"],
     queryFn: ({ pageParam }) =>
@@ -125,14 +123,16 @@ function BackofficeOrganizationsByUsagePage() {
     [],
   )
 
-  const handleRowClick = useCallback(
-    (row: AdminOrganizationUsageItemDto) => {
-      void navigate({
-        to: "/backoffice/organizations/$organizationId",
-        params: { organizationId: row.id },
-      })
-    },
-    [navigate],
+  const renderRowLink = useCallback(
+    (row: AdminOrganizationUsageItemDto, props: { className: string }) => (
+      <Link
+        to="/backoffice/organizations/$organizationId"
+        params={{ organizationId: row.id }}
+        aria-label={`Open ${row.name}`}
+        {...props}
+      />
+    ),
+    [],
   )
 
   return (
@@ -149,9 +149,7 @@ function BackofficeOrganizationsByUsagePage() {
           isLoading={isLoading}
           columns={columns}
           getRowKey={(row) => row.id}
-          onRowClick={handleRowClick}
-          getRowAriaLabel={(row) => `Open ${row.name}`}
-          rowInteractionRole="link"
+          renderRowLink={renderRowLink}
           infiniteScroll={infiniteScroll}
           blankSlate="No organizations have produced traces in the last 30 days."
         />

--- a/apps/web/src/routes/backoffice/wrapped.tsx
+++ b/apps/web/src/routes/backoffice/wrapped.tsx
@@ -150,13 +150,20 @@ function ListColumn({
     [],
   )
 
-  const handleRowClick = useCallback((row: WrappedAnalyticsListItemDto) => {
-    // Open in a new tab. The Wrapped page is a public surface, not part of
-    // the backoffice tree, so we never want to navigate the admin in place.
-    if (typeof window !== "undefined") {
-      window.open(`/wrapped/${row.id}`, "_blank", "noopener,noreferrer")
-    }
-  }, [])
+  // The Wrapped page is a public surface, not part of the backoffice tree, so
+  // rows open in a new tab via a plain anchor (no TanStack route navigation).
+  const renderRowLink = useCallback(
+    (row: WrappedAnalyticsListItemDto, props: { className: string }) => (
+      <a
+        href={`/wrapped/${row.id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Open Wrapped report for ${row.projectName}`}
+        {...props}
+      />
+    ),
+    [],
+  )
 
   return (
     <div className="flex min-h-0 flex-col overflow-hidden border-r border-border">
@@ -166,9 +173,7 @@ function ListColumn({
           isLoading={isLoading}
           columns={columns}
           getRowKey={(row) => row.id}
-          onRowClick={handleRowClick}
-          getRowAriaLabel={(row) => `Open Wrapped report for ${row.projectName}`}
-          rowInteractionRole="link"
+          renderRowLink={renderRowLink}
           blankSlate="No Wrapped reports older than 7 days yet."
         />
       </div>

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight } from "lucide-react"
-import { type KeyboardEvent, type ReactNode, memo, useCallback } from "react"
+import { type KeyboardEvent, memo, type ReactNode, useCallback } from "react"
 import { cn } from "../../utils/cn.ts"
 import { Checkbox, type CheckedState } from "../checkbox/checkbox.tsx"
 import { Text } from "../text/text.tsx"

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -1,9 +1,12 @@
 import { ChevronRight } from "lucide-react"
-import { type KeyboardEvent, memo, useCallback } from "react"
+import { type KeyboardEvent, type ReactNode, memo, useCallback } from "react"
 import { cn } from "../../utils/cn.ts"
 import { Checkbox, type CheckedState } from "../checkbox/checkbox.tsx"
 import { Text } from "../text/text.tsx"
 import type { InfiniteTableColumn } from "./types.ts"
+
+const LINK_STRETCH_CLASS =
+  "absolute inset-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
 
 const SELECTION_COLUMN_WIDTH = 48
 
@@ -20,6 +23,7 @@ interface DataRowProps<T> {
   isExpandable?: boolean
   isExpanded?: boolean
   onClick?: (row: T) => void
+  renderRowLink?: (row: T, props: { className: string }) => ReactNode
   rowInteractionRole?: "button" | "link"
   rowAriaLabel?: string
   dataIndex: number
@@ -39,6 +43,7 @@ function DataRowInner<T>({
   isExpandable,
   isExpanded,
   onClick,
+  renderRowLink,
   rowInteractionRole = "button",
   rowAriaLabel,
   dataIndex,
@@ -54,17 +59,18 @@ function DataRowInner<T>({
     [onClick, row],
   )
 
-  const isClickable = Boolean(onClick)
-  const interactiveRole = isClickable ? rowInteractionRole : undefined
-  const isExpandToggleRow = Boolean(isClickable && isExpandable && !isSubRow)
+  const hasRowLink = Boolean(renderRowLink)
+  const isClickable = Boolean(onClick) || hasRowLink
+  const interactiveRole = onClick ? rowInteractionRole : undefined
+  const isExpandToggleRow = Boolean(onClick && isExpandable && !isSubRow)
   const ariaExpanded = isExpandToggleRow ? Boolean(isExpanded) : undefined
-  const ariaPressed = isClickable && interactiveRole === "button" && !isExpandToggleRow ? Boolean(isActive) : undefined
+  const ariaPressed = onClick && interactiveRole === "button" && !isExpandToggleRow ? Boolean(isActive) : undefined
 
   return (
     <tr
       data-index={dataIndex}
       role={interactiveRole}
-      {...(isClickable && rowAriaLabel ? { "aria-label": rowAriaLabel } : {})}
+      {...(onClick && rowAriaLabel ? { "aria-label": rowAriaLabel } : {})}
       {...(ariaExpanded !== undefined ? { "aria-expanded": ariaExpanded } : {})}
       {...(ariaPressed !== undefined ? { "aria-pressed": ariaPressed } : {})}
       className={cn(
@@ -72,10 +78,11 @@ function DataRowInner<T>({
           "bg-secondary": !isSubRow && !isExpanded,
           "bg-muted": isExpanded && !isActive,
           "bg-accent": isActive,
-          "hover:bg-muted cursor-pointer": onClick && !isExpanded && !isActive,
-          "hover:bg-accent cursor-pointer": onClick && (isExpanded || isActive),
+          "hover:bg-muted cursor-pointer": isClickable && !isExpanded && !isActive,
+          "hover:bg-accent cursor-pointer": isClickable && (isExpanded || isActive),
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset":
-            isClickable,
+            Boolean(onClick),
+          relative: hasRowLink,
         },
         rowClassName,
       )}
@@ -90,6 +97,7 @@ function DataRowInner<T>({
             "px-2 py-2 w-8",
             "first:rounded-l-lg last:rounded-r-lg",
             "align-middle text-sm leading-5 whitespace-nowrap",
+            { "relative z-[1]": hasRowLink },
           )}
         >
           {isExpandable && (
@@ -108,6 +116,7 @@ function DataRowInner<T>({
             "px-4 py-2",
             "first:rounded-l-lg last:rounded-r-lg overflow-hidden",
             "align-middle text-sm leading-5 font-normal whitespace-nowrap text-ellipsis",
+            { "relative z-[1]": hasRowLink },
           )}
           onClick={(e) => {
             e.stopPropagation()
@@ -119,9 +128,10 @@ function DataRowInner<T>({
           <Checkbox checked={checkedState ?? false} className="pointer-events-none" />
         </td>
       )}
-      {columns.map((col) => {
+      {columns.map((col, columnIndex) => {
         const content = col.render(row, dataIndex)
         const useEllipsis = col.ellipsis !== false
+        const isFirstCol = columnIndex === 0
         return (
           <td
             key={col.key}
@@ -135,6 +145,7 @@ function DataRowInner<T>({
               col.cellClassName,
             )}
           >
+            {isFirstCol && renderRowLink ? renderRowLink(row, { className: LINK_STRETCH_CLASS }) : null}
             {typeof content === "string" ? (
               <Text.H5 {...(useEllipsis ? { noWrap: true, ellipsis: true } : {})}>{content || "-"}</Text.H5>
             ) : (

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -76,6 +76,7 @@ export function InfiniteTable<T>({
   onRowClick,
   rowInteractionRole = "button",
   getRowAriaLabel,
+  renderRowLink,
   activeRowKey,
   activeRowAutoScroll = false,
   selection,
@@ -324,6 +325,7 @@ export function InfiniteTable<T>({
                           ...(getRowAriaLabel ? { rowAriaLabel: getRowAriaLabel(row) } : {}),
                         }
                       : {})}
+                    {...(renderRowLink ? { renderRowLink } : {})}
                     dataIndex={virtualRow.index}
                   />
                   {expanded?.isLoading && renderExpandedSkeletonRows(columns, hasExpansion, !!selection)}
@@ -384,6 +386,7 @@ export function InfiniteTable<T>({
                                 ...(getRowAriaLabel ? { rowAriaLabel: getRowAriaLabel(subRow) } : {}),
                               }
                             : {})}
+                          {...(renderRowLink ? { renderRowLink } : {})}
                           dataIndex={virtualRow.index}
                           isSubRow
                         />

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -102,9 +102,27 @@ export type InfiniteTableProps<T> =
       getRowAriaLabel: (row: T) => string
       /** Semantic role for clickable rows (`link` when the action navigates). Defaults to `button`. */
       rowInteractionRole?: "button" | "link"
+      renderRowLink?: undefined
+    })
+  | (InfiniteTableSharedProps<T> & {
+      /**
+       * Render a real anchor for navigation rows (router-agnostic — the app provides the element).
+       * The `props.className` must be spread onto the anchor to apply the stretched-link overlay.
+       * Use this instead of `onRowClick` whenever clicking navigates to a different page.
+       *
+       * @example
+       * renderRowLink={(row, props) => (
+       *   <Link to="/items/$id" params={{ id: row.id }} {...props} aria-label={`Open ${row.name}`} />
+       * )}
+       */
+      renderRowLink: (row: T, props: { className: string }) => ReactNode
+      onRowClick?: undefined
+      getRowAriaLabel?: undefined
+      rowInteractionRole?: undefined
     })
   | (InfiniteTableSharedProps<T> & {
       onRowClick?: undefined
       getRowAriaLabel?: undefined
       rowInteractionRole?: undefined
+      renderRowLink?: undefined
     })


### PR DESCRIPTION
## Summary

Click-triggered navigations now render real anchors (`<Link>` from `@tanstack/react-router`, or plain `<a target="_blank">` when the target sits outside the router tree). `useNavigate` stays for programmatic redirects only — after a mutation, in auth flows, or other non-click code paths.

The win is correctness for things the previous implementation silently broke:

- cmd/ctrl-click and **middle-click** open the target in a new tab
- `href` is present for hover preview, right-click → copy/open, and link sharing
- Keyboard activation (Enter) and focus rings come from the anchor, no hand-rolled `onKeyDown`
- Clicks work before the client bundle has hydrated

## What changed

**`InfiniteTable` — new `renderRowLink` prop** (`packages/ui/src/components/infinite-table/`)

Router-agnostic: the app supplies the anchor element. The table sets `position: relative` on the `<tr>` and the supplied anchor stretches over the row via `absolute inset-0`. Selection and expansion cells get `relative z-[1]` so they stay clickable above the overlay if a future caller combines them.

Use `renderRowLink` for rows that navigate to a different page. Keep `onRowClick` for same-route interactions (toggling a drawer via search params, applying a saved search on the page you're already on, expansion toggles, row selection).

```tsx
<InfiniteTable
  data={items}
  columns={columns}
  getRowKey={(r) => r.id}
  renderRowLink={(row, props) => (
    <Link to="/items/$id" params={{ id: row.id }} aria-label={`Open ${row.name}`} {...props} />
  )}
/>
```

**Four call sites converted**

- `annotation-card.tsx` — `FlaggerBadge` and the issue-link badge wrap their `<Badge>` in a `<Link>`. The `Badge` becomes purely visual; the `<Link>` is the interactive anchor. Removed `useNavigate`, `openFlaggerSettings`, `openLinkedIssue`, and the `role="button"` / manual `onKeyDown` boilerplate.
- `datasets/index.tsx` and `backoffice/organizations/index.tsx` — `onRowClick` + `useNavigate` replaced with `renderRowLink`.
- `backoffice/wrapped.tsx` — `window.open('/wrapped/:id', '_blank')` replaced with `renderRowLink` returning a plain `<a href target="_blank" rel="noopener noreferrer">`. `/wrapped` is a public surface outside the backoffice router tree, so no `<Link>`.

**Skill doc** (`.agents/skills/web-frontend/SKILL.md`)

Adds a `<Link>` vs `useNavigate` section: the rule, the click-vs-programmatic table, the before/after anti-pattern, the `Button asChild` Radix pattern for primitives that support it, the `data-no-navigate` note for click-inside-clickable cases, and the `renderRowLink` rule for tables.

## Out of scope

- `saved-searches-list.tsx` row click — same `/search` route, only search params change. That's the documented "same-route param flip" exception and stays on `useNavigate`.
- All post-mutation `useNavigate` calls in `dataset-name-edit.tsx`, `add-to-dataset-modal.tsx`, `datasets/index.tsx` `handleCreate`, and the onboarding callback — these are programmatic redirects after async work, not click handlers.

## Test plan

- [ ] `pnpm --filter @repo/ui typecheck` — clean
- [ ] `pnpm --filter web typecheck` — same 114 pre-existing errors as `development` (all unrelated `@platform/db-postgres` taxonomy)
- [ ] `pnpm --filter @repo/ui test` — 88/88 pass
- [ ] Datasets list: left-click navigates; **cmd/middle-click opens the dataset in a new tab**; hover shows the URL; keyboard Tab + Enter activates
- [ ] Backoffice → Organizations: same checks against the org detail page
- [ ] Backoffice → Wrapped: row click opens `/wrapped/:id` in a new tab (unchanged behavior); cmd-click and right-click → "Open in new tab" now work properly because it's a real anchor
- [ ] Annotation card flagger badge: click opens flagger settings with the flagger pre-selected; cmd-click opens new tab; the card's own row navigation does not also fire
- [ ] Annotation card issue-link badge: same checks for `/issues?issueId=…`
- [ ] Saved searches list (intentionally unchanged): row click still applies the saved search on the same `/search` page