### PR TITLE
fix(flaggers): prevent malformed message index output

### DIFF
--- a/packages/domain/flaggers/src/use-cases/regression/false-positive-regression.test.ts
+++ b/packages/domain/flaggers/src/use-cases/regression/false-positive-regression.test.ts
@@ -1,0 +1,177 @@
+import {
+  CacheStore,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  TraceId,
+} from "@domain/shared"
+import type { TraceDetail } from "@domain/spans"
+import { LatitudeApiClient } from "@latitude-data/sdk"
+import { createAiLayer } from "@platform/ai"
+import { AIGenerateLive } from "@platform/ai-vercel"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { classifyTraceForFlaggerUseCase } from "../run-flagger.ts"
+
+const INPUT = {
+  organizationId: "a".repeat(24),
+  projectId: "b".repeat(24),
+  traceId: "c".repeat(32),
+} as const
+
+const REGRESSION_DATASET_PROJECT_SLUG = "latitude"
+const FALSE_POSITIVE_REGRESSION_DATASET_SLUG = "flagger-classification-regression-dataset"
+const REGRESSION_DATASET_PAGE_SIZE = 200
+const EXPECTED_FALSE_POSITIVE_REGRESSION_ROWS = 55
+
+const falsePositiveRegressionRowSchema = z.object({
+  metadata: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value
+      return JSON.parse(value) as unknown
+    },
+    z.object({
+      traceMetadata: z.object({
+        flaggerSlug: z.string().min(1),
+      }),
+      allMessages: z.array(z.unknown()),
+      systemInstructions: z.array(z.unknown()),
+    }),
+  ),
+})
+
+type FalsePositiveRegressionRow = z.infer<typeof falsePositiveRegressionRowSchema>["metadata"]
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (value) return value
+  throw new Error(`${name} is required to run flagger regression tests`)
+}
+
+async function fetchFalsePositiveRegressionRows(): Promise<FalsePositiveRegressionRow[]> {
+  const client = new LatitudeApiClient({
+    token: readRequiredEnv("LAT_LATITUDE_TELEMETRY_API_KEY"),
+    baseUrl: process.env.LAT_LATITUDE_API_URL?.trim() || "https://api.latitude.so",
+    maxRetries: 0,
+  })
+
+  const rows: FalsePositiveRegressionRow[] = []
+  let cursor: string | undefined
+
+  do {
+    const page = await client.datasets.listRows(
+      REGRESSION_DATASET_PROJECT_SLUG,
+      FALSE_POSITIVE_REGRESSION_DATASET_SLUG,
+      {
+        limit: REGRESSION_DATASET_PAGE_SIZE,
+        ...(cursor ? { cursor } : {}),
+      },
+    )
+
+    rows.push(...page.items.map((row) => falsePositiveRegressionRowSchema.parse(row).metadata))
+    cursor = page.nextCursor ?? undefined
+  } while (cursor)
+
+  return rows
+}
+
+function createMemoryCacheLayer() {
+  const values = new Map<string, string>()
+
+  return Layer.succeed(CacheStore, {
+    get: (key: string) => Effect.succeed(values.get(key) ?? null),
+    set: (key: string, value: string) =>
+      Effect.sync(() => {
+        values.set(key, value)
+      }),
+    delete: (key: string) =>
+      Effect.sync(() => {
+        values.delete(key)
+      }),
+  })
+}
+
+function makeTraceDetail(input: {
+  readonly traceId: string
+  readonly allMessages: TraceDetail["allMessages"]
+  readonly systemInstructions: TraceDetail["systemInstructions"]
+}): TraceDetail {
+  return {
+    organizationId: OrganizationId(INPUT.organizationId),
+    projectId: ProjectId(INPUT.projectId),
+    traceId: TraceId(input.traceId),
+    spanCount: 1,
+    errorCount: 0,
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:01.000Z"),
+    durationNs: 1,
+    timeToFirstTokenNs: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 0,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    sessionId: SessionId("session"),
+    userId: ExternalUserId("user"),
+    simulationId: SimulationId(""),
+    tags: [],
+    metadata: {},
+    models: [],
+    providers: [],
+    serviceNames: [],
+    rootSpanId: SpanId("r".repeat(16)),
+    rootSpanName: "root",
+    systemInstructions: input.systemInstructions,
+    inputMessages: [],
+    outputMessages: input.allMessages,
+    allMessages: input.allMessages,
+  }
+}
+
+const regressionIt = process.env.RUN_FLAGGER_REGRESSION === "true" ? it : it.skip
+
+describe("flagger false-positive regression dataset", () => {
+  regressionIt(
+    "classifies the Latitude false-positive regression dataset as no-match with live LLM flaggers",
+    async () => {
+      const rows = await fetchFalsePositiveRegressionRows()
+      expect(rows).toHaveLength(EXPECTED_FALSE_POSITIVE_REGRESSION_ROWS)
+
+      const aiLayer = createAiLayer(AIGenerateLive)
+
+      const classifications = rows.map((row, index) => {
+        const traceId = `${INPUT.traceId.slice(0, 30)}${String(index).padStart(2, "0")}`
+
+        return classifyTraceForFlaggerUseCase({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          traceId,
+          flaggerSlug: row.traceMetadata.flaggerSlug,
+          trace: makeTraceDetail({
+            traceId,
+            allMessages: row.allMessages as TraceDetail["allMessages"],
+            systemInstructions: row.systemInstructions as TraceDetail["systemInstructions"],
+          }),
+        }).pipe(
+          Effect.provide(Layer.mergeAll(aiLayer, createMemoryCacheLayer())),
+          Effect.map((result) => ({ index, flaggerSlug: row.traceMetadata.flaggerSlug, result })),
+        )
+      })
+
+      const results = await Effect.runPromise(Effect.all(classifications, { concurrency: 10 }))
+
+      for (const { index, flaggerSlug, result } of results) {
+        expect(result, `row ${index} (${flaggerSlug}) should be no-match`).toEqual({ matched: false })
+      }
+    },
+    600_000,
+  )
+})

