### PR TITLE
feat(traces): add duration composition bar to trace and session drawers

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -62,7 +62,6 @@ export const useSpansByTraceCollection = ({
 const makeSpansBySessionCollection = (
   projectId: string,
   sessionId: string,
-  traceIds: readonly string[],
   startTimeFrom: string | undefined,
   startTimeTo: string | undefined,
 ) =>
@@ -70,8 +69,7 @@ const makeSpansBySessionCollection = (
     queryCollectionOptions({
       queryClient,
       queryKey: ["spans", "session", projectId, sessionId, startTimeFrom, startTimeTo],
-      queryFn: () =>
-        listSpansBySession({ data: { projectId, traceIds: Array.from(traceIds), startTimeFrom, startTimeTo } }),
+      queryFn: () => listSpansBySession({ data: { projectId, sessionId, startTimeFrom, startTimeTo } }),
       getKey: (item: SpanRecord): string => `${item.traceId}-${item.spanId}`,
     }),
   )
@@ -82,19 +80,12 @@ const sessionCollectionsCache: Record<string, SpansBySessionCollection> = {}
 const getSpansBySessionCollection = (
   projectId: string,
   sessionId: string,
-  traceIds: readonly string[],
   startTimeFrom: string | undefined,
   startTimeTo: string | undefined,
 ): SpansBySessionCollection => {
   const cacheKey = `${projectId}:${sessionId}:${startTimeFrom ?? ""}:${startTimeTo ?? ""}`
   if (!sessionCollectionsCache[cacheKey]) {
-    sessionCollectionsCache[cacheKey] = makeSpansBySessionCollection(
-      projectId,
-      sessionId,
-      traceIds,
-      startTimeFrom,
-      startTimeTo,
-    )
+    sessionCollectionsCache[cacheKey] = makeSpansBySessionCollection(projectId, sessionId, startTimeFrom, startTimeTo)
   }
   return sessionCollectionsCache[cacheKey]
 }
@@ -102,17 +93,15 @@ const getSpansBySessionCollection = (
 export const useSpansBySessionCollection = ({
   projectId,
   sessionId,
-  traceIds,
   startTimeFrom,
   startTimeTo,
 }: {
   readonly projectId: string
   readonly sessionId: string
-  readonly traceIds: readonly string[]
   readonly startTimeFrom?: string | undefined
   readonly startTimeTo?: string | undefined
 }) => {
-  const collection = getSpansBySessionCollection(projectId, sessionId, traceIds, startTimeFrom, startTimeTo)
+  const collection = getSpansBySessionCollection(projectId, sessionId, startTimeFrom, startTimeTo)
   return useLiveQuery((q) => q.from({ span: collection }))
 }
 

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import {
   getSpanDetail,
+  listSpansBySession,
   listSpansByTrace,
   mapConversationToSpans,
   type SpanDetailRecord,
@@ -55,6 +56,63 @@ export const useSpansByTraceCollection = ({
   readonly startTimeTo?: string | undefined
 }) => {
   const collection = getSpansByTraceCollection(projectId, traceId, startTimeFrom, startTimeTo)
+  return useLiveQuery((q) => q.from({ span: collection }))
+}
+
+const makeSpansBySessionCollection = (
+  projectId: string,
+  sessionId: string,
+  traceIds: readonly string[],
+  startTimeFrom: string | undefined,
+  startTimeTo: string | undefined,
+) =>
+  createCollection(
+    queryCollectionOptions({
+      queryClient,
+      queryKey: ["spans", "session", projectId, sessionId, startTimeFrom, startTimeTo],
+      queryFn: () =>
+        listSpansBySession({ data: { projectId, traceIds: Array.from(traceIds), startTimeFrom, startTimeTo } }),
+      getKey: (item: SpanRecord): string => `${item.traceId}-${item.spanId}`,
+    }),
+  )
+
+type SpansBySessionCollection = ReturnType<typeof makeSpansBySessionCollection>
+const sessionCollectionsCache: Record<string, SpansBySessionCollection> = {}
+
+const getSpansBySessionCollection = (
+  projectId: string,
+  sessionId: string,
+  traceIds: readonly string[],
+  startTimeFrom: string | undefined,
+  startTimeTo: string | undefined,
+): SpansBySessionCollection => {
+  const cacheKey = `${projectId}:${sessionId}:${startTimeFrom ?? ""}:${startTimeTo ?? ""}`
+  if (!sessionCollectionsCache[cacheKey]) {
+    sessionCollectionsCache[cacheKey] = makeSpansBySessionCollection(
+      projectId,
+      sessionId,
+      traceIds,
+      startTimeFrom,
+      startTimeTo,
+    )
+  }
+  return sessionCollectionsCache[cacheKey]
+}
+
+export const useSpansBySessionCollection = ({
+  projectId,
+  sessionId,
+  traceIds,
+  startTimeFrom,
+  startTimeTo,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceIds: readonly string[]
+  readonly startTimeFrom?: string | undefined
+  readonly startTimeTo?: string | undefined
+}) => {
+  const collection = getSpansBySessionCollection(projectId, sessionId, traceIds, startTimeFrom, startTimeTo)
   return useLiveQuery((q) => q.from({ span: collection }))
 }
 

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -170,6 +170,33 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
     return spans.map(serializeSpan)
   })
 
+export const listSpansBySession = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceIds: z.array(z.string()),
+      startTimeFrom: dateTimeParamSchema.optional(),
+      startTimeTo: dateTimeParamSchema.optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<SpanRecord[]> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const spans = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* SpanRepository
+        return yield* repo.listByTraceIds({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          traceIds: data.traceIds.map((id) => TraceId(id)),
+          ...(data.startTimeFrom ? { startTimeFrom: data.startTimeFrom } : {}),
+          ...(data.startTimeTo ? { startTimeTo: data.startTimeTo } : {}),
+        })
+      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+    return spans.map(serializeSpan)
+  })
+
 export const mapConversationToSpans = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string(), traceId: z.string() }))
   .handler(

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,4 +1,4 @@
-import { OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
+import { OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
 import type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode } from "@domain/spans"
 import { buildConversationSpanMaps, SpanRepository, TraceRepository } from "@domain/spans"
 import { withAi } from "@platform/ai"
@@ -174,7 +174,7 @@ export const listSpansBySession = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string()),
+      sessionId: z.string(),
       startTimeFrom: dateTimeParamSchema.optional(),
       startTimeTo: dateTimeParamSchema.optional(),
     }),
