### PR TITLE
feat(monitors): monitor + alert mutation use-cases [LAT-630]

### DIFF
--- a/packages/domain/monitors/package.json
+++ b/packages/domain/monitors/package.json
@@ -6,7 +6,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "scripts": {
     "check": "biome check src",

--- a/packages/domain/monitors/src/errors.ts
+++ b/packages/domain/monitors/src/errors.ts
@@ -1,0 +1,39 @@
+import { Data } from "effect"
+
+/**
+ * A structurally-locked operation (delete, rename/description edit, alter the
+ * alert set) was attempted on a system monitor. System monitors only allow
+ * mute/unmute and editing an existing alert's configurable values.
+ */
+export class SystemMonitorForbiddenError extends Data.TaggedError("SystemMonitorForbiddenError")<{
+  readonly monitorId: string
+  readonly operation: string
+}> {
+  readonly httpStatus = 403
+  get httpMessage() {
+    return `System monitors cannot be ${this.operation}`
+  }
+}
+
+/** The alert id targeted by `updateMonitorAlertUseCase` is not a live alert of the monitor. */
+export class MonitorAlertNotFoundError extends Data.TaggedError("MonitorAlertNotFoundError")<{
+  readonly monitorId: string
+  readonly alertId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "Monitor alert not found"
+}
+
+/**
+ * A new condition's `kind` does not match the alert's `kind` (kind/source are
+ * immutable — only configurable values may change), or the alert's kind has no
+ * configurable values (`issue.new`, `issue.regressed`, `savedSearch.match`).
+ */
+export class AlertConditionMismatchError extends Data.TaggedError("AlertConditionMismatchError")<{
+  readonly message: string
+}> {
+  readonly httpStatus = 400
+  get httpMessage() {
+    return this.message
+  }
+}

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -1,5 +1,10 @@
 export type { Monitor, MonitorAlert } from "./entities/monitor.ts"
 export { monitorAlertSchema, monitorSchema } from "./entities/monitor.ts"
+export {
+  AlertConditionMismatchError,
+  MonitorAlertNotFoundError,
+  SystemMonitorForbiddenError,
+} from "./errors.ts"
 export { formatHumanReadableAlert, type HumanReadableAlertContext } from "./helpers.ts"
 export type {
   ListMonitorsRepositoryInput,
@@ -12,6 +17,8 @@ export type {
   SystemMonitorDefinition,
 } from "./system-monitors.ts"
 export { SYSTEM_MONITOR_DEFINITIONS } from "./system-monitors.ts"
+export type { DeleteMonitorError, DeleteMonitorInput } from "./use-cases/delete-monitor.ts"
+export { deleteMonitorUseCase } from "./use-cases/delete-monitor.ts"
 export type { GetMonitorBySlugInput } from "./use-cases/get-monitor-by-slug.ts"
 export { getMonitorBySlugUseCase } from "./use-cases/get-monitor-by-slug.ts"
 export type {
@@ -26,8 +33,14 @@ export {
   listMonitorsUseCase,
   MAX_MONITORS_PAGE_SIZE,
 } from "./use-cases/list-monitors.ts"
+export type { SetMonitorMuteError, SetMonitorMuteInput } from "./use-cases/mute-monitor.ts"
+export { muteMonitorUseCase, unmuteMonitorUseCase } from "./use-cases/mute-monitor.ts"
 export type {
   ProvisionSystemMonitorsError,
   ProvisionSystemMonitorsInput,
 } from "./use-cases/provision-system-monitors.ts"
 export { provisionSystemMonitorsUseCase } from "./use-cases/provision-system-monitors.ts"
+export type { UpdateMonitorError, UpdateMonitorInput } from "./use-cases/update-monitor.ts"
+export { updateMonitorUseCase } from "./use-cases/update-monitor.ts"
+export type { UpdateMonitorAlertError, UpdateMonitorAlertInput } from "./use-cases/update-monitor-alert.ts"
+export { updateMonitorAlertUseCase } from "./use-cases/update-monitor-alert.ts"

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -1,4 +1,13 @@
-import type { MonitorId, NotFoundError, ProjectId, RepositoryError, SqlClient } from "@domain/shared"
+import type {
+  AlertIncidentCondition,
+  AlertSeverity,
+  MonitorAlertId,
+  MonitorId,
+  NotFoundError,
+  ProjectId,
+  RepositoryError,
+  SqlClient,
+} from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { Monitor } from "../entities/monitor.ts"
 
@@ -34,6 +43,33 @@ export interface MonitorRepositoryShape {
    * returns `[]`.
    */
   provisionSystemMonitors(monitors: readonly Monitor[]): Effect.Effect<readonly Monitor[], RepositoryError, SqlClient>
+  /** Set or clear `mutedAt` on a live monitor. Fails `NotFoundError` if it doesn't exist. */
+  setMuted(input: {
+    readonly id: MonitorId
+    readonly mutedAt: Date | null
+  }): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
+  /** Soft-delete a live monitor and cascade `deletedAt` to its live alerts (so firing stops; incident history stays joinable). */
+  softDelete(id: MonitorId): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
+  /** Update a live monitor's name/slug/description. Caller resolves the slug. */
+  updateMetadata(input: {
+    readonly id: MonitorId
+    readonly name: string
+    readonly slug: string
+    readonly description: string
+  }): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
+  /** Update a live alert's `source.id` / `condition` / `severity` in place (kind + source type are fixed). */
+  updateAlert(input: {
+    readonly alertId: MonitorAlertId
+    readonly sourceId: string | null
+    readonly condition: AlertIncidentCondition | null
+    readonly severity: AlertSeverity
+  }): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
+  /** Count live monitors in a project holding `slug`, excluding `excludeId` — backs slug regeneration. */
+  countActiveBySlug(input: {
+    readonly projectId: ProjectId
+    readonly slug: string
+    readonly excludeId: MonitorId
+  }): Effect.Effect<number, RepositoryError, SqlClient>
 }
 
 export class MonitorRepository extends Context.Service<MonitorRepository, MonitorRepositoryShape>()(

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -1,0 +1,106 @@
+import { NotFoundError } from "@domain/shared"
+import { Effect } from "effect"
+import type { Monitor } from "../entities/monitor.ts"
+import type { MonitorListPage, MonitorRepositoryShape } from "../ports/monitor-repository.ts"
+
+const isLive = (monitor: Monitor) => monitor.deletedAt === null
+
+/**
+ * In-memory MonitorRepository for unit tests. Seed via the argument and
+ * assert against the returned `monitors` array, which mutations write
+ * through. Mirrors the live repo's org/slug/deleted-aware semantics: reads
+ * ignore soft-deleted rows; `provisionSystemMonitors` inserts only missing
+ * `(projectId, slug)`; `countActiveBySlug` excludes the target + deleted rows;
+ * `updateAlert` patches the alert across whichever live monitor owns it.
+ *
+ * The alert-level `deleted_at` cascade on `softDelete` isn't modelled — the
+ * `MonitorAlert` entity has no `deletedAt`; the fake just marks the monitor.
+ */
+export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
+  const monitors: Monitor[] = [...seed]
+
+  const liveById = (id: string) => monitors.find((monitor) => monitor.id === id && isLive(monitor))
+  const replace = (id: string, next: Monitor) => {
+    const index = monitors.findIndex((monitor) => monitor.id === id)
+    if (index >= 0) monitors[index] = next
+  }
+
+  const repo: MonitorRepositoryShape = {
+    findById: (id) =>
+      Effect.suspend(() => {
+        const monitor = liveById(id)
+        return monitor ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id }))
+      }),
+    findBySlug: ({ projectId, slug }) =>
+      Effect.suspend(() => {
+        const monitor = monitors.find((m) => m.projectId === projectId && m.slug === slug && isLive(m))
+        return monitor ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id: slug }))
+      }),
+    list: ({ projectId, limit, offset, searchQuery }) =>
+      Effect.sync<MonitorListPage>(() => {
+        const query = searchQuery?.toLowerCase()
+        const all = monitors
+          .filter((m) => m.projectId === projectId && isLive(m))
+          .filter((m) => (query ? m.name.toLowerCase().includes(query) : true))
+          .sort((a, b) => {
+            if (a.system !== b.system) return a.system ? -1 : 1
+            if (a.createdAt.getTime() !== b.createdAt.getTime()) return b.createdAt.getTime() - a.createdAt.getTime()
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+          })
+        const items = all.slice(offset, offset + limit)
+        return { items, totalCount: all.length, hasMore: offset + items.length < all.length, limit, offset }
+      }),
+    provisionSystemMonitors: (toProvision) =>
+      Effect.sync(() => {
+        const inserted: Monitor[] = []
+        for (const monitor of toProvision) {
+          if (monitors.some((m) => m.projectId === monitor.projectId && m.slug === monitor.slug && isLive(m))) continue
+          monitors.push(monitor)
+          inserted.push(monitor)
+        }
+        return inserted
+      }),
+    setMuted: ({ id, mutedAt }) =>
+      Effect.suspend(() => {
+        const monitor = liveById(id)
+        if (!monitor) return Effect.fail(new NotFoundError({ entity: "Monitor", id }))
+        replace(id, { ...monitor, mutedAt, updatedAt: new Date() })
+        return Effect.void
+      }),
+    softDelete: (id) =>
+      Effect.suspend(() => {
+        const monitor = liveById(id)
+        if (!monitor) return Effect.fail(new NotFoundError({ entity: "Monitor", id }))
+        const now = new Date()
+        replace(id, { ...monitor, deletedAt: now, updatedAt: now })
+        return Effect.void
+      }),
+    updateMetadata: ({ id, name, slug, description }) =>
+      Effect.suspend(() => {
+        const monitor = liveById(id)
+        if (!monitor) return Effect.fail(new NotFoundError({ entity: "Monitor", id }))
+        replace(id, { ...monitor, name, slug, description, updatedAt: new Date() })
+        return Effect.void
+      }),
+    updateAlert: ({ alertId, sourceId, condition, severity }) =>
+      Effect.suspend(() => {
+        const monitor = monitors.find((m) => isLive(m) && m.alerts.some((alert) => alert.id === alertId))
+        if (!monitor) return Effect.fail(new NotFoundError({ entity: "MonitorAlert", id: alertId }))
+        replace(monitor.id, {
+          ...monitor,
+          alerts: monitor.alerts.map((alert) =>
+            alert.id === alertId ? { ...alert, source: { ...alert.source, id: sourceId }, condition, severity } : alert,
+          ),
+        })
+        return Effect.void
+      }),
+    countActiveBySlug: ({ projectId, slug, excludeId }) =>
+      Effect.sync(
+        () =>
+          monitors.filter((m) => m.projectId === projectId && m.slug === slug && m.id !== excludeId && isLive(m))
+            .length,
+      ),
+  }
+
+  return { repo, monitors }
+}

