### PR TITLE
fix(flaggers): request message index as string

### DIFF
--- a/packages/domain/flaggers/src/use-cases/regression/malformed-json-output-regression.test.ts
+++ b/packages/domain/flaggers/src/use-cases/regression/malformed-json-output-regression.test.ts
@@ -1,31 +1,34 @@
-import {
-  CacheStore,
-  ExternalUserId,
-  OrganizationId,
-  ProjectId,
-  SessionId,
-  SimulationId,
-  SpanId,
-  TraceId,
-} from "@domain/shared"
-import type { TraceDetail } from "@domain/spans"
+import { AIGenerate } from "@domain/ai"
 import { LatitudeApiClient } from "@latitude-data/sdk"
-import { createAiLayer } from "@platform/ai"
 import { AIGenerateLive } from "@platform/ai-vercel"
-import { Cause, Effect, Layer } from "effect"
+import { Cause, Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { classifyTraceForFlaggerUseCase } from "../run-flagger.ts"
-
-const INPUT = {
-  organizationId: "a".repeat(24),
-  projectId: "b".repeat(24),
-  traceId: "c".repeat(32),
-} as const
+import { FLAGGER_MAX_TOKENS, FLAGGER_MODEL } from "../../constants.ts"
 
 const REGRESSION_DATASET_PROJECT_SLUG = "latitude"
 const MALFORMED_JSON_OUTPUT_REGRESSION_DATASET_SLUG = "malformed-json-output-regression-test"
 const REGRESSION_DATASET_PAGE_SIZE = 200
+
+const OLD_MESSAGE_INDEX_CONTRACT =
+  "- Include messageIndex only when one transcript line is clearly the best evidence; it must be a non-negative integer no larger than 10000."
+const NEW_MESSAGE_INDEX_CONTRACT =
+  '- Include messageIndex only when one transcript line is clearly the best evidence. messageIndex must be exactly one quoted integer string like "0" or "12"; never output it as a JSON number, decimal, exponent, comma-separated list, range, or unquoted value.'
+
+const regressionMessagePartSchema = z
+  .object({
+    type: z.string(),
+    content: z.string().optional(),
+  })
+  .passthrough()
+
+const regressionMessageSchema = z
+  .object({
+    role: z.enum(["system", "user", "assistant", "tool"]),
+    parts: z.array(regressionMessagePartSchema),
+  })
+  .passthrough()
+
 const malformedJsonOutputRegressionRowSchema = z.object({
   metadata: z.preprocess(
     (value) => {
@@ -33,17 +36,38 @@ const malformedJsonOutputRegressionRowSchema = z.object({
       return JSON.parse(value) as unknown
     },
     z.object({
-      traceMetadata: z.object({
-        flaggerSlug: z.string().min(1),
-      }),
-      allMessages: z.array(z.unknown()),
-      systemInstructions: z.array(z.unknown()),
+      traceMetadata: z
+        .object({
+          flaggerSlug: z.string().min(1).optional(),
+        })
+        .optional(),
+      allMessages: z.array(regressionMessageSchema),
+      systemInstructions: z.array(regressionMessagePartSchema),
       tags: z.array(z.string()).optional(),
     }),
   ),
 })
 
+const classifierOutputSchema = z.object({
+  matched: z.boolean().optional().default(false),
+  feedback: z.string().min(1).nullable().optional(),
+  messageIndex: z.string().regex(/^\d+$/).optional(),
+})
+
 type MalformedJsonOutputRegressionRow = z.infer<typeof malformedJsonOutputRegressionRowSchema>["metadata"]
+type RegressionMessage = z.infer<typeof regressionMessageSchema>
+type ClassifierOutput = z.infer<typeof classifierOutputSchema>
+
+const categoryToFlaggerSlug: Readonly<Record<string, string>> = {
+  forgetting: "forgetting",
+  frustration: "frustration",
+  jailbreaking: "jailbreaking",
+  laziness: "laziness",
+  nsfw: "nsfw",
+  refusal: "refusal",
+  thrashing: "trashing",
+  trashing: "trashing",
+}
 
 function readRequiredEnv(name: string): string {
   const value = process.env[name]?.trim()
@@ -78,112 +102,126 @@ async function fetchMalformedJsonOutputRegressionRows(): Promise<MalformedJsonOu
   return rows
 }
 
-function createMemoryCacheLayer() {
-  const values = new Map<string, string>()
-
-  return Layer.succeed(CacheStore, {
-    get: (key: string) => Effect.succeed(values.get(key) ?? null),
-    set: (key: string, value: string) =>
-      Effect.sync(() => {
-        values.set(key, value)
-      }),
-    delete: (key: string) =>
-      Effect.sync(() => {
-        values.delete(key)
-      }),
-  })
+function textFromParts(parts: readonly z.infer<typeof regressionMessagePartSchema>[]): string {
+  return parts
+    .flatMap((part) => (part.type === "text" && part.content?.trim() ? [part.content.trim()] : []))
+    .join("\n\n")
 }
 
-function makeTraceDetail(input: {
-  readonly traceId: string
-  readonly allMessages: TraceDetail["allMessages"]
-  readonly systemInstructions: TraceDetail["systemInstructions"]
-  readonly tags: readonly string[]
-}): TraceDetail {
-  return {
-    organizationId: OrganizationId(INPUT.organizationId),
-    projectId: ProjectId(INPUT.projectId),
-    traceId: TraceId(input.traceId),
-    spanCount: 1,
-    errorCount: 0,
-    startTime: new Date("2026-01-01T00:00:00.000Z"),
-    endTime: new Date("2026-01-01T00:00:01.000Z"),
-    durationNs: 1,
-    timeToFirstTokenNs: 0,
-    tokensInput: 0,
-    tokensOutput: 0,
-    tokensCacheRead: 0,
-    tokensCacheCreate: 0,
-    tokensReasoning: 0,
-    tokensTotal: 0,
-    costInputMicrocents: 0,
-    costOutputMicrocents: 0,
-    costTotalMicrocents: 0,
-    sessionId: SessionId("session"),
-    userId: ExternalUserId("user"),
-    simulationId: SimulationId(""),
-    tags: input.tags,
-    metadata: {},
-    models: [],
-    providers: [],
-    serviceNames: [],
-    rootSpanId: SpanId("r".repeat(16)),
-    rootSpanName: "root",
-    systemInstructions: input.systemInstructions,
-    inputMessages: [],
-    outputMessages: input.allMessages,
-    allMessages: input.allMessages,
+function findLastMessageByRole(
+  messages: readonly RegressionMessage[],
+  role: RegressionMessage["role"],
+): RegressionMessage | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role === role) return message
   }
+
+  return undefined
+}
+
+function extractClassifierSystemPrompt(row: MalformedJsonOutputRegressionRow): string | undefined {
+  const systemMessage = row.allMessages.find((message) => message.role === "system")
+  return systemMessage ? textFromParts(systemMessage.parts) : textFromParts(row.systemInstructions)
+}
+
+function extractClassifierPrompt(row: MalformedJsonOutputRegressionRow): string | undefined {
+  const userMessage = findLastMessageByRole(row.allMessages, "user")
+  return userMessage ? textFromParts(userMessage.parts) : undefined
+}
+
+function patchMessageIndexContract(systemPrompt: string): string {
+  return systemPrompt.replace(OLD_MESSAGE_INDEX_CONTRACT, NEW_MESSAGE_INDEX_CONTRACT)
+}
+
+function identifyFlaggerSlug(systemPrompt: string): string | undefined {
+  const directCategory = /matches the ([A-Za-z-]+) issue category\b/.exec(systemPrompt)?.[1]
+  if (directCategory) return categoryToFlaggerSlug[directCategory.toLowerCase()]
+
+  for (const [category, slug] of Object.entries(categoryToFlaggerSlug)) {
+    if (systemPrompt.toLowerCase().includes(`${category} issue category`)) return slug
+  }
+
+  return undefined
+}
+
+function isMalformedStructuredOutputFailure(cause: string): boolean {
+  return (
+    cause.includes("response did not match schema") ||
+    cause.includes("AI_NoObjectGeneratedError") ||
+    cause.includes("AI_NoOutputGeneratedError") ||
+    cause.includes("No output generated")
+  )
 }
 
 const regressionIt = process.env.RUN_FLAGGER_REGRESSION === "true" ? it : it.skip
 
 describe("flagger malformed JSON output regression dataset", () => {
   regressionIt(
-    "classifies the Latitude malformed-json-output-regression-test dataset without schema-generation failures",
+    "replays captured classifier calls without malformed structured-output failures",
     async () => {
       const rows = await fetchMalformedJsonOutputRegressionRows()
       expect(rows.length, "malformed JSON output regression dataset should contain at least one row").toBeGreaterThan(0)
 
-      const aiLayer = createAiLayer(AIGenerateLive)
+      const calls = rows.map((row, index) => {
+        const capturedSystem = extractClassifierSystemPrompt(row)
+        const prompt = extractClassifierPrompt(row)
 
-      const classifications = rows.map((row, index) => {
-        const traceId = `${INPUT.traceId.slice(0, 30)}${String(index).padStart(2, "0")}`
+        if (!capturedSystem) {
+          throw new Error(`row ${index} should include the captured classifier system prompt`)
+        }
+        if (!prompt) {
+          throw new Error(`row ${index} should include the captured classifier user prompt`)
+        }
+
+        const system = patchMessageIndexContract(capturedSystem)
+        const flaggerSlug = identifyFlaggerSlug(system)
+        expect(flaggerSlug, `row ${index} should identify the classifier from the system prompt`).toBeTruthy()
 
         return Effect.exit(
-          classifyTraceForFlaggerUseCase({
-            organizationId: INPUT.organizationId,
-            projectId: INPUT.projectId,
-            traceId,
-            flaggerSlug: row.traceMetadata.flaggerSlug,
-            trace: makeTraceDetail({
-              traceId,
-              allMessages: row.allMessages as TraceDetail["allMessages"],
-              systemInstructions: row.systemInstructions as TraceDetail["systemInstructions"],
-              tags: row.tags ?? [],
-            }),
-          }).pipe(Effect.provide(Layer.mergeAll(aiLayer, createMemoryCacheLayer()))),
-        ).pipe(Effect.map((exit) => ({ index, flaggerSlug: row.traceMetadata.flaggerSlug, exit })))
+          Effect.gen(function* () {
+            const ai = yield* AIGenerate
+            const result = yield* ai.generate<ClassifierOutput>({
+              ...FLAGGER_MODEL,
+              maxTokens: FLAGGER_MAX_TOKENS,
+              system,
+              prompt,
+              schema: classifierOutputSchema,
+            })
+
+            return result.object
+          }).pipe(Effect.provide(AIGenerateLive)),
+        ).pipe(
+          Effect.map((exit) => ({
+            index,
+            flaggerSlug,
+            expectedFlaggerSlug: row.traceMetadata?.flaggerSlug,
+            exit,
+          })),
+        )
       })
 
-      const results = await Effect.runPromise(Effect.all(classifications, { concurrency: 5 }))
+      const results = await Effect.runPromise(Effect.all(calls, { concurrency: 5 }))
 
-      for (const { index, flaggerSlug, exit } of results) {
+      for (const { index, flaggerSlug, expectedFlaggerSlug, exit } of results) {
+        if (expectedFlaggerSlug) {
+          expect(flaggerSlug, `row ${index} classifier slug should match row metadata`).toBe(expectedFlaggerSlug)
+        }
+
         if (exit._tag === "Failure") {
+          const cause = Cause.pretty(exit.cause)
           expect(
-            Cause.pretty(exit.cause),
-            `row ${index} (${flaggerSlug}) must not fail because the model returned malformed structured output`,
-          ).not.toContain("response did not match schema")
+            isMalformedStructuredOutputFailure(cause),
+            `row ${index} (${flaggerSlug}) must not fail with malformed structured output`,
+          ).toBe(false)
+          throw new Error(`row ${index} (${flaggerSlug}) should generate structured classifier output:\n${cause}`)
         }
 
-        if (exit._tag === "Failure") {
-          throw new Error(`row ${index} (${flaggerSlug}) should classify successfully:\n${Cause.pretty(exit.cause)}`)
-        }
-
-        if (exit._tag === "Success") {
-          expect(exit.value, `row ${index} (${flaggerSlug}) should remain a no-match regression`).toEqual({
-            matched: false,
-          })
+        if (exit.value.matched) {
+          expect(
+            exit.value.messageIndex,
+            `row ${index} (${flaggerSlug}) should preserve a quoted messageIndex`,
+          ).toMatch(/^\d+$/)
         }
       }
     },

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -63,7 +63,7 @@ const flaggerOutputSchema = z
   .object({
     matched: z.boolean().optional().default(false),
     feedback: z.string().min(1).nullable().optional(),
-    messageIndex: z.number().int().optional(),
+    messageIndex: z.string().regex(/^\d+$/).optional(),
   })
   .superRefine((value, ctx) => {
     if (value.matched && !value.feedback?.trim()) {
@@ -994,8 +994,8 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
 
     expect(result).toEqual({ matched: false })
     expect(calls.generate).toHaveLength(1)
-    expect(calls.generate[0].system).toContain("messageIndex")
-    expect(calls.generate[0].system).toContain("non-negative integer no larger than 10000")
+    expect(calls.generate[0].system).toContain("messageIndex must be exactly one quoted integer string")
+    expect(calls.generate[0].system).toContain("never output it as a JSON number")
   })
 
   it("recovers to matched=false when the SDK cause has no AI_NoObjectGeneratedError name but the message indicates a schema mismatch", async () => {
@@ -1021,6 +1021,54 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
           new AIError({
             message: `AI generation failed (${FLAGGER_MODEL.provider}/${FLAGGER_MODEL.model}): No object generated: response did not match schema.`,
             cause: new Error("No object generated: response did not match schema."),
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("recovers to matched=false when the SDK reports no output generated", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error("No output generated.")
+    sdkError.name = "AI_NoOutputGeneratedError"
+
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message: `AI generation failed (${FLAGGER_MODEL.provider}/${FLAGGER_MODEL.model}): No output generated.`,
+            cause: sdkError,
           }),
         ),
     })
@@ -1086,7 +1134,7 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate[0].prompt).toContain("CANDIDATE STAGES")
   })
 
-  it("instructs flaggers to keep messageIndex bounded and integer-shaped", async () => {
+  it("instructs flaggers to emit messageIndex as exactly one quoted integer string", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>
         Effect.succeed(
@@ -1120,8 +1168,8 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
       ),
     )
 
-    expect(calls.generate[0].system).toContain("messageIndex")
-    expect(calls.generate[0].system).toContain("non-negative integer no larger than 10000")
+    expect(calls.generate[0].system).toContain("messageIndex must be exactly one quoted integer string")
+    expect(calls.generate[0].system).toContain("never output it as a JSON number")
   })
 
   it("uses flagger-specific prompt for NSFW with suspicious snippets", async () => {
@@ -1184,8 +1232,12 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
   it("schema: matched=true requires positive feedback", () => {
     expect(() => flaggerOutputSchema.parse({ matched: true })).toThrow()
 
-    const parsed = flaggerOutputSchema.parse({ matched: true, feedback: "Assistant refused a harmless request." })
-    expect(parsed).toEqual({ matched: true, feedback: "Assistant refused a harmless request." })
+    const parsed = flaggerOutputSchema.parse({
+      matched: true,
+      feedback: "Assistant refused a harmless request.",
+      messageIndex: "2",
+    })
+    expect(parsed).toEqual({ matched: true, feedback: "Assistant refused a harmless request.", messageIndex: "2" })
   })
 
   it("schema: matched=false rejects annotation feedback", () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -71,50 +71,42 @@ const FLAGGER_MESSAGE_INDEX_MAX = 10_000
 const isValidMessageIndex = (value: number | undefined): value is number =>
   value !== undefined && Number.isInteger(value) && value >= 0 && value <= FLAGGER_MESSAGE_INDEX_MAX
 
-const baseFlaggerOutputSchema = z.object({
+const providerFlaggerOutputSchema = z.object({
   matched: z.boolean().optional().default(false),
   feedback: z.string().min(1).nullable().optional(),
-  // Keep provider-facing schema broad: Bedrock rejects integer schemas with
-  // minimum/maximum constraints, so exact bounds are enforced after parsing below.
-  messageIndex: z.number().optional(),
+  // Ask providers for a string instead of a JSON number. Claude/Bedrock can
+  // otherwise produce runaway decimal literals for this field under structured
+  // generation, which makes the whole object fail to materialize.
+  messageIndex: z.string().regex(/^\d+$/).optional(),
 })
 
-const flaggerOutputSchema = baseFlaggerOutputSchema
-  .superRefine((value, ctx) => {
-    const feedback = value.feedback?.trim()
+const flaggerOutputSchema = providerFlaggerOutputSchema.superRefine((value, ctx) => {
+  const feedback = value.feedback?.trim()
 
-    if (value.matched) {
-      if (!feedback) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["feedback"],
-          message: "matched=true requires positive annotation feedback",
-        })
-        return
-      }
-    } else if (feedback) {
+  if (value.matched) {
+    if (!feedback) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["feedback"],
-        message: "matched=false must not include annotation feedback",
+        message: "matched=true requires positive annotation feedback",
       })
+      return
     }
-  })
-  .transform((value) => {
-    const messageIndex = value.messageIndex
-    return {
-      matched: value.matched,
-      ...(value.matched && value.feedback ? { feedback: value.feedback.trim() } : {}),
-      ...(value.matched && isValidMessageIndex(messageIndex) ? { messageIndex } : {}),
-    }
-  })
+  } else if (feedback) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["feedback"],
+      message: "matched=false must not include annotation feedback",
+    })
+  }
+})
 
 const FLAGGER_OUTPUT_CONTRACT = `
 Structured output contract:
 - Set matched=false when the trace does not belong to this flagger; in that case feedback must be null or omitted.
 - Set matched=true only when the trace belongs to this flagger; in that case feedback is required.
 - For matched=true, feedback must be the final human-readable annotation: one or two short sentences describing the issue and concrete evidence.
-- Include messageIndex only when one transcript line is clearly the best evidence; it must be a non-negative integer no larger than ${FLAGGER_MESSAGE_INDEX_MAX}.
+- Include messageIndex only when one transcript line is clearly the best evidence. messageIndex must be exactly one quoted integer string like "0" or "12"; never output it as a JSON number, decimal, exponent, comma-separated list, range, or unquoted value.
 `.trim()
 
 // Whether a strategy classifies only the evaluated agent's own assistant
@@ -557,10 +549,22 @@ const buildAnnotationReviewPrompt = (
   ].join("\n")
 }
 
+const parseMessageIndex = (value: string | undefined): number | undefined => {
+  if (value === undefined || !/^\d+$/.test(value)) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return isValidMessageIndex(parsed) ? parsed : undefined
+}
+
 const parseFlaggerOutput = (input: unknown): RunFlaggerResult => {
   const parsed = flaggerOutputSchema.safeParse(input)
   if (!parsed.success) return { matched: false }
-  return parsed.data
+
+  const messageIndex = parseMessageIndex(parsed.data.messageIndex)
+  return {
+    matched: parsed.data.matched,
+    ...(parsed.data.matched && parsed.data.feedback ? { feedback: parsed.data.feedback.trim() } : {}),
+    ...(parsed.data.matched && messageIndex !== undefined ? { messageIndex } : {}),
+  }
 }
 
 const loadTraceDetail = (input: RunFlaggerInput) =>
@@ -574,14 +578,14 @@ const loadTraceDetail = (input: RunFlaggerInput) =>
     })
   })
 
