### PR TITLE
refactor(traces): scope outlier baselines project-wide

### DIFF
--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -6,7 +6,7 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-qu
 import { useMemo } from "react"
 import {
   countSessionsByProject,
-  getSessionCohortSummaryByTags,
+  getSessionCohortSummary,
   getSessionDetail,
   getSessionDistinctValues,
   getSessionDistribution,
@@ -230,22 +230,12 @@ export function useSessionIssues({
   })
 }
 
-export function useSessionCohortSummaryByTags({
-  projectId,
-  tags,
-}: {
-  readonly projectId: string
-  readonly tags: ReadonlyArray<string>
-}) {
-  const sortedTags = useMemo(() => [...new Set(tags)].sort(), [tags])
+export function useSessionCohortSummary({ projectId }: { readonly projectId: string }) {
   return useQuery<CohortSummary>({
-    queryKey: ["sessions-cohort-summary-by-tags", projectId, sortedTags],
+    queryKey: ["sessions-cohort-summary", projectId],
     queryFn: () =>
-      getSessionCohortSummaryByTags({
-        data: {
-          projectId,
-          tags: sortedTags,
-        },
+      getSessionCohortSummary({
+        data: { projectId },
       }),
     staleTime: 30_000,
     enabled: projectId.length > 0,

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -20,7 +20,7 @@ import type {
   TraceTimeHistogramBucket,
 } from "@domain/spans"
 import {
-  getSessionCohortSummaryByTagsUseCase,
+  getSessionCohortSummaryUseCase,
   mergeTraceHistogramTimeFilters,
   SessionRepository,
   SpanRepository,
@@ -255,17 +255,16 @@ export const getSessionMetricsByProject = createServerFn({ method: "GET" })
     )
   })
 
-export const getSessionCohortSummaryByTags = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), tags: z.array(z.string()).readonly() }))
+export const getSessionCohortSummary = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string() }))
   .handler(async ({ data }): Promise<CohortSummary> => {
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
 
     return Effect.runPromise(
-      getSessionCohortSummaryByTagsUseCase({
+      getSessionCohortSummaryUseCase({
         organizationId: orgId,
         projectId: ProjectId(data.projectId),
-        tags: data.tags,
       }).pipe(
         withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),

--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -12,7 +12,7 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-qu
 import { useMemo } from "react"
 import {
   countTracesByProject,
-  getTraceCohortSummaryByTags,
+  getTraceCohortSummary,
   getTraceDetail,
   getTraceDistinctValues,
   getTraceDistribution,
@@ -127,25 +127,12 @@ export function useTraceMetrics({
   })
 }
 
-export function useTraceCohortSummaryByTags({
-  projectId,
-  tags,
-}: {
-  readonly projectId: string
-  readonly tags: ReadonlyArray<string>
-}) {
-  // Canonicalize the tag combination for a stable cache key: dedupe + sort so that
-  // ["a","b"] and ["b","a"] share a single query. Tag comparison is case-sensitive
-  // on the backend (ClickHouse String equality), so do NOT lowercase.
-  const sortedTags = useMemo(() => [...new Set(tags)].sort(), [tags])
+export function useTraceCohortSummary({ projectId }: { readonly projectId: string }) {
   return useQuery<CohortSummary>({
-    queryKey: ["traces-cohort-summary-by-tags", projectId, sortedTags],
+    queryKey: ["traces-cohort-summary", projectId],
     queryFn: () =>
-      getTraceCohortSummaryByTags({
-        data: {
-          projectId,
-          tags: sortedTags,
-        },
+      getTraceCohortSummary({
+        data: { projectId },
       }),
     staleTime: 30_000,
     enabled: projectId.length > 0,

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -18,7 +18,7 @@ import type {
   TraceTimeHistogramBucket,
 } from "@domain/spans"
 import {
-  getTraceCohortSummaryByTagsUseCase,
+  getTraceCohortSummaryUseCase,
   getTraceSearchHighlightsUseCase,
   mergeTraceHistogramTimeFilters,
   TraceRepository,
@@ -295,17 +295,16 @@ export const getTraceMetricsByProject = createServerFn({ method: "GET" })
     )
   })
 
-export const getTraceCohortSummaryByTags = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), tags: z.array(z.string()).readonly() }))
+export const getTraceCohortSummary = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string() }))
   .handler(async ({ data }): Promise<CohortSummary> => {
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
 
     return Effect.runPromise(
-      getTraceCohortSummaryByTagsUseCase({
+      getTraceCohortSummaryUseCase({
         organizationId: orgId,
         projectId: ProjectId(data.projectId),
-        tags: data.tags,
       }).pipe(
         withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -188,7 +188,7 @@ export function ProjectTracesTable({
         width: 140,
         render: (trace) => (
           <span className="flex items-center justify-end gap-1">
-            <TraceOutlierBadge projectId={projectId} tags={trace.tags} value={trace.durationNs} metric="durationNs" />
+            <TraceOutlierBadge projectId={projectId} value={trace.durationNs} metric="durationNs" />
             {trace.durationNs > 0 ? formatDuration(trace.durationNs) : "-"}
           </span>
         ),
@@ -212,12 +212,7 @@ export function ProjectTracesTable({
         width: 176,
         render: (trace) => (
           <span className="flex items-center justify-end gap-1">
-            <TraceOutlierBadge
-              projectId={projectId}
-              tags={trace.tags}
-              value={trace.timeToFirstTokenNs}
-              metric="timeToFirstTokenNs"
-            />
+            <TraceOutlierBadge projectId={projectId} value={trace.timeToFirstTokenNs} metric="timeToFirstTokenNs" />
             {trace.timeToFirstTokenNs > 0 ? formatDuration(trace.timeToFirstTokenNs) : "-"}
           </span>
         ),
@@ -245,12 +240,7 @@ export function ProjectTracesTable({
         width: 146,
         render: (trace) => (
           <span className="flex items-center justify-end gap-1">
-            <TraceOutlierBadge
-              projectId={projectId}
-              tags={trace.tags}
-              value={trace.costTotalMicrocents}
-              metric="costTotalMicrocents"
-            />
+            <TraceOutlierBadge projectId={projectId} value={trace.costTotalMicrocents} metric="costTotalMicrocents" />
             {trace.costTotalMicrocents > 0 ? formatPrice(trace.costTotalMicrocents / 100_000_000) : "-"}
           </span>
         ),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -60,7 +60,6 @@ export function MetadataTab({
   const renderBadge = (metric: SessionOutlierMetric, value: number) => (
     <SessionOutlierBadge
       projectId={session.projectId}
-      tags={session.tags}
       value={value}
       metric={metric}
       onThresholdClick={

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-outlier-badge.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-outlier-badge.tsx
@@ -1,7 +1,7 @@
 import { type CohortMetric, type CohortSummary, getMetricPercentileThreshold } from "@domain/spans"
-import { Status, type StatusProps, TagBadgeList, Text, Tooltip } from "@repo/ui"
+import { Status, type StatusProps, Text, Tooltip } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice } from "@repo/utils"
-import { useSessionCohortSummaryByTags } from "../../../../../domains/sessions/sessions.collection.ts"
+import { useSessionCohortSummary } from "../../../../../domains/sessions/sessions.collection.ts"
 
 type Baselines = CohortSummary["baselines"]
 export type SessionOutlierMetric = keyof Baselines
@@ -147,17 +147,15 @@ function QuantileStrip({ baseline, value }: { baseline: Baselines[SessionOutlier
 }
 
 /**
- * A tooltip that explains that the outlier is only scoped to the subset of sessions that match the given tags.
- * And then displays the baseline values for the given metric.
+ * A tooltip that explains that the outlier is scoped to all sessions in the
+ * current project, then displays the baseline values for the given metric.
  */
 function OutlierTooltip({
-  tags,
   cohorts,
   metric,
   level,
   value,
 }: {
-  tags: ReadonlyArray<string>
   cohorts: CohortSummary
   metric: CohortMetric
   level: SessionOutlierLevel
@@ -168,10 +166,9 @@ function OutlierTooltip({
     <div className="flex flex-col gap-4 min-w-64">
       <div className="flex flex-col gap-2">
         <Text.H6>
-          This session's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the sessions
-          with {tags.length === 0 ? "no tags." : tags.length === 1 ? "this tag:" : "these tags:"}
+          This session's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the sessions in
+          this project.
         </Text.H6>
-        {tags.length > 0 && <TagBadgeList tags={tags} />}
       </div>
       <div className="flex flex-col gap-2">
         <SessionValueRow value={value} metric={metric} p50={baseline.p50} />
@@ -193,27 +190,25 @@ function OutlierTooltip({
 
 /**
  * Renders a p90/p95/p99 outlier badge when a session's metric value exceeds the
- * percentile thresholds of its tag-scoped cohort. The cohort baseline is fetched
- * lazily per session via `useSessionCohortSummaryByTags` — TanStack Query dedupes
- * across rows sharing a tag combination.
+ * percentile thresholds of the project-wide cohort. The baseline is fetched
+ * once per project via `useSessionCohortSummary` — TanStack Query dedupes
+ * across every row in the table.
  *
  * When `onThresholdClick` is provided the badge becomes a button that reports
  * the numeric threshold of the matched level (useful for filter-by-threshold).
  */
 export function SessionOutlierBadge({
   projectId,
-  tags,
   value,
   metric,
   onThresholdClick,
 }: {
   readonly projectId: string
-  readonly tags: ReadonlyArray<string>
   readonly value: number
   readonly metric: SessionOutlierMetric
   readonly onThresholdClick?: ((threshold: number, level: SessionOutlierLevel) => void) | undefined
 }) {
-  const { data } = useSessionCohortSummaryByTags({ projectId, tags })
+  const { data } = useSessionCohortSummary({ projectId })
   const level = computeLevel(value, data?.baselines[metric])
   if (!level || !data) return null
 
@@ -234,7 +229,7 @@ export function SessionOutlierBadge({
 
   return (
     <Tooltip asChild trigger={trigger}>
-      <OutlierTooltip tags={tags} cohorts={data} metric={metric} level={level} value={value} />
+      <OutlierTooltip cohorts={data} metric={metric} level={level} value={value} />
     </Tooltip>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -367,12 +367,7 @@ export function SessionsView({
           return (
             <span className="flex items-center justify-end gap-1">
               {row.kind === "session" && (
-                <SessionOutlierBadge
-                  projectId={projectId}
-                  tags={row.session.tags}
-                  value={duration}
-                  metric="durationNs"
-                />
+                <SessionOutlierBadge projectId={projectId} value={duration} metric="durationNs" />
               )}
               {duration > 0 ? formatDuration(duration) : "-"}
             </span>
@@ -397,12 +392,7 @@ export function SessionsView({
           return (
             <span className="flex items-center justify-end gap-1">
               {row.kind === "session" && (
-                <SessionOutlierBadge
-                  projectId={projectId}
-                  tags={row.session.tags}
-                  value={ttft}
-                  metric="timeToFirstTokenNs"
-                />
+                <SessionOutlierBadge projectId={projectId} value={ttft} metric="timeToFirstTokenNs" />
               )}
               {ttft > 0 ? formatDuration(ttft) : "-"}
             </span>
@@ -431,12 +421,7 @@ export function SessionsView({
           return (
             <span className="flex items-center justify-end gap-1">
               {row.kind === "session" && (
-                <SessionOutlierBadge
-                  projectId={projectId}
-                  tags={row.session.tags}
-                  value={costTotalMicrocents}
-                  metric="costTotalMicrocents"
-                />
+                <SessionOutlierBadge projectId={projectId} value={costTotalMicrocents} metric="costTotalMicrocents" />
               )}
               {costTotalMicrocents > 0 ? formatPrice(costTotalMicrocents / 100_000_000) : "-"}
             </span>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -71,7 +71,6 @@ export function TraceTab({
     traceRecord ? (
       <TraceOutlierBadge
         projectId={projectId}
-        tags={traceRecord.tags}
         value={value}
         metric={metric}
         onThresholdClick={onFiltersChange ? (threshold) => handleFilterByThreshold(metric, threshold) : undefined}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-outlier-badge.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-outlier-badge.tsx
@@ -1,7 +1,7 @@
 import { type CohortMetric, type CohortSummary, getMetricPercentileThreshold } from "@domain/spans"
-import { Status, type StatusProps, TagBadgeList, Text, Tooltip } from "@repo/ui"
+import { Status, type StatusProps, Text, Tooltip } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice } from "@repo/utils"
-import { useTraceCohortSummaryByTags } from "../../../../../domains/traces/traces.collection.ts"
+import { useTraceCohortSummary } from "../../../../../domains/traces/traces.collection.ts"
 
 type Baselines = CohortSummary["baselines"]
 export type TraceOutlierMetric = keyof Baselines
@@ -147,17 +147,15 @@ function QuantileStrip({ baseline, value }: { baseline: Baselines[TraceOutlierMe
 }
 
 /**
- * A tooltip that explains that the outlier is only scoped to the subset of traces that match the given tags.
- * And then displays the baseline values for the given metric.
+ * A tooltip that explains that the outlier is scoped to all traces in the
+ * current project, then displays the baseline values for the given metric.
  */
 function OutlierTooltip({
-  tags,
   cohorts,
   metric,
   level,
   value,
 }: {
-  tags: ReadonlyArray<string>
   cohorts: CohortSummary
   metric: CohortMetric
   level: TraceOutlierLevel
@@ -168,10 +166,9 @@ function OutlierTooltip({
     <div className="flex flex-col gap-4 min-w-64">
       <div className="flex flex-col gap-2">
         <Text.H6>
-          This trace's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the traces with{" "}
-          {tags.length === 0 ? "no tags." : tags.length === 1 ? "this tag:" : "these tags:"}
+          This trace's <b>{METRIC_LABELS[metric]}</b> is greater than <b>{LEVEL_LABELS[level]}</b> of the traces in this
+          project.
         </Text.H6>
-        {tags.length > 0 && <TagBadgeList tags={tags} />}
       </div>
       <div className="flex flex-col gap-2">
         <TraceValueRow value={value} metric={metric} p50={baseline.p50} />
@@ -193,27 +190,25 @@ function OutlierTooltip({
 
 /**
  * Renders a p90/p95/p99 outlier badge when a trace's metric value exceeds the
- * percentile thresholds of its tag-scoped cohort. The cohort baseline is fetched
- * lazily per trace via `useTraceCohortSummaryByTags` — TanStack Query dedupes
- * across rows sharing a tag combination.
+ * percentile thresholds of the project-wide cohort. The baseline is fetched
+ * once per project via `useTraceCohortSummary` — TanStack Query dedupes
+ * across every row in the table.
  *
  * When `onThresholdClick` is provided the badge becomes a button that reports
  * the numeric threshold of the matched level (useful for filter-by-threshold).
  */
 export function TraceOutlierBadge({
   projectId,
-  tags,
   value,
   metric,
   onThresholdClick,
 }: {
   readonly projectId: string
-  readonly tags: ReadonlyArray<string>
   readonly value: number
   readonly metric: TraceOutlierMetric
   readonly onThresholdClick?: ((threshold: number, level: TraceOutlierLevel) => void) | undefined
 }) {
-  const { data } = useTraceCohortSummaryByTags({ projectId, tags })
+  const { data } = useTraceCohortSummary({ projectId })
   const level = computeLevel(value, data?.baselines[metric])
   if (!level || !data) return null
 
@@ -234,7 +229,7 @@ export function TraceOutlierBadge({
 
   return (
     <Tooltip asChild trigger={trigger}>
-      <OutlierTooltip tags={tags} cohorts={data} metric={metric} level={level} value={value} />
+      <OutlierTooltip cohorts={data} metric={metric} level={level} value={value} />
     </Tooltip>
   )
 }

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -81,10 +81,10 @@ export {
   TRACE_HISTOGRAM_METRICS,
   TraceRepository,
 } from "./ports/trace-repository.ts"
-export type { GetSessionCohortSummaryByTagsInput } from "./use-cases/get-session-cohort-summary-by-tags.ts"
-export { getSessionCohortSummaryByTagsUseCase } from "./use-cases/get-session-cohort-summary-by-tags.ts"
-export type { GetTraceCohortSummaryByTagsInput } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
-export { getTraceCohortSummaryByTagsUseCase } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
+export type { GetSessionCohortSummaryInput } from "./use-cases/get-session-cohort-summary.ts"
+export { getSessionCohortSummaryUseCase } from "./use-cases/get-session-cohort-summary.ts"
+export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
+export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
 export type {
   LoadTraceForTraceEndFound,
   LoadTraceForTraceEndResult,

--- a/packages/domain/spans/src/cohort-baselines.ts
+++ b/packages/domain/spans/src/cohort-baselines.ts
@@ -1,10 +1,10 @@
 /**
- * Tag-scoped cohort percentile baselines, shared by traces and sessions.
+ * Project-wide cohort percentile baselines, shared by traces and sessions.
  *
- * A "cohort" is the set of traces (or sessions) that share an exact tag
- * combination. For each numeric metric we compute p50/p90/p95/p99 across the
- * cohort and expose them as a baseline that the UI compares a single item's
- * value against (the trace/session outlier badge).
+ * A "cohort" is every trace (or session) in the project. For each numeric
+ * metric we compute p50/p90/p95/p99 across the cohort and expose them as a
+ * baseline that the UI compares a single item's value against (the
+ * trace/session outlier badge).
  *
  * Percentiles are gated by sample count: a p99 derived from 20 samples is
  * noise, so we null it out below the gate. The badge UI treats `null` as

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -143,8 +143,8 @@ export type {
   TraceSearchHighlightsResult,
 } from "./use-cases/compute-trace-search-highlights.ts"
 export { computeTraceSearchHighlights } from "./use-cases/compute-trace-search-highlights.ts"
-export type { GetSessionCohortSummaryByTagsInput } from "./use-cases/get-session-cohort-summary-by-tags.ts"
-export { getSessionCohortSummaryByTagsUseCase } from "./use-cases/get-session-cohort-summary-by-tags.ts"
+export type { GetSessionCohortSummaryInput } from "./use-cases/get-session-cohort-summary.ts"
+export { getSessionCohortSummaryUseCase } from "./use-cases/get-session-cohort-summary.ts"
 export type {
   GetTraceAnalyticsError,
   GetTraceAnalyticsInput,
@@ -154,8 +154,8 @@ export type {
   TraceAnalyticsTotalMetric,
 } from "./use-cases/get-trace-analytics.ts"
 export { getTraceAnalyticsUseCase } from "./use-cases/get-trace-analytics.ts"
-export type { GetTraceCohortSummaryByTagsInput } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
-export { getTraceCohortSummaryByTagsUseCase } from "./use-cases/get-trace-cohort-summary-by-tags.ts"
+export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
+export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
 export { getTraceSearchHighlightsUseCase } from "./use-cases/get-trace-search-highlights.ts"
 export type { IngestSpansInput } from "./use-cases/ingest-spans.ts"
 export { ingestSpansUseCase } from "./use-cases/ingest-spans.ts"

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -22,15 +22,13 @@ import type { NumericRollup, TraceDistribution, TraceTimeHistogramBucket } from 
  */
 export interface SessionRepositoryShape {
   /**
-   * Baseline percentiles scoped to the exact tag combination. Empty `tags` array
-   * matches only untagged sessions. Tag match is order-independent set equality.
-   * Intentionally ignores user filters — the goal is a stable "what's normal for
-   * this kind of session" reference.
+   * Baseline percentiles across every session in the project. Intentionally
+   * ignores user filters — the goal is a stable "what's normal for this
+   * project" reference.
    */
-  getCohortBaselineByTags(input: {
+  getCohortBaseline(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
-    readonly tags: ReadonlyArray<string>
     readonly excludeSessionId?: SessionId
   }): Effect.Effect<CohortBaselineData, RepositoryError, ChSqlClient>
 

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -20,15 +20,13 @@ import type { Trace, TraceDetail } from "../entities/trace.ts"
  */
 export interface TraceRepositoryShape {
   /**
-   * Baseline percentiles scoped to the exact tag combination. Empty `tags` array
-   * matches only untagged traces. Tag match is order-independent set equality.
-   * Intentionally ignores user filters — the goal is a stable "what's normal for
-   * this kind of trace" reference.
+   * Baseline percentiles across every trace in the project. Intentionally
+   * ignores user filters — the goal is a stable "what's normal for this
+   * project" reference.
    */
-  getCohortBaselineByTags(input: {
+  getCohortBaseline(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
-    readonly tags: ReadonlyArray<string>
     readonly excludeTraceId?: TraceId
   }): Effect.Effect<CohortBaselineData, RepositoryError, ChSqlClient>
 

--- a/packages/domain/spans/src/testing/fake-session-repository.ts
+++ b/packages/domain/spans/src/testing/fake-session-repository.ts
@@ -6,7 +6,7 @@ import { emptyTraceDistribution } from "../ports/trace-repository.ts"
 
 export const createFakeSessionRepository = (overrides?: Partial<SessionRepositoryShape>) => {
   const repository: SessionRepositoryShape = {
-    getCohortBaselineByTags: () =>
+    getCohortBaseline: () =>
       Effect.succeed({
         count: 0,
         metrics: {

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -4,7 +4,7 @@ import { emptyTraceDistribution, emptyTraceMetrics, type TraceRepositoryShape } 
 
 export const createFakeTraceRepository = (overrides?: Partial<TraceRepositoryShape>) => {
   const repository: TraceRepositoryShape = {
-    getCohortBaselineByTags: () =>
+    getCohortBaseline: () =>
       Effect.succeed({
         count: 0,
         metrics: {

--- a/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
@@ -4,15 +4,13 @@ import { buildMetricBaselines, type CohortSummary } from "../cohort-baselines.ts
 import { COHORT_SUMMARY_CACHE_TTL_SECONDS } from "../constants.ts"
 import { SessionRepository } from "../ports/session-repository.ts"
 
-export interface GetSessionCohortSummaryByTagsInput {
+export interface GetSessionCohortSummaryInput {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
-  readonly tags: ReadonlyArray<string>
 }
 
-const buildCacheKey = (organizationId: string, projectId: string, sortedTags: readonly string[]): string =>
-  // JSON-encode the tags array so delimiters inside tag values can't collide with the key structure.
-  `org:${organizationId}:projects:${projectId}:session-cohort-baselines:${JSON.stringify(sortedTags)}`
+const buildCacheKey = (organizationId: string, projectId: string): string =>
+  `org:${organizationId}:projects:${projectId}:session-cohort-baseline`
 
 const parseCachedSummary = (json: string): CohortSummary | null => {
   try {
@@ -34,20 +32,13 @@ const parseCachedSummary = (json: string): CohortSummary | null => {
   }
 }
 
-export const getSessionCohortSummaryByTagsUseCase = Effect.fn("spans.getSessionCohortSummaryByTags")(function* (
-  input: GetSessionCohortSummaryByTagsInput,
+export const getSessionCohortSummaryUseCase = Effect.fn("spans.getSessionCohortSummary")(function* (
+  input: GetSessionCohortSummaryInput,
 ) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-  yield* Effect.annotateCurrentSpan("tagsLength", input.tags.length)
 
-  // Canonicalize as a sorted set: dedupe first (ClickHouse stores `tags` as
-  // `groupUniqArrayArray(tags)`, which is already deduped — passing duplicates
-  // through would break the `length(tags) = N` exact-set match and also split
-  // the cache key from the canonical cohort). Then sort for stable, order-
-  // independent cache keys and query params.
-  const sortedTags = [...new Set(input.tags)].sort()
   const cache = yield* CacheStore
-  const cacheKey = buildCacheKey(input.organizationId, input.projectId, sortedTags)
+  const cacheKey = buildCacheKey(input.organizationId, input.projectId)
 
   const cachedJson = yield* cache.get(cacheKey).pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
   if (cachedJson !== null) {
@@ -60,10 +51,9 @@ export const getSessionCohortSummaryByTagsUseCase = Effect.fn("spans.getSessionC
   yield* Effect.annotateCurrentSpan("cache.hit", false)
 
   const sessionRepository = yield* SessionRepository
-  const baselineData = yield* sessionRepository.getCohortBaselineByTags({
+  const baselineData = yield* sessionRepository.getCohortBaseline({
     organizationId: input.organizationId,
     projectId: input.projectId,
-    tags: sortedTags,
   })
   const baselines = buildMetricBaselines(baselineData)
   const summary: CohortSummary = {

--- a/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-session-cohort-summary.ts
@@ -32,6 +32,15 @@ const parseCachedSummary = (json: string): CohortSummary | null => {
   }
 }
 
+/**
+ * Loads the project-wide cohort baseline used to render outlier badges.
+ *
+ * The repository's `excludeSessionId` param is intentionally not threaded
+ * through: the badge is meant to compare against a stable project-wide
+ * reference, so the row being viewed is included in its own baseline. A
+ * future "compare this session to everything else" view could surface the
+ * port-level support if needed.
+ */
 export const getSessionCohortSummaryUseCase = Effect.fn("spans.getSessionCohortSummary")(function* (
   input: GetSessionCohortSummaryInput,
 ) {

--- a/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
@@ -4,15 +4,13 @@ import { buildMetricBaselines, type CohortSummary } from "../cohort-baselines.ts
 import { COHORT_SUMMARY_CACHE_TTL_SECONDS } from "../constants.ts"
 import { TraceRepository } from "../ports/trace-repository.ts"
 
-export interface GetTraceCohortSummaryByTagsInput {
+export interface GetTraceCohortSummaryInput {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
-  readonly tags: ReadonlyArray<string>
 }
 
-const buildCacheKey = (organizationId: string, projectId: string, sortedTags: readonly string[]): string =>
-  // JSON-encode the tags array so delimiters inside tag values can't collide with the key structure.
-  `org:${organizationId}:projects:${projectId}:trace-cohort-baselines:${JSON.stringify(sortedTags)}`
+const buildCacheKey = (organizationId: string, projectId: string): string =>
+  `org:${organizationId}:projects:${projectId}:trace-cohort-baseline`
 
 const parseCachedSummary = (json: string): CohortSummary | null => {
   try {
@@ -34,20 +32,13 @@ const parseCachedSummary = (json: string): CohortSummary | null => {
   }
 }
 
-export const getTraceCohortSummaryByTagsUseCase = Effect.fn("spans.getTraceCohortSummaryByTags")(function* (
-  input: GetTraceCohortSummaryByTagsInput,
+export const getTraceCohortSummaryUseCase = Effect.fn("spans.getTraceCohortSummary")(function* (
+  input: GetTraceCohortSummaryInput,
 ) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-  yield* Effect.annotateCurrentSpan("tagsLength", input.tags.length)
 
-  // Canonicalize as a sorted set: dedupe first (ClickHouse stores `tags` as
-  // `groupUniqArrayArray(tags)`, which is already deduped — passing duplicates
-  // through would break the `length(tags) = N` exact-set match and also split
-  // the cache key from the canonical cohort). Then sort for stable, order-
-  // independent cache keys and query params.
-  const sortedTags = [...new Set(input.tags)].sort()
   const cache = yield* CacheStore
-  const cacheKey = buildCacheKey(input.organizationId, input.projectId, sortedTags)
+  const cacheKey = buildCacheKey(input.organizationId, input.projectId)
 
   const cachedJson = yield* cache.get(cacheKey).pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
   if (cachedJson !== null) {
@@ -60,10 +51,9 @@ export const getTraceCohortSummaryByTagsUseCase = Effect.fn("spans.getTraceCohor
   yield* Effect.annotateCurrentSpan("cache.hit", false)
 
   const traceRepository = yield* TraceRepository
-  const baselineData = yield* traceRepository.getCohortBaselineByTags({
+  const baselineData = yield* traceRepository.getCohortBaseline({
     organizationId: input.organizationId,
     projectId: input.projectId,
-    tags: sortedTags,
   })
   const baselines = buildMetricBaselines(baselineData)
   const summary: CohortSummary = {

--- a/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
@@ -32,6 +32,15 @@ const parseCachedSummary = (json: string): CohortSummary | null => {
   }
 }
 
+/**
+ * Loads the project-wide cohort baseline used to render outlier badges.
+ *
+ * The repository's `excludeTraceId` param is intentionally not threaded
+ * through: the badge is meant to compare against a stable project-wide
+ * reference, so the row being viewed is included in its own baseline. A
+ * future "compare this trace to everything else" view could surface the
+ * port-level support if needed.
+ */
 export const getTraceCohortSummaryUseCase = Effect.fn("spans.getTraceCohortSummary")(function* (
   input: GetTraceCohortSummaryInput,
 ) {

--- a/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
@@ -147,7 +147,7 @@ const makeTrace = (
 
 const makeSessionRepository = (session: SessionDetail | null) =>
   Layer.succeed(SessionRepository, {
-    getCohortBaselineByTags: () =>
+    getCohortBaseline: () =>
       Effect.succeed({
         count: 0,
         metrics: {
@@ -177,7 +177,7 @@ const makeSessionRepository = (session: SessionDetail | null) =>
 
 const makeTraceRepository = (traces: readonly TraceDetail[]) =>
   Layer.succeed(TraceRepository, {
-    getCohortBaselineByTags: () =>
+    getCohortBaseline: () =>
       Effect.succeed({
         count: 0,
         metrics: {

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -614,31 +614,65 @@ describe("SessionRepository", () => {
     })
   })
 
-  describe("getCohortBaselineByTags", () => {
-    const makeTaggedSpan = (overrides: SpanOverrides & { readonly tags: readonly string[] }): SpanRow => ({
+  describe("getCohortBaseline", () => {
+    const taggedSpan = (overrides: SpanOverrides & { readonly tags?: readonly string[] }): SpanRow => ({
       ...makeSpanRow(overrides),
-      tags: [...overrides.tags],
+      ...(overrides.tags ? { tags: [...overrides.tags] } : {}),
+    })
+
+    it("aggregates every session in the project regardless of tags", async () => {
+      const start = new Date(Date.UTC(2026, 5, 1, 10, 0, 0))
+      const rows = [
+        taggedSpan({
+          traceId: `01${"a".repeat(30)}`,
+          spanId: `01${"b".repeat(14)}`,
+          sessionId: "cheap-1",
+          startTime: new Date(start.getTime()),
+          costTotalMicrocents: 100,
+          tags: ["cheap"],
+        }),
+        taggedSpan({
+          traceId: `02${"a".repeat(30)}`,
+          spanId: `02${"b".repeat(14)}`,
+          sessionId: "expensive-1",
+          startTime: new Date(start.getTime() + 1_000),
+          costTotalMicrocents: 200,
+          tags: ["expensive"],
+        }),
+        taggedSpan({
+          traceId: `03${"a".repeat(30)}`,
+          spanId: `03${"b".repeat(14)}`,
+          sessionId: "untagged-1",
+          startTime: new Date(start.getTime() + 2_000),
+          costTotalMicrocents: 300,
+        }),
+      ]
+
+      await insertSpans(rows)
+
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+
+      expect(baseline.count).toBe(3)
+      expect(baseline.metrics.costTotalMicrocents.sampleCount).toBe(3)
+      expect(baseline.metrics.costTotalMicrocents.p50).toBe(200)
     })
 
     it("ignores zero-filled cost and token values in percentile baselines", async () => {
-      const start = new Date(Date.UTC(2026, 5, 1, 10, 0, 0))
+      const start = new Date(Date.UTC(2026, 5, 2, 10, 0, 0))
       const rows = Array.from({ length: 10 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${i.toString(16).padStart(2, "0")}${"a".repeat(30)}`,
-          spanId: `${i.toString(16).padStart(2, "0")}${"b".repeat(14)}`,
+        taggedSpan({
+          traceId: `${(10 + i).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
+          spanId: `${(10 + i).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           sessionId: `cohort-zero-${i}`,
           startTime: new Date(start.getTime() + i * 1_000),
           costTotalMicrocents: i === 9 ? 500 : 0,
           tokensOutput: i === 9 ? 100 : 0,
-          tags: ["cohort-zero"],
         }),
       )
 
       await insertSpans(rows)
 
-      const baseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["cohort-zero"] }),
-      )
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: PROJECT_ID }))
 
       expect(baseline.count).toBe(10)
       expect(baseline.metrics.costTotalMicrocents.sampleCount).toBe(1)
@@ -649,127 +683,21 @@ describe("SessionRepository", () => {
       expect(baseline.metrics.durationNs.sampleCount).toBe(10)
     })
 
-    it("isolates cohorts by exact tag combination, independent of order", async () => {
-      const start = new Date(Date.UTC(2026, 5, 2, 10, 0, 0))
-      const cheapRows = Array.from({ length: 5 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${(20 + i).toString(16).padStart(2, "0")}${"c".repeat(30)}`,
-          spanId: `${(20 + i).toString(16).padStart(2, "0")}${"d".repeat(14)}`,
-          sessionId: `cheap-${i}`,
-          startTime: new Date(start.getTime() + i * 1_000),
-          costTotalMicrocents: 100,
-          tags: ["cheap"],
-        }),
-      )
-      const expensiveRows = Array.from({ length: 5 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${(30 + i).toString(16).padStart(2, "0")}${"c".repeat(30)}`,
-          spanId: `${(30 + i).toString(16).padStart(2, "0")}${"d".repeat(14)}`,
-          sessionId: `expensive-${i}`,
-          startTime: new Date(start.getTime() + i * 1_000),
-          costTotalMicrocents: 10_000,
-          tags: ["expensive"],
-        }),
-      )
-      const reversedOrderRows = Array.from({ length: 3 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${(40 + i).toString(16).padStart(2, "0")}${"c".repeat(30)}`,
-          spanId: `${(40 + i).toString(16).padStart(2, "0")}${"d".repeat(14)}`,
-          sessionId: `mixed-${i}`,
-          startTime: new Date(start.getTime() + i * 1_000),
-          costTotalMicrocents: 500,
-          tags: ["beta", "alpha"],
-        }),
-      )
-
-      await insertSpans([...cheapRows, ...expensiveRows, ...reversedOrderRows])
-
-      const cheapBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["cheap"] }),
-      )
-      const expensiveBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["expensive"] }),
-      )
-
-      expect(cheapBaseline.count).toBe(5)
-      expect(cheapBaseline.metrics.costTotalMicrocents.p50).toBe(100)
-      expect(expensiveBaseline.count).toBe(5)
-      expect(expensiveBaseline.metrics.costTotalMicrocents.p50).toBe(10_000)
-
-      // Order-independent: query ["alpha","beta"] finds sessions stored with ["beta","alpha"].
-      const alphaBetaBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["alpha", "beta"] }),
-      )
-      expect(alphaBetaBaseline.count).toBe(3)
-      expect(alphaBetaBaseline.metrics.costTotalMicrocents.p50).toBe(500)
-
-      // A subset must NOT match a strict superset cohort.
-      const alphaOnlyBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["alpha"] }),
-      )
-      expect(alphaOnlyBaseline.count).toBe(0)
-    })
-
-    it("treats the empty-tags cohort as a distinct bucket of untagged sessions", async () => {
-      const start = new Date(Date.UTC(2026, 5, 3, 10, 0, 0))
-      const taggedRows = Array.from({ length: 2 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${(50 + i).toString(16).padStart(2, "0")}${"e".repeat(30)}`,
-          spanId: `${(50 + i).toString(16).padStart(2, "0")}${"f".repeat(14)}`,
-          sessionId: `tagged-${i}`,
-          startTime: new Date(start.getTime() + i * 1_000),
-          costTotalMicrocents: 123,
-          tags: ["empty-cohort-marker"],
-        }),
-      )
-      const untaggedRows = Array.from({ length: 3 }, (_v, i) =>
-        makeTaggedSpan({
-          traceId: `${(60 + i).toString(16).padStart(2, "0")}${"e".repeat(30)}`,
-          spanId: `${(60 + i).toString(16).padStart(2, "0")}${"f".repeat(14)}`,
-          sessionId: `untagged-${i}`,
-          startTime: new Date(start.getTime() + i * 1_000),
-          costTotalMicrocents: 777,
-          tags: [],
-        }),
-      )
-
-      await insertSpans([...taggedRows, ...untaggedRows])
-
-      const emptyCohort = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: [] }),
-      )
-      expect(emptyCohort.count).toBe(3)
-      expect(emptyCohort.metrics.costTotalMicrocents.p50).toBe(777)
-
-      const taggedCohort = await runCh(
-        repo.getCohortBaselineByTags({
-          organizationId: ORG_ID,
-          projectId: PROJECT_ID,
-          tags: ["empty-cohort-marker"],
-        }),
-      )
-      expect(taggedCohort.count).toBe(2)
-      expect(taggedCohort.metrics.costTotalMicrocents.p50).toBe(123)
-    })
-
     it("gates p95 (<100 samples) and p99 (<1000 samples) to null", async () => {
       const start = new Date(Date.UTC(2026, 5, 4, 10, 0, 0))
       const rows = Array.from({ length: 10 }, (_v, i) =>
-        makeTaggedSpan({
+        taggedSpan({
           traceId: `${(70 + i).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
           spanId: `${(70 + i).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           sessionId: `gated-${i}`,
           startTime: new Date(start.getTime() + i * 1_000),
           costTotalMicrocents: (i + 1) * 10,
-          tags: ["gated"],
         }),
       )
 
       await insertSpans(rows)
 
-      const baseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["gated"] }),
-      )
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: PROJECT_ID }))
 
       expect(baseline.metrics.costTotalMicrocents.p95).toBeNull()
       expect(baseline.metrics.costTotalMicrocents.p99).toBeNull()
@@ -778,32 +706,29 @@ describe("SessionRepository", () => {
     it("honors excludeSessionId", async () => {
       const start = new Date(Date.UTC(2026, 5, 5, 10, 0, 0))
       const keptRows = Array.from({ length: 3 }, (_v, i) =>
-        makeTaggedSpan({
+        taggedSpan({
           traceId: `${(80 + i).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
           spanId: `${(80 + i).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           sessionId: `kept-${i}`,
           startTime: new Date(start.getTime() + i * 1_000),
           costTotalMicrocents: 100,
-          tags: ["excluded"],
         }),
       )
       const excludedSessionId = "excluded-session"
-      const excludedRow = makeTaggedSpan({
+      const excludedRow = taggedSpan({
         traceId: `90${"a".repeat(30)}`,
         spanId: `90${"b".repeat(14)}`,
         sessionId: excludedSessionId,
         startTime: new Date(start.getTime() + 10_000),
         costTotalMicrocents: 999_999,
-        tags: ["excluded"],
       })
 
       await insertSpans([...keptRows, excludedRow])
 
       const baseline = await runCh(
-        repo.getCohortBaselineByTags({
+        repo.getCohortBaseline({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
-          tags: ["excluded"],
           excludeSessionId: SessionId(excludedSessionId),
         }),
       )

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -603,21 +603,14 @@ export const SessionRepositoryLive = Layer.effect(
           )
       })
 
-    const getCohortBaselineByTags: SessionRepositoryShape["getCohortBaselineByTags"] = ({
+    const getCohortBaseline: SessionRepositoryShape["getCohortBaseline"] = ({
       organizationId,
       projectId,
-      tags,
       excludeSessionId,
     }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         const excludeClause = excludeSessionId ? `AND session_id != {excludeSessionId:String}` : ""
-        // Canonicalize as a sorted set for stable param shape. ClickHouse stores `tags` as
-        // `groupUniqArrayArray(tags)` (already deduped), so pairing `length(tags) = N` with
-        // `hasAll(tags, X)` gives order-independent set equality only when the input is a set
-        // too — passing duplicates would send `tagsLen=2` and match no sessions.
-        // Empty `tags` degenerates to `length(tags) = 0` (hasAll is trivially true), isolating untagged sessions.
-        const sortedTags = [...new Set(tags)].sort()
 
         return yield* chSqlClient
           .query(async (client) => {
@@ -651,14 +644,10 @@ export const SessionRepositoryLive = Layer.effect(
                         AND project_id = {projectId:String}
                         ${excludeClause}
                       GROUP BY organization_id, project_id, session_id
-                      HAVING length(tags) = {tagsLen:UInt32}
-                        AND hasAll(tags, {tags:Array(String)})
                     )`,
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                tags: sortedTags,
-                tagsLen: sortedTags.length,
                 ...(excludeSessionId ? { excludeSessionId: excludeSessionId as string } : {}),
               },
               format: "JSONEachRow",
@@ -754,12 +743,12 @@ export const SessionRepositoryLive = Layer.effect(
                 },
               }
             }),
-            Effect.mapError((error) => toRepositoryError(error, "getCohortBaselineByTags")),
+            Effect.mapError((error) => toRepositoryError(error, "getCohortBaseline")),
           )
       })
 
     return {
-      getCohortBaselineByTags,
+      getCohortBaseline,
       listByProjectId,
 
       countByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -186,13 +186,72 @@ describe("TraceRepository", () => {
     })
   })
 
-  describe("getCohortBaselineByTags", () => {
+  describe("getCohortBaseline", () => {
+    // Use a fresh project id so seeded BASELINE_SPANS don't pollute the cohort.
+    const COHORT_PROJECT_ID = ProjectId("cohort-project")
+
+    const makeCohortRow = (opts: {
+      readonly traceId: string
+      readonly spanId: string
+      readonly startTime: Date
+      readonly costTotalMicrocents: number
+      readonly tokensInput: number
+      readonly tokensOutput: number
+      readonly tags?: readonly string[]
+    }): SpanRow => {
+      const row = makeSpanRow(opts)
+      return {
+        ...row,
+        project_id: COHORT_PROJECT_ID,
+        ...(opts.tags ? { tags: [...opts.tags] } : {}),
+      }
+    }
+
+    it("aggregates every trace in the project regardless of tags", async () => {
+      const rows = [
+        makeCohortRow({
+          traceId: `01${"a".repeat(30)}`,
+          spanId: `01${"b".repeat(14)}`,
+          startTime: new Date(Date.UTC(2026, 0, 1, 0, 0, 0)),
+          costTotalMicrocents: 100,
+          tokensInput: 0,
+          tokensOutput: 0,
+          tags: ["cheap"],
+        }),
+        makeCohortRow({
+          traceId: `02${"a".repeat(30)}`,
+          spanId: `02${"b".repeat(14)}`,
+          startTime: new Date(Date.UTC(2026, 0, 1, 0, 0, 1)),
+          costTotalMicrocents: 200,
+          tokensInput: 0,
+          tokensOutput: 0,
+          tags: ["expensive"],
+        }),
+        makeCohortRow({
+          traceId: `03${"a".repeat(30)}`,
+          spanId: `03${"b".repeat(14)}`,
+          startTime: new Date(Date.UTC(2026, 0, 1, 0, 0, 2)),
+          costTotalMicrocents: 300,
+          tokensInput: 0,
+          tokensOutput: 0,
+          tags: [],
+        }),
+      ]
+      await Effect.runPromise(insertJsonEachRow(ch.client, "spans", rows))
+
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: COHORT_PROJECT_ID }))
+
+      expect(baseline.count).toBe(3)
+      expect(baseline.metrics.costTotalMicrocents.sampleCount).toBe(3)
+      expect(baseline.metrics.costTotalMicrocents.p50).toBe(200)
+    })
+
     it("ignores zero-filled cost and token values in percentile baselines", async () => {
       const rows = Array.from({ length: 10 }, (_value, index) => {
-        const startTime = new Date(Date.UTC(2026, 0, 1, 0, 0, index))
-        return makeSpanRow({
-          traceId: `${index.toString(16).padStart(2, "0")}${"a".repeat(30)}`,
-          spanId: `${index.toString(16).padStart(2, "0")}${"b".repeat(14)}`,
+        const startTime = new Date(Date.UTC(2026, 0, 2, 0, 0, index))
+        return makeCohortRow({
+          traceId: `${(10 + index).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
+          spanId: `${(10 + index).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           startTime,
           costTotalMicrocents: index === 9 ? 500 : 0,
           tokensInput: index === 9 ? 100 : 0,
@@ -202,13 +261,7 @@ describe("TraceRepository", () => {
 
       await Effect.runPromise(insertJsonEachRow(ch.client, "spans", rows))
 
-      const baseline = await runCh(
-        repo.getCohortBaselineByTags({
-          organizationId: ORG_ID,
-          projectId: PROJECT_ID,
-          tags: [BASELINE_TEST_TAG],
-        }),
-      )
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: COHORT_PROJECT_ID }))
 
       expect(baseline.metrics.costTotalMicrocents.sampleCount).toBe(1)
       expect(baseline.metrics.costTotalMicrocents.p50).toBe(500)
@@ -221,90 +274,9 @@ describe("TraceRepository", () => {
       expect(baseline.metrics.tokensTotal.p90).toBe(100)
     })
 
-    it("isolates cohorts by exact tag combination, independent of order", async () => {
-      const makeRowWithTags = (traceIdx: number, cost: number, tags: readonly string[]): SpanRow => {
-        const startTime = new Date(Date.UTC(2026, 0, 2, 0, 0, traceIdx))
-        const row = makeSpanRow({
-          traceId: `${traceIdx.toString(16).padStart(2, "0")}${"c".repeat(30)}`,
-          spanId: `${traceIdx.toString(16).padStart(2, "0")}${"d".repeat(14)}`,
-          startTime,
-          costTotalMicrocents: cost,
-          tokensInput: 0,
-          tokensOutput: 0,
-        })
-        return { ...row, tags: [...tags] }
-      }
-
-      const cheapRows = Array.from({ length: 5 }, (_v, i) => makeRowWithTags(i, 100, ["cheap"]))
-      const expensiveRows = Array.from({ length: 5 }, (_v, i) => makeRowWithTags(i + 5, 10_000, ["expensive"]))
-      const reversedOrderRows = Array.from({ length: 3 }, (_v, i) => makeRowWithTags(i + 10, 500, ["beta", "alpha"]))
-
-      await Effect.runPromise(
-        insertJsonEachRow(ch.client, "spans", [...cheapRows, ...expensiveRows, ...reversedOrderRows]),
-      )
-
-      const cheapBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["cheap"] }),
-      )
-      const expensiveBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["expensive"] }),
-      )
-
-      expect(cheapBaseline.metrics.costTotalMicrocents.p50).toBe(100)
-      expect(expensiveBaseline.metrics.costTotalMicrocents.p50).toBe(10_000)
-      expect(cheapBaseline.count).toBe(5)
-      expect(expensiveBaseline.count).toBe(5)
-
-      // Order-independent match: query ["alpha","beta"] finds rows stored with ["beta","alpha"]
-      const alphaBetaBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["alpha", "beta"] }),
-      )
-      expect(alphaBetaBaseline.count).toBe(3)
-      expect(alphaBetaBaseline.metrics.costTotalMicrocents.p50).toBe(500)
-
-      // A subset of tags must NOT match a strict superset cohort.
-      const alphaOnlyBaseline = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: ["alpha"] }),
-      )
-      expect(alphaOnlyBaseline.count).toBe(0)
-    })
-
-    it("treats the empty-tags cohort as a distinct bucket of untagged traces", async () => {
-      const untaggedRows = Array.from({ length: 3 }, (_v, i): SpanRow => {
-        const row = makeSpanRow({
-          traceId: `${(20 + i).toString(16).padStart(2, "0")}${"e".repeat(30)}`,
-          spanId: `${(20 + i).toString(16).padStart(2, "0")}${"f".repeat(14)}`,
-          startTime: new Date(Date.UTC(2026, 0, 3, 0, 0, i)),
-          costTotalMicrocents: 777,
-          tokensInput: 0,
-          tokensOutput: 0,
-        })
-        return { ...row, tags: [] }
-      })
-
-      await Effect.runPromise(insertJsonEachRow(ch.client, "spans", untaggedRows))
-
-      const emptyCohort = await runCh(
-        repo.getCohortBaselineByTags({ organizationId: ORG_ID, projectId: PROJECT_ID, tags: [] }),
-      )
-
-      expect(emptyCohort.count).toBe(3)
-      expect(emptyCohort.metrics.costTotalMicrocents.p50).toBe(777)
-
-      // Tagged-cohort queries must not pick up untagged rows.
-      const taggedCohort = await runCh(
-        repo.getCohortBaselineByTags({
-          organizationId: ORG_ID,
-          projectId: PROJECT_ID,
-          tags: [BASELINE_TEST_TAG],
-        }),
-      )
-      expect(taggedCohort.metrics.costTotalMicrocents.p50).not.toBe(777)
-    })
-
     it("gates p95 (<100 samples) and p99 (<1000 samples) to null", async () => {
       const rows = Array.from({ length: 10 }, (_v, i) =>
-        makeSpanRow({
+        makeCohortRow({
           traceId: `${(30 + i).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
           spanId: `${(30 + i).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           startTime: new Date(Date.UTC(2026, 0, 4, 0, 0, i)),
@@ -315,13 +287,7 @@ describe("TraceRepository", () => {
       )
       await Effect.runPromise(insertJsonEachRow(ch.client, "spans", rows))
 
-      const baseline = await runCh(
-        repo.getCohortBaselineByTags({
-          organizationId: ORG_ID,
-          projectId: PROJECT_ID,
-          tags: [BASELINE_TEST_TAG],
-        }),
-      )
+      const baseline = await runCh(repo.getCohortBaseline({ organizationId: ORG_ID, projectId: COHORT_PROJECT_ID }))
 
       expect(baseline.metrics.costTotalMicrocents.p95).toBeNull()
       expect(baseline.metrics.costTotalMicrocents.p99).toBeNull()
@@ -329,7 +295,7 @@ describe("TraceRepository", () => {
 
     it("honors excludeTraceId", async () => {
       const keptRows = Array.from({ length: 3 }, (_v, i) =>
-        makeSpanRow({
+        makeCohortRow({
           traceId: `${(40 + i).toString(16).padStart(2, "0")}${"a".repeat(30)}`,
           spanId: `${(40 + i).toString(16).padStart(2, "0")}${"b".repeat(14)}`,
           startTime: new Date(Date.UTC(2026, 0, 5, 0, 0, i)),
@@ -338,7 +304,7 @@ describe("TraceRepository", () => {
           tokensOutput: 0,
         }),
       )
-      const excludedRow = makeSpanRow({
+      const excludedRow = makeCohortRow({
         traceId: `44${"a".repeat(30)}`,
         spanId: `44${"b".repeat(14)}`,
         startTime: new Date(Date.UTC(2026, 0, 5, 0, 0, 3)),
@@ -350,10 +316,9 @@ describe("TraceRepository", () => {
       await Effect.runPromise(insertJsonEachRow(ch.client, "spans", [...keptRows, excludedRow]))
 
       const baseline = await runCh(
-        repo.getCohortBaselineByTags({
+        repo.getCohortBaseline({
           organizationId: ORG_ID,
-          projectId: PROJECT_ID,
-          tags: [BASELINE_TEST_TAG],
+          projectId: COHORT_PROJECT_ID,
           excludeTraceId: excludedRow.trace_id as TraceId,
         }),
       )

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -520,21 +520,14 @@ const DEFAULT_SORT: SortColumn = SORT_COLUMNS.startTime as SortColumn
 export const TraceRepositoryLive = Layer.effect(
   TraceRepository,
   Effect.gen(function* () {
-    const getCohortBaselineByTags: TraceRepositoryShape["getCohortBaselineByTags"] = ({
+    const getCohortBaseline: TraceRepositoryShape["getCohortBaseline"] = ({
       organizationId,
       projectId,
-      tags,
       excludeTraceId,
     }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         const excludeClause = excludeTraceId ? `AND trace_id != {excludeTraceId:FixedString(32)}` : ""
-        // Canonicalize as a sorted set for stable param shape. ClickHouse stores `tags` as
-        // `groupUniqArrayArray(tags)` (already deduped), so pairing `length(tags) = N` with
-        // `hasAll(tags, X)` gives order-independent set equality only when the input is a set
-        // too — passing duplicates (e.g. ["a","a"]) would send `tagsLen=2` and match no traces.
-        // Empty `tags` degenerates to `length(tags) = 0` (hasAll is trivially true), isolating untagged traces.
-        const sortedTags = [...new Set(tags)].sort()
 
         return yield* chSqlClient
           .query(async (client) => {
@@ -568,14 +561,10 @@ export const TraceRepositoryLive = Layer.effect(
                         AND project_id = {projectId:String}
                         ${excludeClause}
                       GROUP BY organization_id, project_id, trace_id
-                      HAVING length(tags) = {tagsLen:UInt32}
-                        AND hasAll(tags, {tags:Array(String)})
                     )`,
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                tags: sortedTags,
-                tagsLen: sortedTags.length,
                 ...(excludeTraceId ? { excludeTraceId: excludeTraceId as string } : {}),
               },
               format: "JSONEachRow",
@@ -671,7 +660,7 @@ export const TraceRepositoryLive = Layer.effect(
                 },
               }
             }),
-            Effect.mapError((error) => toRepositoryError(error, "getCohortBaselineByTags")),
+            Effect.mapError((error) => toRepositoryError(error, "getCohortBaseline")),
           )
       })
 
@@ -960,7 +949,7 @@ export const TraceRepositoryLive = Layer.effect(
       })
 
     return {
-      getCohortBaselineByTags,
+      getCohortBaseline,
       listByProjectId,
 
       countByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>


### PR DESCRIPTION
## Summary

- Outlier badges (p90/p95/p99) on traces and sessions now compare against a single **project-wide** percentile baseline instead of a per-tag-set cohort.
- On low-volume or noisy-tagged projects, per-tag cohorts often never reached the sample gate (30 for p90, 100 for p95), so users never saw a badge. Collapsing to a project-wide cohort fixes that and matches our "one project per AI flow" recommendation.
- One Redis key per project (was per tag combination) and one TanStack Query per project (was N per visible tag set), so fewer round-trips from the traces/sessions table.

## What changed

- Drop the `HAVING length(tags) = N AND hasAll(tags, [...])` filter from the cohort SQL in both `trace-repository.ts` and `session-repository.ts`; rename the method to `getCohortBaseline`.
- Rename use-cases, server functions, and hooks accordingly (`...ByTags` → `...`), drop `tags` from their inputs.
- Drop the `tags` prop from `TraceOutlierBadge` / `SessionOutlierBadge` and update every call site (`project-traces-table.tsx`, `sessions-view.tsx`, trace + session detail drawers).
- Tooltip copy now reads "of the traces in this project" / "of the sessions in this project."
- Update fakes, port interfaces, and tests; rewrote the cohort test suites to cover project-wide aggregation, zero-value filtering, sample gating, and `excludeTraceId` / `excludeSessionId`.

## Test plan

- [x] `pnpm typecheck` (75/75 packages clean locally)
- [x] `pnpm biome check` clean locally
- [x] `pnpm --filter @platform/db-clickhouse test -- trace-repository session-repository` — cohort tests pass
- [x] Manual: open a low-volume project's Traces tab → expect to now see `p90/p95` badges next to outlier rows
- [x] Manual: open a high-volume project's Sessions tab → badge tooltip says "of the sessions in this project"

🤖 Generated with [Claude Code](https://claude.com/claude-code)