### PR TITLE
docs: replace demo gif with video on overview page

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -10,10 +10,15 @@ Latitude is an **open-source, MIT-licensed** platform for improving production A
 The core workflow is simple: **observe what happened, search for what matters, track recurring issues, and monitor whether fixes work**.
 
 <Frame>
-  <img
-    src="/assets/readme/gif-ui.gif"
-    alt="Demo of the Latitude UI showing LLM observability, issue tracking, and evaluations"
-  />
+  <iframe
+    width="100%"
+    height="450"
+    src="https://www.youtube.com/embed/QxXjVlnYwps"
+    title="Latitude demo"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
 </Frame>
 
 ## Observability


### PR DESCRIPTION
## Summary
- Replace the `gif-ui.gif` demo image on the Getting Started → Overview page with an embedded YouTube demo video (https://youtu.be/QxXjVlnYwps).

## Test plan
- [ ] Run `npx mint dev` in `docs/` and open `/getting-started/introduction`
- [ ] Confirm the video embed renders and plays in place of the old gif