-// The Vercel AI SDK raises a `NoObjectGeneratedError` (name `AI_NoObjectGeneratedError`)
-// when the model returns output that does not match the requested schema. The flagger
-// treats this as a "no match" signal instead of propagating the failure — the model
-// effectively failed to classify, which for a triage flagger is indistinguishable
-// from matched=false.
+// The Vercel AI SDK raises `NoObjectGeneratedError` / `NoOutputGeneratedError`
+// when the model returns output that does not materialize as the requested schema.
+// The flagger treats this as a "no match" signal instead of propagating the failure
+// — the model effectively failed to classify, which for a triage flagger is
+// indistinguishable from matched=false.
 const isSchemaMismatchCause = (cause: unknown): boolean => {
   if (!(cause instanceof Error)) return false
-  if (cause.name === "AI_NoObjectGeneratedError") return true
+  if (cause.name === "AI_NoObjectGeneratedError" || cause.name === "AI_NoOutputGeneratedError") return true
   return typeof cause.message === "string" && cause.message.includes("response did not match schema")
 }
 
@@ -627,7 +631,7 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
       maxTokens: FLAGGER_MAX_TOKENS,
       system: classificationSystemPrompt,
       prompt: classificationPrompt,
-      schema: baseFlaggerOutputSchema,
+      schema: providerFlaggerOutputSchema,
       telemetry: {
         spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
         // If the trace we are classifying is itself flagger-generated, mark this


### PR DESCRIPTION
## what changed

Flagger classifier structured output now asks providers to return `messageIndex` as a quoted integer string instead of a JSON number. The domain parser converts valid quoted integer strings back to numeric message indexes and drops invalid or out-of-range values. This keeps the annotation message id while avoiding Claude/Bedrock runaway decimal literals that prevented the AI SDK from materializing structured output.

The classifier also treats AI SDK `NoOutputGeneratedError` the same way as schema mismatch failures: the flagger recovers to `{ matched: false }` instead of failing the classification job.

## regression coverage

The malformed JSON regression now replays the captured classifier calls from the Latitude dataset directly. Each row extracts the classifier system/user prompts, identifies the flagger slug from the system prompt, patches in the new `messageIndex` contract, and verifies the live model returns structured output without malformed-output failures.

## validation

- `pnpm --filter @domain/flaggers check`
- `pnpm --filter @domain/flaggers typecheck`
- `pnpm --filter @domain/flaggers test -- src/use-cases/regression/malformed-json-output-regression.test.ts src/use-cases/run-flagger.test.ts`
- `RUN_FLAGGER_REGRESSION=true pnpm exec vitest run src/use-cases/regression/malformed-json-output-regression.test.ts --passWithNoTests`