### PR TITLE
feat(filters): trace/session filter parity

### DIFF
--- a/apps/web/src/components/filters-builder/constants.ts
+++ b/apps/web/src/components/filters-builder/constants.ts
@@ -1,4 +1,9 @@
-import { isPercentileTraceFilterField, type PercentileTraceFilterField, TRACE_FILTER_FIELDS } from "@domain/shared"
+import {
+  isPercentileTraceFilterField,
+  type PercentileSessionFilterField,
+  type PercentileTraceFilterField,
+  TRACE_FILTER_FIELDS,
+} from "@domain/shared"
 import type { FilterMode } from "./multi-select-filter.tsx"
 import type { DistinctColumn } from "./types.ts"
 
@@ -13,12 +18,19 @@ export const MULTI_SELECT_FIELDS = TRACE_FILTER_FIELDS.filter((f) => f.type === 
   label: f.label,
 }))
 
+export const STATUS_FIELDS = TRACE_FILTER_FIELDS.filter((f) => f.type === "status").map((f) => ({
+  field: f.field,
+  label: f.label,
+}))
+
+export type PercentileFieldName = PercentileTraceFilterField | PercentileSessionFilterField
+
 interface NumberRangeFieldDefinition {
   readonly field: string
   readonly label: string
   readonly tooltip: string | undefined
   readonly percentile?: {
-    readonly field?: PercentileTraceFilterField
+    readonly field?: PercentileFieldName
   }
 }
 
@@ -36,7 +48,9 @@ export const NUMBER_RANGE_FIELDS: readonly NumberRangeFieldDefinition[] = TRACE_
 
 export function getTextFieldsForMode(mode: FilterMode) {
   if (mode === "sessions") {
-    return TEXT_FIELDS.filter((f) => f.field !== "name" && f.field !== "traceId")
+    return TEXT_FIELDS.map((f) =>
+      f.field === "traceId" ? { ...f, placeholder: "Enter full trace ID (32 chars)…" } : f,
+    )
   }
   return TEXT_FIELDS
 }

--- a/apps/web/src/components/filters-builder/percentile-filter.tsx
+++ b/apps/web/src/components/filters-builder/percentile-filter.tsx
@@ -1,16 +1,26 @@
-import type { PercentileTraceFilterField } from "@domain/shared"
+import type { PercentileSessionFilterField, PercentileTraceFilterField } from "@domain/shared"
 import { Button, Text, useMountEffect } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice } from "@repo/utils"
 import { XIcon } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
+import { useSessionDistribution } from "../../domains/sessions/sessions.collection.ts"
 import { useTraceDistribution } from "../../domains/traces/traces.collection.ts"
+import type { FilterMode } from "./multi-select-filter.tsx"
+
+type PercentileField = PercentileTraceFilterField | PercentileSessionFilterField
 
 interface PercentileFilterProps {
   readonly projectId: string
-  readonly field: PercentileTraceFilterField
-  /** Locked percentile threshold (0–100), or undefined when no filter is set. */
+  readonly field: PercentileField
   readonly value: number | undefined
   readonly onChange: (percentile: number | undefined) => void
+  readonly mode?: FilterMode
+}
+
+function useDistributionForMode(mode: FilterMode, args: { projectId: string; field: PercentileField }) {
+  const trace = useTraceDistribution({ projectId: args.projectId, field: args.field, enabled: mode === "traces" })
+  const session = useSessionDistribution({ projectId: args.projectId, field: args.field, enabled: mode === "sessions" })
+  return mode === "sessions" ? session : trace
 }
 
 const CHART_HEIGHT = 64
@@ -85,14 +95,14 @@ function buildAreaPath(points: readonly { x: number; y: number }[]): string {
   return `${head} ${curve} L ${last.x.toFixed(2)} ${CHART_HEIGHT} Z`
 }
 