--- a/packages/domain/monitors/src/testing/index.ts
+++ b/packages/domain/monitors/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { createFakeMonitorRepository } from "./fake-monitor-repository.ts"

--- a/packages/domain/monitors/src/use-cases/delete-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/delete-monitor.test.ts
@@ -1,0 +1,69 @@
+import { deleteMonitorUseCase, type Monitor, MonitorRepository, type MonitorRepositoryShape } from "@domain/monitors"
+import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const monitorId = MonitorId("m".repeat(24))
+const at = new Date("2026-06-01T10:00:00.000Z")
+
+const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
+  id: monitorId,
+  organizationId,
+  projectId,
+  slug: "my-monitor",
+  name: "My monitor",
+  description: "",
+  system: overrides.system ?? false,
+  alerts: [],
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: at,
+  updatedAt: at,
+})
+
+const buildRepo = (monitor: Monitor) => {
+  const calls = { softDelete: [] as string[] }
+  const repo: MonitorRepositoryShape = {
+    findById: (id) =>
+      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
+    findBySlug: () => Effect.die("findBySlug not used"),
+    list: () => Effect.die("list not used"),
+    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
+    setMuted: () => Effect.die("setMuted not used"),
+    softDelete: (id) => {
+      calls.softDelete.push(id)
+      return Effect.void
+    },
+    updateMetadata: () => Effect.die("updateMetadata not used"),
+    updateAlert: () => Effect.die("updateAlert not used"),
+    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
+  }
+  return { repo, calls }
+}
+
+const provide = (repo: MonitorRepositoryShape) =>
+  Layer.mergeAll(
+    Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+  )
+
+describe("deleteMonitorUseCase", () => {
+  it("soft-deletes a user monitor", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ system: false }))
+    const result = await Effect.runPromise(deleteMonitorUseCase({ id: monitorId }).pipe(Effect.provide(provide(repo))))
+    expect(result.deletedAt).toBeInstanceOf(Date)
+    expect(calls.softDelete).toEqual([monitorId])
+  })
+
+  it("rejects deleting a system monitor and does not call the repo", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ system: true }))
+    const error = await Effect.runPromise(
+      deleteMonitorUseCase({ id: monitorId }).pipe(Effect.flip, Effect.provide(provide(repo))),
+    )
+    expect(error._tag).toBe("SystemMonitorForbiddenError")
+    expect(calls.softDelete).toEqual([])
+  })
+})

--- a/packages/domain/monitors/src/use-cases/delete-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/delete-monitor.test.ts
@@ -1,8 +1,10 @@
-import { deleteMonitorUseCase, type Monitor, MonitorRepository, type MonitorRepositoryShape } from "@domain/monitors"
-import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { deleteMonitorUseCase, type Monitor, MonitorRepository } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { MonitorId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+import type { MonitorRepositoryShape } from "../ports/monitor-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -24,26 +26,6 @@ const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
   updatedAt: at,
 })
 
-const buildRepo = (monitor: Monitor) => {
-  const calls = { softDelete: [] as string[] }
-  const repo: MonitorRepositoryShape = {
-    findById: (id) =>
-      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
-    findBySlug: () => Effect.die("findBySlug not used"),
-    list: () => Effect.die("list not used"),
-    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
-    setMuted: () => Effect.die("setMuted not used"),
-    softDelete: (id) => {
-      calls.softDelete.push(id)
-      return Effect.void
-    },
-    updateMetadata: () => Effect.die("updateMetadata not used"),
-    updateAlert: () => Effect.die("updateAlert not used"),
-    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
-  }
-  return { repo, calls }
-}
-
 const provide = (repo: MonitorRepositoryShape) =>
   Layer.mergeAll(
     Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
@@ -52,18 +34,18 @@ const provide = (repo: MonitorRepositoryShape) =>
 
 describe("deleteMonitorUseCase", () => {
   it("soft-deletes a user monitor", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ system: false }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ system: false })])
     const result = await Effect.runPromise(deleteMonitorUseCase({ id: monitorId }).pipe(Effect.provide(provide(repo))))
     expect(result.deletedAt).toBeInstanceOf(Date)
-    expect(calls.softDelete).toEqual([monitorId])
+    expect(monitors[0]?.deletedAt).toBeInstanceOf(Date)
   })
 
-  it("rejects deleting a system monitor and does not call the repo", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ system: true }))
+  it("rejects deleting a system monitor and leaves it untouched", async () => {
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ system: true })])
     const error = await Effect.runPromise(
       deleteMonitorUseCase({ id: monitorId }).pipe(Effect.flip, Effect.provide(provide(repo))),
     )
     expect(error._tag).toBe("SystemMonitorForbiddenError")
-    expect(calls.softDelete).toEqual([])
+    expect(monitors[0]?.deletedAt).toBeNull()
   })
 })

--- a/packages/domain/monitors/src/use-cases/delete-monitor.ts
+++ b/packages/domain/monitors/src/use-cases/delete-monitor.ts
@@ -1,0 +1,35 @@
+import { type MonitorId, type NotFoundError, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { Monitor } from "../entities/monitor.ts"
+import { SystemMonitorForbiddenError } from "../errors.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+
+export interface DeleteMonitorInput {
+  readonly id: MonitorId
+}
+
+export type DeleteMonitorError = NotFoundError | RepositoryError | SystemMonitorForbiddenError
+
+/**
+ * Soft-deletes a user monitor (and cascades `deletedAt` to its alerts, so it
+ * stops firing while existing incidents stay attributable). Rejects system
+ * monitors — they're structurally locked.
+ */
+export const deleteMonitorUseCase = (
+  input: DeleteMonitorInput,
+): Effect.Effect<Monitor, DeleteMonitorError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const repository = yield* MonitorRepository
+        const monitor = yield* repository.findById(input.id)
+        if (monitor.system) {
+          return yield* new SystemMonitorForbiddenError({ monitorId: input.id, operation: "deleted" })
+        }
+        const now = new Date()
+        yield* repository.softDelete(input.id)
+        return { ...monitor, deletedAt: now, updatedAt: now }
+      }),
+    )
+  })

--- a/packages/domain/monitors/src/use-cases/mute-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/mute-monitor.test.ts
@@ -1,14 +1,10 @@
-import {
-  type Monitor,
-  MonitorRepository,
-  type MonitorRepositoryShape,
-  muteMonitorUseCase,
-  unmuteMonitorUseCase,
-} from "@domain/monitors"
-import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { type Monitor, MonitorRepository, muteMonitorUseCase, unmuteMonitorUseCase } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { MonitorId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+import type { MonitorRepositoryShape } from "../ports/monitor-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -30,26 +26,6 @@ const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
   updatedAt: at,
 })
 
-const buildRepo = (monitor: Monitor) => {
-  const calls = { setMuted: [] as { id: string; mutedAt: Date | null }[] }
-  const repo: MonitorRepositoryShape = {
-    findById: (id) =>
-      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
-    findBySlug: () => Effect.die("findBySlug not used"),
-    list: () => Effect.die("list not used"),
-    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
-    setMuted: (input) => {
-      calls.setMuted.push(input)
-      return Effect.void
-    },
-    softDelete: () => Effect.die("softDelete not used"),
-    updateMetadata: () => Effect.die("updateMetadata not used"),
-    updateAlert: () => Effect.die("updateAlert not used"),
-    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
-  }
-  return { repo, calls }
-}
-
 const run = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
   Effect.runPromise(
     effect.pipe(
@@ -64,16 +40,16 @@ const run = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, r
 
 describe("muteMonitorUseCase / unmuteMonitorUseCase", () => {
   it("sets mutedAt on mute (user or system monitor)", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ system: true }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ system: true })])
     const result = await run(muteMonitorUseCase({ id: monitorId }), repo)
     expect(result.mutedAt).toBeInstanceOf(Date)
-    expect(calls.setMuted[0]?.mutedAt).toBeInstanceOf(Date)
+    expect(monitors[0]?.mutedAt).toBeInstanceOf(Date)
   })
 
   it("clears mutedAt on unmute", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ mutedAt: at }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ mutedAt: at })])
     const result = await run(unmuteMonitorUseCase({ id: monitorId }), repo)
     expect(result.mutedAt).toBeNull()
-    expect(calls.setMuted[0]?.mutedAt).toBeNull()
+    expect(monitors[0]?.mutedAt).toBeNull()
   })
 })

--- a/packages/domain/monitors/src/use-cases/mute-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/mute-monitor.test.ts
@@ -1,0 +1,79 @@
+import {
+  type Monitor,
+  MonitorRepository,
+  type MonitorRepositoryShape,
+  muteMonitorUseCase,
+  unmuteMonitorUseCase,
+} from "@domain/monitors"
+import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const monitorId = MonitorId("m".repeat(24))
+const at = new Date("2026-06-01T10:00:00.000Z")
+
+const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
+  id: monitorId,
+  organizationId,
+  projectId,
+  slug: "my-monitor",
+  name: "My monitor",
+  description: "",
+  system: overrides.system ?? false,
+  alerts: [],
+  mutedAt: overrides.mutedAt ?? null,
+  deletedAt: null,
+  createdAt: at,
+  updatedAt: at,
+})
+
+const buildRepo = (monitor: Monitor) => {
+  const calls = { setMuted: [] as { id: string; mutedAt: Date | null }[] }
+  const repo: MonitorRepositoryShape = {
+    findById: (id) =>
+      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
+    findBySlug: () => Effect.die("findBySlug not used"),
+    list: () => Effect.die("list not used"),
+    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
+    setMuted: (input) => {
+      calls.setMuted.push(input)
+      return Effect.void
+    },
+    softDelete: () => Effect.die("softDelete not used"),
+    updateMetadata: () => Effect.die("updateMetadata not used"),
+    updateAlert: () => Effect.die("updateAlert not used"),
+    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
+  }
+  return { repo, calls }
+}
+
+const run = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  )
+
+describe("muteMonitorUseCase / unmuteMonitorUseCase", () => {
+  it("sets mutedAt on mute (user or system monitor)", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ system: true }))
+    const result = await run(muteMonitorUseCase({ id: monitorId }), repo)
+    expect(result.mutedAt).toBeInstanceOf(Date)
+    expect(calls.setMuted[0]?.mutedAt).toBeInstanceOf(Date)
+  })
+
+  it("clears mutedAt on unmute", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ mutedAt: at }))
+    const result = await run(unmuteMonitorUseCase({ id: monitorId }), repo)
+    expect(result.mutedAt).toBeNull()
+    expect(calls.setMuted[0]?.mutedAt).toBeNull()
+  })
+})

