### PR TITLE
fix(flaggers): drop node:crypto so run-flagger is browser-safe

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto"
 import {
   AI,
   AI_GENERATE_TELEMETRY_SPAN_NAMES,
@@ -17,6 +16,7 @@ import {
   TraceId,
 } from "@domain/shared"
 import { type TraceDetail, TraceRepository } from "@domain/spans"
+import { hash } from "@repo/utils"
 import { Effect, Option } from "effect"
 import { z } from "zod"
 import {
@@ -213,9 +213,11 @@ type InspectedAgentContext =
   | { readonly available: true; readonly text: string }
   | { readonly available: false; readonly reason: string }
 
-function buildCacheKey(organizationId: string, systemPrompt: string): string {
-  const hash = createHash("sha256").update(systemPrompt).digest("hex")
-  return `org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}${hash}`
+function buildCacheKey(organizationId: string, systemPrompt: string): Effect.Effect<string> {
+  return hash(systemPrompt).pipe(
+    Effect.map((digest) => `org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}${digest}`),
+    Effect.orElseSucceed(() => `org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}fallback`),
+  )
 }
 
 function parseCachedExtraction(value: string): InstructionExtractorOutput | null {
@@ -357,60 +359,58 @@ function getInspectedAgentContext(input: {
   readonly traceId: string
   readonly flaggerSlug: string
 }): Effect.Effect<InspectedAgentContext, never, CacheStore> {
-  const systemPrompt = extractInspectedSystemPrompt(input.trace)
+  return Effect.gen(function* () {
+    const systemPrompt = extractInspectedSystemPrompt(input.trace)
 
-  if (!systemPrompt) {
-    return Effect.succeed({ available: false, reason: "missing inspected agent system prompt" })
-  }
+    if (!systemPrompt) {
+      return { available: false, reason: "missing inspected agent system prompt" } satisfies InspectedAgentContext
+    }
 
-  if (systemPrompt.length <= INSPECTED_AGENT_VERBATIM_MAX_CHARS) {
-    return Effect.succeed({ available: true, text: renderShortSystemPromptContext(systemPrompt) })
-  }
+    if (systemPrompt.length <= INSPECTED_AGENT_VERBATIM_MAX_CHARS) {
+      return { available: true, text: renderShortSystemPromptContext(systemPrompt) } satisfies InspectedAgentContext
+    }
 
-  const cacheKey = buildCacheKey(input.organizationId, systemPrompt)
+    const cacheKey = yield* buildCacheKey(input.organizationId, systemPrompt)
+    const cached = yield* getCachedExtraction(cacheKey)
+    if (cached) return renderExtractionResult(cached)
 
-  return getCachedExtraction(cacheKey).pipe(
-    Effect.flatMap((cached) => {
-      if (cached) return Effect.succeed(renderExtractionResult(cached))
-
-      return input.ai
-        .generate({
-          ...FLAGGER_INSTRUCTION_EXTRACTOR_MODEL,
-          maxTokens: FLAGGER_INSTRUCTION_EXTRACTOR_MAX_TOKENS,
-          system: INSTRUCTION_EXTRACTOR_SYSTEM_PROMPT,
-          prompt: buildInstructionExtractorPrompt(systemPrompt),
-          schema: instructionExtractorOutputSchema,
-          telemetry: {
-            spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
-            tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify, ...reflagSuppressionTags(input.trace.tags)],
-            metadata: buildProjectScopedAiMetadata(
-              { organizationId: input.organizationId, projectId: input.projectId },
-              { traceId: input.traceId, flaggerSlug: input.flaggerSlug, stage: "instruction-extraction" },
-            ),
-          },
-        })
-        .pipe(
-          Effect.flatMap((result) =>
-            Effect.try({
-              try: () => instructionExtractorOutputSchema.parse(result.object),
-              catch: (error) =>
-                new AIError({
-                  message: "Instruction extractor returned invalid structured output.",
-                  cause: error,
-                }),
-            }),
+    return yield* input.ai
+      .generate({
+        ...FLAGGER_INSTRUCTION_EXTRACTOR_MODEL,
+        maxTokens: FLAGGER_INSTRUCTION_EXTRACTOR_MAX_TOKENS,
+        system: INSTRUCTION_EXTRACTOR_SYSTEM_PROMPT,
+        prompt: buildInstructionExtractorPrompt(systemPrompt),
+        schema: instructionExtractorOutputSchema,
+        telemetry: {
+          spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
+          tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify, ...reflagSuppressionTags(input.trace.tags)],
+          metadata: buildProjectScopedAiMetadata(
+            { organizationId: input.organizationId, projectId: input.projectId },
+            { traceId: input.traceId, flaggerSlug: input.flaggerSlug, stage: "instruction-extraction" },
           ),
-          Effect.tap((result) => setCachedExtraction(cacheKey, result)),
-          Effect.map((result) => renderExtractionResult(result)),
-          Effect.catch(() =>
-            Effect.gen(function* () {
-              yield* Effect.annotateCurrentSpan("flagger.instructionExtractionFallback", true)
-              return { available: true, text: renderFallbackAgentContext(systemPrompt) } satisfies InspectedAgentContext
-            }),
-          ),
-        )
-    }),
-  )
+        },
+      })
+      .pipe(
+        Effect.flatMap((result) =>
+          Effect.try({
+            try: () => instructionExtractorOutputSchema.parse(result.object),
+            catch: (error) =>
+              new AIError({
+                message: "Instruction extractor returned invalid structured output.",
+                cause: error,
+              }),
+          }),
+        ),
+        Effect.tap((result) => setCachedExtraction(cacheKey, result)),
+        Effect.map((result) => renderExtractionResult(result)),
+        Effect.catch(() =>
+          Effect.gen(function* () {
+            yield* Effect.annotateCurrentSpan("flagger.instructionExtractionFallback", true)
+            return { available: true, text: renderFallbackAgentContext(systemPrompt) } satisfies InspectedAgentContext
+          }),
+        ),
+      )
+  })
 }
 
 // Footer for assistant-response-centric strategies: restricts the judgement to


### PR DESCRIPTION
## Summary
- `run-flagger.ts` imported `node:crypto` for SHA-256 cache key hashing. The flaggers barrel re-exports `run-flagger.ts`, and `apps/web/src/domains/flaggers/flaggers.functions.ts` pulls the barrel via TanStack Start server functions. The handler stripping in the client bundle doesn't reach barrel re-exports, so `node:crypto` ended up in the client bundle and crashed in the browser:
  > Module "node:crypto" has been externalized for browser compatibility. Cannot access "node:crypto.createHash" in client code.
- Switches the inspected-agent-context cache key to `@repo/utils`' `hash`, which uses `crypto.subtle.digest("SHA-256", …)` and is explicitly documented as safe to load in browser bundles.
- `buildCacheKey` now returns an `Effect`; `getInspectedAgentContext` is rewritten with `Effect.gen` so the call site reads cleanly.

## Test plan
- [x] `pnpm --filter @domain/flaggers typecheck` clean
- [x] `pnpm --filter @domain/flaggers test` — 207 passing, 1 skipped
- [x] `pnpm --filter web typecheck` — only pre-existing `command-palette` error remains
- [ ] Run the web app and confirm the dataset page no longer throws the `node:crypto` browser error
- [ ] Verify the same SHA-256 hex output for an existing cache key payload (Web Crypto and node:crypto produce identical digests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)