### PR TITLE
fix(crypto): use web crypto in app and domain packages

### DIFF
--- a/apps/web/src/domains/support/support.functions.ts
+++ b/apps/web/src/domains/support/support.functions.ts
@@ -1,5 +1,5 @@
-import crypto from "node:crypto"
 import { parseEnvOptional } from "@platform/env"
+import { hmacSha256Hex } from "@repo/utils"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
@@ -53,7 +53,7 @@ export const getSupportUserIdentity = createServerFn({ method: "GET" }).handler(
     // email (see backoffice/-components/account-actions/change-email.tsx),
     // and using email as user_id would split a single account into separate
     // Intercom contacts on every rename.
-    const userHash = crypto.createHmac("sha256", secretKey).update(user.id).digest("hex")
+    const userHash = await Effect.runPromise(hmacSha256Hex({ key: secretKey, message: user.id }))
 
     return {
       appId,

--- a/apps/web/src/server/slack-oauth-state.ts
+++ b/apps/web/src/server/slack-oauth-state.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto"
 import {
   OrganizationId,
   type OrganizationId as OrganizationIdType,
@@ -6,6 +5,7 @@ import {
   type UserId as UserIdType,
 } from "@domain/shared"
 import { createLogger } from "@repo/observability"
+import { randomHex } from "@repo/utils"
 import { z } from "zod"
 
 /**
@@ -81,7 +81,7 @@ export const generateSlackOAuthState = async (input: {
   readonly userId: UserIdType
   readonly returnTo?: string | null
 }): Promise<string> => {
-  const state = randomBytes(STATE_BYTES).toString("hex")
+  const state = randomHex(STATE_BYTES)
   const validatedReturnTo = input.returnTo == null ? null : validateReturnTo(input.returnTo)
   const payload = JSON.stringify({
     organizationId: input.organizationId,

--- a/packages/domain/shared/src/bootstrap-seed-scope.test.ts
+++ b/packages/domain/shared/src/bootstrap-seed-scope.test.ts
@@ -34,73 +34,73 @@ describe("bootstrapSeedScope — invariance with seeds.ts literals", () => {
     expect(bootstrapSeedScope.queueAssigneeUserIds).toEqual([...SEED_MANUAL_QUEUE_ASSIGNEES])
   })
 
-  it("resolves dataset cuids to seeds.ts literals", () => {
-    expect(bootstrapSeedScope.cuid("dataset:warranty")).toBe(SEED_WARRANTY_DATASET_ID)
-    expect(bootstrapSeedScope.cuid("dataset:combination")).toBe(SEED_DATASET_ID)
+  it("resolves dataset cuids to seeds.ts literals", async () => {
+    expect(await bootstrapSeedScope.cuid("dataset:warranty")).toBe(SEED_WARRANTY_DATASET_ID)
+    expect(await bootstrapSeedScope.cuid("dataset:combination")).toBe(SEED_DATASET_ID)
   })
 
-  it("resolves evaluation cuids to seeds.ts literals", () => {
-    expect(bootstrapSeedScope.cuid("evaluation:warranty-active")).toBe(SEED_EVALUATION_ID)
+  it("resolves evaluation cuids to seeds.ts literals", async () => {
+    expect(await bootstrapSeedScope.cuid("evaluation:warranty-active")).toBe(SEED_EVALUATION_ID)
   })
 
-  it("resolves named issue cuids and uuids to seeds.ts literals", () => {
-    expect(bootstrapSeedScope.cuid("issue:warranty-fab")).toBe(SEED_ISSUE_ID)
-    expect(bootstrapSeedScope.uuid("issue:warranty-fab:uuid")).toBe(SEED_ISSUE_UUID)
+  it("resolves named issue cuids and uuids to seeds.ts literals", async () => {
+    expect(await bootstrapSeedScope.cuid("issue:warranty-fab")).toBe(SEED_ISSUE_ID)
+    expect(await bootstrapSeedScope.uuid("issue:warranty-fab:uuid")).toBe(SEED_ISSUE_UUID)
   })
 
-  it("resolves the 128 long-tail issue ids and uuids by index", () => {
+  it("resolves the 128 long-tail issue ids and uuids by index", async () => {
     for (let i = 0; i < SEED_EXTRA_ISSUE_IDS.length; i++) {
-      expect(bootstrapSeedScope.cuid(`issue:extra:${i}`)).toBe(SEED_EXTRA_ISSUE_IDS[i])
-      expect(bootstrapSeedScope.uuid(`issue:extra:${i}:uuid`)).toBe(SEED_EXTRA_ISSUE_UUIDS[i])
+      expect(await bootstrapSeedScope.cuid(`issue:extra:${i}`)).toBe(SEED_EXTRA_ISSUE_IDS[i])
+      expect(await bootstrapSeedScope.uuid(`issue:extra:${i}:uuid`)).toBe(SEED_EXTRA_ISSUE_UUIDS[i])
     }
   })
 
-  it("resolves queue / simulation / score cuids", () => {
-    expect(bootstrapSeedScope.cuid("queue:warranty")).toBe(SEED_ANNOTATION_QUEUE_WARRANTY_ID)
-    expect(bootstrapSeedScope.cuid("simulation:warranty")).toBe(SEED_WARRANTY_SIMULATION_ID)
-    expect(bootstrapSeedScope.cuid("score:passed")).toBe(SEED_SCORE_PASSED_ID)
-    expect(bootstrapSeedScope.cuid("score:ui-polish:human-draft-1")).toBe(SEED_UI_POLISH_SCORE_IDS.humanDraft1)
+  it("resolves queue / simulation / score cuids", async () => {
+    expect(await bootstrapSeedScope.cuid("queue:warranty")).toBe(SEED_ANNOTATION_QUEUE_WARRANTY_ID)
+    expect(await bootstrapSeedScope.cuid("simulation:warranty")).toBe(SEED_WARRANTY_SIMULATION_ID)
+    expect(await bootstrapSeedScope.cuid("score:passed")).toBe(SEED_SCORE_PASSED_ID)
+    expect(await bootstrapSeedScope.cuid("score:ui-polish:human-draft-1")).toBe(SEED_UI_POLISH_SCORE_IDS.humanDraft1)
   })
 
-  it("resolves trace hex via prefix mapping (matches the existing fixedTraceHex output)", () => {
+  it("resolves trace hex via prefix mapping (matches the existing fixedTraceHex output)", async () => {
     // Shape: <prefix:2><index hex padded to 6><24 zeros> = 32 chars total.
-    expect(bootstrapSeedScope.traceHex("annotation", 0)).toBe(`af000000${"0".repeat(24)}`)
-    expect(bootstrapSeedScope.traceHex("annotation", 5)).toBe(`af000005${"0".repeat(24)}`)
+    expect(await bootstrapSeedScope.traceHex("annotation", 0)).toBe(`af000000${"0".repeat(24)}`)
+    expect(await bootstrapSeedScope.traceHex("annotation", 5)).toBe(`af000005${"0".repeat(24)}`)
   })
 
-  it("resolves alignment-fixture trace hex with the +100 index offset", () => {
+  it("resolves alignment-fixture trace hex with the +100 index offset", async () => {
     // SEED_ALIGNMENT_FIXTURE_TRACE_IDS[0] = fixedTraceHex("bf", 100) → "bf00006400000000000000000000000".padded
     // index 100 in hex is "64", padded to 6 chars: "000064"
-    expect(bootstrapSeedScope.traceHex("alignment-fixture", 0)).toBe(`bf000064${"0".repeat(24)}`)
-    expect(bootstrapSeedScope.traceHex("alignment-fixture", 5)).toBe(`bf000069${"0".repeat(24)}`)
+    expect(await bootstrapSeedScope.traceHex("alignment-fixture", 0)).toBe(`bf000064${"0".repeat(24)}`)
+    expect(await bootstrapSeedScope.traceHex("alignment-fixture", 5)).toBe(`bf000069${"0".repeat(24)}`)
   })
 
-  it("resolves the 5 lifecycle trace literals directly (not patterned)", () => {
+  it("resolves the 5 lifecycle trace literals directly (not patterned)", async () => {
     for (let i = 0; i < SEED_LIFECYCLE_TRACE_IDS.length; i++) {
-      expect(bootstrapSeedScope.traceHex("lifecycle", i)).toBe(SEED_LIFECYCLE_TRACE_IDS[i])
+      expect(await bootstrapSeedScope.traceHex("lifecycle", i)).toBe(SEED_LIFECYCLE_TRACE_IDS[i])
     }
   })
 
-  it("resolves the annotation-demo trace/span literals", () => {
-    expect(bootstrapSeedScope.traceHex("annotation-demo", 0)).toBe(SEED_ANNOTATION_DEMO_TRACE_ID)
+  it("resolves the annotation-demo trace/span literals", async () => {
+    expect(await bootstrapSeedScope.traceHex("annotation-demo", 0)).toBe(SEED_ANNOTATION_DEMO_TRACE_ID)
   })
 
-  it("falls through to derivation for unknown keys (forward-compat)", () => {
+  it("falls through to derivation for unknown keys (forward-compat)", async () => {
     // A new fixture key the bootstrap map doesn't know about must produce
     // a deterministic value (not throw, not return undefined).
-    const id = bootstrapSeedScope.cuid("dataset:future-fixture")
+    const id = await bootstrapSeedScope.cuid("dataset:future-fixture")
     expect(id).toMatch(/^[a-f0-9]{24}$/)
   })
 
-  it("preserves the legacy seedScoreId pattern for score-prefix keys", () => {
+  it("preserves the legacy seedScoreId pattern for score-prefix keys", async () => {
     // Pre-refactor `seedScoreId(prefix, index)` produced
     // `${prefix}${index padded 3}${'x' * remaining}`. With score ids now
     // resolved via `scope.cuid("score:<prefix>:<index>")`, the bootstrap
     // override must round-trip those keys back to the same literal so
     // `pnpm seed` is byte-identical and `scores.id` doesn't shift.
-    expect(bootstrapSeedScope.cuid("score:i1:0")).toBe(`i1000${"x".repeat(19)}`)
-    expect(bootstrapSeedScope.cuid("score:i2:5")).toBe(`i2005${"x".repeat(19)}`)
-    expect(bootstrapSeedScope.cuid("score:al:12")).toBe(`al012${"x".repeat(19)}`)
-    expect(bootstrapSeedScope.cuid("score:io:128")).toBe(`io128${"x".repeat(19)}`)
+    expect(await bootstrapSeedScope.cuid("score:i1:0")).toBe(`i1000${"x".repeat(19)}`)
+    expect(await bootstrapSeedScope.cuid("score:i2:5")).toBe(`i2005${"x".repeat(19)}`)
+    expect(await bootstrapSeedScope.cuid("score:al:12")).toBe(`al012${"x".repeat(19)}`)
+    expect(await bootstrapSeedScope.cuid("score:io:128")).toBe(`io128${"x".repeat(19)}`)
   })
 })

--- a/packages/domain/shared/src/seed-scope.test.ts
+++ b/packages/domain/shared/src/seed-scope.test.ts
@@ -11,48 +11,48 @@ const baseInput = {
 }
 
 describe("createSeedScope — derivation", () => {
-  it("produces a 24-char CUID-shaped id from cuid()", () => {
+  it("produces a 24-char CUID-shaped id from cuid()", async () => {
     const scope = createSeedScope(baseInput)
-    const id = scope.cuid("dataset:warranty")
+    const id = await scope.cuid("dataset:warranty")
     expect(id).toHaveLength(CUID_LENGTH)
     expect(id).toMatch(/^[a-f0-9]+$/) // hex is a strict subset of cuid alphabet
   })
 
-  it("produces a UUID v4-shaped string from uuid()", () => {
+  it("produces a UUID v4-shaped string from uuid()", async () => {
     const scope = createSeedScope(baseInput)
-    const id = scope.uuid("issue:warranty-fab")
+    const id = await scope.uuid("issue:warranty-fab")
     expect(id).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/)
   })
 
-  it("produces a 32-char hex string from traceHex()", () => {
+  it("produces a 32-char hex string from traceHex()", async () => {
     const scope = createSeedScope(baseInput)
-    expect(scope.traceHex("annotation", 0)).toMatch(/^[a-f0-9]{32}$/)
+    expect(await scope.traceHex("annotation", 0)).toMatch(/^[a-f0-9]{32}$/)
   })
 
-  it("produces a 16-char hex string from spanHex()", () => {
+  it("produces a 16-char hex string from spanHex()", async () => {
     const scope = createSeedScope(baseInput)
-    expect(scope.spanHex("annotation", 0)).toMatch(/^[a-f0-9]{16}$/)
+    expect(await scope.spanHex("annotation", 0)).toMatch(/^[a-f0-9]{16}$/)
   })
 
-  it("is deterministic for the same (projectId, key)", () => {
+  it("is deterministic for the same (projectId, key)", async () => {
     const a = createSeedScope(baseInput)
     const b = createSeedScope(baseInput)
-    expect(a.cuid("dataset:warranty")).toBe(b.cuid("dataset:warranty"))
-    expect(a.traceHex("annotation", 5)).toBe(b.traceHex("annotation", 5))
+    expect(await a.cuid("dataset:warranty")).toBe(await b.cuid("dataset:warranty"))
+    expect(await a.traceHex("annotation", 5)).toBe(await b.traceHex("annotation", 5))
   })
 
-  it("produces distinct ids for distinct projectIds", () => {
+  it("produces distinct ids for distinct projectIds", async () => {
     // Critical for the demo flow: two demo projects under the same org must
     // not collide on trace/span/entity ids in ClickHouse / Postgres.
     const projectA = createSeedScope({ ...baseInput, projectId: ProjectId("project-a") })
     const projectB = createSeedScope({ ...baseInput, projectId: ProjectId("project-b") })
-    expect(projectA.cuid("dataset:warranty")).not.toBe(projectB.cuid("dataset:warranty"))
-    expect(projectA.traceHex("annotation", 0)).not.toBe(projectB.traceHex("annotation", 0))
+    expect(await projectA.cuid("dataset:warranty")).not.toBe(await projectB.cuid("dataset:warranty"))
+    expect(await projectA.traceHex("annotation", 0)).not.toBe(await projectB.traceHex("annotation", 0))
   })
 
-  it("produces distinct ids for distinct indices on the same key", () => {
+  it("produces distinct ids for distinct indices on the same key", async () => {
     const scope = createSeedScope(baseInput)
-    const ids = Array.from({ length: 16 }, (_, i) => scope.traceHex("annotation", i))
+    const ids = await Promise.all(Array.from({ length: 16 }, (_, i) => scope.traceHex("annotation", i)))
     expect(new Set(ids).size).toBe(16)
   })
 })
@@ -78,17 +78,17 @@ describe("createSeedScope — date helpers", () => {
 })
 
 describe("createSeedScope — overrides", () => {
-  it("returns the override value when defined", () => {
+  it("returns the override value when defined", async () => {
     const scope = createSeedScope({
       ...baseInput,
       overrides: {
         cuid: (key) => (key === "dataset:warranty" ? "literal-id-from-bootstrap" : undefined),
       },
     })
-    expect(scope.cuid("dataset:warranty")).toBe("literal-id-from-bootstrap")
+    expect(await scope.cuid("dataset:warranty")).toBe("literal-id-from-bootstrap")
   })
 
-  it("falls through to derivation when the override returns undefined", () => {
+  it("falls through to derivation when the override returns undefined", async () => {
     // Crucial for forward-compatibility: the bootstrap override map only
     // covers fixture keys that exist today. A new fixture key the seed
     // bodies introduce later must produce a deterministic project-scoped
@@ -99,12 +99,12 @@ describe("createSeedScope — overrides", () => {
         cuid: (key) => (key === "dataset:warranty" ? "literal-id-from-bootstrap" : undefined),
       },
     })
-    const fallback = scope.cuid("dataset:future-fixture")
+    const fallback = await scope.cuid("dataset:future-fixture")
     expect(fallback).toHaveLength(CUID_LENGTH)
     expect(fallback).not.toBe("literal-id-from-bootstrap")
   })
 
-  it("applies the override per-method independently", () => {
+  it("applies the override per-method independently", async () => {
     const scope = createSeedScope({
       ...baseInput,
       overrides: {
@@ -113,8 +113,8 @@ describe("createSeedScope — overrides", () => {
       },
     })
     // traceHex override hit
-    expect(scope.traceHex("annotation", 0)).toBe(`00000000${"0".repeat(24)}`)
+    expect(await scope.traceHex("annotation", 0)).toBe(`00000000${"0".repeat(24)}`)
     // spanHex falls through (no override defined)
-    expect(scope.spanHex("annotation", 0)).toMatch(/^[a-f0-9]{16}$/)
+    expect(await scope.spanHex("annotation", 0)).toMatch(/^[a-f0-9]{16}$/)
   })
 })

--- a/packages/domain/shared/src/seed-scope.ts
+++ b/packages/domain/shared/src/seed-scope.ts
@@ -1,4 +1,5 @@
-import { createHash } from "node:crypto"
+import { hash } from "@repo/utils"
+import { Effect } from "effect"
 import { type ApiKeyId, CUID_LENGTH, type OrganizationId, type ProjectId } from "./id.ts"
 
 /**
@@ -45,13 +46,13 @@ export interface SeedScope {
   readonly apiKeyId: ApiKeyId
 
   /** 24-char CUID-shaped id, stable per `(projectId, key)`. */
-  cuid(key: string): string
+  cuid(key: string): Promise<string>
   /** UUID-v4-shaped string, stable per `(projectId, key)`. */
-  uuid(key: string): string
+  uuid(key: string): Promise<string>
   /** 32-char hex trace id. `index` defaults to `0` for one-off keys. */
-  traceHex(key: string, index?: number): string
+  traceHex(key: string, index?: number): Promise<string>
   /** 16-char hex span id. */
-  spanHex(key: string, index?: number): string
+  spanHex(key: string, index?: number): Promise<string>
   /**
    * Date `daysAgo` before the scope's `timelineAnchor`, at `hour:minute` UTC.
    * Capped to wall-clock "now" so a future-skewed anchor never produces a
@@ -89,17 +90,17 @@ export interface CreateSeedScopeInput {
 
 const FIELD_SEPARATOR = "\x00"
 
-const sha256 = (parts: readonly (string | number)[]): Buffer =>
-  createHash("sha256").update(parts.map(String).join(FIELD_SEPARATOR)).digest()
+const sha256Hex = (parts: readonly (string | number)[]): Promise<string> =>
+  Effect.runPromise(hash(parts.map(String).join(FIELD_SEPARATOR)))
 
-const deriveCuid = (projectId: string, key: string): string =>
-  sha256(["cuid", projectId, key]).toString("hex").slice(0, CUID_LENGTH)
+const deriveCuid = async (projectId: string, key: string): Promise<string> =>
+  (await sha256Hex(["cuid", projectId, key])).slice(0, CUID_LENGTH)
 
-const deriveUuid = (projectId: string, key: string): string => {
+const deriveUuid = async (projectId: string, key: string): Promise<string> => {
   // Layout-compliant v4: `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx` where `y` ∈
   // {8,9,a,b}. We don't strictly need RFC compliance for seed fixtures, but
   // matching the v4 shape avoids tripping consumers that validate UUIDs.
-  const hex = sha256(["uuid", projectId, key]).toString("hex")
+  const hex = await sha256Hex(["uuid", projectId, key])
   const variantNibble = (Number.parseInt(hex.slice(16, 17), 16) & 0x3) | 0x8
   return [
     hex.slice(0, 8),
@@ -113,11 +114,11 @@ const deriveUuid = (projectId: string, key: string): string => {
 const TRACE_HEX_LENGTH = 32
 const SPAN_HEX_LENGTH = 16
 
-const deriveTraceHex = (projectId: string, key: string, index: number): string =>
-  sha256(["trace", projectId, key, index]).toString("hex").slice(0, TRACE_HEX_LENGTH)
+const deriveTraceHex = async (projectId: string, key: string, index: number): Promise<string> =>
+  (await sha256Hex(["trace", projectId, key, index])).slice(0, TRACE_HEX_LENGTH)
 
-const deriveSpanHex = (projectId: string, key: string, index: number): string =>
-  sha256(["span", projectId, key, index]).toString("hex").slice(0, SPAN_HEX_LENGTH)
+const deriveSpanHex = async (projectId: string, key: string, index: number): Promise<string> =>
+  (await sha256Hex(["span", projectId, key, index])).slice(0, SPAN_HEX_LENGTH)
 
 /**
  * Cap computed dates to wall-clock "now" so a future-skewed anchor (or a
@@ -157,10 +158,11 @@ export const createSeedScope = (input: CreateSeedScopeInput): SeedScope => {
     timelineAnchor,
     queueAssigneeUserIds,
     apiKeyId,
-    cuid: (key) => overrides?.cuid?.(key) ?? deriveCuid(projectId, key),
-    uuid: (key) => overrides?.uuid?.(key) ?? deriveUuid(projectId, key),
-    traceHex: (key, index = 0) => overrides?.traceHex?.(key, index) ?? deriveTraceHex(projectId, key, index),
-    spanHex: (key, index = 0) => overrides?.spanHex?.(key, index) ?? deriveSpanHex(projectId, key, index),
+    cuid: async (key) => overrides?.cuid?.(key) ?? (await deriveCuid(projectId, key)),
+    uuid: async (key) => overrides?.uuid?.(key) ?? (await deriveUuid(projectId, key)),
+    traceHex: async (key, index = 0) =>
+      overrides?.traceHex?.(key, index) ?? (await deriveTraceHex(projectId, key, index)),
+    spanHex: async (key, index = 0) => overrides?.spanHex?.(key, index) ?? (await deriveSpanHex(projectId, key, index)),
     dateDaysAgo: (daysAgo, hour = 12, minute = 0) => deriveDateDaysAgo(timelineAnchor, daysAgo, hour, minute),
     timestampDaysAgo: (daysAgo, hour = 12, minute = 0) => deriveTimestampDaysAgo(timelineAnchor, daysAgo, hour, minute),
   }

--- a/packages/domain/spans/src/sampling/deterministic-sampler.test.ts
+++ b/packages/domain/spans/src/sampling/deterministic-sampler.test.ts
@@ -1,42 +1,45 @@
+import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import { deterministicSample } from "./deterministic-sampler.ts"
 
+const runSample = (key: string, rate: number): Promise<boolean> => Effect.runPromise(deterministicSample(key, rate))
+
 describe("deterministicSample", () => {
-  it("returns the same result for the same key", () => {
+  it("returns the same result for the same key", async () => {
     const key = "session-abc"
     const rate = 0.37
-    const first = deterministicSample(key, rate)
+    const first = await runSample(key, rate)
     for (let i = 0; i < 100; i++) {
-      expect(deterministicSample(key, rate)).toBe(first)
+      expect(await runSample(key, rate)).toBe(first)
     }
   })
 
-  it("always keeps when rate >= 1", () => {
-    expect(deterministicSample("any-key", 1)).toBe(true)
-    expect(deterministicSample("another", 1.5)).toBe(true)
+  it("always keeps when rate >= 1", async () => {
+    expect(await runSample("any-key", 1)).toBe(true)
+    expect(await runSample("another", 1.5)).toBe(true)
   })
 
-  it("always drops when rate <= 0", () => {
-    expect(deterministicSample("any-key", 0)).toBe(false)
-    expect(deterministicSample("another", -0.1)).toBe(false)
+  it("always drops when rate <= 0", async () => {
+    expect(await runSample("any-key", 0)).toBe(false)
+    expect(await runSample("another", -0.1)).toBe(false)
   })
 
-  it("distributes ~uniformly at rate 0.5", () => {
+  it("distributes ~uniformly at rate 0.5", async () => {
     const n = 10_000
     let kept = 0
     for (let i = 0; i < n; i++) {
-      if (deterministicSample(`key-${i}`, 0.5)) kept++
+      if (await runSample(`key-${i}`, 0.5)) kept++
     }
     const ratio = kept / n
     expect(ratio).toBeGreaterThan(0.48)
     expect(ratio).toBeLessThan(0.52)
   })
 
-  it("distributes ~uniformly at rate 0.1", () => {
+  it("distributes ~uniformly at rate 0.1", async () => {
     const n = 10_000
     let kept = 0
     for (let i = 0; i < n; i++) {
-      if (deterministicSample(`key-${i}`, 0.1)) kept++
+      if (await runSample(`key-${i}`, 0.1)) kept++
     }
     const ratio = kept / n
     expect(ratio).toBeGreaterThan(0.085)

--- a/packages/domain/spans/src/sampling/deterministic-sampler.ts
+++ b/packages/domain/spans/src/sampling/deterministic-sampler.ts
@@ -1,4 +1,5 @@
-import { createHash } from "node:crypto"
+import { type CryptoError, hash } from "@repo/utils"
+import { Effect } from "effect"
 
 /**
  * Deterministic [0, 1) draw from a key. Two calls with the same key always return
@@ -8,10 +9,12 @@ import { createHash } from "node:crypto"
  * bits — the most a JS number can hold as an exact integer — and divide by 2^53,
  * so the BigInt → Number conversion is lossless and the draw is uniform in [0, 1).
  */
-export function deterministicSample(key: string, rate: number): boolean {
-  if (rate >= 1) return true
-  if (rate <= 0) return false
-  const digest = createHash("sha256").update(key).digest()
-  const draw = Number(digest.readBigUInt64BE(0) >> 11n) / 2 ** 53
-  return draw < rate
+export function deterministicSample(key: string, rate: number): Effect.Effect<boolean, CryptoError> {
+  if (rate >= 1) return Effect.succeed(true)
+  if (rate <= 0) return Effect.succeed(false)
+  return Effect.map(hash(key), (digest) => {
+    const top64Bits = BigInt(`0x${digest.slice(0, 16)}`)
+    const draw = Number(top64Bits >> 11n) / 2 ** 53
+    return draw < rate
+  })
 }

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -10,7 +10,7 @@ import {
   StorageDisk,
   type StorageError,
 } from "@domain/shared"
-import { base64Encode } from "@repo/utils"
+import { base64Encode, type CryptoError } from "@repo/utils"
 import { Effect } from "effect"
 import { SpanDecodingError } from "../errors.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
@@ -91,7 +91,7 @@ export const ingestSpansUseCase = (
   input: IngestSpansInput,
 ): Effect.Effect<
   IngestSpansResult,
-  StorageError | QueuePublishError | RepositoryError | SpanDecodingError,
+  CryptoError | StorageError | QueuePublishError | RepositoryError | SpanDecodingError,
   StorageDisk | QueuePublisher | ProjectRepository | SqlClient
 > =>
   Effect.gen(function* () {
@@ -151,7 +151,7 @@ export const ingestSpansUseCase = (
     const sampling = samplingProject?.settings?.sampling
     if (sampling?.enabled && (sampling.rate ?? 1) < 1) {
       const samplingKey = extractSamplingKey(decoded)
-      if (samplingKey && !deterministicSample(samplingKey, sampling.rate ?? 1)) {
+      if (samplingKey && !(yield* deterministicSample(samplingKey, sampling.rate ?? 1))) {
         yield* Effect.annotateCurrentSpan("sampling.dropped", true)
         yield* Effect.annotateCurrentSpan("sampling.rate", sampling.rate ?? 1)
         // Sampled-out: don't store, don't enqueue. Spans still count as accepted in the OTLP

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -40,8 +40,8 @@ const BASELINE_TEST_TAG = "baseline-missing-values"
 // (~6 spans). They never query the ~hundreds of tau2 trajectory spans, so
 // inserting the full fixed-trace set per test was pure overhead. Same on
 // the score side: only lifecycle analytics are queried, not tau2 issues.
-const BASELINE_SPANS: readonly SpanRow[] = buildCompatibilitySupportSpans(bootstrapSeedScope)
-const BASELINE_SCORES = buildLifecycleAnalyticsRows(bootstrapSeedScope)
+let BASELINE_SPANS: readonly SpanRow[] = []
+let BASELINE_SCORES: Awaited<ReturnType<typeof buildLifecycleAnalyticsRows>> = []
 
 function toClickHouseDateTime(value: Date): string {
   return value.toISOString().replace("T", " ").replace("Z", "")
@@ -126,6 +126,8 @@ describe("TraceRepository", () => {
   let repo: TraceRepositoryShape
 
   beforeAll(async () => {
+    BASELINE_SPANS = await buildCompatibilitySupportSpans(bootstrapSeedScope)
+    BASELINE_SCORES = await buildLifecycleAnalyticsRows(bootstrapSeedScope)
     const combinedLayer = TraceRepositoryLive.pipe(Layer.provideMerge(mockAILayer))
     repo = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/platform/db-clickhouse/src/seeds/datasets/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/datasets/index.ts
@@ -7,10 +7,10 @@ import type { Seeder } from "../types.ts"
 
 const XACT_ID = 1
 
-function buildDatasetRows(scope: SeedScope) {
+async function buildDatasetRows(scope: SeedScope) {
   const orgId = scope.organizationId
-  const warrantyDatasetId = DatasetId(scope.cuid("dataset:warranty"))
-  const combinationDatasetId = DatasetId(scope.cuid("dataset:combination"))
+  const warrantyDatasetId = DatasetId(await scope.cuid("dataset:warranty"))
+  const combinationDatasetId = DatasetId(await scope.cuid("dataset:combination"))
 
   return [
     ...WARRANTY_DATASET_ROWS.map((row, i) => ({
@@ -39,7 +39,7 @@ const seedDatasetRows: Seeder = {
   run: (ctx) =>
     Effect.gen(function* () {
       // Sentinel: the first deterministic warranty row id.
-      const sentinel = DatasetId(ctx.scope.cuid("dataset:warranty"))
+      const sentinel = DatasetId(yield* Effect.promise(() => ctx.scope.cuid("dataset:warranty")))
       const present = yield* isSentinelPresent(
         ctx.client,
         "dataset_rows",
@@ -50,7 +50,8 @@ const seedDatasetRows: Seeder = {
         if (!ctx.quiet) console.log("  -> datasets/issue-guardrail-dataset-rows: already seeded, skipping")
         return
       }
-      yield* insertJsonEachRow(ctx.client, "dataset_rows", buildDatasetRows(ctx.scope))
+      const rows = yield* Effect.promise(() => buildDatasetRows(ctx.scope))
+      yield* insertJsonEachRow(ctx.client, "dataset_rows", rows)
     }),
 }
 

--- a/packages/platform/db-clickhouse/src/seeds/scores/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/scores/index.ts
@@ -21,11 +21,11 @@ const NAMED_ISSUE_KEYS = [
   "flagger",
 ] as const
 
-function scopedIssueIdByFixtureIndex(scope: SeedScope, index: number): string {
+async function scopedIssueIdByFixtureIndex(scope: SeedScope, index: number): Promise<string> {
   const key = NAMED_ISSUE_KEYS[index]
   return key === undefined
-    ? IssueId(scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`))
-    : IssueId(scope.cuid(`issue:${key}`))
+    ? IssueId(await scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`))
+    : IssueId(await scope.cuid(`issue:${key}`))
 }
 
 function createdAtForTau2Issue(scope: SeedScope, issueIndex: number, occurrenceIndex: number): string {
@@ -51,7 +51,7 @@ function buildFailedTrajectoryIndexesByFamily() {
   return byFamily
 }
 
-function buildTau2IssueAnalyticsRows(scope: SeedScope) {
+async function buildTau2IssueAnalyticsRows(scope: SeedScope) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
   const familyKeys = TAU2_SEED_ISSUE_FAMILIES.map((family) => family.key)
@@ -60,51 +60,56 @@ function buildTau2IssueAnalyticsRows(scope: SeedScope) {
     trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
   )
 
-  return SEED_ISSUE_FIXTURES.flatMap((_, issueIndex) => {
-    const family = familyKeys[issueIndex % familyKeys.length]!
-    const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
-    const occurrenceCount = issueIndex < 8 ? 12 : 3
+  const rows = await Promise.all(
+    SEED_ISSUE_FIXTURES.map(async (_, issueIndex) => {
+      const family = familyKeys[issueIndex % familyKeys.length]!
+      const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
+      const occurrenceCount = issueIndex < 8 ? 12 : 3
 
-    return Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => {
-      const trajectoryIndex = candidateIndexes[(issueIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
-      return {
-        id: ScoreId(scope.cuid(`score:tau2-issue:${issueIndex}:${occurrenceIndex}`)),
-        organization_id: orgId,
-        project_id: projectId,
-        session_id: "",
-        trace_id: scope.traceHex("tau2-trajectory", trajectoryIndex),
-        span_id: scope.spanHex("tau2-trajectory-root", trajectoryIndex),
-        source: "custom",
-        source_id: "tau2-seed-classifier",
-        simulation_id: "",
-        issue_id: scopedIssueIdByFixtureIndex(scope, issueIndex),
-        value: 0.05 + (occurrenceIndex % 4) * 0.03,
-        passed: false,
-        errored: false,
-        duration: 0,
-        tokens: 0,
-        cost: 0,
-        created_at: createdAtForTau2Issue(scope, issueIndex, occurrenceIndex),
-      }
-    })
-  })
+      return Promise.all(
+        Array.from({ length: occurrenceCount }, async (_, occurrenceIndex) => {
+          const trajectoryIndex = candidateIndexes[(issueIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+          return {
+            id: ScoreId(await scope.cuid(`score:tau2-issue:${issueIndex}:${occurrenceIndex}`)),
+            organization_id: orgId,
+            project_id: projectId,
+            session_id: "",
+            trace_id: await scope.traceHex("tau2-trajectory", trajectoryIndex),
+            span_id: await scope.spanHex("tau2-trajectory-root", trajectoryIndex),
+            source: "custom",
+            source_id: "tau2-seed-classifier",
+            simulation_id: "",
+            issue_id: await scopedIssueIdByFixtureIndex(scope, issueIndex),
+            value: 0.05 + (occurrenceIndex % 4) * 0.03,
+            passed: false,
+            errored: false,
+            duration: 0,
+            tokens: 0,
+            cost: 0,
+            created_at: createdAtForTau2Issue(scope, issueIndex, occurrenceIndex),
+          }
+        }),
+      )
+    }),
+  )
+  return rows.flat()
 }
 
 /** Compatibility lifecycle scores on fixed trace ids (used by trace filter tests and demos). */
-export function buildLifecycleAnalyticsRows(scope: SeedScope) {
+export async function buildLifecycleAnalyticsRows(scope: SeedScope) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
-  const evaluationWarrantyActiveId = EvaluationId(scope.cuid("evaluation:warranty-active"))
-  const evaluationCombinationId = EvaluationId(scope.cuid("evaluation:combination"))
+  const evaluationWarrantyActiveId = EvaluationId(await scope.cuid("evaluation:warranty-active"))
+  const evaluationCombinationId = EvaluationId(await scope.cuid("evaluation:combination"))
 
   return [
     {
-      id: ScoreId(scope.cuid("score:passed")),
+      id: ScoreId(await scope.cuid("score:passed")),
       organization_id: orgId,
       project_id: projectId,
       session_id: "",
-      trace_id: scope.traceHex("lifecycle", 2),
-      span_id: scope.spanHex("lifecycle", 2),
+      trace_id: await scope.traceHex("lifecycle", 2),
+      span_id: await scope.spanHex("lifecycle", 2),
       source: "evaluation",
       source_id: evaluationWarrantyActiveId,
       simulation_id: "",
@@ -118,12 +123,12 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       created_at: scope.timestampDaysAgo(10, 10),
     },
     {
-      id: ScoreId(scope.cuid("score:errored")),
+      id: ScoreId(await scope.cuid("score:errored")),
       organization_id: orgId,
       project_id: projectId,
       session_id: "",
-      trace_id: scope.traceHex("lifecycle", 3),
-      span_id: scope.spanHex("lifecycle", 3),
+      trace_id: await scope.traceHex("lifecycle", 3),
+      span_id: await scope.spanHex("lifecycle", 3),
       source: "evaluation",
       source_id: evaluationCombinationId,
       simulation_id: "",
@@ -137,11 +142,11 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       created_at: scope.timestampDaysAgo(9, 11),
     },
     {
-      id: ScoreId(scope.cuid("score:api-reviewed")),
+      id: ScoreId(await scope.cuid("score:api-reviewed")),
       organization_id: orgId,
       project_id: projectId,
       session_id: "",
-      trace_id: scope.traceHex("lifecycle", 3),
+      trace_id: await scope.traceHex("lifecycle", 3),
       span_id: "",
       source: "annotation",
       source_id: "API",
@@ -156,11 +161,11 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       created_at: scope.timestampDaysAgo(2, 12, 45),
     },
     {
-      id: ScoreId(scope.cuid("score:pending")),
+      id: ScoreId(await scope.cuid("score:pending")),
       organization_id: orgId,
       project_id: projectId,
       session_id: "",
-      trace_id: scope.traceHex("lifecycle", 4),
+      trace_id: await scope.traceHex("lifecycle", 4),
       span_id: "",
       source: "custom",
       source_id: "seed-import",
@@ -177,9 +182,9 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
   ]
 }
 
-function buildAllAnalyticsRows(scope: SeedScope) {
-  const lifecycleAnalyticsRows = buildLifecycleAnalyticsRows(scope)
-  const tau2IssueAnalyticsRows = buildTau2IssueAnalyticsRows(scope)
+async function buildAllAnalyticsRows(scope: SeedScope) {
+  const lifecycleAnalyticsRows = await buildLifecycleAnalyticsRows(scope)
+  const tau2IssueAnalyticsRows = await buildTau2IssueAnalyticsRows(scope)
 
   return {
     lifecycleAnalyticsRows,
@@ -193,13 +198,13 @@ const seedScores: Seeder = {
   run: (ctx) =>
     Effect.gen(function* () {
       // Sentinel: the first deterministic score id this seeder inserts.
-      const sentinel = ScoreId(ctx.scope.cuid("score:tau2-issue:0:0"))
+      const sentinel = ScoreId(yield* Effect.promise(() => ctx.scope.cuid("score:tau2-issue:0:0")))
       const present = yield* isSentinelPresent(ctx.client, "scores", "id = {sentinel:String}", { sentinel })
       if (present) {
         if (!ctx.quiet) console.log("  -> scores/tau2-support-analytics: already seeded, skipping")
         return
       }
-      const built = buildAllAnalyticsRows(ctx.scope)
+      const built = yield* Effect.promise(() => buildAllAnalyticsRows(ctx.scope))
       yield* insertJsonEachRow(ctx.client, "scores", built.all)
       if (!ctx.quiet) {
         console.log(

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -214,7 +214,7 @@ function createTau2ToolSpan(opts: {
   }
 }
 
-function createCompatibilityChatSpan(opts: {
+async function createCompatibilityChatSpan(opts: {
   scope: SeedScope
   traceKey: string
   index: number
@@ -225,10 +225,10 @@ function createCompatibilityChatSpan(opts: {
   metadata: Record<string, string>
   serviceName?: string
   systemInstruction?: string
-}): SpanRow {
+}): Promise<SpanRow> {
   const start = opts.scope.dateDaysAgo(opts.daysAgo, 10 + opts.index, 0)
-  const traceId = opts.scope.traceHex(opts.traceKey, opts.index)
-  const spanId = opts.scope.spanHex(opts.traceKey, opts.index)
+  const traceId = await opts.scope.traceHex(opts.traceKey, opts.index)
+  const spanId = await opts.scope.spanHex(opts.traceKey, opts.index)
   const inputMessages: Tau2Message[] = [{ role: "user", parts: [{ type: "text", content: opts.userPrompt }] }]
   const outputMessages: Tau2Message[] = [
     { role: "assistant", parts: [{ type: "text", content: opts.assistantResponse }] },
@@ -293,7 +293,7 @@ function createCompatibilityChatSpan(opts: {
   }
 }
 
-export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
+export async function buildCompatibilitySupportSpans(scope: SeedScope): Promise<SpanRow[]> {
   const specs = [
     {
       traceKey: "lifecycle",
@@ -357,16 +357,16 @@ export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
     },
   ] as const
 
-  return specs.map((spec) => createCompatibilityChatSpan({ scope, ...spec }))
+  return Promise.all(specs.map((spec) => createCompatibilityChatSpan({ scope, ...spec })))
 }
 
-function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
+async function buildTau2TrajectorySpans(scope: SeedScope): Promise<SpanRow[]> {
   const spans: SpanRow[] = []
 
-  TAU2_SEED_TRAJECTORIES.forEach((trajectory, trajectoryIndex) => {
+  for (const [trajectoryIndex, trajectory] of TAU2_SEED_TRAJECTORIES.entries()) {
     const messages: readonly Tau2SeedTrajectoryMessage[] = trajectory.messages
-    const traceId = scope.traceHex("tau2-trajectory", trajectoryIndex)
-    const rootSpanId = scope.spanHex("tau2-trajectory-root", trajectoryIndex)
+    const traceId = await scope.traceHex("tau2-trajectory", trajectoryIndex)
+    const rootSpanId = await scope.spanHex("tau2-trajectory-root", trajectoryIndex)
     const serviceName = `tau2-${trajectory.domain}-support-agent`
     const tags = ["support", "tau2-bench", trajectory.domain, trajectory.outcome]
     const metadata = {
@@ -472,7 +472,7 @@ function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
           createTau2LlmSpan({
             scope,
             traceId,
-            spanId: scope.spanHex("tau2-trajectory", trajectoryIndex * 1000 + spanIndex++),
+            spanId: await scope.spanHex("tau2-trajectory", trajectoryIndex * 1000 + spanIndex++),
             parentSpanId: rootSpanId,
             startTime: cursor,
             durationMs,
@@ -496,7 +496,7 @@ function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
         createTau2ToolSpan({
           scope,
           traceId,
-          spanId: scope.spanHex("tau2-trajectory", trajectoryIndex * 1000 + spanIndex++),
+          spanId: await scope.spanHex("tau2-trajectory", trajectoryIndex * 1000 + spanIndex++),
           parentSpanId: rootSpanId,
           startTime: cursor,
           durationMs: 180,
@@ -528,13 +528,13 @@ function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
     root.input_messages = JSON.stringify(rootInputMessages)
     root.output_messages = JSON.stringify(rootOutputMessages)
     root.end_time = formatClickHouseTimestamp(new Date(cursor.getTime() + 50))
-  })
+  }
 
   return spans
 }
 
-function buildAllFixedSpans(scope: SeedScope): SpanRow[] {
-  return [...buildTau2TrajectorySpans(scope), ...buildCompatibilitySupportSpans(scope)]
+async function buildAllFixedSpans(scope: SeedScope): Promise<SpanRow[]> {
+  return [...(await buildTau2TrajectorySpans(scope)), ...(await buildCompatibilitySupportSpans(scope))]
 }
 
 const seedFixedTraces: Seeder = {
@@ -543,13 +543,13 @@ const seedFixedTraces: Seeder = {
     Effect.gen(function* () {
       // Sentinel: the first deterministic tau2 trace_id. Present iff this
       // seeder has run before against the current scope.
-      const sentinel = ctx.scope.traceHex("tau2-trajectory", 0)
+      const sentinel = yield* Effect.promise(() => ctx.scope.traceHex("tau2-trajectory", 0))
       const present = yield* isSentinelPresent(ctx.client, "spans", "trace_id = {sentinel:String}", { sentinel })
       if (present) {
         if (!ctx.quiet) console.log("  -> spans/fixed-traces: already seeded, skipping")
         return
       }
-      const allFixedSpans = buildAllFixedSpans(ctx.scope)
+      const allFixedSpans = yield* Effect.promise(() => buildAllFixedSpans(ctx.scope))
       yield* insertJsonEachRow(ctx.client, "spans", allFixedSpans)
       if (!ctx.quiet) console.log(`  -> spans/fixed-traces: ${allFixedSpans.length} deterministic tau2 spans`)
     }),

--- a/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
@@ -102,11 +102,11 @@ interface BuildSpansArgs {
   readonly spec: OrphanFragmentSpec
 }
 
-function buildOrphanFragmentTraceSpans({ scope, spec }: BuildSpansArgs): SpanRow[] {
-  const traceId = scope.traceHex(spec.traceKey)
-  const rootSpanId = scope.spanHex(`${spec.traceKey}-root`)
-  const middlewareSpanId = scope.spanHex(`${spec.traceKey}-mw`)
-  const llmSpanId = scope.spanHex(`${spec.traceKey}-llm`)
+async function buildOrphanFragmentTraceSpans({ scope, spec }: BuildSpansArgs): Promise<SpanRow[]> {
+  const traceId = await scope.traceHex(spec.traceKey)
+  const rootSpanId = await scope.spanHex(`${spec.traceKey}-root`)
+  const middlewareSpanId = await scope.spanHex(`${spec.traceKey}-mw`)
+  const llmSpanId = await scope.spanHex(`${spec.traceKey}-llm`)
 
   // Outer wrapper starts at the anchor; middleware and LLM nest inside it.
   // Durations chosen so end_time of children is strictly before parent's end.
@@ -273,8 +273,9 @@ function buildOrphanFragmentTraceSpans({ scope, spec }: BuildSpansArgs): SpanRow
   return [httpWrapper, middleware, llm]
 }
 
-function buildAllOrphanFragmentSpans(scope: SeedScope): SpanRow[] {
-  return ORPHAN_FRAGMENT_SPECS.flatMap((spec) => buildOrphanFragmentTraceSpans({ scope, spec }))
+async function buildAllOrphanFragmentSpans(scope: SeedScope): Promise<SpanRow[]> {
+  const spans = await Promise.all(ORPHAN_FRAGMENT_SPECS.map((spec) => buildOrphanFragmentTraceSpans({ scope, spec })))
+  return spans.flat()
 }
 
 const seedOrphanFragments: Seeder = {
@@ -282,13 +283,13 @@ const seedOrphanFragments: Seeder = {
   run: (ctx) =>
     Effect.gen(function* () {
       // Sentinel: the trace_id of the first deterministic mixed-binding trace.
-      const sentinel = ctx.scope.traceHex(ORPHAN_FRAGMENT_SPECS[0]!.traceKey)
+      const sentinel = yield* Effect.promise(() => ctx.scope.traceHex(ORPHAN_FRAGMENT_SPECS[0]!.traceKey))
       const present = yield* isSentinelPresent(ctx.client, "spans", "trace_id = {sentinel:String}", { sentinel })
       if (present) {
         if (!ctx.quiet) console.log("  -> spans/orphan-fragments: already seeded, skipping")
         return
       }
-      const spans = buildAllOrphanFragmentSpans(ctx.scope)
+      const spans = yield* Effect.promise(() => buildAllOrphanFragmentSpans(ctx.scope))
       yield* insertJsonEachRow(ctx.client, "spans", spans)
       if (!ctx.quiet) {
         console.log(

--- a/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
+++ b/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
@@ -103,13 +103,13 @@ const seedAlertIncidents: Seeder = {
         const fixtureScopedIssueIds = new Map<string, string>()
         for (const [index, fixture] of SEED_ISSUE_FIXTURES.entries()) {
           const issueKey = fixtureScopedKey(index)
-          const issueId = fixtureScopedId(index, ctx.scope)
+          const issueId = await fixtureScopedId(index, ctx.scope)
           fixtureScopedIssueIds.set(fixture.id, issueId)
           const fixtureDates = issueFixtureDates(ctx.scope, fixture)
 
           rows.push(
             buildIncidentRow({
-              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.new`),
+              id: await ctx.scope.cuid(`alert-incident:${issueKey}:issue.new`),
               organizationId: ctx.scope.organizationId,
               projectId: ctx.scope.projectId,
               sourceId: issueId,
@@ -134,12 +134,12 @@ const seedAlertIncidents: Seeder = {
         }
 
         for (let index = 0; index < SEED_ISSUE_FIXTURES.length; index++) {
-          const issueId = fixtureScopedId(index, ctx.scope)
+          const issueId = await fixtureScopedId(index, ctx.scope)
           if (!escalatingIssueIds.has(issueId)) continue
           const issueKey = fixtureScopedKey(index)
           rows.push(
             buildIncidentRow({
-              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.escalating`),
+              id: await ctx.scope.cuid(`alert-incident:${issueKey}:issue.escalating`),
               organizationId: ctx.scope.organizationId,
               projectId: ctx.scope.projectId,
               sourceId: issueId,
@@ -163,7 +163,7 @@ const seedAlertIncidents: Seeder = {
           const issueKey = fixtureIndex === -1 ? fixtureIssueId : fixtureScopedKey(fixtureIndex)
           rows.push(
             buildIncidentRow({
-              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.regressed`),
+              id: await ctx.scope.cuid(`alert-incident:${issueKey}:issue.regressed`),
               organizationId: ctx.scope.organizationId,
               projectId: ctx.scope.projectId,
               sourceId: scopedIssueId,

--- a/packages/platform/db-postgres/src/seeds/annotation-queues/index.ts
+++ b/packages/platform/db-postgres/src/seeds/annotation-queues/index.ts
@@ -39,13 +39,13 @@ function pickAssignee(scope: SeedScope, index: number): string {
   return list[index % list.length]!
 }
 
-function buildQueueRows(scope: SeedScope) {
+async function buildQueueRows(scope: SeedScope) {
   const queueDate = (daysAgo: number, hour: number, minute = 0): Date => scope.dateDaysAgo(daysAgo, hour, minute)
   const assignee = (index: number) => pickAssignee(scope, index)
 
   return [
     {
-      id: AnnotationQueueId(scope.cuid("queue:warranty")),
+      id: AnnotationQueueId(await scope.cuid("queue:warranty")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       system: false,
@@ -66,7 +66,7 @@ function buildQueueRows(scope: SeedScope) {
       updatedAt: queueDate(12, 8),
     },
     {
-      id: AnnotationQueueId(scope.cuid("queue:combination")),
+      id: AnnotationQueueId(await scope.cuid("queue:combination")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       system: false,
@@ -87,7 +87,7 @@ function buildQueueRows(scope: SeedScope) {
       updatedAt: queueDate(7, 8),
     },
     {
-      id: AnnotationQueueId(scope.cuid("queue:logistics")),
+      id: AnnotationQueueId(await scope.cuid("queue:logistics")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       system: false,
@@ -107,7 +107,7 @@ function buildQueueRows(scope: SeedScope) {
       updatedAt: queueDate(3, 8, 15),
     },
     {
-      id: AnnotationQueueId(scope.cuid("queue:live")),
+      id: AnnotationQueueId(await scope.cuid("queue:live")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       system: false,
@@ -130,7 +130,7 @@ function buildQueueRows(scope: SeedScope) {
       updatedAt: queueDate(4, 10),
     },
     {
-      id: AnnotationQueueId(scope.cuid("queue:kitchen-sink")),
+      id: AnnotationQueueId(await scope.cuid("queue:kitchen-sink")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       system: false,
@@ -152,24 +152,24 @@ function buildQueueRows(scope: SeedScope) {
   ] satisfies AnnotationQueueRow[]
 }
 
-function buildQueueItemRows(scope: SeedScope) {
+async function buildQueueItemRows(scope: SeedScope) {
   const queueDate = (daysAgo: number, hour: number, minute = 0): Date => scope.dateDaysAgo(daysAgo, hour, minute)
   const assignee = (index: number) => pickAssignee(scope, index)
-  const queueWarrantyId = AnnotationQueueId(scope.cuid("queue:warranty"))
-  const queueCombinationId = AnnotationQueueId(scope.cuid("queue:combination"))
-  const queueLogisticsId = AnnotationQueueId(scope.cuid("queue:logistics"))
-  const queueLiveId = AnnotationQueueId(scope.cuid("queue:live"))
-  const queueKitchenSinkId = AnnotationQueueId(scope.cuid("queue:kitchen-sink"))
+  const queueWarrantyId = AnnotationQueueId(await scope.cuid("queue:warranty"))
+  const queueCombinationId = AnnotationQueueId(await scope.cuid("queue:combination"))
+  const queueLogisticsId = AnnotationQueueId(await scope.cuid("queue:logistics"))
+  const queueLiveId = AnnotationQueueId(await scope.cuid("queue:live"))
+  const queueKitchenSinkId = AnnotationQueueId(await scope.cuid("queue:kitchen-sink"))
 
-  const annotationDemoTraceId = scope.traceHex("annotation-demo", 0)
+  const annotationDemoTraceId = await scope.traceHex("annotation-demo", 0)
 
   return [
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:warranty:pending")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:warranty:pending")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueWarrantyId,
-      traceId: scope.traceHex("annotation", 2),
+      traceId: await scope.traceHex("annotation", 2),
       traceCreatedAt: queueDate(13, 8),
       completedAt: null,
       completedBy: null,
@@ -178,11 +178,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(12, 9),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:warranty:completed-a")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:warranty:completed-a")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueWarrantyId,
-      traceId: scope.traceHex("annotation", 0),
+      traceId: await scope.traceHex("annotation", 0),
       traceCreatedAt: queueDate(13, 7),
       completedAt: queueDate(12, 11, 15),
       completedBy: assignee(0),
@@ -191,11 +191,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(12, 11, 15),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:warranty:completed-b")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:warranty:completed-b")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueWarrantyId,
-      traceId: scope.traceHex("annotation", 8),
+      traceId: await scope.traceHex("annotation", 8),
       traceCreatedAt: queueDate(13, 6),
       completedAt: queueDate(12, 12, 5),
       completedBy: assignee(1),
@@ -204,11 +204,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(12, 12, 5),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:combination:pending")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:combination:pending")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueCombinationId,
-      traceId: scope.traceHex("annotation", 18),
+      traceId: await scope.traceHex("annotation", 18),
       traceCreatedAt: queueDate(8, 8),
       completedAt: null,
       completedBy: null,
@@ -217,11 +217,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(7, 9),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:combination:completed-a")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:combination:completed-a")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueCombinationId,
-      traceId: scope.traceHex("annotation", 16),
+      traceId: await scope.traceHex("annotation", 16),
       traceCreatedAt: queueDate(8, 7),
       completedAt: queueDate(7, 11, 40),
       completedBy: assignee(0),
@@ -230,11 +230,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(7, 11, 40),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:combination:completed-b")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:combination:completed-b")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueCombinationId,
-      traceId: scope.traceHex("annotation", 28),
+      traceId: await scope.traceHex("annotation", 28),
       traceCreatedAt: queueDate(8, 6),
       completedAt: queueDate(7, 12, 10),
       completedBy: assignee(0),
@@ -243,11 +243,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(7, 12, 10),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:logistics:pending")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:logistics:pending")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueLogisticsId,
-      traceId: scope.traceHex("annotation", 40),
+      traceId: await scope.traceHex("annotation", 40),
       traceCreatedAt: queueDate(4, 8),
       completedAt: null,
       completedBy: null,
@@ -256,11 +256,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(3, 9, 20),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:logistics:completed-a")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:logistics:completed-a")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueLogisticsId,
-      traceId: scope.traceHex("annotation", 38),
+      traceId: await scope.traceHex("annotation", 38),
       traceCreatedAt: queueDate(4, 7),
       completedAt: queueDate(3, 10, 35),
       completedBy: assignee(0),
@@ -269,11 +269,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(3, 10, 35),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:logistics:completed-b")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:logistics:completed-b")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueLogisticsId,
-      traceId: scope.traceHex("annotation", 43),
+      traceId: await scope.traceHex("annotation", 43),
       traceCreatedAt: queueDate(4, 6),
       completedAt: queueDate(3, 11),
       completedBy: assignee(0),
@@ -282,11 +282,11 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(3, 11),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:live:pending")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:live:pending")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueLiveId,
-      traceId: scope.traceHex("annotation", 16),
+      traceId: await scope.traceHex("annotation", 16),
       traceCreatedAt: queueDate(5, 8),
       completedAt: null,
       completedBy: null,
@@ -295,7 +295,7 @@ function buildQueueItemRows(scope: SeedScope) {
       updatedAt: queueDate(4, 10, 15),
     },
     {
-      id: AnnotationQueueItemId(scope.cuid("queue-item:kitchen-sink")),
+      id: AnnotationQueueItemId(await scope.cuid("queue-item:kitchen-sink")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       queueId: queueKitchenSinkId,
@@ -315,8 +315,8 @@ const seedAnnotationQueues: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const queueRows = buildQueueRows(ctx.scope)
-        const queueItemRows = buildQueueItemRows(ctx.scope)
+        const queueRows = await buildQueueRows(ctx.scope)
+        const queueItemRows = await buildQueueItemRows(ctx.scope)
 
         const staleQueues = await ctx.db
           .select({ id: annotationQueues.id })

--- a/packages/platform/db-postgres/src/seeds/datasets/index.ts
+++ b/packages/platform/db-postgres/src/seeds/datasets/index.ts
@@ -13,11 +13,11 @@ import { type SeedContext, SeedError, type Seeder } from "../types.ts"
  * descriptions) is identical across projects — only the row identity
  * shifts with the scope.
  */
-const seededDatasets = (scope: SeedScope) =>
+const seededDatasets = async (scope: SeedScope) =>
   [
     {
-      id: DatasetId(scope.cuid("dataset:warranty")),
-      versionId: DatasetVersionId(scope.cuid("dataset:warranty:version")),
+      id: DatasetId(await scope.cuid("dataset:warranty")),
+      versionId: DatasetVersionId(await scope.cuid("dataset:warranty:version")),
       slug: "warranty-coverage-guardrails",
       name: "Warranty Coverage Guardrails",
       description:
@@ -26,8 +26,8 @@ const seededDatasets = (scope: SeedScope) =>
       rowsInserted: WARRANTY_DATASET_ROWS.length,
     },
     {
-      id: DatasetId(scope.cuid("dataset:combination")),
-      versionId: DatasetVersionId(scope.cuid("dataset:combination:version")),
+      id: DatasetId(await scope.cuid("dataset:combination")),
+      versionId: DatasetVersionId(await scope.cuid("dataset:combination:version")),
       slug: "dangerous-combination-guardrails",
       name: "Dangerous Combination Guardrails",
       description:
@@ -42,7 +42,7 @@ const seedDatasets: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        for (const dataset of seededDatasets(ctx.scope)) {
+        for (const dataset of await seededDatasets(ctx.scope)) {
           await ctx.db
             .insert(datasets)
             .values({

--- a/packages/platform/db-postgres/src/seeds/evaluations/index.ts
+++ b/packages/platform/db-postgres/src/seeds/evaluations/index.ts
@@ -183,14 +183,14 @@ const accessAlignment: EvaluationAlignment = {
   },
 }
 
-const buildEvaluationRows = (scope: SeedScope) => {
+const buildEvaluationRows = async (scope: SeedScope) => {
   const at = (daysAgo: number, hour: number, minute = 0) => scope.dateDaysAgo(daysAgo, hour, minute)
   return [
     {
-      id: EvaluationId(scope.cuid("evaluation:warranty-active")),
+      id: EvaluationId(await scope.cuid("evaluation:warranty-active")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
-      issueId: IssueId(scope.cuid("issue:warranty-fab")),
+      issueId: IssueId(await scope.cuid("issue:warranty-fab")),
       name: "Warranty Coverage Fabrication Monitor",
       description:
         "Detects when the support agent invents warranty coverage, waivers, or reimbursement promises for " +
@@ -205,10 +205,10 @@ const buildEvaluationRows = (scope: SeedScope) => {
       updatedAt: at(3, 16, 0),
     },
     {
-      id: EvaluationId(scope.cuid("evaluation:warranty-archived")),
+      id: EvaluationId(await scope.cuid("evaluation:warranty-archived")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
-      issueId: IssueId(scope.cuid("issue:warranty-fab")),
+      issueId: IssueId(await scope.cuid("issue:warranty-fab")),
       name: "Terrain Warranty Promise Detector",
       description:
         "Earlier, narrower monitor that focused on guaranteed coverage for cliff and canyon incidents. It is " +
@@ -223,10 +223,10 @@ const buildEvaluationRows = (scope: SeedScope) => {
       updatedAt: at(46, 9, 0),
     },
     {
-      id: EvaluationId(scope.cuid("evaluation:combination")),
+      id: EvaluationId(await scope.cuid("evaluation:combination")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
-      issueId: IssueId(scope.cuid("issue:combination")),
+      issueId: IssueId(await scope.cuid("issue:combination")),
       name: "Dangerous Combination Guardrail Monitor",
       description:
         "Detects when the support agent recommends unsafe product combinations or fabricates authorization for " +
@@ -241,10 +241,10 @@ const buildEvaluationRows = (scope: SeedScope) => {
       updatedAt: at(5, 11, 30),
     },
     {
-      id: EvaluationId(scope.cuid("evaluation:returns")),
+      id: EvaluationId(await scope.cuid("evaluation:returns")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
-      issueId: IssueId(scope.cuid("issue:returns")),
+      issueId: IssueId(await scope.cuid("issue:returns")),
       name: "Instant Returns Eligibility Monitor",
       description:
         "Detects when the support agent promises refunds, pickups, or fee waivers that still require inspection, " +
@@ -259,10 +259,10 @@ const buildEvaluationRows = (scope: SeedScope) => {
       updatedAt: at(17, 15, 10),
     },
     {
-      id: EvaluationId(scope.cuid("evaluation:access")),
+      id: EvaluationId(await scope.cuid("evaluation:access")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
-      issueId: IssueId(scope.cuid("issue:access")),
+      issueId: IssueId(await scope.cuid("issue:access")),
       name: "Account Recovery Verification Monitor",
       description:
         "Detects when the support agent weakens account-recovery verification by exposing sensitive data, disabling MFA, " +
@@ -284,7 +284,7 @@ const seedEvaluations: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const evaluationRows = buildEvaluationRows(ctx.scope)
+        const evaluationRows = await buildEvaluationRows(ctx.scope)
         for (const row of evaluationRows) {
           const { id, ...set } = row
           await ctx.db.insert(evaluations).values(row).onConflictDoUpdate({

--- a/packages/platform/db-postgres/src/seeds/issues/index.ts
+++ b/packages/platform/db-postgres/src/seeds/issues/index.ts
@@ -19,7 +19,7 @@ const require = createRequire(import.meta.url)
 
 const EMBEDDING_BATCH_SIZE = 64
 
-type IssueLinkedScoreSeedRow = ReturnType<typeof buildIssueLinkedScoreSeedRows>[number]
+type IssueLinkedScoreSeedRow = Awaited<ReturnType<typeof buildIssueLinkedScoreSeedRows>>[number]
 type EmbeddedIssueLinkedScoreSeedRow = IssueLinkedScoreSeedRow & {
   readonly embedding: readonly number[]
 }
@@ -35,12 +35,12 @@ const NAMED_ISSUE_KEYS = [
   "flagger",
 ] as const
 
-export const fixtureScopedId = (index: number, scope: SeedScope): string =>
+export const fixtureScopedId = (index: number, scope: SeedScope): Promise<string> =>
   index < NAMED_ISSUE_KEYS.length
     ? scope.cuid(`issue:${NAMED_ISSUE_KEYS[index]}`)
     : scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`)
 
-const fixtureScopedUuid = (index: number, scope: SeedScope): string =>
+const fixtureScopedUuid = (index: number, scope: SeedScope): Promise<string> =>
   index < NAMED_ISSUE_KEYS.length
     ? scope.uuid(`issue:${NAMED_ISSUE_KEYS[index]}:uuid`)
     : scope.uuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}:uuid`)
@@ -273,7 +273,7 @@ const seedIssues: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const issueLinkedScoreSeedRows = buildIssueLinkedScoreSeedRows(ctx.scope)
+        const issueLinkedScoreSeedRows = await buildIssueLinkedScoreSeedRows(ctx.scope)
 
         const issueScoresByIssueId = new Map<string, IssueLinkedScoreSeedRow[]>()
         for (const row of issueLinkedScoreSeedRows) {
@@ -293,36 +293,38 @@ const seedIssues: Seeder = {
         const voyageApiKey = Effect.runSync(parseEnvOptional("LAT_VOYAGE_API_KEY", "string"))
         const embeddingsByScoreId =
           voyageApiKey === undefined ? null : await embedIssueFeedbacks(issueLinkedScoreSeedRows, voyageApiKey)
-        const issueRows = SEED_ISSUE_FIXTURES.map((issue, index) => {
-          const issueId = fixtureScopedId(index, ctx.scope)
-          const issueUuid = fixtureScopedUuid(index, ctx.scope)
-          const issueScores = issueScoresByIssueId.get(issueId) ?? []
-          const embeddedIssueScores =
-            embeddingsByScoreId === null
-              ? null
-              : issueScores.map((row) => {
-                  const embedding = embeddingsByScoreId.get(row.id)
-                  if (!embedding) {
-                    throw new Error(`Missing seeded issue embedding for score ${row.id}`)
-                  }
+        const issueRows = await Promise.all(
+          SEED_ISSUE_FIXTURES.map(async (issue, index) => {
+            const issueId = await fixtureScopedId(index, ctx.scope)
+            const issueUuid = await fixtureScopedUuid(index, ctx.scope)
+            const issueScores = issueScoresByIssueId.get(issueId) ?? []
+            const embeddedIssueScores =
+              embeddingsByScoreId === null
+                ? null
+                : issueScores.map((row) => {
+                    const embedding = embeddingsByScoreId.get(row.id)
+                    if (!embedding) {
+                      throw new Error(`Missing seeded issue embedding for score ${row.id}`)
+                    }
 
-                  return {
-                    ...row,
-                    embedding,
-                  } satisfies EmbeddedIssueLinkedScoreSeedRow
-                })
+                    return {
+                      ...row,
+                      embedding,
+                    } satisfies EmbeddedIssueLinkedScoreSeedRow
+                  })
 
-          return buildIssueRow({
-            scope: ctx.scope,
-            issue,
-            issueId,
-            issueUuid,
-            organizationId: ctx.scope.organizationId,
-            projectId: ctx.scope.projectId,
-            issueScores,
-            embeddedIssueScores,
-          })
-        })
+            return buildIssueRow({
+              scope: ctx.scope,
+              issue,
+              issueId,
+              issueUuid,
+              organizationId: ctx.scope.organizationId,
+              projectId: ctx.scope.projectId,
+              issueScores,
+              embeddedIssueScores,
+            })
+          }),
+        )
 
         for (const row of issueRows) {
           const { id, ...set } = row

--- a/packages/platform/db-postgres/src/seeds/notifications/index.ts
+++ b/packages/platform/db-postgres/src/seeds/notifications/index.ts
@@ -131,7 +131,7 @@ const seedIncidentNotifications: Seeder = {
             const idempotencyKey = buildIdempotencyKey({ kind: "incident.event", payload })
             for (const member of orgMembers) {
               rows.push({
-                id: NotificationId(ctx.scope.cuid(`notification:${incident.id}:${member.userId}:event`)),
+                id: NotificationId(await ctx.scope.cuid(`notification:${incident.id}:${member.userId}:event`)),
                 organizationId: incident.organizationId,
                 userId: member.userId,
                 kind: "incident.event",
@@ -159,7 +159,7 @@ const seedIncidentNotifications: Seeder = {
           const openedKey = buildIdempotencyKey({ kind: "incident.opened", payload: openedPayload })
           for (const member of orgMembers) {
             rows.push({
-              id: NotificationId(ctx.scope.cuid(`notification:${incident.id}:${member.userId}:opened`)),
+              id: NotificationId(await ctx.scope.cuid(`notification:${incident.id}:${member.userId}:opened`)),
               organizationId: incident.organizationId,
               userId: member.userId,
               kind: "incident.opened",
@@ -186,7 +186,7 @@ const seedIncidentNotifications: Seeder = {
             const closedKey = buildIdempotencyKey({ kind: "incident.closed", payload: closedPayload })
             for (const member of orgMembers) {
               rows.push({
-                id: NotificationId(ctx.scope.cuid(`notification:${incident.id}:${member.userId}:closed`)),
+                id: NotificationId(await ctx.scope.cuid(`notification:${incident.id}:${member.userId}:closed`)),
                 organizationId: incident.organizationId,
                 userId: member.userId,
                 kind: "incident.closed",

--- a/packages/platform/db-postgres/src/seeds/scores/index.ts
+++ b/packages/platform/db-postgres/src/seeds/scores/index.ts
@@ -21,11 +21,11 @@ const NAMED_ISSUE_KEYS = [
   "flagger",
 ] as const
 
-function scopedIssueIdByFixtureIndex(scope: SeedScope, index: number): string {
+async function scopedIssueIdByFixtureIndex(scope: SeedScope, index: number): Promise<string> {
   const key = NAMED_ISSUE_KEYS[index]
   return key === undefined
-    ? IssueId(scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`))
-    : IssueId(scope.cuid(`issue:${key}`))
+    ? IssueId(await scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`))
+    : IssueId(await scope.cuid(`issue:${key}`))
 }
 
 function createdAtForTau2Issue(scope: SeedScope, issueIndex: number, occurrenceIndex: number): Date {
@@ -58,7 +58,7 @@ function buildTau2Feedback(issueName: string, trajectory: Tau2SeedTrajectory): s
   )
 }
 
-function buildTau2IssueScoreRows(scope: SeedScope) {
+async function buildTau2IssueScoreRows(scope: SeedScope) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
   const familyKeys = TAU2_SEED_ISSUE_FAMILIES.map((family) => family.key)
@@ -67,30 +67,84 @@ function buildTau2IssueScoreRows(scope: SeedScope) {
     trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
   )
 
-  return SEED_ISSUE_FIXTURES.flatMap((issue, issueIndex) => {
-    const family = familyKeys[issueIndex % familyKeys.length]!
-    const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
-    const occurrenceCount = issueIndex < 8 ? 12 : 3
+  const rows = await Promise.all(
+    SEED_ISSUE_FIXTURES.map(async (issue, issueIndex) => {
+      const family = familyKeys[issueIndex % familyKeys.length]!
+      const candidateIndexes = failedByFamily.get(family) ?? allFailedTrajectoryIndexes
+      const occurrenceCount = issueIndex < 8 ? 12 : 3
 
-    return Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => {
-      const trajectoryIndex = candidateIndexes[(issueIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+      return Promise.all(
+        Array.from({ length: occurrenceCount }, async (_, occurrenceIndex) => {
+          const trajectoryIndex = candidateIndexes[(issueIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+          const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]!
+          const createdAt = createdAtForTau2Issue(scope, issueIndex, occurrenceIndex)
+
+          return {
+            id: ScoreId(await scope.cuid(`score:tau2-issue:${issueIndex}:${occurrenceIndex}`)),
+            organizationId: orgId,
+            projectId,
+            sessionId: null,
+            traceId: await scope.traceHex("tau2-trajectory", trajectoryIndex),
+            spanId: await scope.spanHex("tau2-trajectory-root", trajectoryIndex),
+            source: "custom" as const,
+            sourceId: "tau2-seed-classifier",
+            simulationId: null,
+            issueId: await scopedIssueIdByFixtureIndex(scope, issueIndex),
+            value: 0.05 + (occurrenceIndex % 4) * 0.03,
+            passed: false,
+            feedback: buildTau2Feedback(issue.name, trajectory),
+            metadata: {
+              dataset: "tau2-bench",
+              sourceFile: trajectory.sourceFile,
+              domain: trajectory.domain,
+              taskId: trajectory.taskId,
+              outcome: trajectory.outcome,
+              reward: String(trajectory.reward),
+              issueFamily: family,
+              trajectoryIndex: String(trajectoryIndex),
+            },
+            error: null,
+            errored: false,
+            duration: 0,
+            tokens: 0,
+            cost: 0,
+            draftedAt: null,
+            createdAt,
+            updatedAt: createdAt,
+          }
+        }),
+      )
+    }),
+  )
+  return rows.flat()
+}
+
+async function buildTau2ControlScoreRows(scope: SeedScope) {
+  const orgId = scope.organizationId
+  const projectId = scope.projectId
+  const successIndexes = TAU2_SEED_TRAJECTORIES.flatMap((trajectory, index) =>
+    trajectory.outcome === "success" && trajectory.reward >= 1 ? [index] : [],
+  ).slice(0, 6)
+
+  return Promise.all(
+    successIndexes.map(async (trajectoryIndex, index) => {
       const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]!
-      const createdAt = createdAtForTau2Issue(scope, issueIndex, occurrenceIndex)
+      const createdAt = scope.dateDaysAgo(index % 7, 9 + index, 15)
 
       return {
-        id: ScoreId(scope.cuid(`score:tau2-issue:${issueIndex}:${occurrenceIndex}`)),
+        id: ScoreId(await scope.cuid(`score:tau2-control:${index}`)),
         organizationId: orgId,
         projectId,
         sessionId: null,
-        traceId: scope.traceHex("tau2-trajectory", trajectoryIndex),
-        spanId: scope.spanHex("tau2-trajectory-root", trajectoryIndex),
+        traceId: await scope.traceHex("tau2-trajectory", trajectoryIndex),
+        spanId: await scope.spanHex("tau2-trajectory-root", trajectoryIndex),
         source: "custom" as const,
         sourceId: "tau2-seed-classifier",
         simulationId: null,
-        issueId: scopedIssueIdByFixtureIndex(scope, issueIndex),
-        value: 0.05 + (occurrenceIndex % 4) * 0.03,
-        passed: false,
-        feedback: buildTau2Feedback(issue.name, trajectory),
+        issueId: null,
+        value: 0.97,
+        passed: true,
+        feedback: `Tau2 ${trajectory.domain} task ${trajectory.taskId} completed successfully with benchmark reward ${trajectory.reward}.`,
         metadata: {
           dataset: "tau2-bench",
           sourceFile: trajectory.sourceFile,
@@ -98,7 +152,6 @@ function buildTau2IssueScoreRows(scope: SeedScope) {
           taskId: trajectory.taskId,
           outcome: trajectory.outcome,
           reward: String(trajectory.reward),
-          issueFamily: family,
           trajectoryIndex: String(trajectoryIndex),
         },
         error: null,
@@ -110,59 +163,13 @@ function buildTau2IssueScoreRows(scope: SeedScope) {
         createdAt,
         updatedAt: createdAt,
       }
-    })
-  })
+    }),
+  )
 }
 
-function buildTau2ControlScoreRows(scope: SeedScope) {
-  const orgId = scope.organizationId
-  const projectId = scope.projectId
-  const successIndexes = TAU2_SEED_TRAJECTORIES.flatMap((trajectory, index) =>
-    trajectory.outcome === "success" && trajectory.reward >= 1 ? [index] : [],
-  ).slice(0, 6)
-
-  return successIndexes.map((trajectoryIndex, index) => {
-    const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]!
-    const createdAt = scope.dateDaysAgo(index % 7, 9 + index, 15)
-
-    return {
-      id: ScoreId(scope.cuid(`score:tau2-control:${index}`)),
-      organizationId: orgId,
-      projectId,
-      sessionId: null,
-      traceId: scope.traceHex("tau2-trajectory", trajectoryIndex),
-      spanId: scope.spanHex("tau2-trajectory-root", trajectoryIndex),
-      source: "custom" as const,
-      sourceId: "tau2-seed-classifier",
-      simulationId: null,
-      issueId: null,
-      value: 0.97,
-      passed: true,
-      feedback: `Tau2 ${trajectory.domain} task ${trajectory.taskId} completed successfully with benchmark reward ${trajectory.reward}.`,
-      metadata: {
-        dataset: "tau2-bench",
-        sourceFile: trajectory.sourceFile,
-        domain: trajectory.domain,
-        taskId: trajectory.taskId,
-        outcome: trajectory.outcome,
-        reward: String(trajectory.reward),
-        trajectoryIndex: String(trajectoryIndex),
-      },
-      error: null,
-      errored: false,
-      duration: 0,
-      tokens: 0,
-      cost: 0,
-      draftedAt: null,
-      createdAt,
-      updatedAt: createdAt,
-    }
-  })
-}
-
-function buildAllScoreRows(scope: SeedScope) {
-  const tau2ControlScoreRows = buildTau2ControlScoreRows(scope)
-  const tau2IssueScoreRows = buildTau2IssueScoreRows(scope)
+async function buildAllScoreRows(scope: SeedScope) {
+  const tau2ControlScoreRows = await buildTau2ControlScoreRows(scope)
+  const tau2IssueScoreRows = await buildTau2IssueScoreRows(scope)
 
   return {
     tau2ControlScoreRows,
@@ -176,8 +183,8 @@ function buildAllScoreRows(scope: SeedScope) {
  * draft state — consumed by the issues seeder to derive issue centroids
  * from feedback embeddings.
  */
-export const buildIssueLinkedScoreSeedRows = (scope: SeedScope) =>
-  buildAllScoreRows(scope).tau2IssueScoreRows.filter(
+export const buildIssueLinkedScoreSeedRows = async (scope: SeedScope) =>
+  (await buildAllScoreRows(scope)).tau2IssueScoreRows.filter(
     (row): row is typeof row & { issueId: string } => row.issueId !== null && row.draftedAt === null,
   )
 
@@ -186,7 +193,7 @@ const seedScores: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const built = buildAllScoreRows(ctx.scope)
+        const built = await buildAllScoreRows(ctx.scope)
         const allScoreRows = built.all
         for (const row of allScoreRows) {
           const { id, ...set } = row

--- a/packages/platform/db-postgres/src/seeds/simulations/index.ts
+++ b/packages/platform/db-postgres/src/seeds/simulations/index.ts
@@ -15,16 +15,16 @@ type SimulationRow = typeof simulations.$inferInsert
  * seeder forward (the demo project's `evaluation:warranty-active`
  * resolves to the same fresh id on both sides of the link).
  */
-const buildSimulationRows = (scope: SeedScope) => {
+const buildSimulationRows = async (scope: SeedScope) => {
   const simulationDate = (daysAgo: number, hour: number, minute = 0): Date => scope.dateDaysAgo(daysAgo, hour, minute)
   return [
     {
-      id: SimulationId(scope.cuid("simulation:warranty")),
+      id: SimulationId(await scope.cuid("simulation:warranty")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       name: "Acme Assist Warranty Regression",
-      dataset: scope.cuid("dataset:warranty"),
-      evaluations: [scope.cuid("evaluation:warranty-active"), scope.cuid("evaluation:warranty-archived")],
+      dataset: await scope.cuid("dataset:warranty"),
+      evaluations: [await scope.cuid("evaluation:warranty-active"), await scope.cuid("evaluation:warranty-archived")],
       passed: true,
       errored: false,
       metadata: {
@@ -40,12 +40,12 @@ const buildSimulationRows = (scope: SeedScope) => {
       updatedAt: simulationDate(6, 9, 6),
     },
     {
-      id: SimulationId(scope.cuid("simulation:combination")),
+      id: SimulationId(await scope.cuid("simulation:combination")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       name: "Acme Assist Combination Safety Regression",
-      dataset: scope.cuid("dataset:combination"),
-      evaluations: [scope.cuid("evaluation:combination")],
+      dataset: await scope.cuid("dataset:combination"),
+      evaluations: [await scope.cuid("evaluation:combination")],
       passed: true,
       errored: false,
       metadata: {
@@ -61,12 +61,12 @@ const buildSimulationRows = (scope: SeedScope) => {
       updatedAt: simulationDate(4, 13, 24),
     },
     {
-      id: SimulationId(scope.cuid("simulation:errored")),
+      id: SimulationId(await scope.cuid("simulation:errored")),
       organizationId: scope.organizationId,
       projectId: scope.projectId,
       name: "Acme Assist Logistics Loader Smoke Test",
       dataset: SIMULATION_DATASET_CUSTOM_SENTINEL,
-      evaluations: [scope.cuid("evaluation:combination")],
+      evaluations: [await scope.cuid("evaluation:combination")],
       passed: false,
       errored: true,
       metadata: {
@@ -90,7 +90,7 @@ const seedSimulations: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const simulationRows = buildSimulationRows(ctx.scope)
+        const simulationRows = await buildSimulationRows(ctx.scope)
         for (const row of simulationRows) {
           const { id, ...set } = row
           await ctx.db.insert(simulations).values(row).onConflictDoUpdate({

--- a/packages/platform/db-postgres/src/seeds/wrapped-reports/index.ts
+++ b/packages/platform/db-postgres/src/seeds/wrapped-reports/index.ts
@@ -207,8 +207,8 @@ const seedWrappedReports: Seeder = {
         const now = ctx.scope.dateDaysAgo(0, 9, 0)
 
         for (let i = 0; i < REPORT_COUNT; i++) {
-          const reportId = WrappedReportId(ctx.scope.cuid(`wr:report:${i}`))
-          const projectId = ctx.scope.cuid(`wr:proj:${i}`)
+          const reportId = WrappedReportId(await ctx.scope.cuid(`wr:report:${i}`))
+          const projectId = await ctx.scope.cuid(`wr:proj:${i}`)
           const orgId = SEED_ORG_ID
 
           const report = buildReport(i, projectId, orgId)

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -36,6 +36,27 @@ export const hash = (value: unknown): Effect.Effect<string, CryptoError> =>
     catch: (cause) => new CryptoError({ operation: "hash", cause }),
   })
 
+export const randomHex = (byteLength: number): string => hexEncode(crypto.getRandomValues(new Uint8Array(byteLength)))
+
+export const hmacSha256Hex = (input: {
+  readonly key: string
+  readonly message: string
+}): Effect.Effect<string, CryptoError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const cryptoKey = await crypto.subtle.importKey(
+        "raw",
+        encodeUtf8(input.key),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      )
+      const signature = await crypto.subtle.sign("HMAC", cryptoKey, encodeUtf8(input.message))
+      return hexEncode(new Uint8Array(signature))
+    },
+    catch: (cause) => new CryptoError({ operation: "hmacSha256Hex", cause }),
+  })
+
 const ALGORITHM = "AES-GCM"
 const IV_LENGTH = 12
 const AUTH_TAG_LENGTH = 16

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,7 +7,7 @@ export {
   hexDecode,
   hexEncode,
 } from "./base64.ts"
-export { CryptoError, decrypt, encodeUtf8, encrypt, hash, toBuffer } from "./crypto.ts"
+export { CryptoError, decrypt, encodeUtf8, encrypt, hash, hmacSha256Hex, randomHex, toBuffer } from "./crypto.ts"
 export { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
 export {
   formatBytes,


### PR DESCRIPTION
## Summary

Removes `node:crypto` usage from app and domain production code so those packages stay portable across browser, edge, and other Web API runtimes.

`@repo/utils` now exposes Web Crypto-backed helpers for random hex tokens and HMAC-SHA256. Domain hashing paths that previously used synchronous Node SHA-256 now use the existing `crypto.subtle.digest` abstraction, so seed-scope id derivation and deterministic span sampling are asynchronous. Platform seeders were updated to await those derived ids when building Postgres and ClickHouse seed rows.

## Notes

Seed data generation still produces deterministic scoped ids, trace ids, and span ids, but the derivation methods on `SeedScope` now return promises. Tooling, tests, telemetry packages, and other non-critical Node-only paths are left unchanged.

## Validation

- `pnpm --filter @repo/utils typecheck`
- `pnpm --filter @domain/shared typecheck`
- `pnpm --filter @domain/spans typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @platform/db-postgres typecheck`
- `pnpm --filter @platform/db-clickhouse typecheck`
- `pnpm --filter @app/workflows typecheck`
- `pnpm --filter @domain/shared test -- seed-scope`
- `pnpm --filter @domain/spans test -- deterministic-sampler`
- `pnpm --filter @app/web test -- slack-oauth-state`
- `pnpm --filter @platform/db-clickhouse test -- trace-repository`