--- a/packages/domain/monitors/src/use-cases/mute-monitor.ts
+++ b/packages/domain/monitors/src/use-cases/mute-monitor.ts
@@ -1,0 +1,33 @@
+import { type MonitorId, type NotFoundError, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { Monitor } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+
+export interface SetMonitorMuteInput {
+  readonly id: MonitorId
+}
+
+export type SetMonitorMuteError = NotFoundError | RepositoryError
+
+// Mute/unmute are allowed on both system and user monitors — muting a monitor
+// is the per-monitor replacement for the legacy per-kind notification toggles.
+const setMute = (
+  id: MonitorId,
+  muted: boolean,
+): Effect.Effect<Monitor, SetMonitorMuteError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const repository = yield* MonitorRepository
+        const monitor = yield* repository.findById(id)
+        const now = new Date()
+        const mutedAt = muted ? now : null
+        yield* repository.setMuted({ id, mutedAt })
+        return { ...monitor, mutedAt, updatedAt: now }
+      }),
+    )
+  })
+
+export const muteMonitorUseCase = (input: SetMonitorMuteInput) => setMute(input.id, true)
+export const unmuteMonitorUseCase = (input: SetMonitorMuteInput) => setMute(input.id, false)

--- a/packages/domain/monitors/src/use-cases/provision-system-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/provision-system-monitors.test.ts
@@ -20,6 +20,11 @@ const buildRepo = () => {
       calls.push(monitors)
       return Effect.succeed(monitors)
     },
+    setMuted: () => Effect.die("setMuted not used"),
+    softDelete: () => Effect.die("softDelete not used"),
+    updateMetadata: () => Effect.die("updateMetadata not used"),
+    updateAlert: () => Effect.die("updateAlert not used"),
+    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
   }
   return { repo, calls }
 }

--- a/packages/domain/monitors/src/use-cases/provision-system-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/provision-system-monitors.test.ts
@@ -1,33 +1,13 @@
-import { type Monitor, MonitorRepository, type MonitorRepositoryShape } from "@domain/monitors"
+import { MonitorRepository, provisionSystemMonitorsUseCase } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
 import { OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
-import { provisionSystemMonitorsUseCase } from "./provision-system-monitors.ts"
+import type { MonitorRepositoryShape } from "../ports/monitor-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
-
-const buildRepo = () => {
-  const calls: (readonly Monitor[])[] = []
-  const repo: MonitorRepositoryShape = {
-    findById: () => Effect.die("findById not used"),
-    findBySlug: () => Effect.die("findBySlug not used"),
-    list: () => Effect.die("list not used"),
-    // Echo the input — the use-case's job is to build the right entities; the
-    // idempotency/skip logic is the repository's and is tested against PGlite.
-    provisionSystemMonitors: (monitors) => {
-      calls.push(monitors)
-      return Effect.succeed(monitors)
-    },
-    setMuted: () => Effect.die("setMuted not used"),
-    softDelete: () => Effect.die("softDelete not used"),
-    updateMetadata: () => Effect.die("updateMetadata not used"),
-    updateAlert: () => Effect.die("updateAlert not used"),
-    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
-  }
-  return { repo, calls }
-}
 
 const run = (repo: MonitorRepositoryShape) =>
   Effect.runPromise(
@@ -43,11 +23,11 @@ const run = (repo: MonitorRepositoryShape) =>
 
 describe("provisionSystemMonitorsUseCase", () => {
   it("builds the three system monitors with org/project scoping, unmuted and system=true", async () => {
-    const { repo, calls } = buildRepo()
+    const { repo, monitors } = createFakeMonitorRepository()
     const result = await run(repo)
 
-    expect(calls.length).toBe(1)
     expect(result.map((m) => m.slug)).toEqual(["issue-discovered", "issue-regressed", "issue-escalating"])
+    expect(monitors.length).toBe(3)
     for (const monitor of result) {
       expect(monitor.system).toBe(true)
       expect(monitor.organizationId).toBe(organizationId)
@@ -61,7 +41,7 @@ describe("provisionSystemMonitorsUseCase", () => {
   })
 
   it("derives alert severity from kind and provisions the escalating sensitivity default", async () => {
-    const { repo } = buildRepo()
+    const { repo } = createFakeMonitorRepository()
     const result = await run(repo)
 
     const bySlug = new Map(result.map((m) => [m.slug, m]))
@@ -80,5 +60,14 @@ describe("provisionSystemMonitorsUseCase", () => {
       severity: "high",
       condition: { kind: "issue.escalating", sensitivity: 3 },
     })
+  })
+
+  it("is idempotent — re-provisioning an already-seeded project inserts nothing", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    await run(repo)
+    const secondRun = await run(repo)
+
+    expect(secondRun).toEqual([])
+    expect(monitors.length).toBe(3)
   })
 })

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.test.ts
@@ -1,0 +1,166 @@
+import {
+  type Monitor,
+  type MonitorAlert,
+  MonitorRepository,
+  type MonitorRepositoryShape,
+  updateMonitorAlertUseCase,
+} from "@domain/monitors"
+import { MonitorAlertId, MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const monitorId = MonitorId("m".repeat(24))
+const alertId = MonitorAlertId("x".repeat(24))
+const at = new Date("2026-06-01T10:00:00.000Z")
+
+const makeAlert = (overrides: Partial<MonitorAlert> & { kind: MonitorAlert["kind"] }): MonitorAlert => ({
+  id: alertId,
+  monitorId,
+  kind: overrides.kind,
+  source: overrides.source ?? { type: "issue", id: null },
+  condition: overrides.condition ?? null,
+  severity: overrides.severity ?? "high",
+  createdAt: at,
+})
+
+const makeMonitor = (overrides: Partial<Monitor> & { alerts: readonly MonitorAlert[] }): Monitor => ({
+  id: monitorId,
+  organizationId,
+  projectId,
+  slug: "my-monitor",
+  name: "My monitor",
+  description: "",
+  system: overrides.system ?? false,
+  alerts: overrides.alerts,
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: at,
+  updatedAt: at,
+})
+
+const buildRepo = (monitor: Monitor) => {
+  const calls = {
+    updateAlert: [] as { alertId: string; sourceId: string | null; condition: unknown; severity: string }[],
+  }
+  const repo: MonitorRepositoryShape = {
+    findById: (id) =>
+      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
+    findBySlug: () => Effect.die("findBySlug not used"),
+    list: () => Effect.die("list not used"),
+    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
+    setMuted: () => Effect.die("setMuted not used"),
+    softDelete: () => Effect.die("softDelete not used"),
+    updateMetadata: () => Effect.die("updateMetadata not used"),
+    updateAlert: (input) => {
+      calls.updateAlert.push(input)
+      return Effect.void
+    },
+    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
+  }
+  return { repo, calls }
+}
+
+const provide = (repo: MonitorRepositoryShape) =>
+  Layer.mergeAll(
+    Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+  )
+
+const run = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
+  Effect.runPromise(effect.pipe(Effect.provide(provide(repo))))
+
+const runError = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
+  Effect.runPromise(effect.pipe(Effect.flip, Effect.provide(provide(repo))))
+
+const escalatingMonitor = (system: boolean) =>
+  makeMonitor({
+    system,
+    alerts: [makeAlert({ kind: "issue.escalating", condition: { kind: "issue.escalating", sensitivity: 3 } })],
+  })
+
+describe("updateMonitorAlertUseCase", () => {
+  it("updates an issue.escalating alert's sensitivity in place (system monitor allowed)", async () => {
+    const { repo, calls } = buildRepo(escalatingMonitor(true))
+    const result = await run(
+      updateMonitorAlertUseCase({ monitorId, alertId, condition: { kind: "issue.escalating", sensitivity: 5 } }),
+      repo,
+    )
+    expect(result.alerts[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 5 })
+    expect(calls.updateAlert[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 5 })
+  })
+
+  it("lets a user monitor change a saved-search alert's source, condition and severity", async () => {
+    const monitor = makeMonitor({
+      alerts: [
+        makeAlert({
+          kind: "savedSearch.threshold",
+          source: { type: "savedSearch", id: "s".repeat(24) },
+          condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 100 } },
+          severity: "medium",
+        }),
+      ],
+    })
+    const { repo, calls } = buildRepo(monitor)
+    const result = await run(
+      updateMonitorAlertUseCase({
+        monitorId,
+        alertId,
+        source: { type: "savedSearch", id: "t".repeat(24) },
+        condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 250 } },
+        severity: "high",
+      }),
+      repo,
+    )
+    expect(result.alerts[0]?.source.id).toBe("t".repeat(24))
+    expect(result.alerts[0]?.severity).toBe("high")
+    expect(calls.updateAlert[0]).toMatchObject({ sourceId: "t".repeat(24), severity: "high" })
+  })
+
+  it("rejects a condition whose kind does not match the alert", async () => {
+    const { repo, calls } = buildRepo(escalatingMonitor(false))
+    const error = await runError(
+      updateMonitorAlertUseCase({
+        monitorId,
+        alertId,
+        condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 100 } },
+      }),
+      repo,
+    )
+    expect(error._tag).toBe("AlertConditionMismatchError")
+    expect(calls.updateAlert).toEqual([])
+  })
+
+  it("rejects changing the severity of a system monitor's alert", async () => {
+    const { repo, calls } = buildRepo(escalatingMonitor(true))
+    const error = await runError(updateMonitorAlertUseCase({ monitorId, alertId, severity: "low" }), repo)
+    expect(error._tag).toBe("SystemMonitorForbiddenError")
+    expect(calls.updateAlert).toEqual([])
+  })
+
+  it("rejects setting a condition on a system monitor's no-condition alert", async () => {
+    const monitor = makeMonitor({ system: true, alerts: [makeAlert({ kind: "issue.new", condition: null })] })
+    const { repo } = buildRepo(monitor)
+    const error = await runError(
+      updateMonitorAlertUseCase({ monitorId, alertId, condition: { kind: "issue.escalating", sensitivity: 2 } }),
+      repo,
+    )
+    // issue.new can't carry an issue.escalating condition — caught as a kind mismatch.
+    expect(error._tag).toBe("AlertConditionMismatchError")
+  })
+
+  it("rejects an unknown alert id", async () => {
+    const { repo } = buildRepo(escalatingMonitor(false))
+    const error = await runError(
+      updateMonitorAlertUseCase({
+        monitorId,
+        alertId: MonitorAlertId("z".repeat(24)),
+        condition: { kind: "issue.escalating", sensitivity: 4 },
+      }),
+      repo,
+    )
+    expect(error._tag).toBe("MonitorAlertNotFoundError")
+  })
+})

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.test.ts
@@ -1,14 +1,10 @@
-import {
-  type Monitor,
-  type MonitorAlert,
-  MonitorRepository,
-  type MonitorRepositoryShape,
-  updateMonitorAlertUseCase,
-} from "@domain/monitors"
-import { MonitorAlertId, MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { type Monitor, type MonitorAlert, MonitorRepository, updateMonitorAlertUseCase } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { MonitorAlertId, MonitorId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+import type { MonitorRepositoryShape } from "../ports/monitor-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -41,28 +37,6 @@ const makeMonitor = (overrides: Partial<Monitor> & { alerts: readonly MonitorAle
   updatedAt: at,
 })
 
