### PR TITLE
fix(infinite-table): right-align string cells when column align is end [LAT-633]

### DIFF
--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -174,7 +174,12 @@ function DataRowInner<T>({
           >
             {isFirstCol && renderRowLink ? renderRowLink(row, { className: LINK_STRETCH_CLASS }) : null}
             {typeof content === "string" ? (
-              <Text.H5 {...(useEllipsis ? { noWrap: true, ellipsis: true } : {})}>{content || "-"}</Text.H5>
+              <Text.H5
+                {...(useEllipsis ? { noWrap: true, ellipsis: true } : {})}
+                {...(col.align === "end" ? { align: "right" } : {})}
+              >
+                {content || "-"}
+              </Text.H5>
             ) : (
               content
             )}


### PR DESCRIPTION
## Summary

- Columns declared with `align: "end"` had right-aligned headers but left-aligned values. The `<td>` gets `text-right`, but `data-row.tsx` auto-wraps string-returning renders in `Text.H5`, and `Text.H5` always emits an explicit `text-left` class (its `align` prop defaults to `"left"`), which overrode the inherited alignment.
- Forwards `align="right"` to the wrapper `Text.H5` when `col.align === "end"`, so values line up with the header (e.g. Issues table "Occurrences" and "Affected traces").

## Test plan

- [x] Open the Issues page; confirm "Occurrences" and "Affected traces" values are right-aligned and line up with their headers.
- [x] Spot-check other `InfiniteTable` usages with `align: "end"` columns to confirm no regressions in left-aligned columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)