### PR TITLE
feat(wrapped-email): add 41st merch promo banner

### DIFF
--- a/apps/workers/src/workers/notification-emailer.ts
+++ b/apps/workers/src/workers/notification-emailer.ts
@@ -1,5 +1,6 @@
 import type { RenderedEmail } from "@domain/email"
 import { NOTIFICATION_EMAIL_RENDERERS, type NotificationEmailRenderContext, sendEmail } from "@domain/email"
+import type { FeatureFlagRepository } from "@domain/feature-flags"
 import type { IssueRepository } from "@domain/issues"
 import {
   type NotificationEmailRenderer,
@@ -12,6 +13,7 @@ import type { QueueConsumer } from "@domain/queue"
 import { NotificationId, OrganizationId, type SqlClient } from "@domain/shared"
 import type { WrappedReportRepository } from "@domain/spans"
 import {
+  FeatureFlagRepositoryLive,
   IssueRepositoryLive,
   NotificationRepositoryLive,
   OrganizationRepositoryLive,
@@ -51,7 +53,7 @@ const repoLayer = Layer.mergeAll(
  * into the use case's signature. Add to this when a new kind needs a
  * new repo for server-side rendering.
  */
-const rendererLayer = Layer.mergeAll(IssueRepositoryLive, WrappedReportRepositoryLive)
+const rendererLayer = Layer.mergeAll(IssueRepositoryLive, WrappedReportRepositoryLive, FeatureFlagRepositoryLive)
 
 const resolveWebAppUrl = (): string => {
   const webUrl = Effect.runSync(parseEnv("LAT_WEB_URL", "string", "http://localhost:3000"))
@@ -84,7 +86,7 @@ export const createNotificationEmailerWorker = ({ consumer }: NotificationEmaile
   // `Effect.suspend` for TS's call-signature narrowing, so widen the
   // dispatch result to the layer's superset and let `Effect.provide`
   // strip everything except `SqlClient` (the boundary contract).
-  type RendererSupersetR = IssueRepository | WrappedReportRepository | SqlClient
+  type RendererSupersetR = IssueRepository | WrappedReportRepository | FeatureFlagRepository | SqlClient
   const renderEmailAdapter: NotificationEmailRenderer = ({
     notificationId,
     notificationCreatedAt,

--- a/packages/domain/email/package.json
+++ b/packages/domain/email/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@domain/feature-flags": "workspace:*",
     "@domain/issues": "workspace:*",
     "@domain/notifications": "workspace:*",
     "@domain/shared": "workspace:*",

--- a/packages/domain/email/src/templates/notifications/types.ts
+++ b/packages/domain/email/src/templates/notifications/types.ts
@@ -1,3 +1,4 @@
+import type { FeatureFlagRepository } from "@domain/feature-flags"
 import type { IssueRepository } from "@domain/issues"
 import type { NOTIFICATION_KIND_META, NotificationKind, RenderNotificationEmailError } from "@domain/notifications"
 import type { SqlClient } from "@domain/shared"
@@ -56,7 +57,7 @@ export type RenderDepsByKind = {
   readonly "incident.event": IssueRepository | SqlClient
   readonly "incident.opened": IssueRepository | SqlClient
   readonly "incident.closed": IssueRepository | SqlClient
-  readonly "wrapped.report": WrappedReportRepository | SqlClient
+  readonly "wrapped.report": WrappedReportRepository | FeatureFlagRepository | SqlClient
   readonly "custom.message": never
 }
 

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/-components/MerchPromoBanner.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/-components/MerchPromoBanner.tsx
@@ -1,0 +1,145 @@
+import { Link, Section } from "@react-email/components"
+// biome-ignore lint/style/useImportType: React is required at runtime for JSX in workers (tsx/esbuild classic transform). Do not downgrade to `import type`.
+import React from "react"
+
+/**
+ * Promotional banner pointing at the 41st.latitude.so merch drop. Gated by
+ * the `wrapped-merch-promo` feature flag — see the dispatcher in
+ * `../index.tsx`.
+ *
+ * Visually departs from the warm-cream Claude-themed sections above on
+ * purpose: matches the 41st landing page's pale-blue + cobalt + black
+ * aesthetic so the reader's eye registers it as a separate "offer" surface
+ * rather than another piece of the recap narrative.
+ */
+
+const PROMO_URL = "https://41st.latitude.so/?utm_source=wrapped_email&utm_medium=email&utm_campaign=merch_41st#howto"
+
+const monoStack = '"SF Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace'
+const sansStack = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+
+const colors = {
+  bandBg: "#EEF2FB",
+  cardBg: "#FFFFFF",
+  ink: "#0F1115",
+  muted: "#5A6275",
+  accent: "#2D5BFF",
+  cta: "#000000",
+  ctaText: "#FFFFFF",
+  hairline: "#D7DEEC",
+}
+
+const eyebrowStyle: React.CSSProperties = {
+  fontFamily: monoStack,
+  fontSize: "11px",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+  color: colors.accent,
+  margin: 0,
+}
+
+const headlineStyle: React.CSSProperties = {
+  fontFamily: sansStack,
+  fontSize: "22px",
+  lineHeight: "28px",
+  fontWeight: 600,
+  color: colors.ink,
+  margin: "10px 0 0 0",
+}
+
+const bodyStyle: React.CSSProperties = {
+  fontFamily: sansStack,
+  fontSize: "14px",
+  lineHeight: "20px",
+  color: colors.muted,
+  margin: "8px 0 0 0",
+}
+
+const ctaStyle: React.CSSProperties = {
+  display: "inline-block",
+  fontFamily: sansStack,
+  fontSize: "13px",
+  fontWeight: 600,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+  color: colors.ctaText,
+  backgroundColor: colors.cta,
+  padding: "12px 22px",
+  textDecoration: "none",
+  marginTop: "18px",
+}
+
+const ribbonStyle: React.CSSProperties = {
+  fontFamily: monoStack,
+  fontSize: "10px",
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  color: colors.muted,
+  margin: 0,
+}
+
+const ribbonStrongStyle: React.CSSProperties = {
+  color: colors.ink,
+  fontWeight: 600,
+}
+
+const ribbonAccentStyle: React.CSSProperties = {
+  color: colors.accent,
+  fontWeight: 600,
+}
+
+export function MerchPromoBanner() {
+  return (
+    <Section
+      style={{
+        marginTop: "32px",
+        backgroundColor: colors.bandBg,
+        padding: "28px 24px",
+      }}
+    >
+      <table
+        role="presentation"
+        cellPadding={0}
+        cellSpacing={0}
+        border={0}
+        width="100%"
+        style={{ borderCollapse: "separate" }}
+      >
+        <tbody>
+          <tr>
+            <td align="center" style={{ paddingBottom: "16px" }}>
+              <p style={ribbonStyle}>
+                <span style={ribbonAccentStyle}>{"DROP 001 · FREE"}</span>
+                {"  ·  "}
+                <span style={ribbonStrongStyle}>{"5 tees · 5 winners"}</span>
+                {"  ·  worldwide shipping"}
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td
+              align="center"
+              style={{
+                backgroundColor: colors.cardBg,
+                border: `1px solid ${colors.hairline}`,
+                padding: "28px 24px",
+                textAlign: "center",
+              }}
+            >
+              <p style={eyebrowStyle}>{"// HOW TO WIN · 3 STEPS"}</p>
+              <p style={headlineStyle}>{"Share your Wrapped on X · win free Latitude merch"}</p>
+              <p style={bodyStyle}>
+                {"Post this week's Wrapped on X and tag "}
+                <span style={{ color: colors.accent, fontWeight: 600 }}>@trylatitude</span>
+                {". Top 5 posts each week get a free tee, DM'd by us, shipped worldwide."}
+              </p>
+              <Link href={PROMO_URL} style={ctaStyle}>
+                {"› Start now"}
+              </Link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </Section>
+  )
+}

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/index.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v1/index.tsx
@@ -1,0 +1,6 @@
+// Re-export so the React Email dev preview server picks up the V1 template at
+// `wrapped-report/claude-code/v1/`. The runtime dispatcher imports the named
+// export from `EmailTemplateV1.tsx` directly.
+import { ClaudeCodeWrappedEmailV1 } from "./EmailTemplateV1.tsx"
+
+export default ClaudeCodeWrappedEmailV1

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/EmailTemplateV2.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/EmailTemplateV2.tsx
@@ -6,6 +6,7 @@ import React from "react"
 import { EmailHeading } from "../../../../../components/EmailHeading.tsx"
 import { WrappedLayout } from "../../../../../components/WrappedLayout.tsx"
 import { emailDesignTokens } from "../../../../../tokens/design-system.ts"
+import { MerchPromoBanner } from "../-components/MerchPromoBanner.tsx"
 import { PersonalityCard } from "../-components/PersonalityCard.tsx"
 import { StatCard } from "../-components/StatCard.tsx"
 
@@ -28,6 +29,12 @@ interface EmailTemplateV2Props {
   readonly report: Report
   readonly webAppUrl: string
   readonly reportId: WrappedReportId
+  /**
+   * Resolved by the dispatcher from the `wrapped-merch-promo` flag. When
+   * true, renders the 41st.latitude.so merch banner between the primary
+   * CTA and the footer. Defaults to false so previews stay flag-free.
+   */
+  readonly showMerchPromo?: boolean
 }
 
 const DATE_RANGE_FMT = new Intl.DateTimeFormat("en-US", {
@@ -336,7 +343,13 @@ function WrappedFooter({
   )
 }
 
-export function ClaudeCodeWrappedEmailV2({ userName, report: reportBase, webAppUrl, reportId }: EmailTemplateV2Props) {
+export function ClaudeCodeWrappedEmailV2({
+  userName,
+  report: reportBase,
+  webAppUrl,
+  reportId,
+  showMerchPromo = false,
+}: EmailTemplateV2Props) {
   // Safe: dispatcher only routes here when reportVersion === 2.
   const report = reportBase as ReportV2
   const base = webAppUrl.replace(/\/$/, "")
@@ -366,6 +379,7 @@ export function ClaudeCodeWrappedEmailV2({ userName, report: reportBase, webAppU
       <LocSection report={report} />
       <PersonalityRevealSection personality={report.personality} imageBaseUrl={imageBaseUrl} />
       <CtaBanner url={reportUrl} />
+      {showMerchPromo ? <MerchPromoBanner /> : null}
     </WrappedLayout>
   )
 }
@@ -374,6 +388,7 @@ ClaudeCodeWrappedEmailV2.PreviewProps = {
   userName: "Alex",
   webAppUrl: "http://localhost:3000",
   reportId: "ccwv2p".padEnd(24, "x").slice(0, 24) as WrappedReportId,
+  showMerchPromo: true,
   report: {
     project: { id: ProjectId("proj-preview"), name: "poncho-ios", slug: "poncho-ios" },
     organization: { id: OrganizationId("org-preview"), name: "Acme" },

--- a/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/index.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/claude-code/v2/index.tsx
@@ -1,0 +1,6 @@
+// Re-export so the React Email dev preview server picks up the V2 template at
+// `wrapped-report/claude-code/v2/`. The runtime dispatcher imports the named
+// export from `EmailTemplateV2.tsx` directly.
+import { ClaudeCodeWrappedEmailV2 } from "./EmailTemplateV2.tsx"
+
+export default ClaudeCodeWrappedEmailV2

--- a/packages/domain/email/src/templates/notifications/wrapped-report/index.tsx
+++ b/packages/domain/email/src/templates/notifications/wrapped-report/index.tsx
@@ -1,3 +1,4 @@
+import { FeatureFlagRepository } from "@domain/feature-flags"
 import { WrappedReportId } from "@domain/shared"
 import {
   CURRENT_REPORT_VERSION,
@@ -43,33 +44,64 @@ interface RenderInput {
   readonly webAppUrl: string
   readonly reportId: string
   readonly reportVersion: ReportVersion
+  /**
+   * Resolved upstream from the `wrapped-merch-promo` flag. V1 ignores it
+   * (the V1 component never received this prop); V2 renders the
+   * 41st.latitude.so banner when true.
+   */
+  readonly showMerchPromo: boolean
 }
+
+const MERCH_PROMO_URL =
+  "https://41st.latitude.so/?utm_source=wrapped_email&utm_medium=email&utm_campaign=merch_41st#howto"
 
 /**
  * Pure HTML builder. Picks a versioned React template by `(type,
  * reportVersion)` and renders to HTML + plaintext.
+ *
+ * V2 receives the optional `showMerchPromo` prop; V1 is rendered through
+ * the shared registry signature, which doesn't include the prop, so old
+ * V1 reports keep their frozen output verbatim.
  */
 const renderWrappedHtml = async (input: RenderInput): Promise<RenderedEmail> => {
   const projectName = input.report.project.name
   const fullReportUrl = `${input.webAppUrl.replace(/\/$/, "")}/wrapped/${input.reportId}`
+  const reportIdBranded = WrappedReportId(input.reportId)
   const templatesForType = TEMPLATE_BY_TYPE_VERSION[input.type] ?? TEMPLATE_BY_TYPE_VERSION.claude_code
-  const Template = templatesForType[input.reportVersion] ?? templatesForType[CURRENT_REPORT_VERSION]
-  return {
-    html: await renderEmail(
+  const resolvedVersion: ReportVersion =
+    input.reportVersion in templatesForType ? input.reportVersion : CURRENT_REPORT_VERSION
+  const Template = templatesForType[resolvedVersion]
+  const emailJsx =
+    resolvedVersion === 2 ? (
+      <ClaudeCodeWrappedEmailV2
+        userName={input.userName}
+        report={input.report}
+        webAppUrl={input.webAppUrl}
+        reportId={reportIdBranded}
+        showMerchPromo={input.showMerchPromo}
+      />
+    ) : (
       <Template
         userName={input.userName}
         report={input.report}
         webAppUrl={input.webAppUrl}
-        reportId={WrappedReportId(input.reportId)}
-      />,
-    ),
+        reportId={reportIdBranded}
+      />
+    )
+  const baseText = `Hi ${input.userName},\n\nYour Claude Code Wrapped for ${projectName} (${formatPlainRange(
+    input.report.window.start,
+    input.report.window.end,
+  )} UTC):\n\n• ${input.report.totals.sessions.toLocaleString("en-US")} sessions\n• ${input.report.totals.toolCalls.toLocaleString(
+    "en-US",
+  )} tool calls\n• ${input.report.totals.filesTouched.toLocaleString("en-US")} files touched\n\nSee your full week:\n${fullReportUrl}`
+  const promoText =
+    input.showMerchPromo && resolvedVersion === 2
+      ? `\n\n---\nShare your Wrapped on X · win free Latitude merch\nPost this week's Wrapped on X and tag @trylatitude. Top 5 posts each week get a free tee, DM'd by us, shipped worldwide.\n${MERCH_PROMO_URL}`
+      : ""
+  return {
+    html: await renderEmail(emailJsx),
     subject: `Your Claude Code week in ${projectName}`,
-    text: `Hi ${input.userName},\n\nYour Claude Code Wrapped for ${projectName} (${formatPlainRange(
-      input.report.window.start,
-      input.report.window.end,
-    )} UTC):\n\n• ${input.report.totals.sessions.toLocaleString("en-US")} sessions\n• ${input.report.totals.toolCalls.toLocaleString(
-      "en-US",
-    )} tool calls\n• ${input.report.totals.filesTouched.toLocaleString("en-US")} files touched\n\nSee your full week:\n${fullReportUrl}`,
+    text: `${baseText}${promoText}`,
   }
 }
 
@@ -99,6 +131,12 @@ export const wrappedReportRenderer: NotificationEmailRenderer<"wrapped.report"> 
         cause,
       })),
     )
+    // Promo flag failures are non-fatal — render the email without the
+    // banner rather than dropping the whole send because of a flag lookup.
+    const flags = yield* FeatureFlagRepository
+    const showMerchPromo = yield* flags
+      .isEnabledForOrganization("wrapped-merch-promo")
+      .pipe(Effect.orElseSucceed(() => false))
     return yield* Effect.tryPromise({
       try: () =>
         renderWrappedHtml({
@@ -108,6 +146,7 @@ export const wrappedReportRenderer: NotificationEmailRenderer<"wrapped.report"> 
           webAppUrl: ctx.webAppUrl,
           reportId: record.id,
           reportVersion: record.reportVersion,
+          showMerchPromo,
         }),
       catch: (cause) => ({
         _tag: "RenderNotificationEmailError" as const,
@@ -117,4 +156,7 @@ export const wrappedReportRenderer: NotificationEmailRenderer<"wrapped.report"> 
     })
   })
 
-export default ClaudeCodeWrappedEmailV1
+// Default export drives the React Email dev preview at /wrapped-report/index —
+// keep it pointed at the current (highest) report version so the parent route
+// in the preview server reflects the version users actually receive.
+export default ClaudeCodeWrappedEmailV2

--- a/packages/domain/feature-flags/src/registry.ts
+++ b/packages/domain/feature-flags/src/registry.ts
@@ -16,6 +16,11 @@ export const FEATURE_FLAGS = {
     name: "Claude Code Wrapped",
     description: "Creates the weekly Wrapped for projects with Claude Code telemetry within the organization.",
   },
+  "wrapped-merch-promo": {
+    emoji: "👕",
+    name: "Wrapped merch promo",
+    description: "Shows the 41st.latitude.so 'share on X for free merch' banner inside the weekly Wrapped email.",
+  },
   "email-notifications": {
     emoji: "✉️",
     name: "Email notifications",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1115,6 +1115,9 @@ importers:
 
   packages/domain/email:
     dependencies:
+      '@domain/feature-flags':
+        specifier: workspace:*
+        version: link:../feature-flags
       '@domain/issues':
         specifier: workspace:*
         version: link:../issues


### PR DESCRIPTION
## summary

Adds a promotional banner inside the Claude Code Wrapped V2 email pointing at the [41st.latitude.so](https://41st.latitude.so/#howto) merch drop. Renders between the primary "See your full week →" CTA and the footer, gated by the new `wrapped-merch-promo` feature flag.

<img width="1003" height="889" alt="8ohRzwuMpEb" src="https://github.com/user-attachments/assets/5dd06be0-4e93-4ef4-ae0b-88798961cc85" />


## why

Time-limited promo: users who share their Wrapped on X and tag `@trylatitude` get a chance at a free tee. The email needs to surface the offer; the landing page owns the rules. Gating on a per-org flag lets us turn the banner on or off without a deploy and pull it cleanly once the drop closes.

## visual design

Departs from the warm-cream Claude theme used elsewhere in the email — pale-blue band, white inner card, cobalt accent, black pill CTA, monospace eyebrow. Matches the 41st landing page, so the reader's eye registers it as a separate "offer" surface rather than another piece of the recap narrative. Doesn't compete with the primary CTA, which keeps the Claude aesthetic. No rounded corners on the band, inner card, or CTA — keeps the editorial feel of the landing page.

## what's wired up

- **Flag** — `wrapped-merch-promo` registered in `packages/domain/feature-flags/src/registry.ts`. Org-scoped per repo convention. Enable in `/backoffice/feature-flags/`. Kebab-case (not snake) because `FeatureFlagId` is a literal union over registry keys.
- **Flag check** — `wrappedReportRenderer` yields `FeatureFlagRepository` and calls `isEnabledForOrganization("wrapped-merch-promo")` with `Effect.orElseSucceed(() => false)`, so a flag-store hiccup degrades to "no banner" rather than dropping the send.
- **Renderer deps** — `RenderDepsByKind["wrapped.report"]` gains `FeatureFlagRepository`; `notification-emailer` worker provides `FeatureFlagRepositoryLive` in its renderer layer.
- **V1 untouched** — only V2 receives `showMerchPromo`. The dispatcher branches the JSX so V1 still renders byte-identical to before; old V1 reports keep their frozen-in-amber output.
- **Plain-text companion** — the `text` field gains a short matching blurb + URL when the flag is on, so non-HTML clients see the offer too.
- **UTMs** — promo URL carries `?utm_source=wrapped_email&utm_medium=email&utm_campaign=merch_41st` for attribution against organic traffic to the landing page.

## dev preview server fix

While testing locally, the React Email dev server was rendering empty cards for `claude-code/v1/` and `claude-code/v2/` and showing V1 at the parent route. The version files only had named exports, and the dispatcher's `export default ClaudeCodeWrappedEmailV1` predated the V2 split. Fixed by:

- Adding re-exporting `index.tsx` files inside `v1/` and `v2/` (matches the `incident-opened/EmailTemplate.tsx` + `incident-opened/index.tsx` pattern already in the repo)
- Re-pointing the dispatcher's default export at V2 so the parent route reflects the current version

Runtime is unaffected — nothing imports the dispatcher's default; the registry consumes the named `wrappedReportRenderer`. `PreviewProps.showMerchPromo = true` on V2 so the dev server shows the banner without flag wiring.

## cleanup after the promo ends

Standard flag-removal lifecycle (see `dev-docs/feature-flags.md`):

1. Delete the `wrapped-merch-promo` entry from `FEATURE_FLAGS`.
2. Drop the flag check, the `showMerchPromo` plumbing, and the `<MerchPromoBanner />` invocation from `wrappedReportRenderer` + `EmailTemplateV2`.
3. Drop `FeatureFlagRepository` from `RenderDepsByKind["wrapped.report"]` and `FeatureFlagRepositoryLive` from the worker's renderer layer.
4. Delete `MerchPromoBanner.tsx`.

CI is load-bearing for step 1 — any leftover reference to the literal stops compiling.

## test plan

- [ ] Run `pnpm --filter @domain/email dev` and confirm `wrapped-report/index` and `wrapped-report/claude-code/v2/` render with the merch banner; `claude-code/v1/` renders without it.
- [ ] Enable `wrapped-merch-promo` for the Acme seed org in `/backoffice/feature-flags/` and trigger a wrapped run from the backoffice; verify the email at Mailpit includes the banner with the cobalt theme and the UTM-tagged URL.
- [ ] Disable the flag and re-run; verify the email renders without the banner and without the plain-text blurb.
- [ ] View the plain-text body in Mailpit's "Source" tab to confirm the trailing block + URL is present only when the flag is on.