@@ -185,10 +185,10 @@ export const listSpansBySession = createServerFn({ method: "GET" })
     const spans = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* SpanRepository
-        return yield* repo.listByTraceIds({
+        return yield* repo.listBySessionId({
           organizationId: orgId,
           projectId: ProjectId(data.projectId),
-          traceIds: data.traceIds.map((id) => TraceId(id)),
+          sessionId: SessionId(data.sessionId),
           ...(data.startTimeFrom ? { startTimeFrom: data.startTimeFrom } : {}),
           ...(data.startTimeTo ? { startTimeTo: data.startTimeTo } : {}),
         })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -73,12 +73,9 @@ export function MetadataTab({
     />
   )
 
-  // Spans across every trace in the session, fetched in one query. The breakdown
-  // is computed per trace and summed, so between-trace gaps never count as idle.
   const { data: spans, isLoading: isSpansLoading } = useSpansBySessionCollection({
     projectId: session.projectId,
     sessionId: session.sessionId,
-    traceIds: session.traceIds,
     startTimeFrom: session.startTime,
     startTimeTo: session.endTime,
   })
@@ -141,7 +138,6 @@ export function MetadataTab({
         </div>
       )}
 
-      {/* ── Duration composition + usage (tokens + cost) ── */}
       <div className="flex flex-col gap-2">
         <DurationBar
           segments={durationBreakdown.segments}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -13,7 +13,10 @@ import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextIcon } from "lucide-react"
 import { useMemo } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
+import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
 import { SessionOutlierBadge, type SessionOutlierMetric } from "../session-outlier-badge.tsx"
+import { DurationBar } from "../trace-detail-drawer/duration-bar.tsx"
+import { computeSessionDurationBreakdown } from "../trace-detail-drawer/duration-composition.ts"
 import { UsageSummary } from "../trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx"
 
 // Sessions only expose percentile filters for duration/TTFT/cost
@@ -70,12 +73,19 @@ export function MetadataTab({
     />
   )
 
-  const durationValue = (
-    <span className="flex items-center gap-1">
-      {renderBadge("durationNs", session.durationNs)}
-      {session.durationNs > 0 ? formatDuration(session.durationNs) : "-"}
-    </span>
-  )
+  // Spans across every trace in the session, fetched in one query. The breakdown
+  // is computed per trace and summed, so between-trace gaps never count as idle.
+  const { data: spans, isLoading: isSpansLoading } = useSpansBySessionCollection({
+    projectId: session.projectId,
+    sessionId: session.sessionId,
+    traceIds: session.traceIds,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const durationBreakdown = useMemo(() => computeSessionDurationBreakdown(spans ?? []), [spans])
+  const fallbackDurationMs = session.durationNs / 1_000_000
+  const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs
+  const durationBadge = renderBadge("durationNs", session.durationNs)
 
   const ttftValue = (
     <span className="flex items-center gap-1">
@@ -94,10 +104,6 @@ export function MetadataTab({
           {
             label: "Start Time",
             value: relativeTime(new Date(session.startTime)),
-          },
-          {
-            label: "Duration",
-            value: durationValue,
           },
           {
             label: "TTFT",
@@ -135,7 +141,16 @@ export function MetadataTab({
         </div>
       )}
 
-      <UsageSummary data={session} costBadges={costBadgesNode} />
+      {/* ── Duration composition + usage (tokens + cost) ── */}
+      <div className="flex flex-col gap-2">
+        <DurationBar
+          segments={durationBreakdown.segments}
+          wallClockMs={durationWallClockMs}
+          badges={durationBadge}
+          isLoading={isSpansLoading}
+        />
+        <UsageSummary data={session} costBadges={costBadgesNode} />
+      </div>
 
       <div className="flex flex-col gap-1">
         <Text.H6 color="foregroundMuted">Tags</Text.H6>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -34,6 +34,7 @@ import type { PaletteCommand } from "../../../../../components/command-palette/t
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
 import { useAnnotationsByTrace } from "../../../../../domains/annotations/annotations.collection.ts"
 import type { AnnotationRecord } from "../../../../../domains/annotations/annotations.functions.ts"
+import { useSpansByTraceCollection } from "../../../../../domains/spans/spans.collection.ts"
 import { useTraceDetail } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -245,6 +246,14 @@ export function TraceDetailBody({
   )
   const isRecordLoading = !trace && !traceDetail
   const traceRecord: TraceRecord | undefined = traceDetail ?? trace
+  // Span list for the Trace tab's duration composition. The Spans tab fetches
+  // with the same key, so the cached collection dedupes both into one fetch.
+  const { data: spans, isLoading: isSpansLoading } = useSpansByTraceCollection({
+    projectId,
+    traceId,
+    startTimeFrom: traceRecord?.startTime,
+    startTimeTo: traceRecord?.endTime,
+  })
   const spansTabSuffix = useMemo(() => getSpansTabSuffix(traceRecord?.spanCount), [traceRecord?.spanCount])
   const tabsWithCounts = useMemo<TabOption<TabId>[]>(
     () =>
@@ -457,6 +466,8 @@ export function TraceDetailBody({
             projectId={projectId}
             traceRecord={traceRecord}
             traceDetail={traceDetail}
+            spans={spans}
+            isSpansLoading={isSpansLoading}
             isRecordLoading={isRecordLoading}
             isDetailLoading={isDetailLoading}
             filters={filters}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-bar.tsx
@@ -1,0 +1,91 @@
+import { Skeleton, Text, Tooltip } from "@repo/ui"
+import { Fragment, type ReactNode } from "react"
+import type { DurationSegment } from "./duration-composition.ts"
+import { SegmentBreakdownRows } from "./segment-breakdown-rows.tsx"
+import { formatDuration } from "./tabs/spans-tab/span-tree/tree-utils.ts"
+
+/**
+ * The composition bar drawn over a measured "duration line" (end-cap ticks +
+ * baseline), distinct from the stacked usage bars so it reads as *time*. Work
+ * categories are solid; idle is a hatched gap so the bar communicates "working
+ * vs waiting" without a legend. Segments sum to the wall-clock total.
+ */
+function Tick() {
+  return <div className="h-3 w-px shrink-0 bg-border" />
+}
+
+function DurationLine({ segments, wallClockMs }: { segments: readonly DurationSegment[]; wallClockMs: number }) {
+  return (
+    <div className="flex h-3 w-full flex-row items-center">
+      <Tick />
+      {segments.map((s, i) => (
+        <Fragment key={s.category}>
+          {i > 0 && <Tick />}
+          <div
+            className="h-2 min-w-[2px]"
+            style={{
+              width: `${(s.ms / wallClockMs) * 100}%`,
+              ...(s.hollow
+                ? {
+                    backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 3px, ${s.color} 3px, ${s.color} 4px)`,
+                  }
+                : { backgroundColor: s.color }),
+            }}
+          />
+        </Fragment>
+      ))}
+      <Tick />
+    </div>
+  )
+}
+
+export function DurationBar({
+  segments,
+  wallClockMs,
+  badges,
+  isLoading = false,
+}: {
+  readonly segments: readonly DurationSegment[]
+  readonly wallClockMs: number
+  readonly badges?: ReactNode
+  readonly isLoading?: boolean
+}) {
+  const hasBar = !isLoading && wallClockMs > 0 && segments.length > 0
+  const breakdownItems = segments.map((s) => ({ label: s.label, value: s.ms, color: s.color }))
+
+  return (
+    <div className="flex min-h-8 flex-row items-center gap-3">
+      <div className="flex min-w-12 self-center">
+        <Text.H6 color="foregroundMuted" noWrap>
+          Duration
+        </Text.H6>
+      </div>
+
+      {isLoading && (
+        <div className="flex min-w-0 w-full max-w-48 self-center items-center">
+          <Skeleton className="h-2 w-full" />
+        </div>
+      )}
+
+      {hasBar && (
+        <Tooltip
+          asChild
+          trigger={
+            <div className="flex min-w-0 w-full max-w-48 self-center items-center">
+              <DurationLine segments={segments} wallClockMs={wallClockMs} />
+            </div>
+          }
+        >
+          <SegmentBreakdownRows segments={breakdownItems} formatValue={formatDuration} />
+        </Tooltip>
+      )}
+
+      <div className="flex items-center gap-2 self-center">
+        <Text.H5 color="foreground" noWrap>
+          {wallClockMs > 0 ? formatDuration(wallClockMs) : "-"}
+        </Text.H5>
+        {badges}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import {
+  computeDurationBreakdown,
+  computeSessionDurationBreakdown,
+  type DurationCategory,
+} from "./duration-composition.ts"
+
+// Build a minimal span; only the fields the helpers read are meaningful.
+function span(partial: {
+  spanId: string
+  parentSpanId?: string
+  traceId?: string
+  operation: string
+  start: number
+  end: number
+}): SpanRecord {
+  return {
+    spanId: partial.spanId,
+    parentSpanId: partial.parentSpanId ?? "",
+    traceId: partial.traceId ?? "t",
+    operation: partial.operation,
+    startTime: new Date(partial.start).toISOString(),
+    endTime: new Date(partial.end).toISOString(),
+  } as unknown as SpanRecord
+}
+
+function ms(
+  segments: ReturnType<typeof computeDurationBreakdown>["segments"],
+): Partial<Record<DurationCategory, number>> {
+  return Object.fromEntries(segments.map((s) => [s.category, s.ms]))
+}
+
+describe("computeDurationBreakdown", () => {
+  it("returns empty for no spans", () => {
+    expect(computeDurationBreakdown([])).toEqual({ segments: [], wallClockMs: 0 })
+  })
+
+  it("attributes a single leaf span entirely to its category with no idle", () => {
+    const { segments, wallClockMs } = computeDurationBreakdown([
+      span({ spanId: "a", operation: "chat", start: 0, end: 1000 }),
+    ])
+    expect(wallClockMs).toBe(1000)
+    expect(ms(segments)).toEqual({ generation: 1000 })
+  })
+
+  it("counts the gap between serial spans as idle", () => {
+    // chat [0,1000] → idle [1000,1500] → tool [1500,2000]
+    const { segments, wallClockMs } = computeDurationBreakdown([
+      span({ spanId: "a", operation: "chat", start: 0, end: 1000 }),
+      span({ spanId: "b", operation: "execute_tool", start: 1500, end: 2000 }),
+    ])
+    expect(wallClockMs).toBe(2000)
+    expect(ms(segments)).toEqual({ generation: 1000, tool: 500, idle: 500 })
+  })
+
+  it("does not double-count parallel siblings (priority resolves overlap)", () => {
+    // Two leaves fully overlapping [0,1000]: generation wins over tool by priority.
+    const { segments, wallClockMs } = computeDurationBreakdown([
+      span({ spanId: "a", operation: "chat", start: 0, end: 1000 }),
+      span({ spanId: "b", operation: "execute_tool", start: 0, end: 1000 }),
+    ])
+    expect(wallClockMs).toBe(1000)
+    expect(ms(segments)).toEqual({ generation: 1000 })
+  })
+
+  it("excludes container (non-leaf) spans and surfaces uncovered time as idle", () => {
+    // root [0,2000] contains one chat child [0,1000]; remaining [1000,2000] is idle.
+    const { segments, wallClockMs } = computeDurationBreakdown([
+      span({ spanId: "root", operation: "invoke_agent", start: 0, end: 2000 }),
+      span({ spanId: "a", parentSpanId: "root", operation: "chat", start: 0, end: 1000 }),
+    ])
+    expect(wallClockMs).toBe(2000)
+    expect(ms(segments)).toEqual({ generation: 1000, idle: 1000 })
+  })
+
+  it("segments always sum to wall-clock duration", () => {
+    const { segments, wallClockMs } = computeDurationBreakdown([
+      span({ spanId: "root", operation: "chain", start: 0, end: 5000 }),
+      span({ spanId: "a", parentSpanId: "root", operation: "chat", start: 100, end: 1200 }),
+      span({ spanId: "b", parentSpanId: "root", operation: "execute_tool", start: 1200, end: 1800 }),
+      span({ spanId: "c", parentSpanId: "root", operation: "retrieval", start: 2500, end: 3000 }),
+      span({ spanId: "d", parentSpanId: "root", operation: "embeddings", start: 3000, end: 3200 }),
+    ])
+    const sum = segments.reduce((acc, s) => acc + s.ms, 0)
+    expect(sum).toBe(wallClockMs)
+  })
+
+  it("maps reranker to retrieval and unknown operations to other", () => {
+    const { segments } = computeDurationBreakdown([
+      span({ spanId: "a", operation: "reranker", start: 0, end: 500 }),
+      span({ spanId: "b", operation: "guardrail", start: 500, end: 800 }),
+    ])
+    expect(ms(segments)).toEqual({ retrieval: 500, other: 300 })
+  })
+})
+
+describe("computeSessionDurationBreakdown", () => {
+  it("does NOT count the gap between traces as idle", () => {
+    // Trace A: chat [0,1000]. Trace B: chat [5000,6000]. The [1000,5000] gap is
+    // between turns and must not appear as idle.
+    const { segments, wallClockMs } = computeSessionDurationBreakdown([
+      span({ spanId: "a", traceId: "A", operation: "chat", start: 0, end: 1000 }),
+      span({ spanId: "b", traceId: "B", operation: "chat", start: 5000, end: 6000 }),
+    ])
+    expect(wallClockMs).toBe(2000)
+    expect(ms(segments)).toEqual({ generation: 2000 })
+  })
+
+  it("sums within-trace idle across traces but ignores between-trace gaps", () => {
+    // Trace A: chat [0,1000] + tool [1500,2000] → 500ms within-trace idle.
+    // Trace B: chat [10000,11000]. Big gap before B is NOT idle.
+    const { segments, wallClockMs } = computeSessionDurationBreakdown([
+      span({ spanId: "a1", traceId: "A", operation: "chat", start: 0, end: 1000 }),
+      span({ spanId: "a2", traceId: "A", operation: "execute_tool", start: 1500, end: 2000 }),
+      span({ spanId: "b1", traceId: "B", operation: "chat", start: 10000, end: 11000 }),
+    ])
+    expect(wallClockMs).toBe(3000)
+    expect(ms(segments)).toEqual({ generation: 2000, tool: 500, idle: 500 })
+  })
+
+  it("returns empty for no spans", () => {
+    expect(computeSessionDurationBreakdown([])).toEqual({ segments: [], wallClockMs: 0 })
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
@@ -1,0 +1,177 @@
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+
+/**
+ * Duration composition — how a trace's wall-clock time was spent.
+ *
+ * A trace is a tree of spans that overlap (a parent `invoke_agent`/`chain` span
+ * contains its children) and can run in parallel (sibling tool calls). So we
+ * cannot sum `duration` per operation — that double-counts. Instead we take the
+ * **leaf** spans (the actual units of work) and **partition the wall-clock
+ * timeline**: every instant is attributed to exactly one category, with any
+ * instant where no leaf is running counted as **idle** (orchestration, network,
+ * waiting). Overlapping categories are resolved by priority so the segments sum
+ * exactly to the wall-clock duration.
+ *
+ * Times come from the spans' ISO `startTime`/`endTime`, so resolution is
+ * milliseconds (the nanosecond precision from ClickHouse does not survive
+ * serialization). That is plenty for trace-level durations.
+ */
+
+export type DurationCategory = "generation" | "tool" | "retrieval" | "other" | "idle"
+type WorkCategory = Exclude<DurationCategory, "idle">
+
+export interface DurationSegment {
+  readonly category: DurationCategory
+  readonly label: string
+  readonly ms: number
+  readonly color: string
+  /** Idle is "no work happening" — rendered as an empty/hatched gap, not a solid fill. */
+  readonly hollow?: boolean
+}
+
+// Green is "generation/output" (matches completion + output cost). The other
+// work categories use warm tones (orange/amber) deliberately distinct from the
+// blue/purple of the token & cost bars, so the two never get confused. Other is
+// neutral slate; idle stays a hatched gray.
+const DURATION_COLORS: Readonly<Record<DurationCategory, string>> = {
+  generation: "#4ade80",
+  tool: "#f97316",
+  retrieval: "#f59e0b",
+  other: "#94a3b8",
+  idle: "#cbd5e1",
+}
+
+const CATEGORY_LABELS: Readonly<Record<DurationCategory, string>> = {
+  generation: "Generation",
+  tool: "Tools",
+  retrieval: "Retrieval",
+  other: "Other",
+  idle: "Idle",
+}
+
+// Canonical render order (also the overlap-resolution priority for work categories).
+const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "tool", "retrieval", "other"]
+const SEGMENT_ORDER: readonly DurationCategory[] = ["generation", "tool", "retrieval", "other", "idle"]
+
+function categoryFor(operation: string): WorkCategory {
+  switch (operation) {
+    case "chat":
+    case "text_completion":
+      return "generation"
+    case "execute_tool":
+      return "tool"
+    case "retrieval":
+    case "reranker":
+      return "retrieval"
+    default:
+      return "other"
+  }
+}
+
+interface Interval {
+  readonly startMs: number
+  readonly endMs: number
+  readonly category: WorkCategory
+}
+
+export function computeDurationBreakdown(spans: readonly SpanRecord[]): {
+  segments: DurationSegment[]
+  wallClockMs: number
+} {
+  // Spans with parseable, positive-length time ranges.
+  const timed = spans
+    .map((span) => ({ span, startMs: Date.parse(span.startTime), endMs: Date.parse(span.endTime) }))
+    .filter((s) => Number.isFinite(s.startMs) && Number.isFinite(s.endMs) && s.endMs > s.startMs)
+
+  if (timed.length === 0) return { segments: [], wallClockMs: 0 }
+
+  // Wall clock spans the full trace, including container spans.
+  const wallStart = Math.min(...timed.map((s) => s.startMs))
+  const wallEnd = Math.max(...timed.map((s) => s.endMs))
+  const wallClockMs = wallEnd - wallStart
+
+  // Leaf = no other span declares it as parent. Container spans are excluded so
+  // their children are not counted twice; the time a container holds beyond its
+  // children naturally falls into idle.
+  const parentIds = new Set(spans.map((s) => s.parentSpanId).filter((id) => id !== ""))
+  const intervals: Interval[] = timed
+    .filter(({ span }) => !parentIds.has(span.spanId))
+    .map(({ span, startMs, endMs }) => ({ startMs, endMs, category: categoryFor(span.operation) }))
+
+  const totals: Record<DurationCategory, number> = {
+    generation: 0,
+    tool: 0,
+    retrieval: 0,
+    other: 0,
+    idle: 0,
+  }
+
+  // Sweep the timeline. Between consecutive event times the set of active
+  // categories is constant; attribute that slice to the highest-priority active
+  // category, or to idle when nothing is running.
+  const events = intervals
+    .flatMap((iv) => [
+      { t: iv.startMs, category: iv.category, delta: 1 },
+      { t: iv.endMs, category: iv.category, delta: -1 },
+    ])
+    .sort((a, b) => a.t - b.t)
+
+  const active: Record<WorkCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0 }
+  const dominant = (): DurationCategory => WORK_PRIORITY.find((c) => active[c] > 0) ?? "idle"
+
+  let cursor = wallStart
+  let i = 0
+  while (i < events.length) {
+    const t = events[i].t
+    if (t > cursor) {
+      totals[dominant()] += t - cursor
+      cursor = t
+    }
+    while (i < events.length && events[i].t === t) {
+      active[events[i].category] += events[i].delta
+      i++
+    }
+  }
+  if (wallEnd > cursor) totals.idle += wallEnd - cursor
+
+  return { segments: toSegments(totals), wallClockMs }
+}
+
+/**
+ * Session-level composition: the breakdown is computed **per trace** and then
+ * summed, so the gaps *between* traces (user think-time between turns) are never
+ * counted as idle — only the idle *within* each trace is. The total then equals
+ * the sum of per-trace wall clocks, matching how `session.durationNs` is derived
+ * (sum of root-span durations).
+ */
+export function computeSessionDurationBreakdown(spans: readonly SpanRecord[]): {
+  segments: DurationSegment[]
+  wallClockMs: number
+} {
+  const byTrace = new Map<string, SpanRecord[]>()
+  for (const span of spans) {
+    const list = byTrace.get(span.traceId)
+    if (list) list.push(span)
+    else byTrace.set(span.traceId, [span])
+  }
+
+  const totals: Record<DurationCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0, idle: 0 }
+  let wallClockMs = 0
+  for (const traceSpans of byTrace.values()) {
+    const breakdown = computeDurationBreakdown(traceSpans)
+    wallClockMs += breakdown.wallClockMs
+    for (const segment of breakdown.segments) totals[segment.category] += segment.ms
+  }
+
+  return { segments: toSegments(totals), wallClockMs }
+}
+
+function toSegments(totals: Record<DurationCategory, number>): DurationSegment[] {
+  return SEGMENT_ORDER.filter((category) => totals[category] > 0).map<DurationSegment>((category) => ({
+    category,
+    label: CATEGORY_LABELS[category],
+    ms: totals[category],
+    color: DURATION_COLORS[category],
+    ...(category === "idle" ? { hollow: true } : {}),
+  }))
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/segment-breakdown-rows.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/segment-breakdown-rows.tsx
@@ -1,0 +1,45 @@
+import { type SegmentBarItem, Text } from "@repo/ui"
+
+/**
+ * The hover tooltip body shared by the usage (tokens/cost) rows and the duration
+ * row: a swatch + label + formatted value per segment, then a Total line and an
+ * optional footnote.
+ */
+export function SegmentBreakdownRows({
+  segments,
+  formatValue,
+  footer,
+}: {
+  readonly segments: readonly SegmentBarItem[]
+  readonly formatValue: (value: number) => string
+  readonly footer?: string
+}) {
+  const total = segments.reduce((sum, s) => sum + s.value, 0)
+
+  return (
+    <div className="flex flex-col gap-1.5 min-w-[160px]">
+      {segments.map((s) => (
+        <div key={s.label} className="flex flex-row items-center justify-between gap-4">
+          <div className="flex flex-row items-center gap-1.5">
+            <div className="w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: s.color }} />
+            <Text.H6 color="foregroundMuted">{s.label}</Text.H6>
+          </div>
+          <Text.H6 color="foreground">{formatValue(s.value)}</Text.H6>
+        </div>
+      ))}
+
+      <hr className="border-t border-border" />
+
+      <div className="flex flex-row items-center justify-between gap-4">
+        <Text.H6 color="foregroundMuted">Total</Text.H6>
+        <Text.H6 color="foreground">{formatValue(total)}</Text.H6>
+      </div>
+
+      {footer && (
+        <Text.H6 color="foregroundMuted" italic>
+          {footer}
+        </Text.H6>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -21,6 +21,7 @@ export function SpansTab({
   readonly onSelectSpan: (spanId: string) => void
   readonly isActive: boolean
 }) {
+  // Shares the cached spans collection with the Trace tab's fetch (same key → one fetch).
   const { data: spans, isLoading } = useSpansByTraceCollection({ projectId, traceId, startTimeFrom, startTimeTo })
   const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
   const treeContainerRef = useRef<HTMLDivElement | null>(null)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -2,6 +2,7 @@ import { SegmentBar, type SegmentBarItem, Text, Tooltip } from "@repo/ui"
 import { formatCount, formatPrice } from "@repo/utils"
 import type React from "react"
 import { useMemo } from "react"
+import { SegmentBreakdownRows } from "../../../segment-breakdown-rows.tsx"
 
 export interface UsageData {
   readonly tokensInput: number
@@ -68,45 +69,6 @@ export function buildCostSegments(data: UsageData): SegmentBarItem[] {
   return segments
 }
 
-function BreakdownRows({
-  segments,
-  formatValue,
-  footer,
-}: {
-  readonly segments: readonly SegmentBarItem[]
-  readonly formatValue: (value: number) => string
-  readonly footer?: string
-}) {
-  const total = segments.reduce((sum, s) => sum + s.value, 0)
-
-  return (
-    <div className="flex flex-col gap-1.5 min-w-[160px]">
-      {segments.map((s) => (
-        <div key={s.label} className="flex flex-row items-center justify-between gap-4">
-          <div className="flex flex-row items-center gap-1.5">
-            <div className="w-2 h-2 rounded-sm shrink-0" style={{ backgroundColor: s.color }} />
-            <Text.H6 color="foregroundMuted">{s.label}</Text.H6>
-          </div>
-          <Text.H6 color="foreground">{formatValue(s.value)}</Text.H6>
-        </div>
-      ))}
-
-      <hr className="border-t border-border" />
-
-      <div className="flex flex-row items-center justify-between gap-4">
-        <Text.H6 color="foregroundMuted">Total</Text.H6>
-        <Text.H6 color="foreground">{formatValue(total)}</Text.H6>
-      </div>
-
-      {footer && (
-        <Text.H6 color="foregroundMuted" italic>
-          {footer}
-        </Text.H6>
-      )}
-    </div>
-  )
-}
-
 function UsageRow({
   label,
   formattedTotal,
@@ -138,7 +100,7 @@ function UsageRow({
         }
         asChild
       >
-        <BreakdownRows segments={segments} formatValue={formatValue} {...(footer ? { footer } : {})} />
+        <SegmentBreakdownRows segments={segments} formatValue={formatValue} {...(footer ? { footer } : {})} />
       </Tooltip>
 
       <div className="flex items-center gap-2 self-center">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -13,8 +13,11 @@ import {
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
 import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextIcon } from "lucide-react"
 import { useMemo } from "react"
+import type { SpanRecord } from "../../../../../../../domains/spans/spans.functions.ts"
 import type { TraceDetailRecord, TraceRecord } from "../../../../../../../domains/traces/traces.functions.ts"
 import { TraceOutlierBadge, type TraceOutlierMetric } from "../../trace-outlier-badge.tsx"
+import { DurationBar } from "../duration-bar.tsx"
+import { computeDurationBreakdown } from "../duration-composition.ts"
 import { UsageSummary } from "./spans-tab/span-detail/usage-summary.tsx"
 
 function JsonBlock({ value }: { readonly value: unknown }) {
@@ -34,6 +37,8 @@ export function TraceTab({
   projectId,
   traceRecord,
   traceDetail,
+  spans,
+  isSpansLoading,
   isRecordLoading,
   isDetailLoading,
   filters,
@@ -44,6 +49,8 @@ export function TraceTab({
   readonly projectId: string
   readonly traceRecord: TraceRecord | undefined
   readonly traceDetail: TraceDetailRecord | null | undefined
+  readonly spans: readonly SpanRecord[] | undefined
+  readonly isSpansLoading: boolean
   readonly isRecordLoading: boolean
   readonly isDetailLoading: boolean
   readonly filters?: FilterSet | undefined
@@ -77,12 +84,13 @@ export function TraceTab({
       />
     ) : null
 
-  const durationValue = traceRecord ? (
-    <span className="flex items-center gap-1">
-      {renderBadge("durationNs", traceRecord.durationNs)}
-      {traceRecord.durationNs > 0 ? formatDuration(traceRecord.durationNs) : "-"}
-    </span>
-  ) : undefined
+  // Duration composition from the span list (leaf intervals partitioned by
+  // category). Falls back to the trace record's wall-clock total (ns → ms) until
+  // spans load or when none are available, so the total always renders.
+  const durationBreakdown = useMemo(() => computeDurationBreakdown(spans ?? []), [spans])
+  const fallbackDurationMs = traceRecord ? traceRecord.durationNs / 1_000_000 : 0
+  const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs
+  const durationBadge = traceRecord ? renderBadge("durationNs", traceRecord.durationNs) : undefined
 
   const ttftValue = traceRecord ? (
     <span className="flex items-center gap-1">
@@ -101,11 +109,6 @@ export function TraceTab({
           {
             label: "Start Time",
             value: traceRecord ? relativeTime(new Date(traceRecord.startTime)) : undefined,
-            isLoading: isRecordLoading,
-          },
-          {
-            label: "Duration",
-            value: durationValue,
             isLoading: isRecordLoading,
           },
           {
@@ -148,8 +151,22 @@ export function TraceTab({
         </div>
       )}
 
-      {/* ── Usage: tokens + cost ── */}
-      {traceRecord && <UsageSummary data={traceRecord} costBadges={costBadgesNode} />}
+      {/* ── Duration composition + usage (tokens + cost) ── */}
+      {isRecordLoading ? (
+        <Skeleton className="h-8 w-full" />
+      ) : (
+        traceRecord && (
+          <div className="flex flex-col gap-2">
+            <DurationBar
+              segments={durationBreakdown.segments}
+              wallClockMs={durationWallClockMs}
+              badges={durationBadge}
+              isLoading={isSpansLoading}
+            />
+            <UsageSummary data={traceRecord} costBadges={costBadgesNode} />
+          </div>
+        )
+      )}
 
       {/* ── Tags ── */}
       <div className="flex flex-col gap-1">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -84,9 +84,7 @@ export function TraceTab({
       />
     ) : null
 
-  // Duration composition from the span list (leaf intervals partitioned by
-  // category). Falls back to the trace record's wall-clock total (ns → ms) until
-  // spans load or when none are available, so the total always renders.
+  // Falls back to the record total until spans load, so the duration always renders.
   const durationBreakdown = useMemo(() => computeDurationBreakdown(spans ?? []), [spans])
   const fallbackDurationMs = traceRecord ? traceRecord.durationNs / 1_000_000 : 0
   const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -39,6 +39,19 @@ export interface SpanRepositoryShape {
     readonly startTimeTo?: Date
   }): Effect.Effect<readonly Span[], RepositoryError, ChSqlClient>
 
+  /**
+   * Spans across a set of traces (e.g. every trace in a session). Filters on
+   * `trace_id IN (...)` rather than `session_id` so it also covers orphan
+   * single-trace sessions, whose spans carry no `session_id`.
+   */
+  listByTraceIds(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceIds: readonly TraceId[]
+    readonly startTimeFrom?: Date
+    readonly startTimeTo?: Date
+  }): Effect.Effect<readonly Span[], RepositoryError, ChSqlClient>
+
   listByProjectId(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -4,6 +4,7 @@ import type {
   OrganizationId,
   ProjectId,
   RepositoryError,
+  SessionId,
   SpanId,
   TraceId,
 } from "@domain/shared"
@@ -40,14 +41,15 @@ export interface SpanRepositoryShape {
   }): Effect.Effect<readonly Span[], RepositoryError, ChSqlClient>
 
   /**
-   * Spans across a set of traces (e.g. every trace in a session). Filters on
-   * `trace_id IN (...)` rather than `session_id` so it also covers orphan
-   * single-trace sessions, whose spans carry no `session_id`.
+   * Every span in a session. Membership mirrors the `sessions_mv` grouping key
+   * (`coalesce(nullIf(session_id, ''), toString(trace_id))`), so it covers both
+   * conversation-id sessions and orphan single-trace sessions (whose spans carry
+   * no `session_id` and are keyed on their `trace_id`).
    */
-  listByTraceIds(input: {
+  listBySessionId(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
-    readonly traceIds: readonly TraceId[]
+    readonly sessionId: SessionId
     readonly startTimeFrom?: Date
     readonly startTimeTo?: Date
   }): Effect.Effect<readonly Span[], RepositoryError, ChSqlClient>

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -14,6 +14,7 @@ export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape
       return Effect.void
     },
     listByTraceId: () => Effect.succeed([]),
+    listByTraceIds: () => Effect.succeed([]),
     listByProjectId: () => Effect.succeed([]),
     findBySpanId: () => Effect.fail(new NotFoundError({ entity: "Span", id: "" })),
     findMessagesForTrace: () => Effect.succeed([]),

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -14,7 +14,7 @@ export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape
       return Effect.void
     },
     listByTraceId: () => Effect.succeed([]),
-    listByTraceIds: () => Effect.succeed([]),
+    listBySessionId: () => Effect.succeed([]),
     listByProjectId: () => Effect.succeed([]),
     findBySpanId: () => Effect.fail(new NotFoundError({ entity: "Span", id: "" })),
     findMessagesForTrace: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -404,15 +404,14 @@ export const SpanRepositoryLive = Layer.effect(
           )
       })
 
-    const listByTraceIds: SpanRepositoryShape["listByTraceIds"] = ({
+    const listBySessionId: SpanRepositoryShape["listBySessionId"] = ({
       organizationId,
       projectId,
-      traceIds,
+      sessionId,
       startTimeFrom,
       startTimeTo,
     }) =>
       Effect.gen(function* () {
-        if (traceIds.length === 0) return []
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         const startFromClause = startTimeFrom
           ? "AND start_time >= parseDateTime64BestEffort({startTimeFrom:String}, 9, 'UTC')"
@@ -423,15 +422,17 @@ export const SpanRepositoryLive = Layer.effect(
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Same `LIMIT 1 BY span_id` dedupe as listByTraceId; filters on a
-              // set of trace ids so a whole session can be fetched in one query.
+              // Session membership mirrors the sessions_mv grouping key exactly:
+              // conversation-id sessions match on session_id, orphan single-trace
+              // sessions (empty session_id) match on toString(trace_id). Same
+              // `LIMIT 1 BY span_id` dedupe as listByTraceId.
               query: `SELECT ${LIST_COLUMNS}
                     FROM (
                       SELECT ${LIST_COLUMNS}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
-                        AND trace_id IN ({traceIds:Array(String)})
+                        AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
                         ${startFromClause}
                         ${startToClause}
                       ORDER BY span_id, ingested_at DESC
@@ -441,7 +442,7 @@ export const SpanRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                traceIds: Array.from(traceIds) as string[],
+                sessionId: sessionId as string,
                 ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
                 ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
               },
@@ -451,7 +452,7 @@ export const SpanRepositoryLive = Layer.effect(
           })
           .pipe(
             Effect.map((rows) => rows.map(toDomainSpan)),
-            Effect.mapError((error) => toRepositoryError(error, "listByTraceIds")),
+            Effect.mapError((error) => toRepositoryError(error, "listBySessionId")),
           )
       })
 
@@ -480,7 +481,7 @@ export const SpanRepositoryLive = Layer.effect(
 
       listByTraceId,
 
-      listByTraceIds,
+      listBySessionId,
 
       listByProjectId,
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -404,6 +404,57 @@ export const SpanRepositoryLive = Layer.effect(
           )
       })
 
+    const listByTraceIds: SpanRepositoryShape["listByTraceIds"] = ({
+      organizationId,
+      projectId,
+      traceIds,
+      startTimeFrom,
+      startTimeTo,
+    }) =>
+      Effect.gen(function* () {
+        if (traceIds.length === 0) return []
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const startFromClause = startTimeFrom
+          ? "AND start_time >= parseDateTime64BestEffort({startTimeFrom:String}, 9, 'UTC')"
+          : ""
+        const startToClause = startTimeTo
+          ? "AND start_time <= parseDateTime64BestEffort({startTimeTo:String}, 9, 'UTC')"
+          : ""
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              // Same `LIMIT 1 BY span_id` dedupe as listByTraceId; filters on a
+              // set of trace ids so a whole session can be fetched in one query.
+              query: `SELECT ${LIST_COLUMNS}
+                    FROM (
+                      SELECT ${LIST_COLUMNS}
+                      FROM spans
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND trace_id IN ({traceIds:Array(String)})
+                        ${startFromClause}
+                        ${startToClause}
+                      ORDER BY span_id, ingested_at DESC
+                      LIMIT 1 BY span_id
+                    )
+                    ORDER BY start_time ASC`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                traceIds: Array.from(traceIds) as string[],
+                ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
+                ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<SpanListRow>()
+          })
+          .pipe(
+            Effect.map((rows) => rows.map(toDomainSpan)),
+            Effect.mapError((error) => toRepositoryError(error, "listByTraceIds")),
+          )
+      })
+
     return {
       // TODO(repositories): rename insert -> save to keep repository write
       // verbs consistent across append-only and upsert-backed stores.
@@ -428,6 +479,8 @@ export const SpanRepositoryLive = Layer.effect(
         }),
 
       listByTraceId,
+
+      listByTraceIds,
 
       listByProjectId,
 


### PR DESCRIPTION
## summary

Replaces the plain "Duration" key-value in the trace and session detail drawers with a **duration composition bar**: a breakdown of where wall-clock time went — AI generation, tool execution, retrieval, and idle (orchestration / network / waiting). All of it is derived from span timings we already ingest; no new telemetry.

The bar is rendered as a measured "ruler" (square segments, a `|` tick at each edge and between every segment) so it reads as *time* and stays visually distinct from the rounded token/cost bars above it. Idle is drawn as a hatched gap rather than a solid color, so "working vs waiting" is legible without a legend. It sits in the same usage group as Tokens and Cost, and the duration outlier badge moves onto it.

<img width="454" height="263" alt="image" src="https://github.com/user-attachments/assets/53da6615-4f3d-4d41-8416-7e27c5331b49" />


## how time is attributed

`computeDurationBreakdown(spans)` partitions the trace's wall-clock timeline:

- **Leaf spans only.** A span is a leaf if no other span lists it as parent. Container spans (`invoke_agent`, `chain`) are excluded so their children aren't double-counted; time a container holds beyond its children falls into idle.
- **Operation → category:** generation (`chat`, `text_completion`), tool (`execute_tool`), retrieval (`retrieval`, `reranker`), other (everything else).
- **Priority-partition sweep.** Because sibling spans can run in parallel, summing per-category durations would exceed wall-clock. Instead the timeline is swept and each instant attributed to one category by priority (generation > tool > retrieval > other), with uncovered instants counted as idle. Segments therefore sum exactly to the wall-clock total.

Times come from the spans' ISO `startTime`/`endTime`, so resolution is milliseconds — the nanosecond precision from ClickHouse doesn't survive serialization, which is fine at trace scale.

## sessions

Sessions span multiple traces with gaps between turns. `computeSessionDurationBreakdown` computes the breakdown **per trace and sums the categories**, so the gaps *between* traces (user think-time) are never counted as idle — only idle *within* each trace is. The bar's total then equals the sum of per-trace wall-clocks, matching how `session.durationNs` is already derived.

This needs spans for a whole session, which had no fetch path. Added `SpanRepository.listByTraceIds` (port + ClickHouse impl + test fake) — it filters `trace_id IN (...)` rather than `session_id`, which also covers orphan single-trace sessions whose spans carry no `session_id`. Same `LIMIT 1 BY span_id` dedupe and start-time partition pruning as `listByTraceId`. Exposed via `listSpansBySession` + `useSpansBySessionCollection`.

## data fetching

The trace tab's bar needs the span list, which previously only loaded when the Spans tab opened. Lifted `useSpansByTraceCollection` to `TraceDetailBody`; the Spans tab still fetches with the same key, so the cached collection dedupes both into one fetch (this also left the session panel's `SpansTab` caller untouched).

## tested

Unit tests for both helpers (`duration-composition.test.ts`): serial gaps → idle, parallel siblings → no double-count, container exclusion, segments-sum-to-wall-clock, and the session case asserting between-trace gaps are not idle. Typecheck + Biome clean across `@domain/spans`, `@platform/db-clickhouse`, and `web`.

Not yet validated against live data in the running app.
