### PR TITLE
fix(web): stop phantom document updates in drafts

### DIFF
--- a/apps/web/src/components/BlocksEditor/Editor/index.tsx
+++ b/apps/web/src/components/BlocksEditor/Editor/index.tsx
@@ -12,7 +12,8 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
-import { useCallback, useMemo, useState } from 'react'
+import { EditorState } from 'lexical'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { BlocksEditorProps } from '../types'
 import { CodeNode } from './nodes/CodeNode'
@@ -38,7 +39,10 @@ import { VariableMenuPlugin } from './plugins/VariablesMenuPlugin'
 import { VariableTransformPlugin } from './plugins/VariableTransformPlugin'
 import { BlocksEditorProvider } from './Provider'
 import { fromBlocksToLexical } from './state/fromBlocksToLexical'
-import { fromLexicalToText } from './state/fromLexicalToText'
+import {
+  createBlocksChangeDeduper,
+  isBlockRootNode,
+} from './state/fromLexicalToText'
 
 const theme = {
   ltr: 'ltr',
@@ -66,11 +70,23 @@ const theme = {
 
 function OnChangeHandler({
   onChange,
+  initialValue,
 }: {
   onChange: BlocksEditorProps['onChange']
+  initialValue: BlocksEditorProps['initialValue']
 }) {
+  const deduper = useRef<
+    ReturnType<typeof createBlocksChangeDeduper> | undefined
+  >(undefined)
+  if (!deduper.current) {
+    deduper.current = createBlocksChangeDeduper(initialValue)
+  }
   const handleChange = useDebouncedCallback(
-    fromLexicalToText({ onChange }),
+    (editorState: EditorState) => {
+      const root = editorState.toJSON().root
+      if (!isBlockRootNode(root)) return
+      deduper.current!(root, onChange)
+    },
     100,
     { trailing: true },
   )
@@ -214,7 +230,7 @@ export function BlocksEditor({
             <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
           )}
           {autoFocus && <AutoFocusPlugin />}
-          <OnChangeHandler onChange={onChange} />
+          <OnChangeHandler onChange={onChange} initialValue={initialValue} />
           <SyncChangesPlugin
             project={project}
             commit={commit}

--- a/apps/web/src/components/BlocksEditor/Editor/state/fromLexicalToText.test.ts
+++ b/apps/web/src/components/BlocksEditor/Editor/state/fromLexicalToText.test.ts
@@ -1,0 +1,59 @@
+import { parse } from 'promptl-ai'
+import { describe, expect, it, vi } from 'vitest'
+import { createBlocksChangeDeduper } from './fromLexicalToText'
+import { BlockRootNode, fromAstToBlocks, fromBlocksToText } from './promptlToLexical'
+
+function buildRoot(prompt: string): BlockRootNode {
+  return fromAstToBlocks({ ast: parse(prompt), prompt })
+}
+
+describe('createBlocksChangeDeduper', () => {
+  it('forwards a change once and suppresses an identical follow-up', () => {
+    const onChange = vi.fn()
+    const deduper = createBlocksChangeDeduper(buildRoot(''))
+    const root = buildRoot('Hello world')
+
+    deduper(root, onChange)
+    deduper(root, onChange)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(fromBlocksToText(root))
+  })
+
+  it('does not forward a change that matches the initial value', () => {
+    const onChange = vi.fn()
+    const initialValue = buildRoot('Some existing prompt')
+    const deduper = createBlocksChangeDeduper(initialValue)
+
+    // The post-load transform re-emits the same (normalized) initial content.
+    deduper(buildRoot('Some existing prompt'), onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('forwards a genuinely different change with its serialized text', () => {
+    const onChange = vi.fn()
+    const deduper = createBlocksChangeDeduper(buildRoot('Before'))
+    const root = buildRoot('After')
+
+    deduper(root, onChange)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(fromBlocksToText(root))
+  })
+
+  it('fires each time the serialized text changes', () => {
+    const onChange = vi.fn()
+    const deduper = createBlocksChangeDeduper(buildRoot(''))
+    const rootA = buildRoot('First edit')
+    const rootB = buildRoot('Second edit')
+
+    deduper(rootA, onChange)
+    deduper(rootB, onChange)
+    deduper(rootB, onChange)
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenNthCalledWith(1, fromBlocksToText(rootA))
+    expect(onChange).toHaveBeenNthCalledWith(2, fromBlocksToText(rootB))
+  })
+})

--- a/apps/web/src/components/BlocksEditor/Editor/state/fromLexicalToText.ts
+++ b/apps/web/src/components/BlocksEditor/Editor/state/fromLexicalToText.ts
@@ -1,25 +1,30 @@
-import { EditorState, SerializedLexicalNode, SerializedRootNode } from 'lexical'
-import { BlocksEditorProps } from '../../types'
+import { SerializedLexicalNode, SerializedRootNode } from 'lexical'
 import { BlockRootNode, fromBlocksToText } from './promptlToLexical'
 
-function isBlockRootNode(
+export function isBlockRootNode(
   node: SerializedRootNode<SerializedLexicalNode>,
 ): node is BlockRootNode {
   return node.type === 'root' && Array.isArray(node.children)
 }
 
-export const fromLexicalToText =
-  ({ onChange }: { onChange: BlocksEditorProps['onChange'] }) =>
-  (editorState: EditorState) => {
-    const jsonState = editorState.toJSON()
-    const root = jsonState.root
-
-    if (!isBlockRootNode(jsonState.root)) {
-      // Typescript happiness is the most important to me.
-      // This can't happen because `EditorState.toJSON()` always returns a root node.
-      console.error('Invalid root node:', root)
-      return
-    }
-
-    onChange(fromBlocksToText(jsonState.root))
+/**
+ * Creates a stateful deduper for the blocks editor's onChange stream.
+ *
+ * Lexical emits an onChange shortly after load (node-transform normalization)
+ * without any user keystroke, and the serialized text round-trip is lossy
+ * (whitespace/indentation are normalized). Both produce a serialized body that
+ * is semantically identical to the initial value but differs from the stored
+ * raw text, which would otherwise create a phantom document version in the
+ * draft. The deduper only forwards a change when the serialized body differs
+ * from the last value it emitted (seeded with the serialized initial value),
+ * so these no-op emissions are suppressed while genuine edits still pass.
+ */
+export function createBlocksChangeDeduper(initialValue: BlockRootNode) {
+  let last = fromBlocksToText(initialValue)
+  return (root: BlockRootNode, onChange: (text: string) => void) => {
+    const text = fromBlocksToText(root)
+    if (text === last) return
+    last = text
+    onChange(text)
   }
+}

--- a/apps/web/src/hooks/useDocumentValueContext.tsx
+++ b/apps/web/src/hooks/useDocumentValueContext.tsx
@@ -87,6 +87,10 @@ export function DocumentValueProvider({
 
       setContentValue(content, opts)
 
+      // Do not persist a no-op edit, otherwise a phantom document version is
+      // created in the draft even though the content did not actually change.
+      if (content === prevContent) return
+
       const updatedDocument = await updateContent({
         documentUuid: _document.documentUuid,
         content,


### PR DESCRIPTION
Users reported prompts showing as **updated** in a draft without anyone editing them. The phantom change has two knock-on effects: changes other versions push to Live stop appearing in the draft, and publishing the draft overwrites those changes. Both are the correct behavior of a draft that holds a `document_version` row — the bug is that the row gets created when nothing meaningful changed.

There was no "did the content actually change?" guard anywhere on the write path, and the default blocks (WYSIWYG) editor makes the problem easy to hit: it serializes its content back to text on every Lexical `onChange`, including the change Lexical fires shortly after load from node-transform normalization (no keystroke involved). That round-trip is lossy — leading/trailing whitespace, `<step>/<system>/<user>` indentation, list formatting, and YAML frontmatter all get normalized. Because promptl hashes the **raw** text (`sha256(rawText + referencedHashes)`), the normalized-but-identical text hashes differently, a draft row is written, and `recomputeChanges` can't recognize it as a no-op.

This PR adds two client-side guards, one per commit.

## skip no-op content saves

`_updateDocumentContent` in `useDocumentValueContext` now returns early when the incoming content equals the current document content, so an unchanged save never reaches the server. This covers the plain text (dev-mode) editor and any exact-match re-emit.

## suppress no-op emissions from the blocks editor

The guard above isn't enough for the blocks editor, because the text it emits is normalized and therefore rarely equal to the stored raw content. `createBlocksChangeDeduper` (in `fromLexicalToText.ts`) is seeded with the serialized initial value and only forwards a change when the serialized body differs from the last value it emitted. The post-load transform serializes to the same baseline and gets swallowed; genuine edits still pass through. `OnChangeHandler` holds the deduper in a ref and runs it inside the existing debounced handler. The unused `fromLexicalToText` is removed in favor of the deduper plus the now-exported `isBlockRootNode`.

The deduper compares **body** text only — frontmatter is appended downstream in `onChangePrompt`, so when the body is unchanged `onChange` never fires and the frontmatter is never reconstructed.

## scope

Client-side only. This stops *new* phantom rows but does not clean drafts that already carry one: raw-text hashing means `recomputeChanges` can't auto-heal those. The retroactive fix — comparing the new content hash against HEAD in `updateDocumentUnsafe` and skipping/removing identical draft rows — was left out deliberately and is the natural follow-up.

## testing

`createBlocksChangeDeduper` has unit tests (`fromLexicalToText.test.ts`, node env, no jsdom) covering duplicate suppression, the post-load baseline match, a genuine change, and firing on each distinct change. The existing `promptlToLexical` serialization suite still passes (76 tests total). `pnpm tc` and `pnpm lint` are clean in `apps/web`.

Commit 1 (the one-line hook guard) has no automated test: it sits in a debounced hook with ~10 store dependencies, and the closest comparable hook test in the repo is `describe.skip`-ed. Verify manually — open a prompt with non-canonical raw text in the default editor, don't type, and confirm it is not marked changed in the draft changes sidebar; then make a real edit and confirm it is.
