### PR TITLE
fix(web): show deleted documents in the draft and history change lists

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangesList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangesList/index.tsx
@@ -227,6 +227,16 @@ export function ChangesList({
     })
   }, [isLoading, changes, documents])
 
+  // Deleted documents are absent from `documents` (it lists the commit's live
+  // documents), so they never appear in `documentsList`. Surface them as their
+  // own rows from the change set.
+  const deletedChanges = useMemo(() => {
+    if (isLoading) return []
+    return changes.documents.all.filter(
+      (cd) => !documentsList.some((d) => d.documentUuid === cd.documentUuid),
+    )
+  }, [isLoading, changes.documents.all, documentsList])
+
   if (isLoading) {
     return (
       <ul className='flex flex-col gap-1'>
@@ -250,6 +260,17 @@ export function ChangesList({
           onSelect={onSelect}
           projectId={projectId}
           commitUuid={commit?.uuid ?? ''}
+        />
+      ))}
+      {deletedChanges.map((change) => (
+        <ListItem
+          key={change.documentUuid}
+          icon='file'
+          label={change.path}
+          hasIssues={change.errors > 0}
+          changeType={change.changeType}
+          selected={selected?.documentUuid === change.documentUuid}
+          onSelect={() => onSelect(change)}
         />
       ))}
     </ul>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/CommitChangesList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/CommitChangesList/index.tsx
@@ -454,6 +454,16 @@ export function CommitChangesList({
     })
   }, [isLoading, changes, documents])
 
+  // Deleted documents are absent from `documents` (it lists the commit's live
+  // documents), so they never appear in `documentsList`. Surface them as their
+  // own rows from the change set.
+  const deletedChanges = useMemo(() => {
+    if (isLoading) return []
+    return changes.documents.all.filter(
+      (cd) => !documentsList.some((d) => d.documentUuid === cd.documentUuid),
+    )
+  }, [isLoading, changes.documents.all, documentsList])
+
   if (!commit) {
     return (
       <div className='w-full h-full flex flex-col items-center justify-center '>
@@ -475,22 +485,41 @@ export function CommitChangesList({
             </li>
           ))
         ) : changes.anyChanges ? (
-          documentsList.map((d) => (
-            <li key={d.documentUuid}>
-              <DocumentChangeList
-                document={d}
-                changes={changes}
+          <>
+            {documentsList.map((d) => (
+              <li key={d.documentUuid}>
+                <DocumentChangeList
+                  document={d}
+                  changes={changes}
+                  project={project}
+                  commit={commit}
+                  selectedDocumentUuid={selectedDocumentUuid}
+                  selectDocumentUuid={selectDocumentUuid}
+                  currentDocumentUuid={currentDocumentUuid}
+                  isCurrentDraft={
+                    !commit.mergedAt && commit.id === currentCommit.id
+                  }
+                />
+              </li>
+            ))}
+            {deletedChanges.map((change) => (
+              <Change
+                key={change.documentUuid}
                 project={project}
                 commit={commit}
-                selectedDocumentUuid={selectedDocumentUuid}
-                selectDocumentUuid={selectDocumentUuid}
-                currentDocumentUuid={currentDocumentUuid}
+                change={change}
+                isSelected={selectedDocumentUuid === change.documentUuid}
+                onSelect={() => selectDocumentUuid(change.documentUuid)}
+                isDimmed={
+                  currentDocumentUuid !== undefined &&
+                  currentDocumentUuid !== change.documentUuid
+                }
                 isCurrentDraft={
                   !commit.mergedAt && commit.id === currentCommit.id
                 }
               />
-            </li>
-          ))
+            ))}
+          </>
         ) : (
           <div className='w-full h-full flex flex-col items-center justify-center p-4'>
             <Text.H5 color='foregroundMuted'>


### PR DESCRIPTION
## what this does

Deleting a file in a draft was not shown in the Merge Draft modal, nor in the Changes History. If the deletion was the only change, the draft looked empty (though it was still publishable).

The deletion was detected correctly the whole time — `getCommitChanges` reports it in `changes.documents.all` and `anyChanges` is true. The problem was purely in how the change lists render.

## why it happened

Both lists build their rows by iterating the commit's live documents and keeping those that have changes:

```ts
documents.filter((d) => changes.documents.all.some((cd) => cd.documentUuid === d.documentUuid) || …)
```

`documents` comes from `getDocumentsAtCommit`, which excludes soft-deleted documents. A deleted document is therefore never in the iterated list, so it gets filtered out and never rendered.

This regressed in #1952 ("Publish Evaluation Changes"), which changed the lists from mapping the change set directly (`changes.documents.clean.map(...)`) to iterating documents — done so each row could nest its evaluation and trigger changes underneath it (which needs the full `DocumentVersion`). Deletions were silently dropped as a side effect.

## the fix

Additive, so the per-document evaluation/trigger nesting is preserved. Each list now also renders the change-set entries that have no live document (the deletions):

- Compute `deletedChanges` = `changes.documents.all` entries whose `documentUuid` is absent from the iterated documents list.
- Merge Draft modal (`ChangesList`): render them as standalone `ListItem` rows, selectable to show the deletion diff.
- Changes History (`CommitChangesList`): render them as standalone `Change` rows, so revert/reset keep working for deletions.

Non-deleted rows still iterate `documents`, keeping the nested evaluation/trigger lists intact.

## testing

- `pnpm tc` clean for `apps/web`; eslint clean on the changed files.
- Deletion detection is already covered at the data layer by `getChanges.test.ts` "shows deleted documents"; this change is presentational (no component-test harness exists for these views).
- Manual: in a draft, delete a file — it now appears in the Merge Draft modal and in the version's history, with a working diff and revert/reset.