-const buildRepo = (monitor: Monitor) => {
-  const calls = {
-    updateAlert: [] as { alertId: string; sourceId: string | null; condition: unknown; severity: string }[],
-  }
-  const repo: MonitorRepositoryShape = {
-    findById: (id) =>
-      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
-    findBySlug: () => Effect.die("findBySlug not used"),
-    list: () => Effect.die("list not used"),
-    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
-    setMuted: () => Effect.die("setMuted not used"),
-    softDelete: () => Effect.die("softDelete not used"),
-    updateMetadata: () => Effect.die("updateMetadata not used"),
-    updateAlert: (input) => {
-      calls.updateAlert.push(input)
-      return Effect.void
-    },
-    countActiveBySlug: () => Effect.die("countActiveBySlug not used"),
-  }
-  return { repo, calls }
-}
-
 const provide = (repo: MonitorRepositoryShape) =>
   Layer.mergeAll(
     Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
@@ -83,13 +57,13 @@ const escalatingMonitor = (system: boolean) =>
 
 describe("updateMonitorAlertUseCase", () => {
   it("updates an issue.escalating alert's sensitivity in place (system monitor allowed)", async () => {
-    const { repo, calls } = buildRepo(escalatingMonitor(true))
+    const { repo, monitors } = createFakeMonitorRepository([escalatingMonitor(true)])
     const result = await run(
       updateMonitorAlertUseCase({ monitorId, alertId, condition: { kind: "issue.escalating", sensitivity: 5 } }),
       repo,
     )
     expect(result.alerts[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 5 })
-    expect(calls.updateAlert[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 5 })
+    expect(monitors[0]?.alerts[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 5 })
   })
 
   it("lets a user monitor change a saved-search alert's source, condition and severity", async () => {
@@ -103,7 +77,7 @@ describe("updateMonitorAlertUseCase", () => {
         }),
       ],
     })
-    const { repo, calls } = buildRepo(monitor)
+    const { repo, monitors } = createFakeMonitorRepository([monitor])
     const result = await run(
       updateMonitorAlertUseCase({
         monitorId,
@@ -116,11 +90,11 @@ describe("updateMonitorAlertUseCase", () => {
     )
     expect(result.alerts[0]?.source.id).toBe("t".repeat(24))
     expect(result.alerts[0]?.severity).toBe("high")
-    expect(calls.updateAlert[0]).toMatchObject({ sourceId: "t".repeat(24), severity: "high" })
+    expect(monitors[0]?.alerts[0]).toMatchObject({ source: { id: "t".repeat(24) }, severity: "high" })
   })
 
   it("rejects a condition whose kind does not match the alert", async () => {
-    const { repo, calls } = buildRepo(escalatingMonitor(false))
+    const { repo, monitors } = createFakeMonitorRepository([escalatingMonitor(false)])
     const error = await runError(
       updateMonitorAlertUseCase({
         monitorId,
@@ -130,19 +104,19 @@ describe("updateMonitorAlertUseCase", () => {
       repo,
     )
     expect(error._tag).toBe("AlertConditionMismatchError")
-    expect(calls.updateAlert).toEqual([])
+    expect(monitors[0]?.alerts[0]?.condition).toEqual({ kind: "issue.escalating", sensitivity: 3 })
   })
 
   it("rejects changing the severity of a system monitor's alert", async () => {
-    const { repo, calls } = buildRepo(escalatingMonitor(true))
+    const { repo, monitors } = createFakeMonitorRepository([escalatingMonitor(true)])
     const error = await runError(updateMonitorAlertUseCase({ monitorId, alertId, severity: "low" }), repo)
     expect(error._tag).toBe("SystemMonitorForbiddenError")
-    expect(calls.updateAlert).toEqual([])
+    expect(monitors[0]?.alerts[0]?.severity).toBe("high")
   })
 
   it("rejects setting a condition on a system monitor's no-condition alert", async () => {
     const monitor = makeMonitor({ system: true, alerts: [makeAlert({ kind: "issue.new", condition: null })] })
-    const { repo } = buildRepo(monitor)
+    const { repo } = createFakeMonitorRepository([monitor])
     const error = await runError(
       updateMonitorAlertUseCase({ monitorId, alertId, condition: { kind: "issue.escalating", sensitivity: 2 } }),
       repo,
@@ -152,7 +126,7 @@ describe("updateMonitorAlertUseCase", () => {
   })
 
   it("rejects an unknown alert id", async () => {
-    const { repo } = buildRepo(escalatingMonitor(false))
+    const { repo } = createFakeMonitorRepository([escalatingMonitor(false)])
     const error = await runError(
       updateMonitorAlertUseCase({
         monitorId,

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
@@ -1,0 +1,110 @@
+import {
+  ALERT_INCIDENT_KIND_SOURCE_TYPE,
+  type AlertIncidentCondition,
+  type AlertIncidentKind,
+  type AlertIncidentSourceType,
+  type AlertSeverity,
+  type MonitorAlertId,
+  type MonitorId,
+  type NotFoundError,
+  type RepositoryError,
+  SqlClient,
+  ValidationError,
+} from "@domain/shared"
+import { Effect } from "effect"
+import type { Monitor } from "../entities/monitor.ts"
+import { AlertConditionMismatchError, MonitorAlertNotFoundError, SystemMonitorForbiddenError } from "../errors.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+
+/** Kinds that carry no `condition` (nothing to configure). Their condition stays `null`. */
+const KINDS_WITHOUT_CONDITION = new Set<AlertIncidentKind>(["issue.new", "issue.regressed", "savedSearch.match"])
+
+const conditionMatchesKind = (condition: AlertIncidentCondition | null, kind: AlertIncidentKind): boolean =>
+  condition === null ? KINDS_WITHOUT_CONDITION.has(kind) : condition.kind === kind
+
+export interface UpdateMonitorAlertInput {
+  readonly monitorId: MonitorId
+  readonly alertId: MonitorAlertId
+  /** `kind` is immutable and intentionally absent. Omitted fields keep their current value. */
+  readonly source?: { readonly type: AlertIncidentSourceType; readonly id: string | null }
+  readonly condition?: AlertIncidentCondition | null
+  readonly severity?: AlertSeverity
+}
+
+export type UpdateMonitorAlertError =
+  | NotFoundError
+  | RepositoryError
+  | MonitorAlertNotFoundError
+  | AlertConditionMismatchError
+  | SystemMonitorForbiddenError
+  | ValidationError
+
+/**
+ * Updates a single existing alert's `source` / `condition` / `severity` in
+ * place. `kind` is immutable (and so is `source.type`, which `kind` fixes).
+ * The resulting `condition` must be appropriate for the alert's kind.
+ *
+ * System monitors are structurally locked: only an existing alert's
+ * configurable condition values may change — any `source` / `severity` change,
+ * or setting a condition on a no-condition kind, is rejected. This is the only
+ * alert mutation system monitors permit.
+ */
+export const updateMonitorAlertUseCase = (
+  input: UpdateMonitorAlertInput,
+): Effect.Effect<Monitor, UpdateMonitorAlertError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const repository = yield* MonitorRepository
+        const monitor = yield* repository.findById(input.monitorId)
+        const alert = monitor.alerts.find((candidate) => candidate.id === input.alertId)
+        if (!alert) {
+          return yield* new MonitorAlertNotFoundError({ monitorId: input.monitorId, alertId: input.alertId })
+        }
+
+        const nextSource = input.source ?? alert.source
+        const nextCondition = input.condition !== undefined ? input.condition : alert.condition
+        const nextSeverity = input.severity ?? alert.severity
+
+        // `source.type` is fixed by the (immutable) kind.
+        if (nextSource.type !== ALERT_INCIDENT_KIND_SOURCE_TYPE[alert.kind]) {
+          return yield* new ValidationError({
+            field: "source",
+            message: `Source type must be "${ALERT_INCIDENT_KIND_SOURCE_TYPE[alert.kind]}" for ${alert.kind}`,
+          })
+        }
+        if (!conditionMatchesKind(nextCondition, alert.kind)) {
+          return yield* new AlertConditionMismatchError({
+            message: `Condition does not match alert kind "${alert.kind}"`,
+          })
+        }
+
+        if (monitor.system) {
+          const sourceChanged =
+            input.source !== undefined &&
+            (input.source.type !== alert.source.type || input.source.id !== alert.source.id)
+          const severityChanged = input.severity !== undefined && input.severity !== alert.severity
+          const conditionOnNonConfigurable = input.condition !== undefined && alert.condition === null
+          if (sourceChanged || severityChanged || conditionOnNonConfigurable) {
+            return yield* new SystemMonitorForbiddenError({ monitorId: input.monitorId, operation: "restructured" })
+          }
+        }
+
+        yield* repository.updateAlert({
+          alertId: input.alertId,
+          sourceId: nextSource.id,
+          condition: nextCondition,
+          severity: nextSeverity,
+        })
+        return {
+          ...monitor,
+          alerts: monitor.alerts.map((candidate) =>
+            candidate.id === input.alertId
+              ? { ...candidate, source: nextSource, condition: nextCondition, severity: nextSeverity }
+              : candidate,
+          ),
+        }
+      }),
+    )
+  })

--- a/packages/domain/monitors/src/use-cases/update-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor.test.ts
@@ -1,0 +1,93 @@
+import { type Monitor, MonitorRepository, type MonitorRepositoryShape, updateMonitorUseCase } from "@domain/monitors"
+import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient, ValidationError } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const monitorId = MonitorId("m".repeat(24))
+const at = new Date("2026-06-01T10:00:00.000Z")
+
+const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
+  id: monitorId,
+  organizationId,
+  projectId,
+  slug: overrides.slug ?? "my-monitor",
+  name: overrides.name ?? "My monitor",
+  description: overrides.description ?? "",
+  system: overrides.system ?? false,
+  alerts: [],
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: at,
+  updatedAt: at,
+})
+
+const buildRepo = (monitor: Monitor) => {
+  const calls = { updateMetadata: [] as { id: string; name: string; slug: string; description: string }[] }
+  const repo: MonitorRepositoryShape = {
+    findById: (id) =>
+      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
+    findBySlug: () => Effect.die("findBySlug not used"),
+    list: () => Effect.die("list not used"),
+    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
+    setMuted: () => Effect.die("setMuted not used"),
+    softDelete: () => Effect.die("softDelete not used"),
+    updateMetadata: (input) => {
+      calls.updateMetadata.push(input)
+      return Effect.void
+    },
+    updateAlert: () => Effect.die("updateAlert not used"),
+    // No live monitor shares the candidate slug.
+    countActiveBySlug: () => Effect.succeed(0),
+  }
+  return { repo, calls }
+}
+
+const provide = (repo: MonitorRepositoryShape) =>
+  Layer.mergeAll(
+    Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+  )
+
+const run = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
+  Effect.runPromise(effect.pipe(Effect.provide(provide(repo))))
+
+const runError = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepository>, repo: MonitorRepositoryShape) =>
+  Effect.runPromise(effect.pipe(Effect.flip, Effect.provide(provide(repo))))
+
+describe("updateMonitorUseCase", () => {
+  it("rejects editing a system monitor", async () => {
+    const { repo } = buildRepo(makeMonitor({ system: true }))
+    const error = await runError(updateMonitorUseCase({ id: monitorId, name: "New" }), repo)
+    expect(error._tag).toBe("SystemMonitorForbiddenError")
+  })
+
+  it("regenerates the slug when the name's normalised form changes", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ name: "My monitor", slug: "my-monitor" }))
+    const result = await run(updateMonitorUseCase({ id: monitorId, name: "Payment errors" }), repo)
+    expect(result.name).toBe("Payment errors")
+    expect(result.slug).toBe("payment-errors")
+    expect(calls.updateMetadata[0]?.slug).toBe("payment-errors")
+  })
+
+  it("keeps the slug stable on a cosmetic (case-only) rename", async () => {
+    const { repo } = buildRepo(makeMonitor({ name: "My monitor", slug: "my-monitor" }))
+    const result = await run(updateMonitorUseCase({ id: monitorId, name: "My Monitor" }), repo)
+    expect(result.slug).toBe("my-monitor")
+  })
+
+  it("rejects an empty name", async () => {
+    const { repo } = buildRepo(makeMonitor())
+    const error = await runError(updateMonitorUseCase({ id: monitorId, name: "   " }), repo)
+    expect(error).toBeInstanceOf(ValidationError)
+  })
+
+  it("updates the description without touching the slug", async () => {
+    const { repo, calls } = buildRepo(makeMonitor({ slug: "my-monitor" }))
+    const result = await run(updateMonitorUseCase({ id: monitorId, description: "Watch 5xx" }), repo)
+    expect(result.description).toBe("Watch 5xx")
+    expect(calls.updateMetadata[0]?.slug).toBe("my-monitor")
+  })
+})

--- a/packages/domain/monitors/src/use-cases/update-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor.test.ts
@@ -1,8 +1,10 @@
-import { type Monitor, MonitorRepository, type MonitorRepositoryShape, updateMonitorUseCase } from "@domain/monitors"
-import { MonitorId, NotFoundError, OrganizationId, ProjectId, SqlClient, ValidationError } from "@domain/shared"
+import { type Monitor, MonitorRepository, updateMonitorUseCase } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { MonitorId, OrganizationId, ProjectId, SqlClient, ValidationError } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+import type { MonitorRepositoryShape } from "../ports/monitor-repository.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -24,27 +26,6 @@ const makeMonitor = (overrides: Partial<Monitor> = {}): Monitor => ({
   updatedAt: at,
 })
 
-const buildRepo = (monitor: Monitor) => {
-  const calls = { updateMetadata: [] as { id: string; name: string; slug: string; description: string }[] }
-  const repo: MonitorRepositoryShape = {
-    findById: (id) =>
-      id === monitor.id ? Effect.succeed(monitor) : Effect.fail(new NotFoundError({ entity: "Monitor", id })),
-    findBySlug: () => Effect.die("findBySlug not used"),
-    list: () => Effect.die("list not used"),
-    provisionSystemMonitors: () => Effect.die("provisionSystemMonitors not used"),
-    setMuted: () => Effect.die("setMuted not used"),
-    softDelete: () => Effect.die("softDelete not used"),
-    updateMetadata: (input) => {
-      calls.updateMetadata.push(input)
-      return Effect.void
-    },
-    updateAlert: () => Effect.die("updateAlert not used"),
-    // No live monitor shares the candidate slug.
-    countActiveBySlug: () => Effect.succeed(0),
-  }
-  return { repo, calls }
-}
-
 const provide = (repo: MonitorRepositoryShape) =>
   Layer.mergeAll(
     Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
@@ -59,35 +40,36 @@ const runError = <A, E>(effect: Effect.Effect<A, E, SqlClient | MonitorRepositor
 
 describe("updateMonitorUseCase", () => {
   it("rejects editing a system monitor", async () => {
-    const { repo } = buildRepo(makeMonitor({ system: true }))
+    const { repo } = createFakeMonitorRepository([makeMonitor({ system: true })])
     const error = await runError(updateMonitorUseCase({ id: monitorId, name: "New" }), repo)
     expect(error._tag).toBe("SystemMonitorForbiddenError")
   })
 
   it("regenerates the slug when the name's normalised form changes", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ name: "My monitor", slug: "my-monitor" }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ name: "My monitor", slug: "my-monitor" })])
     const result = await run(updateMonitorUseCase({ id: monitorId, name: "Payment errors" }), repo)
     expect(result.name).toBe("Payment errors")
     expect(result.slug).toBe("payment-errors")
-    expect(calls.updateMetadata[0]?.slug).toBe("payment-errors")
+    expect(monitors[0]?.slug).toBe("payment-errors")
   })
 
   it("keeps the slug stable on a cosmetic (case-only) rename", async () => {
-    const { repo } = buildRepo(makeMonitor({ name: "My monitor", slug: "my-monitor" }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ name: "My monitor", slug: "my-monitor" })])
     const result = await run(updateMonitorUseCase({ id: monitorId, name: "My Monitor" }), repo)
     expect(result.slug).toBe("my-monitor")
