### PR TITLE
feat(monitors): details panel, consistent kind naming, and system-monitor reset action [LAT-630]

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -7463,7 +7463,7 @@
                     "issue",
                     "savedSearch"
                   ],
-                  "description": "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a saved search."
+                  "description": "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search."
                 },
                 "sourceId": {
                   "type": "string",
@@ -7481,7 +7481,7 @@
                     "savedSearch.threshold",
                     "savedSearch.escalating"
                   ],
-                  "description": "Reason the incident opened. `issue.new` fires when a brand-new issue is discovered; `issue.regressed` when a resolved issue starts occurring again; `issue.escalating` when an existing issue's occurrence rate exceeds its seasonal baseline. The `savedSearch.*` kinds are raised by monitors watching a saved search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when the match count crosses a configured threshold, and `savedSearch.escalating` when it stays elevated for a sustained window."
+                  "description": "Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window."
                 },
                 "severity": {
                   "type": "string",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3820,7 +3820,7 @@
               "issue",
               "savedSearch"
             ],
-            "description": "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a saved search."
+            "description": "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search."
           },
           "sourceId": {
             "type": "string",
@@ -3838,7 +3838,7 @@
               "savedSearch.threshold",
               "savedSearch.escalating"
             ],
-            "description": "Reason the incident opened. `issue.new` fires when a brand-new issue is discovered; `issue.regressed` when a resolved issue starts occurring again; `issue.escalating` when an existing issue's occurrence rate exceeds its seasonal baseline. The `savedSearch.*` kinds are raised by monitors watching a saved search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when the match count crosses a configured threshold, and `savedSearch.escalating` when it stays elevated for a sustained window."
+            "description": "Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window."
           },
           "severity": {
             "type": "string",

--- a/apps/api/src/openapi/entities/incident.ts
+++ b/apps/api/src/openapi/entities/incident.ts
@@ -14,13 +14,13 @@ export const IncidentSchema = z
     sourceType: z
       .enum(INCIDENT_SOURCE_TYPES)
       .describe(
-        "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a saved search.",
+        "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search.",
       ),
     sourceId: cuidSchema.describe("Id of the entity that triggered the incident (matches `sourceType`)."),
     kind: z
       .enum(INCIDENT_KINDS)
       .describe(
-        "Reason the incident opened. `issue.new` fires when a brand-new issue is discovered; `issue.regressed` when a resolved issue starts occurring again; `issue.escalating` when an existing issue's occurrence rate exceeds its seasonal baseline. The `savedSearch.*` kinds are raised by monitors watching a saved search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when the match count crosses a configured threshold, and `savedSearch.escalating` when it stays elevated for a sustained window.",
+        "Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window.",
       ),
     severity: z
       .enum(INCIDENT_SEVERITIES)

--- a/apps/web/src/domains/admin/organizations.functions.test.ts
+++ b/apps/web/src/domains/admin/organizations.functions.test.ts
@@ -4,6 +4,7 @@ import {
   adminCreateDemoProjectInputSchema,
   adminGetOrganizationInputSchema,
   adminListOrganizationsByUsageInputSchema,
+  adminResetSystemMonitorsInputSchema,
 } from "./organizations.functions.ts"
 
 describe("adminGetOrganizationInputSchema", () => {
@@ -92,5 +93,23 @@ describe("adminCreateDemoProjectInputSchema", () => {
 
   it("rejects a missing projectName", () => {
     expect(adminCreateDemoProjectInputSchema.safeParse({ organizationId: "org-123" }).success).toBe(false)
+  })
+})
+
+describe("adminResetSystemMonitorsInputSchema", () => {
+  it("accepts a valid organizationId", () => {
+    expect(adminResetSystemMonitorsInputSchema.safeParse({ organizationId: "org-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty organizationId", () => {
+    expect(adminResetSystemMonitorsInputSchema.safeParse({ organizationId: "" }).success).toBe(false)
+  })
+
+  it("rejects an organizationId above the max length (defensive abuse bound)", () => {
+    expect(adminResetSystemMonitorsInputSchema.safeParse({ organizationId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing organizationId", () => {
+    expect(adminResetSystemMonitorsInputSchema.safeParse({}).success).toBe(false)
   })
 })

--- a/apps/web/src/domains/admin/organizations.functions.ts
+++ b/apps/web/src/domains/admin/organizations.functions.ts
@@ -11,6 +11,7 @@ import {
   type ListOrganizationsByUsageOutput,
   listOrganizationsByUsageUseCase,
   ORGANIZATION_USAGE_MAX_LIMIT,
+  resetSystemMonitorsUseCase,
   upsertBillingOverrideUseCase,
 } from "@domain/admin"
 import { WorkflowStarter } from "@domain/queue"
@@ -22,6 +23,7 @@ import {
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
   invalidateEffectivePlanCache,
+  MonitorRepositoryLive,
   OutboxEventWriterLive,
   ProjectRepositoryLive,
   resolveEffectivePlanCached,
@@ -416,4 +418,29 @@ export const adminCreateDemoProject = createServerFn({ method: "POST" })
       projectSlug: result.projectSlug,
       queueAssigneeUserId: result.queueAssigneeUserId,
     }
+  })
+
+interface AdminResetSystemMonitorsResultDto {
+  readonly projectsCount: number
+  readonly monitorsReset: number
+}
+
+export const adminResetSystemMonitorsInputSchema = z.object({
+  organizationId: z.string().min(1).max(256),
+})
+
+export const adminResetSystemMonitors = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminResetSystemMonitorsInputSchema)
+  .handler(async ({ data }): Promise<AdminResetSystemMonitorsResultDto> => {
+    const client = getAdminPostgresClient()
+
+    const result = await Effect.runPromise(
+      resetSystemMonitorsUseCase({ organizationId: OrganizationId(data.organizationId) }).pipe(
+        withPostgres(Layer.mergeAll(AdminOrganizationRepositoryLive, MonitorRepositoryLive), client),
+        withTracing,
+      ),
+    )
+
+    return { projectsCount: result.projectsCount, monitorsReset: result.monitorsReset }
   })

--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router"
 import { ChevronRightIcon } from "lucide-react"
 import { useRef } from "react"
 import type { AlertIncidentRecord } from "./alerts.functions.ts"
-import { INCIDENT_SEVERITY_COLOR, KIND_LABELS, SEVERITY_LABELS } from "./incident-markers.ts"
+import { formatIncidentKindLabel, INCIDENT_SEVERITY_COLOR, SEVERITY_LABELS } from "./incident-markers.ts"
 
 /**
  * Popover anchored at a chart-bucket point, listing every incident touching that bucket. Each
@@ -118,7 +118,7 @@ export function IncidentMarkerPopover({
                 />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5">
-                    <Text.H6M color="foreground">{KIND_LABELS[incident.kind]}</Text.H6M>
+                    <Text.H6M color="foreground">{formatIncidentKindLabel(incident.kind)}</Text.H6M>
                     <Text.H6 color="foregroundMuted">·</Text.H6>
                     <Text.H6 color="foregroundMuted">{SEVERITY_LABELS[incident.severity]}</Text.H6>
                   </div>

--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -1,4 +1,5 @@
 import type { AlertIncidentKind, AlertSeverity } from "@domain/alerts"
+import { ALERT_INCIDENT_KIND_LABEL } from "@domain/shared"
 import type { BarChartOverlay, BarChartOverlayArea, BarChartOverlayLine } from "@repo/ui"
 import type { AlertIncidentRecord } from "./alerts.functions.ts"
 
@@ -33,14 +34,8 @@ const KIND_TOP_SYMBOL: Record<AlertIncidentKind, TopSymbol> = {
   "savedSearch.escalating": { shape: "rect", size: 7 },
 }
 
-export const KIND_LABELS: Record<AlertIncidentKind, string> = {
-  "issue.new": "New issue",
-  "issue.regressed": "Issue regressed",
-  "issue.escalating": "Issue escalating",
-  "savedSearch.match": "Search match",
-  "savedSearch.threshold": "Search threshold",
-  "savedSearch.escalating": "Search escalating",
-}
+/** Canonical kind labels live in `@domain/shared`; re-exported so chart markers stay in sync with the monitor UI. */
+export const KIND_LABELS = ALERT_INCIDENT_KIND_LABEL
 
 export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
   low: "Low",

--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -34,9 +34,6 @@ const KIND_TOP_SYMBOL: Record<AlertIncidentKind, TopSymbol> = {
   "savedSearch.escalating": { shape: "rect", size: 7 },
 }
 
-/** Canonical kind labels live in `@domain/shared`; re-exported so chart markers stay in sync with the monitor UI. */
-export const KIND_LABELS = ALERT_INCIDENT_KIND_LABEL
-
 export const SEVERITY_LABELS: Record<AlertSeverity, string> = {
   low: "Low",
   medium: "Medium",
@@ -237,5 +234,5 @@ export function buildIncidentMarkers({
 }
 
 export function formatIncidentKindLabel(kind: AlertIncidentKind): string {
-  return KIND_LABELS[kind]
+  return ALERT_INCIDENT_KIND_LABEL[kind]
 }

--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -1,6 +1,7 @@
-import type { InfiniteTableInfiniteScroll } from "@repo/ui"
-import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { type InfiniteTableInfiniteScroll, useToast } from "@repo/ui"
+import { keepPreviousData, useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useCallback, useMemo, useState } from "react"
+import { toUserMessage } from "../../lib/errors.ts"
 import {
   getMonitorBySlug,
   listMonitorIncidents,
@@ -8,6 +9,8 @@ import {
   type MonitorIncidentRecord,
   type MonitorIncidentsCursor,
   type MonitorRecord,
+  muteMonitor,
+  unmuteMonitor,
 } from "./monitors.functions.ts"
 
 export type { MonitorRecord }
@@ -112,4 +115,37 @@ export function useMonitorIncidents(input: {
   )
 
   return { incidents, isLoading, infiniteScroll }
+}
+
+/**
+ * Mute/unmute action shared by the dashboard 3-dots menu and the details panel.
+ * Calls the server fn, invalidates the monitor list + detail queries, and toasts.
+ * Re-throws so the caller can keep its confirmation modal open on failure.
+ */
+export function useMonitorMuteAction(projectId: string) {
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+  const [isPending, setIsPending] = useState(false)
+
+  const setMuted = useCallback(
+    async (monitor: MonitorRecord, muted: boolean) => {
+      setIsPending(true)
+      try {
+        await (muted ? muteMonitor : unmuteMonitor)({ data: { monitorId: monitor.id } })
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["monitors", "list", projectId] }),
+          queryClient.invalidateQueries({ queryKey: ["monitors", "get", projectId] }),
+        ])
+        toast({ description: muted ? "Monitor muted." : "Monitor unmuted." })
+      } catch (error) {
+        toast({ variant: "destructive", description: toUserMessage(error) })
+        throw error
+      } finally {
+        setIsPending(false)
+      }
+    },
+    [projectId, queryClient, toast],
+  )
+
+  return { setMuted, isPending }
 }

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -1,10 +1,13 @@
 import {
+  formatHumanReadableAlert,
   getMonitorBySlugUseCase,
   getMonitorIncidentsUseCase,
   type ListMonitorsResult,
   listMonitorsUseCase,
   type Monitor,
   type MonitorAlert,
+  muteMonitorUseCase,
+  unmuteMonitorUseCase,
 } from "@domain/monitors"
 import { AlertIncidentId, MonitorId, OrganizationId, ProjectId } from "@domain/shared"
 import {
@@ -27,6 +30,9 @@ const toMonitorAlertRecord = (alert: MonitorAlert) => ({
   source: { type: alert.source.type, id: alert.source.id },
   condition: alert.condition,
   severity: alert.severity,
+  // Rendered server-side so the panel/list don't pull `@domain/monitors` into
+  // the client bundle. Saved-search summaries gain the source name in M5.
+  summary: formatHumanReadableAlert(alert),
   createdAt: alert.createdAt.toISOString(),
 })
 
@@ -107,6 +113,30 @@ export const getMonitorBySlug = createServerFn({ method: "GET" })
 
     return result
   })
+
+const monitorMutationInputSchema = z.object({ monitorId: z.string() })
+
+const runMonitorMute = async (monitorId: string, muted: boolean): Promise<MonitorRecord> => {
+  const { organizationId } = await requireSession()
+  const pgClient = getPostgresClient()
+  const useCase = muted ? muteMonitorUseCase : unmuteMonitorUseCase
+
+  return Effect.runPromise(
+    useCase({ id: MonitorId(monitorId) }).pipe(
+      Effect.map(toMonitorRecord),
+      withPostgres(MonitorRepositoryLive, pgClient, OrganizationId(organizationId)),
+      withTracing,
+    ),
+  )
+}
+
+export const muteMonitor = createServerFn({ method: "POST" })
+  .inputValidator(monitorMutationInputSchema)
+  .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, true))
+
+export const unmuteMonitor = createServerFn({ method: "POST" })
+  .inputValidator(monitorMutationInputSchema)
+  .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, false))
 
 /** Keyset cursor over `(startedAt, id)`; `startedAt` is an ISO string on the wire. */
 const incidentCursorSchema = z.object({ startedAt: z.iso.datetime(), id: z.string() })

--- a/apps/web/src/domains/projects/project-sections.ts
+++ b/apps/web/src/domains/projects/project-sections.ts
@@ -1,4 +1,5 @@
 import {
+  BellRingIcon,
   Building2,
   CreditCard,
   DatabaseIcon,
@@ -6,7 +7,6 @@ import {
   type LucideIcon,
   Package,
   Plug,
-  RadarIcon,
   ScanSearch,
   SearchIcon,
   SettingsIcon,
@@ -64,7 +64,7 @@ const PROJECT_SECTIONS: readonly ProjectSection[] = [
   {
     key: "monitors",
     label: "Monitors",
-    icon: RadarIcon,
+    icon: BellRingIcon,
     path: (slug) => `/projects/${slug}/monitors`,
     isActive: (pathname, slug) => pathname.startsWith(`/projects/${slug}/monitors`),
     flag: "monitors",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -141,7 +141,7 @@ function DatasetsPage() {
           <Layout.ActionsRow>
             <Layout.ActionRowItem />
             <Layout.ActionRowItem>
-              <Button variant="outline" onClick={handleCreate} disabled={creating} isLoading={creating}>
+              <Button onClick={handleCreate} disabled={creating} isLoading={creating}>
                 <Icon size="sm" icon={DatabaseAddIcon} />
                 Dataset
               </Button>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
@@ -1,26 +1,180 @@
-import { DetailDrawer, Text } from "@repo/ui"
+import { ALERT_INCIDENT_KIND_LABEL } from "@domain/shared"
+import {
+  Button,
+  CopyableText,
+  DetailDrawer,
+  DetailSection,
+  Icon,
+  LatitudeLogo,
+  Status,
+  type StatusProps,
+  Text,
+  Tooltip,
+} from "@repo/ui"
+import { useHotkeys } from "@tanstack/react-hotkeys"
+import { ArrowDownIcon, ArrowUpIcon, BellIcon, BellOffIcon, MegaphoneIcon, ShieldAlertIcon } from "lucide-react"
+import { useState } from "react"
+import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
+import type { MonitorAlertRecord, MonitorRecord } from "../../../../../../domains/monitors/monitors.functions.ts"
+import { MonitorIncidentsTable } from "./monitor-incidents-table.tsx"
+import { MonitorMuteConfirmModal } from "./monitor-mute-confirm-modal.tsx"
 
-/**
- * Placeholder detail panel for M3 — opening a monitor row sets `monitorSlug` in
- * the URL and renders this stub. The full panel (config + incidents + lifecycle
- * actions) lands in M4; the file is named for that future component so M4
- * expands it in place rather than renaming.
- */
-export function MonitorDetailDrawer({
-  monitorName,
-  onClose,
-}: {
-  readonly monitorName: string
-  readonly onClose: () => void
-}) {
+const SEVERITY_VARIANT: Record<MonitorAlertRecord["severity"], StatusProps["variant"]> = {
+  low: "neutral",
+  medium: "warning",
+  high: "destructive",
+}
+
+/** Icon + "System" badge, styled like a `TagBadge`, shown next to the slug. */
+function SystemTag() {
   return (
-    <DetailDrawer storeKey="monitor-detail-drawer-width" onClose={onClose} closeLabel="Close">
-      <div className="flex flex-col gap-2 p-4">
-        <Text.H4>{monitorName}</Text.H4>
-        <Text.H6 color="foregroundMuted">
-          Monitor configuration and incidents will appear here in an upcoming release.
+    <span className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+      <LatitudeLogo className="h-3 w-3" />
+      System
+    </span>
+  )
+}
+
+// Read-only in M4 — editing an alert's configurable values (the issue.escalating
+// sensitivity control + the saved-search threshold/window forms) lands in M5
+// alongside the shared alert-form components.
+function AlertCard({ alert }: { readonly alert: MonitorAlertRecord }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <Text.H6 color="foregroundMuted" noWrap>
+          {ALERT_INCIDENT_KIND_LABEL[alert.kind]}
         </Text.H6>
+        <Status variant={SEVERITY_VARIANT[alert.severity]} label={alert.severity} />
       </div>
-    </DetailDrawer>
+      <Text.H5>{alert.summary}</Text.H5>
+    </div>
+  )
+}
+
+export function MonitorDetailDrawer({
+  projectId,
+  monitor,
+  onClose,
+  onNext,
+  onPrev,
+  canNavigateNext,
+  canNavigatePrev,
+}: {
+  readonly projectId: string
+  readonly monitor: MonitorRecord
+  readonly onClose: () => void
+  readonly onNext?: () => void
+  readonly onPrev?: () => void
+  readonly canNavigateNext: boolean
+  readonly canNavigatePrev: boolean
+}) {
+  const [muteConfirmOpen, setMuteConfirmOpen] = useState(false)
+  const muted = monitor.mutedAt != null
+
+  useHotkeys([
+    { hotkey: "Alt+ArrowDown", callback: () => onNext?.(), options: { enabled: canNavigateNext && !!onNext } },
+    { hotkey: "Alt+ArrowUp", callback: () => onPrev?.(), options: { enabled: canNavigatePrev && !!onPrev } },
+    { hotkey: "J", callback: () => onNext?.(), options: { enabled: canNavigateNext && !!onNext } },
+    { hotkey: "K", callback: () => onPrev?.(), options: { enabled: canNavigatePrev && !!onPrev } },
+  ])
+
+  return (
+    <>
+      <DetailDrawer
+        storeKey="monitor-detail-drawer-width"
+        onClose={onClose}
+        closeLabel={
+          <>
+            Close <HotkeyBadge hotkey="Escape" />
+          </>
+        }
+        actions={
+          <>
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <Button
+                  variant="ghost"
+                  className="h-8 w-8 p-0"
+                  disabled={!canNavigateNext}
+                  onClick={onNext}
+                  type="button"
+                  aria-label="Next monitor"
+                >
+                  <ArrowDownIcon className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              }
+            >
+              Next monitor <HotkeyBadge hotkey="Alt+ArrowDown" /> <HotkeyBadge hotkey="J" />
+            </Tooltip>
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <Button
+                  variant="ghost"
+                  className="h-8 w-8 p-0"
+                  disabled={!canNavigatePrev}
+                  onClick={onPrev}
+                  type="button"
+                  aria-label="Previous monitor"
+                >
+                  <ArrowUpIcon className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              }
+            >
+              Previous monitor <HotkeyBadge hotkey="Alt+ArrowUp" /> <HotkeyBadge hotkey="K" />
+            </Tooltip>
+          </>
+        }
+        rightActions={
+          <Button variant="outline" type="button" onClick={() => setMuteConfirmOpen(true)}>
+            <Icon icon={muted ? BellIcon : BellOffIcon} size="sm" />
+            {muted ? "Unmute" : "Mute"}
+          </Button>
+        }
+      >
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="flex shrink-0 flex-col gap-3 border-b px-6 py-4">
+            <div className="flex flex-col gap-1">
+              <Text.H4M>{monitor.name}</Text.H4M>
+              {monitor.description ? <Text.H5 color="foregroundMuted">{monitor.description}</Text.H5> : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {monitor.system ? <SystemTag /> : null}
+              <CopyableText value={monitor.slug} size="sm" ellipsis tooltip="Copy monitor slug" />
+              {muted ? <Status variant="neutral" label="Muted" /> : null}
+            </div>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6">
+            <DetailSection icon={<Icon icon={MegaphoneIcon} size="sm" />} label="Alerts" defaultOpen>
+              <div className="flex flex-col gap-2">
+                {monitor.alerts.map((alert) => (
+                  <AlertCard key={alert.id} alert={alert} />
+                ))}
+              </div>
+            </DetailSection>
+
+            <DetailSection
+              icon={<Icon icon={ShieldAlertIcon} size="sm" />}
+              label="Incidents"
+              defaultOpen
+              contentClassName="flex flex-col overflow-hidden pl-0 pt-0 max-h-none"
+            >
+              <MonitorIncidentsTable monitorId={monitor.id} />
+            </DetailSection>
+          </div>
+        </div>
+      </DetailDrawer>
+
+      <MonitorMuteConfirmModal
+        projectId={projectId}
+        monitor={muteConfirmOpen ? monitor : null}
+        onOpenChange={(next) => setMuteConfirmOpen(next !== null)}
+      />
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -1,0 +1,61 @@
+import { CopyableText, InfiniteTable, type InfiniteTableColumn, Status, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import {
+  type MonitorIncidentRecord,
+  useMonitorIncidents,
+} from "../../../../../../domains/monitors/monitors.collection.ts"
+
+const columns: InfiniteTableColumn<MonitorIncidentRecord>[] = [
+  {
+    key: "startedAt",
+    header: "Started",
+    width: 160,
+    minWidth: 120,
+    render: (incident) => <Text.H6 noWrap>{relativeTime(new Date(incident.startedAt))}</Text.H6>,
+  },
+  {
+    key: "status",
+    header: "Status",
+    width: 200,
+    minWidth: 150,
+    render: (incident) =>
+      incident.endedAt ? (
+        <Status variant="warning" label={`Closed ${relativeTime(new Date(incident.endedAt))}`} />
+      ) : (
+        <Status variant="destructive" label={`Ongoing since ${relativeTime(new Date(incident.startedAt))}`} />
+      ),
+  },
+  {
+    // Deep-linking to the issue / saved search (and resolving its name) is a UX-milestone polish item.
+    key: "source",
+    header: "Source",
+    width: 180,
+    minWidth: 120,
+    render: (incident) => <CopyableText value={incident.sourceId} size="sm" ellipsis tooltip="Copy source id" />,
+  },
+  {
+    key: "notified",
+    header: "Notified",
+    width: 110,
+    minWidth: 90,
+    render: (incident) =>
+      incident.notified ? <Status variant="success" label="Notified" /> : <Status variant="neutral" label="Muted" />,
+  },
+]
+
+export function MonitorIncidentsTable({ monitorId }: { readonly monitorId: string }) {
+  const { incidents, isLoading, infiniteScroll } = useMonitorIncidents({ monitorId })
+
+  return (
+    <InfiniteTable
+      data={incidents}
+      isLoading={isLoading}
+      columns={columns}
+      getRowKey={(incident) => incident.id}
+      infiniteScroll={infiniteScroll}
+      blankSlate="No incidents yet."
+      scrollAreaLayout="intrinsic"
+      className="max-h-[min(28rem,50vh)]"
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-mute-confirm-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-mute-confirm-modal.tsx
@@ -1,0 +1,56 @@
+import { Button, Modal } from "@repo/ui"
+import { type MonitorRecord, useMonitorMuteAction } from "../../../../../../domains/monitors/monitors.collection.ts"
+
+/**
+ * Confirmation modal for mute/unmute, shared by the dashboard 3-dots menu and
+ * the details panel. Open when `monitor` is non-null; `onOpenChange(null)`
+ * closes it. The verb flips on the monitor's current `mutedAt`.
+ */
+export function MonitorMuteConfirmModal({
+  projectId,
+  monitor,
+  onOpenChange,
+}: {
+  readonly projectId: string
+  readonly monitor: MonitorRecord | null
+  readonly onOpenChange: (monitor: MonitorRecord | null) => void
+}) {
+  const { setMuted, isPending } = useMonitorMuteAction(projectId)
+  const muted = monitor?.mutedAt != null
+
+  const onConfirm = async () => {
+    if (!monitor) return
+    try {
+      await setMuted(monitor, !muted)
+      onOpenChange(null)
+    } catch {
+      // Error toast is handled in the hook; keep the modal open to retry.
+    }
+  }
+
+  return (
+    <Modal
+      open={monitor !== null}
+      onOpenChange={(open) => {
+        if (!open) onOpenChange(null)
+      }}
+      title={muted ? "Unmute monitor" : "Mute monitor"}
+      description={
+        muted
+          ? "Notifications will resume for new incidents this monitor creates."
+          : "This monitor will keep creating incidents, but it will stop sending notifications."
+      }
+      dismissible
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" disabled={isPending} onClick={() => onOpenChange(null)}>
+            Cancel
+          </Button>
+          <Button disabled={isPending} isLoading={isPending} onClick={() => void onConfirm()}>
+            {muted ? "Unmute" : "Mute"}
+          </Button>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
@@ -3,15 +3,20 @@ import {
   type InfiniteTableColumn,
   type InfiniteTableInfiniteScroll,
   LatitudeLogo,
+  type MenuOption,
+  optionsColumn,
   Status,
   Text,
 } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
+import { BellIcon, BellOffIcon, PencilIcon, Trash2Icon } from "lucide-react"
+import { useState } from "react"
 import type { MonitorRecord } from "../../../../../../domains/monitors/monitors.collection.ts"
 import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { MonitorMuteConfirmModal } from "./monitor-mute-confirm-modal.tsx"
 
 /** Latest-incident summary per row; `null` until incidents land (M3+) → em dash. */
 export interface MonitorLastIncidentSummary {
@@ -44,13 +49,16 @@ export function MonitorsView({
   infiniteScroll,
   activeMonitorSlug,
   onActiveMonitorChange,
+  projectId,
 }: {
   readonly rows: readonly MonitorsTableRow[]
   readonly isLoading: boolean
   readonly infiniteScroll: InfiniteTableInfiniteScroll
   readonly activeMonitorSlug: string | undefined
   readonly onActiveMonitorChange: (slug: string | undefined) => void
+  readonly projectId: string
 }) {
+  const [pendingMute, setPendingMute] = useState<MonitorRecord | null>(null)
   const activeRowKey = activeMonitorSlug
     ? rows.find((r) => r.monitor.slug === activeMonitorSlug)?.monitor.id
     : undefined
@@ -88,27 +96,43 @@ export function MonitorsView({
       minWidth: 180,
       render: (row) => <LastIncidentCell summary={row.lastIncident} />,
     },
+    optionsColumn<MonitorsTableRow>({
+      getOptions: (row): MenuOption[] => [
+        {
+          label: row.monitor.mutedAt ? "Unmute" : "Mute",
+          iconProps: { icon: row.monitor.mutedAt ? BellIcon : BellOffIcon },
+          onClick: () => setPendingMute(row.monitor),
+        },
+        { type: "separator" },
+        // Rename + Delete only apply to user monitors; wired in M5.
+        { label: "Rename", iconProps: { icon: PencilIcon }, disabled: true },
+        { label: "Delete", type: "destructive", iconProps: { icon: Trash2Icon }, disabled: true },
+      ],
+    }),
   ]
 
   return (
-    <Layout.Body>
-      <Layout.List>
-        <InfiniteTable
-          {...listingLayoutIntrinsicScroll.infiniteTable}
-          data={rows}
-          isLoading={isLoading}
-          columns={columns}
-          getRowKey={(row) => row.monitor.id}
-          infiniteScroll={infiniteScroll}
-          {...(activeRowKey ? { activeRowKey } : {})}
-          onRowClick={(row) =>
-            onActiveMonitorChange(row.monitor.slug === activeMonitorSlug ? undefined : row.monitor.slug)
-          }
-          getRowAriaLabel={(row) =>
-            row.monitor.slug === activeMonitorSlug ? `Close ${row.monitor.name}` : `Open ${row.monitor.name}`
-          }
-        />
-      </Layout.List>
-    </Layout.Body>
+    <>
+      <Layout.Body>
+        <Layout.List>
+          <InfiniteTable
+            {...listingLayoutIntrinsicScroll.infiniteTable}
+            data={rows}
+            isLoading={isLoading}
+            columns={columns}
+            getRowKey={(row) => row.monitor.id}
+            infiniteScroll={infiniteScroll}
+            {...(activeRowKey ? { activeRowKey } : {})}
+            onRowClick={(row) =>
+              onActiveMonitorChange(row.monitor.slug === activeMonitorSlug ? undefined : row.monitor.slug)
+            }
+            getRowAriaLabel={(row) =>
+              row.monitor.slug === activeMonitorSlug ? `Close ${row.monitor.name}` : `Open ${row.monitor.name}`
+            }
+          />
+        </Layout.List>
+      </Layout.Body>
+      <MonitorMuteConfirmModal projectId={projectId} monitor={pendingMute} onOpenChange={setPendingMute} />
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Icon, Input, Text, useValueWithDefault } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
-import { LockIcon, PlusIcon, SearchIcon } from "lucide-react"
+import { BellPlusIcon, LockIcon, SearchIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useMonitors } from "../../../../../domains/monitors/monitors.collection.ts"
@@ -70,6 +70,9 @@ function MonitorsPageContent() {
   )
 
   const activeMonitor = monitorSlug ? monitors.find((monitor) => monitor.slug === monitorSlug) : undefined
+  const activeIndex = activeMonitor ? monitors.findIndex((monitor) => monitor.slug === activeMonitor.slug) : -1
+  const prevMonitor = activeIndex > 0 ? monitors[activeIndex - 1] : undefined
+  const nextMonitor = activeIndex >= 0 ? monitors[activeIndex + 1] : undefined
 
   const hasMonitors = totalCount > 0
   const hasActiveFilters = Boolean(searchQuery)
@@ -104,9 +107,9 @@ function MonitorsPageContent() {
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
               {/* Disabled until the create-monitor modal lands in M5. */}
-              <Button size="sm" disabled>
-                <Icon icon={PlusIcon} size="sm" />
-                New monitor
+              <Button disabled>
+                <Icon icon={BellPlusIcon} size="sm" />
+                Monitor
               </Button>
             </Layout.ActionRowItem>
           </Layout.ActionsRow>
@@ -117,14 +120,20 @@ function MonitorsPageContent() {
           infiniteScroll={infiniteScroll}
           activeMonitorSlug={monitorSlug || undefined}
           onActiveMonitorChange={(slug) => setMonitorSlug(slug ?? "")}
+          projectId={project.id}
         />
       </Layout.Content>
-      {monitorSlug ? (
+      {activeMonitor ? (
         <Layout.Aside>
           <MonitorDetailDrawer
-            key={monitorSlug}
-            monitorName={activeMonitor?.name ?? monitorSlug}
+            key={activeMonitor.slug}
+            projectId={project.id}
+            monitor={activeMonitor}
             onClose={() => setMonitorSlug("")}
+            {...(nextMonitor ? { onNext: () => setMonitorSlug(nextMonitor.slug) } : {})}
+            {...(prevMonitor ? { onPrev: () => setMonitorSlug(prevMonitor.slug) } : {})}
+            canNavigateNext={nextMonitor !== undefined}
+            canNavigatePrev={prevMonitor !== undefined}
           />
         </Layout.Aside>
       ) : null}

--- a/apps/web/src/routes/backoffice/-components/organization-actions/reset-system-monitors.tsx
+++ b/apps/web/src/routes/backoffice/-components/organization-actions/reset-system-monitors.tsx
@@ -1,0 +1,75 @@
+import { Alert, Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useRouter } from "@tanstack/react-router"
+import { useState } from "react"
+import { adminResetSystemMonitors } from "../../../../domains/admin/organizations.functions.ts"
+import { toUserMessage } from "../../../../lib/errors.ts"
+
+interface ResetSystemMonitorsButtonProps {
+  readonly organizationId: string
+}
+
+/**
+ * Re-provision the three system monitors to their current definitions on every
+ * project in the org. Lets staff push changes to the monitor titles /
+ * descriptions / default alert condition values onto an org's existing system
+ * monitors. Behind a confirmation modal because it overwrites those values
+ * (including resetting the escalation sensitivity back to the default).
+ */
+export function ResetSystemMonitorsButton({ organizationId }: ResetSystemMonitorsButtonProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+
+  const onConfirm = async () => {
+    setIsPending(true)
+    try {
+      const result = await adminResetSystemMonitors({ data: { organizationId } })
+      toast({
+        description: `Reset ${result.monitorsReset} system monitor${result.monitorsReset === 1 ? "" : "s"} across ${result.projectsCount} project${result.projectsCount === 1 ? "" : "s"}.`,
+      })
+      setIsOpen(false)
+      void router.invalidate()
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not reset system monitors", description: toUserMessage(error) })
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setIsOpen(true)}>
+        Reset system monitors
+      </Button>
+      <Modal.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Modal.Content dismissible size="large">
+          <Modal.Header
+            title="Reset system monitors"
+            description={
+              <Text.H5 color="foregroundMuted">
+                Re-provision the system monitors to their current definitions on every project in this org.
+              </Text.H5>
+            }
+          />
+          <Modal.Body>
+            <Alert
+              variant="warning"
+              description="Re-applies the three system monitors (Issue discovered / Issue regressed / Issue escalating) to every project in this org. Overwrites their names, descriptions, and default alert condition values (e.g. resets the escalation sensitivity to the default). Mute state and incident history are preserved. A monitor slug already held by a user-created monitor is left untouched."
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <CloseTrigger>
+              <Button variant="outline" size="sm">
+                Close
+              </Button>
+            </CloseTrigger>
+            <Button size="sm" onClick={() => void onConfirm()} disabled={isPending}>
+              {isPending ? "Resetting…" : "Reset system monitors"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -17,7 +17,7 @@ import {
 import { relativeTime } from "@repo/utils"
 import { useForm } from "@tanstack/react-form"
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
-import { Flag, SparklesIcon } from "lucide-react"
+import { BellRingIcon, Flag, SparklesIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import {
   type AdminOrganizationFeatureFlagDto,
@@ -46,6 +46,7 @@ import {
   StripeCustomerLink,
 } from "../-components/dashboard/index.ts"
 import { CreateDemoProjectButton } from "../-components/organization-actions/create-demo-project.tsx"
+import { ResetSystemMonitorsButton } from "../-components/organization-actions/reset-system-monitors.tsx"
 import { OrganizationActionRow, OrganizationActionsSection } from "../-components/organization-actions/section.tsx"
 import { MemberRoleBadge, PlatformStaffBadge } from "../-components/role-badges.tsx"
 import { ProjectRow, UserRow } from "../-components/rows/index.ts"
@@ -199,6 +200,12 @@ function BackofficeOrganizationDetailPage() {
           title="Create demo project"
           description="Spin up a fresh project on this org seeded with bootstrap content (datasets, evaluations, issues, ~30 days of telemetry). Runs in the background."
           action={<CreateDemoProjectButton organizationId={organization.id} />}
+        />
+        <OrganizationActionRow
+          icon={BellRingIcon}
+          title="Reset system monitors"
+          description="Re-provision the three system monitors to their current definitions on every project in this org. Overwrites their titles, descriptions, and default alert condition values; preserves mute state and incident history."
+          action={<ResetSystemMonitorsButton organizationId={organization.id} />}
         />
       </OrganizationActionsSection>
 

--- a/apps/web/src/routes/backoffice/organizations/index.tsx
+++ b/apps/web/src/routes/backoffice/organizations/index.tsx
@@ -137,11 +137,13 @@ function BackofficeOrganizationsByUsagePage() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="border-b border-border px-6 py-4">
-        <Text.H4 weight="semibold">Organizations by usage</Text.H4>
-        <Text.H6 color="foregroundMuted">
-          Sorted by trace count over the last 30 days. Click a row to open the org detail page.
-        </Text.H6>
+      <div className="flex items-center gap-4 border-b border-border px-6 py-4">
+        <div className="flex flex-1 flex-col gap-1">
+          <Text.H4 weight="semibold">Organizations by usage</Text.H4>
+          <Text.H6 color="foregroundMuted">
+            Sorted by trace count over the last 30 days. Click a row to open the org detail page.
+          </Text.H6>
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col px-6 pt-4 pb-6">
         <InfiniteTable

--- a/apps/web/src/routes/backoffice/wrapped.tsx
+++ b/apps/web/src/routes/backoffice/wrapped.tsx
@@ -46,7 +46,7 @@ function BackofficeWrappedAnalyticsPage() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center gap-4 border-b border-border px-6 py-4">
-        <div className="flex-1">
+        <div className="flex flex-1 flex-col gap-1">
           <Text.H4 weight="semibold">Wrapped analytics</Text.H4>
           <Text.H6 color="foregroundMuted">
             Latest Wrapped report per project from the last 7 days. Click a row to open the report in a new tab.

--- a/packages/domain/admin/package.json
+++ b/packages/domain/admin/package.json
@@ -15,6 +15,7 @@
     "@domain/billing": "workspace:*",
     "@domain/events": "workspace:*",
     "@domain/feature-flags": "workspace:*",
+    "@domain/monitors": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",
     "@domain/shared": "workspace:*",

--- a/packages/domain/admin/src/organizations/index.ts
+++ b/packages/domain/admin/src/organizations/index.ts
@@ -33,3 +33,8 @@ export {
   adminOrganizationUsageCursorSchema,
   adminOrganizationUsageSummarySchema,
 } from "./organization-usage-summary.ts"
+export {
+  type ResetSystemMonitorsInput,
+  type ResetSystemMonitorsResult,
+  resetSystemMonitorsUseCase,
+} from "./reset-system-monitors.ts"

--- a/packages/domain/admin/src/organizations/reset-system-monitors.test.ts
+++ b/packages/domain/admin/src/organizations/reset-system-monitors.test.ts
@@ -1,0 +1,77 @@
+import { buildSystemMonitors, MonitorRepository } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AdminOrganizationDetails } from "./organization-details.ts"
+import { AdminOrganizationRepository } from "./organization-repository.ts"
+import { resetSystemMonitorsUseCase } from "./reset-system-monitors.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectA = "a".repeat(24)
+const projectB = "b".repeat(24)
+const at = new Date("2026-06-01T10:00:00.000Z")
+
+const makeOrg = (projectIds: readonly string[]): AdminOrganizationDetails => ({
+  id: organizationId,
+  name: "Acme",
+  slug: "acme",
+  stripeCustomerId: null,
+  members: [],
+  projects: projectIds.map((id) => ({ id, name: `Project ${id}`, slug: id, createdAt: at })),
+  createdAt: at,
+  updatedAt: at,
+})
+
+const fakeAdminRepo = (org: AdminOrganizationDetails) =>
+  AdminOrganizationRepository.of({
+    findById: () => Effect.succeed(org),
+    findManySummariesByIds: () => Effect.die("findManySummariesByIds not used"),
+    findFirstApiKeyId: () => Effect.die("findFirstApiKeyId not used"),
+  })
+
+const run = (org: AdminOrganizationDetails, monitorRepo: ReturnType<typeof createFakeMonitorRepository>["repo"]) =>
+  Effect.runPromise(
+    resetSystemMonitorsUseCase({ organizationId }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(AdminOrganizationRepository, fakeAdminRepo(org)),
+          Layer.succeed(MonitorRepository, MonitorRepository.of(monitorRepo)),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  )
+
+describe("resetSystemMonitorsUseCase", () => {
+  it("re-provisions the three system monitors for every project in the org", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    const result = await run(makeOrg([projectA, projectB]), repo)
+
+    expect(result).toEqual({ projectsCount: 2, monitorsReset: 6 })
+    expect(monitors.length).toBe(6)
+    for (const projectId of [projectA, projectB]) {
+      const slugs = monitors
+        .filter((m) => m.projectId === projectId)
+        .map((m) => m.slug)
+        .sort()
+      expect(slugs).toEqual(["issue-discovered", "issue-escalating", "issue-regressed"])
+    }
+  })
+
+  it("overwrites an existing system monitor's metadata (not skip-if-exists)", async () => {
+    const seeded = buildSystemMonitors({ organizationId, projectId: ProjectId(projectA) }).map((monitor) =>
+      monitor.slug === "issue-discovered" ? { ...monitor, name: "Stale name", description: "Stale" } : monitor,
+    )
+    const { repo, monitors } = createFakeMonitorRepository(seeded)
+
+    const result = await run(makeOrg([projectA]), repo)
+
+    expect(result).toEqual({ projectsCount: 1, monitorsReset: 3 })
+    expect(monitors.length).toBe(3)
+    const discovered = monitors.find((m) => m.projectId === projectA && m.slug === "issue-discovered")
+    expect(discovered?.name).toBe("Issue discovered")
+    expect(discovered?.description).toBe("Notifies each time a new issue is detected.")
+  })
+})

--- a/packages/domain/admin/src/organizations/reset-system-monitors.ts
+++ b/packages/domain/admin/src/organizations/reset-system-monitors.ts
@@ -1,0 +1,41 @@
+import { buildSystemMonitors, MonitorRepository } from "@domain/monitors"
+import { type OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { AdminOrganizationRepository } from "./organization-repository.ts"
+
+export interface ResetSystemMonitorsInput {
+  readonly organizationId: OrganizationId
+}
+
+export interface ResetSystemMonitorsResult {
+  readonly projectsCount: number
+  readonly monitorsReset: number
+}
+
+/**
+ * Backoffice "reset system monitors": re-provisions the three system monitors
+ * to their current `SYSTEM_MONITOR_DEFINITIONS` for every project in the org.
+ * Lets staff push definition changes (name/description/alert condition values)
+ * onto an org's existing system monitors. Repo-side it upserts metadata and
+ * resets alert conditions while preserving `mutedAt` and incident history (the
+ * old alerts are soft-deleted, not dropped). Runs in the admin/`"system"`
+ * RLS-off context — the repo filters by the target project, not session org.
+ */
+export const resetSystemMonitorsUseCase = Effect.fn("admin.resetSystemMonitors")(function* (
+  input: ResetSystemMonitorsInput,
+) {
+  yield* Effect.annotateCurrentSpan("admin.targetOrganizationId", input.organizationId)
+
+  const adminRepo = yield* AdminOrganizationRepository
+  const monitorRepo = yield* MonitorRepository
+  const org = yield* adminRepo.findById(input.organizationId)
+
+  let monitorsReset = 0
+  for (const project of org.projects) {
+    const monitors = buildSystemMonitors({ organizationId: input.organizationId, projectId: ProjectId(project.id) })
+    const reset = yield* monitorRepo.resetSystemMonitors(monitors)
+    monitorsReset += reset.length
+  }
+
+  return { projectsCount: org.projects.length, monitorsReset } satisfies ResetSystemMonitorsResult
+})

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -1,5 +1,5 @@
 import type { IncidentSampleExcerpt } from "@domain/notifications"
-import type { AlertIncidentKind, AlertSeverity } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_LABEL, type AlertIncidentKind, type AlertSeverity } from "@domain/shared"
 import { Section } from "@react-email/components"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -20,26 +20,16 @@ import {
   TagsChips,
 } from "../-incident-components.tsx"
 
-const ALERT_KIND_TO_HEADING: Record<AlertIncidentKind, string> = {
-  "issue.new": "New issue",
-  "issue.regressed": "Regressed issue",
-  "issue.escalating": "Escalating issue",
-  // Placeholder copy until the monitors flag path ships polished templates (M6+).
-  "savedSearch.match": "Saved search match",
-  "savedSearch.threshold": "Saved search threshold",
-  "savedSearch.escalating": "Saved search escalating",
-}
-
 const ALERT_KIND_TO_SUBTITLE: Record<AlertIncidentKind, string> = {
-  "issue.new": "We notified everyone watching this project of the new issue.",
-  "issue.regressed": "We notified everyone watching this project — this issue had previously been resolved.",
+  "issue.new": "We notified everyone watching this project — a new issue was discovered.",
+  "issue.regressed": "We notified everyone watching this project — a resolved issue was detected again.",
   "issue.escalating":
-    "We notified everyone watching this project — the issue's occurrence rate crossed the escalation threshold.",
-  "savedSearch.match": "We notified everyone watching this project — a new trace matched the saved search.",
+    "We notified everyone watching this project — an ongoing issue is being detected more than expected.",
+  "savedSearch.match": "We notified everyone watching this project — a new trace matching the search was detected.",
   "savedSearch.threshold":
-    "We notified everyone watching this project — the saved-search match count crossed the configured threshold.",
+    "We notified everyone watching this project — traces matching the search were detected above the configured threshold.",
   "savedSearch.escalating":
-    "We notified everyone watching this project — the saved-search match count stayed above the threshold for the configured window.",
+    "We notified everyone watching this project — traces matching the search stayed above the threshold for the configured window.",
 }
 
 interface IncidentEventEmailProps {
@@ -71,7 +61,7 @@ export function IncidentEventEmail({
   sampleExcerpt,
   webAppUrl,
 }: IncidentEventEmailProps) {
-  const heading = ALERT_KIND_TO_HEADING[incidentKind]
+  const heading = ALERT_INCIDENT_KIND_LABEL[incidentKind]
   const subtitle = ALERT_KIND_TO_SUBTITLE[incidentKind]
   const issueRef = issueName ?? "an issue"
   const scope = formatScope(organizationName, projectName)

--- a/packages/domain/email/src/templates/notifications/incident-event/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/index.tsx
@@ -1,5 +1,5 @@
 import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_LABEL, IssueId } from "@domain/shared"
 import { Effect } from "effect"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -7,12 +7,6 @@ import React from "react"
 import { renderEmail } from "../../../utils/render.ts"
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentEventEmail } from "./EmailTemplate.tsx"
-
-const ALERT_KIND_TO_SUBJECT: Record<string, string> = {
-  "issue.new": "New issue",
-  "issue.regressed": "Regressed issue",
-  "issue.escalating": "Escalating issue",
-}
 
 const buildSourceUrl = (
   ctx: NotificationEmailRenderContext,
@@ -37,7 +31,7 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
     )
     const issueRef = issue?.name ?? "an issue"
     const issueUrl = buildSourceUrl(ctx, payload)
-    const heading = ALERT_KIND_TO_SUBJECT[payload.incidentKind] ?? "Incident"
+    const heading = ALERT_INCIDENT_KIND_LABEL[payload.incidentKind] ?? "Incident"
 
     const html = yield* Effect.tryPromise({
       try: () =>

--- a/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
@@ -81,10 +81,10 @@ export function IncidentOpenedEmail({
       footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
     >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
-        Escalating issue
+        Issue escalating
       </EmailText>
       <EmailText variant="body">
-        We notified everyone watching this project — the issue's occurrence rate crossed the escalation threshold.
+        We notified everyone watching this project — an ongoing issue is being detected more than expected.
       </EmailText>
 
       <SectionHeader label="Issue" />

--- a/packages/domain/integrations/src/templates/notifications/incident-event.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-event.ts
@@ -1,18 +1,12 @@
 import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_LABEL, IssueId } from "@domain/shared"
 import { Effect } from "effect"
 import { actionsLink, contextLine, projectOrOrgContext, sectionMarkdown, severityColor } from "./blocks.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
-const KIND_NAME: Record<string, string> = {
-  "issue.new": "New issue",
-  "issue.regressed": "Issue regressed",
-  "issue.escalating": "Issue escalating",
-}
-
 export const incidentEventRenderer: SlackNotificationRenderer<"incident.event"> = (payload, ctx) =>
   Effect.gen(function* () {
-    const name = KIND_NAME[payload.incidentKind] ?? "Incident"
+    const name = ALERT_INCIDENT_KIND_LABEL[payload.incidentKind] ?? "Incident"
     const color = severityColor(payload.severity)
     const issueUrl = ctx.project
       ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/issues?issueId=${payload.sourceId}`

--- a/packages/domain/monitors/src/helpers.test.ts
+++ b/packages/domain/monitors/src/helpers.test.ts
@@ -22,18 +22,18 @@ const absolute = (count: number): AlertCountThreshold => ({ mode: "absolute", co
 
 describe("formatHumanReadableAlert", () => {
   it("renders the issue.new system alert", () => {
-    expect(formatHumanReadableAlert(baseAlert)).toBe("Alert me every time a new issue is discovered.")
+    expect(formatHumanReadableAlert(baseAlert)).toBe("Alerts each time a new issue is detected.")
   })
 
   it("renders the issue.regressed system alert", () => {
     expect(formatHumanReadableAlert(makeAlert({ kind: "issue.regressed" }))).toBe(
-      "Alert me every time a resolved issue regresses.",
+      "Alerts each time a resolved issue is detected again.",
     )
   })
 
   it("renders the issue.escalating system alert", () => {
     expect(formatHumanReadableAlert(makeAlert({ kind: "issue.escalating" }))).toBe(
-      "Alert me when an issue's occurrence rate crosses the project escalation threshold.",
+      "Alerts when an ongoing issue is being detected more than expected.",
     )
   })
 
@@ -43,7 +43,7 @@ describe("formatHumanReadableAlert", () => {
       source: { type: "savedSearch", id: "s".repeat(24) },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me every time a trace matches '5xx'.",
+      "Alerts each time a new trace matching '5xx' is detected.",
     )
   })
 
@@ -52,7 +52,7 @@ describe("formatHumanReadableAlert", () => {
       kind: "savedSearch.match",
       source: { type: "savedSearch", id: "s".repeat(24) },
     })
-    expect(formatHumanReadableAlert(alert)).toBe("Alert me every time a trace matches a saved search.")
+    expect(formatHumanReadableAlert(alert)).toBe("Alerts each time a new matching trace is detected.")
   })
 
   it("renders savedSearch.threshold absolute mode", () => {
@@ -62,7 +62,7 @@ describe("formatHumanReadableAlert", () => {
       condition: { kind: "savedSearch.threshold", threshold: absolute(100) },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 100 times.",
+      "Alerts when traces matching '5xx' are detected 100 times.",
     )
   })
 
@@ -80,7 +80,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 3 times more than the average of the last 72 hours.",
+      "Alerts when traces matching '5xx' are detected 3 times more than the average of the last 72 hours.",
     )
   })
 
@@ -98,7 +98,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2 times more than the average of the last 7 days.",
+      "Alerts when traces matching '5xx' are detected 2 times more than the average of the last 7 days.",
     )
   })
 
@@ -116,7 +116,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2 times more than yesterday.",
+      "Alerts when traces matching '5xx' are detected 2 times more than yesterday.",
     )
   })
 
@@ -134,7 +134,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2 times more than the previous week.",
+      "Alerts when traces matching '5xx' are detected 2 times more than the previous week.",
     )
   })
 
@@ -148,7 +148,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2 times more than expected.",
+      "Alerts when traces matching '5xx' are detected 2 times more than expected.",
     )
   })
 
@@ -163,7 +163,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 3 times more than expected, sustained for at least 1 hour.",
+      "Alerts when traces matching '5xx' are detected 3 times more than expected, sustained for at least 1 hour.",
     )
   })
 
@@ -177,7 +177,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred more than expected.",
+      "Alerts when traces matching '5xx' are detected more than expected.",
     )
   })
 
@@ -192,7 +192,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2000 times, sustained for at least 5 minutes.",
+      "Alerts when traces matching '5xx' are detected 2000 times, sustained for at least 5 minutes.",
     )
   })
 
@@ -211,7 +211,7 @@ describe("formatHumanReadableAlert", () => {
       },
     })
     expect(formatHumanReadableAlert(alert, { savedSearchName: "5xx" })).toBe(
-      "Alert me when '5xx' matches occurred 2 times more than the average of the last 7 days, sustained for at least 1 hour.",
+      "Alerts when traces matching '5xx' are detected 2 times more than the average of the last 7 days, sustained for at least 1 hour.",
     )
   })
 

--- a/packages/domain/monitors/src/helpers.ts
+++ b/packages/domain/monitors/src/helpers.ts
@@ -2,7 +2,7 @@ import type { AlertBaseline, AlertCountThreshold, AlertDuration, AlertIncidentKi
 import type { MonitorAlert } from "./entities/monitor.ts"
 
 export interface HumanReadableAlertContext {
-  /** Saved-search display name; caller resolves it. Falls back to "a saved search" when absent. */
+  /** Humanised saved-search name/filter; caller resolves it. Falls back to "matching traces" when absent. */
   readonly savedSearchName?: string
 }
 
@@ -33,15 +33,15 @@ const formatBaseline = (baseline: AlertBaseline): string =>
 
 const formatThreshold = (threshold: AlertCountThreshold): string => {
   if (threshold.mode === "absolute") {
-    return `occurred ${threshold.count} times`
+    return `detected ${threshold.count} times`
   }
   if (threshold.mode === "multiplier") {
-    return `occurred ${threshold.factor} times more than ${formatBaseline(threshold.baseline)}`
+    return `detected ${threshold.factor} times more than ${formatBaseline(threshold.baseline)}`
   }
   // sensitivity is the user-facing "N times more than expected"; drop it when unset.
   return threshold.sensitivity === undefined
-    ? "occurred more than expected"
-    : `occurred ${threshold.sensitivity} times more than expected`
+    ? "detected more than expected"
+    : `detected ${threshold.sensitivity} times more than expected`
 }
 
 const formatWindowMinutes = (minutes: number): string => {
@@ -52,16 +52,14 @@ const formatWindowMinutes = (minutes: number): string => {
 }
 
 const issueSentenceForKind: Record<Extract<AlertIncidentKind, `issue.${string}`>, string> = {
-  "issue.new": "Alert me every time a new issue is discovered.",
-  "issue.regressed": "Alert me every time a resolved issue regresses.",
-  "issue.escalating": "Alert me when an issue's occurrence rate crosses the project escalation threshold.",
+  "issue.new": "Alerts each time a new issue is detected.",
+  "issue.regressed": "Alerts each time a resolved issue is detected again.",
+  "issue.escalating": "Alerts when an ongoing issue is being detected more than expected.",
 }
 
-const savedSearchSubject = (alert: MonitorAlert, context?: HumanReadableAlertContext): string => {
-  if (context?.savedSearchName) return `'${context.savedSearchName}' matches`
-  if (alert.source.id === null) return "saved-search matches"
-  return "matches of a saved search"
-}
+/** The thing being detected is a trace; the saved search (humanised by the caller) scopes which. */
+const savedSearchTraceSubject = (context?: HumanReadableAlertContext): string =>
+  context?.savedSearchName ? `traces matching '${context.savedSearchName}'` : "matching traces"
 
 /** Renders an alert as one complete sentence. Shared by the form preview, panel, and notification templates. */
 export function formatHumanReadableAlert(alert: MonitorAlert, context?: HumanReadableAlertContext): string {
@@ -69,19 +67,21 @@ export function formatHumanReadableAlert(alert: MonitorAlert, context?: HumanRea
     return issueSentenceForKind[alert.kind]
   }
 
-  const subject = savedSearchSubject(alert, context)
-
   if (alert.kind === "savedSearch.match") {
-    return `Alert me every time a trace matches ${context?.savedSearchName ? `'${context.savedSearchName}'` : "a saved search"}.`
+    return context?.savedSearchName
+      ? `Alerts each time a new trace matching '${context.savedSearchName}' is detected.`
+      : "Alerts each time a new matching trace is detected."
   }
 
+  const subject = savedSearchTraceSubject(context)
+
   if (alert.kind === "savedSearch.threshold" && alert.condition?.kind === "savedSearch.threshold") {
-    return `Alert me when ${subject} ${formatThreshold(alert.condition.threshold)}.`
+    return `Alerts when ${subject} are ${formatThreshold(alert.condition.threshold)}.`
   }
 
   if (alert.kind === "savedSearch.escalating" && alert.condition?.kind === "savedSearch.escalating") {
     // "sustained for at least X" keeps the window distinct from the baseline period.
-    return `Alert me when ${subject} ${formatThreshold(alert.condition.threshold)}, sustained for at least ${formatWindowMinutes(
+    return `Alerts when ${subject} are ${formatThreshold(alert.condition.threshold)}, sustained for at least ${formatWindowMinutes(
       alert.condition.window.minutes,
     )}.`
   }

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -39,7 +39,7 @@ export type {
   ProvisionSystemMonitorsError,
   ProvisionSystemMonitorsInput,
 } from "./use-cases/provision-system-monitors.ts"
-export { provisionSystemMonitorsUseCase } from "./use-cases/provision-system-monitors.ts"
+export { buildSystemMonitors, provisionSystemMonitorsUseCase } from "./use-cases/provision-system-monitors.ts"
 export type { UpdateMonitorError, UpdateMonitorInput } from "./use-cases/update-monitor.ts"
 export { updateMonitorUseCase } from "./use-cases/update-monitor.ts"
 export type { UpdateMonitorAlertError, UpdateMonitorAlertInput } from "./use-cases/update-monitor-alert.ts"

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -43,6 +43,17 @@ export interface MonitorRepositoryShape {
    * returns `[]`.
    */
   provisionSystemMonitors(monitors: readonly Monitor[]): Effect.Effect<readonly Monitor[], RepositoryError, SqlClient>
+  /**
+   * Re-provision system monitors to the given definitions (backoffice reset).
+   * Upserts each by `(projectId, slug)` — updates name/description on an
+   * existing system monitor (preserving its `mutedAt`), inserts when missing,
+   * and resets its alerts to the definition (soft-deleting the old alerts so
+   * incident history stays joinable, then inserting fresh). Skips a slug held
+   * by a non-system monitor. Filters by the entity's `projectId`, so it is safe
+   * to run from the admin/`"system"` (RLS-off) context. Returns the monitors
+   * that were reset.
+   */
+  resetSystemMonitors(monitors: readonly Monitor[]): Effect.Effect<readonly Monitor[], RepositoryError, SqlClient>
   /** Set or clear `mutedAt` on a live monitor. Fails `NotFoundError` if it doesn't exist. */
   setMuted(input: {
     readonly id: MonitorId

--- a/packages/domain/monitors/src/system-monitors.ts
+++ b/packages/domain/monitors/src/system-monitors.ts
@@ -47,8 +47,7 @@ export const SYSTEM_MONITOR_DEFINITIONS: readonly SystemMonitorDefinition[] = [
   {
     slug: "issue-escalating",
     name: "Issue escalating",
-    description:
-      "Notifies when an ongoing issue's occurrence rate crosses the escalation threshold, and again when it returns to baseline.",
+    description: "Notifies when an ongoing issue is being detected more than expected.",
     alerts: [
       {
         kind: "issue.escalating",

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -60,6 +60,29 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
         }
         return inserted
       }),
+    resetSystemMonitors: (toReset) =>
+      Effect.sync(() => {
+        const reset: Monitor[] = []
+        for (const monitor of toReset) {
+          const existing = monitors.find(
+            (m) => m.projectId === monitor.projectId && m.slug === monitor.slug && isLive(m),
+          )
+          if (existing && !existing.system) continue
+          if (existing) {
+            replace(existing.id, {
+              ...existing,
+              name: monitor.name,
+              description: monitor.description,
+              alerts: monitor.alerts.map((alert) => ({ ...alert, monitorId: existing.id })),
+              updatedAt: new Date(),
+            })
+          } else {
+            monitors.push(monitor)
+          }
+          reset.push(monitor)
+        }
+        return reset
+      }),
     setMuted: ({ id, mutedAt }) =>
       Effect.suspend(() => {
         const monitor = liveById(id)

--- a/packages/domain/monitors/src/use-cases/provision-system-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/provision-system-monitors.ts
@@ -51,6 +51,16 @@ const buildSystemMonitor = (
 }
 
 /**
+ * Materialise the three system monitor entities for a project (fresh ids +
+ * timestamps). Shared by provisioning (insert-if-missing) and the backoffice
+ * reset (re-provision to the current definitions).
+ */
+export const buildSystemMonitors = (input: ProvisionSystemMonitorsInput): Monitor[] => {
+  const now = new Date()
+  return SYSTEM_MONITOR_DEFINITIONS.map((definition) => buildSystemMonitor(definition, input, now))
+}
+
+/**
  * Idempotently provisions the three system issue monitors for a project. On
  * re-run (e.g. a re-published `provision` task, or a project already covered by
  * the backfill) the repository inserts only the missing slugs and returns just
@@ -64,9 +74,6 @@ export const provisionSystemMonitorsUseCase = Effect.fn("monitors.provisionSyste
   yield* Effect.annotateCurrentSpan("monitors.projectId", input.projectId)
 
   const repository = yield* MonitorRepository
-  const now = new Date()
-  const monitors = SYSTEM_MONITOR_DEFINITIONS.map((definition) => buildSystemMonitor(definition, input, now))
-
-  const provisioned = yield* repository.provisionSystemMonitors(monitors)
+  const provisioned = yield* repository.provisionSystemMonitors(buildSystemMonitors(input))
   return provisioned satisfies readonly Monitor[]
 })

--- a/packages/domain/shared/src/alert-incident-kinds.ts
+++ b/packages/domain/shared/src/alert-incident-kinds.ts
@@ -41,6 +41,20 @@ export const ALERT_INCIDENT_KIND_LIFECYCLE: Record<AlertIncidentKind, "point" | 
   "savedSearch.escalating": "sustained",
 }
 
+/**
+ * Canonical human-readable label per kind. Single source of truth — the monitor
+ * panel, incident-chart markers, and email/Slack notification templates all read
+ * this so the same kind never shows two different names.
+ */
+export const ALERT_INCIDENT_KIND_LABEL: Record<AlertIncidentKind, string> = {
+  "issue.new": "Issue discovered",
+  "issue.regressed": "Issue regressed",
+  "issue.escalating": "Issue escalating",
+  "savedSearch.match": "Search match",
+  "savedSearch.threshold": "Search threshold",
+  "savedSearch.escalating": "Search escalating",
+}
+
 /** Kinds users may put on their own monitors; `issue.*` are system-only. Create/update enforce this. */
 export const USER_CREATABLE_ALERT_KINDS = [
   "savedSearch.match",

--- a/packages/platform/db-postgres/drizzle/20260601121626_backfill-system-monitors/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260601121626_backfill-system-monitors/migration.sql
@@ -33,7 +33,7 @@ WHERE NOT EXISTS (
 INSERT INTO "latitude"."monitors" (id, organization_id, project_id, slug, name, description, system, created_at, updated_at)
 SELECT substr(md5(gen_random_uuid()::text), 1, 24), p.organization_id, p.id,
   'issue-escalating', 'Issue escalating',
-  'Notifies when an ongoing issue''s occurrence rate crosses the escalation threshold, and again when it returns to baseline.',
+  'Notifies when an ongoing issue is being detected more than expected.',
   true, now(), now()
 FROM "latitude"."projects" p
 WHERE NOT EXISTS (

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -460,6 +460,160 @@ describe("MonitorRepositoryLive", () => {
     })
   })
 
+  describe("resetSystemMonitors", () => {
+    const makeSystemMonitor = (
+      target: ProjectId,
+      slug: string,
+      name: string,
+      alert: { kind: MonitorAlert["kind"]; severity: AlertSeverity; condition: AlertIncidentCondition | null },
+    ): Monitor => {
+      const monitorId = MonitorId(generateId())
+      const now = new Date("2026-06-01T10:00:00.000Z")
+      return {
+        id: monitorId,
+        organizationId,
+        projectId: target,
+        slug,
+        name,
+        description: `${name} description`,
+        system: true,
+        alerts: [
+          {
+            id: MonitorAlertId(generateId()),
+            monitorId,
+            kind: alert.kind,
+            source: { type: "issue", id: null },
+            condition: alert.condition,
+            severity: alert.severity,
+            createdAt: now,
+          },
+        ],
+        mutedAt: null,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      }
+    }
+
+    const systemMonitors = (target: ProjectId = projectId): Monitor[] => [
+      makeSystemMonitor(target, "issue-discovered", "Issue discovered", {
+        kind: "issue.new",
+        severity: "medium",
+        condition: null,
+      }),
+      makeSystemMonitor(target, "issue-escalating", "Issue escalating", {
+        kind: "issue.escalating",
+        severity: "high",
+        condition: { kind: "issue.escalating", sensitivity: 3 },
+      }),
+    ]
+
+    const reset = (monitors: readonly Monitor[]) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* repository.resetSystemMonitors(monitors)
+        }).pipe(provideRls(database, organizationId)),
+      )
+
+    const list = (target: ProjectId = projectId) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* repository.list({ projectId: target, limit: 50, offset: 0 })
+        }).pipe(provideRls(database, organizationId)),
+      )
+
+    it("inserts the monitors with their alerts on a fresh project", async () => {
+      const result = await reset(systemMonitors())
+      expect(result.map((m) => m.slug)).toEqual(["issue-discovered", "issue-escalating"])
+
+      const page = await list()
+      expect(page.totalCount).toBe(2)
+      const bySlug = new Map(page.items.map((m) => [m.slug, m]))
+      expect(bySlug.get("issue-escalating")?.alerts[0]).toMatchObject({
+        kind: "issue.escalating",
+        condition: { kind: "issue.escalating", sensitivity: 3 },
+      })
+    })
+
+    it("overwrites name/description and resets alert condition values on existing system monitors", async () => {
+      await reset(systemMonitors())
+
+      // Drift the live state: rename the monitor and slacken the escalation sensitivity.
+      const before = await list()
+      const escalating = before.items.find((m) => m.slug === "issue-escalating")
+      await database.db
+        .update(monitorsTable)
+        .set({ name: "Renamed by user", description: "Edited" })
+        .where(eq(monitorsTable.id, escalating?.id ?? ""))
+      await database.db
+        .update(monitorAlertsTable)
+        .set({ condition: { kind: "issue.escalating", sensitivity: 10 } })
+        .where(eq(monitorAlertsTable.monitorId, escalating?.id ?? ""))
+
+      const result = await reset(systemMonitors())
+      expect(result.length).toBe(2)
+
+      const after = await list()
+      expect(after.totalCount).toBe(2)
+      const resetEscalating = after.items.find((m) => m.slug === "issue-escalating")
+      expect(resetEscalating?.id).toBe(escalating?.id) // upsert keeps the existing row
+      expect(resetEscalating?.name).toBe("Issue escalating")
+      expect(resetEscalating?.description).toBe("Issue escalating description")
+      expect(resetEscalating?.alerts.length).toBe(1) // old alert soft-deleted, fresh one inserted
+      expect(resetEscalating?.alerts[0]).toMatchObject({ condition: { kind: "issue.escalating", sensitivity: 3 } })
+    })
+
+    it("preserves the mute state of an existing system monitor", async () => {
+      await reset(systemMonitors())
+      const before = await list()
+      const discovered = before.items.find((m) => m.slug === "issue-discovered")
+      const mutedAt = new Date("2026-06-01T12:00:00.000Z")
+      await database.db
+        .update(monitorsTable)
+        .set({ mutedAt })
+        .where(eq(monitorsTable.id, discovered?.id ?? ""))
+
+      await reset(systemMonitors())
+
+      const after = await list()
+      const resetDiscovered = after.items.find((m) => m.slug === "issue-discovered")
+      expect(resetDiscovered?.mutedAt).toEqual(mutedAt)
+    })
+
+    it("skips a slug already held by a user-created monitor", async () => {
+      const userMonitorId = generateId()
+      await database.db
+        .insert(monitorsTable)
+        .values(
+          makeMonitorRow({ id: userMonitorId, slug: "issue-discovered", name: "My custom monitor", system: false }),
+        )
+
+      const result = await reset(systemMonitors())
+      expect(result.map((m) => m.slug)).toEqual(["issue-escalating"])
+
+      const page = await list()
+      const discovered = page.items.find((m) => m.slug === "issue-discovered")
+      expect(discovered?.id).toBe(userMonitorId)
+      expect(discovered?.name).toBe("My custom monitor")
+      expect(discovered?.system).toBe(false)
+    })
+
+    it("only touches the target project, leaving same-slug monitors on other projects alone", async () => {
+      await reset(systemMonitors(otherProjectId))
+      const otherBefore = await list(otherProjectId)
+      const otherDiscovered = otherBefore.items.find((m) => m.slug === "issue-discovered")
+
+      await reset(systemMonitors(projectId))
+
+      const target = await list(projectId)
+      expect(target.totalCount).toBe(2)
+      const other = await list(otherProjectId)
+      expect(other.items.find((m) => m.slug === "issue-discovered")?.id).toBe(otherDiscovered?.id)
+    })
+  })
+
   describe("mutations", () => {
     const exec = <A, E>(use: (repo: MonitorRepositoryShape) => Effect.Effect<A, E, SqlClient>) =>
       Effect.runPromise(

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -221,6 +221,59 @@ export const MonitorRepositoryLive = Layer.effect(
             return inserted
           })
         }),
+      resetSystemMonitors: (monitorsToReset) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // Filters by the entity's projectId (NOT sqlClient.organizationId): this
+          // runs from the admin/"system" RLS-off context. One transaction.
+          return yield* sqlClient.query(async (db) => {
+            const now = new Date()
+            const reset: Monitor[] = []
+            for (const monitor of monitorsToReset) {
+              const existing = await db
+                .select({ id: monitors.id, system: monitors.system })
+                .from(monitors)
+                .where(
+                  and(
+                    eq(monitors.projectId, monitor.projectId),
+                    eq(monitors.slug, monitor.slug),
+                    isNull(monitors.deletedAt),
+                  ),
+                )
+                .limit(1)
+              const existingRow = existing[0]
+              // Don't clobber a user monitor that happens to hold a system slug.
+              if (existingRow && !existingRow.system) continue
+
+              const effectiveId = existingRow?.id ?? monitor.id
+              if (existingRow) {
+                await db
+                  .update(monitors)
+                  .set({ name: monitor.name, description: monitor.description, updatedAt: now })
+                  .where(eq(monitors.id, effectiveId))
+              } else {
+                await db.insert(monitors).values(toMonitorRow(monitor))
+              }
+
+              // Reset alerts: soft-delete the live ones (keeps the incident→alert
+              // join resolvable) and insert fresh from the definition.
+              await db
+                .update(monitorAlerts)
+                .set({ deletedAt: now })
+                .where(and(eq(monitorAlerts.monitorId, effectiveId), isNull(monitorAlerts.deletedAt)))
+              if (monitor.alerts.length > 0) {
+                await db.insert(monitorAlerts).values(
+                  monitor.alerts.map((alert) => ({
+                    ...toMonitorAlertRow(alert, monitor.organizationId),
+                    monitorId: effectiveId,
+                  })),
+                )
+              }
+              reset.push(monitor)
+            }
+            return reset
+          })
+        }),
       setMuted: ({ id, mutedAt }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/packages/sdk/typescript/src/api/types/Incident.ts
+++ b/packages/sdk/typescript/src/api/types/Incident.ts
@@ -7,11 +7,11 @@ export interface Incident {
     organizationId: string;
     /** Project this incident belongs to. */
     projectId: string;
-    /** Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a saved search. */
+    /** Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search. */
     sourceType: Incident.SourceType;
     /** Id of the entity that triggered the incident (matches `sourceType`). */
     sourceId: string;
-    /** Reason the incident opened. `issue.new` fires when a brand-new issue is discovered; `issue.regressed` when a resolved issue starts occurring again; `issue.escalating` when an existing issue's occurrence rate exceeds its seasonal baseline. The `savedSearch.*` kinds are raised by monitors watching a saved search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when the match count crosses a configured threshold, and `savedSearch.escalating` when it stays elevated for a sustained window. */
+    /** Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window. */
     kind: Incident.Kind;
     /** Severity bucket assigned to the incident: `low`, `medium`, or `high`. */
     severity: Incident.Severity;
@@ -24,13 +24,13 @@ export interface Incident {
 }
 
 export namespace Incident {
-    /** Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a saved search. */
+    /** Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search. */
     export const SourceType = {
         Issue: "issue",
         SavedSearch: "savedSearch",
     } as const;
     export type SourceType = (typeof SourceType)[keyof typeof SourceType];
-    /** Reason the incident opened. `issue.new` fires when a brand-new issue is discovered; `issue.regressed` when a resolved issue starts occurring again; `issue.escalating` when an existing issue's occurrence rate exceeds its seasonal baseline. The `savedSearch.*` kinds are raised by monitors watching a saved search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when the match count crosses a configured threshold, and `savedSearch.escalating` when it stays elevated for a sustained window. */
+    /** Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window. */
     export const Kind = {
         IssueNew: "issue.new",
         IssueRegressed: "issue.regressed",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,6 +923,9 @@ importers:
       '@domain/feature-flags':
         specifier: workspace:*
         version: link:../feature-flags
+      '@domain/monitors':
+        specifier: workspace:*
+        version: link:../monitors
       '@domain/projects':
         specifier: workspace:*
         version: link:../projects

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -294,17 +294,18 @@ export type AlertBaseline = {
  * hardcoded to 5 min, the throttle interval) and `savedSearch.escalating`
  * (current window = the user-configured `window` field).
  *
- * Humanised examples:
+ * Humanised examples (the full sentence prefixes with "Alerts when traces
+ * matching '<search>' are " — see `formatHumanReadableAlert`):
  *   { mode: "absolute", count: 100 }
- *     → "occurred 100 times"
+ *     → "detected 100 times"
  *   { mode: "multiplier", factor: 3,
  *     baseline: { kind: "average", lookback: { unit: "days", days: 7 } } }
- *     → "occurred 3 times more than the average of the last 7 days"
+ *     → "detected 3 times more than the average of the last 7 days"
  *   { mode: "multiplier", factor: 2,
  *     baseline: { kind: "period", lookback: { unit: "days", days: 1 } } }
- *     → "occurred 2 times more than yesterday"
+ *     → "detected 2 times more than yesterday"
  *   { mode: "expected", sensitivity: 2 }
- *     → "occurred 2 times more than expected"
+ *     → "detected 2 times more than expected"
  */
 export type AlertCountThreshold =
   | { mode: "absolute"; count: number }
@@ -932,38 +933,26 @@ Mirrors `issues-empty-state.tsx`. In practice rarely seen post-backfill, since e
 
 | Column | Sortable | Behaviour |
 |---|---|---|
-| Name | no | Truncated. `<LatitudeLogo />` prepended when `system === true`, mirroring the annotation-card pattern. |
+| Name | yes | Truncated. `<LatitudeLogo />` prepended when `system === true`, mirroring the annotation-card pattern. |
 | Status | yes | `<Status variant="primary">Live</Status>` when `mutedAt = null`; `<Status variant="muted">Muted</Status>` otherwise. |
-| Last incident | yes (default desc) | Empty when no incidents. Otherwise: warning badge "Closed Xh ago" if the latest incident has `endedAt != null`; destructive badge "Ongoing since Xh" if `endedAt = null`. Uses `relativeTime` from `@repo/utils`. |
+| Last incident | yes | Empty when no incidents. Otherwise: warning badge "Closed Xh ago" if the latest incident has `endedAt != null`; destructive badge "Ongoing since Xh" if `endedAt = null`. Uses `relativeTime` from `@repo/utils`. |
+| Actions | no | A trailing 3-dots `optionsColumn` menu (the home for all monitor management): **Mute/Unmute** (behind `MonitorMuteConfirmModal`), and **Rename** / **Delete** (user monitors only — disabled for system; the rename modal + delete confirmation are wired in M5). |
+
+**Ordering.** Name / Status / Last incident are all sortable. **System monitors are always pinned to the top of the list** regardless of the active sort; within each group (system, then user) the default sort is **last incident descending**. (Sorting by last incident requires the list read to surface each monitor's latest-incident timestamp — see the Milestone UX task. The current `lastIncident` column is `null` until that lands.)
 
 The "Notifications" column from earlier drafts is gone — notifications are not per-monitor and there's nothing meaningful to surface here.
 
-Row click toggles `monitorSlug`. The selected row gets `activeRowKey` highlight.
+Row click toggles `monitorSlug`. The selected row gets `activeRowKey` highlight. The actions cell stops click propagation so opening the menu doesn't open the panel.
 
 ### Monitor details panel
 
-`apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx`. Mirrors `issue-detail-drawer.tsx`. The panel renders two modes depending on `monitor.system`:
+`apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx`. Mirrors `issue-detail-drawer.tsx`. **A single mode** — monitor management (mute / rename / delete) lives on the dashboard list's 3-dots menu, not the panel. There is no `useEditableText` in the repo, so rename is a modal off that menu (M5), not in-place editing here.
 
-#### System monitor mode (structurally locked, values editable)
-
-- `DetailDrawer` with the same `storeKey="monitor-detail-drawer-width"`.
-- Actions slot: next/prev (chevrons + `Alt+ArrowUp/Down`, `J`/`K` hotkeys).
-- Header:
-  - **Mute / Unmute** ghost button (behind a confirmation modal).
-  - **No delete button**, no name/description edit pencil.
-  - Title = monitor name, subtitle = description — both rendered as plain text (no edit affordance on hover).
-  - `<CopyableText value={monitor.slug} size="sm" />` below the description.
+- `DetailDrawer` with `storeKey="monitor-detail-drawer-width"`. `actions` = next/prev nav chevrons (`Alt+ArrowUp/Down`, `J`/`K`); `rightActions` = a Mute/Unmute button (behind `MonitorMuteConfirmModal`), mirroring where issue details put their lifecycle actions. No delete button.
+- Header body (mirrors `issue-detail-drawer`): bordered block with `Text.H4M` title, `Text.H5` muted description, then a row with `<CopyableText value={monitor.slug} size="sm" />` plus a **"System" tag** (LatitudeLogo + "System", styled like a `TagBadge`) for system monitors and a "Muted" badge when muted. Plain text, no edit affordance.
 - Body sections (collapsible):
+  - **Alerts** — vertical stack of cards showing `formatHumanReadableAlert` (rendered server-side onto the alert record) + kind/severity. **Read-only in M4**; editing the configurable values (the `issue.escalating` sensitivity + saved-search forms via the shared alert-form, saving through `updateMonitorAlertUseCase`) and add/remove (`createMonitorAlert` / `deleteMonitorAlert`) land in **M5**. `null`-condition cards (`issue.new`, `issue.regressed`) stay read-only regardless.
   - **Incidents** — embedded `InfiniteTable` of incidents for this monitor, **keyset-paginated** (`useMonitorIncidents` → `useInfiniteQuery`, cursor over `(started_at, id)`). Incidents are append-heavy and unbounded over time, so keyset avoids offset's scan-and-discard and the page-shift that new incidents would cause; backed by the composite `alert_incidents_monitor_alert_idx (monitor_alert_id, started_at DESC, id DESC)`.
-  - **Alerts** — vertical stack of alert cards. The set is locked (no per-card `X`, no "+ Add alert" dashed card, kind/source not editable), but each card's **configurable values are editable**: the `issue.escalating` card exposes a **sensitivity** control that saves via `updateMonitorAlertUseCase`. Cards whose alert has a `null` condition (`issue.new`, `issue.regressed`) have nothing to tune and render fully read-only. Each card still shows the human-readable summary via `formatHumanReadableAlert`.
-
-#### User monitor mode (editable)
-
-Same shape as above plus:
-
-- Header gets a **Delete** destructive button (behind a confirmation modal).
-- Title and description are **in-place editable**: on hover, dim + show an edit pencil; click to edit; blur to save (`useEditableText` hook drives this). Slug regen happens server-side on name change.
-- **Alerts** section has the per-card `X` button and a dashed "+ Add alert" footer.
 
 #### Incidents section table
 
@@ -1002,7 +991,7 @@ Per card:
 
 Expresses `AlertCountThreshold` + (for escalating) `window` in two rows:
 
-- Row 1 (both threshold and escalating): `"Alert me when it occurred"` + count/amount input + `Select` `["times", "times more than"]`. When "times more than", a second `Select` picks what to compare against. Three groups: **average** (`"the average of the last hour"`, `"… 24 hours"`, `"… 7 days"`), **previous period** (`"yesterday"`, `"the previous week"`), and **expected** (`"expected"`). "The average of the last 7 days" is the default. Picking **average**/**previous period** sets `mode: "multiplier"` and the amount input is the `factor`; picking **expected** sets `mode: "expected"` and the same amount input becomes the `sensitivity` (1–6). The expected option carries an info tooltip (below) explaining it's a dynamically-learned baseline.
+- Row 1 (both threshold and escalating): `"Alert when traces are detected"` + count/amount input + `Select` `["times", "times more than"]`. When "times more than", a second `Select` picks what to compare against. Three groups: **average** (`"the average of the last hour"`, `"… 24 hours"`, `"… 7 days"`), **previous period** (`"yesterday"`, `"the previous week"`), and **expected** (`"expected"`). "The average of the last 7 days" is the default. Picking **average**/**previous period** sets `mode: "multiplier"` and the amount input is the `factor`; picking **expected** sets `mode: "expected"` and the same amount input becomes the `sensitivity` (1–6). The expected option carries an info tooltip (below) explaining it's a dynamically-learned baseline.
 - Row 2 (`savedSearch.escalating` only): `"for at least"` + duration input + `Select` `["minutes", "hours", "days"]`. This is the `window` field. Minimum 5 minutes.
 
 The form binds bidirectionally to the discriminated union. `formatHumanReadableAlert(alert)` renders the union back to text — used in the card preview, table tooltips, and notification templates.
@@ -1030,21 +1019,25 @@ The saved-search assign-user UI is removed. `assignedUserId` and `createdByUserI
 
 `formatHumanReadableAlert(alert)` (in `packages/domain/monitors/src/helpers.ts`) returns one sentence per alert. Examples:
 
+All sentences start with "Alerts" (never "Alert me"); saved-search alerts speak of **traces** being **detected** (not matches "occurring"), and the saved search itself is humanised by the caller via `context.savedSearchName`.
+
 | Alert | Output |
 |---|---|
-| `issue.new`, source `all` | `"Alert me every time a new issue is discovered."` |
-| `issue.regressed`, source `all` | `"Alert me every time a resolved issue regresses."` |
-| `issue.escalating`, source `all` | `"Alert me when an issue's occurrence rate crosses the project escalation threshold."` |
-| `savedSearch.match`, search `"5xx"` | `"Alert me every time a trace matches '5xx'."` |
-| `savedSearch.threshold`, abs 100 | `"Alert me when '5xx' matches occurred 100 times."` |
-| `savedSearch.threshold`, mult 3× average / last 7 days | `"Alert me when '5xx' matches occurred 3 times more than the average of the last 7 days."` |
-| `savedSearch.threshold`, mult 2× of yesterday | `"Alert me when '5xx' matches occurred 2 times more than yesterday."` |
-| `savedSearch.threshold`, expected (sensitivity 2) | `"Alert me when '5xx' matches occurred 2 times more than expected."` |
-| `savedSearch.escalating`, abs 2000, window 5m | `"Alert me when '5xx' matches occurred 2000 times, sustained for at least 5 minutes."` |
-| `savedSearch.escalating`, mult 2× average / last 7 days, window 1h | `"Alert me when '5xx' matches occurred 2 times more than the average of the last 7 days, sustained for at least 1 hour."` |
-| `savedSearch.escalating`, expected (sensitivity 3), window 1h | `"Alert me when '5xx' matches occurred 3 times more than expected, sustained for at least 1 hour."` |
+| `issue.new`, source `all` | `"Alerts each time a new issue is detected."` |
+| `issue.regressed`, source `all` | `"Alerts each time a resolved issue is detected again."` |
+| `issue.escalating`, source `all` | `"Alerts when an ongoing issue is being detected more than expected."` |
+| `savedSearch.match`, search `"5xx"` | `"Alerts each time a new trace matching '5xx' is detected."` |
+| `savedSearch.threshold`, abs 100 | `"Alerts when traces matching '5xx' are detected 100 times."` |
+| `savedSearch.threshold`, mult 3× average / last 7 days | `"Alerts when traces matching '5xx' are detected 3 times more than the average of the last 7 days."` |
+| `savedSearch.threshold`, mult 2× of yesterday | `"Alerts when traces matching '5xx' are detected 2 times more than yesterday."` |
+| `savedSearch.threshold`, expected (sensitivity 2) | `"Alerts when traces matching '5xx' are detected 2 times more than expected."` |
+| `savedSearch.escalating`, abs 2000, window 5m | `"Alerts when traces matching '5xx' are detected 2000 times, sustained for at least 5 minutes."` |
+| `savedSearch.escalating`, mult 2× average / last 7 days, window 1h | `"Alerts when traces matching '5xx' are detected 2 times more than the average of the last 7 days, sustained for at least 1 hour."` |
+| `savedSearch.escalating`, expected (sensitivity 3), window 1h | `"Alerts when traces matching '5xx' are detected 3 times more than expected, sustained for at least 1 hour."` |
 
 Tests cover the matrix. The helper is shared between the API documentation entity (sentence appears in OpenAPI examples), the frontend, and notification templates (rendered into in-app/email when `condition` is set).
+
+**Kind labels** (the short title per kind — "Issue discovered", "Issue regressed", "Issue escalating", "Search match", "Search threshold", "Search escalating") have a single source of truth in `ALERT_INCIDENT_KIND_LABEL` (`@domain/shared`), consumed by the monitor panel, the incident-chart markers, and the email/Slack notification templates so the same kind never shows two different names.
 
 ## API / SDK / MCP
 
@@ -1155,7 +1148,7 @@ export const SYSTEM_MONITOR_DEFINITIONS = [
     slug: "issue-escalating",
     name: "Issue escalating",
     description:
-      "Notifies when an ongoing issue's occurrence rate crosses the escalation threshold, and again when it returns to baseline.",
+      "Notifies when an ongoing issue is being detected more than expected.",
     alerts: [
       {
         kind: "issue.escalating",
@@ -1359,17 +1352,19 @@ Backend mutations (`LAT-630/monitor-mutations`):
 
 Details-panel UI (`LAT-630/details-panel`):
 
-- [ ] Web side: `monitor-detail-drawer.tsx` mirroring `issue-detail-drawer.tsx` (replaces the M3 stub). Both modes:
-  - System mode: read-only header (no name/description pencil, no delete button); Alerts section locked structurally (no `X` / `+`, no kind/source change) but each card's configurable values are editable — the `issue.escalating` card exposes a sensitivity control (saves via `updateMonitorAlertUseCase`); `null`-condition cards render read-only.
-  - User mode: in-place editable name + description (`useEditableText` hook), delete button, and editable alert values (via `updateMonitorAlertUseCase`). Adding/removing alerts (the `+` / per-card `X`) lands in M5 alongside `createMonitorAlert` / `deleteMonitorAlert`.
-- [ ] Mute/unmute/delete monitor + update-alert server functions; confirmation modals where destructive.
-- [ ] Incidents section: embedded `InfiniteTable`; "Notified"/"Muted" column driven by the batched idempotency-key lookup.
+> Management actions (mute/rename/delete) live on a **3-dots menu on the dashboard list**, not in the panel. The panel itself is a single mode (no system/user branching) — `useEditableText` (which the spec originally assumed) doesn't exist in the repo, so rename is a modal off the list menu, landing in M5.
+
+- [x] Dashboard list **3-dots actions column** (`optionsColumn`): **Mute/Unmute** (functional, behind `MonitorMuteConfirmModal`), plus **Rename** and **Delete** items rendered **disabled** — they only apply to user monitors and are fully wired (rename modal + delete confirmation) in M5.
+- [x] `monitor-detail-drawer.tsx` (replaces the M3 stub), mirroring `issue-detail-drawer.tsx`: actions slot = next/prev nav (`Alt+↑/↓`, `J`/`K`) **+ Mute/Unmute** (confirmation); body = name → description → `CopyableText` slug → **Alerts** → **Incidents**. No delete button, no in-place editing.
+- [x] **Alerts section read-only in M4**: cards render `formatHumanReadableAlert` (computed server-side onto the alert record to keep `@domain/monitors` out of the client bundle) + kind/severity. Editing configurable values (the `issue.escalating` sensitivity + saved-search forms) lands in M5 with the shared alert-form components.
+- [x] **Incidents section**: embedded `InfiniteTable` (`useMonitorIncidents`, keyset) — Started / Status (Closed/Ongoing badge) / Source / Notified-or-Muted badge. (Deep-linking the Source to the issue/saved-search + resolving its name is a UX-milestone polish item.)
+- [x] `muteMonitor` / `unmuteMonitor` server functions + `useMonitorMuteAction` hook (invalidates the list + detail queries, toasts); shared `MonitorMuteConfirmModal` used by both the list menu and the panel.
 
 ### Milestone 5 — Create monitor modal and alert editing
 
 > Branch: `LAT-630/create-and-edit` · Estimated size: ~2,600 lines
 
-**Goal:** Users can create a non-system monitor end-to-end. The details panel's Alerts section allows adding/removing alerts (editing already landed via `updateMonitorAlertUseCase` in M4) via the same alert card form. All paths constrain to `USER_CREATABLE_ALERT_KINDS`.
+**Goal:** Users can create a non-system monitor end-to-end, edit/add/remove a monitor's alerts (the create modal and the panel's alert section share the alert-form components), and rename/delete user monitors from the dashboard 3-dots menu. The `updateMonitorAlertUseCase` backend shipped in M4 (monitor-mutations); M5 builds the editing UI on top of it. All paths constrain to `USER_CREATABLE_ALERT_KINDS`.
 
 - [ ] `createMonitorUseCase` — Zod-validated input; inserts the monitor + its alerts atomically, composing `createMonitorAlertUseCase` per alert. Rejects: empty alert list; any alert kind ∉ `USER_CREATABLE_ALERT_KINDS`; `system: true` in the input; saved-search alerts without `source.id`.
 - [ ] `createMonitorAlertUseCase` — adds a single alert to an existing monitor (also used inside `createMonitor`). Enforces the user-creatable allowlist + kind/source.type match + `source.id` for saved searches. **Rejects `system === true`** — no alert may be added to a system monitor.
@@ -1386,18 +1381,21 @@ Details-panel UI (`LAT-630/details-panel`):
   - **`expected` baseline** (its own tooltip, since it behaves differently): "**Expected** is a smart baseline computed automatically from your history — it learns the normal shape of your traffic for each time of day and day of week, so a quiet Sunday night and a busy Monday morning each get their own 'normal'. You don't pick a comparison window; just how sensitive to be. It's the same engine that powers Latitude's automatic issue-escalation alerts." Pair with a **sensitivity** sub-tooltip: "How far above the learned normal counts as a spike. Lower = more sensitive (alerts on smaller deviations, noisier); higher = quieter."
   - **`factor` on multiplier**: "The multiplier. 3 means 'fire when current activity is 3× the baseline rate'."
   - **One-line live-preview** under each alert card showing `formatHumanReadableAlert(alert)` — so the user sees the sentence form of what they're configuring as they edit.
-- [ ] Server functions: `createMonitor`, `createMonitorAlert`, `deleteMonitorAlert` (plus `updateMonitorAlert` from M4).
+- [ ] **Dashboard 3-dots menu — enable Rename + Delete** for user monitors (the M4 placeholders; stay disabled/hidden for system monitors): Rename opens a modal editing name + description (`updateMonitorUseCase`); Delete opens a confirmation (`deleteMonitorUseCase`). Mute/unmute already shipped in M4.
+- [ ] **In-panel alert editing**: the M4 read-only Alerts section becomes editable via the shared alert-form — the `issue.escalating` card's sensitivity control (system + user) and the saved-search threshold/window forms, saving through `updateMonitorAlertUseCase`; add/remove via `createMonitorAlert` / `deleteMonitorAlert`. `null`-condition cards stay read-only.
+- [ ] Server functions: `createMonitor`, `createMonitorAlert`, `deleteMonitorAlert`, `updateMonitor`, `deleteMonitor`, `updateMonitorAlert` (mute/unmute shipped in M4).
 - [ ] Backend tests: creation invariants, alert update invariants, kind/source.type mismatch rejection, kind-not-in-allowlist rejection, saved-search source.id required.
 
 ### Milestone UX — Polish the full Monitors frontend
 
-> Branch: `LAT-630/ux-polish` · Runs after M5, before M6. Frontend-only — no domain/backend changes.
+> Branch: `LAT-630/ux-polish` · Runs after M5, before M6. Mostly frontend — the one backend touch is extending the monitors list read for last-incident sorting (below).
 
 **Goal:** A dedicated pass to bring the entire Monitors frontend (everything built across M1–M5: dashboard, details panel, create modal, alert card + threshold/window forms) to a finished, shippable feel. From M6 onward the work is almost entirely backend (issue-event firing, the saved-search pipeline, API/SDK), so this is the natural moment to fully polish the UI while it's fresh and before backend wiring lands on top of it.
 
-Scope is intentionally left open — the exact polish items are decided when the milestone starts, not prescribed here.
+Scope is intentionally left open — the exact polish items are decided when the milestone starts, not prescribed here. Two items are pre-committed:
 
-Worth front-loading, since it enables the rest: a **`monitors` seeder** (`packages/platform/db-postgres/src/seeds/monitors/`, registered in `all.ts` next to the existing `alert-incidents` seeder, run by `pnpm seed`). It writes the M2/M3 schema directly — monitors + `monitor_alerts` + a spread of `alert_incidents` covering every visual state (open vs closed, muted vs live, notified vs not, each kind/severity, "all"-source vs named-source) — so the polish can exercise the whole frontend now, without waiting for M6/M7 to produce real incidents.
+- **Dashboard column sorting.** Make **Name / Status / Last incident** sortable, with **system monitors always pinned to the top** of the list and a default sort of **last incident descending** (within each group). This needs the monitors list read (`MonitorRepository.list` + `listMonitorsUseCase`) extended to surface and order by each monitor's latest-incident timestamp, and the `lastIncident` column populated from it — the one backend touch in this otherwise frontend milestone.
+- **`monitors` seeder** (worth front-loading, since it enables the rest): `packages/platform/db-postgres/src/seeds/monitors/`, registered in `all.ts` next to the existing `alert-incidents` seeder, run by `pnpm seed`. It writes the M2/M3 schema directly — monitors + `monitor_alerts` + a spread of `alert_incidents` covering every visual state (open vs closed, muted vs live, notified vs not, each kind/severity, "all"-source vs named-source) — so the polish can exercise the whole frontend now, without waiting for M6/M7 to produce real incidents.
 
 ### Milestone 6 — Wire issue-event path to monitors (flag-gated)
 
@@ -1463,7 +1461,7 @@ Smaller than originally estimated because most of the heavy lifting has already 
 
 > Branch: `LAT-630/api-endpoints` · Estimated size: ~2,000 lines (excluding auto-generated files)
 
-**Goal:** All nine monitor endpoints live. SDK regenerated and bumped.
+**Goal:** All thirteen monitor endpoints live. SDK regenerated and bumped.
 
 - [ ] `apps/api/src/routes/monitors.ts` — thirteen endpoints on the `defineApiEndpoint<OrganizationScopedEnv>` factory (incl. `createMonitorAlert` / `updateMonitorAlert` / `deleteMonitorAlert`).
 - [ ] `apps/api/src/openapi/entities/monitor.ts` — `MonitorSchema` + `toMonitorResponse(monitor)` mapper. Rich `.describe(...)` on every field so SDK and MCP tools carry useful docs.


### PR DESCRIPTION
Part of the Monitors MVP (LAT-630). Two pieces of work on the Monitors page and its backoffice tooling, building on the M4 backend (monitor + alert mutations) already merged.

## Monitor details panel

The Monitors dashboard now opens a detail drawer for the selected monitor, mirroring the issue details panel:

- **Header** — monitor name, muted-state description, and a slug row laid out as `[System tag] slug [Muted badge]`. System monitors carry a Latitude-logo "System" tag.
- **Drawer actions** — next/prev navigation chevrons (`Alt+↑/↓`, `J`/`K`) on the left; a Mute/Unmute button on the right, in the same position as the issue panel's lifecycle actions. Muting/unmuting goes through a shared confirmation modal.
- **Alerts section** (megaphone icon) — read-only cards rendering each alert's human-readable summary.
- **Incidents section** (shield-alert icon) — an infinite table of the monitor's incidents (Started / Status / Source / Notified), keyset-paginated.

The dashboard's three-dots options column exposes Mute/Unmute (functional) plus Rename/Delete (present but disabled — wired up in the next milestone).

## Consistent kind naming

Unified the alert-incident kind labels behind a single source of truth, `ALERT_INCIDENT_KIND_LABEL` in `@domain/shared`, and reworded the system-monitor copy so every surface agrees:

- `issue.new` → **Issue discovered**, `issue.regressed` → **Issue regressed**, `issue.escalating` → **Issue escalating** (plus the saved-search kinds).
- Alert descriptions now start with "Alerts …", say "detected" (not "occurred"), and refer to "traces" — applied across the detail drawer, incident markers, the incident-event email/Slack templates, the system-monitor definitions, and the not-yet-shipped backfill migration.
- API/MCP entity descriptions reworded; `openapi.json` and `mcp.json` regenerated (idempotent — no SDK regen, that stays batched to the end of the plan).

## Backoffice: reset system monitors

A staff-only org action (next to **Create demo project**) that re-provisions the three system monitors to their **current** definitions across every project in a chosen org. Unlike the idempotent provision path (skip-if-exists), this **overwrites** the monitors' titles, descriptions, and default alert-condition values — so edits to the definitions can be pushed onto an org's existing system monitors.

- `buildSystemMonitors({ organizationId, projectId })` was extracted from the provision use-case so the definitions live in one place and both paths share them.
- `MonitorRepository.resetSystemMonitors` upserts each monitor in one transaction: it keeps the existing row (and its `mutedAt`), overwrites name/description, soft-deletes the live alerts and inserts fresh ones from the definition. **Mute state and incident history are preserved**; a slug already held by a user-created monitor is left untouched.
- The repo filters by the entity's `projectId` rather than the SqlClient org, because admin handlers run RLS-off under the "system" scope.
- The web surface is a confirmation modal behind `adminResetSystemMonitors` (admin middleware → input validation → admin Postgres client), reporting `Reset N system monitors across M projects`.

## Validation

typecheck (`@app/web`, `@domain/admin`, `@domain/monitors`, `@platform/db-postgres`), biome, and knip are clean. Tests: `@domain/monitors` 38, `@domain/admin` 39, `@platform/db-postgres` 248 (incl. 5 new `resetSystemMonitors` integration tests), web schema 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
