### PR TITLE
fix(search): keep session panel from sliding left on first-hit scroll

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/use-scroll-to-first-highlight.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/use-scroll-to-first-highlight.ts
@@ -30,11 +30,14 @@ function findHighlightNode(container: HTMLElement, messageIndex: number, startOf
   return best?.node ?? null
 }
 
-/**
- * Scrolls to the first resolvable search hit once per (traceId, searchQuery).
- * MutationObserver retries on DOM mutations so we survive MarkdownContent's
- * own collapsed-middle auto-expand without rAF chains.
- */
+function centerVertically(container: HTMLElement, target: Element) {
+  const containerRect = container.getBoundingClientRect()
+  const targetRect = target.getBoundingClientRect()
+  const targetTopWithinContent = targetRect.top - containerRect.top + container.scrollTop
+  const top = targetTopWithinContent - container.clientHeight / 2 + targetRect.height / 2
+  container.scrollTo({ top: Math.max(0, top), behavior: "smooth" })
+}
+
 export function useScrollToFirstHighlight({
   scrollRef,
   traceId,
@@ -63,7 +66,7 @@ export function useScrollToFirstHighlight({
       for (const h of hits) {
         const target = findHighlightNode(container, h.messageIndex, h.startOffset)
         if (target) {
-          target.scrollIntoView({ block: "center", behavior: "smooth" })
+          centerVertically(container, target)
           lastScrolledKey.current = key
           return true
         }


### PR DESCRIPTION
## Summary
- Opening a session/trace from **Search** sometimes rendered the conversation cut off mid-string on the left edge (issue #3384).
- Root cause: `useScrollToFirstHighlight` called `target.scrollIntoView({ block: "center" })`. The default `inline: "nearest"` lets the browser shift `scrollLeft` on any ancestor whose content overflows horizontally (e.g. wide markdown tables, code blocks). `overflow-x: hidden` on the conversation pane *doesn't* block JS-initiated horizontal scrolling — it only stops user input — so the pane stayed pushed left with no way for the user to scroll back.
- Replaces `scrollIntoView` with a direct `container.scrollTo({ top })` after computing the centered offset from `getBoundingClientRect()`. Vertical only, no ancestor traversal. Mirrors what `ScrollNavigator` already does internally.

Fixes #3384

## Test plan
- [x] Open `/projects/<slug>/search`, run a query that matches text inside a long conversation containing wide content (markdown table, fenced code block, long URL). Resize the side drawer narrow.
- [x] Confirm clicking a session row scrolls vertically to the first match and **does not** offset the conversation horizontally — every line starts at the left padding.
- [x] Standalone session view (`/projects/<slug>/` → click a session) still scrolls correctly with no search query.