### PR TITLE
feat(onboarding): optional Slack step with channel routing

### DIFF
--- a/apps/web/src/domains/integrations/integrations.functions.ts
+++ b/apps/web/src/domains/integrations/integrations.functions.ts
@@ -82,16 +82,7 @@ const toRecord = (row: SlackIntegration): SlackIntegrationRecord => ({
   routes: row.routes ?? {},
 })
 
-/**
- * Probes whether Slack OAuth env vars are present in this deployment.
- * Self-hosters without a Slack app registered get `false` so the UI
- * can hide the Connect button (e.g. on the onboarding Slack step)
- * instead of letting users hit a 503 on `/integrations/slack/install`.
- *
- * Dynamic import keeps `@platform/slack` off the client bundle —
- * `@platform/slack`'s barrel re-exports `client.ts` which transitively
- * pulls in `@slack/web-api` (uses `require("node:path")`).
- */
+// Dynamic import keeps `@platform/slack` (and its `@slack/web-api` transitive dep) off the client bundle.
 export const isSlackConfigured = createServerFn({ method: "GET" }).handler(async (): Promise<boolean> => {
   await requireSession()
   const { loadSlackConfig } = await import("@platform/slack")

--- a/apps/web/src/domains/integrations/integrations.functions.ts
+++ b/apps/web/src/domains/integrations/integrations.functions.ts
@@ -82,6 +82,23 @@ const toRecord = (row: SlackIntegration): SlackIntegrationRecord => ({
   routes: row.routes ?? {},
 })
 
+/**
+ * Probes whether Slack OAuth env vars are present in this deployment.
+ * Self-hosters without a Slack app registered get `false` so the UI
+ * can hide the Connect button (e.g. on the onboarding Slack step)
+ * instead of letting users hit a 503 on `/integrations/slack/install`.
+ *
+ * Dynamic import keeps `@platform/slack` off the client bundle —
+ * `@platform/slack`'s barrel re-exports `client.ts` which transitively
+ * pulls in `@slack/web-api` (uses `require("node:path")`).
+ */
+export const isSlackConfigured = createServerFn({ method: "GET" }).handler(async (): Promise<boolean> => {
+  await requireSession()
+  const { loadSlackConfig } = await import("@platform/slack")
+  const config = await Effect.runPromise(loadSlackConfig)
+  return config !== undefined
+})
+
 export const getActiveSlackIntegration = createServerFn({ method: "GET" }).handler(
   async (): Promise<SlackIntegrationRecord | null> => {
     const { organizationId } = await requireSession()

--- a/apps/web/src/domains/projects/projects.collection.ts
+++ b/apps/web/src/domains/projects/projects.collection.ts
@@ -68,7 +68,7 @@ export function createProjectMutation(name: string) {
     organizationId: OrganizationId(""),
     name,
     slug: "",
-    settings: { keepMonitoring: undefined, notifications: undefined, escalation: undefined },
+    settings: { keepMonitoring: undefined, notifications: undefined, escalation: undefined, onboardingType: undefined },
     deletedAt: null,
     createdAt: now,
     updatedAt: now,

--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -62,6 +62,7 @@ export const toRecord = (project: Project) => ({
     keepMonitoring: project.settings?.keepMonitoring,
     notifications: project.settings?.notifications,
     escalation: project.settings?.escalation,
+    onboardingType: project.settings?.onboardingType,
   },
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
   createdAt: project.createdAt.toISOString(),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -393,15 +393,6 @@ function SdkIntegrationInstructions({
   )
 }
 
-/**
- * Optional onboarding step that prompts the user to connect Slack so
- * they get notified when their Flaggers detect issues. Hidden via the
- * `slack` feature flag + env-config probe in {@link OnboardingFlow}.
- *
- * Connect leaves the page (Slack OAuth redirect); the callback
- * bounces back to `/projects/{slug}/onboarding?step=slack&installed=ok`
- * which `OnboardingFlow` toasts on mount.
- */
 function SlackOnboardingStep({
   projectSlug,
   onBack,
@@ -416,9 +407,7 @@ function SlackOnboardingStep({
     queryFn: () => getActiveSlackIntegration(),
   })
   const connected = integration != null
-  // The step's pitch only materialises once `incidents` is routed
-  // somewhere. Until then, leaving counts as skipping — so the
-  // primary CTA stays a ghost "Skip for now" even after connect.
+  // CTA reflects routing, not just connection — no route = nothing gets delivered.
   const incidentsConfigured = (integration?.routes.incidents?.length ?? 0) > 0
 
   const returnTo = `/projects/${projectSlug}/onboarding?step=slack`
@@ -447,11 +436,7 @@ function SlackOnboardingStep({
             title="Slack"
             subtitle="Send Latitude notifications to your Slack workspace."
             actions={
-              // `/integrations/slack/install` is a server-handler-only
-              // route that 302s the browser to Slack — needs a full-
-              // page GET, not client-side routing. Plain `<a>` (inside
-              // a `Button asChild`) gives cmd/middle-click + copy-link
-              // affordances while keeping the full-page nav.
+              // Server-handler route — needs full-page nav, not `<Link>` client routing.
               <Button asChild>
                 <a href={connectHref}>Connect Slack</a>
               </Button>
@@ -476,21 +461,6 @@ function SlackOnboardingStep({
   )
 }
 
-/**
- * Onboarding-only variant of the settings page's connected card.
- * Differs in two ways:
- *
- * - No "Disconnect" affordance — onboarding is not the place to undo
- *   a connection the user just made.
- * - Progressive group reveal: `incidents` shows immediately (the
- *   group this step is selling), while `wrapped_reports` and
- *   `custom_messages` only appear once the user has set at least one
- *   route. The second condition also keeps already-routed groups
- *   visible for users who reconnect after a previous setup.
- *
- * Full routing for all groups (and disconnect) lives at
- * `/settings/integrations`; the footer note points users there.
- */
 function SlackConnectedOnboardingCard({ integration }: { readonly integration: SlackIntegrationRecord }) {
   const hasAnyRoute =
     (integration.routes.incidents?.length ?? 0) > 0 ||
@@ -546,25 +516,10 @@ export function OnboardingFlow({
   const { toast } = useToast()
   const navigate = useNavigate()
 
-  // Slack visibility gate: feature flag is client-side, env probe is
-  // server-side (pre-resolved by the route loader so it's synchronous
-  // on first render — otherwise a click on Continue on the flaggers
-  // step could race the env query and silently skip the slack step).
   const slackFlagEnabled = useHasFeatureFlag("slack")
   const slackStepEnabled = slackFlagEnabled && slackEnvConfigured
 
-  // Honor URL-driven step only if the user has completed the `stack`
-  // step on the server (`onboardingType` is the marker). Otherwise
-  // force them back to `role` — earlier steps have prerequisites that
-  // deep-links would skip past. `onboardingType` is fed in from the
-  // parent route's loader so it's synchronously available on first
-  // render (the route's loader awaits the project lookup).
-  //
-  // We deliberately do NOT also gate on `slackStepEnabled` here: the
-  // user only reaches `?step=slack` by already having seen the
-  // (env-gated) step, so if the URL says `slack`, trust it. Forward
-  // and back transitions still consult `slackStepEnabled` to route
-  // around the step when truly disabled.
+  // Force back to `role` if a URL deep-links past `stack` without `onboardingType` set.
   const onboardingTypeSet = onboardingType != null
   const resolvedInitialStep: OnboardingStep = (() => {
     if (initialStep == null) return "role"
@@ -575,8 +530,6 @@ export function OnboardingFlow({
 
   const [step, setStep] = useState<OnboardingStep>(resolvedInitialStep)
 
-  // Centralizes URL ↔ React state sync. Every step transition flows
-  // through here so the URL stays authoritative and refresh-safe.
   const goToStep = useCallback(
     (next: OnboardingStep) => {
       setStep(next)
@@ -590,8 +543,6 @@ export function OnboardingFlow({
     [navigate, projectSlug],
   )
 
-  // OAuth bounce-back: toast and strip the flash params, preserving
-  // `step` so the user lands exactly where they left.
   useMountEffect(() => {
     if (!flashInstalled && !flashError) return
     if (flashInstalled === "ok") {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -13,7 +13,6 @@ import {
   useMountEffect,
   useToast,
 } from "@repo/ui"
-import { eq } from "@tanstack/react-db"
 import { useForm } from "@tanstack/react-form"
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
@@ -46,7 +45,6 @@ import {
   getActiveSlackIntegration,
   isSlackConfigured,
 } from "../../../../../domains/integrations/integrations.functions.ts"
-import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
@@ -482,6 +480,7 @@ function SlackOnboardingStep({
 export function OnboardingFlow({
   projectId,
   projectSlug,
+  onboardingType,
   initialStep,
   flashInstalled,
   flashError,
@@ -489,6 +488,7 @@ export function OnboardingFlow({
 }: {
   readonly projectId: string
   readonly projectSlug: string
+  readonly onboardingType: "code-agents" | "prod-traces" | undefined
   readonly initialStep?: OnboardingStep
   readonly flashInstalled?: "ok"
   readonly flashError?: "workspace_taken" | "oauth_failed"
@@ -507,16 +507,13 @@ export function OnboardingFlow({
   })
   const slackStepEnabled = slackFlagEnabled && slackEnvConfigured
 
-  const { data: project } = useProjectsCollection(
-    (projects) => projects.where(({ project: p }) => eq(p.id, projectId)).findOne(),
-    [projectId],
-  )
-
   // Honor URL-driven step only if the user has completed the `stack`
   // step on the server (`onboardingType` is the marker). Otherwise
   // force them back to `role` — earlier steps have prerequisites that
-  // deep-links would skip past.
-  const onboardingTypeSet = project?.settings?.onboardingType != null
+  // deep-links would skip past. `onboardingType` is fed in from the
+  // parent route's loader so it's synchronously available on first
+  // render (the route's loader awaits the project lookup).
+  const onboardingTypeSet = onboardingType != null
   const resolvedInitialStep: OnboardingStep = (() => {
     if (initialStep == null) return "role"
     if (initialStep === "role" || initialStep === "stack") return initialStep
@@ -665,7 +662,7 @@ export function OnboardingFlow({
     }
   }
 
-  const resolvedProjectSlug = project?.slug?.trim() || projectSlug.trim()
+  const resolvedProjectSlug = projectSlug.trim()
   const slugForSnippets = resolvedProjectSlug || "your-project-slug"
   const projectSlugForCopy = resolvedProjectSlug
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -419,6 +419,10 @@ function SlackOnboardingStep({
     queryFn: () => getActiveSlackIntegration(),
   })
   const connected = integration != null
+  // The step's pitch only materialises once `incidents` is routed
+  // somewhere. Until then, leaving counts as skipping — so the
+  // primary CTA stays a ghost "Skip for now" even after connect.
+  const incidentsConfigured = (integration?.routes.incidents?.length ?? 0) > 0
 
   const returnTo = `/projects/${projectSlug}/onboarding?step=slack`
   const connectHref = `/integrations/slack/install?return_to=${encodeURIComponent(returnTo)}`
@@ -461,7 +465,7 @@ function SlackOnboardingStep({
           <Button variant="outline" onClick={onBack}>
             Back
           </Button>
-          {connected ? (
+          {incidentsConfigured ? (
             <Button onClick={onContinue}>Continue</Button>
           ) : (
             <Button variant="ghost" onClick={onContinue}>
@@ -558,12 +562,18 @@ export function OnboardingFlow({
   // deep-links would skip past. `onboardingType` is fed in from the
   // parent route's loader so it's synchronously available on first
   // render (the route's loader awaits the project lookup).
+  //
+  // We deliberately do NOT also gate on `slackStepEnabled` here:
+  // `slackEnvConfigured` comes from an async query that is `false`
+  // until it loads, and the user only reaches `?step=slack` by
+  // already having seen the (env-gated) step — so if the URL says
+  // `slack`, trust it. Forward and back transitions still consult
+  // `slackStepEnabled` to route around the step when truly disabled.
   const onboardingTypeSet = onboardingType != null
   const resolvedInitialStep: OnboardingStep = (() => {
     if (initialStep == null) return "role"
     if (initialStep === "role" || initialStep === "stack") return initialStep
     if (!onboardingTypeSet) return "role"
-    if (initialStep === "slack" && !slackStepEnabled) return "telemetry"
     return initialStep
   })()
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -13,6 +13,7 @@ import {
   useMountEffect,
   useToast,
 } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
 import { useForm } from "@tanstack/react-form"
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
@@ -44,12 +45,14 @@ import {
 import {
   getActiveSlackIntegration,
   isSlackConfigured,
+  type SlackIntegrationRecord,
 } from "../../../../../domains/integrations/integrations.functions.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
 import { IntegrationCard } from "../settings/-components/integration-card.tsx"
+import { SLACK_INTEGRATION_QUERY_KEY, SlackRouteRow } from "../settings/-components/slack-route-row.tsx"
 import {
   type CodingMachineAgentId,
   getCodingAgentTelemetryPrompt,
@@ -80,7 +83,6 @@ type StackChoice = "coding-agent-machine" | "production-agent"
 type TelemetrySetupMode = "coding-agent" | "manual"
 type IntegrationPanel = "typescript" | "python" | "opentelemetry"
 
-const SLACK_INTEGRATION_QUERY_KEY = ["slack-integration"] as const
 const SLACK_CONFIGURED_QUERY_KEY = ["slack-configured"] as const
 
 const SETUP_MODE_TAB_OPTIONS = [
@@ -431,18 +433,13 @@ function SlackOnboardingStep({
           <div className="flex flex-col gap-2">
             <Text.H2 weight="medium">Get notified in Slack</Text.H2>
             <Text.H4 color="foregroundMuted">
-              Connect your workspace so Flaggers can alert your team the moment they detect an issue. You can configure
-              which channel receives what in settings later.
+              Connect your workspace so Flaggers can alert your team the moment they detect an issue.
             </Text.H4>
           </div>
         </div>
 
         {isLoading ? null : connected ? (
-          <IntegrationCard
-            icon={SlackIcon}
-            title={integration.teamName}
-            subtitle="Connected — channel routing available in settings."
-          />
+          <SlackConnectedOnboardingCard integration={integration} />
         ) : (
           <IntegrationCard
             icon={SlackIcon}
@@ -473,6 +470,54 @@ function SlackOnboardingStep({
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Onboarding-only variant of the settings page's connected card.
+ * Differs in two ways:
+ *
+ * - No "Disconnect" affordance — onboarding is not the place to undo
+ *   a connection the user just made.
+ * - Progressive group reveal: `incidents` shows immediately (the
+ *   group this step is selling), while `wrapped_reports` and
+ *   `custom_messages` only appear once the user has set at least one
+ *   route. The second condition also keeps already-routed groups
+ *   visible for users who reconnect after a previous setup.
+ *
+ * Full routing for all groups (and disconnect) lives at
+ * `/settings/integrations`; the footer note points users there.
+ */
+function SlackConnectedOnboardingCard({ integration }: { readonly integration: SlackIntegrationRecord }) {
+  const hasAnyRoute =
+    (integration.routes.incidents?.length ?? 0) > 0 ||
+    (integration.routes.wrapped_reports?.length ?? 0) > 0 ||
+    (integration.routes.custom_messages?.length ?? 0) > 0
+
+  const showWrapped = hasAnyRoute || (integration.routes.wrapped_reports?.length ?? 0) > 0
+  const showCustom = hasAnyRoute || (integration.routes.custom_messages?.length ?? 0) > 0
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="rounded-lg border border-border">
+        <div className="flex flex-row items-center gap-3 p-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Icon icon={SlackIcon} />
+          </div>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <Text.H5 weight="semibold">{integration.teamName}</Text.H5>
+            <Text.H6 color="foregroundMuted">Connected {relativeTime(new Date(integration.installedAt))}</Text.H6>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-border p-4">
+          <SlackRouteRow group="incidents" integration={integration} />
+          {showWrapped ? <SlackRouteRow group="wrapped_reports" integration={integration} /> : null}
+          {showCustom ? <SlackRouteRow group="custom_messages" integration={integration} /> : null}
+        </div>
+      </div>
+      <Text.H6 color="foregroundMuted">You can change these anytime in Settings → Integrations.</Text.H6>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   Input,
   ProviderIcon,
+  SlackIcon,
   Tabs,
   Text,
   useMountEffect,
@@ -15,6 +16,7 @@ import {
 import { eq } from "@tanstack/react-db"
 import { useForm } from "@tanstack/react-form"
 import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
 import type { LucideIcon } from "lucide-react"
 import {
   Bot,
@@ -27,8 +29,9 @@ import {
   SquareDashedBottomCode,
   Terminal,
 } from "lucide-react"
-import { lazy, type ReactNode, Suspense, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { lazy, type ReactNode, Suspense, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useApiKeysCollection } from "../../../../../domains/api-keys/api-keys.collection.ts"
+import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { invalidateProjectFlaggers, useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
 import {
   configureProjectFlaggersForOnboarding,
@@ -39,11 +42,16 @@ import {
   FLAGGER_USE_CASE_PRESETS,
   type FlaggerPresetSlug,
 } from "../../../../../domains/flaggers/presets.ts"
+import {
+  getActiveSlackIntegration,
+  isSlackConfigured,
+} from "../../../../../domains/integrations/integrations.functions.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
+import { IntegrationCard } from "../settings/-components/integration-card.tsx"
 import {
   type CodingMachineAgentId,
   getCodingAgentTelemetryPrompt,
@@ -68,10 +76,14 @@ import {
   type TsPackageManager,
 } from "./onboarding-integration-snippets.ts"
 
-type OnboardingStep = "role" | "stack" | "flaggers" | "telemetry"
+export const ONBOARDING_STEPS = ["role", "stack", "flaggers", "slack", "telemetry"] as const
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
 type StackChoice = "coding-agent-machine" | "production-agent"
 type TelemetrySetupMode = "coding-agent" | "manual"
 type IntegrationPanel = "typescript" | "python" | "opentelemetry"
+
+const SLACK_INTEGRATION_QUERY_KEY = ["slack-integration"] as const
+const SLACK_CONFIGURED_QUERY_KEY = ["slack-configured"] as const
 
 const SETUP_MODE_TAB_OPTIONS = [
   { id: "coding-agent" as const, label: "Coding agent", icon: <Bot className="h-4 w-4" /> },
@@ -384,17 +396,176 @@ function SdkIntegrationInstructions({
   )
 }
 
+/**
+ * Optional onboarding step that prompts the user to connect Slack so
+ * they get notified when their Flaggers detect issues. Hidden via the
+ * `slack` feature flag + env-config probe in {@link OnboardingFlow}.
+ *
+ * Connect leaves the page (Slack OAuth redirect); the callback
+ * bounces back to `/projects/{slug}/onboarding?step=slack&installed=ok`
+ * which `OnboardingFlow` toasts on mount.
+ */
+function SlackOnboardingStep({
+  projectSlug,
+  onBack,
+  onContinue,
+}: {
+  readonly projectSlug: string
+  readonly onBack: () => void
+  readonly onContinue: () => void
+}) {
+  const { data: integration, isLoading } = useQuery({
+    queryKey: SLACK_INTEGRATION_QUERY_KEY,
+    queryFn: () => getActiveSlackIntegration(),
+  })
+  const connected = integration != null
+
+  const returnTo = `/projects/${projectSlug}/onboarding?step=slack`
+  const connectHref = `/integrations/slack/install?return_to=${encodeURIComponent(returnTo)}`
+
+  return (
+    <div className="mx-auto w-full max-w-[560px]">
+      <div className="flex w-full flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <div className="h-8 w-8">
+            <img src="/favicon.svg" alt="Latitude" className="h-8 w-8" />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Text.H2 weight="medium">Get notified in Slack</Text.H2>
+            <Text.H4 color="foregroundMuted">
+              Connect your workspace so Flaggers can alert your team the moment they detect an issue. You can configure
+              which channel receives what in settings later.
+            </Text.H4>
+          </div>
+        </div>
+
+        {isLoading ? null : connected ? (
+          <IntegrationCard
+            icon={SlackIcon}
+            title={integration.teamName}
+            subtitle="Connected — channel routing available in settings."
+          />
+        ) : (
+          <IntegrationCard
+            icon={SlackIcon}
+            title="Slack"
+            subtitle="Send Latitude notifications to your Slack workspace."
+            actions={
+              <Button
+                onClick={() => {
+                  window.location.href = connectHref
+                }}
+              >
+                Connect Slack
+              </Button>
+            }
+          />
+        )}
+
+        <div className="flex flex-row flex-wrap items-center gap-3">
+          <Button variant="outline" onClick={onBack}>
+            Back
+          </Button>
+          {connected ? (
+            <Button onClick={onContinue}>Continue</Button>
+          ) : (
+            <Button variant="ghost" onClick={onContinue}>
+              Skip for now
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function OnboardingFlow({
   projectId,
   projectSlug,
+  initialStep,
+  flashInstalled,
+  flashError,
   onOpenProjectTraces,
 }: {
   readonly projectId: string
   readonly projectSlug: string
+  readonly initialStep?: OnboardingStep
+  readonly flashInstalled?: "ok"
+  readonly flashError?: "workspace_taken" | "oauth_failed"
   readonly onOpenProjectTraces: (projectId: string) => Promise<void>
 }) {
   const { toast } = useToast()
-  const [step, setStep] = useState<OnboardingStep>("role")
+  const navigate = useNavigate()
+
+  // Slack visibility gate: feature flag is client-side, env probe is
+  // server-side. The step is shown only when both agree.
+  const slackFlagEnabled = useHasFeatureFlag("slack")
+  const { data: slackEnvConfigured = false } = useQuery({
+    queryKey: SLACK_CONFIGURED_QUERY_KEY,
+    queryFn: () => isSlackConfigured(),
+    staleTime: Infinity,
+  })
+  const slackStepEnabled = slackFlagEnabled && slackEnvConfigured
+
+  const { data: project } = useProjectsCollection(
+    (projects) => projects.where(({ project: p }) => eq(p.id, projectId)).findOne(),
+    [projectId],
+  )
+
+  // Honor URL-driven step only if the user has completed the `stack`
+  // step on the server (`onboardingType` is the marker). Otherwise
+  // force them back to `role` — earlier steps have prerequisites that
+  // deep-links would skip past.
+  const onboardingTypeSet = project?.settings?.onboardingType != null
+  const resolvedInitialStep: OnboardingStep = (() => {
+    if (initialStep == null) return "role"
+    if (initialStep === "role" || initialStep === "stack") return initialStep
+    if (!onboardingTypeSet) return "role"
+    if (initialStep === "slack" && !slackStepEnabled) return "telemetry"
+    return initialStep
+  })()
+
+  const [step, setStep] = useState<OnboardingStep>(resolvedInitialStep)
+
+  // Centralizes URL ↔ React state sync. Every step transition flows
+  // through here so the URL stays authoritative and refresh-safe.
+  const goToStep = useCallback(
+    (next: OnboardingStep) => {
+      setStep(next)
+      void navigate({
+        to: "/projects/$projectSlug/onboarding",
+        params: { projectSlug },
+        search: (prev: Record<string, unknown>) => ({ ...prev, step: next }),
+        replace: true,
+      })
+    },
+    [navigate, projectSlug],
+  )
+
+  // OAuth bounce-back: toast and strip the flash params, preserving
+  // `step` so the user lands exactly where they left.
+  useMountEffect(() => {
+    if (!flashInstalled && !flashError) return
+    if (flashInstalled === "ok") {
+      toast({ description: "Slack connected" })
+    } else if (flashError === "workspace_taken") {
+      toast({
+        variant: "destructive",
+        description: "This Slack workspace is already connected to another Latitude organization.",
+      })
+    } else if (flashError === "oauth_failed") {
+      toast({
+        variant: "destructive",
+        description: "Couldn't complete the Slack install. Please try again.",
+      })
+    }
+    void navigate({
+      to: "/projects/$projectSlug/onboarding",
+      params: { projectSlug },
+      search: ({ installed: _installed, error: _error, ...rest }: Record<string, unknown>) => rest,
+      replace: true,
+    })
+  })
   const [stackChoice, setStackChoice] = useState<StackChoice | null>(null)
   const [codingMachineAgent, setCodingMachineAgent] = useState<CodingMachineAgentId>("claude-code")
   const [selectedProvider, setSelectedProvider] = useState<ProviderEntry>(
@@ -417,7 +588,7 @@ export function OnboardingFlow({
         await submitOnboarding({ data: { jobTitle, phoneNumber, stackChoice: stack, projectId } })
       },
       {
-        onSuccess: () => setStep("flaggers"),
+        onSuccess: () => goToStep("flaggers"),
         onError: (error) => {
           toast({ variant: "destructive", description: toUserMessage(error) })
         },
@@ -429,13 +600,9 @@ export function OnboardingFlow({
     await form.validateField("jobTitle", "change")
     const meta = form.getFieldMeta("jobTitle")
     if (meta && meta.errors.length > 0) return
-    setStep("stack")
+    goToStep("stack")
   }
 
-  const { data: project } = useProjectsCollection(
-    (projects) => projects.where(({ project: p }) => eq(p.id, projectId)).findOne(),
-    [projectId],
-  )
   const { data: apiKeysList } = useApiKeysCollection()
   const { data: projectFlaggers = [], isLoading: isLoadingProjectFlaggers } = useProjectFlaggers(projectId)
   const { data: availableFlaggers = [], isLoading: isLoadingAvailableFlaggers } = useQuery({
@@ -490,7 +657,7 @@ export function OnboardingFlow({
         },
       })
       await invalidateProjectFlaggers(projectId)
-      setStep("telemetry")
+      goToStep(slackStepEnabled ? "slack" : "telemetry")
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
     } finally {
@@ -708,7 +875,7 @@ export function OnboardingFlow({
                 })}
               </div>
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("role")}>
+                <Button variant="outline" onClick={() => goToStep("role")}>
                   Back
                 </Button>
                 <Button
@@ -808,7 +975,7 @@ export function OnboardingFlow({
               </div>
 
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("stack")}>
+                <Button variant="outline" onClick={() => goToStep("stack")}>
                   Back
                 </Button>
                 <Button
@@ -820,6 +987,12 @@ export function OnboardingFlow({
               </div>
             </div>
           </div>
+        ) : step === "slack" ? (
+          <SlackOnboardingStep
+            projectSlug={resolvedProjectSlug || projectSlug}
+            onBack={() => goToStep("flaggers")}
+            onContinue={() => goToStep("telemetry")}
+          />
         ) : stackChoice === "production-agent" ? (
           <div className="mx-auto w-full max-w-[560px]">
             <div className="flex w-full flex-col gap-6">
@@ -984,7 +1157,7 @@ export function OnboardingFlow({
               )}
 
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("flaggers")}>
+                <Button variant="outline" onClick={() => goToStep(slackStepEnabled ? "slack" : "flaggers")}>
                   Back
                 </Button>
                 <Button variant="ghost" onClick={() => void onOpenProjectTraces(projectId)}>
@@ -1063,7 +1236,7 @@ export function OnboardingFlow({
               </div>
 
               <div className="flex flex-row flex-wrap items-center gap-3">
-                <Button variant="outline" onClick={() => setStep("flaggers")}>
+                <Button variant="outline" onClick={() => goToStep(slackStepEnabled ? "slack" : "flaggers")}>
                   Back
                 </Button>
                 <Button variant="ghost" onClick={() => void onOpenProjectTraces(projectId)}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -44,7 +44,6 @@ import {
 } from "../../../../../domains/flaggers/presets.ts"
 import {
   getActiveSlackIntegration,
-  isSlackConfigured,
   type SlackIntegrationRecord,
 } from "../../../../../domains/integrations/integrations.functions.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
@@ -82,8 +81,6 @@ export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
 type StackChoice = "coding-agent-machine" | "production-agent"
 type TelemetrySetupMode = "coding-agent" | "manual"
 type IntegrationPanel = "typescript" | "python" | "opentelemetry"
-
-const SLACK_CONFIGURED_QUERY_KEY = ["slack-configured"] as const
 
 const SETUP_MODE_TAB_OPTIONS = [
   { id: "coding-agent" as const, label: "Coding agent", icon: <Bot className="h-4 w-4" /> },
@@ -450,12 +447,13 @@ function SlackOnboardingStep({
             title="Slack"
             subtitle="Send Latitude notifications to your Slack workspace."
             actions={
-              <Button
-                onClick={() => {
-                  window.location.href = connectHref
-                }}
-              >
-                Connect Slack
+              // `/integrations/slack/install` is a server-handler-only
+              // route that 302s the browser to Slack — needs a full-
+              // page GET, not client-side routing. Plain `<a>` (inside
+              // a `Button asChild`) gives cmd/middle-click + copy-link
+              // affordances while keeping the full-page nav.
+              <Button asChild>
+                <a href={connectHref}>Connect Slack</a>
               </Button>
             }
           />
@@ -530,6 +528,7 @@ export function OnboardingFlow({
   projectId,
   projectSlug,
   onboardingType,
+  slackEnvConfigured,
   initialStep,
   flashInstalled,
   flashError,
@@ -538,6 +537,7 @@ export function OnboardingFlow({
   readonly projectId: string
   readonly projectSlug: string
   readonly onboardingType: "code-agents" | "prod-traces" | undefined
+  readonly slackEnvConfigured: boolean
   readonly initialStep?: OnboardingStep
   readonly flashInstalled?: "ok"
   readonly flashError?: "workspace_taken" | "oauth_failed"
@@ -547,13 +547,10 @@ export function OnboardingFlow({
   const navigate = useNavigate()
 
   // Slack visibility gate: feature flag is client-side, env probe is
-  // server-side. The step is shown only when both agree.
+  // server-side (pre-resolved by the route loader so it's synchronous
+  // on first render — otherwise a click on Continue on the flaggers
+  // step could race the env query and silently skip the slack step).
   const slackFlagEnabled = useHasFeatureFlag("slack")
-  const { data: slackEnvConfigured = false } = useQuery({
-    queryKey: SLACK_CONFIGURED_QUERY_KEY,
-    queryFn: () => isSlackConfigured(),
-    staleTime: Infinity,
-  })
   const slackStepEnabled = slackFlagEnabled && slackEnvConfigured
 
   // Honor URL-driven step only if the user has completed the `stack`
@@ -563,12 +560,11 @@ export function OnboardingFlow({
   // parent route's loader so it's synchronously available on first
   // render (the route's loader awaits the project lookup).
   //
-  // We deliberately do NOT also gate on `slackStepEnabled` here:
-  // `slackEnvConfigured` comes from an async query that is `false`
-  // until it loads, and the user only reaches `?step=slack` by
-  // already having seen the (env-gated) step — so if the URL says
-  // `slack`, trust it. Forward and back transitions still consult
-  // `slackStepEnabled` to route around the step when truly disabled.
+  // We deliberately do NOT also gate on `slackStepEnabled` here: the
+  // user only reaches `?step=slack` by already having seen the
+  // (env-gated) step, so if the URL says `slack`, trust it. Forward
+  // and back transitions still consult `slackStepEnabled` to route
+  // around the step when truly disabled.
   const onboardingTypeSet = onboardingType != null
   const resolvedInitialStep: OnboardingStep = (() => {
     if (initialStep == null) return "role"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -12,11 +12,7 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/onboarding")({
   validateSearch: searchSchema,
-  // Resolve the env probe at load time so the slack step's visibility
-  // gate is synchronous on first render. A client `useQuery` defaults
-  // to `false` while loading, which would race with the user clicking
-  // "Continue" on the flaggers step and silently skip the slack step
-  // even when it should be shown.
+  // Loader-resolved so the visibility gate is synchronous on first render.
   loader: async () => ({ slackEnvConfigured: await isSlackConfigured() }),
   component: ProjectOnboardingPage,
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -25,6 +25,7 @@ function ProjectOnboardingPage() {
       <OnboardingFlow
         projectId={project.id}
         projectSlug={project.slug}
+        onboardingType={project.settings.onboardingType}
         initialStep={search.step}
         flashInstalled={search.installed}
         flashError={search.error}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
+import { isSlackConfigured } from "../../../../domains/integrations/integrations.functions.ts"
 import { ONBOARDING_STEPS, OnboardingFlow } from "./-components/onboarding-flow.tsx"
 import { useRouteProject } from "./-route-data.ts"
 
@@ -11,12 +12,19 @@ const searchSchema = z.object({
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/onboarding")({
   validateSearch: searchSchema,
+  // Resolve the env probe at load time so the slack step's visibility
+  // gate is synchronous on first render. A client `useQuery` defaults
+  // to `false` while loading, which would race with the user clicking
+  // "Continue" on the flaggers step and silently skip the slack step
+  // even when it should be shown.
+  loader: async () => ({ slackEnvConfigured: await isSlackConfigured() }),
   component: ProjectOnboardingPage,
 })
 
 function ProjectOnboardingPage() {
   const { projectSlug } = Route.useParams()
   const project = useRouteProject()
+  const { slackEnvConfigured } = Route.useLoaderData()
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
 
@@ -26,6 +34,7 @@ function ProjectOnboardingPage() {
         projectId={project.id}
         projectSlug={project.slug}
         onboardingType={project.settings.onboardingType}
+        slackEnvConfigured={slackEnvConfigured}
         initialStep={search.step}
         flashInstalled={search.installed}
         flashError={search.error}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -1,8 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { OnboardingFlow } from "./-components/onboarding-flow.tsx"
+import { z } from "zod"
+import { ONBOARDING_STEPS, OnboardingFlow } from "./-components/onboarding-flow.tsx"
 import { useRouteProject } from "./-route-data.ts"
 
+const searchSchema = z.object({
+  step: z.enum(ONBOARDING_STEPS).optional(),
+  installed: z.literal("ok").optional(),
+  error: z.enum(["workspace_taken", "oauth_failed"]).optional(),
+})
+
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/onboarding")({
+  validateSearch: searchSchema,
   component: ProjectOnboardingPage,
 })
 
@@ -10,12 +18,16 @@ function ProjectOnboardingPage() {
   const { projectSlug } = Route.useParams()
   const project = useRouteProject()
   const navigate = Route.useNavigate()
+  const search = Route.useSearch()
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <OnboardingFlow
         projectId={project.id}
         projectSlug={project.slug}
+        initialStep={search.step}
+        flashInstalled={search.installed}
+        flashError={search.error}
         onOpenProjectTraces={async (targetProjectId) => {
           if (targetProjectId !== project.id) return
           await navigate({ to: "/projects/$projectSlug", params: { projectSlug } })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
@@ -1,0 +1,145 @@
+import { NOTIFICATION_GROUP_META, type NotificationGroup } from "@domain/shared"
+import {
+  Button,
+  Combobox,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxSeparator,
+  ComboboxTrigger,
+  Text,
+  useToast,
+} from "@repo/ui"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Loader2, Search } from "lucide-react"
+import { useRef, useState } from "react"
+import {
+  configureSlackRoute,
+  listSlackChannels,
+  removeSlackRoute,
+  type SlackIntegrationRecord,
+} from "../../../../../../domains/integrations/integrations.functions.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+
+/**
+ * Query key for the active Slack integration. Shared between the
+ * settings page and the onboarding step so a save here (the row
+ * triggers `invalidateQueries`) refreshes both surfaces.
+ */
+export const SLACK_INTEGRATION_QUERY_KEY = ["slack-integration"] as const
+export const SLACK_CHANNELS_QUERY_KEY = ["slack-channels"] as const
+
+type ChannelOption = { readonly id: string; readonly name: string }
+const DON_T_SEND: ChannelOption = { id: "", name: "Don't send" }
+
+/**
+ * One row of the Slack notifications routing table: a label for the
+ * notification group plus a channel-picker combobox. Saves on
+ * selection via `configureSlackRoute` / `removeSlackRoute`.
+ *
+ * Used by both the settings page (full table of all groups) and the
+ * onboarding flow (progressive subset). Channel list is fetched on
+ * first open of the combobox and cached for 30s.
+ */
+export function SlackRouteRow({
+  group,
+  integration,
+}: {
+  group: NotificationGroup
+  integration: SlackIntegrationRecord
+}) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const meta = NOTIFICATION_GROUP_META[group]
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const [inputValue, setInputValue] = useState("")
+
+  const {
+    data: rawChannels = [],
+    isFetching,
+    refetch,
+  } = useQuery({
+    queryKey: SLACK_CHANNELS_QUERY_KEY,
+    queryFn: () => listSlackChannels(),
+    staleTime: 30_000,
+  })
+
+  const channels: readonly ChannelOption[] = rawChannels.map((c) => ({ id: c.id, name: c.name }))
+  const allOptions: readonly ChannelOption[] = [DON_T_SEND, ...channels]
+
+  // Use the stored channelName from the integration record so the trigger
+  // shows the correct label immediately, before channels finish loading.
+  const currentRoute = integration.routes[group]?.[0]
+  const selected: ChannelOption = currentRoute
+    ? { id: currentRoute.channelId, name: currentRoute.channelName }
+    : DON_T_SEND
+
+  const mutation = useMutation({
+    mutationFn: (option: ChannelOption) => {
+      if (option.id === "") return removeSlackRoute({ data: { group } })
+      return configureSlackRoute({ data: { group, routes: [{ channelId: option.id, channelName: option.name }] } })
+    },
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: SLACK_INTEGRATION_QUERY_KEY }),
+    onError: (error) => toast({ variant: "destructive", description: toUserMessage(error) }),
+  })
+
+  return (
+    <div className="flex flex-row items-center justify-between gap-4">
+      <Text.H5 color="foregroundMuted">{meta.label}</Text.H5>
+      <div className="w-52 shrink-0">
+        <Combobox
+          modal
+          value={selected}
+          onValueChange={(picked) => {
+            setInputValue("")
+            void mutation.mutateAsync(picked ?? DON_T_SEND)
+          }}
+          items={allOptions}
+          itemToStringValue={(item: ChannelOption) => (item.id === "" ? "Don't send" : `#${item.name}`)}
+          isItemEqualToValue={(a: ChannelOption, b: ChannelOption) => a.id === b.id}
+          onOpenChange={(open) => {
+            if (open) void refetch()
+          }}
+          disabled={mutation.isPending}
+        >
+          <Button asChild variant="outline" size="sm" disabled={mutation.isPending} className="w-full justify-between">
+            <ComboboxTrigger ref={triggerRef}>
+              {selected.id === "" ? (
+                <Text.H5 color="foregroundMuted">Don't send</Text.H5>
+              ) : (
+                <Text.H5>#{selected.name}</Text.H5>
+              )}
+            </ComboboxTrigger>
+          </Button>
+          <ComboboxContent anchor={triggerRef} className="w-64">
+            <div className="flex items-center gap-2 px-3 py-2">
+              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <ComboboxChipsInput
+                placeholder="Search channels…"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                className="flex-1 bg-transparent text-sm placeholder:text-muted-foreground"
+              />
+              {isFetching ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" /> : null}
+            </div>
+            <ComboboxSeparator />
+            <ComboboxList>
+              {(item: ChannelOption) => (
+                <ComboboxItem value={item}>
+                  {item.id === "" ? (
+                    <Text.H5 color="foregroundMuted">Don't send</Text.H5>
+                  ) : (
+                    <Text.H5>#{item.name}</Text.H5>
+                  )}
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+            <ComboboxEmpty>No channels found.</ComboboxEmpty>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
@@ -23,30 +23,14 @@ import {
 } from "../../../../../../domains/integrations/integrations.functions.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 
-/**
- * Query key for the active Slack integration. Shared between the
- * settings page and the onboarding step so a save here (the row
- * triggers `invalidateQueries`) refreshes both surfaces.
- */
+// Shared with the onboarding step so a save here invalidates both surfaces.
 export const SLACK_INTEGRATION_QUERY_KEY = ["slack-integration"] as const
 export const SLACK_CHANNELS_QUERY_KEY = ["slack-channels"] as const
 
 type ChannelOption = { readonly id: string; readonly name: string }
 const DON_T_SEND: ChannelOption = { id: "", name: "Don't send" }
 
-/**
- * One row of the Slack notifications routing table: a label for the
- * notification group plus a channel-picker combobox. Saves on
- * selection via `configureSlackRoute` / `removeSlackRoute`.
- *
- * Used by both the settings page (full table of all groups) and the
- * onboarding flow (progressive subset). The channel list is fetched
- * eagerly on mount (TanStack Query default), refetched whenever the
- * combobox opens, and otherwise cached for 30s — the open-time
- * refetch is intentional so a freshly-invited bot's new channels
- * show up the next time the user opens the picker without waiting
- * for `staleTime` to elapse.
- */
+// Refetches on open so freshly-invited bot channels appear without waiting for `staleTime`.
 export function SlackRouteRow({
   group,
   integration,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
@@ -40,8 +40,12 @@ const DON_T_SEND: ChannelOption = { id: "", name: "Don't send" }
  * selection via `configureSlackRoute` / `removeSlackRoute`.
  *
  * Used by both the settings page (full table of all groups) and the
- * onboarding flow (progressive subset). Channel list is fetched on
- * first open of the combobox and cached for 30s.
+ * onboarding flow (progressive subset). The channel list is fetched
+ * eagerly on mount (TanStack Query default), refetched whenever the
+ * combobox opens, and otherwise cached for 30s — the open-time
+ * refetch is intentional so a freshly-invited bot's new channels
+ * show up the next time the user opens the picker without waiting
+ * for `staleTime` to elapse.
  */
 export function SlackRouteRow({
   group,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
@@ -1,50 +1,26 @@
-import { NOTIFICATION_GROUP_META, NOTIFICATION_GROUPS, type NotificationGroup } from "@domain/shared"
-import {
-  Button,
-  Combobox,
-  ComboboxChipsInput,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxSeparator,
-  ComboboxTrigger,
-  Icon,
-  Modal,
-  SlackIcon,
-  Text,
-  useMountEffect,
-  useToast,
-} from "@repo/ui"
+import { NOTIFICATION_GROUPS } from "@domain/shared"
+import { Button, Icon, Modal, SlackIcon, Text, useMountEffect, useToast } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useRouter } from "@tanstack/react-router"
-import { Loader2, Search, Trash2 } from "lucide-react"
-import { useRef, useState } from "react"
+import { Trash2 } from "lucide-react"
+import { useState } from "react"
 import { z } from "zod"
 import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import {
-  configureSlackRoute,
   disconnectSlackIntegration,
   getActiveSlackIntegration,
-  listSlackChannels,
-  removeSlackRoute,
   type SlackIntegrationRecord,
 } from "../../../../../domains/integrations/integrations.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { IntegrationCard } from "./-components/integration-card.tsx"
 import { SettingsPage } from "./-components/settings-page.tsx"
+import { SLACK_INTEGRATION_QUERY_KEY, SlackRouteRow } from "./-components/slack-route-row.tsx"
 
 const searchSchema = z.object({
   installed: z.literal("ok").optional(),
   error: z.enum(["workspace_taken", "oauth_failed"]).optional(),
 })
-
-const SLACK_QUERY_KEY = ["slack-integration"] as const
-const CHANNELS_QUERY_KEY = ["slack-channels"] as const
-
-type ChannelOption = { readonly id: string; readonly name: string }
-const DON_T_SEND: ChannelOption = { id: "", name: "Don't send" }
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/integrations")({
   validateSearch: searchSchema,
@@ -98,7 +74,7 @@ function IntegrationsSettingsPage() {
 
 function SlackIntegrationSection() {
   const { data, isLoading } = useQuery({
-    queryKey: SLACK_QUERY_KEY,
+    queryKey: SLACK_INTEGRATION_QUERY_KEY,
     queryFn: () => getActiveSlackIntegration(),
   })
   const [disconnectOpen, setDisconnectOpen] = useState(false)
@@ -174,101 +150,6 @@ function ConnectedSlackCard({
   )
 }
 
-function SlackRouteRow({ group, integration }: { group: NotificationGroup; integration: SlackIntegrationRecord }) {
-  const { toast } = useToast()
-  const queryClient = useQueryClient()
-  const meta = NOTIFICATION_GROUP_META[group]
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const [inputValue, setInputValue] = useState("")
-
-  const {
-    data: rawChannels = [],
-    isFetching,
-    refetch,
-  } = useQuery({
-    queryKey: CHANNELS_QUERY_KEY,
-    queryFn: () => listSlackChannels(),
-    staleTime: 30_000,
-  })
-
-  const channels: readonly ChannelOption[] = rawChannels.map((c) => ({ id: c.id, name: c.name }))
-  const allOptions: readonly ChannelOption[] = [DON_T_SEND, ...channels]
-
-  // Use the stored channelName from the integration record so the trigger
-  // shows the correct label immediately, before channels finish loading.
-  const currentRoute = integration.routes[group]?.[0]
-  const selected: ChannelOption = currentRoute
-    ? { id: currentRoute.channelId, name: currentRoute.channelName }
-    : DON_T_SEND
-
-  const mutation = useMutation({
-    mutationFn: (option: ChannelOption) => {
-      if (option.id === "") return removeSlackRoute({ data: { group } })
-      return configureSlackRoute({ data: { group, routes: [{ channelId: option.id, channelName: option.name }] } })
-    },
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: SLACK_QUERY_KEY }),
-    onError: (error) => toast({ variant: "destructive", description: toUserMessage(error) }),
-  })
-
-  return (
-    <div className="flex flex-row items-center justify-between gap-4">
-      <Text.H5 color="foregroundMuted">{meta.label}</Text.H5>
-      <div className="w-52 shrink-0">
-        <Combobox
-          modal
-          value={selected}
-          onValueChange={(picked) => {
-            setInputValue("")
-            void mutation.mutateAsync(picked ?? DON_T_SEND)
-          }}
-          items={allOptions}
-          itemToStringValue={(item: ChannelOption) => (item.id === "" ? "Don't send" : `#${item.name}`)}
-          isItemEqualToValue={(a: ChannelOption, b: ChannelOption) => a.id === b.id}
-          onOpenChange={(open) => {
-            if (open) void refetch()
-          }}
-          disabled={mutation.isPending}
-        >
-          <Button asChild variant="outline" size="sm" disabled={mutation.isPending} className="w-full justify-between">
-            <ComboboxTrigger ref={triggerRef}>
-              {selected.id === "" ? (
-                <Text.H5 color="foregroundMuted">Don't send</Text.H5>
-              ) : (
-                <Text.H5>#{selected.name}</Text.H5>
-              )}
-            </ComboboxTrigger>
-          </Button>
-          <ComboboxContent anchor={triggerRef} className="w-64">
-            <div className="flex items-center gap-2 px-3 py-2">
-              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <ComboboxChipsInput
-                placeholder="Search channels…"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                className="flex-1 bg-transparent text-sm placeholder:text-muted-foreground"
-              />
-              {isFetching ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" /> : null}
-            </div>
-            <ComboboxSeparator />
-            <ComboboxList>
-              {(item: ChannelOption) => (
-                <ComboboxItem value={item}>
-                  {item.id === "" ? (
-                    <Text.H5 color="foregroundMuted">Don't send</Text.H5>
-                  ) : (
-                    <Text.H5>#{item.name}</Text.H5>
-                  )}
-                </ComboboxItem>
-              )}
-            </ComboboxList>
-            <ComboboxEmpty>No channels found.</ComboboxEmpty>
-          </ComboboxContent>
-        </Combobox>
-      </div>
-    </div>
-  )
-}
-
 function DisconnectSlackModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
@@ -282,7 +163,7 @@ function DisconnectSlackModal({ open, onClose }: { open: boolean; onClose: () =>
     setDisconnecting(true)
     try {
       await mutation.mutateAsync()
-      await queryClient.invalidateQueries({ queryKey: SLACK_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: SLACK_INTEGRATION_QUERY_KEY })
       toast({ description: "Slack disconnected" })
       onClose()
     } catch (error) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
@@ -100,12 +100,13 @@ function DisconnectedSlackCard() {
       title="Slack"
       subtitle="Send Latitude notifications to your Slack workspace."
       actions={
-        <Button
-          onClick={() => {
-            window.location.href = "/integrations/slack/install"
-          }}
-        >
-          Connect Slack
+        // `/integrations/slack/install` is a server-handler-only route
+        // that 302s the browser to Slack — needs a full-page GET, not
+        // client-side routing. Plain `<a>` (inside a `Button asChild`)
+        // gives cmd/middle-click + copy-link affordances while keeping
+        // the full-page nav.
+        <Button asChild>
+          <a href="/integrations/slack/install">Connect Slack</a>
         </Button>
       }
     />

--- a/apps/web/src/routes/integrations/slack/install.ts
+++ b/apps/web/src/routes/integrations/slack/install.ts
@@ -4,7 +4,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Effect } from "effect"
 import { requireSession } from "../../../server/auth.ts"
 import { getRedisClient } from "../../../server/clients.ts"
-import { generateSlackOAuthState } from "../../../server/slack-oauth-state.ts"
+import { generateSlackOAuthState, validateReturnTo } from "../../../server/slack-oauth-state.ts"
 
 /**
  * Public OAuth entry point. The user clicks "Connect Slack" in
@@ -21,7 +21,7 @@ import { generateSlackOAuthState } from "../../../server/slack-oauth-state.ts"
 export const Route = createFileRoute("/integrations/slack/install")({
   server: {
     handlers: {
-      GET: async () => {
+      GET: async ({ request }: { request: Request }) => {
         const { organizationId, userId } = await requireSession()
 
         const config = await Effect.runPromise(loadSlackConfig)
@@ -35,10 +35,16 @@ export const Route = createFileRoute("/integrations/slack/install")({
         const webUrl = rawWebUrl.replace(/\/$/, "")
         const redirectUri = `${webUrl}/integrations/slack/oauth/callback`
 
+        // Optional `return_to`: where to send the user after a successful
+        // install. Validated to a safe `/projects/...` path; anything else
+        // is dropped and the callback falls back to its default redirect.
+        const returnTo = validateReturnTo(new URL(request.url).searchParams.get("return_to"))
+
         const state = await generateSlackOAuthState({
           redis: getRedisClient(),
           organizationId,
           userId,
+          returnTo,
         })
 
         const url = await Effect.runPromise(

--- a/apps/web/src/routes/integrations/slack/install.ts
+++ b/apps/web/src/routes/integrations/slack/install.ts
@@ -35,9 +35,6 @@ export const Route = createFileRoute("/integrations/slack/install")({
         const webUrl = rawWebUrl.replace(/\/$/, "")
         const redirectUri = `${webUrl}/integrations/slack/oauth/callback`
 
-        // Optional `return_to`: where to send the user after a successful
-        // install. Validated to a safe `/projects/...` path; anything else
-        // is dropped and the callback falls back to its default redirect.
         const returnTo = validateReturnTo(new URL(request.url).searchParams.get("return_to"))
 
         const state = await generateSlackOAuthState({

--- a/apps/web/src/routes/integrations/slack/oauth/callback.test.ts
+++ b/apps/web/src/routes/integrations/slack/oauth/callback.test.ts
@@ -1,6 +1,6 @@
 import { SlackIntegrationConflictError } from "@domain/integrations"
 import { describe, expect, it } from "vitest"
-import { isWorkspaceConflict } from "./callback.ts"
+import { buildPostInstallRedirect, isWorkspaceConflict } from "./callback.ts"
 
 describe("isWorkspaceConflict", () => {
   it("recognises a directly-thrown SlackIntegrationConflictError", () => {
@@ -26,5 +26,54 @@ describe("isWorkspaceConflict", () => {
     expect(isWorkspaceConflict(undefined)).toBe(false)
     expect(isWorkspaceConflict("string error")).toBe(false)
     expect(isWorkspaceConflict({ cause: { _tag: "SomethingElseError" } })).toBe(false)
+  })
+})
+
+describe("buildPostInstallRedirect", () => {
+  const webUrl = "https://app.example.com"
+
+  it("falls back to /?next=integrations when returnTo is null", () => {
+    const response = buildPostInstallRedirect({ returnTo: null, status: "installed=ok", webUrl })
+    expect(response.status).toBe(302)
+    expect(response.headers.get("Location")).toBe("https://app.example.com/?next=integrations&installed=ok")
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
+  })
+
+  it("appends status with `&` when returnTo already has a query string", () => {
+    const response = buildPostInstallRedirect({
+      returnTo: "/projects/acme/onboarding?step=slack",
+      status: "installed=ok",
+      webUrl,
+    })
+    expect(response.headers.get("Location")).toBe(
+      "https://app.example.com/projects/acme/onboarding?step=slack&installed=ok",
+    )
+  })
+
+  it("appends status with `?` when returnTo has no query string", () => {
+    const response = buildPostInstallRedirect({
+      returnTo: "/projects/acme/onboarding",
+      status: "installed=ok",
+      webUrl,
+    })
+    expect(response.headers.get("Location")).toBe("https://app.example.com/projects/acme/onboarding?installed=ok")
+  })
+
+  it("threads error statuses through unchanged", () => {
+    const taken = buildPostInstallRedirect({
+      returnTo: "/projects/acme/onboarding",
+      status: "error=workspace_taken",
+      webUrl,
+    })
+    expect(taken.headers.get("Location")).toBe(
+      "https://app.example.com/projects/acme/onboarding?error=workspace_taken",
+    )
+
+    const failed = buildPostInstallRedirect({
+      returnTo: null,
+      status: "error=oauth_failed",
+      webUrl,
+    })
+    expect(failed.headers.get("Location")).toBe("https://app.example.com/?next=integrations&error=oauth_failed")
   })
 })

--- a/apps/web/src/routes/integrations/slack/oauth/callback.test.ts
+++ b/apps/web/src/routes/integrations/slack/oauth/callback.test.ts
@@ -65,9 +65,7 @@ describe("buildPostInstallRedirect", () => {
       status: "error=workspace_taken",
       webUrl,
     })
-    expect(taken.headers.get("Location")).toBe(
-      "https://app.example.com/projects/acme/onboarding?error=workspace_taken",
-    )
+    expect(taken.headers.get("Location")).toBe("https://app.example.com/projects/acme/onboarding?error=workspace_taken")
 
     const failed = buildPostInstallRedirect({
       returnTo: null,

--- a/apps/web/src/routes/integrations/slack/oauth/callback.ts
+++ b/apps/web/src/routes/integrations/slack/oauth/callback.ts
@@ -77,23 +77,45 @@ export const Route = createFileRoute("/integrations/slack/oauth/callback")({
         const webUrl = rawWebUrl.replace(/\/$/, "")
 
         const url = new URL(request.url)
-        const code = url.searchParams.get("code")
         const state = url.searchParams.get("state")
-        if (!code || !state) {
-          logger.warn("slack oauth callback missing code or state")
+        const code = url.searchParams.get("code")
+
+        // No state at all → either a replay attempt or a manually-typed
+        // URL. We have no `returnTo` to honor, so fall back to the
+        // default settings redirect.
+        if (!state) {
+          logger.warn("slack oauth callback missing state")
           return redirectToSettings("error=oauth_failed", webUrl)
         }
 
+        // Consume state *before* the missing-code check. If the user
+        // denied access on Slack's consent screen, Slack redirects here
+        // with `state` set but no `code` — we still want to honor the
+        // caller's `returnTo` so onboarding doesn't dump them on the
+        // settings page when they bail out of the OAuth dance.
         const stateEntry = await consumeSlackOAuthState({ redis: getRedisClient(), state })
         if (!stateEntry) {
           logger.warn("slack oauth state not found, expired, or already consumed")
           return redirectToSettings("error=oauth_failed", webUrl)
         }
 
+        if (!code) {
+          logger.info("slack oauth callback missing code (user denied or upstream error)")
+          return buildPostInstallRedirect({
+            returnTo: stateEntry.returnTo,
+            status: "error=oauth_failed",
+            webUrl,
+          })
+        }
+
         const config = await Effect.runPromise(loadSlackConfig)
         if (!config) {
           logger.warn("slack config missing at callback time")
-          return redirectToSettings("error=oauth_failed", webUrl)
+          return buildPostInstallRedirect({
+            returnTo: stateEntry.returnTo,
+            status: "error=oauth_failed",
+            webUrl,
+          })
         }
 
         const redirectUri = `${webUrl}/integrations/slack/oauth/callback`

--- a/apps/web/src/routes/integrations/slack/oauth/callback.ts
+++ b/apps/web/src/routes/integrations/slack/oauth/callback.ts
@@ -24,12 +24,31 @@ const logger = createLogger("slack-oauth-callback")
 
 type FlashStatus = "installed=ok" | "error=workspace_taken" | "error=oauth_failed"
 
-const redirectToSettings = (status: FlashStatus, webUrl: string): Response => {
+const DEFAULT_RETURN_PATH = "/?next=integrations"
+
+/**
+ * Build the post-install redirect response. If the caller passed a
+ * `returnTo` through the OAuth state, append the flash status to that
+ * path; otherwise fall back to the historical settings entry point.
+ *
+ * Exported for unit testing — keeps the URL-shape logic free of the
+ * Slack SDK + Redis dependencies the surrounding handler needs.
+ */
+export const buildPostInstallRedirect = (input: {
+  readonly returnTo: string | null
+  readonly status: FlashStatus
+  readonly webUrl: string
+}): Response => {
+  const path = input.returnTo ?? DEFAULT_RETURN_PATH
+  const separator = path.includes("?") ? "&" : "?"
   const headers = new Headers()
-  headers.set("Location", `${webUrl}/?next=integrations&${status}`)
+  headers.set("Location", `${input.webUrl}${path}${separator}${input.status}`)
   headers.set("Cache-Control", "no-store")
   return new Response(null, { status: 302, headers })
 }
+
+const redirectToSettings = (status: FlashStatus, webUrl: string): Response =>
+  buildPostInstallRedirect({ returnTo: null, status, webUrl })
 
 /**
  * `Effect.runPromise` wraps domain failures in a `FiberFailure` whose
@@ -109,14 +128,22 @@ export const Route = createFileRoute("/integrations/slack/oauth/callback")({
             ),
           )
 
-          return redirectToSettings("installed=ok", webUrl)
+          return buildPostInstallRedirect({ returnTo: stateEntry.returnTo, status: "installed=ok", webUrl })
         } catch (cause) {
           if (isWorkspaceConflict(cause)) {
             logger.info("slack workspace already claimed by another organization")
-            return redirectToSettings("error=workspace_taken", webUrl)
+            return buildPostInstallRedirect({
+              returnTo: stateEntry.returnTo,
+              status: "error=workspace_taken",
+              webUrl,
+            })
           }
           logger.error("slack oauth callback failed", cause)
-          return redirectToSettings("error=oauth_failed", webUrl)
+          return buildPostInstallRedirect({
+            returnTo: stateEntry.returnTo,
+            status: "error=oauth_failed",
+            webUrl,
+          })
         }
       },
     },

--- a/apps/web/src/routes/integrations/slack/oauth/callback.ts
+++ b/apps/web/src/routes/integrations/slack/oauth/callback.ts
@@ -26,14 +26,7 @@ type FlashStatus = "installed=ok" | "error=workspace_taken" | "error=oauth_faile
 
 const DEFAULT_RETURN_PATH = "/?next=integrations"
 
-/**
- * Build the post-install redirect response. If the caller passed a
- * `returnTo` through the OAuth state, append the flash status to that
- * path; otherwise fall back to the historical settings entry point.
- *
- * Exported for unit testing — keeps the URL-shape logic free of the
- * Slack SDK + Redis dependencies the surrounding handler needs.
- */
+// Exported for unit testing.
 export const buildPostInstallRedirect = (input: {
   readonly returnTo: string | null
   readonly status: FlashStatus
@@ -80,19 +73,13 @@ export const Route = createFileRoute("/integrations/slack/oauth/callback")({
         const state = url.searchParams.get("state")
         const code = url.searchParams.get("code")
 
-        // No state at all → either a replay attempt or a manually-typed
-        // URL. We have no `returnTo` to honor, so fall back to the
-        // default settings redirect.
+        // No state → no returnTo to honor.
         if (!state) {
           logger.warn("slack oauth callback missing state")
           return redirectToSettings("error=oauth_failed", webUrl)
         }
 
-        // Consume state *before* the missing-code check. If the user
-        // denied access on Slack's consent screen, Slack redirects here
-        // with `state` set but no `code` — we still want to honor the
-        // caller's `returnTo` so onboarding doesn't dump them on the
-        // settings page when they bail out of the OAuth dance.
+        // Consume state before checking `code` so the user-denied path (state without code) still honors returnTo.
         const stateEntry = await consumeSlackOAuthState({ redis: getRedisClient(), state })
         if (!stateEntry) {
           logger.warn("slack oauth state not found, expired, or already consumed")

--- a/apps/web/src/server/slack-oauth-state.test.ts
+++ b/apps/web/src/server/slack-oauth-state.test.ts
@@ -186,6 +186,7 @@ describe("validateReturnTo", () => {
     ["root", "/"],
     ["contains newline", "/projects/acme/\nonboarding"],
     ["contains null byte", "/projects/acme/\x00onboarding"],
+    ["contains fragment", "/projects/acme/onboarding#section"],
     ["exceeds length cap", `/projects/${"a".repeat(600)}`],
   ])("rejects %s", (_label, input) => {
     expect(validateReturnTo(input as string | null | undefined)).toBeNull()

--- a/apps/web/src/server/slack-oauth-state.test.ts
+++ b/apps/web/src/server/slack-oauth-state.test.ts
@@ -1,6 +1,11 @@
 import { OrganizationId, UserId } from "@domain/shared"
 import { beforeEach, describe, expect, it } from "vitest"
-import { consumeSlackOAuthState, generateSlackOAuthState, type SlackOAuthStateRedis } from "./slack-oauth-state.ts"
+import {
+  consumeSlackOAuthState,
+  generateSlackOAuthState,
+  type SlackOAuthStateRedis,
+  validateReturnTo,
+} from "./slack-oauth-state.ts"
 
 class FakeRedis implements SlackOAuthStateRedis {
   private readonly values = new Map<string, string>()
@@ -105,5 +110,84 @@ describe("generateSlackOAuthState + consumeSlackOAuthState", () => {
     const winners = [a, b].filter((result) => result !== null)
     expect(winners).toHaveLength(1)
     expect(redis.size()).toBe(0)
+  })
+
+  it("round-trips a valid returnTo through generate → consume", async () => {
+    const state = await generateSlackOAuthState({
+      redis,
+      organizationId: ORG_A,
+      userId: USER_A,
+      returnTo: "/projects/acme/onboarding",
+    })
+
+    const payload = await consumeSlackOAuthState({ redis, state })
+    expect(payload?.returnTo).toBe("/projects/acme/onboarding")
+  })
+
+  it("returns returnTo=null when caller passes nothing", async () => {
+    const state = await generateSlackOAuthState({ redis, organizationId: ORG_A, userId: USER_A })
+
+    const payload = await consumeSlackOAuthState({ redis, state })
+    expect(payload?.returnTo).toBeNull()
+  })
+
+  it("drops an invalid returnTo at generate time (stored as null)", async () => {
+    const state = await generateSlackOAuthState({
+      redis,
+      organizationId: ORG_A,
+      userId: USER_A,
+      returnTo: "//evil.com/path",
+    })
+
+    const payload = await consumeSlackOAuthState({ redis, state })
+    expect(payload?.returnTo).toBeNull()
+  })
+
+  it("drops a tampered returnTo at consume time", async () => {
+    // Simulate a record that bypassed `generateSlackOAuthState` and
+    // wrote a bad returnTo directly.
+    await redis.set(
+      "slack:oauth-state:tampered",
+      JSON.stringify({
+        organizationId: ORG_A,
+        userId: USER_A,
+        createdAt: new Date().toISOString(),
+        returnTo: "https://evil.com",
+      }),
+      "EX",
+      600,
+    )
+
+    const payload = await consumeSlackOAuthState({ redis, state: "tampered" })
+    expect(payload).not.toBeNull()
+    expect(payload?.returnTo).toBeNull()
+  })
+})
+
+describe("validateReturnTo", () => {
+  it("accepts a path under /projects/", () => {
+    expect(validateReturnTo("/projects/acme/onboarding")).toBe("/projects/acme/onboarding")
+  })
+
+  it("accepts a /projects/ path with query string", () => {
+    expect(validateReturnTo("/projects/acme/onboarding?step=slack")).toBe("/projects/acme/onboarding?step=slack")
+  })
+
+  it.each([
+    ["empty string", ""],
+    ["null", null],
+    ["undefined", undefined],
+    ["non-string number", 42 as unknown as string],
+    ["protocol-relative", "//evil.com"],
+    ["backslash-escape", "/\\evil.com"],
+    ["absolute URL", "https://evil.com"],
+    ["relative path", "projects/acme/onboarding"],
+    ["unrelated path", "/settings/integrations"],
+    ["root", "/"],
+    ["contains newline", "/projects/acme/\nonboarding"],
+    ["contains null byte", "/projects/acme/\x00onboarding"],
+    ["exceeds length cap", `/projects/${"a".repeat(600)}`],
+  ])("rejects %s", (_label, input) => {
+    expect(validateReturnTo(input as string | null | undefined)).toBeNull()
   })
 })

--- a/apps/web/src/server/slack-oauth-state.ts
+++ b/apps/web/src/server/slack-oauth-state.ts
@@ -44,28 +44,61 @@ export interface SlackOAuthStateRedis {
   getdel(key: string): Promise<string | null>
 }
 
+const RETURN_TO_MAX_LENGTH = 512
+
+/**
+ * Validate a caller-supplied `returnTo` path. Returns the original
+ * string if safe, `null` otherwise. The OAuth callback redirects to
+ * this path verbatim, so any failure here is an open-redirect risk.
+ *
+ * Rules:
+ * - Must be a path starting with `/`.
+ * - No `//` or `/\` prefix (defeats protocol-relative URLs).
+ * - No control characters.
+ * - Allow-list: must begin with `/projects/`. Onboarding is the only
+ *   legitimate caller; settings hits the callback's default redirect.
+ * - Length capped to discourage abuse and keep Redis payloads small.
+ */
+export const validateReturnTo = (input: string | null | undefined): string | null => {
+  if (typeof input !== "string") return null
+  if (input.length === 0 || input.length > RETURN_TO_MAX_LENGTH) return null
+  if (!input.startsWith("/")) return null
+  if (input.startsWith("//") || input.startsWith("/\\")) return null
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) return null
+  }
+  if (!input.startsWith("/projects/")) return null
+  return input
+}
+
 const statePayloadSchema = z.object({
   organizationId: z.string().min(1),
   userId: z.string().min(1),
   createdAt: z.iso.datetime(),
+  returnTo: z.string().optional(),
 })
 
 interface SlackOAuthStatePayload {
   readonly organizationId: OrganizationIdType
   readonly userId: UserIdType
   readonly createdAt: Date
+  readonly returnTo: string | null
 }
 
 export const generateSlackOAuthState = async (input: {
   readonly redis: SlackOAuthStateRedis
   readonly organizationId: OrganizationIdType
   readonly userId: UserIdType
+  readonly returnTo?: string | null
 }): Promise<string> => {
   const state = randomBytes(STATE_BYTES).toString("hex")
+  const validatedReturnTo = input.returnTo == null ? null : validateReturnTo(input.returnTo)
   const payload = JSON.stringify({
     organizationId: input.organizationId,
     userId: input.userId,
     createdAt: new Date().toISOString(),
+    ...(validatedReturnTo === null ? {} : { returnTo: validatedReturnTo }),
   })
   await input.redis.set(buildKey(state), payload, "EX", STATE_TTL_SECONDS)
   return state
@@ -113,9 +146,15 @@ export const consumeSlackOAuthState = async (input: {
     return null
   }
 
+  // Re-validate `returnTo` on consume too — defends against a state
+  // record forged or tampered with after generate (e.g. a future bug
+  // that wrote to Redis without going through `generateSlackOAuthState`).
+  const validatedReturnTo = parsed.data.returnTo == null ? null : validateReturnTo(parsed.data.returnTo)
+
   return {
     organizationId: OrganizationId(parsed.data.organizationId),
     userId: UserId(parsed.data.userId),
     createdAt: new Date(parsed.data.createdAt),
+    returnTo: validatedReturnTo,
   }
 }

--- a/apps/web/src/server/slack-oauth-state.ts
+++ b/apps/web/src/server/slack-oauth-state.ts
@@ -46,22 +46,7 @@ export interface SlackOAuthStateRedis {
 
 const RETURN_TO_MAX_LENGTH = 512
 
-/**
- * Validate a caller-supplied `returnTo` path. Returns the original
- * string if safe, `null` otherwise. The OAuth callback redirects to
- * this path verbatim, so any failure here is an open-redirect risk.
- *
- * Rules:
- * - Must be a path starting with `/`.
- * - No `//` or `/\` prefix (defeats protocol-relative URLs).
- * - No control characters.
- * - No `#` — the callback appends flash params with `&`/`?`, so a
- *   fragment in the input would push the status param past the
- *   fragment boundary and out of the query string.
- * - Allow-list: must begin with `/projects/`. Onboarding is the only
- *   legitimate caller; settings hits the callback's default redirect.
- * - Length capped to discourage abuse and keep Redis payloads small.
- */
+// Reject anything not safe to feed verbatim into the callback's `Location` header.
 export const validateReturnTo = (input: string | null | undefined): string | null => {
   if (typeof input !== "string") return null
   if (input.length === 0 || input.length > RETURN_TO_MAX_LENGTH) return null
@@ -150,9 +135,7 @@ export const consumeSlackOAuthState = async (input: {
     return null
   }
 
-  // Re-validate `returnTo` on consume too — defends against a state
-  // record forged or tampered with after generate (e.g. a future bug
-  // that wrote to Redis without going through `generateSlackOAuthState`).
+  // Re-validate in case the Redis record was written outside this module.
   const validatedReturnTo = parsed.data.returnTo == null ? null : validateReturnTo(parsed.data.returnTo)
 
   return {

--- a/apps/web/src/server/slack-oauth-state.ts
+++ b/apps/web/src/server/slack-oauth-state.ts
@@ -55,6 +55,9 @@ const RETURN_TO_MAX_LENGTH = 512
  * - Must be a path starting with `/`.
  * - No `//` or `/\` prefix (defeats protocol-relative URLs).
  * - No control characters.
+ * - No `#` — the callback appends flash params with `&`/`?`, so a
+ *   fragment in the input would push the status param past the
+ *   fragment boundary and out of the query string.
  * - Allow-list: must begin with `/projects/`. Onboarding is the only
  *   legitimate caller; settings hits the callback's default redirect.
  * - Length capped to discourage abuse and keep Redis payloads small.
@@ -68,6 +71,7 @@ export const validateReturnTo = (input: string | null | undefined): string | nul
     const code = input.charCodeAt(i)
     if (code <= 0x1f || code === 0x7f) return null
   }
+  if (input.includes("#")) return null
   if (!input.startsWith("/projects/")) return null
   return input
 }


### PR DESCRIPTION
## summary

Adds an optional Slack step to the project onboarding wizard, between **flaggers** and **telemetry**. After choosing which Flaggers should monitor their traces, users can connect their Slack workspace and route the resulting incident alerts to a channel without leaving the flow. The step is fully skippable; the rest of onboarding behaves as before.

The new step is hidden when either the `slack` feature flag is off or `LAT_SLACK_CLIENT_ID` / `LAT_SLACK_CLIENT_SECRET` are unset (self-hosted deployments without a Slack app). Channel routing for all three notification groups (`incidents`, `wrapped_reports`, `custom_messages`) still lives at `/settings/integrations` — the onboarding step is a thin gateway, not a replacement.

https://github.com/user-attachments/assets/4f4a0e20-160c-4ed8-9020-c02f8f0bc337

## new step UX

Three visible states, all using the same card primitive as the settings page so users build one mental model:

1. **Disconnected** — \"Connect Slack\" button + ghost \"Skip for now\".
2. **Connected, no incidents routed** — team name + connected timestamp, single channel picker for **Incidents** (the group the step is selling). CTA stays a ghost \"Skip for now\" because the pitch isn't delivered until a route exists.
3. **Connected, incidents routed** — the **Wrapped reports** and **Announcements** rows reveal progressively, and the CTA flips to a primary \"Continue\". A muted footer points users to settings for full control later.

Disconnect is intentionally **not** offered inside onboarding; users can manage that from settings once they're past the wizard.

## OAuth round-trip

Slack OAuth bounces the user out of the app, so onboarding state has to survive a full reload. Two pieces wire this up:

- **Step in URL.** The route now has a `validateSearch` for `step`, `installed`, `error`. A `goToStep(next)` helper centralises React-state + URL sync, so every transition is refresh-safe. Deep-link gate: if the URL points past `stack` but `project.settings.onboardingType` is unset, fall back to `role` — earlier steps have prerequisites that URL hopping shouldn't skip. `onboardingType` is read from the parent route's loader, which is synchronously available on first render.
- **`returnTo` in OAuth state.** `/integrations/slack/install?return_to=/projects/{slug}/onboarding` validates the path (allow-list `/projects/...`, reject protocol-relative, control chars, length > 512) and stores it in the existing Redis-backed CSRF state record. The callback honors `stateEntry.returnTo` on every post-state exit — success, workspace conflict, missing config, **and** the user-denied-on-consent path (Slack returns `state` without `code`, which the old early-return discarded). Only the no-state-at-all branch (replay or hand-typed URL) still falls back to the historic `/?next=integrations`.

Settings keeps its current behaviour: it doesn't pass `return_to`, so its OAuth round-trip continues to land where it always did.

## shared SlackRouteRow

The settings page's per-group channel picker was extracted to `settings/-components/slack-route-row.tsx` and is reused by the onboarding card. Both surfaces invalidate the same `[\"slack-integration\"]` query key on save, so a route change in either place propagates immediately. Settings still renders all three groups in full; the progressive reveal is onboarding-only.

## tests

- `validateReturnTo` accepts `/projects/...` paths, rejects open-redirect-shaped inputs (`//`, backslash, absolute URLs, control chars, paths outside the allow-list, oversize).
- OAuth state round-trip preserves a valid `returnTo`, drops invalid ones at both generate and consume time.
- `buildPostInstallRedirect` correctly composes the `Location` header for paths with/without an existing query string, across all three flash statuses.

## out of scope

- The `UserOnboardingCompleted` event still fires on the `stack → flaggers` transition (i.e. before the slack step), as it did before. Left as-is per discussion — touching analytics timing belongs in its own change.
- No channel auto-routing; the user explicitly picks.