--- a/packages/domain/flaggers/src/use-cases/regression/malformed-json-output-regression.test.ts
+++ b/packages/domain/flaggers/src/use-cases/regression/malformed-json-output-regression.test.ts
@@ -1,0 +1,192 @@
+import {
+  CacheStore,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  TraceId,
+} from "@domain/shared"
+import type { TraceDetail } from "@domain/spans"
+import { LatitudeApiClient } from "@latitude-data/sdk"
+import { createAiLayer } from "@platform/ai"
+import { AIGenerateLive } from "@platform/ai-vercel"
+import { Cause, Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { classifyTraceForFlaggerUseCase } from "../run-flagger.ts"
+
+const INPUT = {
+  organizationId: "a".repeat(24),
+  projectId: "b".repeat(24),
+  traceId: "c".repeat(32),
+} as const
+
+const REGRESSION_DATASET_PROJECT_SLUG = "latitude"
+const MALFORMED_JSON_OUTPUT_REGRESSION_DATASET_SLUG = "malformed-json-output-regression-test"
+const REGRESSION_DATASET_PAGE_SIZE = 200
+const malformedJsonOutputRegressionRowSchema = z.object({
+  metadata: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") return value
+      return JSON.parse(value) as unknown
+    },
+    z.object({
+      traceMetadata: z.object({
+        flaggerSlug: z.string().min(1),
+      }),
+      allMessages: z.array(z.unknown()),
+      systemInstructions: z.array(z.unknown()),
+      tags: z.array(z.string()).optional(),
+    }),
+  ),
+})
+
+type MalformedJsonOutputRegressionRow = z.infer<typeof malformedJsonOutputRegressionRowSchema>["metadata"]
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name]?.trim()
+  if (value) return value
+  throw new Error(`${name} is required to run flagger regression tests`)
+}
+
+async function fetchMalformedJsonOutputRegressionRows(): Promise<MalformedJsonOutputRegressionRow[]> {
+  const client = new LatitudeApiClient({
+    token: readRequiredEnv("LAT_LATITUDE_TELEMETRY_API_KEY"),
+    baseUrl: process.env.LAT_LATITUDE_API_URL?.trim() || "https://api.latitude.so",
+    maxRetries: 0,
+  })
+
+  const rows: MalformedJsonOutputRegressionRow[] = []
+  let cursor: string | undefined
+
+  do {
+    const page = await client.datasets.listRows(
+      REGRESSION_DATASET_PROJECT_SLUG,
+      MALFORMED_JSON_OUTPUT_REGRESSION_DATASET_SLUG,
+      {
+        limit: REGRESSION_DATASET_PAGE_SIZE,
+        ...(cursor ? { cursor } : {}),
+      },
+    )
+
+    rows.push(...page.items.map((row) => malformedJsonOutputRegressionRowSchema.parse(row).metadata))
+    cursor = page.nextCursor ?? undefined
+  } while (cursor)
+
+  return rows
+}
+
+function createMemoryCacheLayer() {
+  const values = new Map<string, string>()
+
+  return Layer.succeed(CacheStore, {
+    get: (key: string) => Effect.succeed(values.get(key) ?? null),
+    set: (key: string, value: string) =>
+      Effect.sync(() => {
+        values.set(key, value)
+      }),
+    delete: (key: string) =>
+      Effect.sync(() => {
+        values.delete(key)
+      }),
+  })
+}
+
+function makeTraceDetail(input: {
+  readonly traceId: string
+  readonly allMessages: TraceDetail["allMessages"]
+  readonly systemInstructions: TraceDetail["systemInstructions"]
+  readonly tags: readonly string[]
+}): TraceDetail {
+  return {
+    organizationId: OrganizationId(INPUT.organizationId),
+    projectId: ProjectId(INPUT.projectId),
+    traceId: TraceId(input.traceId),
+    spanCount: 1,
+    errorCount: 0,
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:01.000Z"),
+    durationNs: 1,
+    timeToFirstTokenNs: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 0,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    sessionId: SessionId("session"),
+    userId: ExternalUserId("user"),
+    simulationId: SimulationId(""),
+    tags: input.tags,
+    metadata: {},
+    models: [],
+    providers: [],
+    serviceNames: [],
+    rootSpanId: SpanId("r".repeat(16)),
+    rootSpanName: "root",
+    systemInstructions: input.systemInstructions,
+    inputMessages: [],
+    outputMessages: input.allMessages,
+    allMessages: input.allMessages,
+  }
+}
+
+const regressionIt = process.env.RUN_FLAGGER_REGRESSION === "true" ? it : it.skip
+
+describe("flagger malformed JSON output regression dataset", () => {
+  regressionIt(
+    "classifies the Latitude malformed-json-output-regression-test dataset without schema-generation failures",
+    async () => {
+      const rows = await fetchMalformedJsonOutputRegressionRows()
+      expect(rows.length, "malformed JSON output regression dataset should contain at least one row").toBeGreaterThan(0)
+
+      const aiLayer = createAiLayer(AIGenerateLive)
+
+      const classifications = rows.map((row, index) => {
+        const traceId = `${INPUT.traceId.slice(0, 30)}${String(index).padStart(2, "0")}`
+
+        return Effect.exit(
+          classifyTraceForFlaggerUseCase({
+            organizationId: INPUT.organizationId,
+            projectId: INPUT.projectId,
+            traceId,
+            flaggerSlug: row.traceMetadata.flaggerSlug,
+            trace: makeTraceDetail({
+              traceId,
+              allMessages: row.allMessages as TraceDetail["allMessages"],
+              systemInstructions: row.systemInstructions as TraceDetail["systemInstructions"],
+              tags: row.tags ?? [],
+            }),
+          }).pipe(Effect.provide(Layer.mergeAll(aiLayer, createMemoryCacheLayer()))),
+        ).pipe(Effect.map((exit) => ({ index, flaggerSlug: row.traceMetadata.flaggerSlug, exit })))
+      })
+
+      const results = await Effect.runPromise(Effect.all(classifications, { concurrency: 5 }))
+
+      for (const { index, flaggerSlug, exit } of results) {
+        if (exit._tag === "Failure") {
+          expect(
+            Cause.pretty(exit.cause),
+            `row ${index} (${flaggerSlug}) must not fail because the model returned malformed structured output`,
+          ).not.toContain("response did not match schema")
+        }
+
+        if (exit._tag === "Failure") {
+          throw new Error(`row ${index} (${flaggerSlug}) should classify successfully:\n${Cause.pretty(exit.cause)}`)
+        }
+
+        if (exit._tag === "Success") {
+          expect(exit.value, `row ${index} (${flaggerSlug}) should remain a no-match regression`).toEqual({
+            matched: false,
+          })
+        }
+      }
+    },
+    600_000,
+  )
+})

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -18,8 +18,6 @@ import {
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
 import { type TraceDetail, TraceRepository } from "@domain/spans"
 import { createFakeTraceRepository } from "@domain/spans/testing"
-import { createAiLayer } from "@platform/ai"
-import { AIGenerateLive } from "@platform/ai-vercel"
 import { Cause, Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
@@ -65,7 +63,7 @@ const flaggerOutputSchema = z
   .object({
     matched: z.boolean().optional().default(false),
     feedback: z.string().min(1).nullable().optional(),
-    messageIndex: z.number().int().nonnegative().optional(),
+    messageIndex: z.number().int().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.matched && !value.feedback?.trim()) {
@@ -131,82 +129,6 @@ function makeTraceDetail(
   }
 }
 
-const REGRESSION_DATASET_PROJECT_SLUG = "latitude"
-const REGRESSION_DATASET_SLUG = "flagger-classification-regression-dataset"
-const REGRESSION_DATASET_PAGE_SIZE = 200
-const EXPECTED_REGRESSION_DATASET_ROWS = 55
-
-function readRequiredEnv(name: string): string {
-  const value = process.env[name]?.trim()
-  if (value) return value
-  throw new Error(`${name} is required to run flagger regression tests`)
-}
-
-function toRecord(value: unknown): Record<string, unknown> | null {
-  if (typeof value === "string") {
-    const parsed = JSON.parse(value) as unknown
-    return toRecord(parsed)
-  }
-
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as Record<string, unknown>
-  }
-
-  return null
-}
-
-interface DatasetRowsPage {
-  readonly items: readonly { readonly metadata: unknown }[]
-  readonly nextCursor?: string | null
-}
-
-interface LatitudeDatasetsClient {
-  listRows(
-    projectSlug: string,
-    datasetSlug: string,
-    request: { readonly limit: number; readonly cursor?: string },
-  ): Promise<DatasetRowsPage>
-}
-
-interface LatitudeApiClientConstructor {
-  new (options: {
-    readonly token: string
-    readonly baseUrl: string
-    readonly maxRetries: number
-  }): {
-    readonly datasets: LatitudeDatasetsClient
-  }
-}
-
-async function fetchFlaggerRegressionRows(): Promise<Array<{ readonly metadata: Record<string, unknown> }>> {
-  const sdk = (await import("@latitude-data/sdk")) as { readonly LatitudeApiClient: LatitudeApiClientConstructor }
-  const client = new sdk.LatitudeApiClient({
-    token: readRequiredEnv("LAT_LATITUDE_TELEMETRY_API_KEY"),
-    baseUrl: process.env.LAT_LATITUDE_API_URL?.trim() || "https://api.latitude.so",
-    maxRetries: 0,
-  })
-
-  const rows: Array<{ readonly metadata: Record<string, unknown> }> = []
-  let cursor: string | undefined
-
-  do {
-    const page = await client.datasets.listRows(REGRESSION_DATASET_PROJECT_SLUG, REGRESSION_DATASET_SLUG, {
-      limit: REGRESSION_DATASET_PAGE_SIZE,
-      ...(cursor ? { cursor } : {}),
-    })
-
-    rows.push(
-      ...page.items.flatMap((row) => {
-        const metadata = toRecord(row.metadata)
-        return metadata ? [{ metadata }] : []
-      }),
-    )
-    cursor = page.nextCursor ?? undefined
-  } while (cursor)
-
-  return rows
-}
-
 function createMemoryCacheLayer(initialEntries: ReadonlyMap<string, string> = new Map()) {
   const values = new Map(initialEntries)
   const writes: Array<{ readonly key: string; readonly value: string; readonly ttlSeconds?: number | undefined }> = []
@@ -227,8 +149,6 @@ function createMemoryCacheLayer(initialEntries: ReadonlyMap<string, string> = ne
     }),
   }
 }
