### PR TITLE
fix(core): prevent drafts from reverting parallel changes to referencing prompts

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangeDiff.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangeDiff.tsx
@@ -1,17 +1,23 @@
 import { TextEditorPlaceholder } from '@latitude-data/web-ui/molecules/TextEditorPlaceholder'
 import { useCurrentCommit } from '$/app/providers/CommitProvider'
 import { DiffViewer } from '@latitude-data/web-ui/molecules/DiffViewer'
+import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { ChangedDocument, ModifiedDocumentType } from '@latitude-data/constants'
 import useDocumentVersions from '$/stores/documentVersions'
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
 import { useMemo } from 'react'
 
+const REFERENCE_ONLY_DESCRIPTION =
+  "This prompt's content hasn't changed — it references another prompt that was modified in this version."
+
 function DocumentDiff({
   oldContent,
   newContent,
+  changeType,
 }: {
   oldContent?: string
   newContent?: string
+  changeType?: ModifiedDocumentType
 }) {
   if (oldContent === undefined || newContent === undefined) {
     return (
@@ -22,7 +28,10 @@ function DocumentDiff({
   }
 
   return (
-    <div className='flex w-full flex-grow'>
+    <div className='flex w-full flex-col flex-grow gap-2'>
+      {changeType === ModifiedDocumentType.UpdatedByReference && (
+        <Alert description={REFERENCE_ONLY_DESCRIPTION} />
+      )}
       <DiffViewer newValue={newContent} oldValue={oldContent} />
     </div>
   )
@@ -69,6 +78,7 @@ export function ChangeDiff({ change }: { change: ChangedDocument }) {
 
   return (
     <DocumentDiff
+      changeType={change.changeType}
       oldContent={change.changeType === ModifiedDocumentType.Created ? '' : headDocument?.content} // prettier-ignore
       newContent={change.changeType === ModifiedDocumentType.Deleted ? '' : currentDocument?.content} // prettier-ignore
     />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/ChangeDiffViewer/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/ChangeDiffViewer/index.tsx
@@ -2,7 +2,12 @@ import { useCommitsChanges } from '$/stores/commitChanges'
 import { useDocumentDiff } from '$/stores/documentDiff'
 import { TextEditorPlaceholder } from '@latitude-data/web-ui/molecules/TextEditorPlaceholder'
 import { DiffViewer } from '@latitude-data/web-ui/molecules/DiffViewer'
+import { Alert } from '@latitude-data/web-ui/atoms/Alert'
+import { ModifiedDocumentType } from '@latitude-data/constants'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+
+const REFERENCE_ONLY_DESCRIPTION =
+  "This prompt's content hasn't changed — it references another prompt that was modified in this version."
 
 export function ChangeDiffViewer({
   commit,
@@ -32,6 +37,15 @@ export function ChangeDiffViewer({
 
   if (!document) {
     return <div className='w-full h-full rounded-md bg-secondary' />
+  }
+
+  if (document.changeType === ModifiedDocumentType.UpdatedByReference) {
+    return (
+      <div className='w-full h-full overflow-hidden flex flex-col gap-2'>
+        <Alert description={REFERENCE_ONLY_DESCRIPTION} />
+        <DiffViewer {...diff} />
+      </div>
+    )
   }
 
   return <DiffViewer {...diff} />

--- a/apps/web/src/components/Sidebar/Files/NodeHeaderWrapper/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/NodeHeaderWrapper/index.tsx
@@ -30,6 +30,7 @@ const MODIFICATION_LABELS: Record<ModifiedDocumentType, string> = {
   [ModifiedDocumentType.Updated]: 'Updated',
   [ModifiedDocumentType.UpdatedPath]: 'Renamed',
   [ModifiedDocumentType.Deleted]: 'Deleted',
+  [ModifiedDocumentType.UpdatedByReference]: 'Updated by reference',
 }
 export type NodeHeaderWrapperProps = {
   depth: number

--- a/packages/constants/src/history.ts
+++ b/packages/constants/src/history.ts
@@ -6,6 +6,9 @@ export enum ModifiedDocumentType {
   Updated = 'updated',
   UpdatedPath = 'updated_path',
   Deleted = 'deleted',
+  // The document's own content did not change; it shows up as changed only
+  // because it references another prompt that did change.
+  UpdatedByReference = 'updated_by_reference',
 }
 
 export type ChangedDocument = {

--- a/packages/core/src/services/commits/getChanges.test.ts
+++ b/packages/core/src/services/commits/getChanges.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../../tests/factories'
 import { getCommitChanges, changesPresenter } from './getChanges'
 import { mergeCommit } from './merge'
+import { DocumentVersionsRepository } from '../../repositories'
 import { deleteDocumentTrigger } from '../documentTriggers/delete'
 
 let project: Project
@@ -114,6 +115,57 @@ describe('getCommitChanges', () => {
       ])
       expect(changes.documents.clean).toEqual(changes.documents.all)
       expect(changes.documents.errors).toEqual([])
+    })
+
+    it('reports a referencing parent as changed without persisting it into the draft', async () => {
+      // Make doc2 reference folder1/doc1 and publish, so the reference is live.
+      await updateDocument({
+        document: documents['doc2']!,
+        content: helpers.createPrompt({
+          provider: 'openai',
+          content: '<prompt path="folder1/doc1" />\nPARENT',
+        }),
+        commit: draftCommit,
+      }).then((r) => r.unwrap())
+      await mergeCommit(draftCommit).then((r) => r.unwrap())
+
+      // New draft: edit only the child.
+      const { commit: draft2 } = await createDraft({ project, user })
+      await updateDocument({
+        document: documents['folder1/doc1']!,
+        content: helpers.createPrompt({
+          provider: 'openai',
+          content: 'content1-v2',
+        }),
+        commit: draft2,
+      }).then((r) => r.unwrap())
+
+      const changes = await getCommitChanges({
+        commit: draft2,
+        workspace,
+      }).then((r) => r.unwrap())
+
+      // Both the edited child and the referencing parent are reported as changed.
+      expect(changes.documents.all).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: 'folder1/doc1',
+            changeType: ModifiedDocumentType.Updated,
+          }),
+          expect.objectContaining({
+            path: 'doc2',
+            changeType: ModifiedDocumentType.Updated,
+          }),
+        ]),
+      )
+
+      // ...but the parent is NOT snapshotted into the draft: only the authored
+      // child has a persisted row, so the parent keeps tracking Live.
+      const docsScope = new DocumentVersionsRepository(workspace.id)
+      const persisted = await docsScope
+        .listCommitChanges(draft2)
+        .then((r) => r.unwrap())
+      expect(persisted.map((d) => d.path)).toEqual(['folder1/doc1'])
     })
 
     it('shows created documents', async () => {

--- a/packages/core/src/services/commits/getChanges.test.ts
+++ b/packages/core/src/services/commits/getChanges.test.ts
@@ -145,7 +145,8 @@ describe('getCommitChanges', () => {
         workspace,
       }).then((r) => r.unwrap())
 
-      // Both the edited child and the referencing parent are reported as changed.
+      // The edited child is a normal content Update; the referencing parent is
+      // reported as UpdatedByReference (its own content didn't change).
       expect(changes.documents.all).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
@@ -154,7 +155,7 @@ describe('getCommitChanges', () => {
           }),
           expect.objectContaining({
             path: 'doc2',
-            changeType: ModifiedDocumentType.Updated,
+            changeType: ModifiedDocumentType.UpdatedByReference,
           }),
         ]),
       )

--- a/packages/core/src/services/commits/getChanges.ts
+++ b/packages/core/src/services/commits/getChanges.ts
@@ -14,7 +14,7 @@ import {
   CommitsRepository,
   DocumentVersionsRepository,
 } from '../../repositories'
-import { recomputeChanges } from '../documents'
+import { computeChanges } from '../documents'
 import { getCommitTriggerChanges } from '../documentTriggers/changes/getTriggerChanges'
 import { getCommitEvaluationChanges } from '../evaluationsV2/changes/getEvaluationChanges'
 
@@ -66,7 +66,10 @@ async function getDraftChanges(
   { workspace, draft }: { workspace: Workspace; draft: Commit },
   transaction = new Transaction(),
 ): PromisedResult<ChangedDocument[]> {
-  const result = await recomputeChanges({ draft, workspace }, transaction)
+  // Compute changes in memory only. We deliberately do NOT persist here:
+  // snapshotting reference-only parents into the draft would stop them from
+  // inheriting later Live changes. Persisting happens at merge.
+  const result = await computeChanges({ draft, workspace }, transaction)
   if (result.error) return result
   const changes = result.value
 

--- a/packages/core/src/services/commits/getChanges.ts
+++ b/packages/core/src/services/commits/getChanges.ts
@@ -50,6 +50,11 @@ export function changesPresenter({
       if (previousDoc!.path !== changedDoc.path) {
         return ModifiedDocumentType.UpdatedPath
       }
+      // The document is in the changed set but its own content is unchanged:
+      // it changed only because a referenced prompt changed.
+      if (previousDoc!.content === changedDoc.content) {
+        return ModifiedDocumentType.UpdatedByReference
+      }
       return ModifiedDocumentType.Updated
     })()
 

--- a/packages/core/src/services/commits/merge.test.ts
+++ b/packages/core/src/services/commits/merge.test.ts
@@ -481,6 +481,53 @@ describe('mergeCommit', () => {
       expect(result.ok).toBe(true)
     })
 
+    it('reports a referencing parent as Updated (not UpdatedByReference) in the published event', async (ctx) => {
+      const { project, user, documents, providers } =
+        await ctx.factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            child: ctx.factories.helpers.createPrompt({
+              provider: 'openai',
+              content: 'CHILD_V1',
+            }),
+            parent: ctx.factories.helpers.createPrompt({
+              provider: 'openai',
+              content: '<prompt path="child" />\nPARENT',
+            }),
+          },
+        })
+
+      const { commit } = await ctx.factories.createDraft({ project, user })
+      await updateDocument({
+        commit,
+        document: documents.find((d) => d.path === 'child')!,
+        content: ctx.factories.helpers.createPrompt({
+          provider: providers[0]!,
+          content: 'CHILD_V2',
+        }),
+      }).then((r) => r.unwrap())
+
+      vi.mocked(publisherModule.publisher.publishLater).mockClear()
+      await mergeCommit(commit).then((r) => r.unwrap())
+      await waitForTransactionCallbacks()
+
+      const calls = vi.mocked(publisherModule.publisher.publishLater).mock.calls
+      const commitPublishedCall = calls.find(
+        (call) => call[0].type === 'commitPublished',
+      )
+      expect(commitPublishedCall).toBeDefined()
+      const changedDocs = commitPublishedCall![0].data.changedDocuments
+      // The parent is reported, but coalesced to Updated for the public event.
+      expect(changedDocs).toContainEqual({
+        path: 'parent',
+        changeType: ModifiedDocumentType.Updated,
+      })
+      expect(changedDocs).toContainEqual({
+        path: 'child',
+        changeType: ModifiedDocumentType.Updated,
+      })
+    })
+
     it('publishes commitMerged event alongside commitPublished', async (ctx) => {
       const { project, workspace, user, providers } =
         await ctx.factories.createProject()

--- a/packages/core/src/services/commits/merge.test.ts
+++ b/packages/core/src/services/commits/merge.test.ts
@@ -11,6 +11,8 @@ import {
   destroyDocument,
 } from '../documents'
 import { mergeCommit } from './merge'
+import { getCommitChanges } from './getChanges'
+import { DocumentVersionsRepository } from '../../repositories'
 import * as publisherModule from '../../events/publisher'
 import { waitForTransactionCallbacks } from '../../tests/helpers'
 
@@ -512,5 +514,225 @@ describe('mergeCommit', () => {
       expect(commitPublishedCall![0].data.workspaceId).toBe(workspace.id)
       expect(commitPublishedCall![0].data.userEmail).toBe(user.email)
     })
+  })
+})
+
+describe('reference-only parent documents across parallel versions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(publisherModule.publisher.publishLater).mockResolvedValue(
+      undefined,
+    )
+  })
+
+  // A parent prompt references a child via `<prompt path="..." />`. Editing the
+  // child in a draft marks the parent as changed (its resolved content changes),
+  // but the parent's OWN content must keep tracking Live until the draft is
+  // actually merged. Otherwise the change list snapshots the parent into the
+  // draft, and publishing the draft reverts any parallel change made to the
+  // parent in the meantime.
+
+  async function setupParentChild(ctx: any) {
+    return ctx.factories.createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      documents: {
+        child: ctx.factories.helpers.createPrompt({
+          provider: 'openai',
+          content: 'CHILD_V1',
+        }),
+        parent: ctx.factories.helpers.createPrompt({
+          provider: 'openai',
+          content: '<prompt path="child" />\nPARENT_V1',
+        }),
+      },
+    })
+  }
+
+  it('does not revert a parallel Live change to the parent when publishing a draft that only changed the child', async (ctx) => {
+    const { project, user, workspace, documents } = await setupParentChild(ctx)
+    const docsScope = new DocumentVersionsRepository(workspace.id)
+    const child = documents.find((d) => d.path === 'child')!
+    const parent = documents.find((d) => d.path === 'parent')!
+
+    // Draft D: edit the child only
+    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftD,
+      document: child,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: 'CHILD_V2',
+      }),
+    }).then((r) => r.unwrap())
+
+    // Listing the draft changes is what (today) snapshots the parent into the
+    // draft as a frozen copy of its current content.
+    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+
+    // A parallel version is published to Live that changes the parent's OWN
+    // content.
+    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftP,
+      document: parent,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: '<prompt path="child" />\nPARENT_V2',
+      }),
+    }).then((r) => r.unwrap())
+    await mergeCommit(draftP).then((r) => r.unwrap())
+
+    // Now publish draft D
+    const mergedD = await mergeCommit(draftD).then((r) => r.unwrap())
+
+    const docsAtMergedD = await docsScope
+      .getDocumentsAtCommit(mergedD)
+      .then((r) => r.unwrap())
+    const mergedParent = docsAtMergedD.find((d) => d.path === 'parent')!
+    const mergedChild = docsAtMergedD.find((d) => d.path === 'child')!
+
+    // The parallel parent change must survive — it must NOT be reverted to V1.
+    expect(mergedParent.content).toContain('PARENT_V2')
+    expect(mergedParent.content).not.toContain('PARENT_V1')
+    // The child change from draft D is applied.
+    expect(mergedChild.content).toContain('CHILD_V2')
+    // The parent's resolved content reflects the new child.
+    expect(mergedParent.resolvedContent).toContain('CHILD_V2')
+  })
+
+  it('resolves the parent against current Live content inside a draft that only changed the child (no frozen snapshot)', async (ctx) => {
+    const { project, user, workspace, documents } = await setupParentChild(ctx)
+    const docsScope = new DocumentVersionsRepository(workspace.id)
+    const child = documents.find((d) => d.path === 'child')!
+    const parent = documents.find((d) => d.path === 'parent')!
+
+    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftD,
+      document: child,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: 'CHILD_V2',
+      }),
+    }).then((r) => r.unwrap())
+
+    // Snapshot trigger (change list)
+    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+
+    // Parallel Live change to the parent's own content
+    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftP,
+      document: parent,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: '<prompt path="child" />\nPARENT_V2',
+      }),
+    }).then((r) => r.unwrap())
+    await mergeCommit(draftP).then((r) => r.unwrap())
+
+    // Inside draft D (still unpublished), the parent must reflect the new Live
+    // content, not a frozen V1 snapshot.
+    const docsAtDraftD = await docsScope
+      .getDocumentsAtCommit(draftD)
+      .then((r) => r.unwrap())
+    const draftParent = docsAtDraftD.find((d) => d.path === 'parent')!
+
+    expect(draftParent.content).toContain('PARENT_V2')
+    expect(draftParent.content).not.toContain('PARENT_V1')
+  })
+
+  it('does not revert a parallel Live change to a transitive (grandparent) reference', async (ctx) => {
+    const { project, user, workspace, documents } =
+      await ctx.factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          child: ctx.factories.helpers.createPrompt({
+            provider: 'openai',
+            content: 'CHILD_V1',
+          }),
+          parent: ctx.factories.helpers.createPrompt({
+            provider: 'openai',
+            content: '<prompt path="child" />\nPARENT_V1',
+          }),
+          grandparent: ctx.factories.helpers.createPrompt({
+            provider: 'openai',
+            content: '<prompt path="parent" />\nGRANDPARENT_V1',
+          }),
+        },
+      })
+    const docsScope = new DocumentVersionsRepository(workspace.id)
+    const child = documents.find((d) => d.path === 'child')!
+    const grandparent = documents.find((d) => d.path === 'grandparent')!
+
+    // Draft D: edit the child only
+    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftD,
+      document: child,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: 'CHILD_V2',
+      }),
+    }).then((r) => r.unwrap())
+
+    // Snapshot trigger — freezes both parent and grandparent into the draft
+    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+
+    // Parallel Live change to the grandparent's own content
+    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftP,
+      document: grandparent,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: '<prompt path="parent" />\nGRANDPARENT_V2',
+      }),
+    }).then((r) => r.unwrap())
+    await mergeCommit(draftP).then((r) => r.unwrap())
+
+    const mergedD = await mergeCommit(draftD).then((r) => r.unwrap())
+
+    const docsAtMergedD = await docsScope
+      .getDocumentsAtCommit(mergedD)
+      .then((r) => r.unwrap())
+    const mergedGrandparent = docsAtMergedD.find(
+      (d) => d.path === 'grandparent',
+    )!
+
+    expect(mergedGrandparent.content).toContain('GRANDPARENT_V2')
+    expect(mergedGrandparent.content).not.toContain('GRANDPARENT_V1')
+    expect(mergedGrandparent.resolvedContent).toContain('CHILD_V2')
+  })
+
+  it('still records the referencing parent as a change in the published version (history preserved)', async (ctx) => {
+    const { project, user, workspace, documents } = await setupParentChild(ctx)
+    const docsScope = new DocumentVersionsRepository(workspace.id)
+    const child = documents.find((d) => d.path === 'child')!
+
+    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    await updateDocument({
+      commit: draftD,
+      document: child,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: 'CHILD_V2',
+      }),
+    }).then((r) => r.unwrap())
+
+    const mergedD = await mergeCommit(draftD).then((r) => r.unwrap())
+
+    const changes = await docsScope
+      .listCommitChanges(mergedD)
+      .then((r) => r.unwrap())
+    const parentChange = changes.find((d) => d.path === 'parent')
+
+    // The parent must still appear as a change in the published version so the
+    // history reflects that its behaviour changed...
+    expect(parentChange).toBeDefined()
+    // ...with its resolved content reflecting the new child...
+    expect(parentChange!.resolvedContent).toContain('CHILD_V2')
+    // ...while its own content is unchanged.
+    expect(parentChange!.content).toContain('PARENT_V1')
   })
 })

