### PR TITLE
feat(command-palette): org-wide search across all projects

### DIFF
--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -19,7 +19,7 @@ import { useIssueSearchCommands } from "./commands/use-issue-search-commands.ts"
 import { useMonitorSearchCommands } from "./commands/use-monitor-search-commands.ts"
 import { useNavigationCommands } from "./commands/use-navigation-commands.ts"
 import { useProjectCommands } from "./commands/use-project-commands.tsx"
-import { useProjectSearchCommands } from "./commands/use-project-search-commands.ts"
+import { useProjectSearchCommands } from "./commands/use-project-search-commands.tsx"
 import { COMMAND_SECTION_LABELS, COMMAND_SECTION_ORDER, type PaletteCommand, type ParentCommand } from "./types.ts"
 
 /**
@@ -235,7 +235,7 @@ export function CommandPalette() {
                 {command.leading ?? <Icon icon={command.icon} size="sm" color="foregroundMuted" />}
                 <span className="flex min-w-0 flex-1 items-center gap-2">
                   <Text.H5 ellipsis noWrap>
-                    {command.title}
+                    {command.titleNode ?? command.title}
                   </Text.H5>
                   {command.subtitle ? (
                     <Text.H6 color="foregroundMuted" ellipsis noWrap>

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -100,8 +100,9 @@ export function CommandPalette() {
     // Contextual commands (contributed by the current view) render first, grouped by sub-heading.
     const contextGroups = buildContextGroups(registeredCommands.filter(matches))
 
-    // In-project search results. Issues are already curated by the hook (semantic + substring),
-    // so they render as-is; datasets/saved searches are full project lists we filter here.
+    // Org-wide search results (every project in the organization, each row tagged with its
+    // project). Issues are already curated and ranked by the hook (lexical + semantic), so they
+    // render as-is; datasets/saved searches/monitors get a secondary client-side token filter.
     const entityGroups: CommandGroupView[] = []
     if (issueResults.length > 0) entityGroups.push({ key: "issues", label: "Issues", commands: issueResults })
     const monitors = monitorResults.filter(matches)

--- a/apps/web/src/components/command-palette/commands/use-current-project.ts
+++ b/apps/web/src/components/command-palette/commands/use-current-project.ts
@@ -5,6 +5,7 @@ const PROJECT_ROUTE_ID = "/_authenticated/projects/$projectSlug"
 interface CurrentProject {
   readonly id: string
   readonly slug: string
+  readonly name: string
 }
 
 /**

--- a/apps/web/src/components/command-palette/commands/use-issue-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-issue-search-commands.ts
@@ -5,6 +5,7 @@ import { useIssuesOrgSearch } from "../../../domains/issues/issues.collection.ts
 import type { OrgIssueSearchRecord } from "../../../domains/issues/issues.functions.ts"
 import { useDebounce } from "../../../lib/hooks/useDebounce.ts"
 import type { PaletteCommand } from "../types.ts"
+import { useCurrentProject } from "./use-current-project.ts"
 
 const RESULT_LIMIT = 10
 const SEMANTIC_DEBOUNCE_MS = 250
@@ -25,18 +26,24 @@ export function useIssueSearchCommands(query: string): {
   readonly isLoading: boolean
 } {
   const navigate = useNavigate()
+  const project = useCurrentProject()
 
   const liveQuery = query.trim()
   const [debouncedQuery, setDebouncedQuery] = useState("")
   useDebounce(() => setDebouncedQuery(query.trim()), SEMANTIC_DEBOUNCE_MS, [query])
 
   // Lexical tier — instant, fires on every keystroke.
-  const { data: lexicalIssues } = useIssuesOrgSearch(liveQuery, { semantic: false, enabled: liveQuery.length > 0 })
+  const { data: lexicalIssues } = useIssuesOrgSearch(liveQuery, {
+    semantic: false,
+    enabled: liveQuery.length > 0,
+    preferProjectId: project?.id,
+  })
 
   // Semantic tier — debounced; embeds the query server-side.
   const { data: semanticIssues, isLoading: semanticLoading } = useIssuesOrgSearch(debouncedQuery, {
     semantic: true,
     enabled: debouncedQuery.length > 0,
+    preferProjectId: project?.id,
   })
 
   const commands = useMemo<readonly PaletteCommand[]>(() => {

--- a/apps/web/src/components/command-palette/commands/use-issue-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-issue-search-commands.ts
@@ -1,89 +1,69 @@
 import { useNavigate } from "@tanstack/react-router"
 import { ShieldAlertIcon } from "lucide-react"
 import { useMemo, useState } from "react"
-import { useIssues } from "../../../domains/issues/issues.collection.ts"
-import type { IssueRecord } from "../../../domains/issues/issues.functions.ts"
+import { useIssuesOrgSearch } from "../../../domains/issues/issues.collection.ts"
+import type { OrgIssueSearchRecord } from "../../../domains/issues/issues.functions.ts"
 import { useDebounce } from "../../../lib/hooks/useDebounce.ts"
 import type { PaletteCommand } from "../types.ts"
-import { useCurrentProject } from "./use-current-project.ts"
 
-const RESULT_LIMIT = 8
-const SEMANTIC_LIMIT = 6
-// Pool of recent issues kept in cache for the instant title-substring fallback.
-const RECENT_POOL_LIMIT = 50
+const RESULT_LIMIT = 10
 const SEMANTIC_DEBOUNCE_MS = 250
 
 /**
- * Issue search results for the current project, combining two strategies:
+ * Org-wide issue search for the palette, across every project in the organization, combining two
+ * tiers from {@link useIssuesOrgSearch}:
  *
- * - **Substring (instant, client-side):** title matches over a cached pool of the most
- *   recent issues. Works offline / without the embedding backend, so obvious matches like
- *   "json" → "JSON output truncated…" always surface.
- * - **Semantic (debounced, server-side):** the same `useIssues` vector search the Issues
- *   page uses, which finds related issues whose titles don't literally contain the query
- *   (requires the embedding pipeline to be available).
+ * - **Lexical (instant):** GIN-backed full-text + name-substring match. Fires on every keystroke.
+ * - **Semantic (debounced):** vector relevance, surfacing related issues whose titles don't
+ *   literally contain the query (requires the embedding pipeline).
  *
- * Substring hits rank first (they're the obvious matches), then semantic hits not already
- * shown. Results bypass the palette's client filter and selecting one opens the issue drawer.
+ * Lexical hits rank first, then semantic hits not already shown (dedupe by id). Each result shows
+ * its owning project (plus current states) and selecting one opens that project's issue drawer.
  */
 export function useIssueSearchCommands(query: string): {
   readonly commands: readonly PaletteCommand[]
   readonly isLoading: boolean
 } {
   const navigate = useNavigate()
-  const project = useCurrentProject()
 
   const liveQuery = query.trim()
   const [debouncedQuery, setDebouncedQuery] = useState("")
   useDebounce(() => setDebouncedQuery(query.trim()), SEMANTIC_DEBOUNCE_MS, [query])
 
-  const inProjectSearch = project !== null && liveQuery.length > 0
-  const semanticEnabled = project !== null && debouncedQuery.length > 0
+  // Lexical tier — instant, fires on every keystroke.
+  const { data: lexicalIssues } = useIssuesOrgSearch(liveQuery, { semantic: false, enabled: liveQuery.length > 0 })
 
-  // Server-side semantic search (debounced).
-  const { data: semanticIssues, isLoading: semanticLoading } = useIssues({
-    projectId: project?.id ?? "",
-    searchQuery: debouncedQuery,
-    limit: SEMANTIC_LIMIT,
-    enabled: semanticEnabled,
-  })
-
-  // Recent-issues pool for the substring fallback — no searchQuery, so it's fetched once per
-  // project and reused for every keystroke.
-  const { data: recentIssues } = useIssues({
-    projectId: project?.id ?? "",
-    limit: RECENT_POOL_LIMIT,
-    enabled: inProjectSearch,
+  // Semantic tier — debounced; embeds the query server-side.
+  const { data: semanticIssues, isLoading: semanticLoading } = useIssuesOrgSearch(debouncedQuery, {
+    semantic: true,
+    enabled: debouncedQuery.length > 0,
   })
 
   const commands = useMemo<readonly PaletteCommand[]>(() => {
-    if (!project || liveQuery.length === 0) return []
+    if (liveQuery.length === 0) return []
 
-    const tokens = liveQuery.toLowerCase().split(/\s+/)
-    const substringMatches = recentIssues.filter((issue) => {
-      const name = issue.name.toLowerCase()
-      return tokens.every((token) => name.includes(token))
-    })
-
-    // Substring matches first, then semantic matches not already shown; dedupe by id.
+    // Lexical matches first, then semantic matches not already shown; dedupe by id.
     const seen = new Set<string>()
-    const merged: IssueRecord[] = []
-    for (const issue of [...substringMatches, ...semanticIssues]) {
+    const merged: OrgIssueSearchRecord[] = []
+    for (const issue of [...lexicalIssues, ...semanticIssues]) {
       if (seen.has(issue.id)) continue
       seen.add(issue.id)
       merged.push(issue)
     }
 
-    return merged.slice(0, RESULT_LIMIT).map((issue) => ({
-      id: `issue-result:${issue.id}`,
-      title: issue.name,
-      icon: ShieldAlertIcon,
-      section: "search",
-      ...(issue.states.length > 0 ? { subtitle: issue.states.join(", ") } : {}),
-      keywords: issue.name,
-      perform: () => navigate({ to: `/projects/${project.slug}/issues`, search: { issueId: issue.id } }),
-    }))
-  }, [project, liveQuery, recentIssues, semanticIssues, navigate])
+    return merged.slice(0, RESULT_LIMIT).map((issue): PaletteCommand => {
+      const subtitle = issue.states.length > 0 ? `${issue.projectName} · ${issue.states.join(", ")}` : issue.projectName
+      return {
+        id: `issue-result:${issue.id}`,
+        title: issue.name,
+        icon: ShieldAlertIcon,
+        section: "search",
+        subtitle,
+        keywords: `${issue.name} ${issue.projectName}`,
+        perform: () => navigate({ to: `/projects/${issue.projectSlug}/issues`, search: { issueId: issue.id } }),
+      }
+    })
+  }, [liveQuery, lexicalIssues, semanticIssues, navigate])
 
-  return { commands, isLoading: semanticEnabled && semanticLoading }
+  return { commands, isLoading: debouncedQuery.length > 0 && semanticLoading }
 }

--- a/apps/web/src/components/command-palette/commands/use-monitor-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-monitor-search-commands.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { useHasFeatureFlag } from "../../../domains/feature-flags/feature-flags.collection.ts"
 import { useMonitorsSearch } from "../../../domains/monitors/monitors.collection.ts"
 import type { PaletteCommand } from "../types.ts"
+import { useCurrentProject } from "./use-current-project.ts"
 
 /**
  * Monitor search results across every project in the organization, each tagged with its owning
@@ -15,10 +16,11 @@ import type { PaletteCommand } from "../types.ts"
 export function useMonitorSearchCommands(query: string): readonly PaletteCommand[] {
   const navigate = useNavigate()
   const monitorsEnabled = useHasFeatureFlag("monitors")
+  const project = useCurrentProject()
 
   const active = monitorsEnabled && query.trim().length > 0
 
-  const { data: monitors } = useMonitorsSearch(query, { enabled: active })
+  const { data: monitors } = useMonitorsSearch(query, { enabled: active, preferProjectId: project?.id })
 
   return useMemo<readonly PaletteCommand[]>(() => {
     if (!active) return []

--- a/apps/web/src/components/command-palette/commands/use-monitor-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-monitor-search-commands.ts
@@ -2,45 +2,39 @@ import { useNavigate } from "@tanstack/react-router"
 import { BellRingIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useHasFeatureFlag } from "../../../domains/feature-flags/feature-flags.collection.ts"
-import { useMonitors } from "../../../domains/monitors/monitors.collection.ts"
+import { useMonitorsSearch } from "../../../domains/monitors/monitors.collection.ts"
 import type { PaletteCommand } from "../types.ts"
-import { useCurrentProject } from "./use-current-project.ts"
-
-const MONITOR_SEARCH_LIMIT = 50
 
 /**
- * Monitor search results for the current project. Gated behind the `monitors` feature flag —
- * mirroring the flag-gated Monitors page and sidebar entry — so monitors are neither fetched
- * nor listed when the flag is off. Results are the project's monitors (fetched only while
- * searching) filtered client-side by the palette; selecting one opens the monitor drawer via
- * the `monitorSlug` param. A muted/system monitor is labelled in its subtitle.
+ * Monitor search results across every project in the organization, each tagged with its owning
+ * project. Gated behind the `monitors` feature flag — mirroring the flag-gated Monitors page and
+ * sidebar entry — so monitors are neither fetched nor listed when the flag is off. Monitors are
+ * fetched only while searching; selecting one opens that project's Monitors page with the monitor
+ * drawer (`monitorSlug`). The subtitle shows the project name, with a muted/system label appended.
  */
 export function useMonitorSearchCommands(query: string): readonly PaletteCommand[] {
   const navigate = useNavigate()
-  const project = useCurrentProject()
   const monitorsEnabled = useHasFeatureFlag("monitors")
 
-  const active = monitorsEnabled && project !== null && query.trim().length > 0
+  const active = monitorsEnabled && query.trim().length > 0
 
-  const { monitors } = useMonitors({
-    projectId: project?.id ?? "",
-    limit: MONITOR_SEARCH_LIMIT,
-    enabled: active,
-  })
+  const { data: monitors } = useMonitorsSearch(query, { enabled: active })
 
   return useMemo<readonly PaletteCommand[]>(() => {
-    if (!active || !project) return []
+    if (!active) return []
     return monitors.map((monitor): PaletteCommand => {
-      const subtitle = monitor.mutedAt ? "Muted" : monitor.system ? "System" : undefined
+      const status = monitor.mutedAt ? "Muted" : monitor.system ? "System" : undefined
+      const subtitle = status ? `${monitor.projectName} · ${status}` : monitor.projectName
       return {
         id: `monitor-result:${monitor.id}`,
         title: monitor.name,
         icon: BellRingIcon,
         section: "search",
-        ...(subtitle ? { subtitle } : {}),
-        keywords: monitor.name,
-        perform: () => navigate({ to: `/projects/${project.slug}/monitors`, search: { monitorSlug: monitor.slug } }),
+        subtitle,
+        keywords: `${monitor.name} ${monitor.projectName}`,
+        perform: () =>
+          navigate({ to: `/projects/${monitor.projectSlug}/monitors`, search: { monitorSlug: monitor.slug } }),
       }
     })
-  }, [active, project, monitors, navigate])
+  }, [active, monitors, navigate])
 }

--- a/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
@@ -2,7 +2,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { BookmarkIcon, DatabaseIcon, SearchIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useDatasetsSearch } from "../../../domains/datasets/datasets.collection.ts"
-import { useSavedSearchesList } from "../../../domains/saved-searches/saved-searches.collection.ts"
+import { useSavedSearchesSearch } from "../../../domains/saved-searches/saved-searches.collection.ts"
 import type { PaletteCommand } from "../types.ts"
 import { useCurrentProject } from "./use-current-project.ts"
 
