### PR TITLE
docs: add contributing guide, code of conduct, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report something that isn't working as expected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug! Please search [existing issues](https://github.com/latitude-dev/latitude-llm/issues) first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what you expected vs. what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Latitude does this affect?
+      options:
+        - Traces / Observability
+        - Evaluations
+        - Search
+        - Web UI
+        - SDK / Telemetry
+        - Other / not sure
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Which version or commit are you running, and is it cloud or self-hosted?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste any error output or attach screenshots. (Logs are automatically formatted as code.)
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Community
+    url: https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw
+    about: Ask questions and chat with the community in our Slack.
+  - name: Security vulnerability
+    url: https://github.com/latitude-dev/latitude-llm/security/policy
+    about: Please report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: For significant changes, please open an issue before building so we can align on the approach. Got a rough idea? Feel free to discuss it in [Slack](https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the problem or use case — not just the solution you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to happen?
+      description: A clear description of what you'd like to see.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Any other approaches, workarounds, or tools you've tried or thought about.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What does this PR do?
+
+<!-- Briefly describe the change for a reviewer with no prior context. -->
+
+## Related issue (if applicable)
+
+<!-- If this PR resolves an issue, link it so it auto-closes on merge, e.g. Closes #123 -->
+
+Closes #
+
+## How was this tested?
+
+<!-- Describe the tests you ran or the steps to verify the change. -->
+
+## Checklist
+
+- [ ] Lint, type-checking, and tests pass locally
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] I have signed the CLA

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Code of Conduct
+
+Latitude is built in the open, and we want it to be a place where anyone feels welcome to contribute, whether that's code, docs, a bug report, or a question in [Slack](https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw). This Code of Conduct sets the baseline we hold ourselves and our community to.
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in the Latitude community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Latitude maintainers are responsible for enforcing these standards and will take fair corrective action in response to any behavior they deem inappropriate. This includes removing, editing, or rejecting contributions that don't align with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies in all Latitude community spaces — our GitHub repositories, issues and pull requests, and the Slack community — and when someone is officially representing Latitude in public.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the Latitude maintainers responsible for enforcement at hello@latitude.so. All complaints will be reviewed and investigated promptly and fairly.
+
+All Latitude maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+Depending on the severity, consequences may range from a private warning to a temporary or permanent ban from the Latitude community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+For answers to common questions, see the [FAQ](https://www.contributor-covenant.org/faq). [Translations are available here](https://www.contributor-covenant.org/translations).
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Latitude
+
+Thanks for taking the time to contribute! ❤️
+
+The best ways to contribute:
+
+- Open and vote on [Issues](https://github.com/latitude-dev/latitude-llm/issues)
+- Improve the [docs](https://docs.latitude.so)
+- Open a pull request
+
+> And if you like the project but don't have time to contribute code, you can also:
+> - Star the repo
+> - Share Latitude with people who'd find it useful
+> - Mention it at meetups or in your project's README
+
+The maintainers hang out in [Slack](https://join.slack.com/t/trylatitude/shared_invite/zt-35wu2h9es-N419qlptPMhyOeIpj3vjzw) if you have questions.
+
+## Making a change
+
+For typos, small docs fixes, and clearly-scoped bugs, just open a PR.
+
+**For new features or anything significant, open an issue first.** Discussing it ahead of time keeps the process smooth, changes that weren't discussed may be rejected.
+
+ We don't assign issues, just comment to claim one, then open a PR. The first quality PR that resolves an issue is the one we merge.
+
+## Reporting issues
+
+Search [existing issues](https://github.com/latitude-dev/latitude-llm/issues) first. A good bug report has a clear description of expected vs. actual behavior, exact repro steps, and your environment. A good feature request explains the problem you're solving, not just the solution.
+
+Found a security vulnerability? Don't open a public issue, see [SECURITY.md](SECURITY.md).
+
+
+## Pull requests
+
+1. Fork and branch from `development` (our trunk; v1 fixes branch from `latitude-v1`).
+2. Keep PRs small and focused. Split large changes, schema separate from logic, refactors first.
+3. Make sure lint, type-checking, and tests pass.
+4. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit and PR titles (e.g. `fix(traces): handle empty spans`). We squash-merge.
+5. Link the issue with `Closes #123`, describe what you tested, and leave "Allow edits from maintainers" checked.
+
+We're a small team, we read everything but may take a few days, longer for big changes. Stale or out-of-scope PRs may be closed, but you're welcome to reopen.
+
+## CLA
+
+The first time you open a PR, a bot will ask you to sign our Contributor License Agreement. It's a one-time step. You keep ownership of your work; you're granting us a license to use it. PRs can't be merged until it's signed.
+
+## Code of Conduct
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.


### PR DESCRIPTION
## Summary

Sets up the open-source contribution surface for the repo:

- **`CONTRIBUTING.md`** — thin, to-the-point guide: ways to contribute, how to find work (good first issues), reporting issues, the PR process, CLA, and Code of Conduct. Setup is intentionally linked out to a separate dev guide.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, adapted for Latitude (maintainer wording, our community spaces, `hello@latitude.so` as the contact), trimmed for length.
- **`.github/ISSUE_TEMPLATE/`** — GitHub issue forms for bug reports and feature requests, plus `config.yml` (blank issues disabled; routes questions → Slack, security → policy).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — description, optional related issue, test notes, and a checklist (lint/types/tests, Conventional Commits, CLA).

## Still needed before this is fully live (follow-ups, mostly dev/admin)

- [ ] **Local development guide** — `CONTRIBUTING.md` links to a placeholder (`docs.latitude.so`); needs the canonical setup URL. Source material exists in `.agents/skills/toolchain-commands`.
- [ ] **CLA bot** — install cla-assistant + approve the CLA text (needs admin + legal sign-off).
- [ ] **Seed `good first issue`s** — curate ~10 beginner-friendly issues so the linked list isn't empty.

## Notes

- Labels used (`bug`, `enhancement`) don't collide with existing workflow labels (`keep-open` for stale, `llm` for triage).
- "We squash-merge" in CONTRIBUTING.md is unverified — please confirm or I'll remove it.