### PR TITLE
fix(datasets): move expected output column after output

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
@@ -129,11 +129,6 @@ const rowColumns: InfiniteTableColumn<DatasetRowRecord>[] = [
     render: (r) => relativeTime(r.createdAt),
   },
   {
-    key: "expectedOutput",
-    header: "Expected output",
-    render: (r) => <ExpectedOutputCell value={r.expectedOutput} />,
-  },
-  {
     key: "input",
     header: "Input",
     render: (r) => <Text.Mono>{formatCellValue(r.input)}</Text.Mono>,
@@ -142,6 +137,11 @@ const rowColumns: InfiniteTableColumn<DatasetRowRecord>[] = [
     key: "output",
     header: "Output",
     render: (r) => <Text.Mono>{formatCellValue(r.output)}</Text.Mono>,
+  },
+  {
+    key: "expectedOutput",
+    header: "Expected output",
+    render: (r) => <ExpectedOutputCell value={r.expectedOutput} />,
   },
 ]
 


### PR DESCRIPTION
Reorders the Datasets table columns so **Expected output** comes after **Output** instead of before **Input**.

New order: `#` → Created → Input → Output → Expected output.

Expected output is the value a row is graded against, so it reads more naturally next to the actual Output than wedged between Created and Input. Pure column reorder in `$datasetId.tsx` — no data or behavior changes.