@@ -16,11 +16,11 @@ interface ProjectSearchCommands {
 const EMPTY: ProjectSearchCommands = { datasets: [], savedSearches: [], tracesFallback: [] }
 
 /**
- * Entity results for the palette. Datasets are searched org-wide (across every project, each
- * result tagged with its owning project) so they surface regardless of which project — if any —
- * the user is currently viewing. Saved searches and the "Search traces for …" fallback remain
- * project-scoped: they navigate into the current project's Search page and so only render while
- * inside a project. Lists are only fetched while the user is actually searching.
+ * Entity results for the palette. Datasets and saved searches are searched org-wide (across every
+ * project, each result tagged with its owning project) so they surface regardless of which
+ * project — if any — the user is currently viewing, and selecting one navigates into that result's
+ * project. The "Search traces for …" fallback stays project-scoped: it opens the current project's
+ * Search page and so only renders while inside a project. Lists are only fetched while searching.
  */
 export function useProjectSearchCommands(query: string): ProjectSearchCommands {
   const navigate = useNavigate()
@@ -28,10 +28,9 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
 
   const trimmed = query.trim()
   const hasQuery = trimmed.length > 0
-  const inProject = project !== null && hasQuery
 
   const { data: datasets } = useDatasetsSearch(trimmed, { enabled: hasQuery })
-  const { data: savedSearches } = useSavedSearchesList(project?.id ?? "", { enabled: inProject })
+  const { data: savedSearches } = useSavedSearchesSearch(trimmed, { enabled: hasQuery })
 
   return useMemo<ProjectSearchCommands>(() => {
     if (!hasQuery) return EMPTY
@@ -48,18 +47,17 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
       }),
     )
 
-    const savedSearchCommands = project
-      ? savedSearches.map(
-          (saved): PaletteCommand => ({
-            id: `saved-search-result:${saved.id}`,
-            title: saved.name,
-            icon: BookmarkIcon,
-            section: "search",
-            keywords: saved.name,
-            perform: () => navigate({ to: `/projects/${project.slug}/search`, search: { savedSearch: saved.slug } }),
-          }),
-        )
-      : []
+    const savedSearchCommands = savedSearches.map(
+      (saved): PaletteCommand => ({
+        id: `saved-search-result:${saved.id}`,
+        title: saved.name,
+        icon: BookmarkIcon,
+        section: "search",
+        subtitle: saved.projectName,
+        keywords: `${saved.name} ${saved.projectName}`,
+        perform: () => navigate({ to: `/projects/${saved.projectSlug}/search`, search: { savedSearch: saved.slug } }),
+      }),
+    )
 
     const tracesFallback: readonly PaletteCommand[] = project
       ? [

--- a/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from "@tanstack/react-router"
 import { BookmarkIcon, DatabaseIcon, SearchIcon } from "lucide-react"
 import { useMemo } from "react"
-import { useDatasetsList } from "../../../domains/datasets/datasets.collection.ts"
+import { useDatasetsSearch } from "../../../domains/datasets/datasets.collection.ts"
 import { useSavedSearchesList } from "../../../domains/saved-searches/saved-searches.collection.ts"
 import type { PaletteCommand } from "../types.ts"
 import { useCurrentProject } from "./use-current-project.ts"
@@ -16,24 +16,25 @@ interface ProjectSearchCommands {
 const EMPTY: ProjectSearchCommands = { datasets: [], savedSearches: [], tracesFallback: [] }
 
 /**
- * In-project entity results for the palette: datasets and saved searches (small, eagerly
- * loaded lists filtered client-side by cmdk) plus a "Search traces for …" fallback that
- * opens the Search page with the query prefilled. Everything is gated on being inside a
- * project with a non-empty query, so the lists are only fetched while the user is searching.
+ * Entity results for the palette. Datasets are searched org-wide (across every project, each
+ * result tagged with its owning project) so they surface regardless of which project — if any —
+ * the user is currently viewing. Saved searches and the "Search traces for …" fallback remain
+ * project-scoped: they navigate into the current project's Search page and so only render while
+ * inside a project. Lists are only fetched while the user is actually searching.
  */
 export function useProjectSearchCommands(query: string): ProjectSearchCommands {
   const navigate = useNavigate()
   const project = useCurrentProject()
 
   const trimmed = query.trim()
-  const active = project !== null && trimmed.length > 0
+  const hasQuery = trimmed.length > 0
+  const inProject = project !== null && hasQuery
 
-  const { data: datasets } = useDatasetsList(project?.id ?? "", { enabled: active })
-  const { data: savedSearches } = useSavedSearchesList(project?.id ?? "", { enabled: active })
+  const { data: datasets } = useDatasetsSearch(trimmed, { enabled: hasQuery })
+  const { data: savedSearches } = useSavedSearchesList(project?.id ?? "", { enabled: inProject })
 
   return useMemo<ProjectSearchCommands>(() => {
-    if (!project || trimmed.length === 0) return EMPTY
-    const projectSlug = project.slug
+    if (!hasQuery) return EMPTY
 
     const datasetCommands = datasets.map(
       (dataset): PaletteCommand => ({
@@ -41,33 +42,38 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
         title: dataset.name,
         icon: DatabaseIcon,
         section: "search",
-        keywords: `${dataset.name} ${dataset.slug}`,
-        perform: () => navigate({ to: `/projects/${projectSlug}/datasets/${dataset.id}` }),
+        subtitle: dataset.projectName,
+        keywords: `${dataset.name} ${dataset.slug} ${dataset.projectName}`,
+        perform: () => navigate({ to: `/projects/${dataset.projectSlug}/datasets/${dataset.id}` }),
       }),
     )
 
-    const savedSearchCommands = savedSearches.map(
-      (saved): PaletteCommand => ({
-        id: `saved-search-result:${saved.id}`,
-        title: saved.name,
-        icon: BookmarkIcon,
-        section: "search",
-        keywords: saved.name,
-        perform: () => navigate({ to: `/projects/${projectSlug}/search`, search: { savedSearch: saved.slug } }),
-      }),
-    )
+    const savedSearchCommands = project
+      ? savedSearches.map(
+          (saved): PaletteCommand => ({
+            id: `saved-search-result:${saved.id}`,
+            title: saved.name,
+            icon: BookmarkIcon,
+            section: "search",
+            keywords: saved.name,
+            perform: () => navigate({ to: `/projects/${project.slug}/search`, search: { savedSearch: saved.slug } }),
+          }),
+        )
+      : []
 
-    const tracesFallback: readonly PaletteCommand[] = [
-      {
-        id: "search-traces",
-        title: `Search traces for "${trimmed}"`,
-        icon: SearchIcon,
-        section: "search",
-        keywords: "search traces",
-        perform: () => navigate({ to: `/projects/${projectSlug}/search`, search: { q: trimmed } }),
-      },
-    ]
+    const tracesFallback: readonly PaletteCommand[] = project
+      ? [
+          {
+            id: "search-traces",
+            title: `Search traces for "${trimmed}"`,
+            icon: SearchIcon,
+            section: "search",
+            keywords: "search traces",
+            perform: () => navigate({ to: `/projects/${project.slug}/search`, search: { q: trimmed } }),
+          },
+        ]
+      : []
 
     return { datasets: datasetCommands, savedSearches: savedSearchCommands, tracesFallback }
-  }, [project, datasets, savedSearches, trimmed, navigate])
+  }, [project, datasets, savedSearches, trimmed, hasQuery, navigate])
 }

--- a/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
+++ b/apps/web/src/components/command-palette/commands/use-project-search-commands.ts
@@ -9,7 +9,7 @@ import { useCurrentProject } from "./use-current-project.ts"
 interface ProjectSearchCommands {
   readonly datasets: readonly PaletteCommand[]
   readonly savedSearches: readonly PaletteCommand[]
-  /** A single "Search traces for …" action that hands the query off to the Search page. */
+  /** A single "Search traces for … in <project>" action that hands the query off to the Search page. */
   readonly tracesFallback: readonly PaletteCommand[]
 }
 
@@ -19,8 +19,9 @@ const EMPTY: ProjectSearchCommands = { datasets: [], savedSearches: [], tracesFa
  * Entity results for the palette. Datasets and saved searches are searched org-wide (across every
  * project, each result tagged with its owning project) so they surface regardless of which
  * project — if any — the user is currently viewing, and selecting one navigates into that result's
- * project. The "Search traces for …" fallback stays project-scoped: it opens the current project's
- * Search page and so only renders while inside a project. Lists are only fetched while searching.
+ * project. The "Search traces for … in <project>" fallback stays project-scoped: it opens the
+ * current project's Search page (and names it, so the narrower scope is explicit), so it only
+ * renders while inside a project. Lists are only fetched while searching.
  */
 export function useProjectSearchCommands(query: string): ProjectSearchCommands {
   const navigate = useNavigate()
@@ -63,7 +64,7 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
       ? [
           {
             id: "search-traces",
-            title: `Search traces for "${trimmed}"`,
+            title: `Search traces for "${trimmed}" in ${project.name}`,
             icon: SearchIcon,
             section: "search",
             keywords: "search traces",

--- a/apps/web/src/components/command-palette/commands/use-project-search-commands.tsx
+++ b/apps/web/src/components/command-palette/commands/use-project-search-commands.tsx
@@ -30,8 +30,8 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
   const trimmed = query.trim()
   const hasQuery = trimmed.length > 0
 
-  const { data: datasets } = useDatasetsSearch(trimmed, { enabled: hasQuery })
-  const { data: savedSearches } = useSavedSearchesSearch(trimmed, { enabled: hasQuery })
+  const { data: datasets } = useDatasetsSearch(trimmed, { enabled: hasQuery, preferProjectId: project?.id })
+  const { data: savedSearches } = useSavedSearchesSearch(trimmed, { enabled: hasQuery, preferProjectId: project?.id })
 
   return useMemo<ProjectSearchCommands>(() => {
     if (!hasQuery) return EMPTY

--- a/apps/web/src/components/command-palette/commands/use-project-search-commands.tsx
+++ b/apps/web/src/components/command-palette/commands/use-project-search-commands.tsx
@@ -64,7 +64,18 @@ export function useProjectSearchCommands(query: string): ProjectSearchCommands {
       ? [
           {
             id: "search-traces",
+            // Plain-text title kept for the matcher / a11y; `titleNode` is what renders. The
+            // scaffolding ("Search traces for" / "in") is muted while the two dynamic values — the
+            // query and the destination project — are emphasized, so they read first.
             title: `Search traces for "${trimmed}" in ${project.name}`,
+            titleNode: (
+              <span className="truncate">
+                <span className="text-muted-foreground">Search traces for </span>
+                <span className="font-medium text-foreground">"{trimmed}"</span>
+                <span className="text-muted-foreground"> in </span>
+                <span className="font-medium text-foreground">{project.name}</span>
+              </span>
+            ),
             icon: SearchIcon,
             section: "search",
             keywords: "search traces",

--- a/apps/web/src/components/command-palette/types.ts
+++ b/apps/web/src/components/command-palette/types.ts
@@ -11,6 +11,12 @@ interface BasePaletteCommand {
   /** Globally unique id (also used as cmdk's item value). */
   readonly id: string
   readonly title: string
+  /**
+   * Optional rich rendering of the title. When set, this is rendered instead of the plain `title`
+   * string (e.g. to emphasize a query and mute surrounding scaffolding). `title` is still required
+   * — it remains the value used by the text matcher and any plain-text contexts.
+   */
+  readonly titleNode?: ReactNode
   readonly icon: LucideIcon
   readonly section: CommandSection
   /** Sub-heading for contextual commands (e.g. "Issue", "Trace"). */

--- a/apps/web/src/domains/datasets/datasets.collection.ts
+++ b/apps/web/src/domains/datasets/datasets.collection.ts
@@ -2,8 +2,10 @@ import type { DatasetListSortBy } from "@domain/datasets"
 import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
 import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { useDeferredValue, useMemo } from "react"
-import type { DatasetRecord, DatasetRowRecord } from "./datasets.functions.ts"
-import { listDatasetsByProject, listRowsQuery } from "./datasets.functions.ts"
+import type { DatasetRecord, DatasetRowRecord, DatasetSearchRecord } from "./datasets.functions.ts"
+import { listDatasetsByProject, listRowsQuery, searchDatasetsOrgWide } from "./datasets.functions.ts"
+
+const ORG_SEARCH_LIMIT = 8
 
 const BATCH_SIZE = 50
 const ROWS_BATCH_SIZE = 50
@@ -109,6 +111,22 @@ export function useDatasetRowsInfiniteScroll({
   const total = paginatedData?.pages[0]?.total
 
   return { data, isLoading, infiniteScroll, total }
+}
+
+/**
+ * Org-wide dataset search for the Command Palette. Returns matching datasets across every project
+ * in the organization (each carrying its owning project's slug/name), not just the current one.
+ */
+export function useDatasetsSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+  const trimmed = searchQuery.trim()
+  const { data, isLoading } = useQuery({
+    queryKey: ["datasets", "orgSearch", trimmed],
+    queryFn: (): Promise<readonly DatasetSearchRecord[]> =>
+      searchDatasetsOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+    staleTime: 30_000,
+    enabled: enabled && trimmed.length > 0,
+  })
+  return { data: data ?? [], isLoading }
 }
 
 export function useDatasetsList(projectId: string, { enabled = true }: { enabled?: boolean } = {}) {

--- a/apps/web/src/domains/datasets/datasets.collection.ts
+++ b/apps/web/src/domains/datasets/datasets.collection.ts
@@ -116,13 +116,23 @@ export function useDatasetRowsInfiniteScroll({
 /**
  * Org-wide dataset search for the Command Palette. Returns matching datasets across every project
  * in the organization (each carrying its owning project's slug/name), not just the current one.
+ * `preferProjectId` (the current project, when inside one) ranks that project's datasets first.
  */
-export function useDatasetsSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+export function useDatasetsSearch(
+  searchQuery: string,
+  { enabled = true, preferProjectId }: { enabled?: boolean; preferProjectId?: string | undefined } = {},
+) {
   const trimmed = searchQuery.trim()
   const { data, isLoading } = useQuery({
-    queryKey: ["datasets", "orgSearch", trimmed],
+    queryKey: ["datasets", "orgSearch", trimmed, preferProjectId ?? null],
     queryFn: (): Promise<readonly DatasetSearchRecord[]> =>
-      searchDatasetsOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+      searchDatasetsOrgWide({
+        data: {
+          searchQuery: trimmed,
+          limit: ORG_SEARCH_LIMIT,
+          ...(preferProjectId ? { preferProjectId } : {}),
+        },
+      }),
     staleTime: 30_000,
     enabled: enabled && trimmed.length > 0,
   })

--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -14,6 +14,7 @@ import {
   listRows,
   parseDatasetCsv,
   prepareDatasetExportUseCase,
+  searchDatasets,
   type TraceSelection,
   type TraceSource,
   updateDatasetDetails,
@@ -194,6 +195,50 @@ export const listDatasetsByProject = createServerFn({ method: "GET" })
       return { datasets, hasMore: page.hasMore }
     }
     return { datasets, hasMore: page.hasMore, nextCursor: page.nextCursor }
+  })
+
+export interface DatasetSearchRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+}
+
+/**
+ * Org-wide dataset search for the Command Palette. Unlike {@link listDatasetsByProject}, this is
+ * not scoped to a single project — it returns matching datasets across every project in the
+ * caller's organization, each tagged with its owning project's slug/name.
+ */
+export const searchDatasetsOrgWide = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      searchQuery: z.string().max(500).optional(),
+      limit: z.number().int().min(1).max(25).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly DatasetSearchRecord[]> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    const results = await Effect.runPromise(
+      searchDatasets({
+        ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.limit !== undefined ? { limit: data.limit } : {}),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+    )
+
+    return results.map(
+      (r): DatasetSearchRecord => ({
+        id: r.id,
+        projectId: r.projectId,
+        projectSlug: r.projectSlug,
+        projectName: r.projectName,
+        slug: r.slug,
+        name: r.name,
+      }),
+    )
   })
 
 export const getDatasetQuery = createServerFn({ method: "GET" })

--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -215,6 +215,7 @@ export const searchDatasetsOrgWide = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       searchQuery: z.string().max(500).optional(),
+      preferProjectId: z.string().optional(),
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
@@ -225,6 +226,7 @@ export const searchDatasetsOrgWide = createServerFn({ method: "GET" })
     const results = await Effect.runPromise(
       searchDatasets({
         ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
       }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )

--- a/apps/web/src/domains/issues/issues.collection.ts
+++ b/apps/web/src/domains/issues/issues.collection.ts
@@ -215,16 +215,28 @@ const ORG_SEARCH_LIMIT = 10
  * Org-wide issue search for the Command Palette. One tier per call: pass `semantic: false` for the
  * instant lexical tier and `semantic: true` for the debounced semantic tier. Results span every
  * project in the organization, each carrying its owning project's slug/name and derived states.
+ * `preferProjectId` (the current project, when inside one) ranks that project's issues first.
  */
 export function useIssuesOrgSearch(
   searchQuery: string,
-  { semantic = false, enabled = true }: { readonly semantic?: boolean; readonly enabled?: boolean } = {},
+  {
+    semantic = false,
+    enabled = true,
+    preferProjectId,
+  }: { readonly semantic?: boolean; readonly enabled?: boolean; readonly preferProjectId?: string | undefined } = {},
 ) {
   const trimmed = searchQuery.trim()
   const { data, isLoading } = useQuery({
-    queryKey: ["issues", "orgSearch", trimmed, semantic],
+    queryKey: ["issues", "orgSearch", trimmed, semantic, preferProjectId ?? null],
     queryFn: (): Promise<readonly OrgIssueSearchRecord[]> =>
-      searchOrgIssues({ data: { searchQuery: trimmed, semantic, limit: ORG_SEARCH_LIMIT } }),
+      searchOrgIssues({
+        data: {
+          searchQuery: trimmed,
+          semantic,
+          limit: ORG_SEARCH_LIMIT,
+          ...(preferProjectId ? { preferProjectId } : {}),
+        },
+      }),
     staleTime: ISSUES_QUERY_STALE_TIME_MS,
     enabled: enabled && trimmed.length > 0,
   })

--- a/apps/web/src/domains/issues/issues.collection.ts
+++ b/apps/web/src/domains/issues/issues.collection.ts
@@ -9,8 +9,16 @@ import type {
   IssuesListResultRecord,
   IssueTracePageRecord,
   IssueTraceRecord,
+  OrgIssueSearchRecord,
 } from "./issues.functions.ts"
-import { countIssueTraces, getIssue, getIssueDetail, listIssues, listIssueTraces } from "./issues.functions.ts"
+import {
+  countIssueTraces,
+  getIssue,
+  getIssueDetail,
+  listIssues,
+  listIssueTraces,
+  searchOrgIssues,
+} from "./issues.functions.ts"
 
 const queryClient = getQueryClient()
 const DEFAULT_ISSUES_BATCH_SIZE = 50
@@ -199,6 +207,28 @@ export function useIssues(input: {
     isReloading: isPlaceholderData,
     infiniteScroll,
   }
+}
+
+const ORG_SEARCH_LIMIT = 10
+
+/**
+ * Org-wide issue search for the Command Palette. One tier per call: pass `semantic: false` for the
+ * instant lexical tier and `semantic: true` for the debounced semantic tier. Results span every
+ * project in the organization, each carrying its owning project's slug/name and derived states.
+ */
+export function useIssuesOrgSearch(
+  searchQuery: string,
+  { semantic = false, enabled = true }: { readonly semantic?: boolean; readonly enabled?: boolean } = {},
+) {
+  const trimmed = searchQuery.trim()
+  const { data, isLoading } = useQuery({
+    queryKey: ["issues", "orgSearch", trimmed, semantic],
+    queryFn: (): Promise<readonly OrgIssueSearchRecord[]> =>
+      searchOrgIssues({ data: { searchQuery: trimmed, semantic, limit: ORG_SEARCH_LIMIT } }),
+    staleTime: ISSUES_QUERY_STALE_TIME_MS,
+    enabled: enabled && trimmed.length > 0,
+  })
+  return { data: data ?? [], isLoading }
 }
 
 export function useIssueDetail({

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -17,6 +17,8 @@ import {
   type ListIssuesResult,
   listIssuesUseCase,
   listIssueTracesUseCase,
+  type OrgIssueSearchItem,
+  searchOrgIssuesUseCase,
   TAG_AGGREGATION_FALLBACK_DAYS,
 } from "@domain/issues"
 import {
@@ -341,6 +343,71 @@ export const listIssues = createServerFn({ method: "GET" })
     )
 
     return toIssuesListResultRecord(result)
+  })
+
+export interface OrgIssueSearchRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+  readonly states: readonly string[]
+}
+
+const toOrgIssueSearchRecord = (item: OrgIssueSearchItem): OrgIssueSearchRecord => ({
+  id: item.id,
+  projectId: item.projectId,
+  projectSlug: item.projectSlug,
+  projectName: item.projectName,
+  slug: item.slug,
+  name: item.name,
+  states: item.states,
+})
+
+/**
+ * Org-wide issue search for the Command Palette. Unlike {@link listIssues} (a project-scoped
+ * analytics pipeline), this is a lightweight search across every project in the caller's
+ * organization. The lexical tier runs always; the semantic tier runs only when `semantic` is set
+ * (the debounced call), embedding the query first. Each result carries its owning project's
+ * slug/name and derived lifecycle states.
+ */
+export const searchOrgIssues = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      searchQuery: z.string().min(1).max(500),
+      semantic: z.boolean().optional(),
+      limit: z.number().int().min(1).max(25).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly OrgIssueSearchRecord[]> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const pgClient = getPostgresClient()
+    const redisClient = getRedisClient()
+
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const search = data.semantic
+          ? yield* embedIssueSearchQueryUseCase({
+              organizationId,
+              // Org-wide search has no single project; `projectId` is telemetry-only on this
+              // use-case (it does not scope the embedding), so we tag it with the org id.
+              projectId: organizationId,
+              query: data.searchQuery,
+            })
+          : undefined
+
+        return yield* searchOrgIssuesUseCase({
+          organizationId: orgId,
+          query: data.searchQuery,
+          ...(search ? { normalizedEmbedding: search.normalizedEmbedding } : {}),
+          ...(data.limit !== undefined ? { limit: data.limit } : {}),
+        })
+      }).pipe(withPostgres(IssueRepositoryLive, pgClient, orgId), withAi(AIEmbedLive, redisClient), withTracing),
+    )
+
+    return results.map(toOrgIssueSearchRecord)
   })
 
 export const getIssue = createServerFn({ method: "GET" })

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -377,6 +377,7 @@ export const searchOrgIssues = createServerFn({ method: "GET" })
     z.object({
       searchQuery: z.string().min(1).max(500),
       semantic: z.boolean().optional(),
+      preferProjectId: z.string().optional(),
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
@@ -402,6 +403,7 @@ export const searchOrgIssues = createServerFn({ method: "GET" })
           organizationId: orgId,
           query: data.searchQuery,
           ...(search ? { normalizedEmbedding: search.normalizedEmbedding } : {}),
+          ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
         })
       }).pipe(withPostgres(IssueRepositoryLive, pgClient, orgId), withAi(AIEmbedLive, redisClient), withTracing),

--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -100,13 +100,23 @@ export function useMonitors(input: {
 /**
  * Org-wide monitor search for the Command Palette. Returns matching monitors across every project
  * in the organization (each carrying its owning project's slug/name plus system/muted status).
+ * `preferProjectId` (the current project, when inside one) ranks that project's monitors first.
  */
-export function useMonitorsSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+export function useMonitorsSearch(
+  searchQuery: string,
+  { enabled = true, preferProjectId }: { enabled?: boolean; preferProjectId?: string | undefined } = {},
+) {
   const trimmed = searchQuery.trim()
   const { data, isLoading } = useQuery({
-    queryKey: ["monitors", "orgSearch", trimmed],
+    queryKey: ["monitors", "orgSearch", trimmed, preferProjectId ?? null],
     queryFn: (): Promise<readonly MonitorSearchRecord[]> =>
-      searchMonitorsOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+      searchMonitorsOrgWide({
+        data: {
+          searchQuery: trimmed,
+          limit: ORG_SEARCH_LIMIT,
+          ...(preferProjectId ? { preferProjectId } : {}),
+        },
+      }),
     staleTime: MONITORS_QUERY_STALE_TIME_MS,
     enabled: enabled && trimmed.length > 0,
   })

--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -16,7 +16,9 @@ import {
   type MonitorIncidentsCursor,
   type MonitorListRowRecord,
   type MonitorRecord,
+  type MonitorSearchRecord,
   muteMonitor,
+  searchMonitorsOrgWide,
   unmuteMonitor,
   updateMonitor,
   updateMonitorAlert,
@@ -35,6 +37,7 @@ export type { MonitorListRowRecord, MonitorRecord }
 export type { MonitorIncidentRecord }
 
 const DEFAULT_MONITORS_PAGE_SIZE = 50
+const ORG_SEARCH_LIMIT = 8
 const DEFAULT_INCIDENTS_PAGE_SIZE = 50
 const MONITORS_QUERY_STALE_TIME_MS = 30_000
 
@@ -92,6 +95,22 @@ export function useMonitors(input: {
     isReloading: isPlaceholderData,
     infiniteScroll,
   }
+}
+
+/**
+ * Org-wide monitor search for the Command Palette. Returns matching monitors across every project
+ * in the organization (each carrying its owning project's slug/name plus system/muted status).
+ */
+export function useMonitorsSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+  const trimmed = searchQuery.trim()
+  const { data, isLoading } = useQuery({
+    queryKey: ["monitors", "orgSearch", trimmed],
+    queryFn: (): Promise<readonly MonitorSearchRecord[]> =>
+      searchMonitorsOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+    staleTime: MONITORS_QUERY_STALE_TIME_MS,
+    enabled: enabled && trimmed.length > 0,
+  })
+  return { data: data ?? [], isLoading }
 }
 
 /** @public Consumed by the M4 details panel; not yet wired in M2. */

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -205,6 +205,7 @@ export const searchMonitorsOrgWide = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       searchQuery: z.string().max(500).optional(),
+      preferProjectId: z.string().optional(),
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
@@ -215,6 +216,7 @@ export const searchMonitorsOrgWide = createServerFn({ method: "GET" })
     const results = await Effect.runPromise(
       searchMonitorsUseCase({
         ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
       }).pipe(withPostgres(MonitorRepositoryLive, pgClient, OrganizationId(organizationId)), withTracing),
     )

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -14,7 +14,9 @@ import {
   type MonitorAlert,
   type MonitorAlertInput,
   type MonitorLastIncident,
+  type MonitorSearchResult,
   muteMonitorUseCase,
+  searchMonitorsUseCase,
   unmuteMonitorUseCase,
   updateMonitorAlertUseCase,
   updateMonitorUseCase,
@@ -170,6 +172,54 @@ export const listMonitors = createServerFn({ method: "GET" })
 
     const names = await resolveSavedSearchNames(orgId, ProjectId(data.projectId), result.items)
     return toListMonitorsResultRecord(result, names)
+  })
+
+export interface MonitorSearchRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+  readonly system: boolean
+  readonly mutedAt: string | null
+}
+
+const toMonitorSearchRecord = (m: MonitorSearchResult): MonitorSearchRecord => ({
+  id: m.id,
+  projectId: m.projectId,
+  projectSlug: m.projectSlug,
+  projectName: m.projectName,
+  slug: m.slug,
+  name: m.name,
+  system: m.system,
+  mutedAt: m.mutedAt?.toISOString() ?? null,
+})
+
+/**
+ * Org-wide monitor search for the Command Palette. Unlike {@link listMonitors}, this returns
+ * matching monitors across every project in the caller's organization, each tagged with its
+ * owning project's slug/name.
+ */
+export const searchMonitorsOrgWide = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      searchQuery: z.string().max(500).optional(),
+      limit: z.number().int().min(1).max(25).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly MonitorSearchRecord[]> => {
+    const { organizationId } = await requireSession()
+    const pgClient = getPostgresClient()
+
+    const results = await Effect.runPromise(
+      searchMonitorsUseCase({
+        ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.limit !== undefined ? { limit: data.limit } : {}),
+      }).pipe(withPostgres(MonitorRepositoryLive, pgClient, OrganizationId(organizationId)), withTracing),
+    )
+
+    return results.map(toMonitorSearchRecord)
   })
 
 const getMonitorInputSchema = z.object({

--- a/apps/web/src/domains/saved-searches/saved-searches.collection.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.collection.ts
@@ -10,8 +10,12 @@ import {
   getSavedSearchBySlugFn,
   listSavedSearchesByProject,
   type SavedSearchRecord,
+  type SavedSearchSearchRecord,
+  searchSavedSearchesOrgWide,
   updateSavedSearchFn,
 } from "./saved-searches.functions.ts"
+
+const ORG_SEARCH_LIMIT = 8
 
 const listKey = (projectId: string) => ["savedSearches", projectId] as const
 const slugKey = (projectId: string, slug: string) => ["savedSearches", projectId, "slug", slug] as const
@@ -22,6 +26,22 @@ export function useSavedSearchesList(projectId: string, { enabled = true }: { en
     queryFn: () => listSavedSearchesByProject({ data: { projectId } }),
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0,
+  })
+  return { data: data ?? [], isLoading }
+}
+
+/**
+ * Org-wide saved-search search for the Command Palette. Returns matching saved searches across
+ * every project in the organization (each carrying its owning project's slug/name).
+ */
+export function useSavedSearchesSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+  const trimmed = searchQuery.trim()
+  const { data, isLoading } = useQuery({
+    queryKey: ["savedSearches", "orgSearch", trimmed],
+    queryFn: (): Promise<readonly SavedSearchSearchRecord[]> =>
+      searchSavedSearchesOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+    staleTime: 30_000,
+    enabled: enabled && trimmed.length > 0,
   })
   return { data: data ?? [], isLoading }
 }

--- a/apps/web/src/domains/saved-searches/saved-searches.collection.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.collection.ts
@@ -33,13 +33,23 @@ export function useSavedSearchesList(projectId: string, { enabled = true }: { en
 /**
  * Org-wide saved-search search for the Command Palette. Returns matching saved searches across
  * every project in the organization (each carrying its owning project's slug/name).
+ * `preferProjectId` (the current project, when inside one) ranks that project's saved searches first.
  */
-export function useSavedSearchesSearch(searchQuery: string, { enabled = true }: { enabled?: boolean } = {}) {
+export function useSavedSearchesSearch(
+  searchQuery: string,
+  { enabled = true, preferProjectId }: { enabled?: boolean; preferProjectId?: string | undefined } = {},
+) {
   const trimmed = searchQuery.trim()
   const { data, isLoading } = useQuery({
-    queryKey: ["savedSearches", "orgSearch", trimmed],
+    queryKey: ["savedSearches", "orgSearch", trimmed, preferProjectId ?? null],
     queryFn: (): Promise<readonly SavedSearchSearchRecord[]> =>
-      searchSavedSearchesOrgWide({ data: { searchQuery: trimmed, limit: ORG_SEARCH_LIMIT } }),
+      searchSavedSearchesOrgWide({
+        data: {
+          searchQuery: trimmed,
+          limit: ORG_SEARCH_LIMIT,
+          ...(preferProjectId ? { preferProjectId } : {}),
+        },
+      }),
     staleTime: 30_000,
     enabled: enabled && trimmed.length > 0,
   })

--- a/apps/web/src/domains/saved-searches/saved-searches.functions.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.functions.ts
@@ -6,6 +6,7 @@ import {
   SAVED_SEARCH_NAME_MAX_LENGTH,
   SAVED_SEARCH_QUERY_MAX_LENGTH,
   type SavedSearch,
+  searchSavedSearches,
   updateSavedSearch,
 } from "@domain/saved-searches"
 import { filterSetSchema, OrganizationId, ProjectId, SavedSearchId, UserId } from "@domain/shared"
@@ -61,6 +62,50 @@ export const listSavedSearchesByProject = createServerFn({ method: "GET" })
       ),
     )
     return page.items.map(toRecord)
+  })
+
+export interface SavedSearchSearchRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+}
+
+/**
+ * Org-wide saved-search search for the Command Palette. Unlike {@link listSavedSearchesByProject},
+ * this returns matching saved searches across every project in the caller's organization, each
+ * tagged with its owning project's slug/name.
+ */
+export const searchSavedSearchesOrgWide = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      searchQuery: z.string().max(500).optional(),
+      limit: z.number().int().min(1).max(25).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly SavedSearchSearchRecord[]> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    const results = await Effect.runPromise(
+      searchSavedSearches({
+        ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.limit !== undefined ? { limit: data.limit } : {}),
+      }).pipe(withPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId), withTracing),
+    )
+
+    return results.map(
+      (r): SavedSearchSearchRecord => ({
+        id: r.id,
+        projectId: r.projectId,
+        projectSlug: r.projectSlug,
+        projectName: r.projectName,
+        slug: r.slug,
+        name: r.name,
+      }),
+    )
   })
 
 export const getSavedSearchBySlugFn = createServerFn({ method: "GET" })