-function formatValueForField(field: PercentileTraceFilterField, value: number): string {
+function formatValueForField(field: PercentileField, value: number): string {
   if (field === "duration" || field === "ttft") return formatDuration(value)
   if (field === "cost") return formatPrice(value / 100_000_000)
   return String(value)
 }
 
-export function PercentileFilter({ projectId, field, value, onChange }: PercentileFilterProps) {
-  const { data: distribution, isLoading, isError } = useTraceDistribution({ projectId, field })
+export function PercentileFilter({ projectId, field, value, onChange, mode = "traces" }: PercentileFilterProps) {
+  const { data: distribution, isLoading, isError } = useDistributionForMode(mode, { projectId, field })
   const [hoverPercentile, setHoverPercentile] = useState<number | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -346,7 +356,9 @@ export function PercentileFilter({ projectId, field, value, onChange }: Percenti
               <Text.H7 color={activeIsHover && lockedPercentile === null ? "foregroundMuted" : "foreground"}>
                 {`≥ p${activePercentile}`}
                 {activeValue !== undefined && totalCount > 0 ? ` · ${formatValueForField(field, activeValue)}` : null}
-                {tracesAtOrAbove !== null ? ` · ~${formatCount(tracesAtOrAbove)} traces` : null}
+                {tracesAtOrAbove !== null
+                  ? ` · ~${formatCount(tracesAtOrAbove)} ${mode === "sessions" ? "sessions" : "traces"}`
+                  : null}
               </Text.H7>
             ) : (
               <Text.H7 color="foregroundMuted">Click chart to set a percentile threshold</Text.H7>

--- a/apps/web/src/components/filters-builder/status-filter.tsx
+++ b/apps/web/src/components/filters-builder/status-filter.tsx
@@ -1,0 +1,41 @@
+import { Button, Icon } from "@repo/ui"
+import { CheckCircle2Icon, XCircleIcon } from "lucide-react"
+
+const STATUS_PICKS = [
+  { value: "ok", label: "OK", icon: CheckCircle2Icon },
+  { value: "error", label: "Error", icon: XCircleIcon },
+] as const
+
+export type StatusFilterValue = (typeof STATUS_PICKS)[number]["value"]
+
+interface StatusFilterProps {
+  readonly selected: readonly StatusFilterValue[]
+  readonly onChange: (next: readonly StatusFilterValue[]) => void
+}
+
+export function StatusFilter({ selected, onChange }: StatusFilterProps) {
+  const toggle = (v: StatusFilterValue) => {
+    onChange(selected.includes(v) ? selected.filter((s) => s !== v) : [...selected, v])
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {STATUS_PICKS.map(({ value, label, icon }) => {
+        const active = selected.includes(value)
+        return (
+          <Button
+            key={value}
+            type="button"
+            size="sm"
+            variant={active ? "default-soft" : "outline"}
+            onClick={() => toggle(value)}
+            aria-pressed={active}
+          >
+            <Icon icon={icon} size="sm" />
+            {label}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -1,4 +1,5 @@
-import type { FilterSet } from "@domain/shared"
+import type { FilterCondition, FilterSet, PercentileSessionFilterField } from "@domain/shared"
+import type { TraceDistribution } from "@domain/spans"
 import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
 import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
@@ -6,6 +7,7 @@ import {
   countSessionsByProject,
   getSessionDetail,
   getSessionDistinctValues,
+  getSessionDistribution,
   getSessionMetricsByProject,
   listSessionIssues,
   listSessionsByProject,
@@ -30,6 +32,38 @@ export function deriveSessionStatus(endTime: string | Date, now: number = Date.n
   return now - last < SESSION_LIVE_THRESHOLD_MS ? "live" : "idle"
 }
 
+/**
+ * Default-on session filter: hide "orphan fragment" rows that carry no LLM
+ * activity (sessions whose every span produced 0 tokens and no model name —
+ * typically OTel-direct customers with mixed span/session-id propagation where
+ * framework spans split off into their own session).
+ *
+ * URL representation of the sidebar toggle:
+ *   - key absent          → default ON; this helper injects the filter.
+ *   - `{op:"eq",value:true}`  → explicit ON; equivalent to absent, filter is kept.
+ *   - `{op:"eq",value:false}` → sentinel meaning "user opted out of the default";
+ *                                this helper STRIPS the field so the repo applies
+ *                                no `hasLlmActivity` clause at all (i.e. shows
+ *                                both LLM-active sessions and orphan fragments).
+ *
+ * The `false` sentinel lives in the URL so the toggle state is shareable, but
+ * never reaches the repo as a filter condition — sending `false` to the
+ * synthetic clause would otherwise narrow the list to *only* orphans, which is
+ * not what "Including orphan fragments" means.
+ */
+function withSessionDefaults(filters: FilterSet | undefined): FilterSet {
+  if (filters?.hasLlmActivity !== undefined) {
+    const explicit = filters.hasLlmActivity
+    const optedOut = explicit.some((c) => c.op === "eq" && (c.value === false || c.value === "false"))
+    if (optedOut) {
+      const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
+      return rest as FilterSet
+    }
+    return filters
+  }
+  return { ...(filters ?? {}), hasLlmActivity: [{ op: "eq", value: true }] }
+}
+
 export function useSessionsInfiniteScroll({
   projectId,
   sorting,
@@ -41,6 +75,8 @@ export function useSessionsInfiniteScroll({
   readonly filters?: FilterSet
   readonly searchQuery?: string
 }) {
+  const effectiveFilters = useMemo(() => withSessionDefaults(filters), [filters])
+
   const {
     data: paginatedData,
     isLoading,
@@ -48,7 +84,7 @@ export function useSessionsInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ["sessionsInfiniteScroll", projectId, sorting, filters, searchQuery],
+    queryKey: ["sessionsInfiniteScroll", projectId, sorting, effectiveFilters, searchQuery],
     queryFn: async ({ pageParam }) => {
       const result = await listSessionsByProject({
         data: {
@@ -57,14 +93,18 @@ export function useSessionsInfiniteScroll({
           cursor: pageParam,
           sortBy: sorting.column,
           sortDirection: sorting.direction,
-          filters,
+          filters: effectiveFilters,
           ...(searchQuery ? { searchQuery } : {}),
         },
       })
       return result ?? { sessions: [], hasMore: false }
     },
     initialPageParam: undefined as
-      | { sortValue: string; secondaryValue?: string | undefined; sessionId: string }
+      | {
+          sortValue: string
+          secondaryValue?: string | undefined
+          sessionId: string
+        }
       | undefined,
     getNextPageParam: (lastPage) => lastPage?.nextCursor,
   })
@@ -113,13 +153,15 @@ export function useSessionsCount({
   readonly filters?: FilterSet
   readonly searchQuery?: string
 }) {
+  const effectiveFilters = useMemo(() => withSessionDefaults(filters), [filters])
+
   const { data, isLoading } = useQuery({
-    queryKey: ["sessionsCount", projectId, filters, searchQuery],
+    queryKey: ["sessionsCount", projectId, effectiveFilters, searchQuery],
     queryFn: () =>
       countSessionsByProject({
         data: {
           projectId,
-          ...(filters ? { filters } : {}),
+          filters: effectiveFilters,
           ...(searchQuery ? { searchQuery } : {}),
         },
       }),
@@ -192,16 +234,38 @@ export function useSessionMetrics({
   readonly projectId: string
   readonly filters?: FilterSet
 }) {
+  const effectiveFilters = useMemo(() => withSessionDefaults(filters), [filters])
+
   return useQuery({
-    queryKey: ["sessions-metrics", projectId, filters],
+    queryKey: ["sessions-metrics", projectId, effectiveFilters],
     queryFn: () =>
       getSessionMetricsByProject({
         data: {
           projectId,
-          ...(filters ? { filters } : {}),
+          filters: effectiveFilters,
         },
       }),
     staleTime: 30_000,
+  })
+}
+
+export function useSessionDistribution({
+  projectId,
+  field,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly field: PercentileSessionFilterField
+  readonly enabled?: boolean
+}) {
+  return useQuery<TraceDistribution>({
+    queryKey: ["session-distribution", projectId, field],
+    queryFn: () => getSessionDistribution({ data: { projectId, field } }),
+    // Distribution is intentionally insensitive to other filters and changes
+    // slowly relative to a user's interaction window — long stale time keeps
+    // the chart steady while picking a threshold.
+    staleTime: 60_000,
+    enabled: enabled && projectId.length > 0,
   })
 }
 
@@ -218,7 +282,10 @@ export function useSessionDistinctValues({
 }) {
   return useQuery({
     queryKey: ["session-distinct", projectId, column, search],
-    queryFn: () => getSessionDistinctValues({ data: { projectId, column, limit: 50, ...(search ? { search } : {}) } }),
+    queryFn: () =>
+      getSessionDistinctValues({
+        data: { projectId, column, limit: 50, ...(search ? { search } : {}) },
+      }),
     staleTime: 60_000,
     enabled: enabled && projectId.length > 0,
     // Keep the previous matches visible while the next query for a new search

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -1,7 +1,22 @@
 import { deriveIssueLifecycleStates, IssueRepository } from "@domain/issues"
 import { ScoreAnalyticsRepository } from "@domain/scores"
-import { filterSetSchema, OrganizationId, ProjectId, SessionId, TraceId } from "@domain/shared"
-import type { Session, SessionDetail, SessionDistinctColumn, SessionMetrics, SessionSearchMatch } from "@domain/spans"
+import {
+  filterSetSchema,
+  OrganizationId,
+  PERCENTILE_SESSION_FILTER_FIELDS,
+  type PercentileSessionFilterField,
+  ProjectId,
+  SessionId,
+  TraceId,
+} from "@domain/shared"
+import type {
+  Session,
+  SessionDetail,
+  SessionDistinctColumn,
+  SessionMetrics,
+  SessionSearchMatch,
+  TraceDistribution,
+} from "@domain/spans"
 import { SessionRepository, SpanRepository } from "@domain/spans"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
@@ -334,6 +349,33 @@ export const listSessionIssues = createServerFn({ method: "GET" })
       }).pipe(
         withPostgres(IssueRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+export const getSessionDistribution = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      field: z.enum(PERCENTILE_SESSION_FILTER_FIELDS),
+    }),
+  )
+  .handler(async ({ data }): Promise<TraceDistribution> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* SessionRepository
+        return yield* repo.getDistribution({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          field: data.field as PercentileSessionFilterField,
+        })
+      }).pipe(
+        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -8,7 +8,7 @@ import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { GeneralAggregations } from "./general-aggregations.tsx"
 import { Histogram } from "./histogram.tsx"
 
-const DEFAULT_HISTOGRAM_METRIC: TraceHistogramMetric = "traces"
+const DEFAULT_HISTOGRAM_METRIC: TraceHistogramMetric = "sessions"
 
 interface TraceAggregationsPanelProps {
   readonly projectId: string
@@ -42,7 +42,7 @@ export function TraceAggregationsPanel({
         <div className="flex items-center justify-between px-4 py-2">
           <div className="flex items-center gap-1.5">
             <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
-            <Text.H6 color="foregroundMuted">Traces statistics</Text.H6>
+            <Text.H6 color="foregroundMuted">Statistics</Text.H6>
           </div>
           <Button variant="ghost" size="icon" onClick={() => setCollapsed(false)} aria-label="Expand statistics">
             <Icon icon={ChevronDown} size="sm" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -3,6 +3,7 @@ import type { TraceHistogramMetric } from "@domain/spans"
 import { Button, cn, Icon, Skeleton, Text } from "@repo/ui"
 import { ChevronUp } from "lucide-react"
 import { useState } from "react"
+import { useSessionsCount } from "../../../../../../domains/sessions/sessions.collection.ts"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
 import { HISTOGRAM_METRIC_DEFINITIONS, type HistogramMetricDefinition } from "./histogram-metrics.ts"
 
@@ -46,7 +47,15 @@ function AggregationItem({
 
 const DASH = "—"
 
-const METRIC_ORDER: readonly TraceHistogramMetric[] = ["traces", "cost", "duration", "tokens", "ttft", "spans"]
+const METRIC_ORDER: readonly TraceHistogramMetric[] = [
+  "sessions",
+  "cost",
+  "duration",
+  "tokens",
+  "ttft",
+  "traces",
+  "spans",
+]
 
 export function GeneralAggregations({
   projectId,
@@ -72,8 +81,12 @@ export function GeneralAggregations({
     projectId,
     ...filterOpts,
   })
+  const { totalCount: sessionTotalCount, isLoading: sessionCountLoading } = useSessionsCount({
+    projectId,
+    ...filterOpts,
+  })
 
-  const loading = metricsLoading || countLoading
+  const loading = metricsLoading || countLoading || sessionCountLoading
 
   // TTFT card is hidden when no trace in the current view recorded a first-token timestamp
   // (`> 0`); showing it would just render "—" forever for projects that don't stream.
@@ -86,6 +99,7 @@ export function GeneralAggregations({
   const [showLeftFade, setShowLeftFade] = useState(false)
 
   const renderValue = (def: HistogramMetricDefinition): string => {
+    if (def.id === "sessions") return def.formatBucket(sessionTotalCount)
     if (def.id === "traces") return def.formatBucket(totalCount)
     if (!traceMetrics) return DASH
     return def.formatBucket(def.selectMetricsValue(traceMetrics, totalCount))

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
@@ -23,6 +23,17 @@ export interface HistogramMetricDefinition {
 const microcentsToUSD = (microcents: number): string => formatPrice(microcents / 100_000_000)
 
 export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric, HistogramMetricDefinition>> = {
+  sessions: {
+    id: "sessions",
+    label: "Sessions",
+    cardSkeletonWidthClassName: "w-16",
+    tooltipNoun: "sessions",
+    formatBucket: formatCount,
+    selectBucket: (b) => b.sessionCount,
+    // Card value is rendered out-of-band from a session-count query — see
+    // `general-aggregations.tsx`. This stub is unused for `sessions`.
+    selectMetricsValue: () => 0,
+  },
   traces: {
     id: "traces",
     label: "Traces",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -138,7 +138,7 @@ export function Histogram({ projectId, projectSlug, filters, metric, showInciden
   if (denseBuckets.length === 0) {
     return (
       <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
-        <Text.H6 color="foregroundMuted">No traces in this time window</Text.H6>
+        <Text.H6 color="foregroundMuted">No activity in this time window</Text.H6>
       </div>
     )
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -1,15 +1,18 @@
-import type { FilterCondition, FilterSet, PercentileTraceFilterField } from "@domain/shared"
-import { Button, Icon, Input, Tabs, Text, Tooltip } from "@repo/ui"
+import type { FilterCondition, FilterSet } from "@domain/shared"
+import { Button, Icon, Input, Switch, Tabs, Text, Tooltip } from "@repo/ui"
 import { ChevronDown, ChevronUp, InfoIcon, XIcon } from "lucide-react"
 import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import {
   getTextFieldsForMode,
   MULTI_SELECT_FIELDS,
   NUMBER_RANGE_FIELDS,
+  type PercentileFieldName,
+  STATUS_FIELDS,
 } from "../../../../../components/filters-builder/constants.ts"
 import { MetadataFilter } from "../../../../../components/filters-builder/metadata-filter/metadata-filter.tsx"
 import { type FilterMode, MultiSelectFilter } from "../../../../../components/filters-builder/multi-select-filter.tsx"
 import { PercentileFilter } from "../../../../../components/filters-builder/percentile-filter.tsx"
+import { StatusFilter, type StatusFilterValue } from "../../../../../components/filters-builder/status-filter.tsx"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 
@@ -46,6 +49,29 @@ function getRangeValues(filters: FilterSet, field: string): { min: number | unde
 function getPercentileValue(filters: FilterSet, field: string): number | undefined {
   const cond = filters[field]?.find((c) => c.op === "gtePercentile")
   return typeof cond?.value === "number" ? cond.value : undefined
+}
+
+const STATUS_VALUES: readonly StatusFilterValue[] = ["ok", "error"]
+
+function getStatusValues(filters: FilterSet, field: string): readonly StatusFilterValue[] {
+  const cond = filters[field]?.find((c) => c.op === "in")
+  const raw = Array.isArray(cond?.value) ? cond.value.map(String) : []
+  return raw.filter((v): v is StatusFilterValue => (STATUS_VALUES as readonly string[]).includes(v))
+}
+
+/**
+ * Tri-state for the "Has LLM activity" toggle:
+ * - URL key absent → treated as on (the default chip applies at the call site).
+ * - `[{op: "eq", value: false}]` → off (user explicitly opted out).
+ * - `[{op: "eq", value: true}]` → on (explicit; equivalent to absent).
+ *
+ * Returning a plain boolean lets the Switch render the right state regardless
+ * of which representation lives in the URL.
+ */
+function getHasLlmActivityOn(filters: FilterSet): boolean {
+  const cond = filters.hasLlmActivity?.find((c) => c.op === "eq")
+  if (cond === undefined) return true
+  return cond.value !== false && cond.value !== "false"
 }
 
 function setFieldConditions(filters: FilterSet, field: string, conditions: FilterCondition[]): FilterSet {
@@ -255,8 +281,9 @@ interface NumberFilterSectionProps {
   readonly label: ReactNode
   readonly field: string
   readonly tooltip: string | undefined
-  readonly percentileField: PercentileTraceFilterField | undefined
+  readonly percentileField: PercentileFieldName | undefined
   readonly projectId: string
+  readonly mode: FilterMode
   readonly minValue: number | undefined
   readonly maxValue: number | undefined
   readonly percentileValue: number | undefined
@@ -270,6 +297,7 @@ function NumberFilterSection({
   tooltip,
   percentileField,
   projectId,
+  mode,
   minValue,
   maxValue,
   percentileValue,
@@ -335,6 +363,7 @@ function NumberFilterSection({
           field={percentileField}
           value={percentileValue}
           onChange={onPercentileChange}
+          mode={mode}
         />
       ) : (
         <NumberRangeFilter
@@ -358,7 +387,8 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
 
   const setContainsFilter = useCallback(
     (field: string, value: string) => {
-      setField(field, value ? [{ op: "contains", value }] : [])
+      const normalized = value.trim()
+      setField(field, normalized ? [{ op: "contains", value: normalized }] : [])
     },
     [setField],
   )
@@ -381,6 +411,13 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
   )
 
   const textFields = getTextFieldsForMode(mode)
+
+  const setHasLlmActivity = useCallback(
+    (on: boolean) => {
+      setField("hasLlmActivity", on ? [] : [{ op: "eq", value: false }])
+    },
+    [setField],
+  )
 
   const metadataEntries = useMemo(() => {
     const entries: { key: string; value: string }[] = []
@@ -420,6 +457,35 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
       </div>
 
       <div className="flex flex-col px-4 overflow-y-auto flex-1">
+        {mode === "sessions" && (
+          <CollapsibleSection
+            label="Has LLM activity"
+            defaultOpen={filters.hasLlmActivity !== undefined && !getHasLlmActivityOn(filters)}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <Text.H7 color="foregroundMuted">
+                {getHasLlmActivityOn(filters) ? "Hiding sessions without any LLM call." : "Including orphan fragments."}
+              </Text.H7>
+              <Switch
+                checked={getHasLlmActivityOn(filters)}
+                onCheckedChange={(next) => setHasLlmActivity(next === true)}
+              />
+            </div>
+          </CollapsibleSection>
+        )}
+
+        {STATUS_FIELDS.map(({ label, field }) => {
+          const selected = getStatusValues(filters, field)
+          return (
+            <CollapsibleSection key={field} label={label} defaultOpen={selected.length > 0}>
+              <StatusFilter
+                selected={selected}
+                onChange={(values) => setField(field, values.length > 0 ? [{ op: "in", value: [...values] }] : [])}
+              />
+            </CollapsibleSection>
+          )
+        })}
+
         {textFields.map(({ label, field, placeholder }) => {
           const value = getTextFilterValue(filters, field)
           return (
@@ -460,6 +526,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
               tooltip={tooltip}
               percentileField={percentile?.field}
               projectId={projectId}
+              mode={mode}
               minValue={range.min}
               maxValue={range.max}
               percentileValue={percentileValue}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -146,6 +146,9 @@ export function MetadataTab({ session }: { readonly session: SessionDetailRecord
           <DetailSummary
             items={[
               { label: "Session ID", value: session.sessionId, copyable: true },
+              ...(session.traceIds.length === 1
+                ? [{ label: "Trace ID", value: session.traceIds[0] as string, copyable: true }]
+                : []),
               ...(session.simulationId?.trim()
                 ? [
                     {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -1,22 +1,30 @@
 import { CopyableText, Icon, ProviderIcon, Status, type TabOption, Tabs, Text, Tooltip } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
-import { GroupIcon, MessageSquareIcon, MessagesSquareIcon, TriangleAlertIcon } from "lucide-react"
+import { GroupIcon, ListTreeIcon, MessageSquareIcon, MessagesSquareIcon, TriangleAlertIcon } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useAnnotationsBySession } from "../../../../../../domains/annotations/annotations.collection.ts"
 import { deriveSessionStatus, useSessionIssues } from "../../../../../../domains/sessions/sessions.collection.ts"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
+import { SpansTab } from "../trace-detail-drawer/tabs/spans-tab.tsx"
 import { AnnotationsTab } from "./annotations-tab.tsx"
 import { ConversationTab } from "./conversation-tab.tsx"
 import { IssuesTab } from "./issues-tab.tsx"
 import { MetadataTab } from "./metadata-tab.tsx"
 import { SessionStatusPill } from "./session-status-pill.tsx"
 
-export type SessionTabId = "session" | "conversation" | "annotations" | "issues"
+export type SessionTabId = "session" | "conversation" | "spans" | "annotations" | "issues"
 
 export function isSessionTab(value: string): value is SessionTabId {
-  return value === "session" || value === "conversation" || value === "annotations" || value === "issues"
+  return (
+    value === "session" ||
+    value === "conversation" ||
+    value === "spans" ||
+    value === "annotations" ||
+    value === "issues"
+  )
 }
 
 const tabCountPillClass =
@@ -51,15 +59,18 @@ export function SessionSlot({
   readonly searchQuery?: string
 }) {
   const traceIds = session.traceIds
-  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<SessionTabId>>(() => new Set([activeTab]))
 
-  // TODO(frontend-use-effect-policy): reactive on `activeTab` because the tab can
-  // change from a URL param (deep link, browser back/forward), not just from the
-  // tab control here. The single source of truth for "mark visited" is this
-  // effect — `selectTab` does not need to write the set itself.
+  // A single-trace session can surface its spans inline
+  const singleTrace = traces.length === 1 ? traces[0] : undefined
+  const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
+  const effectiveActiveTab: SessionTabId = activeTab === "spans" && !singleTrace ? "session" : activeTab
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<SessionTabId>>(() => new Set([effectiveActiveTab]))
+
+  // TODO(frontend-use-effect-policy): visited-set is an accumulator over a
+  // sequence of activeTab changes; can't be derived from current props alone.
   useEffect(() => {
-    setVisitedTabs((prev) => (prev.has(activeTab) ? prev : new Set([...prev, activeTab])))
-  }, [activeTab])
+    setVisitedTabs((prev) => (prev.has(effectiveActiveTab) ? prev : new Set([...prev, effectiveActiveTab])))
+  }, [effectiveActiveTab])
 
   function selectTab(tab: SessionTabId) {
     onActiveTabChange(tab)
@@ -84,8 +95,8 @@ export function SessionSlot({
     return map
   }, [traces])
 
-  const tabs = useMemo<TabOption<SessionTabId>[]>(
-    () => [
+  const tabs = useMemo<TabOption<SessionTabId>[]>(() => {
+    const all: TabOption<SessionTabId>[] = [
       {
         id: "session",
         label: "Session",
@@ -96,6 +107,16 @@ export function SessionSlot({
         label: "Conversation",
         icon: <Icon icon={MessagesSquareIcon} size="sm" />,
       },
+    ]
+    if (singleTrace) {
+      all.push({
+        id: "spans",
+        label: "Spans",
+        icon: <Icon icon={ListTreeIcon} size="sm" />,
+        suffix: countSuffix(singleTrace.spanCount),
+      })
+    }
+    all.push(
       {
         id: "annotations",
         label: "Annotations",
@@ -108,9 +129,9 @@ export function SessionSlot({
         icon: <Icon icon={TriangleAlertIcon} size="sm" />,
         suffix: countSuffix(issueCount),
       },
-    ],
-    [annotationCount, issueCount],
-  )
+    )
+    return all
+  }, [annotationCount, issueCount, singleTrace])
 
   const title = session.rootSpanName || session.sessionId.slice(0, 12)
   const status = deriveSessionStatus(session.endTime)
@@ -156,23 +177,34 @@ export function SessionSlot({
             tooltip="Copy session ID"
           />
         </div>
-        <Tabs options={tabs} active={activeTab} onSelect={selectTab} />
+        <Tabs options={tabs} active={effectiveActiveTab} onSelect={selectTab} />
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {activeTab === "session" && <MetadataTab session={session} />}
+        {effectiveActiveTab === "session" && <MetadataTab session={session} />}
         {visitedTabs.has("conversation") && (
-          <div className={activeTab === "conversation" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+          <div className={effectiveActiveTab === "conversation" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
             <ConversationTab
               projectId={projectId}
               latestTraceId={latestTraceId}
-              isActive={activeTab === "conversation"}
+              isActive={effectiveActiveTab === "conversation"}
               {...(searchQuery ? { searchQuery } : {})}
             />
           </div>
         )}
+        {singleTrace && visitedTabs.has("spans") && (
+          <div className={effectiveActiveTab === "spans" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+            <SpansTab
+              projectId={projectId}
+              traceId={singleTrace.traceId}
+              selectedSpanId={selectedSpanId}
+              onSelectSpan={setSelectedSpanId}
+              isActive={effectiveActiveTab === "spans"}
+            />
+          </div>
+        )}
         {visitedTabs.has("annotations") && (
-          <div className={activeTab === "annotations" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+          <div className={effectiveActiveTab === "annotations" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
             <AnnotationsTab
               projectId={projectId}
               traceIds={traceIds}
@@ -184,7 +216,7 @@ export function SessionSlot({
           </div>
         )}
         {visitedTabs.has("issues") && (
-          <div className={activeTab === "issues" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+          <div className={effectiveActiveTab === "issues" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
             <IssuesTab projectId={projectId} traceIds={traceIds} onOpenIssue={onOpenIssue} />
           </div>
         )}

--- a/packages/domain/shared/src/trace-filter-fields.ts
+++ b/packages/domain/shared/src/trace-filter-fields.ts
@@ -56,5 +56,12 @@ export type PercentileTraceFilterField = (typeof PERCENTILE_TRACE_FILTER_FIELDS)
 export const isPercentileTraceFilterField = (value: string): value is PercentileTraceFilterField =>
   (PERCENTILE_TRACE_FILTER_FIELDS as readonly string[]).includes(value)
 
+export const PERCENTILE_SESSION_FILTER_FIELDS = ["duration", "ttft", "cost"] as const
+
+export type PercentileSessionFilterField = (typeof PERCENTILE_SESSION_FILTER_FIELDS)[number]
+
+export const isPercentileSessionFilterField = (value: string): value is PercentileSessionFilterField =>
+  (PERCENTILE_SESSION_FILTER_FIELDS as readonly string[]).includes(value)
+
 export const STATUS_OPTIONS = ["ok", "error", "unset"] as const
 export type TraceStatus = (typeof STATUS_OPTIONS)[number]

--- a/packages/domain/spans/src/helpers.test.ts
+++ b/packages/domain/spans/src/helpers.test.ts
@@ -45,6 +45,7 @@ describe("denseTraceTimeHistogramBuckets", () => {
     const populated = {
       bucketStart: "2024-06-01T11:00:00.000Z",
       traceCount: 7,
+      sessionCount: 5,
       costTotalMicrocentsSum: 1234,
       durationNsMedian: 5_000_000,
       tokensTotalSum: 200,
@@ -65,6 +66,7 @@ describe("denseTraceTimeHistogramBuckets", () => {
     expect(dense).toHaveLength(2)
     for (const bucket of dense) {
       expect(bucket.traceCount).toBe(0)
+      expect(bucket.sessionCount).toBe(0)
       expect(bucket.costTotalMicrocentsSum).toBe(0)
       expect(bucket.durationNsMedian).toBe(0)
       expect(bucket.tokensTotalSum).toBe(0)
@@ -89,6 +91,7 @@ describe("denseTraceTimeHistogramBuckets", () => {
       {
         bucketStart: "2024-06-01T10:00:00.000Z",
         traceCount: 2,
+        sessionCount: 2,
         costTotalMicrocentsSum: 100,
         durationNsMedian: 1_000,
         tokensTotalSum: 30,
@@ -98,6 +101,7 @@ describe("denseTraceTimeHistogramBuckets", () => {
       {
         bucketStart: "2024-06-01T10:00:00.123Z",
         traceCount: 3,
+        sessionCount: 1,
         costTotalMicrocentsSum: 200,
         durationNsMedian: 2_000,
         tokensTotalSum: 70,
@@ -110,6 +114,7 @@ describe("denseTraceTimeHistogramBuckets", () => {
     expect(dense[0]).toEqual({
       bucketStart: "2024-06-01T10:00:00.000Z",
       traceCount: 5,
+      sessionCount: 3,
       costTotalMicrocentsSum: 300,
       durationNsMedian: 2_000,
       tokensTotalSum: 100,

--- a/packages/domain/spans/src/helpers.ts
+++ b/packages/domain/spans/src/helpers.ts
@@ -178,6 +178,7 @@ export function denseTraceTimeHistogramBuckets(
     buckets.set(key, {
       bucketStart: prev.bucketStart,
       traceCount: prev.traceCount + b.traceCount,
+      sessionCount: prev.sessionCount + b.sessionCount,
       costTotalMicrocentsSum: prev.costTotalMicrocentsSum + b.costTotalMicrocentsSum,
       durationNsMedian: Math.max(prev.durationNsMedian, b.durationNsMedian),
       tokensTotalSum: prev.tokensTotalSum + b.tokensTotalSum,

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -3,6 +3,7 @@ import type {
   FilterSet,
   NotFoundError,
   OrganizationId,
+  PercentileSessionFilterField,
   ProjectId,
   RepositoryError,
   SessionId,
@@ -10,7 +11,7 @@ import type {
 import { Context, type Effect } from "effect"
 import type { Session, SessionDetail } from "../entities/session.ts"
 import type { SessionSearchMatch } from "../entities/session-search-match.ts"
-import type { NumericRollup } from "./trace-repository.ts"
+import type { NumericRollup, TraceDistribution } from "./trace-repository.ts"
 
 /**
  * Repository port for sessions (ClickHouse materialized view).
@@ -51,6 +52,20 @@ export interface SessionRepositoryShape {
     readonly limit?: number
     readonly search?: string
   }): Effect.Effect<readonly string[], RepositoryError, ChSqlClient>
+
+  /**
+   * Numeric distribution of one session column for the project, sampled at every
+   * integer percentile (p0..p100 — 101 values). Mirrors `TraceRepository.getDistribution`
+   * but computed against the session aggregate, since per-session and per-trace
+   * distributions are independent (a session-cost distribution is not the same
+   * as a trace-cost distribution). Intentionally ignores other user filters so
+   * the visualization is stable while the user picks a threshold.
+   */
+  getDistribution(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly field: PercentileSessionFilterField
+  }): Effect.Effect<TraceDistribution, RepositoryError, ChSqlClient>
 }
 
 export type SessionDistinctColumn = "tags" | "models" | "providers" | "serviceNames"

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -194,6 +194,7 @@ export interface TraceTimeHistogramBucket {
   /** Bucket start instant (UTC ISO string). */
   readonly bucketStart: string
   readonly traceCount: number
+  readonly sessionCount: number
   readonly costTotalMicrocentsSum: number
   readonly durationNsMedian: number
   readonly tokensTotalSum: number
@@ -201,8 +202,7 @@ export interface TraceTimeHistogramBucket {
   readonly timeToFirstTokenNsMedian: number
 }
 
-/** Metric series the traces histogram can render. Order matches the metric cards above the chart. */
-export const TRACE_HISTOGRAM_METRICS = ["traces", "cost", "duration", "tokens", "ttft", "spans"] as const
+export const TRACE_HISTOGRAM_METRICS = ["sessions", "cost", "duration", "tokens", "ttft", "traces", "spans"] as const
 
 export type TraceHistogramMetric = (typeof TRACE_HISTOGRAM_METRICS)[number]
 
@@ -230,6 +230,7 @@ export const emptyTraceDistribution = (): TraceDistribution => ({
 export const emptyTraceTimeHistogramBucket = (bucketStart: string): TraceTimeHistogramBucket => ({
   bucketStart,
   traceCount: 0,
+  sessionCount: 0,
   costTotalMicrocentsSum: 0,
   durationNsMedian: 0,
   tokensTotalSum: 0,

--- a/packages/domain/spans/src/testing/fake-session-repository.ts
+++ b/packages/domain/spans/src/testing/fake-session-repository.ts
@@ -2,6 +2,7 @@ import { NotFoundError } from "@domain/shared"
 import { Effect } from "effect"
 import type { SessionRepositoryShape } from "../ports/session-repository.ts"
 import { emptySessionMetrics } from "../ports/session-repository.ts"
+import { emptyTraceDistribution } from "../ports/trace-repository.ts"
 
 export const createFakeSessionRepository = (overrides?: Partial<SessionRepositoryShape>) => {
   const repository: SessionRepositoryShape = {
@@ -10,6 +11,7 @@ export const createFakeSessionRepository = (overrides?: Partial<SessionRepositor
     aggregateMetricsByProjectId: () => Effect.succeed(emptySessionMetrics()),
     findBySessionId: ({ sessionId }) => Effect.fail(new NotFoundError({ entity: "Session", id: sessionId as string })),
     distinctFilterValues: () => Effect.succeed([]),
+    getDistribution: () => Effect.succeed(emptyTraceDistribution()),
     ...overrides,
   }
 

--- a/packages/domain/spans/src/use-cases/get-trace-analytics.test.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-analytics.test.ts
@@ -34,6 +34,7 @@ const buildLayer = (input: {
   readonly histogramBuckets?: ReadonlyArray<{
     bucketStart: string
     traceCount: number
+    sessionCount: number
     costTotalMicrocentsSum: number
     durationNsMedian: number
     tokensTotalSum: number
@@ -115,6 +116,7 @@ describe("getTraceAnalyticsUseCase", () => {
       {
         bucketStart: "2026-04-15T00:00:00.000Z",
         traceCount: 5,
+        sessionCount: 4,
         costTotalMicrocentsSum: 100,
         durationNsMedian: 1000,
         tokensTotalSum: 200,
@@ -124,6 +126,7 @@ describe("getTraceAnalyticsUseCase", () => {
       {
         bucketStart: "2026-04-15T12:00:00.000Z",
         traceCount: 3,
+        sessionCount: 2,
         costTotalMicrocentsSum: 50,
         durationNsMedian: 800,
         tokensTotalSum: 150,

--- a/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
@@ -11,7 +11,13 @@ import {
   TraceId,
 } from "@domain/shared"
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
-import { type SessionDetail, SessionRepository, type TraceDetail, TraceRepository } from "@domain/spans"
+import {
+  emptyTraceDistribution,
+  type SessionDetail,
+  SessionRepository,
+  type TraceDetail,
+  TraceRepository,
+} from "@domain/spans"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { TAXONOMY_EMBEDDING_DIMENSIONS } from "../constants.ts"
@@ -153,6 +159,7 @@ const makeSessionRepository = (session: SessionDetail | null) =>
         timeToFirstTokenNs: { min: 0, max: 0, avg: 0, median: 0, sum: 0 },
       }),
     distinctFilterValues: () => Effect.succeed([]),
+    getDistribution: () => Effect.succeed(emptyTraceDistribution()),
   })
 
 const makeTraceRepository = (traces: readonly TraceDetail[]) =>

--- a/packages/platform/db-clickhouse/src/filter-builder.test.ts
+++ b/packages/platform/db-clickhouse/src/filter-builder.test.ts
@@ -203,3 +203,145 @@ describe("buildClickHouseWhere", () => {
     expect(values).toContainEqual([])
   })
 })
+
+describe("buildClickHouseWhere with arrayContains", () => {
+  const arrayContainsRegistry: ChFieldRegistry = {
+    traceId: { column: "trace_ids", chType: "FixedString(32)", isArray: true, arrayContains: true },
+    tags: { column: "tags", chType: "String", isArray: true, arrayContains: true },
+  }
+
+  it("routes scalar eq to has(col, …)", () => {
+    const filters: FilterSet = { traceId: [{ op: "eq", value: "abc123" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("has(trace_ids, {f_0:FixedString(32)})")
+    expect(params.f_0).toBe("abc123")
+  })
+
+  it("routes scalar neq to NOT has(col, …)", () => {
+    const filters: FilterSet = { traceId: [{ op: "neq", value: "abc123" }] }
+    const { clauses } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("NOT has(trace_ids, {f_0:FixedString(32)})")
+  })
+
+  it("routes contains to has(col, …) and does NOT auto-wrap value in %", () => {
+    const filters: FilterSet = { traceId: [{ op: "contains", value: "abc123" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("has(trace_ids, {f_0:FixedString(32)})")
+    expect(params.f_0).toBe("abc123")
+  })
+
+  it("routes notContains to NOT has(col, …) without % wrapping", () => {
+    const filters: FilterSet = { tags: [{ op: "notContains", value: "internal" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("NOT has(tags, {f_0:String})")
+    expect(params.f_0).toBe("internal")
+  })
+
+  it("keeps in/notIn on hasAny — arrayContains only affects scalar ops", () => {
+    const filters: FilterSet = {
+      tags: [{ op: "in", value: ["prod", "staging"] }],
+    }
+    const { clauses, params } = buildClickHouseWhere(filters, arrayContainsRegistry)
+    expect(clauses[0]).toBe("hasAny(tags, {f_0:Array(String)})")
+    expect(params.f_0).toEqual(["prod", "staging"])
+  })
+})
+
+describe("buildClickHouseWhere with synthetic fields", () => {
+  const syntheticRegistry: ChFieldRegistry = {
+    status: {
+      kind: "synthetic",
+      buildClause: (cond) => {
+        const fragments: Record<string, string> = {
+          ok: "(error_count = 0 AND span_count > 0)",
+          error: "(error_count > 0)",
+          unset: "(span_count = 0)",
+        }
+        const raw = Array.isArray(cond.value) ? cond.value : [cond.value]
+        const parts = raw.map((v) => fragments[String(v)] ?? "1 = 0")
+        const disjunction = parts.join(" OR ")
+        switch (cond.op) {
+          case "eq":
+          case "in":
+            return { clause: `(${disjunction})`, params: {} }
+          case "neq":
+          case "notIn":
+            return { clause: `NOT (${disjunction})`, params: {} }
+          default:
+            throw new Error(`Unsupported status op: ${cond.op}`)
+        }
+      },
+    },
+    hasLlmActivity: {
+      kind: "synthetic",
+      buildClause: (cond) => {
+        const fragment = "(tokens_total > 0 OR length(models) > 0)"
+        const truthy = cond.value === true
+        return {
+          clause: truthy ? fragment : `NOT ${fragment}`,
+          params: {},
+        }
+      },
+    },
+  }
+
+  it("invokes the synthetic buildClause for eq", () => {
+    const filters: FilterSet = { status: [{ op: "eq", value: "error" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses[0]).toBe("((error_count > 0))")
+    expect(params).toEqual({})
+  })
+
+  it("invokes the synthetic buildClause for in across multiple values", () => {
+    const filters: FilterSet = { status: [{ op: "in", value: ["ok", "error"] }] }
+    const { clauses } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses[0]).toBe("((error_count = 0 AND span_count > 0) OR (error_count > 0))")
+  })
+
+  it("invokes the synthetic buildClause for neq (negation)", () => {
+    const filters: FilterSet = { status: [{ op: "neq", value: "error" }] }
+    const { clauses } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses[0]).toBe("NOT ((error_count > 0))")
+  })
+
+  it("handles boolean-valued synthetic clauses", () => {
+    const filters: FilterSet = { hasLlmActivity: [{ op: "eq", value: true }] }
+    const { clauses } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses[0]).toBe("(tokens_total > 0 OR length(models) > 0)")
+  })
+
+  it("handles boolean-valued synthetic clauses (negated)", () => {
+    const filters: FilterSet = { hasLlmActivity: [{ op: "eq", value: false }] }
+    const { clauses } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses[0]).toBe("NOT (tokens_total > 0 OR length(models) > 0)")
+  })
+
+  it("merges params returned by the synthetic buildClause", () => {
+    const paramRegistry: ChFieldRegistry = {
+      paramSynthetic: {
+        kind: "synthetic",
+        buildClause: (_cond, paramPrefix) => ({
+          clause: `(some_col > {${paramPrefix}_a:UInt64} AND other_col < {${paramPrefix}_b:UInt64})`,
+          params: { [`${paramPrefix}_a`]: 10, [`${paramPrefix}_b`]: 100 },
+        }),
+      },
+    }
+    const filters: FilterSet = { paramSynthetic: [{ op: "eq", value: "ignored" }] }
+    const { clauses, params } = buildClickHouseWhere(filters, paramRegistry)
+    expect(clauses[0]).toBe("(some_col > {f_0_a:UInt64} AND other_col < {f_0_b:UInt64})")
+    expect(params).toEqual({ f_0_a: 10, f_0_b: 100 })
+  })
+
+  it("emits multiple clauses when a synthetic field has multiple conditions", () => {
+    const filters: FilterSet = {
+      status: [
+        { op: "in", value: ["error"] },
+        { op: "notIn", value: ["unset"] },
+      ],
+    }
+    const { clauses } = buildClickHouseWhere(filters, syntheticRegistry)
+    expect(clauses).toHaveLength(2)
+    expect(clauses[0]).toBe("((error_count > 0))")
+    expect(clauses[1]).toBe("NOT ((span_count = 0))")
+  })
+})

--- a/packages/platform/db-clickhouse/src/filter-builder.ts
+++ b/packages/platform/db-clickhouse/src/filter-builder.ts
@@ -4,18 +4,26 @@ import type { FilterCondition, FilterOperator, FilterSet } from "@domain/shared"
 // ClickHouse-specific field mapping
 // ---------------------------------------------------------------------------
 
-export interface ChFieldMapping {
-  /** SQL column expression or alias used in SELECT/HAVING */
+export interface ScalarFieldMapping {
   readonly column: string
-  /** ClickHouse parameter type (e.g. "String", "UInt64", "Array(String)") */
   readonly chType: string
-  /** Whether this is an array column (in/notIn use hasAny instead of IN) */
   readonly isArray?: boolean
-  /**
-   * Optional value transform before SQL binding (e.g. status string -> int).
-   * Receives the condition value and must return a value suitable for the chType.
-   */
+  readonly arrayContains?: boolean
   readonly mapValue?: (value: FilterCondition["value"]) => FilterCondition["value"]
+}
+
+export interface SyntheticFieldMapping {
+  readonly kind: "synthetic"
+  readonly buildClause: (
+    cond: FilterCondition,
+    paramPrefix: string,
+  ) => { readonly clause: string; readonly params: Record<string, unknown> }
+}
+
+export type ChFieldMapping = ScalarFieldMapping | SyntheticFieldMapping
+
+function isSyntheticMapping(mapping: ChFieldMapping): mapping is SyntheticFieldMapping {
+  return "kind" in mapping && mapping.kind === "synthetic"
 }
 
 export type ChFieldRegistry<K extends string = string> = Readonly<Record<K, ChFieldMapping>>
@@ -90,10 +98,22 @@ export function buildClickHouseWhere(
     const mapping = registry[field]
     if (!mapping) continue
 
+    if (isSyntheticMapping(mapping)) {
+      for (const cond of conditions) {
+        const subPrefix = `${prefix}_${paramIdx++}`
+        const { clause, params: extraParams } = mapping.buildClause(cond, subPrefix)
+        clauses.push(clause)
+        Object.assign(params, extraParams)
+      }
+      continue
+    }
+
     for (const cond of conditions) {
       const p = `${prefix}_${paramIdx++}`
       let value: FilterCondition["value"] = mapping.mapValue ? mapping.mapValue(cond.value) : cond.value
-      if ((cond.op === "contains" || cond.op === "notContains") && typeof value === "string") {
+      const ilikeWrap =
+        (cond.op === "contains" || cond.op === "notContains") && !(mapping.isArray && mapping.arrayContains)
+      if (ilikeWrap && typeof value === "string") {
         value = `%${value}%`
       }
       params[p] = value
@@ -108,14 +128,21 @@ export function buildClickHouseWhere(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function buildClause(mapping: ChFieldMapping, paramName: string, cond: FilterCondition): string {
-  const { column, chType, isArray } = mapping
+function buildClause(mapping: ScalarFieldMapping, paramName: string, cond: FilterCondition): string {
+  const { column, chType, isArray, arrayContains } = mapping
 
   // Array fields: in/notIn use hasAny
   if (isArray && (cond.op === "in" || cond.op === "notIn")) {
     return cond.op === "in"
       ? `hasAny(${column}, {${paramName}:Array(${chType})})`
       : `NOT hasAny(${column}, {${paramName}:Array(${chType})})`
+  }
+
+  if (isArray && arrayContains && (cond.op === "eq" || cond.op === "contains")) {
+    return `has(${column}, {${paramName}:${chType}})`
+  }
+  if (isArray && arrayContains && (cond.op === "neq" || cond.op === "notContains")) {
+    return `NOT has(${column}, {${paramName}:${chType}})`
   }
 
   // Scalar in/notIn

--- a/packages/platform/db-clickhouse/src/registries/helpers.ts
+++ b/packages/platform/db-clickhouse/src/registries/helpers.ts
@@ -1,10 +1,6 @@
 import type { FilterCondition } from "@domain/shared"
 
 /**
- * Shared `mapValue` helpers for ClickHouse field registries (`trace-fields`, `session-fields`, …).
- */
-
-/**
  * ClickHouse `DateTime64(9, 'UTC')` bound parameters reject typical JS `toISOString()` output with a
  * trailing `Z` (BAD_QUERY_PARAMETER: parsed incompletely — the `Z` is an extra byte). Normalize to
  * `YYYY-MM-DD HH:MM:SS.sss...` without a timezone suffix so parameterized queries bind correctly.
@@ -16,11 +12,64 @@ export function mapDateTime64UtcQueryParam(value: FilterCondition["value"]): Fil
   return withoutZ.replace("T", " ")
 }
 
-const STATUS_TO_INT: Record<string, number> = { unset: 0, ok: 1, error: 2 }
+type StatusEnum = "ok" | "error" | "unset"
+const STATUS_FRAGMENTS: Readonly<Record<StatusEnum, string>> = {
+  ok: "(error_count = 0 AND span_count > 0)",
+  error: "(error_count > 0)",
+  unset: "(span_count = 0)",
+}
 
-export function mapStatusValue(value: FilterCondition["value"]): FilterCondition["value"] {
-  if (Array.isArray(value)) {
-    return value.map((v) => STATUS_TO_INT[String(v)] ?? -1).filter((n) => n >= 0)
+function isStatusEnum(value: unknown): value is StatusEnum {
+  return value === "ok" || value === "error" || value === "unset"
+}
+
+function collectStatuses(value: FilterCondition["value"]): readonly StatusEnum[] {
+  const raw = Array.isArray(value) ? value : [value]
+  const out: StatusEnum[] = []
+  for (const v of raw) {
+    if (isStatusEnum(v) && !out.includes(v)) out.push(v)
   }
-  return STATUS_TO_INT[String(value)] ?? -1
+  return out
+}
+
+export function buildStatusClause(
+  cond: FilterCondition,
+  _paramPrefix: string,
+): { readonly clause: string; readonly params: Record<string, unknown> } {
+  const statuses = collectStatuses(cond.value)
+
+  switch (cond.op) {
+    case "eq":
+    case "in": {
+      if (statuses.length === 0) return { clause: "1 = 0", params: {} }
+      const disjunction = statuses.map((s) => STATUS_FRAGMENTS[s]).join(" OR ")
+      return { clause: `(${disjunction})`, params: {} }
+    }
+    case "neq":
+    case "notIn": {
+      if (statuses.length === 0) return { clause: "1 = 1", params: {} }
+      const disjunction = statuses.map((s) => STATUS_FRAGMENTS[s]).join(" OR ")
+      return { clause: `NOT (${disjunction})`, params: {} }
+    }
+    default:
+      throw new Error(`Unsupported status filter operator: ${cond.op}`)
+  }
+}
+
+const HAS_LLM_ACTIVITY_FRAGMENT = "(tokens_total > 0 OR length(models) > 0)"
+
+export function buildHasLlmActivityClause(
+  cond: FilterCondition,
+  _paramPrefix: string,
+): { readonly clause: string; readonly params: Record<string, unknown> } {
+  const truthy = cond.value === true || cond.value === "true" || cond.value === 1
+
+  switch (cond.op) {
+    case "eq":
+      return { clause: truthy ? HAS_LLM_ACTIVITY_FRAGMENT : `NOT ${HAS_LLM_ACTIVITY_FRAGMENT}`, params: {} }
+    case "neq":
+      return { clause: truthy ? `NOT ${HAS_LLM_ACTIVITY_FRAGMENT}` : HAS_LLM_ACTIVITY_FRAGMENT, params: {} }
+    default:
+      throw new Error(`Unsupported hasLlmActivity filter operator: ${cond.op}`)
+  }
 }

--- a/packages/platform/db-clickhouse/src/registries/session-fields.ts
+++ b/packages/platform/db-clickhouse/src/registries/session-fields.ts
@@ -1,15 +1,18 @@
 import type { ChFieldRegistry } from "../filter-builder.ts"
-import { mapDateTime64UtcQueryParam } from "./helpers.ts"
+import { buildHasLlmActivityClause, buildStatusClause, mapDateTime64UtcQueryParam } from "./helpers.ts"
 
 export const SESSION_FIELD_REGISTRY: ChFieldRegistry = {
+  status: { kind: "synthetic", buildClause: buildStatusClause },
+  hasLlmActivity: { kind: "synthetic", buildClause: buildHasLlmActivityClause },
   sessionId: { column: "session_id", chType: "String" },
+  traceId: { column: "trace_ids", chType: "FixedString(32)", isArray: true, arrayContains: true },
   simulationId: { column: "simulation_id", chType: "String" },
   userId: { column: "user_id", chType: "String" },
   name: { column: "root_span_name", chType: "String" },
-  tags: { column: "tags", chType: "String", isArray: true },
-  models: { column: "models", chType: "String", isArray: true },
-  providers: { column: "providers", chType: "String", isArray: true },
-  serviceNames: { column: "service_names", chType: "String", isArray: true },
+  tags: { column: "tags", chType: "String", isArray: true, arrayContains: true },
+  models: { column: "models", chType: "String", isArray: true, arrayContains: true },
+  providers: { column: "providers", chType: "String", isArray: true, arrayContains: true },
+  serviceNames: { column: "service_names", chType: "String", isArray: true, arrayContains: true },
   cost: { column: "cost_total_microcents", chType: "UInt64" },
   duration: { column: "duration_ns", chType: "Int64" },
   ttft: { column: "time_to_first_token_ns", chType: "Int64" },

--- a/packages/platform/db-clickhouse/src/registries/trace-fields.ts
+++ b/packages/platform/db-clickhouse/src/registries/trace-fields.ts
@@ -1,20 +1,23 @@
 import type { TraceFilterFieldName } from "@domain/shared"
 import type { ChFieldRegistry } from "../filter-builder.ts"
-import { mapDateTime64UtcQueryParam, mapStatusValue } from "./helpers.ts"
+import { buildStatusClause, mapDateTime64UtcQueryParam } from "./helpers.ts"
 
 type InternalField = "startTime"
 
 export const TRACE_FIELD_REGISTRY: ChFieldRegistry<TraceFilterFieldName | InternalField> = {
-  status: { column: "overall_status", chType: "UInt8", mapValue: mapStatusValue },
+  // `status` is synthetic on both tables — derived from `error_count` /
+  // `span_count`. See `buildStatusClause` for the enum semantics. The previous
+  // entry referenced `overall_status`, dropped in migration 00005.
+  status: { kind: "synthetic", buildClause: buildStatusClause },
   name: { column: "root_span_name", chType: "String" },
   traceId: { column: "trace_id", chType: "String" },
   sessionId: { column: "session_id", chType: "String" },
   simulationId: { column: "simulation_id", chType: "String" },
   userId: { column: "user_id", chType: "String" },
-  tags: { column: "tags", chType: "String", isArray: true },
-  models: { column: "models", chType: "String", isArray: true },
-  providers: { column: "providers", chType: "String", isArray: true },
-  serviceNames: { column: "service_names", chType: "String", isArray: true },
+  tags: { column: "tags", chType: "String", isArray: true, arrayContains: true },
+  models: { column: "models", chType: "String", isArray: true, arrayContains: true },
+  providers: { column: "providers", chType: "String", isArray: true, arrayContains: true },
+  serviceNames: { column: "service_names", chType: "String", isArray: true, arrayContains: true },
   duration: { column: "duration_ns", chType: "Int64" },
   ttft: { column: "time_to_first_token_ns", chType: "Int64" },
   cost: { column: "cost_total_microcents", chType: "UInt64" },

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -516,6 +516,75 @@ describe("SessionRepository", () => {
     })
   })
 
+  describe("getDistribution", () => {
+    it("returns the empty distribution shape when the project has no sessions", async () => {
+      const dist = await runCh(
+        repo.getDistribution({
+          organizationId: ORG_ID,
+          projectId: ProjectId("ppppppppppppppppppppppp9"),
+          field: "cost",
+        }),
+      )
+      expect(dist.count).toBe(0)
+      expect(dist.percentileValues).toHaveLength(101)
+      expect(dist.percentileValues.every((v) => v === 0)).toBe(true)
+    })
+
+    it("samples 101 percentile levels with p100 hitting the max for sum-aggregated fields", async () => {
+      const start = new Date(Date.UTC(2026, 0, 2, 10, 0, 0))
+      const costs = [100, 500, 5_000, 50_000]
+      await insertSpans(
+        costs.map((cost, i) =>
+          makeSpanRow({
+            traceId: `c${i}`.padEnd(32, "0"),
+            spanId: `c${i}`.padEnd(16, "0"),
+            sessionId: `cost-session-${i}`,
+            startTime: new Date(start.getTime() + i * 1_000),
+            costTotalMicrocents: cost,
+          }),
+        ),
+      )
+
+      const dist = await runCh(repo.getDistribution({ organizationId: ORG_ID, projectId: PROJECT_ID, field: "cost" }))
+      expect(dist.count).toBe(costs.length)
+      expect(dist.percentileValues).toHaveLength(101)
+      expect(dist.percentileValues[0]).toBe(100)
+      expect(dist.percentileValues[100]).toBe(50_000)
+    })
+
+    it("ignores zero-valued rows for ttft so the distribution reflects only sessions that streamed", async () => {
+      const start = new Date(Date.UTC(2026, 0, 3, 10, 0, 0))
+      await insertSpans([
+        makeSpanRow({
+          traceId: "ttft-a".padEnd(32, "0"),
+          spanId: "ttft-a".padEnd(16, "0"),
+          sessionId: "ttft-a",
+          startTime: start,
+          timeToFirstTokenNs: 10_000_000,
+        }),
+        makeSpanRow({
+          traceId: "ttft-b".padEnd(32, "0"),
+          spanId: "ttft-b".padEnd(16, "0"),
+          sessionId: "ttft-b",
+          startTime: new Date(start.getTime() + 1_000),
+          timeToFirstTokenNs: 50_000_000,
+        }),
+        makeSpanRow({
+          traceId: "ttft-z".padEnd(32, "0"),
+          spanId: "ttft-z".padEnd(16, "0"),
+          sessionId: "ttft-zero",
+          startTime: new Date(start.getTime() + 2_000),
+          // sentinel 0 — must not contribute to the distribution
+        }),
+      ])
+
+      const dist = await runCh(repo.getDistribution({ organizationId: ORG_ID, projectId: PROJECT_ID, field: "ttft" }))
+      expect(dist.count).toBe(2)
+      expect(dist.percentileValues[0]).toBe(10_000_000)
+      expect(dist.percentileValues[100]).toBe(50_000_000)
+    })
+  })
+
   describe("aggregateMetricsByProjectId", () => {
     it("rolls up time_to_first_token_ns across sessions, ignoring sentinel zeros", async () => {
       const start = new Date(Date.UTC(2026, 0, 1, 10, 0, 0))

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -3,9 +3,15 @@ import {
   ChSqlClient,
   type ChSqlClientShape,
   ExternalUserId,
+  type FilterCondition,
   type FilterSet,
   isNotFoundError,
+  isPercentileSessionFilterField,
   NotFoundError,
+  type OrganizationId,
+  type PercentileSessionFilterField,
+  type ProjectId,
+  type RepositoryError,
   SessionId,
   SimulationId,
   SpanId,
@@ -13,8 +19,14 @@ import {
   ProjectId as toProjectId,
   toRepositoryError,
 } from "@domain/shared"
-import type { Session, SessionDetail, SessionListPage, SessionMetrics } from "@domain/spans"
-import { emptySessionMetrics, parseSearchQuery, SessionRepository, type SessionRepositoryShape } from "@domain/spans"
+import type { Session, SessionDetail, SessionListPage, SessionMetrics, TraceDistribution } from "@domain/spans"
+import {
+  emptySessionMetrics,
+  emptyTraceDistribution,
+  parseSearchQuery,
+  SessionRepository,
+  type SessionRepositoryShape,
+} from "@domain/spans"
 import { normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
@@ -292,6 +304,128 @@ function buildSessionFilterClauses(filters: FilterSet | undefined): {
   }
 }
 
+interface PercentileColumnSpec {
+  readonly column: string
+  readonly ignoreZeros: boolean
+}
+
+const PERCENTILE_FIELD_SPECS: Readonly<Record<PercentileSessionFilterField, PercentileColumnSpec>> = {
+  duration: { column: "duration_ns", ignoreZeros: false },
+  cost: { column: "cost_total_microcents", ignoreZeros: false },
+  ttft: { column: "time_to_first_token_ns", ignoreZeros: true },
+}
+
+function quantileExpr(spec: PercentileColumnSpec, levelParam: string): string {
+  return spec.ignoreZeros
+    ? `quantileTDigestIf({${levelParam}:Float64})(${spec.column}, ${spec.column} > 0)`
+    : `quantileTDigest({${levelParam}:Float64})(${spec.column})`
+}
+
+const PERCENTILE_NO_MATCH_SENTINEL = Number.MAX_SAFE_INTEGER
+
+/** Number of percentile buckets sampled in the distribution: p0..p100 inclusive. */
+const PERCENTILE_LEVEL_COUNT = 101
+const PERCENTILE_LEVELS = Array.from({ length: PERCENTILE_LEVEL_COUNT }, (_, i) => (i / 100).toFixed(2)).join(", ")
+
+interface PercentileRequestEntry {
+  readonly field: PercentileSessionFilterField
+  readonly percentile: number
+  readonly conditionIndex: number
+  readonly conditions: FilterCondition[]
+}
+
+function collectPercentileRequests(filters: FilterSet | undefined): {
+  readonly requests: readonly PercentileRequestEntry[]
+  readonly cloned: Record<string, FilterCondition[]> | undefined
+} {
+  if (!filters) return { requests: [], cloned: undefined }
+
+  let cloned: Record<string, FilterCondition[]> | undefined
+  const requests: PercentileRequestEntry[] = []
+
+  for (const [field, conds] of Object.entries(filters)) {
+    if (!conds) continue
+    const hasPct = conds.some((c) => c.op === "gtePercentile")
+    if (!hasPct) continue
+
+    if (!isPercentileSessionFilterField(field)) continue
+
+    if (!cloned) cloned = {}
+    const arr = [...conds] as FilterCondition[]
+    cloned[field] = arr
+    arr.forEach((c, idx) => {
+      if (c.op === "gtePercentile" && typeof c.value === "number") {
+        requests.push({ field, percentile: c.value, conditionIndex: idx, conditions: arr })
+      }
+    })
+  }
+
+  if (!cloned) return { requests: [], cloned: undefined }
+
+  // Carry over fields without percentile filters into the cloned set.
+  for (const [field, conds] of Object.entries(filters)) {
+    if (!conds) continue
+    if (cloned[field]) continue
+    cloned[field] = conds as FilterCondition[]
+  }
+
+  return { requests, cloned }
+}
+
+const resolvePercentileFilters = (
+  organizationId: OrganizationId,
+  projectId: ProjectId,
+  filters: FilterSet | undefined,
+): Effect.Effect<FilterSet | undefined, RepositoryError, ChSqlClient> => {
+  const { requests, cloned } = collectPercentileRequests(filters)
+  if (requests.length === 0 || !cloned) return Effect.succeed(filters)
+
+  return Effect.gen(function* () {
+    const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+
+    const params: Record<string, unknown> = {
+      organizationId: organizationId as string,
+      projectId: projectId as string,
+    }
+    const aliases: string[] = []
+    requests.forEach((req, idx) => {
+      const spec = PERCENTILE_FIELD_SPECS[req.field]
+      const levelParam = `pct_lvl_${idx}`
+      params[levelParam] = Math.max(0, Math.min(1, req.percentile / 100))
+      aliases.push(`${quantileExpr(spec, levelParam)} AS pct_${idx}`)
+    })
+
+    const rows = yield* chSqlClient
+      .query(async (client) => {
+        const result = await client.query({
+          query: `SELECT ${aliases.join(", ")}
+                  FROM (
+                    SELECT ${LIST_SELECT}
+                    FROM sessions
+                    WHERE organization_id = {organizationId:String}
+                      AND project_id = {projectId:String}
+                    GROUP BY organization_id, project_id, session_id
+                  )`,
+          query_params: params,
+          format: "JSONEachRow",
+        })
+        return result.json<Record<string, number | string | null>>()
+      })
+      .pipe(Effect.mapError((error) => toRepositoryError(error, "resolvePercentileFilters")))
+
+    const row = rows[0] ?? {}
+    requests.forEach((req, idx) => {
+      const raw = row[`pct_${idx}`]
+      const numeric =
+        typeof raw === "number" ? raw : raw != null && raw !== "" && !Number.isNaN(Number(raw)) ? Number(raw) : NaN
+      const threshold = Number.isFinite(numeric) && numeric > 0 ? Math.floor(numeric) : PERCENTILE_NO_MATCH_SENTINEL
+      req.conditions[req.conditionIndex] = { op: "gte", value: threshold }
+    })
+
+    return cloned as FilterSet
+  })
+}
+
 const DEFAULT_SORT: SortColumn = SORT_COLUMNS.lastActivity as SortColumn
 
 export const SessionRepositoryLive = Layer.effect(
@@ -332,6 +466,8 @@ export const SessionRepositoryLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         const limit = options.limit ?? 50
 
+        const resolvedFilters = yield* resolvePercentileFilters(organizationId, projectId, options.filters)
+
         const parsed =
           options.searchQuery && options.searchQuery.length > 0 ? parseSearchQuery(options.searchQuery) : undefined
 
@@ -340,7 +476,7 @@ export const SessionRepositoryLive = Layer.effect(
             organizationId,
             projectId,
             parsed,
-            filters: options.filters,
+            filters: resolvedFilters,
             cursor: options.cursor,
             limit,
             sortBy: options.sortBy,
@@ -356,7 +492,7 @@ export const SessionRepositoryLive = Layer.effect(
         const orderDir = options.sortDirection === "asc" ? "ASC" : "DESC"
         const cmp = orderDir === "DESC" ? "<" : ">"
 
-        const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(options.filters)
+        const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(resolvedFilters)
 
         const havingParts: string[] = [...havingClauses]
         if (options.cursor) {
@@ -420,13 +556,14 @@ export const SessionRepositoryLive = Layer.effect(
       countByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const resolvedFilters = yield* resolvePercentileFilters(organizationId, projectId, filters)
 
           const parsed = searchQuery && searchQuery.length > 0 ? parseSearchQuery(searchQuery) : undefined
           if (parsed && isActiveSearch(parsed)) {
-            return yield* countSessionsBySearchQuery({ organizationId, projectId, parsed, filters })
+            return yield* countSessionsBySearchQuery({ organizationId, projectId, parsed, filters: resolvedFilters })
           }
 
-          const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(filters)
+          const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(resolvedFilters)
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
 
@@ -463,7 +600,8 @@ export const SessionRepositoryLive = Layer.effect(
       aggregateMetricsByProjectId: ({ organizationId, projectId, filters }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
-          const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(filters)
+          const resolvedFilters = yield* resolvePercentileFilters(organizationId, projectId, filters)
+          const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(resolvedFilters)
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
 
@@ -549,6 +687,55 @@ export const SessionRepositoryLive = Layer.effect(
               Effect.mapError((error) =>
                 isNotFoundError(error) ? error : toRepositoryError(error, "findBySessionId"),
               ),
+            )
+        }),
+
+      getDistribution: ({ organizationId, projectId, field }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const spec = PERCENTILE_FIELD_SPECS[field]
+
+          const filterClause = spec.ignoreZeros ? `, ${spec.column} > 0` : ""
+          const quantilesFn = spec.ignoreZeros ? "quantilesTDigestIf" : "quantilesTDigest"
+          const countFn = spec.ignoreZeros ? `countIf(${spec.column} > 0)` : "count()"
+
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                          ${countFn} AS cnt,
+                          ${quantilesFn}(${PERCENTILE_LEVELS})(${spec.column}${filterClause}) AS pcts
+                        FROM (
+                          SELECT ${LIST_SELECT}
+                          FROM sessions
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                          GROUP BY organization_id, project_id, session_id
+                        )`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<{ cnt: string | number; pcts: ReadonlyArray<number | string | null> }>()
+            })
+            .pipe(
+              Effect.map((rows): TraceDistribution => {
+                const row = rows[0]
+                if (!row) return emptyTraceDistribution()
+                const count = Number(row.cnt) || 0
+                if (count === 0) return emptyTraceDistribution()
+                const percentileValues = (row.pcts ?? []).map((v) => {
+                  const n = typeof v === "number" ? v : v != null ? Number(v) : 0
+                  return Number.isFinite(n) ? n : 0
+                })
+                while (percentileValues.length < PERCENTILE_LEVEL_COUNT)
+                  percentileValues.push(percentileValues.at(-1) ?? 0)
+                if (percentileValues.length > PERCENTILE_LEVEL_COUNT) percentileValues.length = PERCENTILE_LEVEL_COUNT
+                return { count, percentileValues }
+              }),
+              Effect.mapError((error) => toRepositoryError(error, "getDistribution")),
             )
         }),
 

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -134,6 +134,7 @@ type TraceDetailRow = TraceListRow & {
  * `quantileTDigest(0.5)` (TTFT also gates on `> 0` to ignore the sentinel).
  */
 const HISTOGRAM_BUCKET_SELECT = `count() AS trace_count,
+  uniqExact(coalesce(nullIf(session_id, ''), toString(trace_id))) AS session_count,
   sum(cost_total_microcents) AS cost_sum,
   quantileTDigest(0.5)(duration_ns) AS duration_median,
   sum(tokens_total) AS tokens_sum,
@@ -143,6 +144,7 @@ const HISTOGRAM_BUCKET_SELECT = `count() AS trace_count,
 type TraceHistogramBucketRow = {
   bucket_start: string
   trace_count: string
+  session_count: string
   cost_sum: string
   duration_median: string
   tokens_sum: string
@@ -254,6 +256,7 @@ const toTtftRollup = (row: TraceMetricsRow) => ({
 const toHistogramBucket = (row: TraceHistogramBucketRow): TraceTimeHistogramBucket => ({
   bucketStart: parseCHDate(row.bucket_start).toISOString(),
   traceCount: Number(row.trace_count),
+  sessionCount: Number(row.session_count),
   costTotalMicrocentsSum: Number(row.cost_sum),
   durationNsMedian: Number(row.duration_median),
   tokensTotalSum: Number(row.tokens_sum),

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -4,6 +4,7 @@ import { insertJsonEachRow } from "../../sql.ts"
 import type { SeedContext, Seeder } from "../types.ts"
 import { fixedTraceSeeders } from "./fixed-traces.ts"
 import { generateAllSpans, type SpanRow, type TraceConfig } from "./generator.ts"
+import { orphanFragmentSeeders } from "./orphan-fragments.ts"
 
 const TRACE_COUNT = 2000
 const BATCH_SIZE = 500
@@ -49,4 +50,4 @@ export const runSpansSeed = (
     return traceIds
   })
 
-export const spanSeeders: Seeder[] = [...fixedTraceSeeders]
+export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders]

--- a/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
@@ -1,0 +1,301 @@
+import type { SeedScope } from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { insertJsonEachRow } from "../../sql.ts"
+import { isSentinelPresent } from "../idempotency.ts"
+import type { Seeder } from "../types.ts"
+import type { SpanRow } from "./span-builders.ts"
+
+function formatClickHouseTimestamp(date: Date): string {
+  return date.toISOString().replace("T", " ").replace("Z", "000")
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(12, Math.ceil(text.length / 4))
+}
+
+interface OrphanFragmentSpec {
+  /** Stable key used to derive trace/span ids via `scope.traceHex` / `scope.spanHex`. */
+  readonly traceKey: string
+  readonly daysAgo: number
+  /** Service name on the outer framework spans (HTTP server, middleware). */
+  readonly frameworkServiceName: string
+  /** Service name on the inner LLM span — typically the SDK's `service.name`. */
+  readonly llmServiceName: string
+  /** Model id surfaced on the LLM span (and so on the "real" session row). */
+  readonly model: string
+  readonly responseModel: string
+  readonly provider: string
+  /** Session id carried by the LLM span only — distinct from the trace_id. */
+  readonly sessionId: string
+  readonly userPrompt: string
+  readonly assistantResponse: string
+  readonly systemInstruction: string
+  /** Name of the outer HTTP wrapper span (e.g. "POST /api/chat"). */
+  readonly httpSpanName: string
+  /** Name of the inner middleware span (e.g. "auth.verify"). */
+  readonly middlewareSpanName: string
+  /** OpenTelemetry instrumentation scope on the framework spans. */
+  readonly frameworkScopeName: string
+  /** OpenTelemetry instrumentation scope on the LLM span. */
+  readonly llmScopeName: string
+}
+
+const ORPHAN_FRAGMENT_SPECS: readonly OrphanFragmentSpec[] = [
+  {
+    traceKey: "orphan-fragment-vercel-ai-next",
+    daysAgo: 2,
+    frameworkServiceName: "acme-chat-app",
+    llmServiceName: "vercel-ai-sdk",
+    model: "gpt-4o-mini",
+    responseModel: "gpt-4o-mini-2024-07-18",
+    provider: "openai",
+    sessionId: "session-vercel-ai-demo",
+    userPrompt: "Draft a release announcement for the new payments API.",
+    assistantResponse:
+      "Here is a draft announcement highlighting authentication, idempotency, and the migration timeline for the new payments API.",
+    systemInstruction: "You are a release-notes copywriter for an internal developer-tools team.",
+    httpSpanName: "POST /api/chat",
+    middlewareSpanName: "next.middleware",
+    frameworkScopeName: "@opentelemetry/instrumentation-undici",
+    llmScopeName: "ai-sdk",
+  },
+  {
+    traceKey: "orphan-fragment-langchain-express",
+    daysAgo: 4,
+    frameworkServiceName: "acme-rag-gateway",
+    llmServiceName: "langchain-runtime",
+    model: "gpt-4.1",
+    responseModel: "gpt-4.1-2025-04-14",
+    provider: "openai",
+    sessionId: "session-langchain-demo",
+    userPrompt: "Summarize the SLA changes proposed for the enterprise tier.",
+    assistantResponse:
+      "The enterprise tier raises uptime to 99.95%, expands incident response coverage to 24/7, and removes the cap on cross-region failover events.",
+    systemInstruction: "You are a contracts assistant. Answer only from the retrieved context.",
+    httpSpanName: "POST /v1/answer",
+    middlewareSpanName: "express.middleware - cors",
+    frameworkScopeName: "@opentelemetry/instrumentation-express",
+    llmScopeName: "langchain-otel",
+  },
+  {
+    traceKey: "orphan-fragment-anthropic-cloudflare",
+    daysAgo: 6,
+    frameworkServiceName: "acme-edge-worker",
+    llmServiceName: "anthropic-sdk",
+    model: "claude-sonnet-4-6",
+    responseModel: "claude-sonnet-4-6-20250929",
+    provider: "anthropic",
+    sessionId: "session-anthropic-demo",
+    userPrompt: "Explain the difference between idempotency keys and request retries.",
+    assistantResponse:
+      "Idempotency keys deduplicate a single user-intended operation across retries; request retries are the mechanism the client uses to deliver the same idempotent call again after a network failure.",
+    systemInstruction: "You are a friendly developer-relations engineer answering API questions.",
+    httpSpanName: "fetch /ask",
+    middlewareSpanName: "worker.routes",
+    frameworkScopeName: "@opentelemetry/instrumentation-cloudflare-workers",
+    llmScopeName: "anthropic-instrumentation",
+  },
+]
+
+interface BuildSpansArgs {
+  readonly scope: SeedScope
+  readonly spec: OrphanFragmentSpec
+}
+
+function buildOrphanFragmentTraceSpans({ scope, spec }: BuildSpansArgs): SpanRow[] {
+  const traceId = scope.traceHex(spec.traceKey)
+  const rootSpanId = scope.spanHex(`${spec.traceKey}-root`)
+  const middlewareSpanId = scope.spanHex(`${spec.traceKey}-mw`)
+  const llmSpanId = scope.spanHex(`${spec.traceKey}-llm`)
+
+  // Outer wrapper starts at the anchor; middleware and LLM nest inside it.
+  // Durations chosen so end_time of children is strictly before parent's end.
+  const rootStart = scope.dateDaysAgo(spec.daysAgo, 14, 30)
+  const rootDurationMs = 1850
+  const middlewareStart = new Date(rootStart.getTime() + 10)
+  const middlewareDurationMs = 12
+  const llmStart = new Date(rootStart.getTime() + 40)
+  const llmDurationMs = 1600
+
+  const baseTags = ["orphan-fragment-demo", "otel-direct"]
+  const baseMetadata: Record<string, string> = {
+    seed: "orphan-fragments",
+    story: spec.traceKey,
+    sdk_version: "1.3.1",
+  }
+
+  const inputMessagesJson = JSON.stringify([{ role: "user", parts: [{ type: "text", content: spec.userPrompt }] }])
+  const outputMessagesJson = JSON.stringify([
+    { role: "assistant", parts: [{ type: "text", content: spec.assistantResponse }] },
+  ])
+  const systemInstructionsJson = JSON.stringify([{ type: "text", content: spec.systemInstruction }])
+
+  const inputTokens = estimateTokens(spec.userPrompt + spec.systemInstruction)
+  const outputTokens = estimateTokens(spec.assistantResponse)
+  const costInputMicrocents = inputTokens * 25
+  const costOutputMicrocents = outputTokens * 100
+
+  const httpWrapper: SpanRow = {
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    // session_id="" is the critical bit: this span has no SDK session binding,
+    // so the MV's coalesce falls back to trace_id and forms an orphan-fragment
+    // session row alongside the real (LLM-bound) one.
+    session_id: "",
+    user_id: "",
+    trace_id: traceId,
+    span_id: rootSpanId,
+    parent_span_id: "",
+    api_key_id: scope.apiKeyId,
+    simulation_id: "",
+    start_time: formatClickHouseTimestamp(rootStart),
+    end_time: formatClickHouseTimestamp(new Date(rootStart.getTime() + rootDurationMs)),
+    name: spec.httpSpanName,
+    service_name: spec.frameworkServiceName,
+    kind: 2,
+    status_code: 1,
+    status_message: "",
+    error_type: "",
+    tags: [...baseTags],
+    metadata: { ...baseMetadata, layer: "http" },
+    operation: "unspecified",
+    provider: "",
+    model: "",
+    response_model: "",
+    tokens_input: 0,
+    tokens_output: 0,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: 0,
+    cost_output_microcents: 0,
+    cost_total_microcents: 0,
+    cost_is_estimated: 0,
+    time_to_first_token_ns: 0,
+    is_streaming: 0,
+    response_id: "",
+    finish_reasons: [],
+    input_messages: "",
+    output_messages: "",
+    system_instructions: "",
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: { "http.method": "POST", "http.route": spec.httpSpanName.split(" ")[1] ?? "/" },
+    attr_int: { "http.status_code": 200 },
+    attr_float: {},
+    attr_bool: {},
+    resource_string: { "service.name": spec.frameworkServiceName },
+    scope_name: spec.frameworkScopeName,
+    scope_version: "1.0.0",
+  }
+
+  const middleware: SpanRow = {
+    ...httpWrapper,
+    span_id: middlewareSpanId,
+    parent_span_id: rootSpanId,
+    start_time: formatClickHouseTimestamp(middlewareStart),
+    end_time: formatClickHouseTimestamp(new Date(middlewareStart.getTime() + middlewareDurationMs)),
+    name: spec.middlewareSpanName,
+    kind: 1,
+    metadata: { ...baseMetadata, layer: "middleware" },
+    attr_string: {},
+    attr_int: {},
+  }
+
+  const llm: SpanRow = {
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    // The LLM span carries the SDK's `gen_ai.conversation.id`, which lands in
+    // `session_id` post-extraction. This is what produces the "real" session
+    // row distinct from the orphan fragment above.
+    session_id: spec.sessionId,
+    user_id: "",
+    trace_id: traceId,
+    span_id: llmSpanId,
+    parent_span_id: rootSpanId,
+    api_key_id: scope.apiKeyId,
+    simulation_id: "",
+    start_time: formatClickHouseTimestamp(llmStart),
+    end_time: formatClickHouseTimestamp(new Date(llmStart.getTime() + llmDurationMs)),
+    name: `chat ${spec.model}`,
+    service_name: spec.llmServiceName,
+    kind: 1,
+    status_code: 1,
+    status_message: "",
+    error_type: "",
+    tags: [...baseTags],
+    metadata: { ...baseMetadata, layer: "llm" },
+    operation: "chat",
+    provider: spec.provider,
+    model: spec.model,
+    response_model: spec.responseModel,
+    tokens_input: inputTokens,
+    tokens_output: outputTokens,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: costInputMicrocents,
+    cost_output_microcents: costOutputMicrocents,
+    cost_total_microcents: costInputMicrocents + costOutputMicrocents,
+    cost_is_estimated: 0,
+    time_to_first_token_ns: 250_000_000,
+    is_streaming: 1,
+    response_id: `resp_${spec.traceKey}`,
+    finish_reasons: ["stop"],
+    input_messages: inputMessagesJson,
+    output_messages: outputMessagesJson,
+    system_instructions: systemInstructionsJson,
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: {
+      "gen_ai.system": spec.provider,
+      "gen_ai.request.model": spec.model,
+      "gen_ai.response.model": spec.responseModel,
+      "gen_ai.conversation.id": spec.sessionId,
+    },
+    attr_int: {
+      "gen_ai.usage.input_tokens": inputTokens,
+      "gen_ai.usage.output_tokens": outputTokens,
+    },
+    attr_float: { "gen_ai.request.temperature": 0.2 },
+    attr_bool: {},
+    resource_string: { "service.name": spec.llmServiceName },
+    scope_name: spec.llmScopeName,
+    scope_version: "1.0.0",
+  }
+
+  return [httpWrapper, middleware, llm]
+}
+
+function buildAllOrphanFragmentSpans(scope: SeedScope): SpanRow[] {
+  return ORPHAN_FRAGMENT_SPECS.flatMap((spec) => buildOrphanFragmentTraceSpans({ scope, spec }))
+}
+
+const seedOrphanFragments: Seeder = {
+  name: "spans/orphan-fragments",
+  run: (ctx) =>
+    Effect.gen(function* () {
+      // Sentinel: the trace_id of the first deterministic mixed-binding trace.
+      const sentinel = ctx.scope.traceHex(ORPHAN_FRAGMENT_SPECS[0]!.traceKey)
+      const present = yield* isSentinelPresent(ctx.client, "spans", "trace_id = {sentinel:String}", { sentinel })
+      if (present) {
+        if (!ctx.quiet) console.log("  -> spans/orphan-fragments: already seeded, skipping")
+        return
+      }
+      const spans = buildAllOrphanFragmentSpans(ctx.scope)
+      yield* insertJsonEachRow(ctx.client, "spans", spans)
+      if (!ctx.quiet) {
+        console.log(
+          `  -> spans/orphan-fragments: ${spans.length} spans across ${ORPHAN_FRAGMENT_SPECS.length} mixed-binding traces`,
+        )
+      }
+    }),
+}
+
+export const orphanFragmentSeeders: readonly Seeder[] = [seedOrphanFragments]


### PR DESCRIPTION
Closes LAT-600.

## What ships

Brings the sessions filter surface to parity with traces, fixes the broken trace `status` filter, and lays in a default-on \"Has LLM activity\" chip that hides orphan-fragment session rows for OTel-direct customers.

### Backend

| Layer | Change |
|---|---|
| `filter-builder.ts` | `ChFieldMapping` becomes a discriminated union: `ScalarFieldMapping` (with optional `arrayContains` flag — routes scalar `eq`/`neq` against an array column to `has(col, …)` / `NOT has(col, …)`) or `SyntheticFieldMapping` (`kind: \"synthetic\"`, owns clause + param generation outright). |
| `helpers.ts` | New `buildStatusClause` derives `ok`/`error`/`unset` from `error_count` / `span_count` on both tables. New `buildHasLlmActivityClause` synthesizes `tokens_total > 0 OR length(models) > 0`. Removed `mapStatusValue` (no remaining consumer). |
| `trace-fields.ts` | Replaces the broken `status: { column: \"overall_status\", … }` entry — `overall_status` was dropped in migration 00005, so any query touching the trace status filter previously failed at execution time. Now synthetic, identical to sessions. `tags` / `models` / `providers` / `serviceNames` gain `arrayContains: true`. |
| `session-fields.ts` | Adds `status` (synthetic), `hasLlmActivity` (synthetic), `traceId` (against `trace_ids`, with `arrayContains`). Array fields gain `arrayContains: true`. |
| `domain/shared` | Adds `PERCENTILE_SESSION_FILTER_FIELDS` / `PercentileSessionFilterField` / `isPercentileSessionFilterField` — mirror of the trace versions. |
| `SessionRepository` port | New `getDistribution(field)` method, parallel to the trace port. |
| `session-repository.ts` | Mirrors the trace repo's percentile pipeline (`PERCENTILE_FIELD_SPECS`, `quantileExpr`, `collectPercentileRequests`, `resolvePercentileFilters`, `getDistribution`). Wires `resolvePercentileFilters` into `listByProjectId`, `countByProjectId`, and `aggregateMetricsByProjectId`. |
| `sessions.functions.ts` | New `getSessionDistribution` server fn. |
| `fake-session-repository.ts` | No-op `getDistribution` to satisfy the widened port. |

### UI

| Layer | Change |
|---|---|
| `filters-builder/constants.ts` | Drops the `name` / `traceId` exclusion in `getTextFieldsForMode` (those fields now work on sessions). Exports `STATUS_FIELDS` and a `PercentileFieldName` union covering both modes. |
| `filters-builder/status-filter.tsx` (new) | Two-toggle chip group exposing `ok` / `error`. `unset` is intentionally hidden — unreachable on sessions (the MV's coalesce keeps `span_count > 0`) and a span-level OTel concept that doesn't roll up cleanly on traces. The synthetic registry clause still accepts `unset` from API callers. |
| `filters-builder/percentile-filter.tsx` | Takes a `mode` prop and dispatches to either `useTraceDistribution` or `useSessionDistribution`. Entity label flips between \"traces\" and \"sessions\". |
| `filters-sidebar.tsx` | Renders `StatusFilter` for both modes; renders a \"Has LLM activity\" `Switch` section (sessions mode only, default on); threads `mode` into `NumberFilterSection` → `PercentileFilter`. |
| `sessions.collection.ts` | New `useSessionDistribution` hook. New `withSessionDefaults(filters)` helper centralizes the orphan-fragment-hider default: list/count/metrics hooks inject `hasLlmActivity = true` unless the user has explicitly opted out by storing the chip as `false` in URL filters. |

## Default chip behavior

The \"Has LLM activity\" toggle on the sessions sidebar starts in the on position. URL representation:

- key absent → treated as on (default applied at API call time, URL stays clean).
- `hasLlmActivity = [{op: \"eq\", value: false}]` → off (user explicitly opted out; the sidebar Switch reads as off and orphan-fragment rows reappear).
- `hasLlmActivity = [{op: \"eq\", value: true}]` → on (explicit; equivalent to absent).

The Switch writes the explicit `false` condition on toggle-off and removes the key on toggle-on, so the URL stays minimal in the common case while still being shareable.

## Pre-existing bug fixed

`status` filter on traces (`TRACE_FIELD_REGISTRY.status`) referenced `overall_status`, dropped in CH migration 00005. Any consumer that wired the chip would crash at query time. No UI was wired to it yet, so this was dead-but-broken — now both fixed and parity-extended to sessions.

## Seed coverage

Verified that the existing CH seeds (`pattern-generators.ts`, `fixed-traces.ts`) **do not** produce any session or trace that would fail `hasLlmActivity = true`. Every seeded trace contains either tokens > 0 (regular patterns) or a non-empty `model` (error pattern), and all spans in a trace share a `session_id`, so no orphan fragments. Default chip will be a no-op in dev against current seed data — to verify the chip's behavior locally, the seed pipeline would need a new pattern that emits an LLM span with a `session_id` plus framework spans without one. Not included in this PR; happy to add as a follow-up if useful.

## Migration

None. `00016_session_parity.sql` already provides the columns this PR depends on (`root_span_name`, `time_of_first_token`, `duration_ns`, `trace_ids` on the `sessions` table).

## Typecheck

`pnpm --filter @domain/shared --filter @domain/spans --filter @platform/db-clickhouse --filter @app/web typecheck` — clean.

## Manual verification recommended

- Sessions tab: \"Has LLM activity\" Switch is on by default. Toggling off writes `…hasLlmActivity…value\":false…` to the URL. (No visible row change in dev seed data — see Seed coverage above.)
- Sessions tab: Status chips (OK / Error) filter the list.
- Sessions tab: Trace ID chip (newly visible) accepts a 32-char trace id and returns sessions containing it.
- Sessions tab: Percentile threshold on Duration / TTFT / Cost — chart renders against the session distribution; label reads \"sessions\".
- Traces tab: Saved views referencing `status` (previously broken) now resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)