+    expect(monitors[0]?.slug).toBe("my-monitor")
   })
 
   it("rejects an empty name", async () => {
-    const { repo } = buildRepo(makeMonitor())
+    const { repo } = createFakeMonitorRepository([makeMonitor()])
     const error = await runError(updateMonitorUseCase({ id: monitorId, name: "   " }), repo)
     expect(error).toBeInstanceOf(ValidationError)
   })
 
   it("updates the description without touching the slug", async () => {
-    const { repo, calls } = buildRepo(makeMonitor({ slug: "my-monitor" }))
+    const { repo, monitors } = createFakeMonitorRepository([makeMonitor({ slug: "my-monitor" })])
     const result = await run(updateMonitorUseCase({ id: monitorId, description: "Watch 5xx" }), repo)
     expect(result.description).toBe("Watch 5xx")
-    expect(calls.updateMetadata[0]?.slug).toBe("my-monitor")
+    expect(monitors[0]?.slug).toBe("my-monitor")
   })
 })

--- a/packages/domain/monitors/src/use-cases/update-monitor.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor.ts
@@ -1,0 +1,82 @@
+import {
+  generateSlug,
+  type MonitorId,
+  type NotFoundError,
+  type RepositoryError,
+  SqlClient,
+  toSlug,
+  ValidationError,
+} from "@domain/shared"
+import { Effect } from "effect"
+import type { Monitor } from "../entities/monitor.ts"
+import { SystemMonitorForbiddenError } from "../errors.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+
+const NAME_MAX_LENGTH = 128
+
+export interface UpdateMonitorInput {
+  readonly id: MonitorId
+  readonly name?: string
+  readonly description?: string
+}
+
+export type UpdateMonitorError = NotFoundError | RepositoryError | SystemMonitorForbiddenError | ValidationError
+
+/**
+ * Edits a user monitor's metadata (name + description) only — its alerts are
+ * managed through the monitor-alert use-cases. Rejects system monitors (locked).
+ * Regenerates the slug only when the name's normalised form changes, so a
+ * cosmetic capitalisation edit keeps the URL stable.
+ */
+export const updateMonitorUseCase = (
+  input: UpdateMonitorInput,
+): Effect.Effect<Monitor, UpdateMonitorError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const repository = yield* MonitorRepository
+        const monitor = yield* repository.findById(input.id)
+        if (monitor.system) {
+          return yield* new SystemMonitorForbiddenError({ monitorId: input.id, operation: "edited" })
+        }
+
+        let nextName = monitor.name
+        let nextSlug = monitor.slug
+        if (input.name !== undefined) {
+          const trimmed = input.name.trim()
+          if (trimmed.length < 1 || trimmed.length > NAME_MAX_LENGTH) {
+            return yield* new ValidationError({
+              field: "name",
+              message: `Name must be 1–${NAME_MAX_LENGTH} characters`,
+            })
+          }
+          if (trimmed !== monitor.name) {
+            if (toSlug(trimmed) !== monitor.slug) {
+              nextSlug = yield* generateSlug({
+                name: trimmed,
+                count: (slug) =>
+                  repository.countActiveBySlug({ projectId: monitor.projectId, slug, excludeId: input.id }),
+              }).pipe(
+                Effect.catchTag("InvalidSlugInputError", (error) =>
+                  Effect.fail(new ValidationError({ field: "name", message: error.reason })),
+                ),
+              )
+            }
+            nextName = trimmed
+          }
+        }
+
+        const nextDescription = input.description !== undefined ? input.description.trim() : monitor.description
+
+        const now = new Date()
+        yield* repository.updateMetadata({
+          id: input.id,
+          name: nextName,
+          slug: nextSlug,
+          description: nextDescription,
+        })
+        return { ...monitor, name: nextName, slug: nextSlug, description: nextDescription, updatedAt: now }
+      }),
+    )
+  })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1,4 +1,4 @@
-import { type Monitor, type MonitorAlert, MonitorRepository } from "@domain/monitors"
+import { type Monitor, type MonitorAlert, MonitorRepository, type MonitorRepositoryShape } from "@domain/monitors"
 import {
   type AlertIncidentCondition,
   type AlertSeverity,
@@ -7,7 +7,9 @@ import {
   MonitorId,
   OrganizationId,
   ProjectId,
+  type SqlClient,
 } from "@domain/shared"
+import { eq } from "drizzle-orm"
 import { Effect, Exit } from "effect"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { monitorAlerts as monitorAlertsTable } from "../schema/monitor-alerts.ts"
@@ -455,6 +457,134 @@ describe("MonitorRepositoryLive", () => {
       const page = await list()
       expect(page.totalCount).toBe(3)
       expect(page.items.flatMap((m) => m.alerts).length).toBe(3)
+    })
+  })
+
+  describe("mutations", () => {
+    const exec = <A, E>(use: (repo: MonitorRepositoryShape) => Effect.Effect<A, E, SqlClient>) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* use(repository)
+        }).pipe(provideRls(database, organizationId)),
+      )
+
+    const execExit = <A, E>(use: (repo: MonitorRepositoryShape) => Effect.Effect<A, E, SqlClient>) =>
+      Effect.runPromiseExit(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* use(repository)
+        }).pipe(provideRls(database, organizationId)),
+      )
+
+    it("setMuted sets muted_at on a live monitor", async () => {
+      const id = generateId()
+      await database.db.insert(monitorsTable).values(makeMonitorRow({ id, slug: "m", name: "M" }))
+      await exec((r) => r.setMuted({ id: MonitorId(id), mutedAt: new Date("2026-06-02T00:00:00.000Z") }))
+
+      const [row] = await database.db.select().from(monitorsTable).where(eq(monitorsTable.id, id))
+      expect(row?.mutedAt).not.toBeNull()
+    })
+
+    it("setMuted fails NotFoundError for a missing monitor", async () => {
+      const exit = await execExit((r) => r.setMuted({ id: MonitorId(generateId()), mutedAt: new Date() }))
+      expect(Exit.isFailure(exit)).toBe(true)
+    })
+
+    it("softDelete marks the monitor and cascades deleted_at to its live alerts", async () => {
+      const id = generateId()
+      const aliveAlert = generateId()
+      await database.db.insert(monitorsTable).values(makeMonitorRow({ id, slug: "m", name: "M" }))
+      await database.db.insert(monitorAlertsTable).values(makeAlertRow({ id: aliveAlert, monitorId: id }))
+
+      await exec((r) => r.softDelete(MonitorId(id)))
+
+      const [monitorRow] = await database.db.select().from(monitorsTable).where(eq(monitorsTable.id, id))
+      expect(monitorRow?.deletedAt).not.toBeNull()
+      const [alertRow] = await database.db
+        .select()
+        .from(monitorAlertsTable)
+        .where(eq(monitorAlertsTable.id, aliveAlert))
+      expect(alertRow?.deletedAt).not.toBeNull()
+    })
+
+    it("updateMetadata updates name, slug and description", async () => {
+      const id = generateId()
+      await database.db.insert(monitorsTable).values(makeMonitorRow({ id, slug: "old", name: "Old" }))
+
+      await exec((r) =>
+        r.updateMetadata({ id: MonitorId(id), name: "New name", slug: "new-name", description: "Desc" }),
+      )
+
+      const [row] = await database.db.select().from(monitorsTable).where(eq(monitorsTable.id, id))
+      expect(row).toMatchObject({ name: "New name", slug: "new-name", description: "Desc" })
+    })
+
+    it("updateAlert replaces an alert's source, condition and severity", async () => {
+      const id = generateId()
+      const alert = generateId()
+      await database.db.insert(monitorsTable).values(makeMonitorRow({ id, slug: "m", name: "M" }))
+      await database.db.insert(monitorAlertsTable).values(
+        makeAlertRow({
+          id: alert,
+          monitorId: id,
+          kind: "savedSearch.threshold",
+          sourceType: "savedSearch",
+          sourceId: "s".repeat(24),
+          condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 100 } },
+          severity: "medium",
+        }),
+      )
+
+      await exec((r) =>
+        r.updateAlert({
+          alertId: MonitorAlertId(alert),
+          sourceId: "t".repeat(24),
+          condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 250 } },
+          severity: "high",
+        }),
+      )
+
+      const [row] = await database.db.select().from(monitorAlertsTable).where(eq(monitorAlertsTable.id, alert))
+      expect(row).toMatchObject({
+        sourceId: "t".repeat(24),
+        severity: "high",
+        condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 250 } },
+      })
+    })
+
+    it("updateAlert fails NotFoundError for a missing alert", async () => {
+      const exit = await execExit((r) =>
+        r.updateAlert({
+          alertId: MonitorAlertId(generateId()),
+          sourceId: null,
+          condition: { kind: "issue.escalating", sensitivity: 4 },
+          severity: "high",
+        }),
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
+    })
+
+    it("countActiveBySlug counts live same-slug monitors, excluding the target and soft-deleted rows", async () => {
+      const liveA = generateId()
+      const otherB = generateId()
+      const ghost = generateId()
+      await database.db.insert(monitorsTable).values([
+        makeMonitorRow({ id: liveA, slug: "taken", name: "A" }),
+        makeMonitorRow({ id: otherB, slug: "b-slug", name: "B" }),
+        // Soft-deleted "taken" — allowed alongside the live one by the partial unique index.
+        makeMonitorRow({ id: ghost, slug: "taken", name: "Ghost", deletedAt: new Date("2026-05-30T00:00:00.000Z") }),
+      ])
+
+      const countExcludingB = await exec((r) =>
+        r.countActiveBySlug({ projectId, slug: "taken", excludeId: MonitorId(otherB) }),
+      )
+      expect(countExcludingB).toBe(1)
+
+      const countExcludingA = await exec((r) =>
+        r.countActiveBySlug({ projectId, slug: "taken", excludeId: MonitorId(liveA) }),
+      )
+      expect(countExcludingA).toBe(0)
     })
   })
 })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -1,6 +1,6 @@
 import { type Monitor, type MonitorAlert, MonitorRepository, monitorSchema } from "@domain/monitors"
 import { NotFoundError, SqlClient, type SqlClientShape } from "@domain/shared"