-
-const regressionIt = process.env.RUN_FLAGGER_REGRESSION === "true" ? it : it.skip
 
 describe("runFlaggerUseCase", () => {
   it("uses the LLM flagger for jailbreaking with suspicious snippets prompt", async () => {
@@ -547,57 +467,6 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].prompt).toContain("This cached agent designs dashboards.")
   })
-
-  regressionIt(
-    "classifies the Latitude dataset false-positive regressions as no-match with the live LLM flaggers",
-    async () => {
-      const rows = await fetchFlaggerRegressionRows()
-      expect(rows).toHaveLength(EXPECTED_REGRESSION_DATASET_ROWS)
-
-      const aiLayer = createAiLayer(AIGenerateLive)
-
-      const cases = rows.map((row, index) => {
-        const traceMetadata = row.metadata.traceMetadata
-        expect(traceMetadata).toBeTypeOf("object")
-        expect(traceMetadata).not.toBeNull()
-        const flaggerSlug = (traceMetadata as { readonly flaggerSlug?: unknown }).flaggerSlug
-        expect(flaggerSlug).toBeTypeOf("string")
-
-        const allMessages = row.metadata.allMessages
-        const systemInstructions = row.metadata.systemInstructions
-        expect(Array.isArray(allMessages)).toBe(true)
-        expect(Array.isArray(systemInstructions)).toBe(true)
-
-        return { index, flaggerSlug: flaggerSlug as string, allMessages, systemInstructions }
-      })
-
-      // Each row makes 1-3 live LLM calls; run them with bounded concurrency so
-      // the suite completes well within the timeout instead of serially stalling.
-      const classifications = cases.map((testCase) =>
-        classifyTraceForFlaggerUseCase({
-          organizationId: INPUT.organizationId,
-          projectId: INPUT.projectId,
-          traceId: `${INPUT.traceId.slice(0, 30)}${String(testCase.index).padStart(2, "0")}`,
-          flaggerSlug: testCase.flaggerSlug,
-          trace: makeTraceDetail(
-            testCase.allMessages as TraceDetail["allMessages"],
-            [],
-            testCase.systemInstructions as TraceDetail["systemInstructions"],
-          ),
-        }).pipe(
-          Effect.provide(Layer.mergeAll(aiLayer, createMemoryCacheLayer().layer)),
-          Effect.map((result) => ({ index: testCase.index, flaggerSlug: testCase.flaggerSlug, result })),
-        ),
-      )
-
-      const results = await Effect.runPromise(Effect.all(classifications, { concurrency: 10 }))
-
-      for (const { index, flaggerSlug, result } of results) {
-        expect(result, `row ${index} (${flaggerSlug}) should be no-match`).toEqual({ matched: false })
-      }
-    },
-    600_000,
-  )
 
   it("stamps the LLM call with the no-reflag tag when the trace is itself flagger-generated", async () => {
     const { repository } = createFakeTraceRepository({
@@ -1063,6 +932,72 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate[1].prompt).toContain("No jailbreaking behavior detected")
   })
 
+  it("recovers to matched=false for the runaway decimal messageIndex output from trace-0e838fd", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail(
+            [
+              {
+                role: "user",
+                parts: [
+                  { type: "text", content: "Classify only text inside evaluated_trace_assistant_response tags." },
+                ],
+              },
+              {
+                role: "assistant",
+                parts: [{ type: "text", content: '{"matched": false, "messageIndex": 0}' }],
+              },
+            ],
+            [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+            [
+              {
+                type: "text",
+                content:
+                  "You are a triage flagger for LLM telemetry traces. Decide whether the trace matches the Laziness issue category.",
+              },
+            ],
+          ),
+        ),
+    })
+
+    const runawayMessageIndexOutput = `{"matched": true, "messageIndex": 1.${"0".repeat(12_000)}`
+    const sdkError = new Error(
+      `No object generated: response did not match schema. Output: ${runawayMessageIndexOutput}`,
+    )
+    sdkError.name = "AI_NoObjectGeneratedError"
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message: `AI generation failed (${FLAGGER_MODEL.provider}/${FLAGGER_MODEL.model}): No object generated: response did not match schema.`,
+            cause: sdkError,
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate[0].system).toContain("messageIndex")
+    expect(calls.generate[0].system).toContain("non-negative integer no larger than 10000")
+  })
+
   it("recovers to matched=false when the SDK cause has no AI_NoObjectGeneratedError name but the message indicates a schema mismatch", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>
@@ -1149,6 +1084,44 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     // Laziness prompt includes work signals
     expect(calls.generate[0].prompt).toContain("OVERALL WORK SIGNALS")
     expect(calls.generate[0].prompt).toContain("CANDIDATE STAGES")
+  })
+
+  it("instructs flaggers to keep messageIndex bounded and integer-shaped", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I will not do it." }],
+            },
+          ]),
+        ),
+    })
+
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
+
+    await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(calls.generate[0].system).toContain("messageIndex")
+    expect(calls.generate[0].system).toContain("non-negative integer no larger than 10000")
   })
 
   it("uses flagger-specific prompt for NSFW with suspicious snippets", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -66,9 +66,16 @@ export interface ClassifyTraceForFlaggerInput {
   readonly strategyOverride?: FlaggerStrategy
 }
 
+const FLAGGER_MESSAGE_INDEX_MAX = 10_000
+
+const isValidMessageIndex = (value: number | undefined): value is number =>
+  value !== undefined && Number.isInteger(value) && value >= 0 && value <= FLAGGER_MESSAGE_INDEX_MAX
+
 const baseFlaggerOutputSchema = z.object({
   matched: z.boolean().optional().default(false),
   feedback: z.string().min(1).nullable().optional(),
+  // Keep provider-facing schema broad: Bedrock rejects integer schemas with
+  // minimum/maximum constraints, so exact bounds are enforced after parsing below.
   messageIndex: z.number().optional(),
 })
 
@@ -98,9 +105,7 @@ const flaggerOutputSchema = baseFlaggerOutputSchema
     return {
       matched: value.matched,
       ...(value.matched && value.feedback ? { feedback: value.feedback.trim() } : {}),
-      ...(value.matched && Number.isInteger(messageIndex) && messageIndex !== undefined && messageIndex >= 0
-        ? { messageIndex }
-        : {}),
+      ...(value.matched && isValidMessageIndex(messageIndex) ? { messageIndex } : {}),
     }
   })
 
