### PR TITLE
fix(issues): restore lifecycle buttons to drawer toolbar [LAT-634]

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -4,6 +4,7 @@ import { ChevronLeftIcon } from "lucide-react"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
 import { useSessionDetail } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { IssueLifecycleActions } from "../issues/-components/issue-lifecycle-actions.tsx"
 import { IssueSlot } from "./session-detail-drawer/issue-slot.tsx"
 import { isSessionTab, SessionSlot } from "./session-detail-drawer/session-slot.tsx"
 import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
@@ -120,6 +121,9 @@ export function SessionDetailDrawer({
             View session <HotkeyBadge hotkey="Escape" />
           </Tooltip>
         ) : undefined
+      }
+      rightActions={
+        detailKind === "issue" ? <IssueLifecycleActions projectId={projectId} issueId={issueId} /> : undefined
       }
     >
       {sessionLoading && !session ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -1,19 +1,14 @@
 import {
   Button,
-  CloseTrigger,
   CopyableText,
   DetailDrawer,
   DetailSection,
   Icon,
-  Label,
-  Modal,
   Sheet,
   Skeleton,
-  Switch,
   TagList,
   Text,
   Tooltip,
-  useToast,
 } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
@@ -23,23 +18,17 @@ import {
   ArrowUpIcon,
   CheckIcon,
   DatabaseIcon,
-  PauseIcon,
-  PlayIcon,
   TextAlignStartIcon,
-  XIcon,
 } from "lucide-react"
 import { type ReactNode, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
 import {
-  invalidateIssueQueries,
   useIssueDetail,
   useIssueTracesCount,
   useIssueTracesInfiniteScroll,
 } from "../../../../../../domains/issues/issues.collection.ts"
-import { applyIssueLifecycleAction } from "../../../../../../domains/issues/issues.functions.ts"
-import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { useSelectableRows } from "../../../../../../lib/hooks/useSelectableRows.ts"
 import { AddToDatasetModal } from "../../-components/add-to-dataset-modal.tsx"
 import {
@@ -50,6 +39,7 @@ import {
 import { TraceDetailDrawer } from "../../-components/trace-detail-drawer.tsx"
 import { IssueDrawerEvaluations } from "./issue-drawer-evaluations.tsx"
 import { formatIssueAgeAgoLabel, formatSeenAgeParts } from "./issue-formatters.ts"
+import { IssueLifecycleActions } from "./issue-lifecycle-actions.tsx"
 import { IssueLifecycleStatuses } from "./issue-lifecycle-statuses.tsx"
 import { IssueTrendBar } from "./issue-trend-bar.tsx"
 
@@ -111,39 +101,7 @@ function IssueLifecycleTimestampSummaryValue({
   )
 }
 
-type LifecycleConfirmationAction = "ignore" | "unignore" | "unresolve"
-
 const ISSUE_TRACE_COLUMN_IDS = ["startTime", "name", "tags", "duration"] as const satisfies readonly TraceColumnId[]
-
-function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
-  switch (action) {
-    case "ignore":
-      return {
-        title: "Ignore issue",
-        description:
-          "Mark this issue as ignored. We won't monitor or alert you about new occurrences of this issue anymore",
-        confirmLabel: "Ignore",
-        confirmIcon: PauseIcon,
-        confirmVariant: "destructive" as const,
-      }
-    case "unignore":
-      return {
-        title: "Unignore issue",
-        description: "Stop ignoring this issue. New occurrences will surface it again",
-        confirmLabel: "Unignore",
-        confirmIcon: PlayIcon,
-        confirmVariant: undefined,
-      }
-    case "unresolve":
-      return {
-        title: "Unresolve issue",
-        description: "Reopen this issue. New occurrences won't mark this issue as regressed",
-        confirmLabel: "Unresolve",
-        confirmIcon: XIcon,
-        confirmVariant: "destructive" as const,
-      }
-  }
-}
 
 /**
  * Issue detail surface minus the `DetailDrawer` chrome (close, next/prev nav).
@@ -167,7 +125,6 @@ export function IssueDetailBody({
   readonly issueId: string
   readonly onOverlayActiveChange?: (active: boolean) => void
 }) {
-  const { toast } = useToast()
   const { data: issue, isLoading } = useIssueDetail({ projectId, issueId })
   const {
     data: traces,
@@ -178,10 +135,6 @@ export function IssueDetailBody({
     issueId,
     enabled: issue !== null,
   })
-  const [resolveModalOpen, setResolveModalOpen] = useState(false)
-  const [lifecycleConfirmAction, setLifecycleConfirmAction] = useState<LifecycleConfirmationAction | null>(null)
-  const [keepMonitoring, setKeepMonitoring] = useState(true)
-  const [isLifecycleLoading, setIsLifecycleLoading] = useState(false)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
   const [traceSheetTraceId, setTraceSheetTraceId] = useState<string | null>(null)
   const [traceSheetOpen, setTraceSheetOpen] = useState(false)
@@ -220,9 +173,6 @@ export function IssueDetailBody({
     enabled: incidentsFlagEnabled && trendIncidentRange !== null,
   })
   const { selectedCount, bulkSelection, clearSelections } = traceSelection
-  const hasActiveLinkedEvaluations =
-    issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
-  const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
 
   const openTraceSheet = (traceId: string) => {
     setTraceSheetTraceId(traceId)
@@ -260,94 +210,27 @@ export function IssueDetailBody({
     return `Open trace ${shortName} in the conversation panel`
   }
 
-  const runLifecycleCommand = async (command: "resolve" | "unresolve" | "ignore" | "unignore", override?: boolean) => {
-    setIsLifecycleLoading(true)
-    try {
-      await applyIssueLifecycleAction({
-        data: {
-          projectId,
-          issueId,
-          command,
-          ...(override !== undefined ? { keepMonitoring: override } : {}),
-        },
-      })
-      await invalidateIssueQueries(projectId, issueId)
-      toast({
-        description:
-          command === "resolve"
-            ? "Issue resolved."
-            : command === "unresolve"
-              ? "Issue reopened."
-              : command === "ignore"
-                ? "Issue ignored."
-                : "Issue unignored.",
-      })
-      setResolveModalOpen(false)
-      setLifecycleConfirmAction(null)
-    } catch (error) {
-      toast({
-        variant: "destructive",
-        description: toUserMessage(error),
-      })
-    } finally {
-      setIsLifecycleLoading(false)
-    }
-  }
-
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex shrink-0 flex-col gap-3 border-b px-6 py-4">
-          <div className="flex flex-row items-start justify-between gap-4">
-            <div className="flex min-w-0 flex-1 flex-col gap-2">
-              <div className="flex flex-col gap-1">
-                {isLoading ? (
-                  <Skeleton className="h-7 w-56" />
-                ) : (
-                  <Text.H4M>{issue?.name ?? "Issue not found"}</Text.H4M>
-                )}
-                {isLoading ? (
-                  <Skeleton className="h-5 w-full" />
-                ) : (
-                  <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
-                )}
-              </div>
-              {!isLoading && issue && (
-                <div className="flex flex-wrap items-center gap-2">
-                  <div className="flex min-w-[33%] max-w-max flex-1">
-                    <CopyableText value={issue.slug} size="sm" ellipsis tooltip="Copy issue slug" />
-                  </div>
-                  {issue.tags.length > 0 && <TagList tags={issue.tags} wrap />}
-                </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1">
+              {isLoading ? <Skeleton className="h-7 w-56" /> : <Text.H4M>{issue?.name ?? "Issue not found"}</Text.H4M>}
+              {isLoading ? (
+                <Skeleton className="h-5 w-full" />
+              ) : (
+                <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
               )}
             </div>
-            <div className="flex shrink-0 flex-row items-center gap-1">
-              <Button
-                variant="ghost"
-                className="text-foreground group-hover:text-secondary-foreground/80"
-                disabled={issue === null || issue === undefined || isLifecycleLoading}
-                onClick={() => setLifecycleConfirmAction(issue?.ignoredAt ? "unignore" : "ignore")}
-              >
-                <Icon icon={issue?.ignoredAt ? PlayIcon : PauseIcon} size="sm" />
-                {issue?.ignoredAt ? "Unignore" : "Ignore"}
-              </Button>
-              <Button
-                variant="outline"
-                disabled={issue === null || issue === undefined || isLifecycleLoading}
-                onClick={() => {
-                  if (issue?.resolvedAt) {
-                    setLifecycleConfirmAction("unresolve")
-                    return
-                  }
-
-                  setKeepMonitoring(issue?.keepMonitoringDefault ?? true)
-                  setResolveModalOpen(true)
-                }}
-              >
-                <Icon icon={issue?.resolvedAt ? XIcon : CheckIcon} size="sm" />
-                {issue?.resolvedAt ? "Unresolve" : "Resolve"}
-              </Button>
-            </div>
+            {!isLoading && issue && (
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex min-w-[33%] max-w-max flex-1">
+                  <CopyableText value={issue.slug} size="sm" ellipsis tooltip="Copy issue slug" />
+                </div>
+                {issue.tags.length > 0 && <TagList tags={issue.tags} wrap />}
+              </div>
+            )}
           </div>
         </div>
 
@@ -483,68 +366,6 @@ export function IssueDetailBody({
             onSuccess={clearSelections}
           />
         )}
-
-        <Modal.Root open={resolveModalOpen} onOpenChange={setResolveModalOpen}>
-          <Modal.Content dismissible>
-            <Modal.Header
-              title="Resolve issue"
-              description="Mark this issue as resolved. If this issue starts occurring again we will alert you and promote it as regressed"
-            />
-            {hasActiveLinkedEvaluations ? (
-              <Modal.Body>
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-row items-center justify-between gap-4">
-                    <div className="flex flex-col gap-1">
-                      <Label htmlFor="keep-monitoring-on-resolve">Keep monitoring this issue</Label>
-                      <Text.H6 color="foregroundMuted">
-                        Evaluations monitoring this issue will stay active to detect further regressions
-                      </Text.H6>
-                    </div>
-                    <Switch
-                      id="keep-monitoring-on-resolve"
-                      checked={keepMonitoring}
-                      onCheckedChange={setKeepMonitoring}
-                      disabled={isLifecycleLoading}
-                      aria-label="Keep monitoring this issue"
-                    />
-                  </div>
-                </div>
-              </Modal.Body>
-            ) : null}
-            <Modal.Footer>
-              <Button variant="outline" onClick={() => setResolveModalOpen(false)} disabled={isLifecycleLoading}>
-                Cancel
-              </Button>
-              <Button onClick={() => void runLifecycleCommand("resolve", keepMonitoring)} disabled={isLifecycleLoading}>
-                <Icon icon={CheckIcon} size="sm" />
-                Resolve
-              </Button>
-            </Modal.Footer>
-          </Modal.Content>
-        </Modal.Root>
-
-        <Modal.Root
-          open={lifecycleConfirmAction !== null}
-          onOpenChange={(open) => (!open ? setLifecycleConfirmAction(null) : undefined)}
-        >
-          <Modal.Content dismissible>
-            <Modal.Header
-              title={lifecycleConfirmation?.title ?? "Confirm issue action"}
-              description={lifecycleConfirmation?.description ?? "Are you sure you want to continue?"}
-            />
-            <Modal.Footer>
-              <CloseTrigger />
-              <Button
-                {...(lifecycleConfirmation?.confirmVariant ? { variant: lifecycleConfirmation.confirmVariant } : {})}
-                onClick={() => (lifecycleConfirmAction ? void runLifecycleCommand(lifecycleConfirmAction) : undefined)}
-                disabled={lifecycleConfirmAction === null || isLifecycleLoading}
-              >
-                <Icon icon={lifecycleConfirmation?.confirmIcon ?? XIcon} size="sm" />
-                {lifecycleConfirmation?.confirmLabel ?? "Confirm"}
-              </Button>
-            </Modal.Footer>
-          </Modal.Content>
-        </Modal.Root>
       </div>
 
       <Sheet
@@ -660,6 +481,7 @@ export function IssueDetailDrawer({
           </Tooltip>
         </>
       }
+      rightActions={<IssueLifecycleActions projectId={projectId} issueId={issueId} />}
     >
       <IssueDetailBody projectId={projectId} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
     </DetailDrawer>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-lifecycle-actions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-lifecycle-actions.tsx
@@ -1,0 +1,190 @@
+import { Button, CloseTrigger, Icon, Label, Modal, Switch, Text, useToast } from "@repo/ui"
+import { CheckIcon, PauseIcon, PlayIcon, XIcon } from "lucide-react"
+import { useState } from "react"
+import { invalidateIssueQueries, useIssueDetail } from "../../../../../../domains/issues/issues.collection.ts"
+import { applyIssueLifecycleAction } from "../../../../../../domains/issues/issues.functions.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+
+type LifecycleConfirmationAction = "ignore" | "unignore" | "unresolve"
+
+function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
+  switch (action) {
+    case "ignore":
+      return {
+        title: "Ignore issue",
+        description:
+          "Mark this issue as ignored. We won't monitor or alert you about new occurrences of this issue anymore",
+        confirmLabel: "Ignore",
+        confirmIcon: PauseIcon,
+        confirmVariant: "destructive" as const,
+      }
+    case "unignore":
+      return {
+        title: "Unignore issue",
+        description: "Stop ignoring this issue. New occurrences will surface it again",
+        confirmLabel: "Unignore",
+        confirmIcon: PlayIcon,
+        confirmVariant: undefined,
+      }
+    case "unresolve":
+      return {
+        title: "Unresolve issue",
+        description: "Reopen this issue. New occurrences won't mark this issue as regressed",
+        confirmLabel: "Unresolve",
+        confirmIcon: XIcon,
+        confirmVariant: "destructive" as const,
+      }
+  }
+}
+
+/**
+ * Ignore + Resolve buttons (and their confirmation modals) for an issue.
+ *
+ * Lifted out of the body so both the standalone issue drawer and the
+ * session-panel issue slot can render these in the top toolbar (alongside
+ * next/prev or "View session"), instead of cramming them next to the title.
+ */
+export function IssueLifecycleActions({
+  projectId,
+  issueId,
+}: {
+  readonly projectId: string
+  readonly issueId: string
+}) {
+  const { toast } = useToast()
+  const { data: issue } = useIssueDetail({ projectId, issueId })
+  const [resolveModalOpen, setResolveModalOpen] = useState(false)
+  const [lifecycleConfirmAction, setLifecycleConfirmAction] = useState<LifecycleConfirmationAction | null>(null)
+  const [keepMonitoring, setKeepMonitoring] = useState(true)
+  const [isLifecycleLoading, setIsLifecycleLoading] = useState(false)
+
+  const hasActiveLinkedEvaluations =
+    issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
+  const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
+
+  const runLifecycleCommand = async (command: "resolve" | "unresolve" | "ignore" | "unignore", override?: boolean) => {
+    setIsLifecycleLoading(true)
+    try {
+      await applyIssueLifecycleAction({
+        data: {
+          projectId,
+          issueId,
+          command,
+          ...(override !== undefined ? { keepMonitoring: override } : {}),
+        },
+      })
+      await invalidateIssueQueries(projectId, issueId)
+      toast({
+        description:
+          command === "resolve"
+            ? "Issue resolved."
+            : command === "unresolve"
+              ? "Issue reopened."
+              : command === "ignore"
+                ? "Issue ignored."
+                : "Issue unignored.",
+      })
+      setResolveModalOpen(false)
+      setLifecycleConfirmAction(null)
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        description: toUserMessage(error),
+      })
+    } finally {
+      setIsLifecycleLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        className="text-foreground group-hover:text-secondary-foreground/80"
+        disabled={issue === null || issue === undefined || isLifecycleLoading}
+        onClick={() => setLifecycleConfirmAction(issue?.ignoredAt ? "unignore" : "ignore")}
+      >
+        <Icon icon={issue?.ignoredAt ? PlayIcon : PauseIcon} size="sm" />
+        {issue?.ignoredAt ? "Unignore" : "Ignore"}
+      </Button>
+      <Button
+        variant="outline"
+        disabled={issue === null || issue === undefined || isLifecycleLoading}
+        onClick={() => {
+          if (issue?.resolvedAt) {
+            setLifecycleConfirmAction("unresolve")
+            return
+          }
+
+          setKeepMonitoring(issue?.keepMonitoringDefault ?? true)
+          setResolveModalOpen(true)
+        }}
+      >
+        <Icon icon={issue?.resolvedAt ? XIcon : CheckIcon} size="sm" />
+        {issue?.resolvedAt ? "Unresolve" : "Resolve"}
+      </Button>
+
+      <Modal.Root open={resolveModalOpen} onOpenChange={setResolveModalOpen}>
+        <Modal.Content dismissible>
+          <Modal.Header
+            title="Resolve issue"
+            description="Mark this issue as resolved. If this issue starts occurring again we will alert you and promote it as regressed"
+          />
+          {hasActiveLinkedEvaluations ? (
+            <Modal.Body>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-row items-center justify-between gap-4">
+                  <div className="flex flex-col gap-1">
+                    <Label htmlFor="keep-monitoring-on-resolve">Keep monitoring this issue</Label>
+                    <Text.H6 color="foregroundMuted">
+                      Evaluations monitoring this issue will stay active to detect further regressions
+                    </Text.H6>
+                  </div>
+                  <Switch
+                    id="keep-monitoring-on-resolve"
+                    checked={keepMonitoring}
+                    onCheckedChange={setKeepMonitoring}
+                    disabled={isLifecycleLoading}
+                    aria-label="Keep monitoring this issue"
+                  />
+                </div>
+              </div>
+            </Modal.Body>
+          ) : null}
+          <Modal.Footer>
+            <Button variant="outline" onClick={() => setResolveModalOpen(false)} disabled={isLifecycleLoading}>
+              Cancel
+            </Button>
+            <Button onClick={() => void runLifecycleCommand("resolve", keepMonitoring)} disabled={isLifecycleLoading}>
+              <Icon icon={CheckIcon} size="sm" />
+              Resolve
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+
+      <Modal.Root
+        open={lifecycleConfirmAction !== null}
+        onOpenChange={(open) => (!open ? setLifecycleConfirmAction(null) : undefined)}
+      >
+        <Modal.Content dismissible>
+          <Modal.Header
+            title={lifecycleConfirmation?.title ?? "Confirm issue action"}
+            description={lifecycleConfirmation?.description ?? "Are you sure you want to continue?"}
+          />
+          <Modal.Footer>
+            <CloseTrigger />
+            <Button
+              {...(lifecycleConfirmation?.confirmVariant ? { variant: lifecycleConfirmation.confirmVariant } : {})}
+              onClick={() => (lifecycleConfirmAction ? void runLifecycleCommand(lifecycleConfirmAction) : undefined)}
+              disabled={lifecycleConfirmAction === null || isLifecycleLoading}
+            >
+              <Icon icon={lifecycleConfirmation?.confirmIcon ?? XIcon} size="sm" />
+              {lifecycleConfirmation?.confirmLabel ?? "Confirm"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Resolves [LAT-634](https://linear.app/latitude/issue/LAT-634/improve-issues-lifecycle-actions-display).
- After the LAT-624 session-drawer refactor, Ignore/Resolve drifted into the issue title/description row — looked cramped and off-pattern.
- Extracted `IssueLifecycleActions` (buttons + Resolve & confirm modals) so the standalone issue drawer renders them in `DetailDrawer`'s `rightActions` (alongside next/prev), and the session drawer renders them in `rightActions` (alongside "View session") when an issue is open. The body header card is back to just title / description / slug / tags.

## Test plan
- [x] Open the standalone issues drawer: Ignore & Resolve sit in the top toolbar opposite Close/next/prev. Resolve modal (with "Keep monitoring" switch when there are active evaluations) and the ignore/unignore/unresolve confirmation modal still work.
- [x] In the session drawer, open an issue from the Issues tab: Ignore & Resolve appear in the top toolbar on the right (next to the "View session" back button). Clicking through Ignore/Resolve flows updates the issue and the drawer reflects state.
- [x] Trace-overlay behavior unchanged: clicking a trace from the issue body still opens the side `Sheet`, Escape returns to the issue, parent panel state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)