--- a/packages/core/src/services/commits/merge.test.ts
+++ b/packages/core/src/services/commits/merge.test.ts
@@ -1,5 +1,5 @@
 import { eq } from 'drizzle-orm'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type TestContext } from 'vitest'
 
 import { database } from '../../client'
 import { ModifiedDocumentType, Providers } from '@latitude-data/constants'
@@ -532,7 +532,7 @@ describe('reference-only parent documents across parallel versions', () => {
   // draft, and publishing the draft reverts any parallel change made to the
   // parent in the meantime.
 
-  async function setupParentChild(ctx: any) {
+  async function setupParentChild(ctx: TestContext) {
     return ctx.factories.createProject({
       providers: [{ type: Providers.OpenAI, name: 'openai' }],
       documents: {

--- a/packages/core/src/services/commits/merge.test.ts
+++ b/packages/core/src/services/commits/merge.test.ts
@@ -555,7 +555,10 @@ describe('reference-only parent documents across parallel versions', () => {
     const parent = documents.find((d) => d.path === 'parent')!
 
     // Draft D: edit the child only
-    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftD } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftD,
       document: child,
@@ -567,11 +570,16 @@ describe('reference-only parent documents across parallel versions', () => {
 
     // Listing the draft changes is what (today) snapshots the parent into the
     // draft as a frozen copy of its current content.
-    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+    await getCommitChanges({ workspace, commit: draftD }).then((r) =>
+      r.unwrap(),
+    )
 
     // A parallel version is published to Live that changes the parent's OWN
     // content.
-    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftP } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftP,
       document: parent,
@@ -606,7 +614,10 @@ describe('reference-only parent documents across parallel versions', () => {
     const child = documents.find((d) => d.path === 'child')!
     const parent = documents.find((d) => d.path === 'parent')!
 
-    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftD } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftD,
       document: child,
@@ -617,10 +628,15 @@ describe('reference-only parent documents across parallel versions', () => {
     }).then((r) => r.unwrap())
 
     // Snapshot trigger (change list)
-    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+    await getCommitChanges({ workspace, commit: draftD }).then((r) =>
+      r.unwrap(),
+    )
 
     // Parallel Live change to the parent's own content
-    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftP } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftP,
       document: parent,
@@ -666,7 +682,10 @@ describe('reference-only parent documents across parallel versions', () => {
     const grandparent = documents.find((d) => d.path === 'grandparent')!
 
     // Draft D: edit the child only
-    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftD } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftD,
       document: child,
@@ -677,10 +696,15 @@ describe('reference-only parent documents across parallel versions', () => {
     }).then((r) => r.unwrap())
 
     // Snapshot trigger — freezes both parent and grandparent into the draft
-    await getCommitChanges({ workspace, commit: draftD }).then((r) => r.unwrap())
+    await getCommitChanges({ workspace, commit: draftD }).then((r) =>
+      r.unwrap(),
+    )
 
     // Parallel Live change to the grandparent's own content
-    const { commit: draftP } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftP } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftP,
       document: grandparent,
@@ -710,7 +734,10 @@ describe('reference-only parent documents across parallel versions', () => {
     const docsScope = new DocumentVersionsRepository(workspace.id)
     const child = documents.find((d) => d.path === 'child')!
 
-    const { commit: draftD } = await ctx.factories.createDraft({ project, user })
+    const { commit: draftD } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
     await updateDocument({
       commit: draftD,
       document: child,

--- a/packages/core/src/services/commits/merge.ts
+++ b/packages/core/src/services/commits/merge.ts
@@ -12,7 +12,7 @@ import {
   UnprocessableEntityError,
 } from '../../lib/errors'
 import { commits } from '../../schema/models/commits'
-import { recomputeChanges } from '../documents'
+import { computeChanges, recomputeChanges } from '../documents'
 import { pingProjectUpdate } from '../projects'
 import { handleTriggerMerge } from '../documentTriggers/handleMerge'
 import {
@@ -27,8 +27,6 @@ import { captureException } from '../../utils/datadogCapture'
 
 type ValidationResult = {
   workspace: Workspace
-  changedDocuments: DocumentVersion[]
-  headDocuments: DocumentVersion[]
 }
 
 /**
@@ -115,7 +113,10 @@ export async function mergeCommit(
         return Result.error(new NotFoundError('Workspace not found'))
       }
 
-      const recomputedResults = await recomputeChanges(
+      // Validate against an in-memory computation only. The actual snapshot is
+      // materialized later, inside the locked phase, against the then-current
+      // head (see phase 3) so a parallel publish is never reverted.
+      const recomputedResults = await computeChanges(
         { draft: commit, workspace },
         transaction,
       )
@@ -174,14 +175,13 @@ export async function mergeCommit(
         )
       }
 
-      return Result.ok({ workspace, changedDocuments, headDocuments })
+      return Result.ok({ workspace })
     },
   )
 
   if (!Result.isOk(validationResult)) return validationResult
 
-  const { workspace, changedDocuments, headDocuments } =
-    validationResult.unwrap()
+  const { workspace } = validationResult.unwrap()
 
   // Phase 2: handle trigger merge outside of any active transaction
   const handleTriggerMergeResult = await handleTriggerMerge(
@@ -194,14 +194,8 @@ export async function mergeCommit(
 
   if (!Result.isOk(handleTriggerMergeResult)) return handleTriggerMergeResult
 
-  const documentChanges: CommitPublishedDocumentChange[] = changesPresenter({
-    currentCommitChanges: changedDocuments,
-    previousCommitDocuments: headDocuments,
-    errors: {},
-  }).map((doc) => ({
-    path: doc.path,
-    changeType: doc.changeType,
-  }))
+  // Computed inside the locked phase below from the freshly materialized state.
+  let documentChanges: CommitPublishedDocumentChange[] = []
 
   // Phase 3: finalize merge in a new short transaction
   return transaction.call<Commit>(
@@ -209,6 +203,25 @@ export async function mergeCommit(
       await tx.execute(
         sql`SELECT pg_advisory_xact_lock(${sql.raw(String(commit.projectId))})`,
       )
+
+      // Materialize the draft's changes against the current head while holding
+      // the project lock. Reference-only parents are snapshotted from the latest
+      // Live content, so a version published in parallel since validation is not
+      // reverted.
+      const recomputed = await recomputeChanges(
+        { draft: commit, workspace },
+        transaction,
+      )
+      if (recomputed.error) return recomputed
+
+      documentChanges = changesPresenter({
+        currentCommitChanges: recomputed.value.changedDocuments,
+        previousCommitDocuments: recomputed.value.headDocuments,
+        errors: {},
+      }).map((doc) => ({
+        path: doc.path,
+        changeType: doc.changeType,
+      }))
 
       const lastMergedCommit = await tx
         .select()

--- a/packages/core/src/services/commits/merge.ts
+++ b/packages/core/src/services/commits/merge.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 
+import { ModifiedDocumentType } from '@latitude-data/constants'
 import { type Commit } from '../../schema/models/types/Commit'
 import { type DocumentVersion } from '../../schema/models/types/DocumentVersion'
 import { type Workspace } from '../../schema/models/types/Workspace'
@@ -220,7 +221,13 @@ export async function mergeCommit(
         errors: {},
       }).map((doc) => ({
         path: doc.path,
-        changeType: doc.changeType,
+        // The published-changes event is a public contract (webhooks). Collapse
+        // the UI-only `UpdatedByReference` back to `Updated` so consumers keep
+        // seeing the existing set of change types.
+        changeType:
+          doc.changeType === ModifiedDocumentType.UpdatedByReference
+            ? ModifiedDocumentType.Updated
+            : doc.changeType,
       }))
 
       const lastMergedCommit = await tx

--- a/packages/core/src/services/documents/recomputeChanges/index.ts
+++ b/packages/core/src/services/documents/recomputeChanges/index.ts
@@ -195,7 +195,21 @@ export type RecomputedChanges = {
   errors: { [documentUuid: string]: Error[] }
 }
 
-export async function recomputeChanges(
+/**
+ * Computes, in memory, the set of documents that have changed in a draft commit
+ * WITHOUT persisting anything.
+ *
+ * A document counts as changed when its resolved content (which inlines any
+ * referenced documents) differs from the head version. Documents that change
+ * only because a referenced document changed — e.g. a parent prompt of an edited
+ * child — are reported as changed but keep tracking the head content; they are
+ * NOT snapshotted into the draft. This keeps such parents inheriting later Live
+ * changes until the draft is actually published.
+ *
+ * Use this on read paths (e.g. listing draft changes). Persisting the changes is
+ * done separately at merge time via {@link recomputeChanges}.
+ */
+export async function computeChanges(
   {
     workspace,
     draft,
@@ -242,10 +256,9 @@ export async function recomputeChanges(
       { workspaceId: workspace.id },
       tx,
     )
-    if (agentToolsMapResult.error)
-      return Result.error(agentToolsMapResult.error)
+    if (agentToolsMapResult.error) return Result.error(agentToolsMapResult.error)
 
-    const { documents: documentsToUpdate, errors } =
+    const { documents: changedDocuments, errors } =
       await resolveDocumentChanges({
         originalDocuments: mergedDocuments,
         newDocuments: draftDocuments,
@@ -254,18 +267,53 @@ export async function recomputeChanges(
         integrationNames: allIntegrations.map((i) => i.name),
       })
 
+    return Result.ok({
+      headDocuments: mergedDocuments,
+      changedDocuments,
+      mainDocumentChanged,
+      errors,
+    })
+  })
+}
+
+/**
+ * Computes draft changes via {@link computeChanges} and PERSISTS them as
+ * document versions in the draft commit: inserting reference-only parents,
+ * updating existing rows, and removing rows that no longer differ from head.
+ *
+ * Because this snapshots reference-only parents into the commit (freezing their
+ * content), it must only be used when finalizing a draft (i.e. at merge), never
+ * on read paths — otherwise a parent stops inheriting later Live changes.
+ */
+export async function recomputeChanges(
+  {
+    workspace,
+    draft,
+  }: {
+    workspace: Workspace
+    draft: Commit
+  },
+  transaction = new Transaction(),
+): Promise<TypedResult<RecomputedChanges, Error>> {
+  return transaction.call(async () => {
+    const computed = await computeChanges({ workspace, draft }, transaction)
+    if (computed.error) return computed
+
+    const { changedDocuments, headDocuments, mainDocumentChanged, errors } =
+      computed.value
+
     const newDraftDocuments = (
       await replaceCommitChanges(
         {
           commit: draft,
-          documentChanges: documentsToUpdate,
+          documentChanges: changedDocuments,
         },
         transaction,
       )
     ).unwrap()
 
     return Result.ok({
-      headDocuments: mergedDocuments,
+      headDocuments,
       changedDocuments: newDraftDocuments,
       mainDocumentChanged,
       errors,

--- a/packages/core/src/services/documents/recomputeChanges/index.ts
+++ b/packages/core/src/services/documents/recomputeChanges/index.ts
@@ -256,7 +256,8 @@ export async function computeChanges(
       { workspaceId: workspace.id },
       tx,
     )
-    if (agentToolsMapResult.error) return Result.error(agentToolsMapResult.error)
+    if (agentToolsMapResult.error)
+      return Result.error(agentToolsMapResult.error)
 
     const { documents: changedDocuments, errors } =
       await resolveDocumentChanges({

--- a/packages/web-ui/src/ds/molecules/DocumentChange/colors.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentChange/colors.ts
@@ -7,18 +7,21 @@ export const MODIFICATION_ICONS: Record<ModifiedDocumentType, IconName> = {
   [ModifiedDocumentType.Updated]: 'modification',
   [ModifiedDocumentType.UpdatedPath]: 'squareArrowRight',
   [ModifiedDocumentType.Deleted]: 'deletion',
+  [ModifiedDocumentType.UpdatedByReference]: 'squareDashed',
 }
 export const MODIFICATION_COLORS: Record<ModifiedDocumentType, TextColor> = {
   [ModifiedDocumentType.Created]: 'success',
   [ModifiedDocumentType.Updated]: 'accentForeground',
   [ModifiedDocumentType.UpdatedPath]: 'accentForeground',
   [ModifiedDocumentType.Deleted]: 'destructive',
+  [ModifiedDocumentType.UpdatedByReference]: 'foregroundMuted',
 }
 export const MODIFICATION_BACKGROUNDS: Record<ModifiedDocumentType, string> = {
   [ModifiedDocumentType.Created]: 'bg-success/10',
   [ModifiedDocumentType.Updated]: 'bg-accent-foreground/5',
   [ModifiedDocumentType.UpdatedPath]: 'bg-accent-foreground/5',
   [ModifiedDocumentType.Deleted]: 'bg-destructive/10',
+  [ModifiedDocumentType.UpdatedByReference]: 'bg-muted',
 }
 
 export const MODIFICATION_BACKGROUNDS_HOVER: Record<
@@ -29,6 +32,7 @@ export const MODIFICATION_BACKGROUNDS_HOVER: Record<
   [ModifiedDocumentType.Updated]: 'hover:bg-accent-foreground/5',
   [ModifiedDocumentType.UpdatedPath]: 'hover:bg-accent-foreground/5',
   [ModifiedDocumentType.Deleted]: 'hover:bg-destructive/10',
+  [ModifiedDocumentType.UpdatedByReference]: 'hover:bg-muted',
 }
 
 export const MODIFICATION_LABELS: Record<ModifiedDocumentType, string> = {
@@ -36,4 +40,5 @@ export const MODIFICATION_LABELS: Record<ModifiedDocumentType, string> = {
   [ModifiedDocumentType.Updated]: 'Updated',
   [ModifiedDocumentType.UpdatedPath]: 'Updated path',
   [ModifiedDocumentType.Deleted]: 'Deleted',
+  [ModifiedDocumentType.UpdatedByReference]: 'Updated by reference',
 }


### PR DESCRIPTION
## what this does

Fixes a bug where publishing a draft could silently revert a change that had been published to a referencing prompt in a parallel version, and improves how reference-only changes are shown in the UI.

A prompt can reference another via `<prompt path="…" />`. When a child prompt is edited in a draft, the parent that references it is shown as changed too, so you can see its behaviour will change. The change-list code recorded this by writing a full copy of the parent's content into the draft. That snapshot then shadowed the live version of the parent: any later change published to the parent in another version was no longer inherited by the draft, and publishing the draft wrote the stale snapshot back over live — reverting the parallel change, even though nobody touched the parent in this draft.

<img width="1205" height="978" alt="image" src="https://github.com/user-attachments/assets/9aa41fac-d7d2-4610-8ebb-284ae28c7a26" />


## the fix

Reference-only parents are no longer snapshotted into a draft. `recomputeChanges` is split in two:

- `computeChanges` — pure, in-memory. Reports which documents changed (including referencing parents) without writing anything. The draft change list (`getChanges`) now uses this.
- `recomputeChanges` — computes, then persists the changed set (insert/update + GC of reverted rows). Used only at merge.

With no parent row in the draft, the parent resolves against current live content while the draft is open and gets a fresh snapshot only when the draft is published. No schema change or provenance flag is needed, because derived parents are simply never written during a draft.

Persistence also moved into merge's locked finalize phase: merge validates with `computeChanges`, then materializes via `recomputeChanges` inside the per-project advisory lock, reading the current head. This closes a race where a version published between validation and finalize could still be reverted.

## behaviour preserved

A published version still records the referencing parent as a change — it gets a real row at merge with refreshed `resolvedContent` — so version history is unchanged. The merged-commit snapshot model and its caches are untouched; the fix only changes whether a parent is persisted *during* a draft, never how merged versions are stored.

## distinguishing reference-only changes in the UI

A referencing parent showing up as a plain "Updated" with an empty diff was confusing — it looked edited when only a prompt it references changed. New `ModifiedDocumentType.UpdatedByReference` covers this case: `changesPresenter` assigns it when a changed document's own content and path are unchanged.

- In the merge-draft modal and the changes history it renders with a muted dashed-square icon and an "Updated by reference" label instead of the blue "Updated" treatment.
- The diff for these stays in place (it's empty by definition) with a muted note above it: *"This prompt's content hasn't changed — it references another prompt that was modified in this version."*
- The `commitPublished` event coalesces `UpdatedByReference` back to `Updated`, so the webhook payload is unchanged for external consumers.

The sidebar file tree is unaffected: it derives change type from `contentHash`, which doesn't change for a reference-only parent.

## scope and notes

- Only inline `<prompt path>` references are affected. The `agents` config setting maps agent name→path and doesn't inline agent content, so editing an agent never produced this snapshot in the first place.
- Left for a follow-up: the now-mostly-vestigial per-commit `resolvedContent` nulling on draft edits (`updateUnsafe.ts`).

## testing

- Regression tests reproduce the revert on publish, the stale draft resolution, and a transitive grandparent case; plus a guard that the parent still appears in published history, and a unit test that the parent is reported as changed but not persisted into the draft.
- New tests assert the reference-only classification (`UpdatedByReference` for the parent, `Updated` for the edited child) and that the published event coalesces it back to `Updated`.
- `pnpm tc` clean across `constants`, `web-ui`, `web`, and `core` (the new enum value forces every change-type map to be filled). `src/services/commits` + `src/services/documents` green.
