### PR TITLE
feat(flaggers): rework configuration UX in onboarding and settings

### DIFF
--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -70,3 +70,34 @@ export const FLAGGER_USE_CASE_PRESETS = [
     enabledSlugs: ["nsfw", "jailbreaking", "refusal", "frustration", "empty-response"],
   },
 ] as const satisfies ReadonlyArray<FlaggerUseCasePreset>
+
+interface FlaggerGroup {
+  readonly id: string
+  readonly label: string
+  readonly description: string
+  readonly slugs: ReadonlyArray<FlaggerPresetSlug>
+}
+
+// Groups must collectively cover every FLAGGER_STRATEGY_SLUG. Add new strategies here when they ship.
+export const FLAGGER_GROUPS = [
+  {
+    id: "response-validity",
+    label: "Response validity",
+    description: "Free deterministic checks; always run on every trace.",
+    slugs: ["empty-response", "tool-call-errors", "output-schema-validation"],
+  },
+  {
+    id: "user-signals",
+    label: "User-side signals",
+    description: "LLM-based detection of risky or unhappy user behavior.",
+    slugs: ["frustration", "jailbreaking", "nsfw"],
+  },
+  {
+    id: "agent-behavior",
+    label: "Agent behavior",
+    description: "LLM-based detection of failure modes in the agent's own output.",
+    slugs: ["refusal", "laziness", "forgetting", "trashing"],
+  },
+] as const satisfies ReadonlyArray<FlaggerGroup>
+
+export const FLAGGER_DISPLAY_ORDER: ReadonlyArray<FlaggerPresetSlug> = FLAGGER_GROUPS.flatMap((group) => group.slugs)

--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -78,7 +78,6 @@ interface FlaggerGroup {
   readonly slugs: ReadonlyArray<FlaggerPresetSlug>
 }
 
-// Groups must collectively cover every FLAGGER_STRATEGY_SLUG. Add new strategies here when they ship.
 export const FLAGGER_GROUPS = [
   {
     id: "response-validity",
@@ -99,6 +98,15 @@ export const FLAGGER_GROUPS = [
     slugs: ["refusal", "laziness", "forgetting", "trashing"],
   },
 ] as const satisfies ReadonlyArray<FlaggerGroup>
+
+// Compile-time assertion: FLAGGER_GROUPS must cover every FLAGGER_STRATEGY_SLUG. If a new slug
+// is added but missing from any group, the type below resolves to the missing slug name(s)
+// instead of `true`, and the assignment fails typecheck with the missing slug surfaced in the
+// diagnostic. Keeps settings from silently dropping rows when a strategy ships.
+type _MissingFromFlaggerGroups = Exclude<FlaggerPresetSlug, (typeof FLAGGER_GROUPS)[number]["slugs"][number]>
+const _assertFlaggerGroupsExhaustive: [_MissingFromFlaggerGroups] extends [never] ? true : _MissingFromFlaggerGroups =
+  true
+void _assertFlaggerGroupsExhaustive
 
 // Onboarding sorts the flat card grid by user-side first, then agent-side, then deterministic
 // programmatic checks — easier-to-grasp categories lead so the user can scan and pick fast.

--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -100,4 +100,14 @@ export const FLAGGER_GROUPS = [
   },
 ] as const satisfies ReadonlyArray<FlaggerGroup>
 
-export const FLAGGER_DISPLAY_ORDER: ReadonlyArray<FlaggerPresetSlug> = FLAGGER_GROUPS.flatMap((group) => group.slugs)
+// Onboarding sorts the flat card grid by user-side first, then agent-side, then deterministic
+// programmatic checks — easier-to-grasp categories lead so the user can scan and pick fast.
+const ONBOARDING_GROUP_ORDER: ReadonlyArray<(typeof FLAGGER_GROUPS)[number]["id"]> = [
+  "user-signals",
+  "agent-behavior",
+  "response-validity",
+]
+
+export const FLAGGER_ONBOARDING_ORDER: ReadonlyArray<FlaggerPresetSlug> = ONBOARDING_GROUP_ORDER.flatMap(
+  (groupId) => FLAGGER_GROUPS.find((group) => group.id === groupId)?.slugs ?? [],
+)