--- a/apps/web/src/domains/saved-searches/saved-searches.functions.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.functions.ts
@@ -82,6 +82,7 @@ export const searchSavedSearchesOrgWide = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       searchQuery: z.string().max(500).optional(),
+      preferProjectId: z.string().optional(),
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
@@ -92,6 +93,7 @@ export const searchSavedSearchesOrgWide = createServerFn({ method: "GET" })
     const results = await Effect.runPromise(
       searchSavedSearches({
         ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
+        ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
       }).pipe(withPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId), withTracing),
     )

--- a/packages/domain/datasets/src/index.ts
+++ b/packages/domain/datasets/src/index.ts
@@ -25,6 +25,7 @@ export {
   type DatasetListPage,
   type DatasetListSortBy,
   DatasetRepository,
+  type DatasetSearchResult,
 } from "./ports/dataset-repository.ts"
 export { DatasetRowRepository, type DatasetRowRepositoryShape } from "./ports/dataset-row-repository.ts"
 export {
@@ -57,6 +58,7 @@ export {
   prepareDatasetExportUseCase,
 } from "./use-cases/prepare-dataset-export.ts"
 export { renameDataset } from "./use-cases/rename-dataset.ts"
+export { searchDatasets } from "./use-cases/search-datasets.ts"
 export { updateDatasetDetails } from "./use-cases/update-dataset-details.ts"
 export { updateRow } from "./use-cases/update-row.ts"
 export { buildValidRowId } from "./validate-row-id.ts"

--- a/packages/domain/datasets/src/ports/dataset-repository.ts
+++ b/packages/domain/datasets/src/ports/dataset-repository.ts
@@ -69,7 +69,8 @@ export class DatasetRepository extends Context.Service<
     /**
      * Org-wide name search across every project in the organization (RLS-scoped to the caller's
      * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
-     * dataset name; omit it to list the most recent datasets. Soft-deleted datasets and datasets in
+     * dataset name, ordered by match quality (exact > prefix > substring) then most recent; omit it
+     * to list the most recent datasets. Soft-deleted datasets and datasets in
      * soft-deleted projects are excluded.
      */
     searchOrgWide(args: {

--- a/packages/domain/datasets/src/ports/dataset-repository.ts
+++ b/packages/domain/datasets/src/ports/dataset-repository.ts
@@ -71,10 +71,12 @@ export class DatasetRepository extends Context.Service<
      * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
      * dataset name, ordered by match quality (exact > prefix > substring) then most recent; omit it
      * to list the most recent datasets. Soft-deleted datasets and datasets in
-     * soft-deleted projects are excluded.
+     * soft-deleted projects are excluded. When `preferProjectId` is set, datasets in that project
+     * are ranked ahead of the rest (the palette passes the current project so local results lead).
      */
     searchOrgWide(args: {
       readonly searchQuery?: string
+      readonly preferProjectId?: ProjectId
       readonly limit: number
     }): Effect.Effect<readonly DatasetSearchResult[], RepositoryError, SqlClient>
 

--- a/packages/domain/datasets/src/ports/dataset-repository.ts
+++ b/packages/domain/datasets/src/ports/dataset-repository.ts
@@ -24,6 +24,20 @@ export interface DatasetListPage {
   readonly nextCursor?: DatasetListCursor
 }
 
+/**
+ * Lightweight, org-wide dataset projection for the Command Palette search. Carries the owning
+ * project's slug/name so a cross-project result can be displayed and navigated to without a
+ * second lookup. Not the full {@link Dataset} — search only needs identity + display fields.
+ */
+export interface DatasetSearchResult {
+  readonly id: DatasetId
+  readonly projectId: ProjectId
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+}
+
 export class DatasetRepository extends Context.Service<
   DatasetRepository,
   {
@@ -51,6 +65,17 @@ export class DatasetRepository extends Context.Service<
       readonly projectId: ProjectId
       readonly options?: DatasetListOptions
     }): Effect.Effect<DatasetListPage, RepositoryError, SqlClient>
+
+    /**
+     * Org-wide name search across every project in the organization (RLS-scoped to the caller's
+     * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
+     * dataset name; omit it to list the most recent datasets. Soft-deleted datasets and datasets in
+     * soft-deleted projects are excluded.
+     */
+    searchOrgWide(args: {
+      readonly searchQuery?: string
+      readonly limit: number
+    }): Effect.Effect<readonly DatasetSearchResult[], RepositoryError, SqlClient>
 
     existsByNameInProject(args: {
       readonly projectId: ProjectId

--- a/packages/domain/datasets/src/testing/fake-dataset-repository.ts
+++ b/packages/domain/datasets/src/testing/fake-dataset-repository.ts
@@ -145,8 +145,14 @@ export const createFakeDatasetRepository = (
       Effect.sync(() => {
         const q = args.searchQuery?.trim().toLowerCase()
         const matched = [...datasets.values()].filter((d) => !d.deletedAt && (!q || d.name.toLowerCase().includes(q)))
-        // Newest-first, mirroring the live repo's `desc(createdAt), desc(id)` ordering.
-        const sorted = matched.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime() || cmpStrings(b.id, a.id))
+        // Best name match first then newest, mirroring the live repo's `nameMatchScore desc,
+        // createdAt desc, id desc` ordering.
+        const score = (name: string) =>
+          !q ? 1 : name.toLowerCase() === q ? 3 : name.toLowerCase().startsWith(q) ? 2 : 1
+        const sorted = matched.sort(
+          (a, b) =>
+            score(b.name) - score(a.name) || b.createdAt.getTime() - a.createdAt.getTime() || cmpStrings(b.id, a.id),
+        )
         return sorted.slice(0, args.limit).map((d) => ({
           id: d.id,
           projectId: d.projectId,

--- a/packages/domain/datasets/src/testing/fake-dataset-repository.ts
+++ b/packages/domain/datasets/src/testing/fake-dataset-repository.ts
@@ -141,6 +141,22 @@ export const createFakeDatasetRepository = (
         return page
       }),
 
+    searchOrgWide: (args) =>
+      Effect.sync(() => {
+        const q = args.searchQuery?.trim().toLowerCase()
+        const matched = [...datasets.values()].filter((d) => !d.deletedAt && (!q || d.name.toLowerCase().includes(q)))
+        const sorted = matched.sort((a, b) => cmpStrings(a.name, b.name) || cmpStrings(a.id, b.id))
+        return sorted.slice(0, args.limit).map((d) => ({
+          id: d.id,
+          projectId: d.projectId,
+          // Fakes have no `projects` table; synthesize stable project display fields from the id.
+          projectSlug: `project-${d.projectId}`,
+          projectName: `Project ${d.projectId}`,
+          slug: d.slug,
+          name: d.name,
+        }))
+      }),
+
     existsByNameInProject: (args) =>
       Effect.sync(() =>
         [...datasets.values()].some(

--- a/packages/domain/datasets/src/testing/fake-dataset-repository.ts
+++ b/packages/domain/datasets/src/testing/fake-dataset-repository.ts
@@ -145,7 +145,8 @@ export const createFakeDatasetRepository = (
       Effect.sync(() => {
         const q = args.searchQuery?.trim().toLowerCase()
         const matched = [...datasets.values()].filter((d) => !d.deletedAt && (!q || d.name.toLowerCase().includes(q)))
-        const sorted = matched.sort((a, b) => cmpStrings(a.name, b.name) || cmpStrings(a.id, b.id))
+        // Newest-first, mirroring the live repo's `desc(createdAt), desc(id)` ordering.
+        const sorted = matched.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime() || cmpStrings(b.id, a.id))
         return sorted.slice(0, args.limit).map((d) => ({
           id: d.id,
           projectId: d.projectId,

--- a/packages/domain/datasets/src/testing/fake-dataset-repository.ts
+++ b/packages/domain/datasets/src/testing/fake-dataset-repository.ts
@@ -145,13 +145,16 @@ export const createFakeDatasetRepository = (
       Effect.sync(() => {
         const q = args.searchQuery?.trim().toLowerCase()
         const matched = [...datasets.values()].filter((d) => !d.deletedAt && (!q || d.name.toLowerCase().includes(q)))
-        // Best name match first then newest, mirroring the live repo's `nameMatchScore desc,
-        // createdAt desc, id desc` ordering.
+        // Preferred project first, then best name match, then newest — mirroring the live repo.
+        const prefer = (projectId: string) => (args.preferProjectId && projectId === args.preferProjectId ? 1 : 0)
         const score = (name: string) =>
           !q ? 1 : name.toLowerCase() === q ? 3 : name.toLowerCase().startsWith(q) ? 2 : 1
         const sorted = matched.sort(
           (a, b) =>
-            score(b.name) - score(a.name) || b.createdAt.getTime() - a.createdAt.getTime() || cmpStrings(b.id, a.id),
+            prefer(b.projectId) - prefer(a.projectId) ||
+            score(b.name) - score(a.name) ||
+            b.createdAt.getTime() - a.createdAt.getTime() ||
+            cmpStrings(b.id, a.id),
         )
         return sorted.slice(0, args.limit).map((d) => ({
           id: d.id,

--- a/packages/domain/datasets/src/use-cases/search-datasets.test.ts
+++ b/packages/domain/datasets/src/use-cases/search-datasets.test.ts
@@ -1,0 +1,70 @@
+import { DatasetId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Dataset } from "../entities/dataset.ts"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+import { createFakeDatasetRepository } from "../testing/fake-dataset-repository.ts"
+import { searchDatasets } from "./search-datasets.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectA = ProjectId("a".repeat(24))
+const projectB = ProjectId("b".repeat(24))
+
+const inertSqlClient = {
+  organizationId,
+  transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+  query: () => Effect.die("SqlClient.query should not be called"),
+}
+
+const makeDataset = (id: string, projectId: ProjectId, name: string): Dataset => ({
+  id: DatasetId(id.padEnd(24, "0")),
+  organizationId,
+  projectId,
+  slug: name.toLowerCase().replace(/\s+/g, "-"),
+  name,
+  description: null,
+  fileKey: null,
+  currentVersion: 0,
+  latestVersionId: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+})
+
+const run = (seed: readonly Dataset[], args: { readonly searchQuery?: string; readonly limit?: number }) => {
+  const { repository } = createFakeDatasetRepository(seed)
+  return Effect.runPromise(
+    searchDatasets(args).pipe(
+      Effect.provide(
+        Layer.mergeAll(Layer.succeed(DatasetRepository, repository), Layer.succeed(SqlClient, inertSqlClient as never)),
+      ),
+    ),
+  )
+}
+
+describe("searchDatasets", () => {
+  const seed = [
+    makeDataset("d1", projectA, "Customer Reviews"),
+    makeDataset("d2", projectB, "Customer Orders"),
+    makeDataset("d3", projectA, "Unrelated Logs"),
+  ]
+
+  it("returns matching datasets across multiple projects in the org", async () => {
+    const results = await run(seed, { searchQuery: "customer" })
+    expect(results.map((r) => r.name).sort()).toEqual(["Customer Orders", "Customer Reviews"])
+    // spans more than one project
+    expect(new Set(results.map((r) => r.projectId)).size).toBe(2)
+  })
+
+  it("carries owning project display fields", async () => {
+    const results = await run(seed, { searchQuery: "reviews" })
+    expect(results).toHaveLength(1)
+    expect(results[0]?.projectId).toBe(projectA)
+    expect(results[0]?.projectSlug).toContain(projectA)
+    expect(results[0]?.projectName).toContain(projectA)
+  })
+
+  it("respects the limit", async () => {
+    const results = await run(seed, { searchQuery: "customer", limit: 1 })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/packages/domain/datasets/src/use-cases/search-datasets.ts
+++ b/packages/domain/datasets/src/use-cases/search-datasets.ts
@@ -1,3 +1,4 @@
+import type { ProjectId } from "@domain/shared"
 import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 
@@ -6,15 +7,18 @@ const DEFAULT_SEARCH_LIMIT = 8
 /**
  * Org-wide dataset name search for the Command Palette. Delegates to the repository's org-scoped
  * search (RLS-bound to the caller's organization); results span every project in the org and carry
- * their owning project's slug/name.
+ * their owning project's slug/name. `preferProjectId` (the palette's current project, when any)
+ * ranks that project's datasets first.
  */
 export const searchDatasets = Effect.fn("datasets.searchDatasets")(function* (args: {
   readonly searchQuery?: string
+  readonly preferProjectId?: ProjectId
   readonly limit?: number
 }) {
   const repo = yield* DatasetRepository
   return yield* repo.searchOrgWide({
     ...(args.searchQuery !== undefined ? { searchQuery: args.searchQuery } : {}),
+    ...(args.preferProjectId !== undefined ? { preferProjectId: args.preferProjectId } : {}),
     limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
   })
 })

--- a/packages/domain/datasets/src/use-cases/search-datasets.ts
+++ b/packages/domain/datasets/src/use-cases/search-datasets.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+
+const DEFAULT_SEARCH_LIMIT = 8
+
+/**
+ * Org-wide dataset name search for the Command Palette. Delegates to the repository's org-scoped
+ * search (RLS-bound to the caller's organization); results span every project in the org and carry
+ * their owning project's slug/name.
+ */
+export const searchDatasets = Effect.fn("datasets.searchDatasets")(function* (args: {
+  readonly searchQuery?: string
+  readonly limit?: number
+}) {
+  const repo = yield* DatasetRepository
+  return yield* repo.searchOrgWide({
+    ...(args.searchQuery !== undefined ? { searchQuery: args.searchQuery } : {}),
+    limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
+  })
+})

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -84,6 +84,7 @@ export {
   type IssueSearchCandidate,
   type IssueWithLifecycle,
   type ListIssuesRepositoryInput,
+  type OrgIssueSearchHit,
 } from "./ports/issue-repository.ts"
 export {
   type ApplyIssueLifecycleCommandError,
@@ -211,6 +212,11 @@ export {
   type RetrievalResult,
   rerankIssueCandidatesUseCase,
 } from "./use-cases/rerank-issue-candidates.ts"
+export {
+  type OrgIssueSearchItem,
+  type SearchOrgIssuesInput,
+  searchOrgIssuesUseCase,
+} from "./use-cases/search-org-issues.ts"
 export {
   type SweepEscalatingIssuesPublish,
   type SweepEscalatingIssuesResult,

--- a/packages/domain/issues/src/ports/issue-repository.ts
+++ b/packages/domain/issues/src/ports/issue-repository.ts
@@ -34,6 +34,18 @@ export interface IssueSearchCandidate {
   readonly score: number
 }
 
+/**
+ * One org-wide search hit for the Command Palette: the matched issue (with lifecycle flags so the
+ * caller can derive its states without a second read) plus its owning project's slug/name and the
+ * relevance score of whichever tier produced it.
+ */
+export interface OrgIssueSearchHit {
+  readonly issue: IssueWithLifecycle
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly score: number
+}
+
 export interface ListIssuesRepositoryInput {
   readonly projectId: ProjectId
   readonly limit: number
@@ -57,6 +69,23 @@ export interface IssueRepositoryShape {
     readonly query: string
     readonly normalizedEmbedding: readonly number[]
   }): Effect.Effect<readonly IssueSearchCandidate[], RepositoryError, SqlClient>
+  /**
+   * Org-wide issue search across every project in the organization (RLS-scoped to the caller's
+   * org), powering the Command Palette. Two tiers selected by `normalizedEmbedding`:
+   *
+   * - **Lexical** (no embedding): full-text match on the issue's search document OR a
+   *   case-insensitive substring match on its name. Instant and index-backed (GIN).
+   * - **Semantic** (embedding present): the hybrid vector + lexical relevance blend, surfacing
+   *   related issues whose names don't literally contain the query.
+   *
+   * Each hit carries lifecycle flags and the owning project's slug/name. Issues in soft-deleted
+   * projects are excluded. The caller merges the two tiers (lexical first) and caps the result.
+   */
+  searchOrgWide(input: {
+    readonly query: string
+    readonly normalizedEmbedding?: readonly number[]
+    readonly limit: number
+  }): Effect.Effect<readonly OrgIssueSearchHit[], RepositoryError, SqlClient>
   /**
    * Point-lookup by `(projectId, slug)`. Slugs are unique within a project,
    * so this is the natural read path for slug-keyed API endpoints.

--- a/packages/domain/issues/src/ports/issue-repository.ts
+++ b/packages/domain/issues/src/ports/issue-repository.ts
@@ -80,10 +80,14 @@ export interface IssueRepositoryShape {
    *
    * Each hit carries lifecycle flags and the owning project's slug/name. Issues in soft-deleted
    * projects are excluded. The caller merges the two tiers (lexical first) and caps the result.
+   * When `preferProjectId` is set, that project's issues rank first *within each tier* (so a
+   * current-project lexical hit still beats an other-project semantic hit) — the palette passes the
+   * current project so local results lead.
    */
   searchOrgWide(input: {
     readonly query: string
     readonly normalizedEmbedding?: readonly number[]
+    readonly preferProjectId?: ProjectId
     readonly limit: number
   }): Effect.Effect<readonly OrgIssueSearchHit[], RepositoryError, SqlClient>
   /**

--- a/packages/domain/issues/src/testing/fake-issue-repository.ts
+++ b/packages/domain/issues/src/testing/fake-issue-repository.ts
@@ -65,13 +65,16 @@ export const createFakeIssueRepository = (
           })),
       ),
 
-    searchOrgWide: ({ query, limit }) =>
+    searchOrgWide: ({ query, preferProjectId, limit }) =>
       Effect.sync(() => {
-        // Default fake behavior: org-wide case-insensitive name match, embedding-agnostic. Tests
-        // that need distinct lexical vs semantic tiers override this method.
+        // Default fake behavior: org-wide case-insensitive name match, embedding-agnostic, with the
+        // preferred project's issues first. Tests that need distinct lexical vs semantic tiers
+        // override this method.
         const q = query.trim().toLowerCase()
+        const prefer = (projectId: string) => (preferProjectId && projectId === preferProjectId ? 1 : 0)
         return [...issues.values()]
           .filter((issue) => issue.name.toLowerCase().includes(q))
+          .sort((a, b) => prefer(b.projectId) - prefer(a.projectId))
           .slice(0, limit)
           .map((issue) => ({
             issue: withLifecycle(issue),

--- a/packages/domain/issues/src/testing/fake-issue-repository.ts
+++ b/packages/domain/issues/src/testing/fake-issue-repository.ts
@@ -65,6 +65,22 @@ export const createFakeIssueRepository = (
           })),
       ),
 
+    searchOrgWide: ({ query, limit }) =>
+      Effect.sync(() => {
+        // Default fake behavior: org-wide case-insensitive name match, embedding-agnostic. Tests
+        // that need distinct lexical vs semantic tiers override this method.
+        const q = query.trim().toLowerCase()
+        return [...issues.values()]
+          .filter((issue) => issue.name.toLowerCase().includes(q))
+          .slice(0, limit)
+          .map((issue) => ({
+            issue: withLifecycle(issue),
+            projectSlug: `project-${issue.projectId}`,
+            projectName: `Project ${issue.projectId}`,
+            score: 1,
+          }))
+      }),
+
     findBySlug: ({ projectId, slug }) =>
       Effect.gen(function* () {
         const issue = [...issues.values()].find((i) => i.projectId === projectId && i.slug === slug)

--- a/packages/domain/issues/src/use-cases/search-org-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/search-org-issues.test.ts
@@ -1,0 +1,104 @@
+import { IssueId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Issue } from "../entities/issue.ts"
+import { createIssueCentroid } from "../helpers.ts"
+import {
+  IssueRepository,
+  type IssueRepositoryShape,
+  type IssueWithLifecycle,
+  type OrgIssueSearchHit,
+} from "../ports/issue-repository.ts"
+import { createFakeIssueRepository } from "../testing/fake-issue-repository.ts"
+import { searchOrgIssuesUseCase } from "./search-org-issues.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectA = ProjectId("a".repeat(24))
+const projectB = ProjectId("b".repeat(24))
+
+const makeIssue = (id: string, projectId: ProjectId, name: string, overrides: Partial<Issue> = {}): Issue => ({
+  id: IssueId(id.padEnd(24, "0")),
+  organizationId: organizationId as string,
+  projectId: projectId as string,
+  slug: name.toLowerCase().replace(/\s+/g, "-"),
+  name,
+  description: "",
+  source: "annotation",
+  centroid: createIssueCentroid(),
+  clusteredAt: new Date("2026-03-01T00:00:00.000Z"),
+  escalatedAt: null,
+  resolvedAt: null,
+  ignoredAt: null,
+  createdAt: new Date("2026-03-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+  ...overrides,
+})
+
+const hit = (issue: Issue, score: number): OrgIssueSearchHit => ({
+  issue: Object.assign({}, issue, { lifecycle: { isEscalating: false, isRegressed: false } }) as IssueWithLifecycle,
+  projectSlug: `slug-${issue.projectId}`,
+  projectName: `Project ${issue.projectId}`,
+  score,
+})
+
+const run = (
+  searchOrgWide: IssueRepositoryShape["searchOrgWide"],
+  args: { readonly query: string; readonly normalizedEmbedding?: readonly number[]; readonly limit?: number },
+) => {
+  const { repository } = createFakeIssueRepository([], { searchOrgWide })
+  return Effect.runPromise(
+    searchOrgIssuesUseCase({ organizationId, ...args }).pipe(
+      Effect.provide(
+        Layer.mergeAll(Layer.succeed(IssueRepository, repository), Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    ),
+  )
+}
+
+const lexA = makeIssue("ix1", projectA, "Payment Errors")
+const lexB = makeIssue("ix2", projectB, "Error Rate", { resolvedAt: new Date("2026-03-02T00:00:00.000Z") })
+const semC = makeIssue("ix3", projectA, "Latency")
+
+describe("searchOrgIssuesUseCase", () => {
+  it("returns lexical hits across projects with derived states when no embedding is passed", async () => {
+    const searchOrgWide: IssueRepositoryShape["searchOrgWide"] = ({ limit }) =>
+      Effect.sync(() => [hit(lexA, 0.9), hit(lexB, 0.8)].slice(0, limit))
+
+    const results = await run(searchOrgWide, { query: "error" })
+
+    expect(results.map((r) => r.id)).toEqual([lexA.id, lexB.id])
+    expect(new Set(results.map((r) => r.projectId)).size).toBe(2)
+    // lexB is resolved → its derived states include "resolved"
+    expect(results.find((r) => r.id === lexB.id)?.states).toContain("resolved")
+    expect(results[0]?.projectName).toContain(projectA)
+    expect(results[0]?.projectSlug).toContain(projectA)
+  })
+
+  it("merges lexical-first, then de-duped semantic hits", async () => {
+    const searchOrgWide: IssueRepositoryShape["searchOrgWide"] = ({ normalizedEmbedding, limit }) =>
+      Effect.sync(
+        () =>
+          normalizedEmbedding === undefined
+            ? [hit(lexA, 0.9), hit(lexB, 0.8)].slice(0, limit) // lexical tier
+            : [hit(lexA, 0.7), hit(semC, 0.6)].slice(0, limit), // semantic tier (lexA overlaps)
+      )
+
+    const results = await run(searchOrgWide, { query: "error", normalizedEmbedding: [0.1, 0.2] })
+
+    // lexical first (lexA, lexB), then semantic minus the duplicate lexA → semC appended
+    expect(results.map((r) => r.id)).toEqual([lexA.id, lexB.id, semC.id])
+  })
+
+  it("caps the merged result at the limit", async () => {
+    const searchOrgWide: IssueRepositoryShape["searchOrgWide"] = ({ normalizedEmbedding, limit }) =>
+      Effect.sync(() =>
+        normalizedEmbedding === undefined ? [hit(lexA, 0.9), hit(lexB, 0.8)].slice(0, limit) : [hit(semC, 0.6)],
+      )
+
+    const results = await run(searchOrgWide, { query: "error", normalizedEmbedding: [0.1, 0.2], limit: 2 })
+
+    expect(results).toHaveLength(2)
+    expect(results.map((r) => r.id)).toEqual([lexA.id, lexB.id])
+  })
+})

--- a/packages/domain/issues/src/use-cases/search-org-issues.ts
+++ b/packages/domain/issues/src/use-cases/search-org-issues.ts
@@ -1,0 +1,73 @@
+import type { OrganizationId, RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { deriveIssueLifecycleStates } from "../helpers.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+
+const DEFAULT_SEARCH_LIMIT = 10
+
+export interface OrgIssueSearchItem {
+  readonly id: string
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+  readonly states: readonly string[]
+}
+
+export interface SearchOrgIssuesInput {
+  /** Telemetry only — scoping is enforced by the {@link SqlClient}'s RLS context, not this value. */
+  readonly organizationId: OrganizationId
+  readonly query: string
+  /** When provided, the semantic tier runs in addition to the lexical tier. */
+  readonly normalizedEmbedding?: readonly number[]
+  readonly limit?: number
+  readonly now?: Date
+}
+
+/**
+ * Org-wide issue search for the Command Palette. Runs the repository's lexical tier always and the
+ * semantic tier when an embedding is supplied, then merges them **lexical-first**, de-duplicates by
+ * issue id, and caps at `limit`. Lifecycle states are derived here (Postgres-only — no ClickHouse),
+ * so each result is ready to render with its project and current states.
+ */
+export const searchOrgIssuesUseCase = (
+  input: SearchOrgIssuesInput,
+): Effect.Effect<readonly OrgIssueSearchItem[], RepositoryError, IssueRepository | SqlClient> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("organizationId", String(input.organizationId))
+    const repo = yield* IssueRepository
+    const now = input.now ?? new Date()
+    const limit = input.limit ?? DEFAULT_SEARCH_LIMIT
+
+    const lexical = yield* repo.searchOrgWide({ query: input.query, limit })
+    const semantic = input.normalizedEmbedding
+      ? yield* repo.searchOrgWide({ query: input.query, normalizedEmbedding: input.normalizedEmbedding, limit })
+      : []
+
+    // Lexical (exact/keyword) hits rank first, then semantic hits not already shown; dedupe by id.
+    const seen = new Set<string>()
+    const merged: OrgIssueSearchItem[] = []
+    for (const hit of [...lexical, ...semantic]) {
+      if (seen.has(hit.issue.id)) continue
+      seen.add(hit.issue.id)
+      merged.push({
+        id: hit.issue.id,
+        projectId: hit.issue.projectId,
+        projectSlug: hit.projectSlug,
+        projectName: hit.projectName,
+        slug: hit.issue.slug,
+        name: hit.issue.name,
+        states: [
+          ...deriveIssueLifecycleStates({
+            issue: hit.issue,
+            isEscalating: hit.issue.lifecycle.isEscalating,
+            isRegressed: hit.issue.lifecycle.isRegressed,
+            now,
+          }),
+        ],
+      })
+      if (merged.length >= limit) break
+    }
+    return merged
+  }).pipe(Effect.withSpan("issues.searchOrgIssues"))

--- a/packages/domain/issues/src/use-cases/search-org-issues.ts
+++ b/packages/domain/issues/src/use-cases/search-org-issues.ts
@@ -1,4 +1,4 @@
-import type { OrganizationId, RepositoryError, SqlClient } from "@domain/shared"
+import type { OrganizationId, ProjectId, RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { deriveIssueLifecycleStates } from "../helpers.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
@@ -21,6 +21,8 @@ export interface SearchOrgIssuesInput {
   readonly query: string
   /** When provided, the semantic tier runs in addition to the lexical tier. */
   readonly normalizedEmbedding?: readonly number[]
+  /** The palette's current project, when any — its issues rank first within each tier. */
+  readonly preferProjectId?: ProjectId
   readonly limit?: number
   readonly now?: Date
 }
@@ -40,9 +42,15 @@ export const searchOrgIssuesUseCase = (
     const now = input.now ?? new Date()
     const limit = input.limit ?? DEFAULT_SEARCH_LIMIT
 
-    const lexical = yield* repo.searchOrgWide({ query: input.query, limit })
+    const prefer = input.preferProjectId !== undefined ? { preferProjectId: input.preferProjectId } : {}
+    const lexical = yield* repo.searchOrgWide({ query: input.query, limit, ...prefer })
     const semantic = input.normalizedEmbedding
-      ? yield* repo.searchOrgWide({ query: input.query, normalizedEmbedding: input.normalizedEmbedding, limit })
+      ? yield* repo.searchOrgWide({
+          query: input.query,
+          normalizedEmbedding: input.normalizedEmbedding,
+          limit,
+          ...prefer,
+        })
       : []
 
     // Lexical (exact/keyword) hits rank first, then semantic hits not already shown; dedupe by id.

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -16,6 +16,7 @@ export type {
   MonitorLastIncident,
   MonitorListPage,
   MonitorRepositoryShape,
+  MonitorSearchResult,
 } from "./ports/monitor-repository.ts"
 export { MonitorRepository } from "./ports/monitor-repository.ts"
 export type {
@@ -59,6 +60,8 @@ export type {
 export { buildSystemMonitors, provisionSystemMonitorsUseCase } from "./use-cases/provision-system-monitors.ts"
 export type { ResolveMonitorAlertsForSourceEventInput } from "./use-cases/resolve-monitor-alerts-for-source-event.ts"
 export { resolveMonitorAlertsForSourceEventUseCase } from "./use-cases/resolve-monitor-alerts-for-source-event.ts"
+export type { SearchMonitorsInput } from "./use-cases/search-monitors.ts"
+export { searchMonitorsUseCase } from "./use-cases/search-monitors.ts"
 export type { UpdateMonitorError, UpdateMonitorInput } from "./use-cases/update-monitor.ts"
 export { updateMonitorUseCase } from "./use-cases/update-monitor.ts"
 export type { UpdateMonitorAlertError, UpdateMonitorAlertInput } from "./use-cases/update-monitor-alert.ts"

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -67,10 +67,12 @@ export interface MonitorRepositoryShape {
    * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
    * monitor name, ordered by match quality (exact > prefix > substring), then system monitors, then
    * most recent; omit it to list system monitors first, then the most recent. Soft-deleted monitors and monitors in
-   * soft-deleted projects are excluded.
+   * soft-deleted projects are excluded. When `preferProjectId` is set, that project's monitors are
+   * ranked first (the palette passes the current project so local results lead).
    */
   searchOrgWide(input: {
     readonly searchQuery?: string
+    readonly preferProjectId?: ProjectId
     readonly limit: number
   }): Effect.Effect<readonly MonitorSearchResult[], RepositoryError, SqlClient>
   /**

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -36,6 +36,23 @@ export interface MonitorListPage {
   readonly offset: number
 }
 
+/**
+ * Lightweight, org-wide monitor projection for the Command Palette. Carries the owning project's
+ * slug/name (for display + navigation) plus the `system`/`mutedAt` status the palette shows in a
+ * result's subtitle. Skips the alert join the full {@link Monitor} read does — search doesn't need
+ * alerts.
+ */
+export interface MonitorSearchResult {
+  readonly id: MonitorId
+  readonly projectId: ProjectId
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+  readonly system: boolean
+  readonly mutedAt: Date | null
+}
+
 export interface MonitorRepositoryShape {
   findById(id: MonitorId): Effect.Effect<Monitor, NotFoundError | RepositoryError, SqlClient>
   /** Point-lookup by `(projectId, slug)` over non-deleted rows. */
@@ -45,6 +62,16 @@ export interface MonitorRepositoryShape {
   }): Effect.Effect<Monitor, NotFoundError | RepositoryError, SqlClient>
   /** Non-deleted monitors for a project, ordered most-recent incident first (no-incident last), tiebroken by `created_at DESC, id`. */
   list(input: ListMonitorsRepositoryInput): Effect.Effect<MonitorListPage, RepositoryError, SqlClient>
+  /**
+   * Org-wide name search across every project in the organization (RLS-scoped to the caller's
+   * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
+   * monitor name; omit it to list the most recent. Soft-deleted monitors and monitors in
+   * soft-deleted projects are excluded.
+   */
+  searchOrgWide(input: {
+    readonly searchQuery?: string
+    readonly limit: number
+  }): Effect.Effect<readonly MonitorSearchResult[], RepositoryError, SqlClient>
   /**
    * Insert each monitor (with its alerts) only when no live row already holds
    * its `(projectId, slug)`. Atomic and idempotent — returns just the monitors

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -65,7 +65,8 @@ export interface MonitorRepositoryShape {
   /**
    * Org-wide name search across every project in the organization (RLS-scoped to the caller's
    * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
-   * monitor name; omit it to list the most recent. Soft-deleted monitors and monitors in
+   * monitor name, ordered by match quality (exact > prefix > substring), then system monitors, then
+   * most recent; omit it to list system monitors first, then the most recent. Soft-deleted monitors and monitors in
    * soft-deleted projects are excluded.
    */
   searchOrgWide(input: {

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -58,6 +58,30 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
           offset,
         }
       }),
+    searchOrgWide: ({ searchQuery, limit }) =>
+      Effect.sync(() => {
+        const query = searchQuery?.trim().toLowerCase()
+        return monitors
+          .filter(isLive)
+          .filter((m) => (query ? m.name.toLowerCase().includes(query) : true))
+          .sort((a, b) => {
+            if (a.system !== b.system) return a.system ? -1 : 1
+            if (a.createdAt.getTime() !== b.createdAt.getTime()) return b.createdAt.getTime() - a.createdAt.getTime()
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+          })
+          .slice(0, limit)
+          .map((m) => ({
+            id: m.id,
+            projectId: m.projectId,
+            // Fakes have no `projects` table; synthesize stable project display fields from the id.
+            projectSlug: `project-${m.projectId}`,
+            projectName: `Project ${m.projectId}`,
+            slug: m.slug,
+            name: m.name,
+            system: m.system,
+            mutedAt: m.mutedAt,
+          }))
+      }),
     provisionSystemMonitors: (toProvision) =>
       Effect.sync(() => {
         const inserted: Monitor[] = []

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -58,16 +58,18 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
           offset,
         }
       }),
-    searchOrgWide: ({ searchQuery, limit }) =>
+    searchOrgWide: ({ searchQuery, preferProjectId, limit }) =>
       Effect.sync(() => {
         const query = searchQuery?.trim().toLowerCase()
-        // Best name match first, then system monitors, then newest — mirroring the live repo.
+        // Preferred project first, then best name match, then system monitors, then newest.
+        const prefer = (projectId: string) => (preferProjectId && projectId === preferProjectId ? 1 : 0)
         const score = (name: string) =>
           !query ? 1 : name.toLowerCase() === query ? 3 : name.toLowerCase().startsWith(query) ? 2 : 1
         return monitors
           .filter(isLive)
           .filter((m) => (query ? m.name.toLowerCase().includes(query) : true))
           .sort((a, b) => {
+            if (prefer(a.projectId) !== prefer(b.projectId)) return prefer(b.projectId) - prefer(a.projectId)
             if (score(a.name) !== score(b.name)) return score(b.name) - score(a.name)
             if (a.system !== b.system) return a.system ? -1 : 1
             if (a.createdAt.getTime() !== b.createdAt.getTime()) return b.createdAt.getTime() - a.createdAt.getTime()

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -61,10 +61,14 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
     searchOrgWide: ({ searchQuery, limit }) =>
       Effect.sync(() => {
         const query = searchQuery?.trim().toLowerCase()
+        // Best name match first, then system monitors, then newest — mirroring the live repo.
+        const score = (name: string) =>
+          !query ? 1 : name.toLowerCase() === query ? 3 : name.toLowerCase().startsWith(query) ? 2 : 1
         return monitors
           .filter(isLive)
           .filter((m) => (query ? m.name.toLowerCase().includes(query) : true))
           .sort((a, b) => {
+            if (score(a.name) !== score(b.name)) return score(b.name) - score(a.name)
             if (a.system !== b.system) return a.system ? -1 : 1
             if (a.createdAt.getTime() !== b.createdAt.getTime()) return b.createdAt.getTime() - a.createdAt.getTime()
             return a.id < b.id ? -1 : a.id > b.id ? 1 : 0

--- a/packages/domain/monitors/src/use-cases/search-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/search-monitors.test.ts
@@ -1,0 +1,67 @@
+import { MonitorId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Monitor } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import { createFakeMonitorRepository } from "../testing/fake-monitor-repository.ts"
+import { searchMonitorsUseCase } from "./search-monitors.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectA = ProjectId("a".repeat(24))
+const projectB = ProjectId("b".repeat(24))
+
+const makeMonitor = (id: string, projectId: ProjectId, name: string, overrides: Partial<Monitor> = {}): Monitor => ({
+  id: MonitorId(id.padEnd(24, "0")),
+  organizationId,
+  projectId,
+  slug: name.toLowerCase().replace(/\s+/g, "-"),
+  name,
+  description: "",
+  system: false,
+  alerts: [],
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  ...overrides,
+})
+
+const run = (seed: readonly Monitor[], args: { readonly searchQuery?: string; readonly limit?: number }) => {
+  const { repo } = createFakeMonitorRepository(seed)
+  return Effect.runPromise(
+    searchMonitorsUseCase(args).pipe(
+      Effect.provide(
+        Layer.mergeAll(Layer.succeed(MonitorRepository, repo), Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    ),
+  )
+}
+
+describe("searchMonitorsUseCase", () => {
+  const seed = [
+    makeMonitor("m1", projectA, "Latency Spikes"),
+    makeMonitor("m2", projectB, "Latency Budget", { mutedAt: new Date("2026-02-01T00:00:00.000Z") }),
+    makeMonitor("m3", projectA, "Error Rate"),
+  ]
+
+  it("returns matching monitors across multiple projects in the org", async () => {
+    const results = await run(seed, { searchQuery: "latency" })
+    expect(results.map((r) => r.name).sort()).toEqual(["Latency Budget", "Latency Spikes"])
+    expect(new Set(results.map((r) => r.projectId)).size).toBe(2)
+  })
+
+  it("carries project display fields and status", async () => {
+    const results = await run(seed, { searchQuery: "budget" })
+    expect(results).toHaveLength(1)
+    expect(results[0]?.projectId).toBe(projectB)
+    expect(results[0]?.projectSlug).toContain(projectB)
+    expect(results[0]?.projectName).toContain(projectB)
+    expect(results[0]?.mutedAt).not.toBeNull()
+  })
+
+  it("respects the limit", async () => {
+    const results = await run(seed, { searchQuery: "latency", limit: 1 })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/packages/domain/monitors/src/use-cases/search-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/search-monitors.ts
@@ -1,4 +1,4 @@
-import type { RepositoryError, SqlClient } from "@domain/shared"
+import type { ProjectId, RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { MonitorRepository, type MonitorSearchResult } from "../ports/monitor-repository.ts"
 
@@ -6,6 +6,7 @@ const DEFAULT_SEARCH_LIMIT = 8
 
 export interface SearchMonitorsInput {
   readonly searchQuery?: string
+  readonly preferProjectId?: ProjectId
   readonly limit?: number
 }
 
@@ -13,6 +14,7 @@ export interface SearchMonitorsInput {
  * Org-wide monitor name search for the Command Palette. Delegates to the repository's org-scoped
  * search (RLS-bound to the caller's organization); results span every project in the org and carry
  * their owning project's slug/name plus the system/muted status the palette renders.
+ * `preferProjectId` (the palette's current project, when any) ranks that project's monitors first.
  */
 export const searchMonitorsUseCase = (
   input: SearchMonitorsInput,
@@ -22,6 +24,7 @@ export const searchMonitorsUseCase = (
     const trimmedSearchQuery = input.searchQuery?.trim()
     return yield* repository.searchOrgWide({
       ...(trimmedSearchQuery ? { searchQuery: trimmedSearchQuery } : {}),
+      ...(input.preferProjectId !== undefined ? { preferProjectId: input.preferProjectId } : {}),
       limit: input.limit ?? DEFAULT_SEARCH_LIMIT,
     })
   })

--- a/packages/domain/monitors/src/use-cases/search-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/search-monitors.ts
@@ -1,0 +1,27 @@
+import type { RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { MonitorRepository, type MonitorSearchResult } from "../ports/monitor-repository.ts"
+
+const DEFAULT_SEARCH_LIMIT = 8
+
+export interface SearchMonitorsInput {
+  readonly searchQuery?: string
+  readonly limit?: number
+}
+
+/**
+ * Org-wide monitor name search for the Command Palette. Delegates to the repository's org-scoped
+ * search (RLS-bound to the caller's organization); results span every project in the org and carry
+ * their owning project's slug/name plus the system/muted status the palette renders.
+ */
+export const searchMonitorsUseCase = (
+  input: SearchMonitorsInput,
+): Effect.Effect<readonly MonitorSearchResult[], RepositoryError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const repository = yield* MonitorRepository
+    const trimmedSearchQuery = input.searchQuery?.trim()
+    return yield* repository.searchOrgWide({
+      ...(trimmedSearchQuery ? { searchQuery: trimmedSearchQuery } : {}),
+      limit: input.limit ?? DEFAULT_SEARCH_LIMIT,
+    })
+  })

--- a/packages/domain/saved-searches/src/index.ts
+++ b/packages/domain/saved-searches/src/index.ts
@@ -11,10 +11,12 @@ export {
   type SavedSearchListPage,
   SavedSearchRepository,
   type SavedSearchRepositoryShape,
+  type SavedSearchSearchResult,
 } from "./ports/saved-search-repository.ts"
 export { type AssignSavedSearchInput, assignSavedSearchUseCase } from "./use-cases/assign-saved-search.ts"
 export { type CreateSavedSearchInput, createSavedSearch } from "./use-cases/create-saved-search.ts"
 export { deleteSavedSearch } from "./use-cases/delete-saved-search.ts"
 export { getSavedSearchBySlug } from "./use-cases/get-saved-search-by-slug.ts"
 export { listSavedSearches } from "./use-cases/list-saved-searches.ts"
+export { searchSavedSearches } from "./use-cases/search-saved-searches.ts"
 export { type UpdateSavedSearchInput, updateSavedSearch } from "./use-cases/update-saved-search.ts"

--- a/packages/domain/saved-searches/src/ports/saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/ports/saved-search-repository.ts
@@ -68,7 +68,8 @@ export interface SavedSearchRepositoryShape {
   /**
    * Org-wide name search across every project in the organization (RLS-scoped to the caller's
    * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
-   * saved-search name; omit it to list the most recent. Soft-deleted saved searches and saved
+   * saved-search name, ordered by match quality (exact > prefix > substring) then most recent; omit
+   * it to list the most recent. Soft-deleted saved searches and saved
    * searches in soft-deleted projects are excluded.
    */
   searchOrgWide(args: {

--- a/packages/domain/saved-searches/src/ports/saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/ports/saved-search-repository.ts
@@ -7,6 +7,20 @@ export interface SavedSearchListPage {
   readonly items: readonly SavedSearch[]
 }
 
+/**
+ * Lightweight, org-wide saved-search projection for the Command Palette. Carries the owning
+ * project's slug/name so a cross-project result can be displayed and navigated to without a
+ * second lookup.
+ */
+export interface SavedSearchSearchResult {
+  readonly id: SavedSearchId
+  readonly projectId: ProjectId
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly slug: string
+  readonly name: string
+}
+
 export interface CreateSavedSearchRepoInput {
   readonly id?: SavedSearchId
   readonly projectId: ProjectId
@@ -51,6 +65,16 @@ export interface SavedSearchRepositoryShape {
   }): Effect.Effect<SavedSearch, SavedSearchNotFoundError | RepositoryError, SqlClient>
   countBySlug(args: CountBySlugRepoInput): Effect.Effect<number, RepositoryError, SqlClient>
   listByProject(args: ListSavedSearchesRepoInput): Effect.Effect<SavedSearchListPage, RepositoryError, SqlClient>
+  /**
+   * Org-wide name search across every project in the organization (RLS-scoped to the caller's
+   * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
+   * saved-search name; omit it to list the most recent. Soft-deleted saved searches and saved
+   * searches in soft-deleted projects are excluded.
+   */
+  searchOrgWide(args: {
+    readonly searchQuery?: string
+    readonly limit: number
+  }): Effect.Effect<readonly SavedSearchSearchResult[], RepositoryError, SqlClient>
   update(
     args: UpdateSavedSearchRepoInput,
   ): Effect.Effect<SavedSearch, SavedSearchNotFoundError | DuplicateSavedSearchSlugError | RepositoryError, SqlClient>

--- a/packages/domain/saved-searches/src/ports/saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/ports/saved-search-repository.ts
@@ -70,10 +70,12 @@ export interface SavedSearchRepositoryShape {
    * org). Powers the Command Palette. `searchQuery` is a case-insensitive substring match on the
    * saved-search name, ordered by match quality (exact > prefix > substring) then most recent; omit
    * it to list the most recent. Soft-deleted saved searches and saved
-   * searches in soft-deleted projects are excluded.
+   * searches in soft-deleted projects are excluded. When `preferProjectId` is set, that project's
+   * saved searches are ranked first (the palette passes the current project so local results lead).
    */
   searchOrgWide(args: {
     readonly searchQuery?: string
+    readonly preferProjectId?: ProjectId
     readonly limit: number
   }): Effect.Effect<readonly SavedSearchSearchResult[], RepositoryError, SqlClient>
   update(

--- a/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
@@ -79,16 +79,22 @@ export const createFakeSavedSearchRepository = (seed: readonly SavedSearch[] = [
         return { items }
       }),
 
-    searchOrgWide: ({ searchQuery, limit }) =>
+    searchOrgWide: ({ searchQuery, preferProjectId, limit }) =>
       Effect.sync(() => {
         const q = searchQuery?.trim().toLowerCase()
-        // Best name match first then newest, mirroring the live repo's ordering.
+        // Preferred project first, then best name match, then newest — mirroring the live repo.
+        const prefer = (projectId: string) => (preferProjectId && projectId === preferProjectId ? 1 : 0)
         const score = (name: string) =>
           !q ? 1 : name.toLowerCase() === q ? 3 : name.toLowerCase().startsWith(q) ? 2 : 1
         return [...rows.values()]
           .filter(isLive)
           .filter((row) => (q ? row.name.toLowerCase().includes(q) : true))
-          .sort((a, b) => score(b.name) - score(a.name) || b.createdAt.getTime() - a.createdAt.getTime())
+          .sort(
+            (a, b) =>
+              prefer(b.projectId) - prefer(a.projectId) ||
+              score(b.name) - score(a.name) ||
+              b.createdAt.getTime() - a.createdAt.getTime(),
+          )
           .slice(0, limit)
           .map((row) => ({
             id: row.id,

--- a/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
@@ -82,10 +82,13 @@ export const createFakeSavedSearchRepository = (seed: readonly SavedSearch[] = [
     searchOrgWide: ({ searchQuery, limit }) =>
       Effect.sync(() => {
         const q = searchQuery?.trim().toLowerCase()
+        // Best name match first then newest, mirroring the live repo's ordering.
+        const score = (name: string) =>
+          !q ? 1 : name.toLowerCase() === q ? 3 : name.toLowerCase().startsWith(q) ? 2 : 1
         return [...rows.values()]
           .filter(isLive)
           .filter((row) => (q ? row.name.toLowerCase().includes(q) : true))
-          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .sort((a, b) => score(b.name) - score(a.name) || b.createdAt.getTime() - a.createdAt.getTime())
           .slice(0, limit)
           .map((row) => ({
             id: row.id,

--- a/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
+++ b/packages/domain/saved-searches/src/testing/fake-saved-search-repository.ts
@@ -79,6 +79,25 @@ export const createFakeSavedSearchRepository = (seed: readonly SavedSearch[] = [
         return { items }
       }),
 
+    searchOrgWide: ({ searchQuery, limit }) =>
+      Effect.sync(() => {
+        const q = searchQuery?.trim().toLowerCase()
+        return [...rows.values()]
+          .filter(isLive)
+          .filter((row) => (q ? row.name.toLowerCase().includes(q) : true))
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, limit)
+          .map((row) => ({
+            id: row.id,
+            projectId: row.projectId,
+            // Fakes have no `projects` table; synthesize stable project display fields from the id.
+            projectSlug: `project-${row.projectId}`,
+            projectName: `Project ${row.projectId}`,
+            slug: row.slug,
+            name: row.name,
+          }))
+      }),
+
     update: (args) =>
       Effect.gen(function* () {
         const current = rows.get(args.id)

--- a/packages/domain/saved-searches/src/use-cases/search-saved-searches.test.ts
+++ b/packages/domain/saved-searches/src/use-cases/search-saved-searches.test.ts
@@ -1,0 +1,85 @@
+import { ProjectId, SavedSearchId, SqlClient, UserId } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { SavedSearch } from "../entities/saved-search.ts"
+import { SavedSearchRepository } from "../ports/saved-search-repository.ts"
+import { createFakeSavedSearchRepository } from "../testing/fake-saved-search-repository.ts"
+import { searchSavedSearches } from "./search-saved-searches.ts"
+
+const PROJECT_A = ProjectId("a".repeat(24))
+const PROJECT_B = ProjectId("b".repeat(24))
+const CREATED_BY = UserId("u".repeat(24))
+
+const makeRow = (
+  overrides: Partial<SavedSearch> & Pick<SavedSearch, "id" | "slug" | "name" | "createdAt">,
+): SavedSearch => ({
+  organizationId: "fake-org".padEnd(24, "0") as SavedSearch["organizationId"],
+  projectId: PROJECT_A,
+  query: "x",
+  filterSet: {},
+  assignedUserId: null,
+  createdByUserId: CREATED_BY,
+  deletedAt: null,
+  updatedAt: overrides.createdAt,
+  ...overrides,
+})
+
+const run = (seed: readonly SavedSearch[], args: { readonly searchQuery?: string; readonly limit?: number }) => {
+  const { repository } = createFakeSavedSearchRepository(seed)
+  return Effect.runPromise(
+    searchSavedSearches(args).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(SavedSearchRepository, repository),
+          Layer.succeed(SqlClient, createFakeSqlClient()),
+        ),
+      ),
+    ),
+  )
+}
+
+describe("searchSavedSearches", () => {
+  const seed = [
+    makeRow({
+      id: SavedSearchId("1".repeat(24)),
+      slug: "errors-a",
+      name: "Errors",
+      createdAt: new Date("2025-01-01"),
+      projectId: PROJECT_A,
+    }),
+    makeRow({
+      id: SavedSearchId("2".repeat(24)),
+      slug: "errors-b",
+      name: "Error spikes",
+      createdAt: new Date("2025-02-01"),
+      projectId: PROJECT_B,
+    }),
+    makeRow({
+      id: SavedSearchId("3".repeat(24)),
+      slug: "latency",
+      name: "Latency",
+      createdAt: new Date("2025-03-01"),
+      projectId: PROJECT_A,
+    }),
+  ]
+
+  it("returns matching saved searches across multiple projects in the org", async () => {
+    const results = await run(seed, { searchQuery: "error" })
+    expect(results.map((r) => r.name).sort()).toEqual(["Error spikes", "Errors"])
+    expect(new Set(results.map((r) => r.projectId)).size).toBe(2)
+  })
+
+  it("carries owning project display fields", async () => {
+    const results = await run(seed, { searchQuery: "latency" })
+    expect(results).toHaveLength(1)
+    expect(results[0]?.projectId).toBe(PROJECT_A)
+    expect(results[0]?.projectSlug).toContain(PROJECT_A)
+    expect(results[0]?.projectName).toContain(PROJECT_A)
+  })
+
+  it("respects the limit", async () => {
+    const results = await run(seed, { searchQuery: "error", limit: 1 })
+    expect(results).toHaveLength(1)
+  })
+})

--- a/packages/domain/saved-searches/src/use-cases/search-saved-searches.ts
+++ b/packages/domain/saved-searches/src/use-cases/search-saved-searches.ts
@@ -1,3 +1,4 @@
+import type { ProjectId } from "@domain/shared"
 import { Effect } from "effect"
 import { SavedSearchRepository } from "../ports/saved-search-repository.ts"
 
@@ -6,15 +7,18 @@ const DEFAULT_SEARCH_LIMIT = 8
 /**
  * Org-wide saved-search name search for the Command Palette. Delegates to the repository's
  * org-scoped search (RLS-bound to the caller's organization); results span every project in the
- * org and carry their owning project's slug/name.
+ * org and carry their owning project's slug/name. `preferProjectId` (the palette's current project,
+ * when any) ranks that project's saved searches first.
  */
 export const searchSavedSearches = Effect.fn("savedSearches.searchSavedSearches")(function* (args: {
   readonly searchQuery?: string
+  readonly preferProjectId?: ProjectId
   readonly limit?: number
 }) {
   const repo = yield* SavedSearchRepository
   return yield* repo.searchOrgWide({
     ...(args.searchQuery !== undefined ? { searchQuery: args.searchQuery } : {}),
+    ...(args.preferProjectId !== undefined ? { preferProjectId: args.preferProjectId } : {}),
     limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
   })
 })

--- a/packages/domain/saved-searches/src/use-cases/search-saved-searches.ts
+++ b/packages/domain/saved-searches/src/use-cases/search-saved-searches.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import { SavedSearchRepository } from "../ports/saved-search-repository.ts"
+
+const DEFAULT_SEARCH_LIMIT = 8
+
+/**
+ * Org-wide saved-search name search for the Command Palette. Delegates to the repository's
+ * org-scoped search (RLS-bound to the caller's organization); results span every project in the
+ * org and carry their owning project's slug/name.
+ */
+export const searchSavedSearches = Effect.fn("savedSearches.searchSavedSearches")(function* (args: {
+  readonly searchQuery?: string
+  readonly limit?: number
+}) {
+  const repo = yield* SavedSearchRepository
+  return yield* repo.searchOrgWide({
+    ...(args.searchQuery !== undefined ? { searchQuery: args.searchQuery } : {}),
+    limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
 import { datasets } from "../schema/datasets.ts"
 import { datasetVersions } from "../schema/datasetVersions.ts"
+import { projects } from "../schema/projects.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
 import { DatasetRepositoryLive } from "./dataset-repository.ts"
@@ -330,5 +331,137 @@ describe("DatasetRepositoryLive listByProject", () => {
         ),
       ).rejects.toThrow()
     })
+  })
+})
+
+const SEARCH_ORG_ID = OrganizationId("org-search-ds-test")
+const SEARCH_OTHER_ORG_ID = OrganizationId("org-search-ds-other")
+const SEARCH_PROJECT_A = ProjectId("proj-search-ds-a")
+const SEARCH_PROJECT_B = ProjectId("proj-search-ds-b")
+const SEARCH_PROJECT_DELETED = ProjectId("proj-search-ds-del")
+const SEARCH_PROJECT_OTHER = ProjectId("proj-search-ds-oth")
+
+describe("DatasetRepositoryLive searchOrgWide", () => {
+  const runSearch = <A, E>(effect: Effect.Effect<A, E, DatasetRepository | SqlClient>) =>
+    Effect.runPromise(effect.pipe(withPostgres(DatasetRepositoryLive, pg.adminPostgresClient, SEARCH_ORG_ID)))
+
+  beforeAll(async () => {
+    const db = pg.db
+    const baseTime = new Date("2025-02-01T12:00:00.000Z")
+
+    await db.insert(projects).values([
+      { id: SEARCH_PROJECT_A, organizationId: SEARCH_ORG_ID, name: "Alpha Project", slug: "alpha" },
+      { id: SEARCH_PROJECT_B, organizationId: SEARCH_ORG_ID, name: "Beta Project", slug: "beta" },
+      {
+        id: SEARCH_PROJECT_DELETED,
+        organizationId: SEARCH_ORG_ID,
+        name: "Gone Project",
+        slug: "gone",
+        deletedAt: baseTime,
+      },
+      { id: SEARCH_PROJECT_OTHER, organizationId: SEARCH_OTHER_ORG_ID, name: "Other Org Project", slug: "other" },
+    ])
+
+    await db.insert(datasets).values([
+      {
+        id: makeId("sds1"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "customer-reviews",
+        name: "Customer Reviews",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("sds2"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_B,
+        slug: "customer-orders",
+        name: "Customer Orders",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("sds3"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "unrelated",
+        name: "Unrelated Logs",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("sds4"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "customer-deleted",
+        name: "Customer Deleted",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+        deletedAt: baseTime,
+      },
+      {
+        id: makeId("sds5"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_DELETED,
+        slug: "customer-in-deleted-project",
+        name: "Customer In Deleted Project",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: makeId("sds6"),
+        organizationId: SEARCH_OTHER_ORG_ID,
+        projectId: SEARCH_PROJECT_OTHER,
+        slug: "customer-secret",
+        name: "Customer Secret",
+        currentVersion: 0,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+  })
+
+  it("matches datasets across multiple projects in the org and tags them with the project", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "customer", limit: 25 })
+      }),
+    )
+
+    expect(results.map((r) => r.name).sort()).toEqual(["Customer Orders", "Customer Reviews"])
+    const reviews = results.find((r) => r.name === "Customer Reviews")
+    const orders = results.find((r) => r.name === "Customer Orders")
+    expect(reviews).toMatchObject({ projectId: SEARCH_PROJECT_A, projectSlug: "alpha", projectName: "Alpha Project" })
+    expect(orders).toMatchObject({ projectId: SEARCH_PROJECT_B, projectSlug: "beta", projectName: "Beta Project" })
+  })
+
+  it("excludes soft-deleted datasets, datasets in soft-deleted projects, and other organizations", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "customer", limit: 25 })
+      }),
+    )
+    const names = results.map((r) => r.name)
+    expect(names).not.toContain("Customer Deleted")
+    expect(names).not.toContain("Customer In Deleted Project")
+    expect(names).not.toContain("Customer Secret")
+  })
+
+  it("respects the limit", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "customer", limit: 1 })
+      }),
+    )
+    expect(results).toHaveLength(1)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
@@ -509,4 +509,25 @@ describe("DatasetRepositoryLive searchOrgWide", () => {
     )
     expect(results.map((r) => r.name)).toEqual(["Zebra", "Zebra Report", "My Zebra Log"])
   })
+
+  it("ranks the preferred project's datasets first", async () => {
+    // "Customer Reviews" (project A) and "Customer Orders" (project B) score equally for "customer".
+    const withoutPreference = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "customer", limit: 25 })
+      }),
+    )
+    expect(withoutPreference.map((r) => r.name).sort()).toEqual(["Customer Orders", "Customer Reviews"])
+
+    const preferB = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "customer", preferProjectId: SEARCH_PROJECT_B, limit: 25 })
+      }),
+    )
+    // Project B's dataset now leads, even though match quality/recency are equal.
+    expect(preferB[0]?.name).toBe("Customer Orders")
+    expect(preferB[0]?.projectId).toBe(SEARCH_PROJECT_B)
+  })
 })

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.test.ts
@@ -464,4 +464,49 @@ describe("DatasetRepositoryLive searchOrgWide", () => {
     )
     expect(results).toHaveLength(1)
   })
+
+  it("orders by name-match quality: exact, then prefix, then substring", async () => {
+    const t = new Date("2025-02-02T12:00:00.000Z")
+    await pg.db.insert(datasets).values([
+      // Inserted substring-first to prove ordering isn't just insertion/recency order.
+      {
+        id: makeId("dsm3"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "my-zebra-log",
+        name: "My Zebra Log",
+        currentVersion: 0,
+        createdAt: t,
+        updatedAt: t,
+      },
+      {
+        id: makeId("dsm2"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "zebra-report",
+        name: "Zebra Report",
+        currentVersion: 0,
+        createdAt: t,
+        updatedAt: t,
+      },
+      {
+        id: makeId("dsm1"),
+        organizationId: SEARCH_ORG_ID,
+        projectId: SEARCH_PROJECT_A,
+        slug: "zebra",
+        name: "Zebra",
+        currentVersion: 0,
+        createdAt: t,
+        updatedAt: t,
+      },
+    ])
+
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* DatasetRepository
+        return yield* repo.searchOrgWide({ searchQuery: "zebra", limit: 25 })
+      }),
+    )
+    expect(results.map((r) => r.name)).toEqual(["Zebra", "Zebra Report", "My Zebra Log"])
+  })
 })

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.ts
@@ -238,7 +238,9 @@ export const DatasetRepositoryLive = Layer.effect(
               .from(datasets)
               .innerJoin(projects, eq(projects.id, datasets.projectId))
               .where(where)
-              .orderBy(asc(datasets.name), asc(datasets.id))
+              // Newest-first, matching the "most recent" contract and the other org-wide searches
+              // (saved searches / monitors).
+              .orderBy(desc(datasets.createdAt), desc(datasets.id))
               .limit(args.limit),
           )
 

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.ts
@@ -15,7 +15,7 @@ import type { Operator } from "../client.ts"
 import { datasets } from "../schema/datasets.ts"
 import { datasetVersions } from "../schema/datasetVersions.ts"
 import { projects } from "../schema/projects.ts"
-import { nameMatchScore } from "./org-search.ts"
+import { nameMatchScore, preferProjectFirst } from "./org-search.ts"
 
 const toDomainDataset = (row: typeof datasets.$inferSelect, latestVersionId?: string | null): Dataset => ({
   id: DatasetId(row.id),
@@ -225,9 +225,12 @@ export const DatasetRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             ...(trimmed ? [ilike(datasets.name, `%${trimmed}%`)] : []),
           )
-          const orderBy = trimmed
-            ? [desc(nameMatchScore(datasets.name, trimmed)), desc(datasets.createdAt), desc(datasets.id)]
-            : [desc(datasets.createdAt), desc(datasets.id)]
+          const orderBy = [
+            ...preferProjectFirst(datasets.projectId, args.preferProjectId),
+            ...(trimmed
+              ? [desc(nameMatchScore(datasets.name, trimmed)), desc(datasets.createdAt), desc(datasets.id)]
+              : [desc(datasets.createdAt), desc(datasets.id)]),
+          ]
 
           const rows = yield* sqlClient.query((db) =>
             db

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.ts
@@ -1,4 +1,4 @@
-import type { Dataset, DatasetListCursor, DatasetListPage, DatasetVersion } from "@domain/datasets"
+import type { Dataset, DatasetListCursor, DatasetListPage, DatasetSearchResult, DatasetVersion } from "@domain/datasets"
 import { type DATASET_LIST_SORT_COLUMNS, DatasetNotFoundError, DatasetRepository } from "@domain/datasets"
 import {
   DatasetId,
@@ -9,11 +9,12 @@ import {
   SqlClient,
   type SqlClientShape,
 } from "@domain/shared"
-import { and, asc, desc, eq, getColumns, gt, isNull, lt, ne, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, getColumns, gt, ilike, isNull, lt, ne, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { datasets } from "../schema/datasets.ts"
 import { datasetVersions } from "../schema/datasetVersions.ts"
+import { projects } from "../schema/projects.ts"
 
 const toDomainDataset = (row: typeof datasets.$inferSelect, latestVersionId?: string | null): Dataset => ({
   id: DatasetId(row.id),
@@ -211,6 +212,46 @@ export const DatasetRepositoryLive = Layer.effect(
             ? { datasets: items, hasMore, nextCursor }
             : { datasets: items, hasMore }
           return page
+        }),
+
+      searchOrgWide: (args) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const trimmed = args.searchQuery?.trim()
+          const where = and(
+            eq(datasets.organizationId, sqlClient.organizationId),
+            isNull(datasets.deletedAt),
+            isNull(projects.deletedAt),
+            ...(trimmed ? [ilike(datasets.name, `%${trimmed}%`)] : []),
+          )
+
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: datasets.id,
+                projectId: datasets.projectId,
+                projectSlug: projects.slug,
+                projectName: projects.name,
+                slug: datasets.slug,
+                name: datasets.name,
+              })
+              .from(datasets)
+              .innerJoin(projects, eq(projects.id, datasets.projectId))
+              .where(where)
+              .orderBy(asc(datasets.name), asc(datasets.id))
+              .limit(args.limit),
+          )
+
+          return rows.map(
+            (row): DatasetSearchResult => ({
+              id: DatasetId(row.id),
+              projectId: ProjectId(row.projectId),
+              projectSlug: row.projectSlug,
+              projectName: row.projectName,
+              slug: row.slug,
+              name: row.name,
+            }),
+          )
         }),
 
       existsByNameInProject: (args) =>

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.ts
@@ -15,6 +15,7 @@ import type { Operator } from "../client.ts"
 import { datasets } from "../schema/datasets.ts"
 import { datasetVersions } from "../schema/datasetVersions.ts"
 import { projects } from "../schema/projects.ts"
+import { nameMatchScore } from "./org-search.ts"
 
 const toDomainDataset = (row: typeof datasets.$inferSelect, latestVersionId?: string | null): Dataset => ({
   id: DatasetId(row.id),
@@ -224,6 +225,9 @@ export const DatasetRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             ...(trimmed ? [ilike(datasets.name, `%${trimmed}%`)] : []),
           )
+          const orderBy = trimmed
+            ? [desc(nameMatchScore(datasets.name, trimmed)), desc(datasets.createdAt), desc(datasets.id)]
+            : [desc(datasets.createdAt), desc(datasets.id)]
 
           const rows = yield* sqlClient.query((db) =>
             db
@@ -238,9 +242,9 @@ export const DatasetRepositoryLive = Layer.effect(
               .from(datasets)
               .innerJoin(projects, eq(projects.id, datasets.projectId))
               .where(where)
-              // Newest-first, matching the "most recent" contract and the other org-wide searches
-              // (saved searches / monitors).
-              .orderBy(desc(datasets.createdAt), desc(datasets.id))
+              // Best name match first (exact > prefix > substring), then most recent. With no
+              // query every row scores equally, so it falls back to newest-first.
+              .orderBy(...orderBy)
               .limit(args.limit),
           )
 

--- a/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
@@ -698,6 +698,7 @@ describe("IssueRepositoryLive searchOrgWide", () => {
   const search = (input: {
     readonly query: string
     readonly normalizedEmbedding?: readonly number[]
+    readonly preferProjectId?: ProjectId
     readonly limit: number
   }) =>
     Effect.runPromise(
@@ -770,6 +771,14 @@ describe("IssueRepositoryLive searchOrgWide", () => {
     it("respects the limit", async () => {
       const results = await search({ query: "timeout", limit: 1 })
       expect(results).toHaveLength(1)
+    })
+
+    it("ranks the preferred project's issues first within the tier", async () => {
+      const results = await search({ query: "timeout", preferProjectId: projB, limit: 25 })
+      const names = results.map((r) => r.issue.name)
+      // "Checkout timeout" lives in project B; preferring B floats it ahead of project A's match.
+      expect(names.indexOf("Checkout timeout")).toBeLessThan(names.indexOf("Payment timeout errors"))
+      expect(results[0]?.issue.projectId).toBe(projB)
     })
   })
 

--- a/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
@@ -10,6 +10,7 @@ import { Effect } from "effect"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { alertIncidents as alertIncidentsTable } from "../schema/alert-incidents.ts"
 import { issues as issuesTable } from "../schema/issues.ts"
+import { projects as projectsTable } from "../schema/projects.ts"
 import { scores as scoresTable } from "../schema/scores.ts"
 import { closeInMemoryPostgres, createInMemoryPostgres, type InMemoryPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
@@ -651,6 +652,135 @@ describe("IssueRepositoryLive", () => {
       const findByIdsFlags = new Map(findByIdsResult.map((item) => [item.id, item.lifecycle] as const))
       expect(findByIdsFlags.get(escalatingIssue.id)).toEqual({ isEscalating: true, isRegressed: false })
       expect(findByIdsFlags.get(regressedIssue.id)).toEqual({ isEscalating: false, isRegressed: true })
+    })
+  })
+})
+
+describe("IssueRepositoryLive searchOrgWide", () => {
+  let database: InMemoryPostgres
+
+  const iid = (prefix: string) => prefix.padEnd(24, "x").slice(0, 24)
+
+  // Issue reads go through `issueSchema.parse`, which requires 24-char cuid ids — pad org/project ids.
+  const searchOrgId = OrganizationId(iid("org-issue-search-test"))
+  const otherOrgId = OrganizationId(iid("org-issue-search-othr"))
+  const projA = ProjectId(iid("proj-issue-search-a"))
+  const projB = ProjectId(iid("proj-issue-search-b"))
+  const projDeleted = ProjectId(iid("proj-issue-search-del"))
+  const projOther = ProjectId(iid("proj-issue-search-oth"))
+  const baseTime = new Date("2026-04-01T00:00:00.000Z")
+
+  const issueRow = (
+    id: string,
+    org: OrganizationId,
+    project: ProjectId,
+    name: string,
+    extra: Partial<typeof issuesTable.$inferInsert> = {},
+  ): typeof issuesTable.$inferInsert => ({
+    id: iid(id),
+    organizationId: org,
+    projectId: project,
+    slug: toSlug(name),
+    name,
+    description: `Description for ${name}`,
+    source: "annotation",
+    centroid: createIssueCentroid(),
+    centroidEmbedding: null,
+    clusteredAt: baseTime,
+    escalatedAt: null,
+    resolvedAt: null,
+    ignoredAt: null,
+    createdAt: baseTime,
+    updatedAt: baseTime,
+    ...extra,
+  })
+
+  const search = (input: {
+    readonly query: string
+    readonly normalizedEmbedding?: readonly number[]
+    readonly limit: number
+  }) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* IssueRepository
+        return yield* repo.searchOrgWide(input)
+      }).pipe(withPostgres(IssueRepositoryLive, database.appPostgresClient, searchOrgId)),
+    )
+
+  beforeAll(async () => {
+    database = await createInMemoryPostgres()
+
+    await database.db.insert(projectsTable).values([
+      { id: projA, organizationId: searchOrgId, name: "Alpha Project", slug: "iss-alpha" },
+      { id: projB, organizationId: searchOrgId, name: "Beta Project", slug: "iss-beta" },
+      { id: projDeleted, organizationId: searchOrgId, name: "Gone Project", slug: "iss-gone", deletedAt: baseTime },
+      { id: projOther, organizationId: otherOrgId, name: "Other Org Project", slug: "iss-other" },
+    ])
+
+    // Lexical issues (no embedding) across two live projects, a deleted project, and another org.
+    await database.db
+      .insert(issuesTable)
+      .values([
+        issueRow("isl1", searchOrgId, projA, "Payment timeout errors"),
+        issueRow("isl2", searchOrgId, projB, "Checkout timeout"),
+        issueRow("isl3", searchOrgId, projA, "Unrelated latency"),
+        issueRow("isl4", searchOrgId, projDeleted, "Timeout in deleted project"),
+        issueRow("isl5", otherOrgId, projOther, "Timeout secret"),
+      ])
+
+    // Semantic issues: identical 1-hot embedding in two live projects + one in another org. The
+    // centroid must have positive mass + the right model to satisfy the embedding consistency check.
+    const sharedEmbedding = makeEmbedding({ 0: 1 })
+    const embeddedCentroid = { ...createIssueCentroid(), base: sharedEmbedding, mass: 1 }
+    const embedded = { centroid: embeddedCentroid, centroidEmbedding: sharedEmbedding }
+    await database.db
+      .insert(issuesTable)
+      .values([
+        issueRow("ise1", searchOrgId, projA, "Zeta alpha", embedded),
+        issueRow("ise2", searchOrgId, projB, "Zeta beta", embedded),
+        issueRow("ise3", otherOrgId, projOther, "Zeta secret", embedded),
+      ])
+  })
+
+  afterAll(async () => {
+    await closeInMemoryPostgres(database)
+  })
+
+  describe("lexical tier (no embedding)", () => {
+    it("matches across projects and tags each hit with its project", async () => {
+      const results = await search({ query: "timeout", limit: 25 })
+      const byName = new Map(results.map((r) => [r.issue.name, r]))
+      expect(byName.has("Payment timeout errors")).toBe(true)
+      expect(byName.has("Checkout timeout")).toBe(true)
+      expect(byName.get("Payment timeout errors")).toMatchObject({
+        projectSlug: "iss-alpha",
+        projectName: "Alpha Project",
+      })
+      expect(byName.get("Checkout timeout")).toMatchObject({ projectSlug: "iss-beta", projectName: "Beta Project" })
+    })
+
+    it("excludes issues in deleted projects and other organizations", async () => {
+      const results = await search({ query: "timeout", limit: 25 })
+      const names = results.map((r) => r.issue.name)
+      expect(names).not.toContain("Timeout in deleted project")
+      expect(names).not.toContain("Timeout secret")
+      expect(names).not.toContain("Unrelated latency")
+    })
+
+    it("respects the limit", async () => {
+      const results = await search({ query: "timeout", limit: 1 })
+      expect(results).toHaveLength(1)
+    })
+  })
+
+  describe("semantic tier (embedding)", () => {
+    it("matches by embedding across projects and excludes other orgs", async () => {
+      const results = await search({ query: "zeta", normalizedEmbedding: makeEmbedding({ 0: 1 }), limit: 25 })
+      const names = results.map((r) => r.issue.name)
+      expect(names).toContain("Zeta alpha")
+      expect(names).toContain("Zeta beta")
+      expect(names).not.toContain("Zeta secret")
+      expect(new Set(results.filter((r) => r.issue.name.startsWith("Zeta")).map((r) => r.issue.projectId)).size).toBe(2)
     })
   })
 })

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -13,13 +13,15 @@ import {
   issueSchema,
   MIN_OCCURRENCES_FOR_VISIBILITY,
   normalizeIssueCentroid,
+  type OrgIssueSearchHit,
 } from "@domain/issues"
 import { IssueId, NotFoundError, type ProjectId, RepositoryError, SqlClient, type SqlClientShape } from "@domain/shared"
-import { and, asc, desc, eq, getTableColumns, inArray, isNotNull, ne, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, getTableColumns, ilike, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { alertIncidents } from "../schema/alert-incidents.ts"
 import { issues } from "../schema/issues.ts"
+import { projects } from "../schema/projects.ts"
 import { scores } from "../schema/scores.ts"
 
 // Lifecycle flags derived from `alert_incidents` are joined onto every
@@ -92,6 +94,19 @@ const toIssueWithLifecycle = (row: IssueRowWithLifecycle): IssueWithLifecycle =>
   }
   return Object.assign({}, issue, { lifecycle })
 }
+
+type OrgIssueSearchRow = IssueRowWithLifecycle & {
+  readonly projectSlug: string
+  readonly projectName: string
+  readonly score: number
+}
+
+const toOrgIssueSearchHit = (row: OrgIssueSearchRow): OrgIssueSearchHit => ({
+  issue: toIssueWithLifecycle(row),
+  projectSlug: row.projectSlug,
+  projectName: row.projectName,
+  score: Number(row.score),
+})
 
 const validateVector = (
   vector: readonly number[],
@@ -321,6 +336,77 @@ const issueRepositoryCoreLive = Layer.effect(
             ...row,
             issueId: IssueId(row.issueId),
           }))
+        }),
+
+      searchOrgWide: ({ query, normalizedEmbedding, limit }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const lexicalQuery = sql`websearch_to_tsquery('english', ${query})`
+
+          // Lexical tier: GIN-backed full-text match OR a literal name substring. No embedding
+          // round-trip, so this is the instant, index-backed path.
+          if (normalizedEmbedding === undefined) {
+            const lexicalScore = sql<number>`ts_rank_cd(${issues.searchDocument}, ${lexicalQuery})::double precision`
+            const rows = yield* sqlClient.query((db, organizationId) =>
+              db
+                .select({
+                  ...issueColumnsWithLifecycle,
+                  projectSlug: projects.slug,
+                  projectName: projects.name,
+                  score: lexicalScore,
+                })
+                .from(issues)
+                .innerJoin(projects, eq(projects.id, issues.projectId))
+                .where(
+                  and(
+                    eq(issues.organizationId, organizationId),
+                    isNull(projects.deletedAt),
+                    or(sql`${issues.searchDocument} @@ ${lexicalQuery}`, ilike(issues.name, `%${query}%`)),
+                  ),
+                )
+                .orderBy(desc(lexicalScore), desc(issues.updatedAt), asc(issues.id))
+                .limit(limit),
+            )
+            return rows.map(toOrgIssueSearchHit)
+          }
+
+          // Semantic tier: the same vector + lexical blend `hybridSearch` uses, but org-wide.
+          // NB: `centroid_embedding` has no ANN index (see schema) — this is an exact cosine scan
+          // over every org issue. Acceptable for the debounced, capped palette tier; revisit with
+          // an HNSW index if a large org regresses.
+          const vector = yield* validateVector(normalizedEmbedding, "IssueRepository.searchOrgWide")
+          const queryVector = sql.raw(`'[${vector.join(",")}]'::vector`)
+          const vectorScore = sql<number>`(1::double precision - (${issues.centroidEmbedding} <=> ${queryVector}))`
+          const lexicalScore = sql<number>`least(
+            1::double precision,
+            greatest(0::double precision, ts_rank_cd(${issues.searchDocument}, ${lexicalQuery})::double precision)
+          )`
+          const score = sql<number>`(${ISSUE_DISCOVERY_SEARCH_RATIO}::double precision * ${vectorScore} + ${
+            1 - ISSUE_DISCOVERY_SEARCH_RATIO
+          }::double precision * ${lexicalScore})`
+
+          const rows = yield* sqlClient.query((db, organizationId) =>
+            db
+              .select({
+                ...issueColumnsWithLifecycle,
+                projectSlug: projects.slug,
+                projectName: projects.name,
+                score,
+              })
+              .from(issues)
+              .innerJoin(projects, eq(projects.id, issues.projectId))
+              .where(
+                and(
+                  eq(issues.organizationId, organizationId),
+                  isNull(projects.deletedAt),
+                  isNotNull(issues.centroidEmbedding),
+                  sql`(${score} >= ${ISSUE_DISCOVERY_MIN_SIMILARITY} OR ${vectorScore} >= ${ISSUE_DISCOVERY_MIN_VECTOR_SIMILARITY})`,
+                ),
+              )
+              .orderBy(desc(score), desc(vectorScore), desc(issues.updatedAt), asc(issues.id))
+              .limit(limit),
+          )
+          return rows.map(toOrgIssueSearchHit)
         }),
 
       save: (issue: Issue) =>

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -23,6 +23,7 @@ import { alertIncidents } from "../schema/alert-incidents.ts"
 import { issues } from "../schema/issues.ts"
 import { projects } from "../schema/projects.ts"
 import { scores } from "../schema/scores.ts"
+import { preferProjectFirst } from "./org-search.ts"
 
 // Lifecycle flags derived from `alert_incidents` are joined onto every
 // non-locking issue read. The two EXISTS subqueries are the system of record
@@ -338,10 +339,13 @@ const issueRepositoryCoreLive = Layer.effect(
           }))
         }),
 
-      searchOrgWide: ({ query, normalizedEmbedding, limit }) =>
+      searchOrgWide: ({ query, normalizedEmbedding, preferProjectId, limit }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const lexicalQuery = sql`websearch_to_tsquery('english', ${query})`
+          // Current project first *within* the tier, so a local lexical hit still beats a remote
+          // semantic one (the tiers are merged lexical-first by the caller).
+          const projectFirst = preferProjectFirst(issues.projectId, preferProjectId)
 
           // Lexical tier: GIN-backed full-text match OR a literal name substring. No embedding
           // round-trip, so this is the instant, index-backed path.
@@ -364,7 +368,7 @@ const issueRepositoryCoreLive = Layer.effect(
                     or(sql`${issues.searchDocument} @@ ${lexicalQuery}`, ilike(issues.name, `%${query}%`)),
                   ),
                 )
-                .orderBy(desc(lexicalScore), desc(issues.updatedAt), asc(issues.id))
+                .orderBy(...projectFirst, desc(lexicalScore), desc(issues.updatedAt), asc(issues.id))
                 .limit(limit),
             )
             return rows.map(toOrgIssueSearchHit)
@@ -403,7 +407,7 @@ const issueRepositoryCoreLive = Layer.effect(
                   sql`(${score} >= ${ISSUE_DISCOVERY_MIN_SIMILARITY} OR ${vectorScore} >= ${ISSUE_DISCOVERY_MIN_VECTOR_SIMILARITY})`,
                 ),
               )
-              .orderBy(desc(score), desc(vectorScore), desc(issues.updatedAt), asc(issues.id))
+              .orderBy(...projectFirst, desc(score), desc(vectorScore), desc(issues.updatedAt), asc(issues.id))
               .limit(limit),
           )
           return rows.map(toOrgIssueSearchHit)

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1119,7 +1119,11 @@ describe("MonitorRepositoryLive searchOrgWide", () => {
     await closeInMemoryPostgres(database)
   })
 
-  const search = (args: { readonly searchQuery?: string; readonly limit: number }) =>
+  const search = (args: {
+    readonly searchQuery?: string
+    readonly preferProjectId?: ProjectId
+    readonly limit: number
+  }) =>
     Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* MonitorRepository
@@ -1177,5 +1181,13 @@ describe("MonitorRepositoryLive searchOrgWide", () => {
 
     const results = await search({ searchQuery: "zebra", limit: 25 })
     expect(results.map((r) => r.name)).toEqual(["Zebra", "Zebra System", "Zebra User"])
+  })
+
+  it("ranks the preferred project's monitors first, ahead of match quality", async () => {
+    // For "error": "Error Rate" (project B) is a prefix match (higher score) than the substring
+    // "Payment Errors" (project A). Preferring project A floats it above the better match.
+    const preferA = await search({ searchQuery: "error", preferProjectId: projA, limit: 25 })
+    expect(preferA[0]?.name).toBe("Payment Errors")
+    expect(preferA[0]?.projectId).toBe(projA)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -16,6 +16,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { alertIncidents as alertIncidentsTable } from "../schema/alert-incidents.ts"
 import { monitorAlerts as monitorAlertsTable } from "../schema/monitor-alerts.ts"
 import { monitors as monitorsTable } from "../schema/monitors.ts"
+import { projects as projectsTable } from "../schema/projects.ts"
 import { closeInMemoryPostgres, createInMemoryPostgres, type InMemoryPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
 import { MonitorRepositoryLive } from "./monitor-repository.ts"
@@ -1054,5 +1055,98 @@ describe("MonitorRepositoryLive", () => {
       expect(await resolve({ kind: "issue.new", sourceId: issueId })).toHaveLength(1)
       expect(await resolve({ kind: "issue.new", sourceId: "z".repeat(24) })).toEqual([])
     })
+  })
+})
+
+describe("MonitorRepositoryLive searchOrgWide", () => {
+  let database: InMemoryPostgres
+
+  const searchOrgId = OrganizationId("org-mon-search-test")
+  const otherOrgId = OrganizationId("org-mon-search-other")
+  const projA = ProjectId("proj-mon-search-a")
+  const projB = ProjectId("proj-mon-search-b")
+  const projDeleted = ProjectId("proj-mon-search-del")
+  const projOther = ProjectId("proj-mon-search-oth")
+
+  const monId = (prefix: string) => prefix.padEnd(24, "x").slice(0, 24)
+
+  beforeAll(async () => {
+    database = await createInMemoryPostgres()
+    const baseTime = new Date("2026-05-29T10:00:00.000Z")
+
+    await database.db.insert(projectsTable).values([
+      { id: projA, organizationId: searchOrgId, name: "Alpha Project", slug: "mon-alpha" },
+      { id: projB, organizationId: searchOrgId, name: "Beta Project", slug: "mon-beta" },
+      { id: projDeleted, organizationId: searchOrgId, name: "Gone Project", slug: "mon-gone", deletedAt: baseTime },
+      { id: projOther, organizationId: otherOrgId, name: "Other Org Project", slug: "mon-other" },
+    ])
+
+    const monitorRow = (
+      id: string,
+      organizationId: OrganizationId,
+      projectId: ProjectId,
+      slug: string,
+      name: string,
+      extra: Partial<typeof monitorsTable.$inferInsert> = {},
+    ): typeof monitorsTable.$inferInsert => ({
+      id: monId(id),
+      organizationId,
+      projectId,
+      slug,
+      name,
+      description: "",
+      system: false,
+      mutedAt: null,
+      deletedAt: null,
+      createdAt: baseTime,
+      updatedAt: baseTime,
+      ...extra,
+    })
+
+    await database.db
+      .insert(monitorsTable)
+      .values([
+        monitorRow("msm1", searchOrgId, projA, "errors-a", "Payment Errors"),
+        monitorRow("msm2", searchOrgId, projB, "errors-b", "Error Rate", { mutedAt: baseTime }),
+        monitorRow("msm3", searchOrgId, projA, "latency", "Latency"),
+        monitorRow("msm4", searchOrgId, projA, "errors-del", "Errors Deleted", { deletedAt: baseTime }),
+        monitorRow("msm5", searchOrgId, projDeleted, "errors-gone", "Errors In Deleted Project"),
+        monitorRow("msm6", otherOrgId, projOther, "errors-secret", "Errors Secret"),
+      ])
+  })
+
+  afterAll(async () => {
+    await closeInMemoryPostgres(database)
+  })
+
+  const search = (args: { readonly searchQuery?: string; readonly limit: number }) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* MonitorRepository
+        return yield* repo.searchOrgWide(args)
+      }).pipe(withPostgres(MonitorRepositoryLive, database.appPostgresClient, searchOrgId)),
+    )
+
+  it("matches monitors across multiple projects in the org and tags them with the project + status", async () => {
+    const results = await search({ searchQuery: "error", limit: 25 })
+    expect(results.map((r) => r.name).sort()).toEqual(["Error Rate", "Payment Errors"])
+    const payment = results.find((r) => r.name === "Payment Errors")
+    const errorRate = results.find((r) => r.name === "Error Rate")
+    expect(payment).toMatchObject({ projectId: projA, projectSlug: "mon-alpha", projectName: "Alpha Project" })
+    expect(errorRate?.projectSlug).toBe("mon-beta")
+    expect(errorRate?.mutedAt).not.toBeNull()
+  })
+
+  it("excludes soft-deleted monitors, deleted projects, and other organizations", async () => {
+    const results = await search({ searchQuery: "error", limit: 25 })
+    const names = results.map((r) => r.name)
+    expect(names).not.toContain("Errors Deleted")
+    expect(names).not.toContain("Errors In Deleted Project")
+    expect(names).not.toContain("Errors Secret")
+  })
+
+  it("respects the limit", async () => {
+    const results = await search({ searchQuery: "error", limit: 1 })
+    expect(results).toHaveLength(1)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1149,4 +1149,33 @@ describe("MonitorRepositoryLive searchOrgWide", () => {
     const results = await search({ searchQuery: "error", limit: 1 })
     expect(results).toHaveLength(1)
   })
+
+  it("orders by name-match quality first, then system monitors as a tiebreak", async () => {
+    const t = new Date("2026-05-30T12:00:00.000Z")
+    const mk = (id: string, slug: string, name: string, system: boolean): typeof monitorsTable.$inferInsert => ({
+      id: monId(id),
+      organizationId: searchOrgId,
+      projectId: projA,
+      slug,
+      name,
+      description: "",
+      system,
+      mutedAt: null,
+      deletedAt: null,
+      createdAt: t,
+      updatedAt: t,
+    })
+    // Exact match must lead even though it's non-system; among the two equal-score prefix matches,
+    // the system monitor wins the tiebreak.
+    await database.db
+      .insert(monitorsTable)
+      .values([
+        mk("mzm3", "zebra-user", "Zebra User", false),
+        mk("mzm2", "zebra-system", "Zebra System", true),
+        mk("mzm1", "zebra", "Zebra", false),
+      ])
+
+    const results = await search({ searchQuery: "zebra", limit: 25 })
+    expect(results.map((r) => r.name)).toEqual(["Zebra", "Zebra System", "Zebra User"])
+  })
 })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -14,6 +14,7 @@ import { alertIncidents } from "../schema/alert-incidents.ts"
 import { monitorAlerts } from "../schema/monitor-alerts.ts"
 import { monitors } from "../schema/monitors.ts"
 import { projects } from "../schema/projects.ts"
+import { nameMatchScore } from "./org-search.ts"
 
 const toMonitorAlert = (row: typeof monitorAlerts.$inferSelect): MonitorAlert => ({
   id: row.id as MonitorAlert["id"],
@@ -244,6 +245,16 @@ export const MonitorRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             trimmed ? ilike(monitors.name, `%${trimmed}%`) : undefined,
           )
+          // Best name match first (exact > prefix > substring), then system monitors, then newest.
+          // With no query every row scores equally, so it falls back to system-first then newest.
+          const orderBy = trimmed
+            ? [
+                desc(nameMatchScore(monitors.name, trimmed)),
+                desc(monitors.system),
+                desc(monitors.createdAt),
+                asc(monitors.id),
+              ]
+            : [desc(monitors.system), desc(monitors.createdAt), asc(monitors.id)]
 
           const rows = yield* sqlClient.query((db) =>
             db
@@ -260,8 +271,7 @@ export const MonitorRepositoryLive = Layer.effect(
               .from(monitors)
               .innerJoin(projects, eq(projects.id, monitors.projectId))
               .where(where)
-              // System monitors land at the top, otherwise newest first.
-              .orderBy(desc(monitors.system), desc(monitors.createdAt), asc(monitors.id))
+              .orderBy(...orderBy)
               .limit(limit),
           )
 

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -14,7 +14,7 @@ import { alertIncidents } from "../schema/alert-incidents.ts"
 import { monitorAlerts } from "../schema/monitor-alerts.ts"
 import { monitors } from "../schema/monitors.ts"
 import { projects } from "../schema/projects.ts"
-import { nameMatchScore } from "./org-search.ts"
+import { nameMatchScore, preferProjectFirst } from "./org-search.ts"
 
 const toMonitorAlert = (row: typeof monitorAlerts.$inferSelect): MonitorAlert => ({
   id: row.id as MonitorAlert["id"],
@@ -234,7 +234,7 @@ export const MonitorRepositoryLive = Layer.effect(
             offset,
           }
         }),
-      searchOrgWide: ({ searchQuery, limit }) =>
+      searchOrgWide: ({ searchQuery, preferProjectId, limit }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const { organizationId } = sqlClient
@@ -245,16 +245,19 @@ export const MonitorRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             trimmed ? ilike(monitors.name, `%${trimmed}%`) : undefined,
           )
-          // Best name match first (exact > prefix > substring), then system monitors, then newest.
-          // With no query every row scores equally, so it falls back to system-first then newest.
-          const orderBy = trimmed
-            ? [
-                desc(nameMatchScore(monitors.name, trimmed)),
-                desc(monitors.system),
-                desc(monitors.createdAt),
-                asc(monitors.id),
-              ]
-            : [desc(monitors.system), desc(monitors.createdAt), asc(monitors.id)]
+          // Preferred project first, then best name match (exact > prefix > substring), then system
+          // monitors, then newest. With no query the score is uniform → system-first then newest.
+          const orderBy = [
+            ...preferProjectFirst(monitors.projectId, preferProjectId),
+            ...(trimmed
+              ? [
+                  desc(nameMatchScore(monitors.name, trimmed)),
+                  desc(monitors.system),
+                  desc(monitors.createdAt),
+                  asc(monitors.id),
+                ]
+              : [desc(monitors.system), desc(monitors.createdAt), asc(monitors.id)]),
+          ]
 
           const rows = yield* sqlClient.query((db) =>
             db

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -3,15 +3,17 @@ import {
   type MonitorAlert,
   type MonitorLastIncident,
   MonitorRepository,
+  type MonitorSearchResult,
   monitorSchema,
 } from "@domain/monitors"
-import { NotFoundError, SqlClient, type SqlClientShape } from "@domain/shared"
+import { type MonitorId, NotFoundError, type ProjectId, SqlClient, type SqlClientShape } from "@domain/shared"
 import { and, asc, count, desc, eq, getTableColumns, ilike, inArray, isNull, max, ne, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { alertIncidents } from "../schema/alert-incidents.ts"
 import { monitorAlerts } from "../schema/monitor-alerts.ts"
 import { monitors } from "../schema/monitors.ts"
+import { projects } from "../schema/projects.ts"
 
 const toMonitorAlert = (row: typeof monitorAlerts.$inferSelect): MonitorAlert => ({
   id: row.id as MonitorAlert["id"],
@@ -230,6 +232,51 @@ export const MonitorRepositoryLive = Layer.effect(
             limit,
             offset,
           }
+        }),
+      searchOrgWide: ({ searchQuery, limit }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const { organizationId } = sqlClient
+          const trimmed = searchQuery?.trim()
+          const where = and(
+            eq(monitors.organizationId, organizationId),
+            isNull(monitors.deletedAt),
+            isNull(projects.deletedAt),
+            trimmed ? ilike(monitors.name, `%${trimmed}%`) : undefined,
+          )
+
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: monitors.id,
+                projectId: monitors.projectId,
+                projectSlug: projects.slug,
+                projectName: projects.name,
+                slug: monitors.slug,
+                name: monitors.name,
+                system: monitors.system,
+                mutedAt: monitors.mutedAt,
+              })
+              .from(monitors)
+              .innerJoin(projects, eq(projects.id, monitors.projectId))
+              .where(where)
+              // System monitors land at the top, otherwise newest first.
+              .orderBy(desc(monitors.system), desc(monitors.createdAt), asc(monitors.id))
+              .limit(limit),
+          )
+
+          return rows.map(
+            (row): MonitorSearchResult => ({
+              id: row.id as MonitorId,
+              projectId: row.projectId as ProjectId,
+              projectSlug: row.projectSlug,
+              projectName: row.projectName,
+              slug: row.slug,
+              name: row.name,
+              system: row.system,
+              mutedAt: row.mutedAt,
+            }),
+          )
         }),
       provisionSystemMonitors: (monitorsToProvision) =>
         Effect.gen(function* () {

--- a/packages/platform/db-postgres/src/repositories/org-search.ts
+++ b/packages/platform/db-postgres/src/repositories/org-search.ts
@@ -1,0 +1,14 @@
+import { type AnyColumn, type SQL, sql } from "drizzle-orm"
+
+/**
+ * Relevance score for an org-wide name search, used to order Command Palette results: exact name
+ * match (3) > name starts with the query (2) > substring match (1). Callers order by this DESC and
+ * then by recency, so the best name match leads and ties fall back to newest-first. Mirrors the
+ * `ILIKE %query%` filter the searches apply, so every returned row scores at least 1.
+ */
+export const nameMatchScore = (column: AnyColumn, query: string): SQL<number> =>
+  sql<number>`case
+    when lower(${column}) = lower(${query}) then 3
+    when ${column} ilike ${`${query}%`} then 2
+    else 1
+  end`

--- a/packages/platform/db-postgres/src/repositories/org-search.ts
+++ b/packages/platform/db-postgres/src/repositories/org-search.ts
@@ -1,4 +1,4 @@
-import { type AnyColumn, type SQL, sql } from "drizzle-orm"
+import { type AnyColumn, desc, type SQL, sql } from "drizzle-orm"
 
 /**
  * Relevance score for an org-wide name search, used to order Command Palette results: exact name
@@ -12,3 +12,12 @@ export const nameMatchScore = (column: AnyColumn, query: string): SQL<number> =>
     when ${column} ilike ${`${query}%`} then 2
     else 1
   end`
+
+/**
+ * Leading `ORDER BY` term(s) that float results from `preferProjectId` ahead of the rest, so that
+ * when the Command Palette is opened from inside a project that project's results come first. Spread
+ * into `orderBy(...)` before the relevance/recency terms. Returns an empty list (no-op) when no
+ * project is preferred — e.g. the palette is opened outside any project.
+ */
+export const preferProjectFirst = (projectColumn: AnyColumn, preferProjectId: string | undefined): SQL[] =>
+  preferProjectId ? [desc(sql<boolean>`(${projectColumn} = ${preferProjectId})`)] : []

--- a/packages/platform/db-postgres/src/repositories/saved-search-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/saved-search-repository.test.ts
@@ -540,4 +540,37 @@ describe("SavedSearchRepositoryLive searchOrgWide", () => {
     )
     expect(results).toHaveLength(1)
   })
+
+  it("orders by name-match quality: exact, then prefix, then substring", async () => {
+    const t = new Date("2025-03-02T12:00:00.000Z")
+    const mk = (id: string, slug: string, name: string) => ({
+      id: ssId(id),
+      organizationId: SS_ORG_ID,
+      projectId: SS_PROJECT_A,
+      slug,
+      name,
+      query: "x",
+      filterSet: {},
+      assignedUserId: null,
+      createdByUserId: CREATOR_USER_ID,
+      createdAt: t,
+      updatedAt: t,
+    })
+    // Inserted substring-first to prove ordering isn't just insertion/recency order.
+    await pg.db
+      .insert(savedSearches)
+      .values([
+        mk("ssm3", "my-zebra-log", "My Zebra Log"),
+        mk("ssm2", "zebra-report", "Zebra Report"),
+        mk("ssm1", "zebra", "Zebra"),
+      ])
+
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* SavedSearchRepository
+        return yield* repo.searchOrgWide({ searchQuery: "zebra", limit: 25 })
+      }),
+    )
+    expect(results.map((r) => r.name)).toEqual(["Zebra", "Zebra Report", "My Zebra Log"])
+  })
 })

--- a/packages/platform/db-postgres/src/repositories/saved-search-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/saved-search-repository.test.ts
@@ -1,7 +1,8 @@
 import { DuplicateSavedSearchSlugError, SavedSearchNotFoundError, SavedSearchRepository } from "@domain/saved-searches"
 import { OrganizationId, ProjectId, type SqlClient, UserId } from "@domain/shared"
 import { Effect } from "effect"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { projects } from "../schema/projects.ts"
 import { savedSearches } from "../schema/saved-searches.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
@@ -441,5 +442,102 @@ describe("SavedSearchRepositoryLive", () => {
       }),
     )
     expect(otherOrgPage.items).toHaveLength(0)
+  })
+})
+
+const SS_ORG_ID = OrganizationId("org-ss-search-test")
+const SS_OTHER_ORG_ID = OrganizationId("org-ss-search-other")
+const SS_PROJECT_A = ProjectId("proj-ss-search-a")
+const SS_PROJECT_B = ProjectId("proj-ss-search-b")
+const SS_PROJECT_DELETED = ProjectId("proj-ss-search-del")
+const SS_PROJECT_OTHER = ProjectId("proj-ss-search-oth")
+
+const ssId = (prefix: string) => prefix.padEnd(24, "x").slice(0, 24)
+
+describe("SavedSearchRepositoryLive searchOrgWide", () => {
+  const runSearch = <A, E>(effect: Effect.Effect<A, E, SavedSearchRepository | SqlClient>) =>
+    Effect.runPromise(effect.pipe(withPostgres(SavedSearchRepositoryLive, pg.adminPostgresClient, SS_ORG_ID)))
+
+  beforeAll(async () => {
+    const db = pg.db
+    const baseTime = new Date("2025-03-01T12:00:00.000Z")
+
+    await db.insert(projects).values([
+      { id: SS_PROJECT_A, organizationId: SS_ORG_ID, name: "Alpha Project", slug: "ss-alpha" },
+      { id: SS_PROJECT_B, organizationId: SS_ORG_ID, name: "Beta Project", slug: "ss-beta" },
+      { id: SS_PROJECT_DELETED, organizationId: SS_ORG_ID, name: "Gone Project", slug: "ss-gone", deletedAt: baseTime },
+      { id: SS_PROJECT_OTHER, organizationId: SS_OTHER_ORG_ID, name: "Other Org Project", slug: "ss-other" },
+    ])
+
+    const row = (
+      id: string,
+      organizationId: OrganizationId,
+      projectId: ProjectId,
+      slug: string,
+      name: string,
+      extra: { deletedAt?: Date } = {},
+    ) => ({
+      id: ssId(id),
+      organizationId,
+      projectId,
+      slug,
+      name,
+      query: "x",
+      filterSet: {},
+      assignedUserId: null,
+      createdByUserId: CREATOR_USER_ID,
+      createdAt: baseTime,
+      updatedAt: baseTime,
+      ...(extra.deletedAt ? { deletedAt: extra.deletedAt } : {}),
+    })
+
+    await db
+      .insert(savedSearches)
+      .values([
+        row("sss1", SS_ORG_ID, SS_PROJECT_A, "errors-a", "Payment Errors"),
+        row("sss2", SS_ORG_ID, SS_PROJECT_B, "errors-b", "Error Spikes"),
+        row("sss3", SS_ORG_ID, SS_PROJECT_A, "latency", "Latency"),
+        row("sss4", SS_ORG_ID, SS_PROJECT_A, "errors-del", "Errors Deleted", { deletedAt: baseTime }),
+        row("sss5", SS_ORG_ID, SS_PROJECT_DELETED, "errors-gone", "Errors In Deleted Project"),
+        row("sss6", SS_OTHER_ORG_ID, SS_PROJECT_OTHER, "errors-secret", "Errors Secret"),
+      ])
+  })
+
+  it("matches saved searches across multiple projects in the org and tags them with the project", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* SavedSearchRepository
+        return yield* repo.searchOrgWide({ searchQuery: "error", limit: 25 })
+      }),
+    )
+
+    expect(results.map((r) => r.name).sort()).toEqual(["Error Spikes", "Payment Errors"])
+    const payment = results.find((r) => r.name === "Payment Errors")
+    const spikes = results.find((r) => r.name === "Error Spikes")
+    expect(payment).toMatchObject({ projectId: SS_PROJECT_A, projectSlug: "ss-alpha", projectName: "Alpha Project" })
+    expect(spikes).toMatchObject({ projectId: SS_PROJECT_B, projectSlug: "ss-beta", projectName: "Beta Project" })
+  })
+
+  it("excludes soft-deleted saved searches, deleted projects, and other organizations", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* SavedSearchRepository
+        return yield* repo.searchOrgWide({ searchQuery: "error", limit: 25 })
+      }),
+    )
+    const names = results.map((r) => r.name)
+    expect(names).not.toContain("Errors Deleted")
+    expect(names).not.toContain("Errors In Deleted Project")
+    expect(names).not.toContain("Errors Secret")
+  })
+
+  it("respects the limit", async () => {
+    const results = await runSearch(
+      Effect.gen(function* () {
+        const repo = yield* SavedSearchRepository
+        return yield* repo.searchOrgWide({ searchQuery: "error", limit: 1 })
+      }),
+    )
+    expect(results).toHaveLength(1)
   })
 })

--- a/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
@@ -19,6 +19,7 @@ import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { projects } from "../schema/projects.ts"
 import { savedSearches } from "../schema/saved-searches.ts"
+import { nameMatchScore } from "./org-search.ts"
 
 const isUniqueViolation = (cause: unknown): boolean => {
   let current: unknown = cause
@@ -171,6 +172,11 @@ export const SavedSearchRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             ...(trimmed ? [ilike(savedSearches.name, `%${trimmed}%`)] : []),
           )
+          // Best name match first (exact > prefix > substring), then most recent. With no query
+          // every row scores equally, so it falls back to newest-first.
+          const orderBy = trimmed
+            ? [desc(nameMatchScore(savedSearches.name, trimmed)), desc(savedSearches.createdAt), desc(savedSearches.id)]
+            : [desc(savedSearches.createdAt), desc(savedSearches.id)]
 
           const rows = yield* sqlClient.query((db) =>
             db
@@ -185,7 +191,7 @@ export const SavedSearchRepositoryLive = Layer.effect(
               .from(savedSearches)
               .innerJoin(projects, eq(projects.id, savedSearches.projectId))
               .where(conditions)
-              .orderBy(desc(savedSearches.createdAt), desc(savedSearches.id))
+              .orderBy(...orderBy)
               .limit(args.limit),
           )
 

--- a/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
@@ -3,6 +3,7 @@ import {
   type SavedSearch,
   SavedSearchNotFoundError,
   SavedSearchRepository,
+  type SavedSearchSearchResult,
 } from "@domain/saved-searches"
 import {
   OrganizationId,
@@ -13,9 +14,10 @@ import {
   type SqlClientShape,
   UserId,
 } from "@domain/shared"
-import { and, desc, eq, isNull, ne, sql } from "drizzle-orm"
+import { and, desc, eq, ilike, isNull, ne, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
+import { projects } from "../schema/projects.ts"
 import { savedSearches } from "../schema/saved-searches.ts"
 
 const isUniqueViolation = (cause: unknown): boolean => {
@@ -157,6 +159,46 @@ export const SavedSearchRepositoryLive = Layer.effect(
             db.select().from(savedSearches).where(conditions).orderBy(desc(savedSearches.createdAt)),
           )
           return { items: rows.map(toSavedSearch) }
+        }),
+
+      searchOrgWide: (args) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const trimmed = args.searchQuery?.trim()
+          const conditions = and(
+            eq(savedSearches.organizationId, sqlClient.organizationId),
+            isNull(savedSearches.deletedAt),
+            isNull(projects.deletedAt),
+            ...(trimmed ? [ilike(savedSearches.name, `%${trimmed}%`)] : []),
+          )
+
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: savedSearches.id,
+                projectId: savedSearches.projectId,
+                projectSlug: projects.slug,
+                projectName: projects.name,
+                slug: savedSearches.slug,
+                name: savedSearches.name,
+              })
+              .from(savedSearches)
+              .innerJoin(projects, eq(projects.id, savedSearches.projectId))
+              .where(conditions)
+              .orderBy(desc(savedSearches.createdAt), desc(savedSearches.id))
+              .limit(args.limit),
+          )
+
+          return rows.map(
+            (row): SavedSearchSearchResult => ({
+              id: SavedSearchId(row.id),
+              projectId: ProjectId(row.projectId),
+              projectSlug: row.projectSlug,
+              projectName: row.projectName,
+              slug: row.slug,
+              name: row.name,
+            }),
+          )
         }),
 
       update: (args) =>

