### PR TITLE
Issues panel in session drawer (LAT-624)

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -97,7 +97,8 @@ export const createAnnotation = createServerFn({ method: "POST" })
       queueId: z.string().optional(),
       value: z.number(),
       passed: z.boolean(),
-      feedback: z.string().min(1),
+      // Empty feedback is allowed — `passed` carries the signal. Downstream issue eligibility drops empty-feedback rows before embedding.
+      feedback: z.string(),
       anchor: annotationAnchorSchema.optional(),
       issueId: z.string().optional(),
     }),
@@ -147,7 +148,7 @@ export const updateAnnotation = createServerFn({ method: "POST" })
       queueId: z.string().optional(),
       value: z.number(),
       passed: z.boolean(),
-      feedback: z.string().min(1),
+      feedback: z.string(),
       issueId: z.string().optional(),
     }),
   )
@@ -238,7 +239,7 @@ export const listAnnotationsBySession = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string().length(32)).max(100),
+      traceIds: z.array(z.string().length(32)).max(500),
       limit: z.number().optional(),
       offset: z.number().optional(),
       draftMode: scoreDraftModeSchema.optional(),
@@ -275,7 +276,7 @@ export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string().length(32)).max(100),
+      traceIds: z.array(z.string().length(32)).max(500),
       draftMode: scoreDraftModeSchema.optional(),
     }),
   )

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -261,7 +261,7 @@ export const getSessionDetail = createServerFn({ method: "GET" })
  * `traceIds` (not `session_id`) so orphan sessions still surface their issues.
  * Ordered by last-seen descending (the CH query's order).
  */
-interface SessionIssueRecord {
+export interface SessionIssueRecord {
   readonly id: string
   readonly name: string
   readonly description: string

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -277,7 +277,7 @@ export const listSessionIssues = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string().length(32)).max(100),
+      traceIds: z.array(z.string().length(32)).max(500),
     }),
   )
   .handler(async ({ data }): Promise<readonly SessionIssueRecord[]> => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-conversation-annotation-focus.ts
@@ -46,11 +46,18 @@ export function useConversationAnnotationFocus({
     textSelectionPopoverControlsRef,
   })
 
+  // TODO(frontend-use-effect-policy): reactive on `isConversationActive` flipping
+  // true — drains a scroll request that was queued while the tab was mounted but
+  // not visible. No callback exists at the activation site; this needs the effect.
   useEffect(() => {
     if (isConversationActive) executePendingScroll()
   }, [isConversationActive, executePendingScroll])
 
   const focusHandledRef = useRef<string | null>(null)
+  // TODO(frontend-use-effect-policy): four independent async conditions must all
+  // be true simultaneously (tab active, detail loaded, annotations loaded, focus
+  // id present). Replacing this with an event would require a multi-source state
+  // machine; the effect is the right shape here.
   useEffect(() => {
     // Cleared request → reset the guard so the next one (even the same id) fires.
     if (!focusAnnotationId) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-trace-annotations-data.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-trace-annotations-data.test.ts
@@ -152,7 +152,7 @@ describe("useTraceAnnotationsData", () => {
       )
     })
 
-    it("trims whitespace and defaults empty comment to single space", () => {
+    it("trims whitespace and leaves empty comments empty", () => {
       const { result } = renderHook(() => useTraceAnnotationsData({ projectId: "proj-1", traceId: "trace-1" }))
 
       act(() => {
@@ -165,7 +165,7 @@ describe("useTraceAnnotationsData", () => {
 
       expect(mockMutate).toHaveBeenCalledWith(
         expect.objectContaining({
-          feedback: " ",
+          feedback: "",
         }),
         undefined,
       )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-trace-annotations-data.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-trace-annotations-data.ts
@@ -121,7 +121,7 @@ export function useTraceAnnotationsData({ projectId, traceId }: UseTraceAnnotati
 
   const createAnnotation = useCallback(
     (data: AnnotationFormData, options?: { onSuccess?: () => void }) => {
-      const feedback = data.comment.trim() || " "
+      const feedback = data.comment.trim()
       createMutation.mutate(
         {
           projectId,
@@ -141,7 +141,7 @@ export function useTraceAnnotationsData({ projectId, traceId }: UseTraceAnnotati
 
   const updateAnnotation = useCallback(
     (scoreId: string, data: AnnotationFormData, options?: { onSuccess?: () => void }) => {
-      const feedback = data.comment.trim() || " "
+      const feedback = data.comment.trim()
       updateMutation.mutate(
         {
           scoreId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
@@ -55,7 +55,7 @@ export function TraceAnnotationsList({
           traceId,
           value: data.passed ? 1 : 0,
           passed: data.passed,
-          feedback: data.comment || " ",
+          feedback: data.comment.trim(),
           ...(data.issueId ? { issueId: data.issueId } : {}),
         })
       }
@@ -67,7 +67,7 @@ export function TraceAnnotationsList({
           traceId,
           value: data.passed ? 1 : 0,
           passed: data.passed,
-          feedback: data.comment || " ",
+          feedback: data.comment.trim(),
           issueId: data.issueId ?? undefined,
         })
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -4,8 +4,9 @@ import { ChevronLeftIcon } from "lucide-react"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
 import { useSessionDetail } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { IssueSlot } from "./session-detail-drawer/issue-slot.tsx"
 import { isSessionTab, SessionSlot } from "./session-detail-drawer/session-slot.tsx"
-import { SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
+import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
 import { isTraceDetailTab, type TraceDetailTabId, TraceSlot } from "./session-detail-drawer/trace-slot.tsx"
 import { useSessionTraces } from "./session-detail-drawer/use-session-traces.ts"
 
@@ -28,6 +29,7 @@ export function SessionDetailDrawer({
   readonly searchQuery?: string
 }) {
   const [traceId, setTraceId] = useParamState("traceId", "")
+  const [issueId, setIssueId] = useParamState("issueId", "")
   const [, setFocusAnnotationId] = useParamState("annotationId", "")
   const [q] = useParamState("q", "")
   const defaultSessionTab = q.length > 0 ? "conversation" : "session"
@@ -46,13 +48,24 @@ export function SessionDetailDrawer({
   })
   const { traces } = useSessionTraces({ projectId, sessionId })
 
-  const showTrace = traceId.length > 0
+  // Trace beats issue when both are set — clicking a trace from inside the
+  // issue slot sets `traceId` without touching `issueId`, and we want the
+  // trace pane on top. Going back to session clears both, so we never end up
+  // in a state where the issue would reappear after the trace closes.
+  const detailKind: DetailSlotKind | null = traceId.length > 0 ? "trace" : issueId.length > 0 ? "issue" : null
+  const showDetail = detailKind !== null
 
   const openTrace = (nextTraceId: string, options: OpenTraceOptions = {}) => {
     const { focusAnnotationId, targetTab } = options
     setFocusAnnotationId(focusAnnotationId ?? "")
     setTraceTab(targetTab ?? (focusAnnotationId ? "conversation" : "trace"))
     setTraceId(nextTraceId)
+  }
+
+  const openIssue = (nextIssueId: string) => {
+    setFocusAnnotationId("")
+    setTraceId("")
+    setIssueId(nextIssueId)
   }
 
   const focusAnnotationInConversation = (annotationId: string) => {
@@ -63,18 +76,20 @@ export function SessionDetailDrawer({
   const backToSession = () => {
     setFocusAnnotationId("")
     setTraceId("")
+    setIssueId("")
   }
 
   const handleClose = () => {
     setFocusAnnotationId("")
     setTraceId("")
+    setIssueId("")
     onClose()
   }
 
   useHotkeys([
     {
       hotkey: "Escape",
-      callback: () => (showTrace ? backToSession() : handleClose()),
+      callback: () => (showDetail ? backToSession() : handleClose()),
       options: { ignoreInputs: true, conflictBehavior: "allow" },
     },
   ])
@@ -89,7 +104,7 @@ export function SessionDetailDrawer({
         </>
       }
       actions={
-        showTrace ? (
+        showDetail ? (
           <Tooltip
             asChild
             side="bottom"
@@ -117,7 +132,7 @@ export function SessionDetailDrawer({
         </div>
       ) : (
         <SlotTransition
-          showTrace={showTrace}
+          detailKind={detailKind}
           sessionSlot={
             <SessionSlot
               projectId={projectId}
@@ -127,15 +142,17 @@ export function SessionDetailDrawer({
               activeTab={activeTab}
               onActiveTabChange={setActiveTab}
               onOpenTrace={openTrace}
+              onOpenIssue={openIssue}
               onOpenInConversation={focusAnnotationInConversation}
               {...(searchQuery ? { searchQuery } : {})}
             />
           }
           traceSlot={
-            showTrace ? (
+            detailKind === "trace" ? (
               <TraceSlot projectId={projectId} traceId={traceId} {...(searchQuery ? { searchQuery } : {})} />
             ) : null
           }
+          issueSlot={detailKind === "issue" ? <IssueSlot projectId={projectId} issueId={issueId} /> : null}
         />
       )}
     </DetailDrawer>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -48,10 +48,12 @@ export function SessionDetailDrawer({
   })
   const { traces } = useSessionTraces({ projectId, sessionId })
 
-  // Trace beats issue when both are set — clicking a trace from inside the
-  // issue slot sets `traceId` without touching `issueId`, and we want the
-  // trace pane on top. Going back to session clears both, so we never end up
-  // in a state where the issue would reappear after the trace closes.
+  // Defensive precedence for URLs that arrive with both params already set
+  // (deep links, browser history, hand-edited URLs). Our own code never sets
+  // both at the same time — opening a trace from inside the issue slot uses
+  // `IssueDetailBody`'s local Sheet state, not the `traceId` param. Trace
+  // wins so a stale `issueId` doesn't shadow the requested trace; "View
+  // session" clears both so we can't land in an ambiguous state after close.
   const detailKind: DetailSlotKind | null = traceId.length > 0 ? "trace" : issueId.length > 0 ? "issue" : null
   const showDetail = detailKind !== null
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/annotations-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/annotations-tab.tsx
@@ -51,7 +51,7 @@ export function AnnotationsTab({
           traceId: latestTraceId,
           value: annotationData.passed ? 1 : 0,
           passed: annotationData.passed,
-          feedback: annotationData.comment || " ",
+          feedback: annotationData.comment.trim(),
           ...(annotationData.issueId ? { issueId: annotationData.issueId } : {}),
         })
       }}
@@ -65,7 +65,7 @@ export function AnnotationsTab({
           traceId,
           value: annotationData.passed ? 1 : 0,
           passed: annotationData.passed,
-          feedback: annotationData.comment || " ",
+          feedback: annotationData.comment.trim(),
           issueId: annotationData.issueId ?? undefined,
         })
       }}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/issue-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/issue-slot.tsx
@@ -1,0 +1,14 @@
+import { IssueDetailBody } from "../../issues/-components/issue-detail-drawer.tsx"
+
+/**
+ * The issue slot reuses the standalone issue drawer's body (`IssueDetailBody`)
+ * — same header, lifecycle actions, trend, evaluations, traces table, and
+ * trace overlay — minus the `DetailDrawer` chrome and next/prev nav.
+ *
+ * Clicking a trace inside this slot opens the body's fixed-position overlay
+ * on top of everything (same pattern as the standalone issues route), so
+ * Escape returns the user to the issue panel, not to the session view.
+ */
+export function IssueSlot({ projectId, issueId }: { readonly projectId: string; readonly issueId: string }) {
+  return <IssueDetailBody projectId={projectId} issueId={issueId} />
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/issues-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/issues-tab.tsx
@@ -1,32 +1,97 @@
-import { Text } from "@repo/ui"
-import { formatCount, relativeTime } from "@repo/utils"
+import { InfiniteTable, type InfiniteTableColumn, type InfiniteTableSorting, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { useMemo, useState } from "react"
 import { IssueLifecycleStatuses } from "../../../../../../components/issues/issue-lifecycle-statuses.tsx"
+import { getPrimaryLifecycleState } from "../../../../../../components/issues/lifecycle-formatters.ts"
 import { useSessionIssues } from "../../../../../../domains/sessions/sessions.collection.ts"
-import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
+import type { SessionIssueRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
+
+// Mirrors the standalone issues table's primary-state ordering so "Status" sort
+// surfaces the most actionable issues first (regressed → escalating → new → …).
+const LIFECYCLE_PRIORITY: readonly string[] = ["regressed", "escalating", "new", "ongoing", "resolved", "ignored"]
+
+const DEFAULT_SORTING: InfiniteTableSorting = {
+  column: "lastSeen",
+  direction: "desc",
+}
+
+function lifecycleRank(states: readonly string[]): number {
+  const primary = getPrimaryLifecycleState(states)
+  if (!primary) return LIFECYCLE_PRIORITY.length
+  const idx = LIFECYCLE_PRIORITY.indexOf(primary)
+  return idx === -1 ? LIFECYCLE_PRIORITY.length : idx
+}
+
+function compareIssues(a: SessionIssueRecord, b: SessionIssueRecord, sorting: InfiniteTableSorting): number {
+  const dir = sorting.direction === "asc" ? 1 : -1
+  switch (sorting.column) {
+    case "name":
+      return dir * a.name.localeCompare(b.name)
+    case "state":
+      return dir * (lifecycleRank(a.states) - lifecycleRank(b.states))
+    case "lastSeen":
+      return dir * (Date.parse(a.lastSeenAt) - Date.parse(b.lastSeenAt))
+    default:
+      return 0
+  }
+}
 
 export function IssuesTab({
   projectId,
   traceIds,
-  traceNumberById,
-  onOpenTrace,
+  onOpenIssue,
 }: {
   readonly projectId: string
   readonly traceIds: readonly string[]
-  readonly traceNumberById: ReadonlyMap<string, number>
-  /** Default target tab is `"trace"` (the Trace overview), per the session panel contract. */
-  readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
+  readonly onOpenIssue: (issueId: string) => void
 }) {
   const { data: issues, isLoading, isError } = useSessionIssues({ projectId, traceIds })
+  const [sorting, setSorting] = useState<InfiniteTableSorting>(DEFAULT_SORTING)
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-4">
-        {[0, 1].map((i) => (
-          <div key={i} className="h-20 animate-pulse rounded-md bg-muted" />
-        ))}
-      </div>
-    )
-  }
+  const sortedIssues = useMemo(() => {
+    if (!issues) return []
+    return [...issues].sort((a, b) => compareIssues(a, b, sorting))
+  }, [issues, sorting])
+
+  const columns = useMemo<InfiniteTableColumn<SessionIssueRecord>[]>(
+    () => [
+      {
+        key: "name",
+        header: "Issue",
+        sortKey: "name",
+        minWidth: 200,
+        render: (issue) => (
+          <Text.H5 noWrap ellipsis>
+            {issue.name}
+          </Text.H5>
+        ),
+      },
+      {
+        key: "status",
+        header: "Status",
+        sortKey: "state",
+        width: 130,
+        minWidth: 110,
+        render: (issue) => {
+          const primaryState = getPrimaryLifecycleState(issue.states)
+          return <IssueLifecycleStatuses states={primaryState ? [primaryState] : []} wrap={false} />
+        },
+      },
+      {
+        key: "seenAt",
+        header: "Seen at",
+        sortKey: "lastSeen",
+        width: 120,
+        minWidth: 100,
+        render: (issue) => (
+          <Text.H5 color="foregroundMuted" noWrap>
+            {relativeTime(new Date(issue.lastSeenAt))}
+          </Text.H5>
+        ),
+      },
+    ],
+    [],
+  )
 
   if (isError) {
     return (
@@ -36,48 +101,20 @@ export function IssuesTab({
     )
   }
 
-  if (!issues || issues.length === 0) {
-    return (
-      <div className="flex flex-1 items-center justify-center px-6 py-10">
-        <Text.H5 color="foregroundMuted">No issues detected in this session.</Text.H5>
-      </div>
-    )
-  }
-
   return (
-    <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-3">
-      {issues.map((issue) => (
-        <div key={issue.id} className="flex flex-col gap-2 rounded-md border px-3 py-2.5">
-          <div className="flex items-start justify-between gap-2">
-            <Text.H5>{issue.name}</Text.H5>
-            <IssueLifecycleStatuses states={issue.states} wrap={false} />
-          </div>
-          <div className="flex items-center gap-3">
-            <Text.H6 color="foregroundMuted">
-              {formatCount(issue.occurrences)} occurrence{issue.occurrences === 1 ? "" : "s"}
-            </Text.H6>
-            <Text.H6 color="foregroundMuted">last seen {relativeTime(new Date(issue.lastSeenAt))}</Text.H6>
-          </div>
-          {issue.traceIds.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-1.5">
-              <Text.H6 color="foregroundMuted">Affected:</Text.H6>
-              {issue.traceIds.map((traceId) => {
-                const traceNumber = traceNumberById.get(traceId)
-                return (
-                  <button
-                    type="button"
-                    key={traceId}
-                    onClick={() => onOpenTrace(traceId)}
-                    className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary hover:bg-primary/20"
-                  >
-                    {traceNumber !== undefined ? `Trace ${traceNumber}` : traceId.slice(0, 8)}
-                  </button>
-                )
-              })}
-            </div>
-          ) : null}
-        </div>
-      ))}
+    <div className="flex min-h-0 flex-1 flex-col px-6">
+      <InfiniteTable
+        data={sortedIssues}
+        isLoading={isLoading}
+        columns={columns}
+        getRowKey={(issue) => issue.id}
+        onRowClick={(issue) => onOpenIssue(issue.id)}
+        getRowAriaLabel={(issue) => `Open issue ${issue.name}`}
+        sorting={sorting}
+        defaultSorting={DEFAULT_SORTING}
+        onSortChange={setSorting}
+        blankSlate="No issues detected in this session."
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -35,18 +35,18 @@ export function SessionSlot({
   activeTab,
   onActiveTabChange,
   onOpenTrace,
+  onOpenIssue,
   onOpenInConversation,
   searchQuery,
 }: {
   readonly projectId: string
   readonly session: SessionDetailRecord
-  /** Session's traces, ordered by start time — used for the "Trace N" badges. */
   readonly traces: readonly TraceRecord[]
   readonly latestTraceId: string
   readonly activeTab: SessionTabId
   readonly onActiveTabChange: (tab: SessionTabId) => void
   readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
-  /** Inline annotation on the latest trace → switch to Conversation, focused on it. */
+  readonly onOpenIssue: (issueId: string) => void
   readonly onOpenInConversation: (annotationId: string) => void
   readonly searchQuery?: string
 }) {
@@ -182,12 +182,7 @@ export function SessionSlot({
         )}
         {visitedTabs.has("issues") && (
           <div className={activeTab === "issues" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-            <IssuesTab
-              projectId={projectId}
-              traceIds={traceIds}
-              traceNumberById={traceNumberById}
-              onOpenTrace={onOpenTrace}
-            />
+            <IssuesTab projectId={projectId} traceIds={traceIds} onOpenIssue={onOpenIssue} />
           </div>
         )}
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -53,13 +53,16 @@ export function SessionSlot({
   const traceIds = session.traceIds
   const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<SessionTabId>>(() => new Set([activeTab]))
 
+  // TODO(frontend-use-effect-policy): reactive on `activeTab` because the tab can
+  // change from a URL param (deep link, browser back/forward), not just from the
+  // tab control here. The single source of truth for "mark visited" is this
+  // effect — `selectTab` does not need to write the set itself.
   useEffect(() => {
     setVisitedTabs((prev) => (prev.has(activeTab) ? prev : new Set([...prev, activeTab])))
   }, [activeTab])
 
   function selectTab(tab: SessionTabId) {
     onActiveTabChange(tab)
-    setVisitedTabs((prev) => new Set([...prev, tab]))
   }
 
   // Badge counts. Both queries are shared (same key) with the tab panes, so

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/slot-transition.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/slot-transition.tsx
@@ -1,30 +1,45 @@
 import type { ReactNode } from "react"
 
+export type DetailSlotKind = "trace" | "issue"
+
 /**
- * Horizontal slide between the session slot and the trace slot, driven purely
- * by CSS transforms (no animation library). Each pane is absolutely positioned
- * at `inset-0` (always full drawer width/height) and translated independently:
- * the session slot sits at 0 and slides off to the left (`-100%`) while the
- * trace slot comes in from the right (`+100%` → `0`). Only one pane is on
- * screen at a time; the other is translated fully off-screen, `aria-hidden`,
- * and `inert` so Tab/Enter can't reach controls the user can't see.
+ * Horizontal slide between the session slot and a detail slot (trace or
+ * issue), driven purely by CSS transforms (no animation library). Each pane is
+ * absolutely positioned at `inset-0` (always full drawer width/height) and
+ * translated independently: the session slot sits at 0 and slides off to the
+ * left (`-100%`) while the detail slot comes in from the right (`+100%` → `0`).
+ *
+ * `trace` and `issue` panes share the +100% offset because they are mutually
+ * exclusive — only one detail kind can be open at a time. Switching between
+ * them swaps the rendered pane in place (no slide); the slide animation only
+ * fires when entering or leaving the session view.
+ *
+ * Only one pane is on screen at a time; the others are translated fully
+ * off-screen, `aria-hidden`, and `inert` so Tab/Enter can't reach controls the
+ * user can't see.
  */
 export function SlotTransition({
-  showTrace,
+  detailKind,
   sessionSlot,
   traceSlot,
+  issueSlot,
 }: {
-  readonly showTrace: boolean
+  /** `null` means the session pane is visible. */
+  readonly detailKind: DetailSlotKind | null
   readonly sessionSlot: ReactNode
   readonly traceSlot: ReactNode
+  readonly issueSlot: ReactNode
 }) {
+  const showDetail = detailKind !== null
+  const showTrace = detailKind === "trace"
+  const showIssue = detailKind === "issue"
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden">
       <div
         className="absolute inset-0 flex flex-col transition-transform duration-200 ease-out"
-        style={{ transform: showTrace ? "translateX(-100%)" : "translateX(0)" }}
-        aria-hidden={showTrace}
-        inert={showTrace}
+        style={{ transform: showDetail ? "translateX(-100%)" : "translateX(0)" }}
+        aria-hidden={showDetail}
+        inert={showDetail}
       >
         {sessionSlot}
       </div>
@@ -35,6 +50,14 @@ export function SlotTransition({
         inert={!showTrace}
       >
         {traceSlot}
+      </div>
+      <div
+        className="absolute inset-0 flex flex-col transition-transform duration-200 ease-out"
+        style={{ transform: showIssue ? "translateX(0)" : "translateX(100%)" }}
+        aria-hidden={!showIssue}
+        inert={!showIssue}
+      >
+        {issueSlot}
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/trace-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/trace-slot.tsx
@@ -1,11 +1,7 @@
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
-import { TraceDetailBody } from "../trace-detail-drawer.tsx"
+import { isTraceDetailTab, TraceDetailBody, type TraceDetailTabId } from "../trace-detail-drawer.tsx"
 
-export type TraceDetailTabId = "trace" | "conversation" | "spans" | "annotations"
-
-export function isTraceDetailTab(value: string): value is TraceDetailTabId {
-  return value === "trace" || value === "conversation" || value === "spans" || value === "annotations"
-}
+export { isTraceDetailTab, type TraceDetailTabId }
 
 /**
  * The trace slot reuses the standalone trace drawer's body (`TraceDetailBody`)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -37,7 +37,13 @@ import { ConversationTab } from "./trace-detail-drawer/tabs/conversation-tab.tsx
 import { SpansTab } from "./trace-detail-drawer/tabs/spans-tab.tsx"
 import { TraceTab } from "./trace-detail-drawer/tabs/trace-tab.tsx"
 
-type TabId = "trace" | "conversation" | "spans" | "annotations"
+export type TraceDetailTabId = "trace" | "conversation" | "spans" | "annotations"
+
+export function isTraceDetailTab(value: string): value is TraceDetailTabId {
+  return value === "trace" || value === "conversation" || value === "spans" || value === "annotations"
+}
+
+type TabId = TraceDetailTabId
 
 const TABS: TabOption<TabId>[] = [
   {
@@ -61,10 +67,6 @@ const TABS: TabOption<TabId>[] = [
     icon: <Icon icon={MessageSquareIcon} size="sm" />,
   },
 ]
-
-function isTraceDetailTab(v: string): v is TabId {
-  return v === "trace" || v === "conversation" || v === "spans" || v === "annotations"
-}
 
 const tabCountPillClass =
   "inline-flex min-h-5 min-w-[1.125rem] shrink-0 items-center justify-center rounded-full bg-muted px-1.5 text-[0.6875rem] font-medium leading-none text-muted-foreground"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -2,12 +2,12 @@ import {
   Button,
   CloseTrigger,
   CopyableText,
-  cn,
   DetailDrawer,
   DetailSection,
   Icon,
   Label,
   Modal,
+  Sheet,
   Skeleton,
   Switch,
   TagList,
@@ -28,7 +28,7 @@ import {
   TextAlignStartIcon,
   XIcon,
 } from "lucide-react"
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
@@ -115,12 +115,6 @@ type LifecycleConfirmationAction = "ignore" | "unignore" | "unresolve"
 
 const ISSUE_TRACE_COLUMN_IDS = ["startTime", "name", "tags", "duration"] as const satisfies readonly TraceColumnId[]
 
-// Must match the trace overlay panel's `duration-300` slide animation. We tear the overlay down
-// with a timer after this delay rather than listening for `transitionend`, because that event
-// never fires when motion is reduced or the transition is interrupted, which would leave the
-// overlay logically open and the trace row stuck in its active state.
-const TRACE_PANEL_TRANSITION_MS = 300
-
 function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
   switch (action) {
     case "ignore":
@@ -151,22 +145,27 @@ function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
   }
 }
 
-export function IssueDetailDrawer({
+/**
+ * Issue detail surface minus the `DetailDrawer` chrome (close, next/prev nav).
+ *
+ * Owns which trace is showing in the side `Sheet` so the standalone drawer
+ * and the session-panel issue slot share the same "click trace → sliding
+ * panel on top" behavior — Escape closes the sheet back to the issue, never
+ * to whatever the parent panel would do next (the `Sheet` captures Escape
+ * with `stopImmediatePropagation`).
+ *
+ * `onOverlayActiveChange` lets the parent observe sheet open/close — used by
+ * the standalone drawer to disable its next/previous-issue arrows while a
+ * trace is showing.
+ */
+export function IssueDetailBody({
   projectId,
   issueId,
-  onClose,
-  onNextIssue,
-  onPrevIssue,
-  canNavigateNext,
-  canNavigatePrev,
+  onOverlayActiveChange,
 }: {
   readonly projectId: string
   readonly issueId: string
-  readonly onClose: () => void
-  readonly onNextIssue?: () => void
-  readonly onPrevIssue?: () => void
-  readonly canNavigateNext: boolean
-  readonly canNavigatePrev: boolean
+  readonly onOverlayActiveChange?: (active: boolean) => void
 }) {
   const { toast } = useToast()
   const { data: issue, isLoading } = useIssueDetail({ projectId, issueId })
@@ -184,10 +183,8 @@ export function IssueDetailDrawer({
   const [keepMonitoring, setKeepMonitoring] = useState(true)
   const [isLifecycleLoading, setIsLifecycleLoading] = useState(false)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
-  const [traceOverlayTraceId, setTraceOverlayTraceId] = useState<string | null>(null)
-  const [tracePanelEntered, setTracePanelEntered] = useState(false)
-  const traceOverlayCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const previousTraceOverlayIdRef = useRef<string | null>(null)
+  const [traceSheetTraceId, setTraceSheetTraceId] = useState<string | null>(null)
+  const [traceSheetOpen, setTraceSheetOpen] = useState(false)
 
   const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
   const totalTraceCount = useIssueTracesCount({ projectId, issueId, enabled: issue !== null })
@@ -227,74 +224,33 @@ export function IssueDetailDrawer({
     issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
   const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
 
-  const clearTraceOverlayCloseTimer = useCallback(() => {
-    if (traceOverlayCloseTimerRef.current !== null) {
-      clearTimeout(traceOverlayCloseTimerRef.current)
-      traceOverlayCloseTimerRef.current = null
-    }
-  }, [])
-
-  const finishCloseTraceOverlay = useCallback(() => {
-    clearTraceOverlayCloseTimer()
-    setTraceOverlayTraceId(null)
-  }, [clearTraceOverlayCloseTimer])
-
-  const openTraceOverlay = useCallback(
-    (traceId: string) => {
-      clearTraceOverlayCloseTimer()
-      setTraceOverlayTraceId(traceId)
-    },
-    [clearTraceOverlayCloseTimer],
-  )
-
-  const requestCloseTraceOverlay = useCallback(() => {
-    if (traceOverlayTraceId === null) return
-    setTracePanelEntered(false)
-    clearTraceOverlayCloseTimer()
-    traceOverlayCloseTimerRef.current = setTimeout(finishCloseTraceOverlay, TRACE_PANEL_TRANSITION_MS)
-  }, [traceOverlayTraceId, clearTraceOverlayCloseTimer, finishCloseTraceOverlay])
-
-  useEffect(() => clearTraceOverlayCloseTimer, [clearTraceOverlayCloseTimer])
-
-  useEffect(() => {
-    if (traceOverlayTraceId === null) {
-      setTracePanelEntered(false)
-      previousTraceOverlayIdRef.current = null
-      return
-    }
-    const wasAlreadyOpen = previousTraceOverlayIdRef.current !== null
-    previousTraceOverlayIdRef.current = traceOverlayTraceId
-    if (wasAlreadyOpen) {
-      setTracePanelEntered(true)
-      return
-    }
-    setTracePanelEntered(false)
-    const id = requestAnimationFrame(() => {
-      requestAnimationFrame(() => setTracePanelEntered(true))
-    })
-    return () => cancelAnimationFrame(id)
-  }, [traceOverlayTraceId])
-
-  const traceOverlayIndex = traceOverlayTraceId ? traceIds.indexOf(traceOverlayTraceId) : -1
-  const canNavigateNextTraceInOverlay =
-    traceOverlayTraceId !== null &&
-    traceIds.length > 0 &&
-    (traceOverlayIndex < 0 || traceOverlayIndex < traceIds.length - 1)
-  const canNavigatePrevTraceInOverlay =
-    traceOverlayTraceId !== null && traceIds.length > 0 && (traceOverlayIndex < 0 || traceOverlayIndex > 0)
-
-  const onNextTraceInOverlay = () => {
-    if (!traceOverlayTraceId) return
-    const idx = traceIds.indexOf(traceOverlayTraceId)
-    const next = idx < 0 ? traceIds[0] : traceIds[idx + 1]
-    if (next) setTraceOverlayTraceId(next)
+  const openTraceSheet = (traceId: string) => {
+    setTraceSheetTraceId(traceId)
+    setTraceSheetOpen(true)
   }
 
-  const onPrevTraceInOverlay = () => {
-    if (!traceOverlayTraceId) return
-    const idx = traceIds.indexOf(traceOverlayTraceId)
+  useEffect(() => {
+    onOverlayActiveChange?.(traceSheetOpen)
+  }, [traceSheetOpen, onOverlayActiveChange])
+
+  const traceSheetIndex = traceSheetTraceId ? traceIds.indexOf(traceSheetTraceId) : -1
+  const canNavigateNextTraceInSheet =
+    traceSheetTraceId !== null && traceIds.length > 0 && (traceSheetIndex < 0 || traceSheetIndex < traceIds.length - 1)
+  const canNavigatePrevTraceInSheet =
+    traceSheetTraceId !== null && traceIds.length > 0 && (traceSheetIndex < 0 || traceSheetIndex > 0)
+
+  const onNextTraceInSheet = () => {
+    if (!traceSheetTraceId) return
+    const idx = traceIds.indexOf(traceSheetTraceId)
+    const next = idx < 0 ? traceIds[0] : traceIds[idx + 1]
+    if (next) setTraceSheetTraceId(next)
+  }
+
+  const onPrevTraceInSheet = () => {
+    if (!traceSheetTraceId) return
+    const idx = traceIds.indexOf(traceSheetTraceId)
     const prev = idx <= 0 ? undefined : traceIds[idx - 1]
-    if (prev) setTraceOverlayTraceId(prev)
+    if (prev) setTraceSheetTraceId(prev)
   }
 
   const getTraceRowAriaLabel = (input: { readonly traceId: string; readonly rootSpanName: string }) => {
@@ -336,125 +292,64 @@ export function IssueDetailDrawer({
     }
   }
 
-  useHotkeys([
-    {
-      hotkey: "Alt+ArrowDown",
-      callback: () => onNextIssue?.(),
-      options: { enabled: canNavigateNext && !!onNextIssue && traceOverlayTraceId === null },
-    },
-    {
-      hotkey: "Alt+ArrowUp",
-      callback: () => onPrevIssue?.(),
-      options: { enabled: canNavigatePrev && !!onPrevIssue && traceOverlayTraceId === null },
-    },
-    {
-      hotkey: "Escape",
-      callback: requestCloseTraceOverlay,
-      options: { enabled: traceOverlayTraceId !== null, ignoreInputs: true },
-    },
-  ])
-
   return (
     <>
-      <DetailDrawer
-        storeKey="issue-detail-drawer-width"
-        onClose={onClose}
-        closeLabel={
-          <>
-            Close <HotkeyBadge hotkey="Escape" />
-          </>
-        }
-        actions={
-          <>
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <Button
-                  variant="ghost"
-                  className="w-8 h-8 p-0"
-                  disabled={!canNavigateNext}
-                  onClick={onNextIssue}
-                  type="button"
-                  aria-label="Next issue"
-                >
-                  <ArrowDownIcon className="w-4 h-4 text-muted-foreground" />
-                </Button>
-              }
-            >
-              Next issue <HotkeyBadge hotkey="Alt+ArrowDown" /> <HotkeyBadge hotkey="J" />
-            </Tooltip>
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <Button
-                  variant="ghost"
-                  className="w-8 h-8 p-0"
-                  disabled={!canNavigatePrev}
-                  onClick={onPrevIssue}
-                  type="button"
-                  aria-label="Previous issue"
-                >
-                  <ArrowUpIcon className="w-4 h-4 text-muted-foreground" />
-                </Button>
-              }
-            >
-              Previous issue <HotkeyBadge hotkey="Alt+ArrowUp" /> <HotkeyBadge hotkey="K" />
-            </Tooltip>
-          </>
-        }
-        rightActions={
-          <>
-            <Button
-              variant="ghost"
-              className="text-foreground group-hover:text-secondary-foreground/80"
-              disabled={issue === null || issue === undefined || isLifecycleLoading}
-              onClick={() => setLifecycleConfirmAction(issue?.ignoredAt ? "unignore" : "ignore")}
-            >
-              <Icon icon={issue?.ignoredAt ? PlayIcon : PauseIcon} size="sm" />
-              {issue?.ignoredAt ? "Unignore" : "Ignore"}
-            </Button>
-            <Button
-              variant="outline"
-              disabled={issue === null || issue === undefined || isLifecycleLoading}
-              onClick={() => {
-                if (issue?.resolvedAt) {
-                  setLifecycleConfirmAction("unresolve")
-                  return
-                }
-
-                setKeepMonitoring(issue?.keepMonitoringDefault ?? true)
-                setResolveModalOpen(true)
-              }}
-            >
-              <Icon icon={issue?.resolvedAt ? XIcon : CheckIcon} size="sm" />
-              {issue?.resolvedAt ? "Unresolve" : "Resolve"}
-            </Button>
-          </>
-        }
-        header={
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col gap-1">
-              {isLoading ? <Skeleton className="h-7 w-56" /> : <Text.H4M>{issue?.name ?? "Issue not found"}</Text.H4M>}
-              {isLoading ? (
-                <Skeleton className="h-5 w-full" />
-              ) : (
-                <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex shrink-0 flex-col gap-3 border-b px-6 py-4">
+          <div className="flex flex-row items-start justify-between gap-4">
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <div className="flex flex-col gap-1">
+                {isLoading ? (
+                  <Skeleton className="h-7 w-56" />
+                ) : (
+                  <Text.H4M>{issue?.name ?? "Issue not found"}</Text.H4M>
+                )}
+                {isLoading ? (
+                  <Skeleton className="h-5 w-full" />
+                ) : (
+                  <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
+                )}
+              </div>
+              {!isLoading && issue && (
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex min-w-[33%] max-w-max flex-1">
+                    <CopyableText value={issue.slug} size="sm" ellipsis tooltip="Copy issue slug" />
+                  </div>
+                  {issue.tags.length > 0 && <TagList tags={issue.tags} wrap />}
+                </div>
               )}
             </div>
-            {!isLoading && issue && (
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="flex min-w-[33%] max-w-max flex-1">
-                  <CopyableText value={issue.slug} size="sm" ellipsis tooltip="Copy issue slug" />
-                </div>
-                {issue.tags.length > 0 && <TagList tags={issue.tags} wrap />}
-              </div>
-            )}
+            <div className="flex shrink-0 flex-row items-center gap-1">
+              <Button
+                variant="ghost"
+                className="text-foreground group-hover:text-secondary-foreground/80"
+                disabled={issue === null || issue === undefined || isLifecycleLoading}
+                onClick={() => setLifecycleConfirmAction(issue?.ignoredAt ? "unignore" : "ignore")}
+              >
+                <Icon icon={issue?.ignoredAt ? PlayIcon : PauseIcon} size="sm" />
+                {issue?.ignoredAt ? "Unignore" : "Ignore"}
+              </Button>
+              <Button
+                variant="outline"
+                disabled={issue === null || issue === undefined || isLifecycleLoading}
+                onClick={() => {
+                  if (issue?.resolvedAt) {
+                    setLifecycleConfirmAction("unresolve")
+                    return
+                  }
+
+                  setKeepMonitoring(issue?.keepMonitoringDefault ?? true)
+                  setResolveModalOpen(true)
+                }}
+              >
+                <Icon icon={issue?.resolvedAt ? XIcon : CheckIcon} size="sm" />
+                {issue?.resolvedAt ? "Unresolve" : "Resolve"}
+              </Button>
+            </div>
           </div>
-        }
-      >
-        <div className="flex flex-col flex-1 overflow-y-auto p-6 gap-6">
+        </div>
+
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6">
           <div className="flex flex-col gap-4">
             <div className="flex flex-row flex-wrap content-start items-start gap-x-8 gap-y-4">
               {isLoading ? (
@@ -535,7 +430,6 @@ export function IssueDetailDrawer({
               issueId={issueId}
               issueSource={issue?.source ?? "annotation"}
               evaluations={issue?.evaluations ?? []}
-              flaggerSlugs={issue?.flaggerSlugs ?? []}
               canMonitorIssue={issue ? issue.resolvedAt === null && issue.ignoredAt === null : false}
               isIssueLoading={isLoading}
             />
@@ -562,10 +456,10 @@ export function IssueDetailDrawer({
               isLoading={tracesLoading}
               visibleColumnIds={ISSUE_TRACE_COLUMN_IDS}
               defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
-              onTraceClick={(trace) => openTraceOverlay(trace.traceId)}
+              onTraceClick={(trace) => openTraceSheet(trace.traceId)}
               getTraceRowAriaLabel={getTraceRowAriaLabel}
               rowInteractionRole="button"
-              activeTraceId={traceOverlayTraceId ?? undefined}
+              activeTraceId={traceSheetTraceId ?? undefined}
               selection={traceSelection}
               infiniteScroll={infiniteScroll}
               blankSlate="This issue has not been seen on any traces yet."
@@ -574,121 +468,197 @@ export function IssueDetailDrawer({
             />
           </DetailSection>
         </div>
-      </DetailDrawer>
 
-      {bulkSelection && (
-        <AddToDatasetModal
-          open={addToDatasetOpen}
-          onOpenChange={setAddToDatasetOpen}
-          projectId={projectId}
-          issueId={issueId}
-          selection={bulkSelection}
-          selectedCount={selectedCount}
-          onSuccess={clearSelections}
-        />
-      )}
-
-      <Modal.Root open={resolveModalOpen} onOpenChange={setResolveModalOpen}>
-        <Modal.Content dismissible>
-          <Modal.Header
-            title="Resolve issue"
-            description="Mark this issue as resolved. If this issue starts occurring again we will alert you and promote it as regressed"
+        {bulkSelection && (
+          <AddToDatasetModal
+            open={addToDatasetOpen}
+            onOpenChange={setAddToDatasetOpen}
+            projectId={projectId}
+            issueId={issueId}
+            selection={bulkSelection}
+            selectedCount={selectedCount}
+            onSuccess={clearSelections}
           />
-          {hasActiveLinkedEvaluations ? (
-            <Modal.Body>
-              <div className="flex flex-col gap-3">
-                <div className="flex flex-row items-center justify-between gap-4">
-                  <div className="flex flex-col gap-1">
-                    <Label htmlFor="keep-monitoring-on-resolve">Keep monitoring this issue</Label>
-                    <Text.H6 color="foregroundMuted">
-                      Evaluations monitoring this issue will stay active to detect further regressions
-                    </Text.H6>
-                  </div>
-                  <Switch
-                    id="keep-monitoring-on-resolve"
-                    checked={keepMonitoring}
-                    onCheckedChange={setKeepMonitoring}
-                    disabled={isLifecycleLoading}
-                    aria-label="Keep monitoring this issue"
-                  />
-                </div>
-              </div>
-            </Modal.Body>
-          ) : null}
-          <Modal.Footer>
-            <Button variant="outline" onClick={() => setResolveModalOpen(false)} disabled={isLifecycleLoading}>
-              Cancel
-            </Button>
-            <Button onClick={() => void runLifecycleCommand("resolve", keepMonitoring)} disabled={isLifecycleLoading}>
-              <Icon icon={CheckIcon} size="sm" />
-              Resolve
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal.Root>
+        )}
 
-      <Modal.Root
-        open={lifecycleConfirmAction !== null}
-        onOpenChange={(open) => (!open ? setLifecycleConfirmAction(null) : undefined)}
-      >
-        <Modal.Content dismissible>
-          <Modal.Header
-            title={lifecycleConfirmation?.title ?? "Confirm issue action"}
-            description={lifecycleConfirmation?.description ?? "Are you sure you want to continue?"}
-          />
-          <Modal.Footer>
-            <CloseTrigger />
-            <Button
-              {...(lifecycleConfirmation?.confirmVariant ? { variant: lifecycleConfirmation.confirmVariant } : {})}
-              onClick={() => (lifecycleConfirmAction ? void runLifecycleCommand(lifecycleConfirmAction) : undefined)}
-              disabled={lifecycleConfirmAction === null || isLifecycleLoading}
-            >
-              <Icon icon={lifecycleConfirmation?.confirmIcon ?? XIcon} size="sm" />
-              {lifecycleConfirmation?.confirmLabel ?? "Confirm"}
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal.Root>
-
-      {traceOverlayTraceId !== null ? (
-        <>
-          <button
-            type="button"
-            aria-label="Close trace panel"
-            className={cn(
-              "fixed inset-0 z-[45] bg-foreground/10 transition-opacity duration-200",
-              tracePanelEntered ? "opacity-100" : "pointer-events-none opacity-0",
-            )}
-            onClick={requestCloseTraceOverlay}
-          />
-          <div
-            className={cn(
-              "fixed inset-y-0 right-0 z-[50] flex max-h-dvh shadow-2xl will-change-transform transition-transform duration-300 ease-out",
-              tracePanelEntered ? "translate-x-0" : "translate-x-full",
-            )}
-          >
-            <TraceDetailDrawer
-              key={traceOverlayTraceId}
-              projectId={projectId}
-              traceId={traceOverlayTraceId}
-              trace={traces.find((t) => t.traceId === traceOverlayTraceId)}
-              onClose={requestCloseTraceOverlay}
-              onNextTrace={onNextTraceInOverlay}
-              onPrevTrace={onPrevTraceInOverlay}
-              canNavigateNext={canNavigateNextTraceInOverlay}
-              canNavigatePrev={canNavigatePrevTraceInOverlay}
-              urlSyncedTabs={false}
-              initialTab="conversation"
-              drawerStoreKey="issue-trace-detail-drawer-width"
-              closeLabel={
-                <>
-                  Back to issue <HotkeyBadge hotkey="Escape" />
-                </>
-              }
+        <Modal.Root open={resolveModalOpen} onOpenChange={setResolveModalOpen}>
+          <Modal.Content dismissible>
+            <Modal.Header
+              title="Resolve issue"
+              description="Mark this issue as resolved. If this issue starts occurring again we will alert you and promote it as regressed"
             />
-          </div>
-        </>
-      ) : null}
+            {hasActiveLinkedEvaluations ? (
+              <Modal.Body>
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-row items-center justify-between gap-4">
+                    <div className="flex flex-col gap-1">
+                      <Label htmlFor="keep-monitoring-on-resolve">Keep monitoring this issue</Label>
+                      <Text.H6 color="foregroundMuted">
+                        Evaluations monitoring this issue will stay active to detect further regressions
+                      </Text.H6>
+                    </div>
+                    <Switch
+                      id="keep-monitoring-on-resolve"
+                      checked={keepMonitoring}
+                      onCheckedChange={setKeepMonitoring}
+                      disabled={isLifecycleLoading}
+                      aria-label="Keep monitoring this issue"
+                    />
+                  </div>
+                </div>
+              </Modal.Body>
+            ) : null}
+            <Modal.Footer>
+              <Button variant="outline" onClick={() => setResolveModalOpen(false)} disabled={isLifecycleLoading}>
+                Cancel
+              </Button>
+              <Button onClick={() => void runLifecycleCommand("resolve", keepMonitoring)} disabled={isLifecycleLoading}>
+                <Icon icon={CheckIcon} size="sm" />
+                Resolve
+              </Button>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal.Root>
+
+        <Modal.Root
+          open={lifecycleConfirmAction !== null}
+          onOpenChange={(open) => (!open ? setLifecycleConfirmAction(null) : undefined)}
+        >
+          <Modal.Content dismissible>
+            <Modal.Header
+              title={lifecycleConfirmation?.title ?? "Confirm issue action"}
+              description={lifecycleConfirmation?.description ?? "Are you sure you want to continue?"}
+            />
+            <Modal.Footer>
+              <CloseTrigger />
+              <Button
+                {...(lifecycleConfirmation?.confirmVariant ? { variant: lifecycleConfirmation.confirmVariant } : {})}
+                onClick={() => (lifecycleConfirmAction ? void runLifecycleCommand(lifecycleConfirmAction) : undefined)}
+                disabled={lifecycleConfirmAction === null || isLifecycleLoading}
+              >
+                <Icon icon={lifecycleConfirmation?.confirmIcon ?? XIcon} size="sm" />
+                {lifecycleConfirmation?.confirmLabel ?? "Confirm"}
+              </Button>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal.Root>
+      </div>
+
+      <Sheet
+        open={traceSheetOpen}
+        onClose={() => setTraceSheetOpen(false)}
+        onClosed={() => setTraceSheetTraceId(null)}
+        closeAriaLabel="Close trace panel"
+      >
+        {traceSheetTraceId ? (
+          <TraceDetailDrawer
+            key={traceSheetTraceId}
+            projectId={projectId}
+            traceId={traceSheetTraceId}
+            trace={traces.find((t) => t.traceId === traceSheetTraceId)}
+            onClose={() => setTraceSheetOpen(false)}
+            onNextTrace={onNextTraceInSheet}
+            onPrevTrace={onPrevTraceInSheet}
+            canNavigateNext={canNavigateNextTraceInSheet}
+            canNavigatePrev={canNavigatePrevTraceInSheet}
+            urlSyncedTabs={false}
+            initialTab="conversation"
+            drawerStoreKey="issue-trace-detail-drawer-width"
+            closeLabel={
+              <>
+                Back to issue <HotkeyBadge hotkey="Escape" />
+              </>
+            }
+          />
+        ) : null}
+      </Sheet>
     </>
+  )
+}
+
+export function IssueDetailDrawer({
+  projectId,
+  issueId,
+  onClose,
+  onNextIssue,
+  onPrevIssue,
+  canNavigateNext,
+  canNavigatePrev,
+}: {
+  readonly projectId: string
+  readonly issueId: string
+  readonly onClose: () => void
+  readonly onNextIssue?: () => void
+  readonly onPrevIssue?: () => void
+  readonly canNavigateNext: boolean
+  readonly canNavigatePrev: boolean
+}) {
+  const [overlayActive, setOverlayActive] = useState(false)
+
+  useHotkeys([
+    {
+      hotkey: "Alt+ArrowDown",
+      callback: () => onNextIssue?.(),
+      options: { enabled: canNavigateNext && !!onNextIssue && !overlayActive },
+    },
+    {
+      hotkey: "Alt+ArrowUp",
+      callback: () => onPrevIssue?.(),
+      options: { enabled: canNavigatePrev && !!onPrevIssue && !overlayActive },
+    },
+  ])
+
+  return (
+    <DetailDrawer
+      storeKey="issue-detail-drawer-width"
+      onClose={onClose}
+      closeLabel={
+        <>
+          Close <HotkeyBadge hotkey="Escape" />
+        </>
+      }
+      actions={
+        <>
+          <Tooltip
+            asChild
+            side="bottom"
+            trigger={
+              <Button
+                variant="ghost"
+                className="w-8 h-8 p-0"
+                disabled={!canNavigateNext}
+                onClick={onNextIssue}
+                type="button"
+                aria-label="Next issue"
+              >
+                <ArrowDownIcon className="w-4 h-4 text-muted-foreground" />
+              </Button>
+            }
+          >
+            Next issue <HotkeyBadge hotkey="Alt+ArrowDown" /> <HotkeyBadge hotkey="J" />
+          </Tooltip>
+          <Tooltip
+            asChild
+            side="bottom"
+            trigger={
+              <Button
+                variant="ghost"
+                className="w-8 h-8 p-0"
+                disabled={!canNavigatePrev}
+                onClick={onPrevIssue}
+                type="button"
+                aria-label="Previous issue"
+              >
+                <ArrowUpIcon className="w-4 h-4 text-muted-foreground" />
+              </Button>
+            }
+          >
+            Previous issue <HotkeyBadge hotkey="Alt+ArrowUp" /> <HotkeyBadge hotkey="K" />
+          </Tooltip>
+        </>
+      }
+    >
+      <IssueDetailBody projectId={projectId} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
+    </DetailDrawer>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -28,7 +28,7 @@ import {
   TextAlignStartIcon,
   XIcon,
 } from "lucide-react"
-import { type ReactNode, useEffect, useMemo, useState } from "react"
+import { type ReactNode, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
@@ -227,11 +227,13 @@ export function IssueDetailBody({
   const openTraceSheet = (traceId: string) => {
     setTraceSheetTraceId(traceId)
     setTraceSheetOpen(true)
+    onOverlayActiveChange?.(true)
   }
 
-  useEffect(() => {
-    onOverlayActiveChange?.(traceSheetOpen)
-  }, [traceSheetOpen, onOverlayActiveChange])
+  const closeTraceSheet = () => {
+    setTraceSheetOpen(false)
+    onOverlayActiveChange?.(false)
+  }
 
   const traceSheetIndex = traceSheetTraceId ? traceIds.indexOf(traceSheetTraceId) : -1
   const canNavigateNextTraceInSheet =
@@ -546,7 +548,7 @@ export function IssueDetailBody({
 
       <Sheet
         open={traceSheetOpen}
-        onClose={() => setTraceSheetOpen(false)}
+        onClose={closeTraceSheet}
         onClosed={() => setTraceSheetTraceId(null)}
         closeAriaLabel="Close trace panel"
       >
@@ -556,7 +558,7 @@ export function IssueDetailBody({
             projectId={projectId}
             traceId={traceSheetTraceId}
             trace={traces.find((t) => t.traceId === traceSheetTraceId)}
-            onClose={() => setTraceSheetOpen(false)}
+            onClose={closeTraceSheet}
             onNextTrace={onNextTraceInSheet}
             onPrevTrace={onPrevTraceInSheet}
             canNavigateNext={canNavigateNextTraceInSheet}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -432,6 +432,7 @@ export function IssueDetailBody({
               issueId={issueId}
               issueSource={issue?.source ?? "annotation"}
               evaluations={issue?.evaluations ?? []}
+              flaggerSlugs={issue?.flaggerSlugs ?? []}
               canMonitorIssue={issue ? issue.resolvedAt === null && issue.ignoredAt === null : false}
               isIssueLoading={isLoading}
             />

--- a/packages/domain/annotations/src/helpers/annotation-draft-write-schema.ts
+++ b/packages/domain/annotations/src/helpers/annotation-draft-write-schema.ts
@@ -20,7 +20,7 @@ const annotationDraftWriteCoreSchema = z.object({
   annotatorId: cuidSchema.transform(UserId).nullable().default(null),
   value: scoreValueSchema,
   passed: z.boolean(),
-  feedback: z.string().min(1),
+  feedback: z.string(),
 })
 
 /** Persist payload: optional nested `anchor` carrying message/part/offset indices. */

--- a/packages/ui/src/components/sheet/sheet.tsx
+++ b/packages/ui/src/components/sheet/sheet.tsx
@@ -1,0 +1,125 @@
+import { type ReactNode, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import { cn } from "../../utils/cn.ts"
+
+const ENTER_TRANSITION_MS = 300
+
+/**
+ * Side-anchored panel that overlays the page with a dimming backdrop —
+ * what other libraries call a Sheet (shadcn/ui, Radix) or Slide-over
+ * (Tailwind UI / Headless UI). Distinct from `DetailDrawer`, which is the
+ * docked, resizable, persistent right panel.
+ *
+ * `open` drives the animation: flip it to `true` and the panel mounts +
+ * slides in from the right; flip back to `false` and it slides out and
+ * unmounts after the exit animation finishes. Children are snapshotted at
+ * each render where `open` is true, so consumers can clear their bound
+ * state in `onClose` and the panel will still animate out with the right
+ * content. Use `onClosed` if you need a precise post-animation hook.
+ *
+ * Escape is captured at the document level with `stopImmediatePropagation`,
+ * so this sheet's close pre-empts any parent hotkey handler (e.g. an outer
+ * "back to previous view") without the parent needing to know about it.
+ */
+export function Sheet({
+  open,
+  onClose,
+  onClosed,
+  children,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  closeAriaLabel = "Close panel",
+}: {
+  readonly open: boolean
+  readonly onClose: () => void
+  /** Fired after the exit animation finishes — use to clear bound state. */
+  readonly onClosed?: () => void
+  readonly children: ReactNode
+  readonly closeOnBackdrop?: boolean
+  readonly closeOnEscape?: boolean
+  readonly closeAriaLabel?: string
+}) {
+  const [mounted, setMounted] = useState(open)
+  const [entered, setEntered] = useState(false)
+  const onClosedRef = useRef(onClosed)
+  onClosedRef.current = onClosed
+
+  // Snapshot children whenever the sheet is open, so the exit animation
+  // can keep rendering the last-known content even if the consumer clears
+  // its backing state when it calls `onClose`.
+  const childrenRef = useRef(children)
+  if (open) {
+    childrenRef.current = children
+  }
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+      // Double rAF: mount first paint at `translate-x-full`, then flip on
+      // the next frame so the browser actually animates the transform.
+      // `transitionend` is unreliable when motion is reduced or interrupted,
+      // so we drive both phases off plain timers.
+      let cancelled = false
+      const enterId = requestAnimationFrame(() => {
+        if (cancelled) return
+        requestAnimationFrame(() => {
+          if (!cancelled) setEntered(true)
+        })
+      })
+      return () => {
+        cancelled = true
+        cancelAnimationFrame(enterId)
+      }
+    }
+    setEntered(false)
+    const exitId = setTimeout(() => {
+      setMounted(false)
+      onClosedRef.current?.()
+    }, ENTER_TRANSITION_MS)
+    return () => clearTimeout(exitId)
+  }, [open])
+
+  useEffect(() => {
+    if (!open || !closeOnEscape) return
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      if (event.defaultPrevented) return
+      const target = event.target as HTMLElement | null
+      const isEditable =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target?.isContentEditable ?? false)
+      if (isEditable) return
+      event.stopImmediatePropagation()
+      event.preventDefault()
+      onClose()
+    }
+    document.addEventListener("keydown", handler, { capture: true })
+    return () => document.removeEventListener("keydown", handler, { capture: true })
+  }, [open, closeOnEscape, onClose])
+
+  if (!mounted || typeof document === "undefined") return null
+
+  return createPortal(
+    <>
+      <button
+        type="button"
+        aria-label={closeAriaLabel}
+        className={cn(
+          "fixed inset-0 z-[45] bg-foreground/10 transition-opacity duration-200",
+          entered ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={closeOnBackdrop ? onClose : undefined}
+      />
+      <div
+        className={cn(
+          "fixed inset-y-0 right-0 z-[50] flex max-h-dvh shadow-2xl will-change-transform transition-transform duration-300 ease-out",
+          entered ? "translate-x-0" : "translate-x-full",
+        )}
+      >
+        {childrenRef.current}
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/packages/ui/src/components/sheet/sheet.tsx
+++ b/packages/ui/src/components/sheet/sheet.tsx
@@ -41,6 +41,10 @@ export function Sheet({
 }) {
   const [mounted, setMounted] = useState(open)
   const [entered, setEntered] = useState(false)
+  // Tracks whether this Sheet has ever been opened. Without it, the first
+  // render with `open === false` would schedule the exit timer and fire
+  // `onClosed` 300ms later — even though no open/close cycle happened.
+  const hasOpenedRef = useRef(open)
   const onClosedRef = useRef(onClosed)
   onClosedRef.current = onClosed
 
@@ -54,6 +58,7 @@ export function Sheet({
 
   useEffect(() => {
     if (open) {
+      hasOpenedRef.current = true
       setMounted(true)
       // Double rAF: mount first paint at `translate-x-full`, then flip on
       // the next frame so the browser actually animates the transform.
@@ -71,6 +76,7 @@ export function Sheet({
         cancelAnimationFrame(enterId)
       }
     }
+    if (!hasOpenedRef.current) return
     setEntered(false)
     const exitId = setTimeout(() => {
       setMounted(false)
@@ -112,6 +118,9 @@ export function Sheet({
         onClick={closeOnBackdrop ? onClose : undefined}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={closeAriaLabel}
         className={cn(
           "fixed inset-y-0 right-0 z-[50] flex max-h-dvh shadow-2xl will-change-transform transition-transform duration-300 ease-out",
           entered ? "translate-x-0" : "translate-x-full",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -231,6 +231,7 @@ export {
   type SelectOptionGroup,
   type SelectProps,
 } from "./components/select/index.tsx"
+export { Sheet } from "./components/sheet/sheet.tsx"
 export { Skeleton } from "./components/skeleton/skeleton.tsx"
 export { Slider, type SliderProps } from "./components/slider/index.tsx"
 export {


### PR DESCRIPTION
# What?

Slide-into-issue from the session drawer's Issues tab, with a generic `Sheet` component for the trace-on-top-of-issue overlay.

- Issues tab is now an `InfiniteTable` (Name / Status / Seen at) with client-side sortable columns. Click → slides into the full issue body via a new `IssueSlot`.
- Extracted `IssueDetailBody` out of `IssueDetailDrawer` so both the standalone issues route and the session-panel slot share the same header, lifecycle actions, trend, evaluations, and traces table.
- Inside the issue panel, clicking a trace opens a new `@repo/ui` `Sheet` component on top (slide-in from the right, backdrop dim, capture-phase Escape with `stopImmediatePropagation` so it pre-empts the session drawer's "back to session"). Escape returns to the issue, not the session.
- Sheet handles its own mount/unmount + animation timing and snapshots children during exit, so callers just toggle `open`.
- Session drawer's slot transition now supports three slots (session / trace / issue) with the trace and issue panes sharing the off-screen origin.

## Test plan
- [x] Open a session with issues; click an issue → slides to issue panel; "View session" / Escape returns.
- [x] Inside the issue panel, click a trace row → Sheet slides in; Escape closes only the Sheet.
- [x] Sort Issues tab by Name / Status / Seen at — both directions.
- [x] Standalone issues route still works (Alt+↑/↓ between issues, click trace opens overlay, Escape closes overlay, Ignore/Resolve actions).