--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -1,0 +1,72 @@
+import type { FLAGGER_STRATEGY_SLUGS } from "@domain/flaggers"
+
+export type FlaggerPresetSlug = (typeof FLAGGER_STRATEGY_SLUGS)[number]
+
+interface FlaggerUseCasePreset {
+  readonly id: string
+  readonly label: string
+  readonly description: string
+  readonly enabledSlugs: ReadonlyArray<FlaggerPresetSlug>
+}
+
+export const FLAGGER_USE_CASE_PRESETS = [
+  {
+    id: "support-agent",
+    label: "Support agent",
+    description: "Customer-facing assistants handling questions, escalations, and account workflows.",
+    enabledSlugs: [
+      "frustration",
+      "refusal",
+      "forgetting",
+      "tool-call-errors",
+      "empty-response",
+      "jailbreaking",
+      "nsfw",
+    ],
+  },
+  {
+    id: "coding-agent",
+    label: "Coding agent",
+    description: "Agents that edit files, call tools, and work through multi-step implementation tasks.",
+    enabledSlugs: [
+      "laziness",
+      "trashing",
+      "tool-call-errors",
+      "empty-response",
+      "refusal",
+      "forgetting",
+      "output-schema-validation",
+      "frustration",
+    ],
+  },
+  {
+    id: "sales-agent",
+    label: "Sales agent",
+    description: "Lead qualification and buyer-facing assistants where tone and follow-through matter.",
+    enabledSlugs: ["frustration", "refusal", "forgetting", "empty-response", "jailbreaking", "nsfw"],
+  },
+  {
+    id: "tool-workflow-agent",
+    label: "Tool workflow agent",
+    description: "Agents that coordinate tools, APIs, and structured workflows.",
+    enabledSlugs: ["tool-call-errors", "trashing", "output-schema-validation", "empty-response", "laziness"],
+  },
+  {
+    id: "knowledge-base-agent",
+    label: "Knowledge-base agent",
+    description: "RAG and documentation assistants that need to preserve context and answer directly.",
+    enabledSlugs: ["forgetting", "refusal", "empty-response", "frustration", "laziness"],
+  },
+  {
+    id: "structured-extraction-agent",
+    label: "Structured extraction",
+    description: "Extraction and classification agents that return machine-readable output.",
+    enabledSlugs: ["output-schema-validation", "empty-response", "tool-call-errors", "laziness"],
+  },
+  {
+    id: "safety-agent",
+    label: "Safety agent",
+    description: "Moderation and policy-sensitive assistants exposed to adversarial or unsafe inputs.",
+    enabledSlugs: ["nsfw", "jailbreaking", "refusal", "frustration", "empty-response"],
+  },
+] as const satisfies ReadonlyArray<FlaggerUseCasePreset>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
-import type { FLAGGER_STRATEGY_SLUGS } from "@domain/flaggers"
 import {
+  Badge,
   Button,
   CodeBlock,
   CopyButton,
@@ -35,6 +35,7 @@ import {
   configureProjectFlaggersForOnboarding,
   listAvailableFlaggers,
 } from "../../../../../domains/flaggers/flaggers.functions.ts"
+import { FLAGGER_USE_CASE_PRESETS, type FlaggerPresetSlug } from "../../../../../domains/flaggers/presets.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
@@ -68,7 +69,6 @@ type OnboardingStep = "role" | "stack" | "flaggers" | "telemetry"
 type StackChoice = "coding-agent-machine" | "production-agent"
 type TelemetrySetupMode = "coding-agent" | "manual"
 type IntegrationPanel = "typescript" | "python" | "opentelemetry"
-type FlaggerPresetSlug = (typeof FLAGGER_STRATEGY_SLUGS)[number]
 
 const SETUP_MODE_TAB_OPTIONS = [
   { id: "coding-agent" as const, label: "Coding agent", icon: <Bot className="h-4 w-4" /> },
@@ -104,98 +104,6 @@ const CODING_MACHINE_AGENT_TAB_OPTIONS = [
     icon: <OnboardingCodingAgentTabIcon src={ONBOARDING_OPENCLAW_LOGO_SRC} />,
   },
 ] as const satisfies ReadonlyArray<{ id: CodingMachineAgentId; label: string; icon: ReactNode }>
-
-const FLAGGER_USE_CASE_PRESETS = [
-  {
-    id: "support-agent",
-    label: "Support agent",
-    description: "Customer-facing assistants handling questions, escalations, and account workflows.",
-    enabledSlugs: [
-      "frustration",
-      "refusal",
-      "forgetting",
-      "tool-call-errors",
-      "empty-response",
-      "jailbreaking",
-      "nsfw",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "coding-agent",
-    label: "Coding agent",
-    description: "Agents that edit files, call tools, and work through multi-step implementation tasks.",
-    enabledSlugs: [
-      "laziness",
-      "trashing",
-      "tool-call-errors",
-      "empty-response",
-      "refusal",
-      "forgetting",
-      "output-schema-validation",
-      "frustration",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "sales-agent",
-    label: "Sales agent",
-    description: "Lead qualification and buyer-facing assistants where tone and follow-through matter.",
-    enabledSlugs: [
-      "frustration",
-      "refusal",
-      "forgetting",
-      "empty-response",
-      "jailbreaking",
-      "nsfw",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "tool-workflow-agent",
-    label: "Tool workflow agent",
-    description: "Agents that coordinate tools, APIs, and structured workflows.",
-    enabledSlugs: [
-      "tool-call-errors",
-      "trashing",
-      "output-schema-validation",
-      "empty-response",
-      "laziness",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "knowledge-base-agent",
-    label: "Knowledge-base agent",
-    description: "RAG and documentation assistants that need to preserve context and answer directly.",
-    enabledSlugs: [
-      "forgetting",
-      "refusal",
-      "empty-response",
-      "frustration",
-      "laziness",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "structured-extraction-agent",
-    label: "Structured extraction",
-    description: "Extraction and classification agents that return machine-readable output.",
-    enabledSlugs: [
-      "output-schema-validation",
-      "empty-response",
-      "tool-call-errors",
-      "laziness",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-  {
-    id: "safety-agent",
-    label: "Safety agent",
-    description: "Moderation and policy-sensitive assistants exposed to adversarial or unsafe inputs.",
-    enabledSlugs: [
-      "nsfw",
-      "jailbreaking",
-      "refusal",
-      "frustration",
-      "empty-response",
-    ] satisfies ReadonlyArray<FlaggerPresetSlug>,
-  },
-] as const
 
 const STACK_CHOICE_OPTIONS: ReadonlyArray<{
   readonly id: StackChoice
@@ -539,6 +447,13 @@ export function OnboardingFlow({
   const enabledFlaggerSlugs =
     selectedFlaggerSlugs ?? (projectFlaggers.length > 0 ? currentEnabledFlaggerSlugs : new Set(availableFlaggerSlugs))
 
+  const activePresetId =
+    FLAGGER_USE_CASE_PRESETS.find(
+      (preset) =>
+        preset.enabledSlugs.length === enabledFlaggerSlugs.size &&
+        preset.enabledSlugs.every((slug) => enabledFlaggerSlugs.has(slug)),
+    )?.id ?? null
+
   const toggleFlaggerSelection = (slug: string) => {
     setSelectedFlaggerSlugs((current) => {
       const next = new Set(current ?? enabledFlaggerSlugs)
@@ -551,7 +466,7 @@ export function OnboardingFlow({
     })
   }
 
-  const applyFlaggerPreset = (enabledSlugs: readonly string[]) => {
+  const applyFlaggerPreset = (enabledSlugs: ReadonlyArray<FlaggerPresetSlug>) => {
     setSelectedFlaggerSlugs(new Set(enabledSlugs))
   }
 
@@ -811,22 +726,34 @@ export function OnboardingFlow({
                     Latitude inspects all incoming traces and creates issues when they detect common failure patterns.
                     Choose the patterns you want to monitor.
                   </Text.H4>
+                  <Text.H5 color="foregroundMuted">
+                    You can fine-tune sampling rates per flagger later in Project settings.
+                  </Text.H5>
                 </div>
               </div>
 
               <div className="flex flex-col gap-6">
                 <div className="flex flex-row flex-wrap gap-2">
-                  {FLAGGER_USE_CASE_PRESETS.map((preset) => (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      onClick={() => applyFlaggerPreset(preset.enabledSlugs)}
-                      className="inline-flex cursor-pointer rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:border-primary/40 hover:bg-accent/10"
-                      title={preset.description}
-                    >
-                      {preset.label}
-                    </button>
-                  ))}
+                  {FLAGGER_USE_CASE_PRESETS.map((preset) => {
+                    const isActive = activePresetId === preset.id
+                    return (
+                      <button
+                        key={preset.id}
+                        type="button"
+                        aria-pressed={isActive}
+                        onClick={() => applyFlaggerPreset(preset.enabledSlugs)}
+                        className={cn(
+                          "inline-flex cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                          isActive
+                            ? "border-primary bg-primary-muted/40 text-primary"
+                            : "border-border bg-background text-foreground hover:border-primary/40 hover:bg-accent/10",
+                        )}
+                        title={preset.description}
+                      >
+                        {preset.label}
+                      </button>
+                    )
+                  })}
                 </div>
 
                 {isLoadingAvailableFlaggers || isLoadingProjectFlaggers ? (
@@ -835,6 +762,7 @@ export function OnboardingFlow({
                   <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3">
                     {availableFlaggers.map((flagger) => {
                       const selected = enabledFlaggerSlugs.has(flagger.slug)
+                      const isDeterministic = flagger.mode === "deterministic"
                       return (
                         <button
                           key={flagger.slug}
@@ -850,7 +778,14 @@ export function OnboardingFlow({
                           )}
                         >
                           <div className="flex min-w-0 flex-col gap-1.5">
-                            <Text.H5M>{flagger.name}</Text.H5M>
+                            <div className="flex flex-row items-center gap-2">
+                              <Text.H5M>{flagger.name}</Text.H5M>
+                              {isDeterministic ? (
+                                <Badge variant="muted" size="small">
+                                  Always-on · free
+                                </Badge>
+                              ) : null}
+                            </div>
                             <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
                           </div>
                           <div className="flex flex-row justify-end">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -747,21 +747,16 @@ export function OnboardingFlow({
                   {FLAGGER_USE_CASE_PRESETS.map((preset) => {
                     const isActive = activePresetId === preset.id
                     return (
-                      <button
+                      <Button
                         key={preset.id}
-                        type="button"
+                        variant={isActive ? "default-soft" : "outline"}
+                        size="sm"
                         aria-pressed={isActive}
                         onClick={() => applyFlaggerPreset(preset.enabledSlugs)}
-                        className={cn(
-                          "inline-flex cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-                          isActive
-                            ? "border-primary bg-primary-muted/40 text-primary"
-                            : "border-border bg-background text-foreground hover:border-primary/40 hover:bg-accent/10",
-                        )}
                         title={preset.description}
                       >
                         {preset.label}
-                      </button>
+                      </Button>
                     )
                   })}
                 </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -1,6 +1,5 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
 import {
-  Badge,
   Button,
   CodeBlock,
   CopyButton,
@@ -35,7 +34,11 @@ import {
   configureProjectFlaggersForOnboarding,
   listAvailableFlaggers,
 } from "../../../../../domains/flaggers/flaggers.functions.ts"
-import { FLAGGER_USE_CASE_PRESETS, type FlaggerPresetSlug } from "../../../../../domains/flaggers/presets.ts"
+import {
+  FLAGGER_DISPLAY_ORDER,
+  FLAGGER_USE_CASE_PRESETS,
+  type FlaggerPresetSlug,
+} from "../../../../../domains/flaggers/presets.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
@@ -440,7 +443,14 @@ export function OnboardingFlow({
     queryFn: () => listAvailableFlaggers(),
   })
 
-  const availableFlaggerSlugs = availableFlaggers.map((flagger) => flagger.slug)
+  const sortedAvailableFlaggers = useMemo(() => {
+    const indexBySlug = new Map<string, number>(FLAGGER_DISPLAY_ORDER.map((slug, index) => [slug, index]))
+    const fallbackIndex = FLAGGER_DISPLAY_ORDER.length
+    return [...availableFlaggers].sort(
+      (a, b) => (indexBySlug.get(a.slug) ?? fallbackIndex) - (indexBySlug.get(b.slug) ?? fallbackIndex),
+    )
+  }, [availableFlaggers])
+  const availableFlaggerSlugs = sortedAvailableFlaggers.map((flagger) => flagger.slug)
   const currentEnabledFlaggerSlugs = new Set(
     projectFlaggers.filter((flagger) => flagger.enabled).map((flagger) => flagger.slug),
   )
@@ -760,9 +770,8 @@ export function OnboardingFlow({
                   <Text.H5 color="foregroundMuted">Loading flaggers…</Text.H5>
                 ) : (
                   <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3">
-                    {availableFlaggers.map((flagger) => {
+                    {sortedAvailableFlaggers.map((flagger) => {
                       const selected = enabledFlaggerSlugs.has(flagger.slug)
-                      const isDeterministic = flagger.mode === "deterministic"
                       return (
                         <button
                           key={flagger.slug}
@@ -778,14 +787,7 @@ export function OnboardingFlow({
                           )}
                         >
                           <div className="flex min-w-0 flex-col gap-1.5">
-                            <div className="flex flex-row items-center gap-2">
-                              <Text.H5M>{flagger.name}</Text.H5M>
-                              {isDeterministic ? (
-                                <Badge variant="muted" size="small">
-                                  Always-on · free
-                                </Badge>
-                              ) : null}
-                            </div>
+                            <Text.H5M>{flagger.name}</Text.H5M>
                             <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
                           </div>
                           <div className="flex flex-row justify-end">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -35,7 +35,7 @@ import {
   listAvailableFlaggers,
 } from "../../../../../domains/flaggers/flaggers.functions.ts"
 import {
-  FLAGGER_DISPLAY_ORDER,
+  FLAGGER_ONBOARDING_ORDER,
   FLAGGER_USE_CASE_PRESETS,
   type FlaggerPresetSlug,
 } from "../../../../../domains/flaggers/presets.ts"
@@ -444,8 +444,8 @@ export function OnboardingFlow({
   })
 
   const sortedAvailableFlaggers = useMemo(() => {
-    const indexBySlug = new Map<string, number>(FLAGGER_DISPLAY_ORDER.map((slug, index) => [slug, index]))
-    const fallbackIndex = FLAGGER_DISPLAY_ORDER.length
+    const indexBySlug = new Map<string, number>(FLAGGER_ONBOARDING_ORDER.map((slug, index) => [slug, index]))
+    const fallbackIndex = FLAGGER_ONBOARDING_ORDER.length
     return [...availableFlaggers].sort(
       (a, b) => (indexBySlug.get(a.slug) ?? fallbackIndex) - (indexBySlug.get(b.slug) ?? fallbackIndex),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -33,15 +33,10 @@ export function SettingsPage({ title, description, actions, children, headerStic
   return (
     <>
       <div
-        className={cn(
-          "flex flex-row items-center justify-between gap-4",
-          headerSticky && [
-            "sticky top-0 z-10",
-            "-mx-6 px-6 py-3",
-            "border-b border-border",
-            "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
-          ],
-        )}
+        className={cn("flex flex-row items-center justify-between gap-4", {
+          "sticky top-0 z-10 -mx-6 border-b border-border bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80":
+            headerSticky,
+        })}
       >
         {header}
         {actions ? <div className="shrink-0">{actions}</div> : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -14,9 +14,10 @@ interface SettingsPageProps {
   readonly description?: ReactNode
   readonly actions?: ReactNode
   readonly children: ReactNode
+  readonly footer?: ReactNode
 }
 
-export function SettingsPage({ title, description, actions, children }: SettingsPageProps) {
+export function SettingsPage({ title, description, actions, children, footer }: SettingsPageProps) {
   const header = (
     <div className="flex flex-col gap-1">
       {typeof title === "string" ? <SettingsPageTitle>{title}</SettingsPageTitle> : title}
@@ -34,7 +35,12 @@ export function SettingsPage({ title, description, actions, children }: Settings
       ) : (
         header
       )}
-      <div className="flex flex-col gap-6">{children}</div>
+      <div className="flex flex-col gap-6 pb-2">{children}</div>
+      {footer ? (
+        <div className="sticky bottom-0 -mx-6 border-t border-border bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+          {footer}
+        </div>
+      ) : null}
     </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@repo/ui"
+import { cn, Text } from "@repo/ui"
 import type { ReactNode } from "react"
 
 interface SettingsPageTitleProps {
@@ -14,10 +14,15 @@ interface SettingsPageProps {
   readonly description?: ReactNode
   readonly actions?: ReactNode
   readonly children: ReactNode
-  readonly footer?: ReactNode
+  /**
+   * When true, the title/description/actions header sticks to the top of the scroll
+   * container with a background + bottom border. Use this to surface action controls
+   * (e.g. Apply/Discard) when the page has unsaved changes.
+   */
+  readonly headerSticky?: boolean
 }
 
-export function SettingsPage({ title, description, actions, children, footer }: SettingsPageProps) {
+export function SettingsPage({ title, description, actions, children, headerSticky = false }: SettingsPageProps) {
   const header = (
     <div className="flex flex-col gap-1">
       {typeof title === "string" ? <SettingsPageTitle>{title}</SettingsPageTitle> : title}
@@ -27,20 +32,21 @@ export function SettingsPage({ title, description, actions, children, footer }: 
 
   return (
     <>
-      {actions ? (
-        <div className="flex flex-row items-start justify-between gap-4">
-          {header}
-          <div className="shrink-0">{actions}</div>
-        </div>
-      ) : (
-        header
-      )}
-      <div className="flex flex-col gap-6 pb-2">{children}</div>
-      {footer ? (
-        <div className="sticky bottom-0 -mx-6 border-t border-border bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-          {footer}
-        </div>
-      ) : null}
+      <div
+        className={cn(
+          "flex flex-row items-center justify-between gap-4",
+          headerSticky && [
+            "sticky top-0 z-10",
+            "-mx-6 px-6 py-3",
+            "border-b border-border",
+            "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80",
+          ],
+        )}
+      >
+        {header}
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </div>
+      <div className="flex flex-col gap-6">{children}</div>
     </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -1,9 +1,7 @@
 import {
+  Badge,
   Button,
-  CloseTrigger,
   cn,
-  Icon,
-  Modal,
   Slider,
   Switch,
   Table,
@@ -17,11 +15,11 @@ import {
   useToast,
 } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
-import { createFileRoute } from "@tanstack/react-router"
-import { Pencil } from "lucide-react"
-import { useRef, useState } from "react"
+import { createFileRoute, useBlocker } from "@tanstack/react-router"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { updateFlaggerMutation, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
 import type { FlaggerRecord } from "../../../../../domains/flaggers/flaggers.functions.ts"
+import { FLAGGER_USE_CASE_PRESETS, type FlaggerPresetSlug } from "../../../../../domains/flaggers/presets.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -32,11 +30,17 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
   component: ProjectFlaggersSettingsPage,
 })
 
+interface PendingFlagger {
+  readonly enabled: boolean
+  readonly sampling: number
+}
+
 function ProjectFlaggersSettingsPage() {
   const { projectSlug } = Route.useParams()
   const { toast } = useToast()
   const routeProject = useRouteProject()
-  const [editingFlagger, setEditingFlagger] = useState<FlaggerRecord | null>(null)
+  const [pending, setPending] = useState<Record<string, PendingFlagger>>({})
+  const [isApplying, setIsApplying] = useState(false)
 
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),
@@ -46,8 +50,131 @@ function ProjectFlaggersSettingsPage() {
   const currentProject = project ?? routeProject
   const { data: flaggers = [], isLoading: isLoadingFlaggers } = useProjectFlaggers(currentProject.id)
 
-  // Flagger annotations deep-link here with `?flagger=<slug>` to point at the
-  // flagger that authored them; scroll it into view once and keep it highlighted.
+  const flaggersById = useMemo(() => {
+    const map = new Map<string, FlaggerRecord>()
+    for (const flagger of flaggers) map.set(flagger.id, flagger)
+    return map
+  }, [flaggers])
+
+  const resolved = useMemo(
+    () =>
+      flaggers.map((flagger) => {
+        const overlay = pending[flagger.id]
+        const viewEnabled = overlay?.enabled ?? flagger.enabled
+        const viewSampling = overlay?.sampling ?? flagger.sampling
+        const isDirty =
+          overlay !== undefined && (overlay.enabled !== flagger.enabled || overlay.sampling !== flagger.sampling)
+        return { ...flagger, viewEnabled, viewSampling, isDirty }
+      }),
+    [flaggers, pending],
+  )
+
+  const dirtyCount = resolved.reduce((acc, row) => (row.isDirty ? acc + 1 : acc), 0)
+  const hasDirty = dirtyCount > 0
+
+  const enabledSlugsResolved = useMemo(
+    () => new Set(resolved.filter((row) => row.viewEnabled).map((row) => row.slug)),
+    [resolved],
+  )
+  const activePresetId =
+    FLAGGER_USE_CASE_PRESETS.find(
+      (preset) =>
+        preset.enabledSlugs.length === enabledSlugsResolved.size &&
+        preset.enabledSlugs.every((slug) => enabledSlugsResolved.has(slug)),
+    )?.id ?? null
+
+  const setRowChange = (id: string, change: Partial<PendingFlagger>) => {
+    setPending((prev) => {
+      const server = flaggersById.get(id)
+      if (!server) return prev
+      const baseline = prev[id] ?? { enabled: server.enabled, sampling: server.sampling }
+      const next: PendingFlagger = { ...baseline, ...change }
+      if (next.enabled === server.enabled && next.sampling === server.sampling) {
+        const { [id]: _drop, ...rest } = prev
+        return rest
+      }
+      return { ...prev, [id]: next }
+    })
+  }
+
+  const applyPreset = (presetEnabledSlugs: ReadonlyArray<FlaggerPresetSlug>) => {
+    const enabledSet = new Set<string>(presetEnabledSlugs)
+    setPending((prev) => {
+      const next: Record<string, PendingFlagger> = {}
+      for (const flagger of flaggers) {
+        const desiredEnabled = enabledSet.has(flagger.slug)
+        const desiredSampling = prev[flagger.id]?.sampling ?? flagger.sampling
+        if (desiredEnabled !== flagger.enabled || desiredSampling !== flagger.sampling) {
+          next[flagger.id] = { enabled: desiredEnabled, sampling: desiredSampling }
+        }
+      }
+      return next
+    })
+  }
+
+  const discard = () => setPending({})
+
+  const apply = async () => {
+    if (!hasDirty || isApplying) return
+    setIsApplying(true)
+    try {
+      const entries = Object.entries(pending)
+      const transactions = entries
+        .map(([id, overlay]) => {
+          const flagger = flaggersById.get(id)
+          if (!flagger) return null
+          return updateFlaggerMutation({
+            projectId: currentProject.id,
+            id,
+            slug: flagger.slug,
+            enabled: overlay.enabled,
+            sampling: overlay.sampling,
+          })
+        })
+        .filter((t): t is NonNullable<typeof t> => t !== null)
+
+      await Promise.all(transactions.map((t) => t.isPersisted.promise))
+      setPending({})
+      toast({
+        description: `Updated ${entries.length} flagger${entries.length === 1 ? "" : "s"}`,
+      })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setIsApplying(false)
+    }
+  }
+
+  const applyRef = useRef(apply)
+  applyRef.current = apply
+
+  useEffect(() => {
+    if (!hasDirty) return
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const inField =
+        !!target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable === true)
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault()
+        void applyRef.current()
+      } else if (event.key === "Escape" && !inField) {
+        event.preventDefault()
+        setPending({})
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [hasDirty])
+
+  useBlocker({
+    shouldBlockFn: () => {
+      if (!hasDirty) return false
+      return !window.confirm("You have unsaved flagger changes. Leave anyway?")
+    },
+    enableBeforeUnload: () => hasDirty,
+    disabled: !hasDirty,
+  })
+
   const [targetFlaggerSlug] = useParamState("flagger", "")
   const hasScrolledToTargetRef = useRef(false)
   const scrollTargetRef = (node: HTMLTableRowElement | null) => {
@@ -57,170 +184,146 @@ function ProjectFlaggersSettingsPage() {
     }
   }
 
-  const handleFlaggerEnabledChange = async (flagger: FlaggerRecord, enabled: boolean) => {
-    try {
-      const transaction = updateFlaggerMutation({
-        projectId: currentProject.id,
-        id: flagger.id,
-        slug: flagger.slug,
-        enabled,
-      })
-      await transaction.isPersisted.promise
-      toast({ description: "Flagger settings updated" })
-    } catch (error) {
-      toast({ variant: "destructive", description: toUserMessage(error) })
-    }
-  }
-
-  const handleFlaggerSamplingUpdate = async (flagger: FlaggerRecord, sampling: number) => {
-    try {
-      const transaction = updateFlaggerMutation({
-        projectId: currentProject.id,
-        id: flagger.id,
-        slug: flagger.slug,
-        sampling,
-      })
-      await transaction.isPersisted.promise
-      toast({ description: "Flagger settings updated" })
-      setEditingFlagger(null)
-    } catch (error) {
-      toast({ variant: "destructive", description: toUserMessage(error) })
-    }
-  }
+  const footer = hasDirty ? (
+    <div className="flex flex-row items-center justify-between gap-4">
+      <Text.H5 color="foregroundMuted">
+        {dirtyCount} unsaved change{dirtyCount === 1 ? "" : "s"}
+      </Text.H5>
+      <div className="flex flex-row items-center gap-2">
+        <Button variant="outline" onClick={discard} disabled={isApplying}>
+          Discard
+        </Button>
+        <Button onClick={() => void apply()} isLoading={isApplying}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  ) : null
 
   return (
     <SettingsPage
       title="Flaggers"
       description="Flaggers automatically inspect new traces for known failure patterns and create issues when they detect regressions"
+      footer={footer}
     >
-      <div className="flex w-full flex-col gap-1">
+      <div className="flex w-full flex-col gap-4">
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (
           <Text.H5 color="foregroundMuted">No flaggers have been provisioned for this project yet</Text.H5>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Flagger</TableHead>
-                <TableHead className="w-10">Enabled</TableHead>
-                <TableHead>Sampling</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {flaggers.map((flagger) => {
-                const isTarget = targetFlaggerSlug !== "" && flagger.slug === targetFlaggerSlug
-                return (
-                  <TableRow
-                    key={flagger.id}
-                    ref={isTarget ? scrollTargetRef : undefined}
-                    verticalPadding
-                    hoverable={false}
-                    className={cn({ "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget })}
-                  >
-                    <TableCell className="max-w-[28rem]">
-                      <div className="flex flex-col gap-1">
-                        <Text.H5M>{flagger.name}</Text.H5M>
-                        <Text.H6 color="foregroundMuted">{flagger.description}</Text.H6>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <Switch
-                        checked={flagger.enabled}
-                        onCheckedChange={(checked) => void handleFlaggerEnabledChange(flagger, checked)}
-                        aria-label={`${flagger.enabled ? "Disable" : "Enable"} ${flagger.name}`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-row items-center gap-1">
-                        <Text.H5>{flagger.sampling}%</Text.H5>
-                        <Tooltip
-                          asChild
-                          trigger={
-                            <Button variant="ghost" size="icon" onClick={() => setEditingFlagger(flagger)}>
-                              <Icon icon={Pencil} size="sm" />
-                            </Button>
-                          }
-                        >
-                          Edit sampling rate
-                        </Tooltip>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
+          <>
+            <div className="flex flex-col gap-2">
+              <Text.H6 color="foregroundMuted">Apply a use-case preset</Text.H6>
+              <div className="flex flex-row flex-wrap gap-2">
+                {FLAGGER_USE_CASE_PRESETS.map((preset) => {
+                  const isActive = activePresetId === preset.id
+                  return (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      aria-pressed={isActive}
+                      onClick={() => applyPreset(preset.enabledSlugs)}
+                      className={cn(
+                        "inline-flex cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                        isActive
+                          ? "border-primary bg-primary-muted/40 text-primary"
+                          : "border-border bg-background text-foreground hover:border-primary/40 hover:bg-accent/10",
+                      )}
+                      title={preset.description}
+                    >
+                      {preset.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Flagger</TableHead>
+                  <TableHead className="w-10">Enabled</TableHead>
+                  <TableHead className="w-[280px]">Sampling</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {resolved.map((row) => {
+                  const isTarget = targetFlaggerSlug !== "" && row.slug === targetFlaggerSlug
+                  const isDeterministic = row.mode === "deterministic"
+                  return (
+                    <TableRow
+                      key={row.id}
+                      ref={isTarget ? scrollTargetRef : undefined}
+                      verticalPadding
+                      hoverable={false}
+                      className={cn({ "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget })}
+                    >
+                      <TableCell className="max-w-[28rem]">
+                        <div className="flex flex-col gap-1">
+                          <div className="flex flex-row items-center gap-2">
+                            <Text.H5M>{row.name}</Text.H5M>
+                            {isDeterministic ? (
+                              <Badge variant="muted" size="small">
+                                Always-on · free
+                              </Badge>
+                            ) : null}
+                            {row.isDirty ? (
+                              <span
+                                role="img"
+                                className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                                aria-label="Unsaved changes"
+                                title="Unsaved changes"
+                              />
+                            ) : null}
+                          </div>
+                          <Text.H6 color="foregroundMuted">{row.description}</Text.H6>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Switch
+                          checked={row.viewEnabled}
+                          onCheckedChange={(checked) => setRowChange(row.id, { enabled: checked })}
+                          aria-label={`${row.viewEnabled ? "Disable" : "Enable"} ${row.name}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        {isDeterministic ? (
+                          <Tooltip
+                            asChild
+                            trigger={
+                              <span className="inline-flex">
+                                <Text.H5 color="foregroundMuted">—</Text.H5>
+                              </span>
+                            }
+                          >
+                            Always runs · sampling not applicable
+                          </Tooltip>
+                        ) : (
+                          <div className="flex flex-col gap-1">
+                            <div className="flex flex-row items-center gap-3">
+                              <Slider
+                                min={0}
+                                max={100}
+                                step={1}
+                                value={[row.viewSampling]}
+                                onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
+                                className="w-44"
+                              />
+                              <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>
+                            </div>
+                            <Text.H6 color="foregroundMuted">
+                              30 credits per scan · runs on {row.viewSampling}% of eligible traces
+                            </Text.H6>
+                          </div>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </>
         )}
       </div>
-
-      {editingFlagger ? (
-        <EditFlaggerModal
-          flagger={editingFlagger}
-          onClose={() => setEditingFlagger(null)}
-          onSave={handleFlaggerSamplingUpdate}
-        />
-      ) : null}
     </SettingsPage>
-  )
-}
-
-function EditFlaggerModal({
-  flagger,
-  onClose,
-  onSave,
-}: {
-  readonly flagger: FlaggerRecord
-  readonly onClose: () => void
-  readonly onSave: (flagger: FlaggerRecord, sampling: number) => Promise<void>
-}) {
-  const [sampling, setSampling] = useState(flagger.sampling)
-  const [isSaving, setIsSaving] = useState(false)
-
-  const handleSave = async () => {
-    setIsSaving(true)
-    try {
-      await onSave(flagger, sampling)
-    } finally {
-      setIsSaving(false)
-    }
-  }
-
-  return (
-    <Modal
-      open
-      dismissible
-      scrollable={false}
-      onOpenChange={(open) => (!open ? onClose() : undefined)}
-      title={`Edit ${flagger.name} sampling`}
-      description="Configure what percentage of eligible traces this flagger samples."
-      footer={
-        <>
-          <CloseTrigger />
-          <Button onClick={() => void handleSave()} isLoading={isSaving}>
-            Save
-          </Button>
-        </>
-      }
-    >
-      <div className="flex flex-col gap-6 pb-6">
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-row items-baseline justify-between gap-4">
-            <Text.H6 color="foregroundMuted">Sampling rate</Text.H6>
-            <Text.H4M color="foreground">{sampling}%</Text.H4M>
-          </div>
-          <Slider
-            min={0}
-            max={100}
-            step={1}
-            value={[sampling]}
-            onValueChange={(values) => setSampling(values[0] ?? 0)}
-          />
-          <Text.H6 color="foregroundMuted">
-            {sampling === 0
-              ? "0% pauses sampling for this flagger."
-              : `Runs on ${sampling}% of eligible incoming traces.`}
-          </Text.H6>
-        </div>
-      </div>
-    </Modal>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -284,6 +284,7 @@ function ProjectFlaggersSettingsPage() {
                                       step={1}
                                       value={[row.viewSampling]}
                                       onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
+                                      disabled={!row.viewEnabled}
                                     />
                                   </div>
                                   <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -207,21 +207,16 @@ function ProjectFlaggersSettingsPage() {
                 {FLAGGER_USE_CASE_PRESETS.map((preset) => {
                   const isActive = activePresetId === preset.id
                   return (
-                    <button
+                    <Button
                       key={preset.id}
-                      type="button"
+                      variant={isActive ? "default-soft" : "outline"}
+                      size="sm"
                       aria-pressed={isActive}
                       onClick={() => applyPreset(preset.enabledSlugs)}
-                      className={cn(
-                        "inline-flex cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-                        isActive
-                          ? "border-primary bg-primary-muted/40 text-primary"
-                          : "border-border bg-background text-foreground hover:border-primary/40 hover:bg-accent/10",
-                      )}
                       title={preset.description}
                     >
                       {preset.label}
-                    </button>
+                    </Button>
                   )
                 })}
               </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -136,6 +136,8 @@ function ProjectFlaggersSettingsPage() {
 
   const applyRef = useRef(apply)
   applyRef.current = apply
+  const isApplyingRef = useRef(isApplying)
+  isApplyingRef.current = isApplying
 
   useEffect(() => {
     if (!hasDirty) return
@@ -146,7 +148,7 @@ function ProjectFlaggersSettingsPage() {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
         event.preventDefault()
         void applyRef.current()
-      } else if (event.key === "Escape" && !inField) {
+      } else if (event.key === "Escape" && !inField && !isApplyingRef.current) {
         event.preventDefault()
         setPending({})
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -1,25 +1,14 @@
-import {
-  Badge,
-  Button,
-  cn,
-  Slider,
-  Switch,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-  Text,
-  Tooltip,
-  useToast,
-} from "@repo/ui"
+import { Button, cn, Slider, Switch, Text, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, useBlocker } from "@tanstack/react-router"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { updateFlaggerMutation, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
 import type { FlaggerRecord } from "../../../../../domains/flaggers/flaggers.functions.ts"
-import { FLAGGER_USE_CASE_PRESETS, type FlaggerPresetSlug } from "../../../../../domains/flaggers/presets.ts"
+import {
+  FLAGGER_GROUPS,
+  FLAGGER_USE_CASE_PRESETS,
+  type FlaggerPresetSlug,
+} from "../../../../../domains/flaggers/presets.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -177,7 +166,7 @@ function ProjectFlaggersSettingsPage() {
 
   const [targetFlaggerSlug] = useParamState("flagger", "")
   const hasScrolledToTargetRef = useRef(false)
-  const scrollTargetRef = (node: HTMLTableRowElement | null) => {
+  const scrollTargetRef = (node: HTMLDivElement | null) => {
     if (node && !hasScrolledToTargetRef.current) {
       hasScrolledToTargetRef.current = true
       node.scrollIntoView({ block: "center", behavior: "smooth" })
@@ -206,7 +195,7 @@ function ProjectFlaggersSettingsPage() {
       description="Flaggers automatically inspect new traces for known failure patterns and create issues when they detect regressions"
       footer={footer}
     >
-      <div className="flex w-full flex-col gap-4">
+      <div className="flex w-full flex-col gap-6">
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (
           <Text.H5 color="foregroundMuted">No flaggers have been provisioned for this project yet</Text.H5>
         ) : (
@@ -237,90 +226,81 @@ function ProjectFlaggersSettingsPage() {
               </div>
             </div>
 
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Flagger</TableHead>
-                  <TableHead className="w-10">Enabled</TableHead>
-                  <TableHead className="w-[280px]">Sampling</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {resolved.map((row) => {
-                  const isTarget = targetFlaggerSlug !== "" && row.slug === targetFlaggerSlug
-                  const isDeterministic = row.mode === "deterministic"
-                  return (
-                    <TableRow
-                      key={row.id}
-                      ref={isTarget ? scrollTargetRef : undefined}
-                      verticalPadding
-                      hoverable={false}
-                      className={cn({ "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget })}
-                    >
-                      <TableCell className="max-w-[28rem]">
-                        <div className="flex flex-col gap-1">
-                          <div className="flex flex-row items-center gap-2">
-                            <Text.H5M>{row.name}</Text.H5M>
-                            {isDeterministic ? (
-                              <Badge variant="muted" size="small">
-                                Always-on · free
-                              </Badge>
-                            ) : null}
-                            {row.isDirty ? (
-                              <span
-                                role="img"
-                                className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
-                                aria-label="Unsaved changes"
-                                title="Unsaved changes"
-                              />
-                            ) : null}
-                          </div>
-                          <Text.H6 color="foregroundMuted">{row.description}</Text.H6>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Switch
-                          checked={row.viewEnabled}
-                          onCheckedChange={(checked) => setRowChange(row.id, { enabled: checked })}
-                          aria-label={`${row.viewEnabled ? "Disable" : "Enable"} ${row.name}`}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        {isDeterministic ? (
-                          <Tooltip
-                            asChild
-                            trigger={
-                              <span className="inline-flex">
-                                <Text.H5 color="foregroundMuted">—</Text.H5>
-                              </span>
-                            }
+            <div className="flex flex-col gap-8">
+              {FLAGGER_GROUPS.map((group) => {
+                const groupRows = group.slugs
+                  .map((slug) => resolved.find((row) => row.slug === slug))
+                  .filter((row): row is NonNullable<typeof row> => row !== undefined)
+                if (groupRows.length === 0) return null
+                return (
+                  <div key={group.id} className="flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                      <Text.H5M>{group.label}</Text.H5M>
+                      <Text.H6 color="foregroundMuted">{group.description}</Text.H6>
+                    </div>
+                    <div className="divide-y divide-border">
+                      {groupRows.map((row) => {
+                        const isTarget = targetFlaggerSlug !== "" && row.slug === targetFlaggerSlug
+                        const isDeterministic = row.mode === "deterministic"
+                        return (
+                          <div
+                            key={row.id}
+                            ref={isTarget ? scrollTargetRef : undefined}
+                            className={cn("flex flex-col gap-3 rounded-md py-4", {
+                              "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget,
+                            })}
                           >
-                            Always runs · sampling not applicable
-                          </Tooltip>
-                        ) : (
-                          <div className="flex flex-col gap-1">
-                            <div className="flex flex-row items-center gap-3">
-                              <Slider
-                                min={0}
-                                max={100}
-                                step={1}
-                                value={[row.viewSampling]}
-                                onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
-                                className="w-44"
-                              />
-                              <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>
+                            <div className="flex flex-row items-start justify-between gap-4">
+                              <div className="flex min-w-0 flex-col gap-1">
+                                <div className="flex flex-row items-center gap-2">
+                                  <Text.H5M>{row.name}</Text.H5M>
+                                  {row.isDirty ? (
+                                    <span
+                                      role="img"
+                                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-primary"
+                                      aria-label="Unsaved changes"
+                                      title="Unsaved changes"
+                                    />
+                                  ) : null}
+                                </div>
+                                <Text.H6 color="foregroundMuted">{row.description}</Text.H6>
+                              </div>
+                              <div className="shrink-0">
+                                <Switch
+                                  checked={row.viewEnabled}
+                                  onCheckedChange={(checked) => setRowChange(row.id, { enabled: checked })}
+                                  aria-label={`${row.viewEnabled ? "Disable" : "Enable"} ${row.name}`}
+                                />
+                              </div>
                             </div>
-                            <Text.H6 color="foregroundMuted">
-                              30 credits per scan · runs on {row.viewSampling}% of eligible traces
-                            </Text.H6>
+                            {isDeterministic ? (
+                              <Text.H6 color="foregroundMuted">Free · Runs on 100% of eligible traces</Text.H6>
+                            ) : (
+                              <div className="flex flex-row flex-wrap items-center gap-x-4 gap-y-2">
+                                <div className="flex min-w-[200px] flex-1 flex-row items-center gap-3">
+                                  <Slider
+                                    min={0}
+                                    max={100}
+                                    step={1}
+                                    value={[row.viewSampling]}
+                                    onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
+                                    className="flex-1"
+                                  />
+                                  <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>
+                                </div>
+                                <Text.H6 color="foregroundMuted">
+                                  30 credits per scan · runs on {row.viewSampling}% of eligible traces
+                                </Text.H6>
+                              </div>
+                            )}
                           </div>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
           </>
         )}
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -195,7 +195,7 @@ function ProjectFlaggersSettingsPage() {
       description="Flaggers automatically inspect new traces for known failure patterns and create issues when they detect regressions"
       footer={footer}
     >
-      <div className="flex w-full flex-col gap-6">
+      <div className="flex w-full max-w-2xl flex-col gap-8">
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (
           <Text.H5 color="foregroundMuted">No flaggers have been provisioned for this project yet</Text.H5>
         ) : (
@@ -233,12 +233,12 @@ function ProjectFlaggersSettingsPage() {
                   .filter((row): row is NonNullable<typeof row> => row !== undefined)
                 if (groupRows.length === 0) return null
                 return (
-                  <div key={group.id} className="flex flex-col gap-3">
+                  <div key={group.id} className="flex flex-col gap-4">
                     <div className="flex flex-col gap-1">
-                      <Text.H5M>{group.label}</Text.H5M>
-                      <Text.H6 color="foregroundMuted">{group.description}</Text.H6>
+                      <Text.H4M>{group.label}</Text.H4M>
+                      <Text.H5 color="foregroundMuted">{group.description}</Text.H5>
                     </div>
-                    <div className="divide-y divide-border">
+                    <div className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card">
                       {groupRows.map((row) => {
                         const isTarget = targetFlaggerSlug !== "" && row.slug === targetFlaggerSlug
                         const isDeterministic = row.mode === "deterministic"
@@ -246,8 +246,8 @@ function ProjectFlaggersSettingsPage() {
                           <div
                             key={row.id}
                             ref={isTarget ? scrollTargetRef : undefined}
-                            className={cn("flex flex-col gap-3 rounded-md py-4", {
-                              "ring-2 ring-primary ring-offset-2 ring-offset-background": isTarget,
+                            className={cn("flex flex-col gap-3 border-l-2 border-transparent px-4 py-4", {
+                              "border-primary bg-primary-muted/20": isTarget,
                             })}
                           >
                             <div className="flex flex-row items-start justify-between gap-4">
@@ -277,15 +277,16 @@ function ProjectFlaggersSettingsPage() {
                               <Text.H6 color="foregroundMuted">Free · Runs on 100% of eligible traces</Text.H6>
                             ) : (
                               <div className="flex flex-row flex-wrap items-center gap-x-4 gap-y-2">
-                                <div className="flex min-w-[200px] flex-1 flex-row items-center gap-3">
-                                  <Slider
-                                    min={0}
-                                    max={100}
-                                    step={1}
-                                    value={[row.viewSampling]}
-                                    onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
-                                    className="flex-1"
-                                  />
+                                <div className="flex flex-row items-center gap-3">
+                                  <div className="w-48">
+                                    <Slider
+                                      min={0}
+                                      max={100}
+                                      step={1}
+                                      value={[row.viewSampling]}
+                                      onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
+                                    />
+                                  </div>
                                   <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>
                                 </div>
                                 <Text.H6 color="foregroundMuted">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -285,6 +285,7 @@ function ProjectFlaggersSettingsPage() {
                                       value={[row.viewSampling]}
                                       onValueChange={(values) => setRowChange(row.id, { sampling: values[0] ?? 0 })}
                                       disabled={!row.viewEnabled}
+                                      aria-label={`Sampling rate for ${row.name}`}
                                     />
                                   </div>
                                   <Text.H5 className="w-10 tabular-nums">{row.viewSampling}%</Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/flaggers.tsx
@@ -173,19 +173,17 @@ function ProjectFlaggersSettingsPage() {
     }
   }
 
-  const footer = hasDirty ? (
-    <div className="flex flex-row items-center justify-between gap-4">
+  const dirtyActions = hasDirty ? (
+    <div className="flex flex-row items-center gap-3">
       <Text.H5 color="foregroundMuted">
         {dirtyCount} unsaved change{dirtyCount === 1 ? "" : "s"}
       </Text.H5>
-      <div className="flex flex-row items-center gap-2">
-        <Button variant="outline" onClick={discard} disabled={isApplying}>
-          Discard
-        </Button>
-        <Button onClick={() => void apply()} isLoading={isApplying}>
-          Apply
-        </Button>
-      </div>
+      <Button variant="outline" onClick={discard} disabled={isApplying}>
+        Discard
+      </Button>
+      <Button onClick={() => void apply()} isLoading={isApplying}>
+        Apply
+      </Button>
     </div>
   ) : null
 
@@ -193,7 +191,8 @@ function ProjectFlaggersSettingsPage() {
     <SettingsPage
       title="Flaggers"
       description="Flaggers automatically inspect new traces for known failure patterns and create issues when they detect regressions"
-      footer={footer}
+      actions={dirtyActions}
+      headerSticky={hasDirty}
     >
       <div className="flex w-full max-w-2xl flex-col gap-8">
         {isLoadingFlaggers ? null : flaggers.length === 0 ? (

--- a/packages/ui/src/components/slider/index.tsx
+++ b/packages/ui/src/components/slider/index.tsx
@@ -1,5 +1,6 @@
 import * as SliderPrimitive from "@radix-ui/react-slider"
 import type { ComponentPropsWithoutRef, ComponentRef, Ref } from "react"
+import { cn } from "../../utils/cn.ts"
 
 export type SliderProps = ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
 
@@ -11,16 +12,24 @@ export function Slider({
   return (
     <SliderPrimitive.Root
       ref={ref}
-      className={`relative flex w-full touch-none select-none items-center ${className}`}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
+        className,
+      )}
       {...props}
     >
       <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted">
-        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+        <SliderPrimitive.Range className="absolute h-full bg-primary data-[disabled]:bg-muted-foreground" />
       </SliderPrimitive.Track>
       {(props.value ?? props.defaultValue ?? [0]).map((_, i) => (
         <SliderPrimitive.Thumb
           key={i}
-          className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 cursor-pointer"
+          className={cn(
+            "block h-4 w-4 cursor-pointer rounded-full border border-primary/50 bg-background shadow transition-colors",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            "data-[disabled]:cursor-not-allowed",
+          )}
         />
       ))}
     </SliderPrimitive.Root>


### PR DESCRIPTION
Reworks how teams configure flaggers in both the onboarding flow and the project settings page. The two surfaces stay shape-distinct (onboarding = card grid, settings = grouped list) but now share use-case presets and the same semantic grouping of strategies.

## settings page

https://github.com/user-attachments/assets/e8fe0414-7192-49b7-beed-efc69d017969

Per-row autosave + edit modal is replaced with a buffered-edit model. Switches and inline sliders write to a local pending buffer keyed by flagger id. The page header — normally indistinguishable from any other settings page — becomes sticky and surfaces `N unsaved changes · Discard · Apply` on the right as soon as the buffer is non-empty. Apply fires one `updateFlaggerMutation` per dirty row in parallel and clears the buffer on success.

Other settings page changes:

- Flaggers are grouped into three sections: **Response validity** (deterministic, always-on, free), **User-side signals**, **Agent behavior**. Each section has a one-line subtitle that carries the free-vs-LLM context, replacing the per-row badge.
- Use-case preset chips (Support agent / Coding agent / etc.) appear above the list and bulk-edit the buffer while preserving sampling on rows that stay enabled. The chip whose `enabledSlugs` matches the current selection highlights as active.
- Each LLM row shows a compact cost line next to its slider — `30 credits per scan · runs on N% of eligible traces` — so users tuning sampling see the cost shape. Deterministic rows show `Free · Runs on 100% of eligible traces` in the same slot, no slider.
- `Cmd/Ctrl+S` applies, `Esc` discards. `useBlocker` plus `beforeunload` guard against losing unsaved changes on navigation or tab close.
- Deep-link `?flagger=<slug>` continues to scroll the targeted row into view; the highlight is a left-edge accent instead of a ring so it doesn't clip against the group card's \`overflow-hidden\`.

## onboarding

Same card grid, but cards now sort user-side → agent-side → programmatic so the easier-to-grasp behavioral categories lead. The use-case preset chip whose selection matches the current state highlights as active, fixing the previous "did clicking the chip do anything?" feedback gap. A small line under the page title tells users they can tune sampling rates later in settings, so they don't feel obliged to think about sampling here.

## new SettingsPage prop

\`SettingsPage\` gains an optional \`headerSticky\` boolean. When false (every other settings page), the header looks identical to before. When true, the header gets \`position: sticky\`, a background, and a bottom border. Flaggers is currently the only consumer.

## what's deferred

- **Absolute cost projection.** The cost line shows "30 credits per scan · runs on N%" but not "≈ N scans / month" — \`countTracesByProject\` only returns a total count, not a daily rate. A \`countTracesByProjectSinceDays\` endpoint + projection math is a clean follow-up.
- **Bulk update endpoint.** Apply uses N parallel \`updateFlaggerMutation\` calls. A \`updateProjectFlaggers\` mirror of \`configureProjectFlaggersForOnboarding\` would be cleaner but isn't load-bearing at 10 rows.

## verification

Walked through onboarding and settings manually — preset highlight, dirty buffer, Apply/Discard, keyboard shortcuts, navigation/tab-close blocker, deep link. Typecheck and biome clean.