### PR TITLE
Fix Trashing repeat detection anchors

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
@@ -17,10 +17,11 @@ describe("trashingStrategy.detectDeterministically", () => {
       if (result?.kind === "matched") {
         expect(result.feedback).toMatch(/Thrashing/)
         expect(result.feedback).toMatch(/3 times/)
+        expect(result.messageIndex).toBe(2)
       }
     })
 
-    it("matches an A-B-A-B-A oscillation (A appears 3×)", () => {
+    it("does not hard-match non-consecutive A-B-A-B-A repetition", () => {
       const trace = makeTrace([
         assistantToolCall("enable", { x: 1 }),
         assistantToolCall("disable", { x: 1 }),
@@ -29,7 +30,7 @@ describe("trashingStrategy.detectDeterministically", () => {
         assistantToolCall("enable", { x: 1 }),
       ])
 
-      expect(trashingStrategy.detectDeterministically?.(trace)).toMatchObject({ kind: "matched" })
+      expect(trashingStrategy.detectDeterministically?.(trace)).toEqual({ kind: "ambiguous" })
     })
 
     it("reports the actual repeat count in feedback when >3", () => {
@@ -44,6 +45,7 @@ describe("trashingStrategy.detectDeterministically", () => {
       const result = trashingStrategy.detectDeterministically?.(trace)
       if (result?.kind === "matched") {
         expect(result.feedback).toMatch(/5 times/)
+        expect(result.messageIndex).toBe(4)
       } else {
         throw new Error("expected matched")
       }
@@ -104,6 +106,24 @@ describe("trashingStrategy.detectDeterministically", () => {
         assistantToolCall("search", { q: "a" }),
         assistantToolCall("search", { q: "b" }),
         assistantToolCall("search", { q: "c" }),
+      ])
+
+      expect(trashingStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("returns no-match when exact reads recur across separate work, not consecutively", () => {
+      const trace = makeTrace([
+        assistantToolCall("Read", { file_path: "/Users/paula/to-do/context/MARKETING-TODO.md" }),
+        assistantToolCall("Write", { file_path: "/Users/paula/to-do/context/MARKETING-TODO.md", content: "initial" }),
+        assistantToolCall("Read", { file_path: "/Users/paula/to-do/context/MARKETING-TODO.md" }),
+        assistantToolCall("Edit", {
+          file_path: "/Users/paula/to-do/context/MARKETING-TODO.md",
+          old_string: "a",
+          new_string: "b",
+        }),
+        assistantToolCall("Read", { file_path: "/Users/paula/to-do/context/MARKETING-TODO.md" }),
+        assistantToolCall("Skill", { skill: "anthropic-skills:marketing-todo" }),
+        assistantToolCall("Read", { file_path: "/Users/paula/to-do/context/MARKETING-TODO.md" }),
       ])
 
       expect(trashingStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })

--- a/packages/domain/flaggers/src/flagger-strategies/trashing.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/trashing.ts
@@ -82,6 +82,7 @@ Return no explanation outside the structured output.
 // ---------------------------------------------------------------------------
 
 interface ToolCallEntry {
+  readonly messageIndex: number
   readonly turn: number
   readonly name: string
   readonly argsPreview: string
@@ -104,7 +105,8 @@ function extractToolCallSequence(trace: Pick<TraceDetail, "allMessages">): reado
   const entries: ToolCallEntry[] = []
   let turn = 0
 
-  for (const message of trace.allMessages) {
+  for (let messageIndex = 0; messageIndex < trace.allMessages.length; messageIndex++) {
+    const message = trace.allMessages[messageIndex]!
     if (message.role !== "assistant") continue
     turn++
 
@@ -115,6 +117,7 @@ function extractToolCallSequence(trace: Pick<TraceDetail, "allMessages">): reado
 
       const rawArgs = (part as { arguments?: unknown }).arguments
       entries.push({
+        messageIndex,
         turn,
         name,
         argsPreview: previewArguments(rawArgs),
@@ -186,6 +189,36 @@ const maxCount = (counts: Map<unknown, number>): number => {
   return max
 }
 
+const toolCallSignature = (entry: ToolCallEntry): string => `${entry.name}\0${entry.argsPreview}`
+
+const longestConsecutiveSignatureRun = (
+  entries: readonly ToolCallEntry[],
+): { readonly count: number; readonly messageIndex?: number | undefined } => {
+  let bestCount = 0
+  let bestMessageIndex: number | undefined
+  let currentSignature: string | undefined
+  let currentCount = 0
+  let currentMessageIndex: number | undefined
+
+  for (const entry of entries) {
+    const signature = toolCallSignature(entry)
+    if (signature === currentSignature) {
+      currentCount++
+    } else {
+      currentSignature = signature
+      currentCount = 1
+    }
+    currentMessageIndex = entry.messageIndex
+
+    if (currentCount > bestCount) {
+      bestCount = currentCount
+      bestMessageIndex = currentMessageIndex
+    }
+  }
+
+  return { count: bestCount, messageIndex: bestMessageIndex }
+}
+
 // ---------------------------------------------------------------------------
 // Thrashing Strategy implementation
 // ---------------------------------------------------------------------------
@@ -208,13 +241,13 @@ export const trashingStrategy: FlaggerStrategy = {
       return { kind: "no-match" }
     }
 
-    const signatureCounts = countBy(entries, (entry) => `${entry.name} ${entry.argsPreview}`)
-    const maxSignatureCount = maxCount(signatureCounts)
+    const signatureRun = longestConsecutiveSignatureRun(entries)
 
-    if (maxSignatureCount >= MATCHED_IDENTICAL_CALL_THRESHOLD) {
+    if (signatureRun.count >= MATCHED_IDENTICAL_CALL_THRESHOLD) {
       return {
         kind: "matched",
-        feedback: `Thrashing: identical tool+args invocation repeated ${maxSignatureCount} times`,
+        feedback: `Thrashing: identical tool+args invocation repeated ${signatureRun.count} times`,
+        messageIndex: signatureRun.messageIndex,
       }
     }
 


### PR DESCRIPTION
Trashing deterministic detection was counting identical tool+args invocations across the whole trace. That produced false positives when the same tool was legitimately reused across separate user turns or after state changes, such as reading the same todo file several times during unrelated work.

This PR changes the hard-match path to require a consecutive run of identical tool+args invocations. Non-consecutive repeated patterns still flow through the existing ambiguous path when they meet the dominance threshold, so LLM verification can decide whether they are actual trashing.

The detector now records the source conversation message index for each tool call and includes the offending messageIndex on deterministic matches. This lets system-authored Trashing annotations anchor to the repeated invocation instead of appearing as global trace annotations.

Validated with:
- `pnpm --filter @domain/flaggers test -- src/flagger-strategies/trashing.test.ts`
- `pnpm --filter @domain/flaggers typecheck`
- pre-commit format/knip hook