-import { and, asc, count, desc, eq, ilike, inArray, isNull, sql } from "drizzle-orm"
+import { and, asc, count, desc, eq, ilike, inArray, isNull, ne, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { monitorAlerts } from "../schema/monitor-alerts.ts"
@@ -220,6 +220,101 @@ export const MonitorRepositoryLive = Layer.effect(
             }
             return inserted
           })
+        }),
+      setMuted: ({ id, mutedAt }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          const updated = yield* sqlClient.query((db) =>
+            db
+              .update(monitors)
+              .set({ mutedAt, updatedAt: new Date() })
+              .where(and(eq(monitors.organizationId, organizationId), eq(monitors.id, id), isNull(monitors.deletedAt)))
+              .returning({ id: monitors.id }),
+          )
+          if (updated.length === 0) return yield* new NotFoundError({ entity: "Monitor", id })
+        }),
+      softDelete: (id) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          // Monitor + its live alerts in one transaction: the alert cascade stops
+          // firing (active-alert reads filter deleted_at), while the incident→alert
+          // join (which ignores deleted_at) keeps history attributable.
+          const deleted = yield* sqlClient.query(async (db) => {
+            const now = new Date()
+            const rows = await db
+              .update(monitors)
+              .set({ deletedAt: now, updatedAt: now })
+              .where(and(eq(monitors.organizationId, organizationId), eq(monitors.id, id), isNull(monitors.deletedAt)))
+              .returning({ id: monitors.id })
+            if (rows.length > 0) {
+              await db
+                .update(monitorAlerts)
+                .set({ deletedAt: now })
+                .where(
+                  and(
+                    eq(monitorAlerts.organizationId, organizationId),
+                    eq(monitorAlerts.monitorId, id),
+                    isNull(monitorAlerts.deletedAt),
+                  ),
+                )
+            }
+            return rows
+          })
+          if (deleted.length === 0) return yield* new NotFoundError({ entity: "Monitor", id })
+        }),
+      updateMetadata: ({ id, name, slug, description }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          const updated = yield* sqlClient.query((db) =>
+            db
+              .update(monitors)
+              .set({ name, slug, description, updatedAt: new Date() })
+              .where(and(eq(monitors.organizationId, organizationId), eq(monitors.id, id), isNull(monitors.deletedAt)))
+              .returning({ id: monitors.id }),
+          )
+          if (updated.length === 0) return yield* new NotFoundError({ entity: "Monitor", id })
+        }),
+      updateAlert: ({ alertId, sourceId, condition, severity }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          const updated = yield* sqlClient.query((db) =>
+            db
+              .update(monitorAlerts)
+              .set({ sourceId, condition, severity, updatedAt: new Date() })
+              .where(
+                and(
+                  eq(monitorAlerts.organizationId, organizationId),
+                  eq(monitorAlerts.id, alertId),
+                  isNull(monitorAlerts.deletedAt),
+                ),
+              )
+              .returning({ id: monitorAlerts.id }),
+          )
+          if (updated.length === 0) return yield* new NotFoundError({ entity: "MonitorAlert", id: alertId })
+        }),
+      countActiveBySlug: ({ projectId, slug, excludeId }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({ value: count() })
+              .from(monitors)
+              .where(
+                and(
+                  eq(monitors.organizationId, organizationId),
+                  eq(monitors.projectId, projectId),
+                  eq(monitors.slug, slug),
+                  ne(monitors.id, excludeId),
+                  isNull(monitors.deletedAt),
+                ),
+              ),
+          )
+          return Number(rows[0]?.value ?? 0)
         }),
     }),
   ),

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -955,7 +955,7 @@ Row click toggles `monitorSlug`. The selected row gets `activeRowKey` highlight.
   - `<CopyableText value={monitor.slug} size="sm" />` below the description.
 - Body sections (collapsible):
   - **Incidents** — embedded `InfiniteTable` of incidents for this monitor, **keyset-paginated** (`useMonitorIncidents` → `useInfiniteQuery`, cursor over `(started_at, id)`). Incidents are append-heavy and unbounded over time, so keyset avoids offset's scan-and-discard and the page-shift that new incidents would cause; backed by the composite `alert_incidents_monitor_alert_idx (monitor_alert_id, started_at DESC, id DESC)`.
-  - **Alerts** — vertical stack of alert cards. The set is locked (no per-card `X`, no "+ Add alert" dashed card, kind/source not editable), but each card's **configurable values are editable**: the `issue.escalating` card exposes a **sensitivity** control that saves via `configureMonitorAlertUseCase`. Cards whose alert has a `null` condition (`issue.new`, `issue.regressed`) have nothing to tune and render fully read-only. Each card still shows the human-readable summary via `formatHumanReadableAlert`.
+  - **Alerts** — vertical stack of alert cards. The set is locked (no per-card `X`, no "+ Add alert" dashed card, kind/source not editable), but each card's **configurable values are editable**: the `issue.escalating` card exposes a **sensitivity** control that saves via `updateMonitorAlertUseCase`. Cards whose alert has a `null` condition (`issue.new`, `issue.regressed`) have nothing to tune and render fully read-only. Each card still shows the human-readable summary via `formatHumanReadableAlert`.
 
 #### User monitor mode (editable)
 
@@ -1050,6 +1050,8 @@ Tests cover the matrix. The helper is shared between the API documentation entit
 
 ### Endpoints (under `/v1/projects/{projectSlug}/monitors`)
 
+Monitor CRUD and monitor-alert CRUD are separate operation families.
+
 | Method | Path | Operation id |
 |---|---|---|
 | GET | `/` | `listMonitors` |
@@ -1057,14 +1059,19 @@ Tests cover the matrix. The helper is shared between the API documentation entit
 | GET | `/{monitorSlug}` | `getMonitor` |
 | PATCH | `/{monitorSlug}` | `updateMonitor` |
 | DELETE | `/{monitorSlug}` | `deleteMonitor` |