@@ -109,7 +114,7 @@ Structured output contract:
 - Set matched=false when the trace does not belong to this flagger; in that case feedback must be null or omitted.
 - Set matched=true only when the trace belongs to this flagger; in that case feedback is required.
 - For matched=true, feedback must be the final human-readable annotation: one or two short sentences describing the issue and concrete evidence.
-- Include messageIndex only when one transcript line is clearly the best evidence.
+- Include messageIndex only when one transcript line is clearly the best evidence; it must be a non-negative integer no larger than ${FLAGGER_MESSAGE_INDEX_MAX}.
 `.trim()
 
 // Whether a strategy classifies only the evaluated agent's own assistant


### PR DESCRIPTION
## What changed

Tightens the flagger structured-output contract around `messageIndex` so models are told to return a bounded non-negative integer while keeping the provider-facing schema broad enough for Bedrock. Parsed outputs now only retain `messageIndex` when it is an integer between 0 and 10,000; malformed/schema-mismatch outputs continue to recover to `{ matched: false }`.

Moves live Latitude regression coverage out of the default `run-flagger.test.ts` file and into `src/use-cases/regression/`, with separate datasets for false positives and malformed JSON output. The malformed-output regression uses the new `malformed-json-output-regression-test` dataset.

## Validation

- `pnpm --filter @domain/flaggers typecheck`
- `pnpm --filter @domain/flaggers test -- run-flagger.test.ts regression/false-positive-regression.test.ts regression/malformed-json-output-regression.test.ts`
- `cd packages/domain/flaggers && RUN_FLAGGER_REGRESSION=true pnpm exec vitest run src/use-cases/regression/malformed-json-output-regression.test.ts`
