### PR TITLE
fix(taxonomy): freeze clock in taxonomy worker tests

### DIFF
--- a/apps/workers/src/workers/taxonomy.test.ts
+++ b/apps/workers/src/workers/taxonomy.test.ts
@@ -22,7 +22,7 @@ import {
 } from "@platform/db-postgres"
 import { setupTestClickHouse, setupTestPostgres } from "@platform/testkit"
 import { Effect, Layer } from "effect"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const { mockAi, testEmbedding } = vi.hoisted(() => {
   const embedding = new Array(2048).fill(0)
@@ -264,6 +264,15 @@ const listLatestTaxonomyRun = () =>
   )
 
 describe("taxonomy observeSession worker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(START_TIME)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("writes a noise observation when no active clusters exist", async () => {
     const traceId = TRACE_ID
     await insertSessionSpan(traceId, SESSION_ID)


### PR DESCRIPTION
## Summary
- The e2e gardening test in `apps/workers/src/workers/taxonomy.test.ts` was time-dependent: noise observations were seeded at a fixed `START_TIME = 2026-05-24` and relied on wall-clock `Date.now()` falling within the 7-day `listNoise` lookback used by `runProjectGardeningUseCase`.
- Once more than 7 days passed (test broke starting 2026-05-31), the observations dropped out of the lookback, no cluster was born, and `firstPass.clusters` assertion at line 413 failed with `expected [] to have a length of 1`.
- Fix: pin `Date` to `START_TIME` via `vi.setSystemTime` in `beforeEach` / restore in `afterEach`. No production code changes.

## Test plan
- [x] `pnpm exec vitest run src/workers/taxonomy.test.ts` from `apps/workers` — all 6 tests pass
- [x] `pnpm --filter @app/workers typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)