### PR TITLE
feat(monitors): visual scaffold for the Monitors page [LAT-630]

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -54,6 +54,7 @@ import { Route as AuthenticatedProjectsProjectSlugSettingsRouteImport } from './
 import { Route as AuthenticatedProjectsProjectSlugOnboardingRouteImport } from './routes/_authenticated/projects/$projectSlug/onboarding'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/index'
 import { Route as AuthenticatedProjectsProjectSlugSearchIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/search/index'
+import { Route as AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/index'
 import { Route as AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/datasets/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsOrganizationRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/organization'
@@ -311,6 +312,12 @@ const AuthenticatedProjectsProjectSlugSearchIndexRoute =
     path: '/search/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugMonitorsIndexRoute =
+  AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport.update({
+    id: '/monitors/',
+    path: '/monitors/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugIssuesIndexRoute =
   AuthenticatedProjectsProjectSlugIssuesIndexRouteImport.update({
     id: '/issues/',
@@ -439,6 +446,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/settings/organization': typeof AuthenticatedProjectsProjectSlugSettingsOrganizationRoute
   '/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/monitors/': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/projects/$projectSlug/search/': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/projects/$projectSlug/settings/': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
 }
@@ -493,6 +501,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/settings/organization': typeof AuthenticatedProjectsProjectSlugSettingsOrganizationRoute
   '/projects/$projectSlug/datasets': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/issues': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/monitors': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/projects/$projectSlug/search': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
 }
@@ -553,6 +562,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/settings/organization': typeof AuthenticatedProjectsProjectSlugSettingsOrganizationRoute
   '/_authenticated/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/_authenticated/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/_authenticated/projects/$projectSlug/monitors/': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/_authenticated/projects/$projectSlug/search/': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/_authenticated/projects/$projectSlug/settings/': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
 }
@@ -613,6 +623,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/organization'
     | '/projects/$projectSlug/datasets/'
     | '/projects/$projectSlug/issues/'
+    | '/projects/$projectSlug/monitors/'
     | '/projects/$projectSlug/search/'
     | '/projects/$projectSlug/settings/'
   fileRoutesByTo: FileRoutesByTo
@@ -667,6 +678,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/organization'
     | '/projects/$projectSlug/datasets'
     | '/projects/$projectSlug/issues'
+    | '/projects/$projectSlug/monitors'
     | '/projects/$projectSlug/search'
     | '/projects/$projectSlug/settings'
   id:
@@ -726,6 +738,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/settings/organization'
     | '/_authenticated/projects/$projectSlug/datasets/'
     | '/_authenticated/projects/$projectSlug/issues/'
+    | '/_authenticated/projects/$projectSlug/monitors/'
     | '/_authenticated/projects/$projectSlug/search/'
     | '/_authenticated/projects/$projectSlug/settings/'
   fileRoutesById: FileRoutesById
@@ -1071,6 +1084,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSearchIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/monitors/': {
+      id: '/_authenticated/projects/$projectSlug/monitors/'
+      path: '/monitors'
+      fullPath: '/projects/$projectSlug/monitors/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/issues/': {
       id: '/_authenticated/projects/$projectSlug/issues/'
       path: '/issues'
@@ -1251,6 +1271,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugDatasetsDatasetIdRoute: typeof AuthenticatedProjectsProjectSlugDatasetsDatasetIdRoute
   AuthenticatedProjectsProjectSlugDatasetsIndexRoute: typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  AuthenticatedProjectsProjectSlugMonitorsIndexRoute: typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   AuthenticatedProjectsProjectSlugSearchIndexRoute: typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
 }
 
@@ -1268,6 +1289,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugDatasetsIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIndexRoute:
       AuthenticatedProjectsProjectSlugIssuesIndexRoute,
+    AuthenticatedProjectsProjectSlugMonitorsIndexRoute:
+      AuthenticatedProjectsProjectSlugMonitorsIndexRoute,
     AuthenticatedProjectsProjectSlugSearchIndexRoute:
       AuthenticatedProjectsProjectSlugSearchIndexRoute,
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -7,8 +7,9 @@ import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Outlet, redirect, useRouterState } from "@tanstack/react-router"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
-import { DatabaseIcon, SearchIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
+import { DatabaseIcon, RadarIcon, SearchIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
 import { z } from "zod"
+import { useHasFeatureFlag } from "../../../domains/feature-flags/feature-flags.collection.ts"
 import { useProjectsCollection } from "../../../domains/projects/projects.collection.ts"
 import { type ProjectRecord, rememberLastProjectSlug, toRecord } from "../../../domains/projects/projects.functions.ts"
 import { getLatestWrappedReportForProject } from "../../../domains/wrapped/wrapped.functions.ts"
@@ -74,8 +75,10 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
     pathname.startsWith(`/projects/${projectSlug}/traces`)
   const isSearchActive = pathname.startsWith(`/projects/${projectSlug}/search`)
   const isIssuesActive = pathname.startsWith(`/projects/${projectSlug}/issues`)
+  const isMonitorsActive = pathname.startsWith(`/projects/${projectSlug}/monitors`)
   const isDatasetsActive = pathname.startsWith(`/projects/${projectSlug}/datasets`)
   const isSettingsActive = pathname.startsWith(`/projects/${projectSlug}/settings`)
+  const monitorsEnabled = useHasFeatureFlag("monitors")
 
   // Fire-and-forget client-side fetch: surfaces a sidebar shortcut to this
   // week's Wrapped report when one exists. Returns null for the typical
@@ -136,6 +139,15 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
             active={isIssuesActive}
             collapsed={collapsed}
           />
+          {monitorsEnabled ? (
+            <NavItem
+              icon={RadarIcon}
+              label="Monitors"
+              to={`/projects/${projectSlug}/monitors`}
+              active={isMonitorsActive}
+              collapsed={collapsed}
+            />
+          ) : null}
           <NavItem
             icon={DatabaseIcon}
             label="Datasets"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-empty-state.tsx
@@ -1,0 +1,30 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { ExternalLinkIcon, RadarIcon } from "lucide-react"
+
+export function MonitorsEmptyState({ isLoading = false }: { readonly isLoading?: boolean }) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={RadarIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>{isLoading ? "Loading monitors" : "No monitors yet"}</Text.H3>
+          <Text.H5 color="foregroundMuted" centered>
+            {isLoading
+              ? "Preparing your monitors view."
+              : "Monitors watch your project's issues and searches and open incidents when their alert conditions are met."}
+          </Text.H5>
+        </div>
+        {!isLoading ? (
+          <a href="https://docs.latitude.so/monitors/overview" target="_blank" rel="noopener noreferrer">
+            <Button>
+              <Icon size="sm" icon={ExternalLinkIcon} />
+              Read the docs
+            </Button>
+          </a>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx
@@ -1,0 +1,82 @@
+import { Button, Icon, Input, Text } from "@repo/ui"
+import { createFileRoute } from "@tanstack/react-router"
+import { LockIcon, PlusIcon, SearchIcon } from "lucide-react"
+import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
+import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
+import { MonitorsEmptyState } from "./-components/monitors-empty-state.tsx"
+
+function MonitorsBreadcrumb() {
+  return <BreadcrumbText variant="current">Monitors</BreadcrumbText>
+}
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/monitors/")({
+  staticData: {
+    breadcrumb: MonitorsBreadcrumb,
+  },
+  component: MonitorsPage,
+})
+
+function MonitorsPage() {
+  const monitorsEnabled = useHasFeatureFlag("monitors")
+
+  if (!monitorsEnabled) {
+    return (
+      <Layout>
+        <Layout.Content>
+          <FeatureFlagOffSplash />
+        </Layout.Content>
+      </Layout>
+    )
+  }
+
+  return (
+    <Layout>
+      <Layout.Content>
+        <Layout.Actions>
+          <Layout.ActionsRow>
+            <Layout.ActionRowItem>
+              <div className="relative">
+                <Input
+                  value=""
+                  onChange={() => {}}
+                  placeholder="Search monitors"
+                  size="sm"
+                  className="w-64 pl-8 rounded-lg"
+                  disabled
+                />
+                <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              </div>
+            </Layout.ActionRowItem>
+            <Layout.ActionRowItem>
+              <Button size="sm" disabled>
+                <Icon icon={PlusIcon} size="sm" />
+                New monitor
+              </Button>
+            </Layout.ActionRowItem>
+          </Layout.ActionsRow>
+        </Layout.Actions>
+        <MonitorsEmptyState />
+      </Layout.Content>
+    </Layout>
+  )
+}
+
+function FeatureFlagOffSplash() {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={LockIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>Monitors aren't available yet</Text.H3>
+          <Text.H5 color="foregroundMuted" centered>
+            This feature is rolling out gradually. Reach out to support if you'd like early access for your
+            organization.
+          </Text.H5>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/domain/feature-flags/src/registry.ts
+++ b/packages/domain/feature-flags/src/registry.ts
@@ -41,6 +41,12 @@ export const FEATURE_FLAGS = {
     name: "Timeline incidents overlay",
     description: "Renders the incident overlay on trace and issue timeline histograms.",
   },
+  monitors: {
+    emoji: "📡",
+    name: "Monitors",
+    description:
+      "Unified alerting surface (per-monitor lifecycle, with notification delivery routed through the existing org/project notification settings).",
+  },
 } as const satisfies Record<string, { readonly emoji: string; readonly name: string; readonly description: string }>
 
 export type FeatureFlagId = keyof typeof FEATURE_FLAGS

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -1198,10 +1198,10 @@ The first milestones prioritise **visible progress**: M1 ships the sidebar entry
 
 **Goal:** A stakeholder enables the `monitors` flag for their org and sees a new "Monitors" item in the project sidebar that leads to an empty page with a "No monitors yet" empty state. Zero backend wiring.
 
-- [ ] Register `monitors` in `packages/domain/feature-flags/src/registry.ts`.
-- [ ] Add the `Monitors` nav item in `apps/web/src/routes/_authenticated/projects/$projectSlug.tsx` (`ProjectSidebar`), positioned between Issues and Datasets, gated by `useHasFeatureFlag("monitors")`.
-- [ ] Create `apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx` with the `ListingLayout` shell, empty toolbar (search input + disabled "+ New monitor" button), and an empty state component (`monitors-empty-state.tsx`).
-- [ ] Frontend feature-flag gate on the route: "Not available" splash if the flag is off (no longer a borrowable pattern in the codebase — `session-search-v2` was removed in #3320; implement as a small consistent helper).
+- [x] Register `monitors` in `packages/domain/feature-flags/src/registry.ts`.
+- [x] Add the `Monitors` nav item in `apps/web/src/routes/_authenticated/projects/$projectSlug.tsx` (`ProjectSidebar`), positioned between Issues and Datasets, gated by `useHasFeatureFlag("monitors")`.
+- [x] Create `apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx` with the `ListingLayout` shell, empty toolbar (search input + disabled "+ New monitor" button), and an empty state component (`monitors-empty-state.tsx`).
+- [x] Frontend feature-flag gate on the route: "Not available" splash if the flag is off (no longer a borrowable pattern in the codebase — `session-search-v2` was removed in #3320; implement as a small consistent helper).
 
 ### Milestone 2 — Backend foundation: schema, entities, repository, list/get use-cases
 


### PR DESCRIPTION
First milestone of the Monitors feature ([spec](specs/monitors.md)). Pure
visual scaffold — no backend wiring, no data, no use-cases.

## Summary

- Registers a new `monitors` feature flag in `@domain/feature-flags`.
- Adds a `Monitors` entry to the project sidebar (between Issues and
  Datasets, `RadarIcon`), gated by `useHasFeatureFlag("monitors")` so it
  stays hidden for orgs without the flag.
- New route at `/projects/{slug}/monitors`:
  - When the flag is **on**: `ListingLayout` shell with a disabled
    search input + disabled "+ New monitor" button, and the new
    `MonitorsEmptyState` ("No monitors yet").
  - When the flag is **off** (or the user lands on the route directly):
    a "Monitors aren't available yet" splash.

The disabled toolbar controls and the empty state are placeholders that
will become live in M2 (backend foundation) and M5 (create flow). The
docs link in the empty state currently 404s — it lands as part of M10.