-| PATCH | `/{monitorSlug}/alerts/{alertId}` | `configureMonitorAlert` |
+| GET | `/{monitorSlug}/alerts` | `listMonitorAlerts` |
+| POST | `/{monitorSlug}/alerts` | `createMonitorAlert` |
+| GET | `/{monitorSlug}/alerts/{alertId}` | `getMonitorAlert` |
+| PATCH | `/{monitorSlug}/alerts/{alertId}` | `updateMonitorAlert` |
+| DELETE | `/{monitorSlug}/alerts/{alertId}` | `deleteMonitorAlert` |
 | GET | `/{monitorSlug}/incidents` | `listMonitorIncidents` |
 | POST | `/{monitorSlug}/mute` | `muteMonitor` |
 | POST | `/{monitorSlug}/unmute` | `unmuteMonitor` |
 
-- `createMonitor` and `updateMonitor` reject `kind ∉ USER_CREATABLE_ALERT_KINDS`, reject any input with `system: true`, and require a valid `source.id` for saved-search alerts.
-- `updateMonitor` (metadata + alert-set changes) and `deleteMonitor` reject when the target's `system === true`. For system monitors the only valid mutations are `mute` / `unmute` and `configureMonitorAlert`.
-- `configureMonitorAlert` updates an existing alert's *configurable values* (its `condition`) in place — allowed on system **and** user monitors. It rejects any change to `kind` / `source` and any `condition` whose shape doesn't match the alert's kind. (For the system "Issue escalating" monitor this is how `sensitivity` is tuned.)
+- **Alert reads are projections, not a domain read path.** The domain has no separate "read alert" use-case — monitors are always read with their alerts baked in (`getMonitorBySlugUseCase`). `listMonitorAlerts` / `getMonitorAlert` exist only at the API layer, for SDK/MCP surface completeness and consistency: each reads the monitor via the existing use-case and projects `.alerts` (404 on an `alertId` not present). They add no extra query and no new domain code.
+
+- **Monitor CRUD.** `createMonitor` takes the monitor metadata + a non-empty list of alerts (each created through `createMonitorAlert` internally); it rejects `kind ∉ USER_CREATABLE_ALERT_KINDS`, `system: true`, and saved-search alerts without a `source.id`. `updateMonitor` edits **metadata only** (name + description) and rejects `system === true`. `deleteMonitor` soft-deletes the monitor and cascades `deleted_at` to its alerts; rejects `system === true`. `mute` / `unmute` are allowed on both modes.
+- **Monitor-alert CRUD.** `createMonitorAlert` adds one alert (rejects `system` monitors, enforces the user-creatable allowlist + `source.id`); `deleteMonitorAlert` removes one (soft-delete; rejects `system` monitors; can't empty the active alert list). `updateMonitorAlert` updates an existing alert's `source` / `condition` / `severity` in place — `kind` is immutable (and `source.type`, which the kind fixes). On **system** monitors it's the only permitted alert mutation, and only an existing alert's configurable condition values may change (source / severity / setting a condition on a no-condition kind are rejected). For the system "Issue escalating" monitor this is how `sensitivity` is tuned.
 - Field descriptions on the OpenAPI schemas are rich enough to render meaningfully as MCP tool descriptions (the same descriptions propagate to the TS SDK via codegen).
 
 ### `assign` endpoint removal
@@ -1253,7 +1260,7 @@ For legacy incidents (`monitorAlertId IS NULL`, flag-off orgs), layer 1 is absen
 Backend tests follow the testing skill's conventions (PGlite testkit; org/project fixtures from `@repo/testing`):
 
 - **Schema & repository** — round-trip writes; uniqueness on `(project_id, slug) WHERE deleted_at IS NULL`; RLS enforcement (a query without the org context returns nothing).
-- **Use-cases** — create/update/delete (rejection on `system === true` for update-metadata, alert-set update, and delete), update with kind ∉ `USER_CREATABLE_ALERT_KINDS` rejected, mute/unmute (system allowed), `configureMonitorAlert` (system allowed for condition values; kind/source change rejected; add/remove rejected), list with name search, get by slug, list incidents.
+- **Use-cases** — monitor CRUD: `createMonitor` (rejects empty alerts / non-allowlisted kind / `system: true` / missing saved-search `source.id`), `updateMonitor` (metadata only; `system` rejected), `deleteMonitor` (`system` rejected; cascades to alerts), `mute`/`unmute` (system allowed), list with name search, get by slug, list incidents. Alert CRUD: `createMonitorAlert` / `deleteMonitorAlert` (both reject `system`; allowlist + can't-empty enforced), `updateMonitorAlert` (kind immutable; condition-vs-kind + source-type validation; on system only an existing alert's configurable condition values change — source/severity/no-condition rejected).
 - **System monitor provisioning** — idempotent re-run; data-migration backfill correctness against `SYSTEM_MONITOR_DEFINITIONS`.
 - **Issue-event monitor resolution** — `resolveMonitorsForSourceEvent` returns all-of-type + specific-id matches; flag-on multi-monitor fan-out; flag-off legacy parity.
 - **`startedAt` backtracking** — `issue.escalating` incident `startedAt` is the first-bucket-crossing timestamp from the trend window, not now.
@@ -1263,7 +1270,7 @@ Backend tests follow the testing skill's conventions (PGlite testkit; org/projec
 - **Saved-search firing** — covered in M7 against the actual firing helpers.
 - **Source cascade** — delete of issue / saved search soft-deletes matching alerts (incidents stay attributable via the join) and soft-deletes the monitor if its active alert list empties.
 - **Human-readable alert formatter** — table-driven test over the matrix above.
-- **API endpoints** — request/response contract for the nine endpoints; 400s for forbidden combos (kind not in user-creatable allowlist, kind/source.type mismatch, delete on system monitor, empty alerts, `configureMonitorAlert` changing kind/source).
+- **API endpoints** — request/response contract for the thirteen endpoints; 400s for forbidden combos (kind not in user-creatable allowlist, kind/source.type mismatch, delete on system monitor, empty alerts, adding/deleting alerts on a system monitor, `updateMonitorAlert` changing kind/source on a system monitor).
 
 ## Documentation
 
@@ -1338,29 +1345,36 @@ The first milestones prioritise **visible progress**: M1 ships the sidebar entry
 
 ### Milestone 4 — Monitor details panel: structurally-locked system mode + editable user mode
 
-> Branch: `LAT-630/details-panel` · Estimated size: ~2,600 lines
+> Split into two PRs to stay reviewable: **backend mutations** (`LAT-630/monitor-mutations`, done) then the **details-panel UI** (`LAT-630/details-panel`). Combined estimate ~2,600 lines.
 
 **Goal:** Clicking a monitor opens a working details panel with next/prev navigation, mute/unmute (both modes), delete (user mode only), and editable alert configuration values (both modes — the system "Issue escalating" monitor's `sensitivity` is tunable here). The Incidents section is wired to the existing alert-incidents data. The Notified/Muted badge is correctly derived.
 
-- [ ] `muteMonitorUseCase`, `unmuteMonitorUseCase` (both modes allowed).
-- [ ] `deleteMonitorUseCase` — rejects on `system === true`.
-- [ ] `updateMonitorMetadataUseCase` — rejects on `system === true`; validates length; regenerates slug if name changed.
-- [ ] `configureMonitorAlertUseCase(alertId, condition)` — updates the *configurable values* of an existing alert in place (system AND user monitors). Validates that `kind` and `source` are unchanged and that the new `condition` matches the alert's kind; does NOT add/remove alerts. This is the only alert mutation permitted on system monitors.
-- [ ] Web side: `monitor-detail-drawer.tsx` mirroring `issue-detail-drawer.tsx`. Both modes:
-  - System mode: read-only header (no name/description pencil, no delete button); Alerts section locked structurally (no `X` / `+`, no kind/source change) but each card's configurable values are editable — the `issue.escalating` card exposes a sensitivity control (saves via `configureMonitorAlertUseCase`); `null`-condition cards render read-only.
-  - User mode: in-place editable name + description (`useEditableText` hook), delete button, fully editable Alerts section.
-- [ ] Mute/unmute/delete + configure-alert server functions; confirmation modals where destructive.
+Backend mutations (`LAT-630/monitor-mutations`):
+
+- [x] `muteMonitorUseCase`, `unmuteMonitorUseCase` (both modes allowed) + repo `setMuted`.
+- [x] `deleteMonitorUseCase` — rejects on `system === true` (`SystemMonitorForbiddenError`); repo `softDelete` cascades `deletedAt` to the monitor's live alerts so it stops firing while the incident→alert join keeps history attributable.
+- [x] `updateMonitorUseCase` — edits **metadata only** (name + description); rejects on `system === true`; validates name length (1–128); regenerates slug (via shared `generateSlug` + repo `countActiveBySlug`) only when the name's normalised form changes. Repo `updateMetadata`.
+- [x] `updateMonitorAlertUseCase({ monitorId, alertId, source?, condition?, severity? })` — the single per-alert update (replaces the old `configureMonitorAlert` + `updateMonitorAlerts` set-replacement). `kind` is immutable (and `source.type`, which the kind fixes). The resulting `condition` must match the alert's kind (`AlertConditionMismatchError` otherwise); source-type mismatch → `ValidationError`; unknown alert → `MonitorAlertNotFoundError`. On **system** monitors only an existing alert's configurable condition values may change — source / severity / setting a condition on a no-condition kind are rejected (`SystemMonitorForbiddenError`). Repo `updateAlert` sets `source_id` / `condition` / `severity`.
+- [x] Backend tests: mute/unmute (both modes), delete (system rejection + cascade), metadata update (system rejection, slug regen, cosmetic-rename stability, name validation), configure-alert (kind-mismatch rejected, unknown-alert rejected, `issue.escalating` sensitivity round-trips); repo-level idempotency/RLS via PGlite.
+
+Details-panel UI (`LAT-630/details-panel`):
+
+- [ ] Web side: `monitor-detail-drawer.tsx` mirroring `issue-detail-drawer.tsx` (replaces the M3 stub). Both modes:
+  - System mode: read-only header (no name/description pencil, no delete button); Alerts section locked structurally (no `X` / `+`, no kind/source change) but each card's configurable values are editable — the `issue.escalating` card exposes a sensitivity control (saves via `updateMonitorAlertUseCase`); `null`-condition cards render read-only.
+  - User mode: in-place editable name + description (`useEditableText` hook), delete button, and editable alert values (via `updateMonitorAlertUseCase`). Adding/removing alerts (the `+` / per-card `X`) lands in M5 alongside `createMonitorAlert` / `deleteMonitorAlert`.
+- [ ] Mute/unmute/delete monitor + update-alert server functions; confirmation modals where destructive.
 - [ ] Incidents section: embedded `InfiniteTable`; "Notified"/"Muted" column driven by the batched idempotency-key lookup.
-- [ ] Backend tests: mute/unmute (both modes), delete (system rejection), metadata update (system rejection, slug regen), configure-alert (system: condition-value edit allowed; kind/source change rejected; add/remove rejected; `issue.escalating` sensitivity round-trips).
 
 ### Milestone 5 — Create monitor modal and alert editing
 
 > Branch: `LAT-630/create-and-edit` · Estimated size: ~2,600 lines
 
-**Goal:** Users can create a non-system monitor end-to-end. The details panel's Alerts section allows adding/removing/editing alerts via the same alert card form. All paths constrain to `USER_CREATABLE_ALERT_KINDS`.
+**Goal:** Users can create a non-system monitor end-to-end. The details panel's Alerts section allows adding/removing alerts (editing already landed via `updateMonitorAlertUseCase` in M4) via the same alert card form. All paths constrain to `USER_CREATABLE_ALERT_KINDS`.
 
-- [ ] `createMonitorUseCase` — Zod-validated input; inserts monitor + alerts atomically. Rejects: empty alert list; any alert kind ∉ `USER_CREATABLE_ALERT_KINDS`; `system: true` in the input; saved-search alerts without `source.id`.
-- [ ] `updateMonitorAlertsUseCase` — set-style replacement via **soft-delete + insert** (removed alerts get `deleted_at = now()`, never hard-deleted, so their incident history stays attributable; edited alerts = soft-delete old + insert new). Active alert list cannot become empty; same kind/source.id constraints. **Rejects `system === true`** — system monitors are structurally locked, so their alerts change only via `configureMonitorAlertUseCase` (M4), which edits configurable values in place without touching the alert set.
+- [ ] `createMonitorUseCase` — Zod-validated input; inserts the monitor + its alerts atomically, composing `createMonitorAlertUseCase` per alert. Rejects: empty alert list; any alert kind ∉ `USER_CREATABLE_ALERT_KINDS`; `system: true` in the input; saved-search alerts without `source.id`.
+- [ ] `createMonitorAlertUseCase` — adds a single alert to an existing monitor (also used inside `createMonitor`). Enforces the user-creatable allowlist + kind/source.type match + `source.id` for saved searches. **Rejects `system === true`** — no alert may be added to a system monitor.
+- [ ] `deleteMonitorAlertUseCase` — soft-deletes a single alert (`deleted_at = now()`, never hard-deleted, so incident history stays attributable). The active alert list cannot become empty. **Rejects `system === true`** — system monitors are structurally locked.
+  > Per-alert *editing* (`updateMonitorAlertUseCase`) shipped in M4; M5 adds the create/delete halves of the alert CRUD family. There is no set-replacement use-case — alert changes are always granular.
 - [ ] Shared `alert-form` components in `apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/`, reused by both the create modal and the panel Alerts section.
 - [ ] Saved-search Combobox source picker — no "All saved searches" option; inline "Create a saved search" link when the project has none.
 - [ ] Threshold + window form for the two complex saved-search kinds, covering all three threshold modes (absolute, multiplier, expected). The baseline `Select` includes the **expected** option, which switches the shared amount input to mean `sensitivity`. `formatHumanReadableAlert` drives the card preview.
@@ -1372,8 +1386,18 @@ The first milestones prioritise **visible progress**: M1 ships the sidebar entry
   - **`expected` baseline** (its own tooltip, since it behaves differently): "**Expected** is a smart baseline computed automatically from your history — it learns the normal shape of your traffic for each time of day and day of week, so a quiet Sunday night and a busy Monday morning each get their own 'normal'. You don't pick a comparison window; just how sensitive to be. It's the same engine that powers Latitude's automatic issue-escalation alerts." Pair with a **sensitivity** sub-tooltip: "How far above the learned normal counts as a spike. Lower = more sensitive (alerts on smaller deviations, noisier); higher = quieter."
   - **`factor` on multiplier**: "The multiplier. 3 means 'fire when current activity is 3× the baseline rate'."
   - **One-line live-preview** under each alert card showing `formatHumanReadableAlert(alert)` — so the user sees the sentence form of what they're configuring as they edit.
-- [ ] Server functions: `createMonitor`, `updateMonitorAlerts`.
+- [ ] Server functions: `createMonitor`, `createMonitorAlert`, `deleteMonitorAlert` (plus `updateMonitorAlert` from M4).
 - [ ] Backend tests: creation invariants, alert update invariants, kind/source.type mismatch rejection, kind-not-in-allowlist rejection, saved-search source.id required.
+
+### Milestone UX — Polish the full Monitors frontend
+
+> Branch: `LAT-630/ux-polish` · Runs after M5, before M6. Frontend-only — no domain/backend changes.
+
+**Goal:** A dedicated pass to bring the entire Monitors frontend (everything built across M1–M5: dashboard, details panel, create modal, alert card + threshold/window forms) to a finished, shippable feel. From M6 onward the work is almost entirely backend (issue-event firing, the saved-search pipeline, API/SDK), so this is the natural moment to fully polish the UI while it's fresh and before backend wiring lands on top of it.
+
+Scope is intentionally left open — the exact polish items are decided when the milestone starts, not prescribed here.
+
+Worth front-loading, since it enables the rest: a **`monitors` seeder** (`packages/platform/db-postgres/src/seeds/monitors/`, registered in `all.ts` next to the existing `alert-incidents` seeder, run by `pnpm seed`). It writes the M2/M3 schema directly — monitors + `monitor_alerts` + a spread of `alert_incidents` covering every visual state (open vs closed, muted vs live, notified vs not, each kind/severity, "all"-source vs named-source) — so the polish can exercise the whole frontend now, without waiting for M6/M7 to produce real incidents.
 
 ### Milestone 6 — Wire issue-event path to monitors (flag-gated)
 
@@ -1441,13 +1465,13 @@ Smaller than originally estimated because most of the heavy lifting has already 
 
 **Goal:** All nine monitor endpoints live. SDK regenerated and bumped.
 
-- [ ] `apps/api/src/routes/monitors.ts` — nine endpoints on the `defineApiEndpoint<OrganizationScopedEnv>` factory (incl. `configureMonitorAlert`).
+- [ ] `apps/api/src/routes/monitors.ts` — thirteen endpoints on the `defineApiEndpoint<OrganizationScopedEnv>` factory (incl. `createMonitorAlert` / `updateMonitorAlert` / `deleteMonitorAlert`).
 - [ ] `apps/api/src/openapi/entities/monitor.ts` — `MonitorSchema` + `toMonitorResponse(monitor)` mapper. Rich `.describe(...)` on every field so SDK and MCP tools carry useful docs.
 - [ ] Register routes in `apps/api/src/routes/index.ts` at `/v1/projects/:projectSlug/monitors`.
 - [ ] Reuse domain Zod schemas for input validation.
 - [ ] `pnpm openapi:emit && pnpm mcp:emit && pnpm --filter @latitude-data/sdk generate`. Commit the generated files in the same PR.
 - [ ] Bump SDK version in `packages/sdk/package.json` and add a CHANGELOG entry under `packages/sdk/CHANGELOG.md`.
-- [ ] Backend tests for the nine endpoints: schema validation, auth/scope, response shape, error cases (delete on system monitor, kind not in allowlist, mismatched kind/source.type, `configureMonitorAlert` rejecting kind/source change, system `updateMonitor`/`deleteMonitor` rejection, system `configureMonitorAlert` allowed).
+- [ ] Backend tests for the thirteen endpoints: schema validation, auth/scope, response shape, error cases (delete on system monitor, kind not in allowlist, mismatched kind/source.type, `updateMonitorAlert` rejecting kind/source change on system, create/delete alert on system rejected, system `updateMonitor`/`deleteMonitor` rejection, system `updateMonitorAlert` condition edit allowed).
 
 ### Milestone 10 — User-facing documentation
 


### PR DESCRIPTION
The **backend half of M4** — the monitor details-panel use-cases. Split from the panel UI (which follows in `LAT-630/details-panel`) to keep each PR reviewable. No HTTP/API surface yet (that's M9); these are domain use-cases + repository methods the web server-functions will call.

> Part of the LAT-630 Monitors plan (`specs/monitors.md`). Structured as two CRUD families — **monitor CRUD** and **monitor-alert CRUD** — rather than ad-hoc per-field use-cases.

## Monitor mutations (`@domain/monitors`)
- **`updateMonitorUseCase`** — metadata only (name + description); rejects system monitors; regenerates the slug only when the name's *normalised* form changes (shared `generateSlug` + repo `countActiveBySlug`), so a cosmetic case edit keeps the URL stable.
- **`deleteMonitorUseCase`** — soft-deletes the monitor and **cascades `deleted_at` to its live alerts** (firing stops; the incident→alert join keeps history attributable); rejects system monitors.
- **`muteMonitorUseCase` / `unmuteMonitorUseCase`** — set/clear `mutedAt`; allowed on **both** system and user monitors (per-monitor mute replaces the legacy per-kind toggles).

## Alert mutations (`@domain/monitors`)
- **`updateMonitorAlertUseCase`** — the single per-alert update (replaces the earlier `configureMonitorAlert` and the planned set-replacement `updateMonitorAlerts`). `kind` is immutable (and `source.type`, which the kind fixes); `source`/`condition`/`severity` are editable on user monitors; the resulting `condition` must match the alert's kind. On **system** monitors only an existing alert's configurable condition values may change — source/severity/no-condition edits are rejected.

New errors: `SystemMonitorForbiddenError` (403), `MonitorAlertNotFoundError` (404), `AlertConditionMismatchError` (400).

## Repository (`@platform/db-postgres`)
`setMuted`, `softDelete` (cascade to alerts), `updateMetadata`, `updateAlert` (`source_id`/`condition`/`severity`), `countActiveBySlug` — all org-scoped, `deleted_at`-aware, `NotFoundError` on miss.

## Tests
One file per use-case (`mute-monitor`, `delete-monitor`, `update-monitor`, `update-monitor-alert`) + repository idempotency/mutation tests against PGlite. `@domain/monitors` 37 tests, `@platform/db-postgres` monitor-repository 21 tests.

## Spec
- Reworked into the **monitor CRUD + alert CRUD** families (granular create/update/delete alerts — no set-replacement). API surface adds create/update/delete + read-projection alert endpoints (13 total; reads are thin projections over the monitor read, no new domain use-case).
- `createMonitor` / `createMonitorAlert` / `deleteMonitorAlert` deferred to **M5** (the create modal + add/remove-alert UI).
- Added a **Milestone UX** frontend-polish milestone between M5 and M6, with a `monitors` seeder as its front-loaded enabler.

## Verification
`pnpm typecheck` 75/75 · biome clean · knip clean · 37 + 21 tests.

## Out of scope
Details-panel UI (`LAT-630/details-panel`), create + add/remove-alert (M5), issue-event firing (M6), saved-search pipeline (M7), public API/SDK/MCP (M9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