--- a/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/saved-search-repository.ts
@@ -19,7 +19,7 @@ import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { projects } from "../schema/projects.ts"
 import { savedSearches } from "../schema/saved-searches.ts"
-import { nameMatchScore } from "./org-search.ts"
+import { nameMatchScore, preferProjectFirst } from "./org-search.ts"
 
 const isUniqueViolation = (cause: unknown): boolean => {
   let current: unknown = cause
@@ -172,11 +172,18 @@ export const SavedSearchRepositoryLive = Layer.effect(
             isNull(projects.deletedAt),
             ...(trimmed ? [ilike(savedSearches.name, `%${trimmed}%`)] : []),
           )
-          // Best name match first (exact > prefix > substring), then most recent. With no query
-          // every row scores equally, so it falls back to newest-first.
-          const orderBy = trimmed
-            ? [desc(nameMatchScore(savedSearches.name, trimmed)), desc(savedSearches.createdAt), desc(savedSearches.id)]
-            : [desc(savedSearches.createdAt), desc(savedSearches.id)]
+          // Preferred project first, then best name match (exact > prefix > substring), then most
+          // recent. With no query the score is uniform, so it falls back to newest-first.
+          const orderBy = [
+            ...preferProjectFirst(savedSearches.projectId, args.preferProjectId),
+            ...(trimmed
+              ? [
+                  desc(nameMatchScore(savedSearches.name, trimmed)),
+                  desc(savedSearches.createdAt),
+                  desc(savedSearches.id),
+                ]
+              : [desc(savedSearches.createdAt), desc(savedSearches.id)]),
+          ]
 
           const rows = yield* sqlClient.query((db) =>
             db


### PR DESCRIPTION
## Summary

The command palette only searched the **current project**: every search hook required a project from the route and disabled itself outside one. So searching from an org-level page returned nothing, and finding an entity in another project meant navigating into it first.

This makes Issues, Datasets, Saved searches, and Monitors search **across every project in the organization**, and each result shows which project it belongs to. Selecting a result navigates into that result's project.

## How it works

All four tables already carry `organization_id` (with `organizationRLSPolicy` and composite `(organization_id, project_id, …)` indexes), so "org-wide" means dropping the `project_id` predicate — org scoping stays enforced by RLS. No schema migration.

Per entity (Datasets, Saved searches, Monitors) the change is one vertical slice:
- a new `searchOrgWide` repository method (drops the project predicate, `INNER JOIN`s `projects` to tag each row with `projectSlug` + `projectName`),
- a thin use-case, an org-wide RPC, and a client hook,
- the palette hook drops its current-project gate and renders the project name in the subtitle, navigating via each result's own project slug.

The existing project-scoped methods (`listByProject`, `listMonitors`, etc.) are untouched — the project pages still use them.

## Issues

Issues don't reuse `listIssuesUseCase` (a heavyweight ClickHouse analytics pipeline coupled to one project that would drop cross-project hits). Instead a dedicated lightweight path:

- `IssueRepository.searchOrgWide` runs two tiers org-wide: **lexical** (GIN-backed full-text OR name substring — instant, no embedding) and **semantic** (the hybrid vector + lexical blend, embedding-gated).
- `searchOrgIssuesUseCase` merges them **lexical-first**, dedupes by id, caps the result, and derives lifecycle states from Postgres only (no ClickHouse).
- The RPC embeds the query server-side only on the debounced semantic call; the palette fires the lexical tier on every keystroke and the semantic tier after a 250ms debounce.

The semantic tier is an exact cosine scan over all org issues (`centroid_embedding` has no ANN index — see the schema note). Fine for the debounced, capped palette tier; add an HNSW index if a large org regresses.

## Traces fallback

There's no org-wide trace search, so the `Search traces for "…"` action stays project-scoped and only renders inside a project. To make that narrower scope explicit now that everything else is org-wide, it reads `Search traces for "query" in Project` with the query and project name emphasized and the scaffolding muted.

## Decisions / scope

- **New dedicated methods rather than making `projectId` optional** on the existing ones — keeps project-scoped callers and their RLS-guard predicate intact, and avoids accidental org-wide leaks.
- **No current-project bias.** Considered sorting current-project results first, but for relevance-ranked issues it would override the lexical-first ordering, so it's left out.
- Multi-word queries for datasets/saved-searches/monitors use a contiguous `ILIKE` (issues handle multi-token via full-text); could tokenize server-side later.

## Testing

Per entity: a use-case unit test (cross-project matches, project tagging, limit; for issues also lexical-first merge + dedupe + state derivation) and an adapter integration test under RLS asserting cross-project matches and exclusion of soft-deleted rows, soft-deleted projects, and other organizations.

Full-workspace `tsgo` typecheck passes (75/75). Affected suites green: db-postgres 267, issues 139, monitors 59, saved-searches 27, datasets 25.
