### PR TITLE
fix(issues): honor ignored lifecycle during transitions

### DIFF
--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
@@ -350,6 +350,46 @@ describe("assignScoreToIssueUseCase", () => {
       )
     })
 
+    it("does not emit IssueRegressed or clear resolvedAt for ignored issues", async () => {
+      const resolvedAt = new Date("2026-04-01T00:00:00.000Z")
+      const ignoredAt = new Date("2026-04-02T00:00:00.000Z")
+      const existingIssue = makeIssue({ resolvedAt, ignoredAt })
+      const { repository: scoreRepository, scores } = createFakeScoreRepository()
+      const { repository: issueRepository, issues } = createFakeIssueRepository([existingIssue])
+      const score = makeScore({ createdAt: new Date("2026-04-15T10:00:00.000Z") })
+      scores.set(score.id, score)
+      const writtenEvents: unknown[] = []
+
+      await Effect.runPromise(
+        assignScoreToIssueUseCase({
+          organizationId,
+          projectId,
+          scoreId: score.id,
+          issueId: existingIssue.id,
+          normalizedEmbedding: makeEmbedding(),
+        }).pipe(
+          Effect.provideService(ScoreRepository, scoreRepository),
+          Effect.provideService(IssueRepository, issueRepository),
+          Effect.provideService(OutboxEventWriter, {
+            write: (event) =>
+              Effect.sync(() => {
+                writtenEvents.push(event)
+              }),
+          }),
+          Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+          Effect.provideService(DistributedLockRepository, passthroughLockRepository),
+        ),
+      )
+
+      expect(scores.get(score.id)?.issueId).toBe(existingIssue.id)
+      expect(issues.get(existingIssue.id)?.resolvedAt?.getTime()).toBe(resolvedAt.getTime())
+      expect(issues.get(existingIssue.id)?.ignoredAt?.getTime()).toBe(ignoredAt.getTime())
+      expect(writtenEvents.find((e) => (e as { eventName?: string }).eventName === "IssueRegressed")).toBeUndefined()
+      expect(
+        writtenEvents.find((e) => (e as { eventName?: string }).eventName === "ScoreAssignedToIssue"),
+      ).toBeDefined()
+    })
+
     it("does not emit IssueRegressed and preserves resolvedAt when score predates resolution", async () => {
       const resolvedAt = new Date("2026-04-15T00:00:00.000Z")
       const existingIssue = makeIssue({ resolvedAt })

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
@@ -99,7 +99,8 @@ const buildIssueWithAssignedScore = ({
   // "is the issue regressed" a stored fact (and gives the regression event
   // idempotency for free — a subsequent score in the same cycle won't see
   // resolvedAt != null and won't re-emit).
-  const isRegression = issue.resolvedAt !== null && score.createdAt.getTime() > issue.resolvedAt.getTime()
+  const isRegression =
+    issue.ignoredAt === null && issue.resolvedAt !== null && score.createdAt.getTime() > issue.resolvedAt.getTime()
 
   return {
     updatedIssue: {

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -98,7 +98,7 @@ const provideTestLayers = (params: {
   readonly dwellWrites?: UpdateAlertIncidentExitDwellInput[]
   readonly projectSettings?: ProjectSettings | null
 }) => {
-  const { repository: issueRepository } = createFakeIssueRepository([params.issue], undefined, {
+  const { repository: issueRepository, issues } = createFakeIssueRepository([params.issue], undefined, {
     lifecycle: new Map([[params.issue.id, { isEscalating: params.isEscalating ?? false, isRegressed: false }]]),
   })
   const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
@@ -123,6 +123,7 @@ const provideTestLayers = (params: {
 
   return {
     dwellWrites,
+    issues,
     apply: <A, E>(
       effect: Effect.Effect<
         A,
@@ -180,6 +181,51 @@ describe("checkIssueEscalationUseCase", () => {
     })
     const escalated = events[0]?.payload as { entrySignals: EntrySignalsSnapshot | null }
     expect(escalated.entrySignals).toMatchObject({ entryCount24h: 600, kShort: 3, kLong: 2 })
+  })
+
+  it("clears resolvedAt when a resolved issue enters escalation", async () => {
+    const resolvedAt = new Date("2026-05-01T10:00:00.000Z")
+    const issue = makeIssue({
+      createdAt: new Date("2026-04-01T10:00:00.000Z"),
+      resolvedAt,
+    })
+    const events: OutboxWriteEvent[] = []
+    const { apply, issues } = provideTestLayers({
+      issue,
+      isEscalating: false,
+      signals: makeSignals({ recent1h: 25, recent6h: 150, recent24h: 600 }),
+      events,
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("entered")
+    expect(issues.get(issue.id)?.resolvedAt).toBeNull()
+    expect(issues.get(issue.id)?.updatedAt.getTime()).toBeGreaterThan(resolvedAt.getTime())
+    expect(events).toHaveLength(1)
+    expect(events[0]?.eventName).toBe("IssueEscalated")
+  })
+
+  it("does not transition ignored issues into escalation", async () => {
+    const ignoredAt = new Date("2026-05-01T10:00:00.000Z")
+    const issue = makeIssue({
+      createdAt: new Date("2026-04-01T10:00:00.000Z"),
+      ignoredAt,
+    })
+    const events: OutboxWriteEvent[] = []
+    const { apply, issues } = provideTestLayers({
+      issue,
+      isEscalating: false,
+      signals: makeSignals({ recent1h: 100, recent6h: 600, recent24h: 2400 }),
+      events,
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("none")
+    expect(result.currentlyEscalating).toBe(false)
+    expect(issues.get(issue.id)?.ignoredAt?.getTime()).toBe(ignoredAt.getTime())
+    expect(events).toHaveLength(0)
   })
 
   it("does not emit IssueEscalated while the issue is still new", async () => {

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -9,7 +9,7 @@ import {
   ProjectId,
   type RepositoryError,
   SettingsReader,
-  type SqlClient,
+  SqlClient,
 } from "@domain/shared"
 import { Effect } from "effect"
 import { DEFAULT_ESCALATION_SENSITIVITY_K } from "../constants.ts"
@@ -65,6 +65,7 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
     const outboxEventWriter = yield* OutboxEventWriter
     const alertIncidentRepository = yield* AlertIncidentRepository
     const settingsReader = yield* SettingsReader
+    const sqlClient = yield* SqlClient
 
     const issueWithLifecycle = yield* issueRepository
       .findById(IssueId(input.issueId))
@@ -76,6 +77,13 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
 
     const wasEscalating = issueWithLifecycle.lifecycle.isEscalating
     const now = new Date()
+
+    // Ignored issues keep accepting score assignments for analytics / matching,
+    // but user intent is that they no longer drive automated lifecycle changes
+    // or alerting transitions.
+    if (issueWithLifecycle.ignoredAt !== null) {
+      return { transition: "none", currentlyEscalating: wasEscalating } satisfies CheckIssueEscalationResult
+    }
 
     const [signals, projectSettings, openIncident] = yield* Effect.all(
       [
@@ -115,19 +123,31 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
     })
 
     if (decision.transition === "enter") {
-      yield* outboxEventWriter.write({
-        eventName: "IssueEscalated",
-        aggregateType: "issue",
-        aggregateId: issueWithLifecycle.id,
-        organizationId: issueWithLifecycle.organizationId,
-        payload: {
-          organizationId: issueWithLifecycle.organizationId,
-          projectId: issueWithLifecycle.projectId,
-          issueId: issueWithLifecycle.id,
-          escalatedAt: now.toISOString(),
-          entrySignals: decision.entrySignalsSnapshot ?? null,
-        },
-      })
+      yield* sqlClient.transaction(
+        Effect.gen(function* () {
+          if (issueWithLifecycle.resolvedAt !== null) {
+            yield* issueRepository.save({
+              ...issueWithLifecycle,
+              resolvedAt: null,
+              updatedAt: now,
+            })
+          }
+
+          yield* outboxEventWriter.write({
+            eventName: "IssueEscalated",
+            aggregateType: "issue",
+            aggregateId: issueWithLifecycle.id,
+            organizationId: issueWithLifecycle.organizationId,
+            payload: {
+              organizationId: issueWithLifecycle.organizationId,
+              projectId: issueWithLifecycle.projectId,
+              issueId: issueWithLifecycle.id,
+              escalatedAt: now.toISOString(),
+              entrySignals: decision.entrySignalsSnapshot ?? null,
+            },
+          })
+        }),
+      )
       return { transition: "entered", currentlyEscalating: true } satisfies CheckIssueEscalationResult
     }
 


### PR DESCRIPTION
## summary

Updates issue lifecycle transitions so ignored issues keep accepting score assignments for tracking, but do not trigger automated lifecycle changes or alerting transitions. Ignored issues no longer regress when assigned newer scores and escalation checks short-circuit before emitting `IssueEscalated`.

Resolved issues can still enter escalation. When they do, the escalation check clears `resolvedAt` in the same transaction as the `IssueEscalated` outbox event so the issue returns to the active lifecycle group.

## validation

- `pnpm --filter @domain/issues test -- check-issue-escalation.test.ts assign-score-to-issue.test.ts`
- `pnpm --filter @domain/issues check`
- `pnpm --filter @domain/issues typecheck`
- commit hook: `pnpm format` + `pnpm knip`
