### PR TITLE
feat(monitors): saved-search firing pipeline [LAT-630]

### DIFF
--- a/apps/api/src/routes/saved-searches.ts
+++ b/apps/api/src/routes/saved-searches.ts
@@ -314,7 +314,7 @@ const deleteSavedSearchEndpoint = savedSearchEndpoint({
         yield* deleteSavedSearch({ savedSearchId: current.id })
       }).pipe(
         withPostgres(
-          Layer.mergeAll(ProjectRepositoryLive, SavedSearchRepositoryLive),
+          Layer.mergeAll(ProjectRepositoryLive, SavedSearchRepositoryLive, OutboxEventWriterLive),
           c.var.postgresClient,
           organizationId,
         ),

--- a/apps/web/src/domains/alerts/alerts.functions.ts
+++ b/apps/web/src/domains/alerts/alerts.functions.ts
@@ -6,8 +6,17 @@ import {
   type AlertSeverity,
 } from "@domain/alerts"
 import { IssueRepository, type IssueWithLifecycle } from "@domain/issues"
-import { IssueId, OrganizationId, ProjectId } from "@domain/shared"
-import { AlertIncidentRepositoryLive, IssueRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { formatHumanReadableAlert } from "@domain/monitors"
+import { type IncidentMonitorInfo, IncidentMonitorReader } from "@domain/notifications"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import { IssueId, OrganizationId, ProjectId, SavedSearchId } from "@domain/shared"
+import {
+  AlertIncidentRepositoryLive,
+  IncidentMonitorReaderLive,
+  IssueRepositoryLive,
+  SavedSearchRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
@@ -34,9 +43,21 @@ export interface AlertIncidentRecord {
   readonly endedAt: string | null
   /** Resolved name of the issue tied to the incident; `null` if not found (e.g., deleted). */
   readonly issueName: string | null
+  /** Resolved name of the saved search tied to the incident (the source); `null` on issue rows or when deleted. */
+  readonly savedSearchName: string | null
+  /** Owning monitor name + slug for the attribution line + deep link; `null` on legacy or issue rows. */
+  readonly monitorName: string | null
+  readonly monitorSlug: string | null
+  /** Humanised firing condition; `null` for no-condition kinds. Drives the saved-search subtitle. */
+  readonly conditionSummary: string | null
 }
 
-const toRecord = (incident: AlertIncident, issue: IssueWithLifecycle | undefined): AlertIncidentRecord => ({
+const toRecord = (
+  incident: AlertIncident,
+  issue: IssueWithLifecycle | undefined,
+  savedSearchName: string | undefined,
+  monitor: IncidentMonitorInfo | undefined,
+): AlertIncidentRecord => ({
   id: incident.id,
   projectId: incident.projectId,
   kind: incident.kind,
@@ -46,6 +67,12 @@ const toRecord = (incident: AlertIncident, issue: IssueWithLifecycle | undefined
   startedAt: incident.startedAt.toISOString(),
   endedAt: incident.endedAt?.toISOString() ?? null,
   issueName: issue?.name ?? null,
+  savedSearchName: savedSearchName ?? null,
+  monitorName: monitor?.name ?? null,
+  monitorSlug: monitor?.slug ?? null,
+  conditionSummary: incident.condition
+    ? formatHumanReadableAlert({ kind: incident.kind, condition: incident.condition })
+    : null,
 })
 
 /**
@@ -68,6 +95,8 @@ export const listProjectAlertIncidentsInRange = createServerFn({
       Effect.gen(function* () {
         const incidentRepo = yield* AlertIncidentRepository
         const issueRepo = yield* IssueRepository
+        const savedSearchRepo = yield* SavedSearchRepository
+        const monitorReader = yield* IncidentMonitorReader
 
         const incidents = yield* incidentRepo.listByProjectId({
           organizationId: orgId,
@@ -88,9 +117,47 @@ export const listProjectAlertIncidentsInRange = createServerFn({
             : ([] as readonly IssueWithLifecycle[])
         const issueById = new Map(issues.map((issue) => [issue.id, issue] as const))
 
-        return incidents.map((incident) => toRecord(incident, issueById.get(IssueId(incident.sourceId))))
+        // Saved-search names are the source label for `savedSearch.*` rows (mirrors the issue name).
+        const savedSearchIds = Array.from(
+          new Set(incidents.filter((i) => i.sourceType === "savedSearch").map((i) => i.sourceId)),
+        )
+        const savedSearchNameById = new Map<string, string>()
+        for (const id of savedSearchIds) {
+          const found = yield* savedSearchRepo.findById(SavedSearchId(id)).pipe(
+            Effect.map((s) => s.name),
+            Effect.catchTag("SavedSearchNotFoundError", () => Effect.succeed(null)),
+          )
+          if (found !== null) savedSearchNameById.set(id, found)
+        }
+
+        const monitorAlertIds = Array.from(
+          new Set(incidents.filter((i) => i.monitorAlertId !== null).map((i) => i.monitorAlertId as string)),
+        )
+        const monitorByAlertId = new Map<string, IncidentMonitorInfo>()
+        for (const alertId of monitorAlertIds) {
+          const info = yield* monitorReader.findByAlertId(alertId)
+          if (info) monitorByAlertId.set(alertId, info)
+        }
+
+        return incidents.map((incident) =>
+          toRecord(
+            incident,
+            issueById.get(IssueId(incident.sourceId)),
+            savedSearchNameById.get(incident.sourceId),
+            incident.monitorAlertId ? monitorByAlertId.get(incident.monitorAlertId) : undefined,
+          ),
+        )
       }).pipe(
-        withPostgres(Layer.mergeAll(AlertIncidentRepositoryLive, IssueRepositoryLive), pgClient, orgId),
+        withPostgres(
+          Layer.mergeAll(
+            AlertIncidentRepositoryLive,
+            IssueRepositoryLive,
+            SavedSearchRepositoryLive,
+            IncidentMonitorReaderLive,
+          ),
+          pgClient,
+          orgId,
+        ),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/alerts/incident-marker-popover.tsx
+++ b/apps/web/src/domains/alerts/incident-marker-popover.tsx
@@ -6,10 +6,10 @@ import type { AlertIncidentRecord } from "./alerts.functions.ts"
 import { formatIncidentKindLabel, INCIDENT_SEVERITY_COLOR, SEVERITY_LABELS } from "./incident-markers.ts"
 
 /**
- * Popover anchored at a chart-bucket point, listing every incident touching that bucket. Each
- * row links to the issue detail drawer via `?issueId=…` on `/projects/$projectSlug/issues`.
- * The popover is consumer-owned — the chart surfaces the bucket anchor; this component
- * renders the list and the navigation links.
+ * Popover anchored at a chart-bucket point, listing every incident touching that bucket. Issue
+ * rows link to the issue drawer (`?issueId=…`); saved-search rows link to their monitor
+ * (`?monitorSlug=…`). The popover is consumer-owned — the chart surfaces the bucket anchor; this
+ * component renders the list and the navigation links.
  *
  * `preserveSearchParams=true` is for the issues analytics panel (popover is on the issues page
  * itself), where lifecycle, time filter and sort search params should survive the row-click
@@ -47,6 +47,101 @@ function formatTiming(incident: AlertIncidentRecord): string {
     return `${formatTimeShort(incident.startedAt)} → ${formatTimeShort(incident.endedAt)}`
   }
   return formatTimeShort(incident.startedAt)
+}
+
+const ROW_CLASS = "flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-accent focus-visible:bg-accent outline-none"
+
+/**
+ * One incident row. Issue incidents link to the issue drawer; saved-search incidents link to their
+ * monitor (and fall back to a non-interactive row when the monitor alert was deleted). The primary
+ * label is the issue name for issues and the saved search name for saved searches, followed (saved
+ * search only) by the humanised condition and the "Created by monitor X" attribution.
+ */
+function IncidentRow({
+  incident,
+  projectSlug,
+  preserveSearchParams,
+  onNavigate,
+}: {
+  readonly incident: AlertIncidentRecord
+  readonly projectSlug: string
+  readonly preserveSearchParams: boolean
+  readonly onNavigate: () => void
+}) {
+  const isSavedSearch = incident.sourceType === "savedSearch"
+  const primaryLabel = isSavedSearch ? incident.savedSearchName : incident.issueName
+  const navigable = !isSavedSearch || Boolean(incident.monitorSlug)
+
+  const body = (
+    <>
+      <span
+        aria-hidden
+        className="mt-1 inline-block size-2 shrink-0 rounded-full"
+        style={{ background: INCIDENT_SEVERITY_COLOR[incident.severity] }}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <Text.H6M color="foreground">{formatIncidentKindLabel(incident.kind)}</Text.H6M>
+          <Text.H6 color="foregroundMuted">·</Text.H6>
+          <Text.H6 color="foregroundMuted">{SEVERITY_LABELS[incident.severity]}</Text.H6>
+        </div>
+        <div className="flex min-w-0 flex-col">
+          {primaryLabel ? (
+            <Text.H6 color="foreground" className="min-w-0 truncate">
+              {primaryLabel}
+            </Text.H6>
+          ) : null}
+          {isSavedSearch && incident.conditionSummary ? (
+            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
+              {incident.conditionSummary}
+            </Text.H6>
+          ) : null}
+          {isSavedSearch && incident.monitorName ? (
+            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
+              Created by monitor <b>{incident.monitorName}</b>
+            </Text.H6>
+          ) : null}
+          <Text.H6 color="foregroundMuted" noWrap>
+            {formatTiming(incident)}
+          </Text.H6>
+        </div>
+      </div>
+      {navigable ? <ChevronRightIcon className="mt-1 size-3.5 shrink-0 text-muted-foreground" aria-hidden /> : null}
+    </>
+  )
+
+  if (isSavedSearch) {
+    if (!incident.monitorSlug) {
+      return <div className="flex items-start gap-2 px-2 py-1.5">{body}</div>
+    }
+    return (
+      <Link
+        to="/projects/$projectSlug/monitors"
+        params={{ projectSlug }}
+        search={{ monitorSlug: incident.monitorSlug }}
+        onClick={onNavigate}
+        className={ROW_CLASS}
+      >
+        {body}
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      to="/projects/$projectSlug/issues"
+      params={{ projectSlug }}
+      search={
+        preserveSearchParams
+          ? (prev: Record<string, unknown>) => ({ ...prev, issueId: incident.sourceId })
+          : { issueId: incident.sourceId }
+      }
+      onClick={onNavigate}
+      className={ROW_CLASS}
+    >
+      {body}
+    </Link>
+  )
 }
 
 export function IncidentMarkerPopover({
@@ -100,41 +195,12 @@ export function IncidentMarkerPopover({
         <ul className="flex flex-col">
           {incidents.map((incident) => (
             <li key={incident.id}>
-              <Link
-                to="/projects/$projectSlug/issues"
-                params={{ projectSlug }}
-                search={
-                  preserveSearchParams
-                    ? (prev: Record<string, unknown>) => ({ ...prev, issueId: incident.sourceId })
-                    : { issueId: incident.sourceId }
-                }
-                onClick={() => onOpenChange(false)}
-                className="flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-accent focus-visible:bg-accent outline-none"
-              >
-                <span
-                  aria-hidden
-                  className="mt-1 inline-block size-2 shrink-0 rounded-full"
-                  style={{ background: INCIDENT_SEVERITY_COLOR[incident.severity] }}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <Text.H6M color="foreground">{formatIncidentKindLabel(incident.kind)}</Text.H6M>
-                    <Text.H6 color="foregroundMuted">·</Text.H6>
-                    <Text.H6 color="foregroundMuted">{SEVERITY_LABELS[incident.severity]}</Text.H6>
-                  </div>
-                  <div className="flex min-w-0 flex-col">
-                    {incident.issueName ? (
-                      <Text.H6 color="foreground" className="min-w-0 truncate">
-                        {incident.issueName}
-                      </Text.H6>
-                    ) : null}
-                    <Text.H6 color="foregroundMuted" noWrap>
-                      {formatTiming(incident)}
-                    </Text.H6>
-                  </div>
-                </div>
-                <ChevronRightIcon className="mt-1 size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-              </Link>
+              <IncidentRow
+                incident={incident}
+                projectSlug={projectSlug}
+                preserveSearchParams={preserveSearchParams}
+                onNavigate={() => onOpenChange(false)}
+              />
             </li>
           ))}
         </ul>

--- a/apps/web/src/domains/saved-searches/saved-searches.functions.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.functions.ts
@@ -191,7 +191,7 @@ export const deleteSavedSearchFn = createServerFn({ method: "POST" })
 
     await Effect.runPromise(
       deleteSavedSearch({ savedSearchId: SavedSearchId(data.id) }).pipe(
-        withPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId),
+        withPostgres(Layer.mergeAll(SavedSearchRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
         withTracing,
       ),
     )

--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/-incident-helpers.ts
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/-incident-helpers.ts
@@ -5,6 +5,7 @@ import {
   type IssueLifecycleSummaryRecord,
 } from "../../../../../../domains/issues/issues.functions.ts"
 import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
+import { useSavedSearchesList } from "../../../../../../domains/saved-searches/saved-searches.collection.ts"
 
 interface IncidentTarget {
   readonly projectId: string | null | undefined
@@ -42,4 +43,29 @@ export function useIssueUrl(target: IncidentTarget): string | undefined {
   )
   if (!project) return undefined
   return `/projects/${project.slug}/issues?issueId=${encodeURIComponent(target.sourceId)}`
+}
+
+/**
+ * Live-resolve the source saved search's name (the incident's `sourceId`), mirroring
+ * `useLiveIssueSummary`. `null` while loading or when the saved search was deleted.
+ */
+export function useLiveSavedSearchName(target: {
+  readonly projectId: string | null | undefined
+  readonly savedSearchId: string
+}): string | null {
+  const { data } = useSavedSearchesList(target.projectId ?? "", { enabled: Boolean(target.projectId) })
+  return data.find((s) => s.id === target.savedSearchId)?.name ?? null
+}
+
+/** `/projects/<slug>/monitors?monitorSlug=<slug>` deep link for saved-search incidents. Undefined without a slug or while the project loads. */
+export function useMonitorUrl(target: {
+  readonly projectId: string | null | undefined
+  readonly monitorSlug: string | undefined
+}): string | undefined {
+  const { data: project } = useProjectsCollection(
+    (projects) => projects.where(({ project: p }) => eq(p.id, target.projectId ?? " ")).findOne(),
+    [target.projectId ?? null],
+  )
+  if (!project || !target.monitorSlug) return undefined
+  return `/projects/${project.slug}/monitors?monitorSlug=${encodeURIComponent(target.monitorSlug)}`
 }

--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/index.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/index.tsx
@@ -13,12 +13,13 @@ import { BaseNotification } from "../../base-notification.tsx"
 import { IssueEscalatingNotification } from "./issue-escalating.tsx"
 import { IssueNewNotification } from "./issue-new.tsx"
 import { IssueRegressedNotification } from "./issue-regressed.tsx"
+import { SavedSearchIncidentNotification } from "./saved-search.tsx"
 
 /**
  * Notification kinds map 1:1 to lifecycle events:
- * - `incident.event`  → one-shot (issue.new, issue.regressed)
- * - `incident.opened` → sustained start (issue.escalating)
- * - `incident.closed` → sustained close (issue.escalating)
+ * - `incident.event`  → one-shot (issue.new, issue.regressed, savedSearch.match, savedSearch.threshold)
+ * - `incident.opened` → sustained start (issue.escalating, savedSearch.escalating)
+ * - `incident.closed` → sustained close (issue.escalating, savedSearch.escalating)
  */
 export type IncidentEvent = "event" | "opened" | "closed"
 
@@ -44,26 +45,36 @@ const renderEvent = (notification: NotificationRecord, payload: IncidentEventPay
       return <IssueNewNotification notification={notification} payload={payload} event="event" />
     case "issue.regressed":
       return <IssueRegressedNotification notification={notification} payload={payload} event="event" />
+    case "savedSearch.match":
+    case "savedSearch.threshold":
+      return <SavedSearchIncidentNotification notification={notification} payload={payload} event="event" />
     case "issue.escalating":
-      // Sustained kind shouldn't land as incident.event; defensive fallback.
+    case "savedSearch.escalating":
+      // Sustained kinds shouldn't land as incident.event; defensive fallback.
       return <Unsupported notification={notification} />
   }
 }
 
 const renderOpened = (notification: NotificationRecord, payload: IncidentOpenedPayload) => {
-  if (payload.incidentKind !== "issue.escalating") {
-    // Eventful kinds shouldn't land as opened; defensive fallback.
-    return <Unsupported notification={notification} />
+  if (payload.incidentKind === "issue.escalating") {
+    return <IssueEscalatingNotification notification={notification} payload={payload} event="opened" />
   }
-  return <IssueEscalatingNotification notification={notification} payload={payload} event="opened" />
+  if (payload.incidentKind === "savedSearch.escalating") {
+    return <SavedSearchIncidentNotification notification={notification} payload={payload} event="opened" />
+  }
+  // Eventful kinds shouldn't land as opened; defensive fallback.
+  return <Unsupported notification={notification} />
 }
 
 const renderClosed = (notification: NotificationRecord, payload: IncidentClosedPayload) => {
-  if (payload.incidentKind !== "issue.escalating") {
-    // Eventful kinds shouldn't land as closed; defensive fallback.
-    return <Unsupported notification={notification} />
+  if (payload.incidentKind === "issue.escalating") {
+    return <IssueEscalatingNotification notification={notification} payload={payload} event="closed" />
   }
-  return <IssueEscalatingNotification notification={notification} payload={payload} event="closed" />
+  if (payload.incidentKind === "savedSearch.escalating") {
+    return <SavedSearchIncidentNotification notification={notification} payload={payload} event="closed" />
+  }
+  // Eventful kinds shouldn't land as closed; defensive fallback.
+  return <Unsupported notification={notification} />
 }
 
 export function IncidentNotification({ notification }: { readonly notification: NotificationRecord }) {

--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/issue-escalating.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/issue-escalating.tsx
@@ -37,7 +37,7 @@ export function IssueEscalatingNotification({
       url={url}
     >
       {live?.name ? <IssueSummaryCard name={live.name} states={states} /> : null}
-      <EscalatingTrend trend={payload.trend} states={states} />
+      {payload.trend ? <EscalatingTrend trend={payload.trend} states={states} /> : null}
       <MonitorAttribution payload={payload} />
     </BaseNotification>
   )
@@ -49,7 +49,13 @@ export function IssueEscalatingNotification({
  * incident transition, so the bell and the email render from one
  * source of truth.
  */
-function EscalatingTrend({ trend, states }: { readonly trend: EscalatingTrend; readonly states: readonly string[] }) {
+function EscalatingTrend({
+  trend,
+  states,
+}: {
+  readonly trend: NonNullable<EscalatingTrend>
+  readonly states: readonly string[]
+}) {
   const buckets = trend.points.map((point) => ({ bucket: point.t, count: point.count }))
   const escalationThresholds = trend.points
     .filter((point): point is typeof point & { threshold: number } => point.threshold !== null)

--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/monitor-attribution.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/monitor-attribution.tsx
@@ -5,8 +5,9 @@ import { Text } from "@repo/ui"
 type IncidentPayload = IncidentEventPayload | IncidentOpenedPayload | IncidentClosedPayload
 
 /**
- * "Created by monitor X" line (+ humanised rule). Plain text, not a link — the card
- * already links to the source and nesting anchors is invalid. Nothing on legacy incidents.
+ * Humanised alert rule followed by the "Created by monitor X" attribution. Plain text, not a
+ * link — the card already links to the source and nesting anchors is invalid. Nothing on legacy
+ * incidents.
  */
 export function MonitorAttribution({ payload }: { readonly payload: IncidentPayload }) {
   if (!payload.monitorName) return null
@@ -15,10 +16,10 @@ export function MonitorAttribution({ payload }: { readonly payload: IncidentPayl
     : null
   return (
     <div className="flex flex-col gap-0.5 pt-1">
+      {summary ? <Text.H6 color="foregroundMuted">{summary}</Text.H6> : null}
       <Text.H6 color="foregroundMuted">
         Created by monitor <b>{payload.monitorName}</b>
       </Text.H6>
-      {summary ? <Text.H6 color="foregroundMuted">{summary}</Text.H6> : null}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/saved-search.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/saved-search.tsx
@@ -1,0 +1,48 @@
+import type { IncidentClosedPayload, IncidentEventPayload, IncidentOpenedPayload } from "@domain/notifications"
+import { Text } from "@repo/ui"
+import { SearchAlertIcon } from "lucide-react"
+import type { NotificationRecord } from "../../../../../../domains/notifications/notifications.functions.ts"
+import { BaseNotification } from "../../base-notification.tsx"
+import { useLiveSavedSearchName, useMonitorUrl } from "./-incident-helpers.ts"
+import type { IncidentEvent } from "./index.tsx"
+import { MonitorAttribution } from "./monitor-attribution.tsx"
+
+const TITLE: Record<IncidentEvent, string> = {
+  event: "A search alert fired.",
+  opened: "A search alert is escalating.",
+  closed: "A search alert stopped escalating.",
+}
+
+/**
+ * Renders `savedSearch.*` incident notifications. The descriptive content is the
+ * source saved search's name (live-resolved) plus the monitor attribution + condition.
+ */
+export function SavedSearchIncidentNotification({
+  notification,
+  payload,
+  event,
+}: {
+  readonly notification: NotificationRecord
+  readonly payload: IncidentEventPayload | IncidentOpenedPayload | IncidentClosedPayload
+  readonly event: IncidentEvent
+}) {
+  const seenAt = notification.seenAt ? new Date(notification.seenAt) : undefined
+  const createdAt = new Date(notification.createdAt)
+  const url = useMonitorUrl({ projectId: notification.projectId, monitorSlug: payload.monitorSlug })
+  const savedSearchName = useLiveSavedSearchName({ projectId: notification.projectId, savedSearchId: payload.sourceId })
+
+  return (
+    <BaseNotification
+      notificationId={notification.id}
+      seenAt={seenAt}
+      createdAt={createdAt}
+      projectId={notification.projectId}
+      icon={<SearchAlertIcon />}
+      title={TITLE[event]}
+      url={url}
+    >
+      {savedSearchName ? <Text.H5M color="foregroundMuted">{savedSearchName}</Text.H5M> : null}
+      <MonitorAttribution payload={payload} />
+    </BaseNotification>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -1,4 +1,4 @@
-import { CopyableText, InfiniteTable, type InfiniteTableColumn, Status, Text } from "@repo/ui"
+import { InfiniteTable, type InfiniteTableColumn, Status, Text } from "@repo/ui"
 import { formatDuration } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { type ReactNode, useCallback } from "react"
@@ -8,10 +8,20 @@ import {
 } from "../../../../../../domains/monitors/monitors.collection.ts"
 import { IncidentStatus } from "./incident-status.tsx"
 
-/** Falls back to a copyable raw id when the source was deleted and its name is unresolved. */
+/** Human-readable, lowercased source-type labels for the deleted-source fallback. */
+const SOURCE_TYPE_LABEL: Record<MonitorIncidentRecord["sourceType"], string> = {
+  issue: "issue",
+  savedSearch: "saved search",
+}
+
+/** Shows the resolved source name, or an italic "Deleted <type>" once the source is gone. */
 function SourceCell({ incident }: { readonly incident: MonitorIncidentRecord }) {
   if (!incident.sourceName) {
-    return <CopyableText value={incident.sourceId} size="sm" ellipsis tooltip="Copy source id" />
+    return (
+      <Text.H6 color="foregroundMuted" noWrap ellipsis className="italic">
+        Deleted {SOURCE_TYPE_LABEL[incident.sourceType]}
+      </Text.H6>
+    )
   }
   return (
     <Text.H6 noWrap ellipsis>

--- a/apps/web/src/routes/api/notifications/$nid/incident-trend[.]png.ts
+++ b/apps/web/src/routes/api/notifications/$nid/incident-trend[.]png.ts
@@ -83,10 +83,14 @@ export const Route = createFileRoute("/api/notifications/$nid/incident-trend.png
         const parsed = schema.safeParse(loaded.payload)
         if (!parsed.success) return respondTransparent()
 
+        // No trend snapshot → nothing to chart (e.g. saved-search incidents carry no issue trend).
+        const trend = parsed.data.trend
+        if (!trend) return respondTransparent()
+
         const breach = "breach" in parsed.data ? parsed.data.breach : undefined
         try {
           const png = await renderIncidentTrendPng({
-            trend: parsed.data.trend,
+            trend,
             ...(breach ? { breach } : {}),
           })
           return respondPng(png)

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -2,6 +2,7 @@ import { createBullBoard } from "@bull-board/api"
 import { BullMQAdapter } from "@bull-board/api/bullMQAdapter"
 import { HonoAdapter } from "@bull-board/hono"
 import { ESCALATION_SWEEPER_KEY, ESCALATION_SWEEPER_PATTERN } from "@domain/issues"
+import { SAVED_SEARCH_MONITORS_SWEEPER_KEY, SAVED_SEARCH_MONITORS_SWEEPER_PATTERN } from "@domain/monitors"
 import { TAXONOMY_GARDENING_CRON_KEY, TAXONOMY_GARDENING_CRON_PATTERN } from "@domain/taxonomy"
 import { serve } from "@hono/node-server"
 import { serveStatic } from "@hono/node-server/serve-static"
@@ -52,6 +53,7 @@ import { createEvaluationsWorker } from "./workers/evaluations.ts"
 import { createExportsWorker } from "./workers/exports.ts"
 import { createIssuesWorker } from "./workers/issues.ts"
 import { createLiveEvaluationsWorker } from "./workers/live-evaluations.ts"
+import { createMonitorsWorker } from "./workers/monitors.ts"
 import { createNotificationEmailerWorker } from "./workers/notification-emailer.ts"
 import { createNotificationSlackWorker } from "./workers/notification-slack.ts"
 import { createNotificationsWorker } from "./workers/notifications.ts"
@@ -194,6 +196,7 @@ const bootstrap = async () => {
     })
     createExportsWorker(ctx)
     await createIssuesWorker({ ...ctx, adminPostgresClient: getAdminPostgresClient() })
+    createMonitorsWorker({ ...ctx, adminPostgresClient: getAdminPostgresClient() })
     createEvaluationsWorker(ctx)
     createAnnotationScoresWorker(ctx)
     createLiveEvaluationsWorker(ctx)
@@ -255,6 +258,20 @@ const bootstrap = async () => {
           "sweepEscalating",
           {},
           { key: ESCALATION_SWEEPER_KEY, pattern: ESCALATION_SWEEPER_PATTERN, tz: "UTC" },
+        )
+        .pipe(withTracing),
+    )
+
+    // 5-minute saved-search firing sweep. Opens incidents in low-traffic orgs
+    // (where trace-end doesn't keep re-triggering the throttled check) and lets
+    // sustained incidents close once their dwell elapses on quiet traffic.
+    await Effect.runPromise(
+      queuePublisher
+        .scheduleRepeatable(
+          "monitors",
+          "sweepSavedSearchMonitors",
+          {},
+          { key: SAVED_SEARCH_MONITORS_SWEEPER_KEY, pattern: SAVED_SEARCH_MONITORS_SWEEPER_PATTERN, tz: "UTC" },
         )
         .pipe(withTracing),
     )

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -188,6 +188,19 @@ export const createDomainEventsWorker = ({
         dedupeKey: `alert-incidents:issue.escalation-ended:${event.payload.issueId}:${event.payload.endedAt}`,
       }),
 
+    SavedSearchDeleted: (event) =>
+      pub.publish(
+        "monitors",
+        "onSourceDeleted",
+        {
+          organizationId: event.payload.organizationId,
+          projectId: event.payload.projectId,
+          sourceType: "savedSearch",
+          sourceId: event.payload.searchId,
+        },
+        { dedupeKey: `monitors:on-source-deleted:savedSearch:${event.payload.searchId}` },
+      ),
+
     IncidentCreated: (event) =>
       pub.publish(
         "notifications",

--- a/apps/workers/src/workers/monitors.ts
+++ b/apps/workers/src/workers/monitors.ts
@@ -1,0 +1,121 @@
+import { hasFeatureFlagUseCase } from "@domain/feature-flags"
+import {
+  cascadeSourceDeletionUseCase,
+  checkSavedSearchMonitorsUseCase,
+  sweepSavedSearchMonitorsUseCase,
+} from "@domain/monitors"
+import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
+import { OrganizationId } from "@domain/shared"
+import { withAi } from "@platform/ai"
+import { AIEmbedLive } from "@platform/ai-voyage"
+import type { RedisClient } from "@platform/cache-redis"
+import { type ClickHouseClient, SavedSearchMatchReaderLive, withClickHouse } from "@platform/db-clickhouse"
+import {
+  AlertIncidentRepositoryLive,
+  FeatureFlagRepositoryLive,
+  MonitorRepositoryLive,
+  OutboxEventWriterLive,
+  type PostgresClient,
+  SavedSearchRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { createLogger, withTracing } from "@repo/observability"
+import { Effect, Layer } from "effect"
+import { getAdminPostgresClient, getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
+
+const logger = createLogger("monitors")
+
+interface MonitorsDeps {
+  consumer: QueueConsumer
+  publisher: QueuePublisherShape
+  postgresClient?: PostgresClient
+  /** Admin client — the cross-org sweep reads `monitor_alerts` regardless of org (RLS bypass). */
+  adminPostgresClient?: PostgresClient
+  clickhouseClient?: ClickHouseClient
+  redisClient?: RedisClient
+}
+
+// Feature flag + saved-search resolution + incident writes all live on Postgres;
+// the firing scan reads counts from ClickHouse (provided per-handler below).
+const checkRepoLayer = Layer.mergeAll(
+  MonitorRepositoryLive,
+  AlertIncidentRepositoryLive,
+  OutboxEventWriterLive,
+  SavedSearchRepositoryLive,
+  FeatureFlagRepositoryLive,
+)
+
+export const createMonitorsWorker = ({
+  consumer,
+  publisher,
+  postgresClient,
+  adminPostgresClient,
+  clickhouseClient,
+  redisClient,
+}: MonitorsDeps) => {
+  const pgClient = postgresClient ?? getPostgresClient()
+  const adminPgClient = adminPostgresClient ?? getAdminPostgresClient()
+  const chClient = clickhouseClient ?? getClickhouseClient()
+  const rdClient = redisClient ?? getRedisClient()
+
+  consumer.subscribe("monitors", {
+    // Firing only runs for flag-on orgs (belt-and-suspenders — flag-off orgs can't create these monitors).
+    checkSavedSearchMonitors: (payload) =>
+      Effect.gen(function* () {
+        const enabled = yield* hasFeatureFlagUseCase({ identifier: "monitors" })
+        if (!enabled) return { evaluated: 0, failed: 0 }
+        return yield* checkSavedSearchMonitorsUseCase(payload)
+      }).pipe(
+        withPostgres(checkRepoLayer, pgClient, OrganizationId(payload.organizationId)),
+        withClickHouse(SavedSearchMatchReaderLive, chClient, OrganizationId(payload.organizationId)),
+        withAi(AIEmbedLive, rdClient),
+        Effect.tap((result) =>
+          Effect.sync(() =>
+            logger.info(
+              `Saved-search check for ${payload.projectId}: evaluated=${result.evaluated} failed=${result.failed}`,
+            ),
+          ),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() => logger.error(`Saved-search check failed for ${payload.projectId}`, error)),
+        ),
+        withTracing,
+        Effect.asVoid,
+      ),
+    sweepSavedSearchMonitors: () =>
+      sweepSavedSearchMonitorsUseCase({
+        publish: (target) =>
+          publisher.publish("monitors", "checkSavedSearchMonitors", target, {
+            dedupeKey: `monitors:check-saved-search-sweep:${target.organizationId}:${target.projectId}`,
+          }),
+      }).pipe(
+        withPostgres(MonitorRepositoryLive, adminPgClient),
+        Effect.tap((result) =>
+          Effect.sync(() =>
+            logger.info(
+              `Saved-search sweep: published=${result.published} failed=${result.failed} attempted=${result.attempted}`,
+            ),
+          ),
+        ),
+        Effect.tapError((error) => Effect.sync(() => logger.error("Saved-search sweep failed", error))),
+        withTracing,
+        Effect.asVoid,
+      ),
+    onSourceDeleted: (payload) =>
+      cascadeSourceDeletionUseCase({ sourceType: payload.sourceType, sourceId: payload.sourceId }).pipe(
+        withPostgres(MonitorRepositoryLive, pgClient, OrganizationId(payload.organizationId)),
+        Effect.tap((result) =>
+          Effect.sync(() =>
+            logger.info(
+              `Source cascade ${payload.sourceType}:${payload.sourceId}: alerts=${result.deletedAlertCount} monitors=${result.deletedMonitorCount}`,
+            ),
+          ),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() => logger.error(`Source cascade failed for ${payload.sourceType}:${payload.sourceId}`, error)),
+        ),
+        withTracing,
+        Effect.asVoid,
+      ),
+  })
+}

--- a/apps/workers/src/workers/notification-emailer.ts
+++ b/apps/workers/src/workers/notification-emailer.ts
@@ -18,6 +18,7 @@ import {
   NotificationRepositoryLive,
   OrganizationRepositoryLive,
   ProjectRepositoryLive,
+  SavedSearchRepositoryLive,
   UserRepositoryLive,
   WrappedReportRepositoryLive,
   withPostgres,
@@ -53,7 +54,12 @@ const repoLayer = Layer.mergeAll(
  * into the use case's signature. Add to this when a new kind needs a
  * new repo for server-side rendering.
  */
-const rendererLayer = Layer.mergeAll(IssueRepositoryLive, WrappedReportRepositoryLive, FeatureFlagRepositoryLive)
+const rendererLayer = Layer.mergeAll(
+  IssueRepositoryLive,
+  SavedSearchRepositoryLive,
+  WrappedReportRepositoryLive,
+  FeatureFlagRepositoryLive,
+)
 
 const resolveWebAppUrl = (): string => {
   const webUrl = Effect.runSync(parseEnv("LAT_WEB_URL", "string", "http://localhost:3000"))

--- a/apps/workers/src/workers/notification-slack.ts
+++ b/apps/workers/src/workers/notification-slack.ts
@@ -19,6 +19,7 @@ import {
   IssueRepositoryLive,
   OrganizationRepositoryLive,
   ProjectRepositoryLive,
+  SavedSearchRepositoryLive,
   SlackDeliveryRepositoryLive,
   SlackIntegrationRepositoryLive,
   withPostgres,
@@ -60,6 +61,7 @@ const buildSlackRefresherLayer = () => {
 
 const repoLayer = Layer.mergeAll(
   IssueRepositoryLive,
+  SavedSearchRepositoryLive,
   OrganizationRepositoryLive,
   ProjectRepositoryLive,
   SlackIntegrationRepositoryLive,

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -8,6 +8,7 @@ import {
   listAllActiveEvaluations,
   orchestrateTraceEndLiveEvaluationExecutesUseCase,
 } from "@domain/evaluations"
+import { SAVED_SEARCH_MONITORS_THROTTLE_MS } from "@domain/monitors"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import {
@@ -231,6 +232,26 @@ export const runTraceEndJob =
         startTime: traceDetail.startTime.toISOString(),
         rootSpanName: traceDetail.rootSpanName,
       })
+
+      // Saved-search firing check, throttled to one run per project per 5 min.
+      yield* publisher
+        .publish(
+          "monitors",
+          "checkSavedSearchMonitors",
+          { organizationId: payload.organizationId, projectId: payload.projectId },
+          {
+            dedupeKey: `org:${payload.organizationId}:monitors:check-saved-search:${payload.projectId}`,
+            throttleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
+          },
+        )
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logError("Failed to enqueue saved-search monitors check", {
+              ...buildRunLogContext(payload),
+              error,
+            }),
+          ),
+        )
 
       const canonicalSessionId =
         traceDetail.sessionId && traceDetail.sessionId.length > 0 ? traceDetail.sessionId : traceDetail.traceId

--- a/packages/domain/alerts/src/entities/alert-incident.ts
+++ b/packages/domain/alerts/src/entities/alert-incident.ts
@@ -5,6 +5,7 @@ import {
   type AlertIncidentKind,
   type AlertIncidentSourceType,
   type AlertSeverity,
+  alertBaselineSchema,
   alertIncidentConditionSchema,
   alertIncidentIdSchema,
   alertIncidentKindSchema,
@@ -65,6 +66,32 @@ export const entrySignalsSnapshotSchema = z.object({
 
 export type EntrySignalsSnapshot = z.infer<typeof entrySignalsSnapshotSchema>
 
+/**
+ * Entry snapshot for a `savedSearch.escalating` incident: the threshold frozen at
+ * open time so the close-side compares against it rather than re-resolving a
+ * drifting baseline. `baselineCount` + `baseline` are multiplier-mode only.
+ */
+export const savedSearchEntrySignalsSchema = z.object({
+  evaluatedThreshold: z.number(),
+  baselineCount: z.number().optional(),
+  baseline: alertBaselineSchema.optional(),
+})
+
+export type SavedSearchEntrySignals = z.infer<typeof savedSearchEntrySignalsSchema>
+
+/** Polymorphic `entrySignals` (issue seasonal | saved-search frozen threshold), narrowed per-kind at the read site — the two shapes share no key. */
+export const incidentEntrySignalsSchema = z.union([entrySignalsSnapshotSchema, savedSearchEntrySignalsSchema])
+
+export type IncidentEntrySignals = z.infer<typeof incidentEntrySignalsSchema>
+
+/** Narrow a stored snapshot to the issue-escalation shape — the only consumer of the seasonal scalars. */
+export const isIssueEscalationEntrySignals = (signals: IncidentEntrySignals | null): signals is EntrySignalsSnapshot =>
+  signals !== null && "expected1h" in signals
+
+/** Narrow a stored snapshot to the saved-search shape — the sustained close-side reads its frozen threshold. */
+export const isSavedSearchEntrySignals = (signals: IncidentEntrySignals | null): signals is SavedSearchEntrySignals =>
+  signals !== null && "evaluatedThreshold" in signals
+
 export const alertIncidentSchema = z.object({
   id: alertIncidentIdSchema,
   organizationId: organizationIdSchema,
@@ -76,7 +103,7 @@ export const alertIncidentSchema = z.object({
   startedAt: z.date(),
   endedAt: z.date().nullable(),
   createdAt: z.date(),
-  entrySignals: entrySignalsSnapshotSchema.nullable(),
+  entrySignals: incidentEntrySignalsSchema.nullable(),
   exitEligibleSince: z.date().nullable(),
   // Firing monitor alert; `null` on legacy/flag-off rows. `.default(null)` keeps pre-monitors `.parse` callers valid.
   monitorAlertId: monitorAlertIdSchema.nullable().default(null),

--- a/packages/domain/alerts/src/index.ts
+++ b/packages/domain/alerts/src/index.ts
@@ -4,6 +4,8 @@ export type {
   AlertIncidentSourceType,
   AlertSeverity,
   EntrySignalsSnapshot,
+  IncidentEntrySignals,
+  SavedSearchEntrySignals,
 } from "./entities/alert-incident.ts"
 export {
   ALERT_INCIDENT_KINDS,
@@ -14,7 +16,11 @@ export {
   alertIncidentSourceTypeSchema,
   alertSeveritySchema,
   entrySignalsSnapshotSchema,
+  incidentEntrySignalsSchema,
+  isIssueEscalationEntrySignals,
+  isSavedSearchEntrySignals,
   SEVERITY_FOR_KIND,
+  savedSearchEntrySignalsSchema,
 } from "./entities/alert-incident.ts"
 export type {
   AlertIncidentCursor,
@@ -26,6 +32,7 @@ export type {
   ListAlertIncidentsByMonitorIdInput,
   ListAlertIncidentsByProjectInput,
   MonitorIncidentStats,
+  SetAlertIncidentEndedAtInput,
   UpdateAlertIncidentExitDwellInput,
 } from "./ports/alert-incident-repository.ts"
 export { AlertIncidentRepository } from "./ports/alert-incident-repository.ts"

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -35,6 +35,11 @@ export interface UpdateAlertIncidentExitDwellInput {
   readonly exitEligibleSince: Date | null
 }
 
+export interface SetAlertIncidentEndedAtInput {
+  readonly id: AlertIncidentId
+  readonly endedAt: Date
+}
+
 export interface ListAlertIncidentsByProjectInput {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
@@ -115,6 +120,14 @@ export interface AlertIncidentRepositoryShape {
    * because the dwell can advance many times without the incident closing.
    */
   updateExitDwell(input: UpdateAlertIncidentExitDwellInput): Effect.Effect<void, RepositoryError, SqlClient>
+  /** The open incident fired by `monitorAlertId` (org scope), or `null`. Saved-search machines track lifecycle per firing alert, not per `(source, kind)`. */
+  findOpenByMonitorAlertId(
+    monitorAlertId: MonitorAlertId,
+  ): Effect.Effect<AlertIncident | null, RepositoryError, SqlClient>
+  /** Whether `monitorAlertId` has ever fired (org scope). Backs the absolute-threshold one-time short-circuit. */
+  existsByMonitorAlertId(monitorAlertId: MonitorAlertId): Effect.Effect<boolean, RepositoryError, SqlClient>
+  /** Set `ended_at` on one incident by id (org scope) — the saved-search machines already hold the row; close events (if any) are emitted by the caller. */
+  setEndedAt(input: SetAlertIncidentEndedAtInput): Effect.Effect<void, RepositoryError, SqlClient>
   /**
    * Returns every incident in the project whose lifetime overlaps the optional `[from, to]`
    * window, ordered ascending by `started_at`. Uses the

--- a/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
@@ -30,6 +30,9 @@ function createTestLayers(opts: { closedId: string | null }) {
       listByMonitorId: () => Effect.die("listByMonitorId not used in this test"),
       statsByMonitorId: () => Effect.die("statsByMonitorId not used in this test"),
       listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used in this test"),
+      findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used in this test"),
+      existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used in this test"),
+      setEndedAt: () => Effect.die("setEndedAt not used in this test"),
     }),
   )
 

--- a/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
@@ -29,6 +29,9 @@ function createTestLayers() {
       listByMonitorId: () => Effect.die("listByMonitorId not used in this test"),
       statsByMonitorId: () => Effect.die("statsByMonitorId not used in this test"),
       listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used in this test"),
+      findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used in this test"),
+      existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used in this test"),
+      setEndedAt: () => Effect.die("setEndedAt not used in this test"),
     }),
   )
 

--- a/packages/domain/email/package.json
+++ b/packages/domain/email/package.json
@@ -15,6 +15,7 @@
     "@domain/issues": "workspace:*",
     "@domain/monitors": "workspace:*",
     "@domain/notifications": "workspace:*",
+    "@domain/saved-searches": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "@react-email/components": "1.0.12",

--- a/packages/domain/email/src/templates/notifications/-incident-source.ts
+++ b/packages/domain/email/src/templates/notifications/-incident-source.ts
@@ -1,0 +1,37 @@
+import { IssueRepository } from "@domain/issues"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import { IssueId, SavedSearchId } from "@domain/shared"
+import { Effect } from "effect"
+
+/** Live-resolved display name of an incident's source. `description` is issue-only. `null` name when the source was deleted. */
+interface ResolvedIncidentSource {
+  readonly name: string | null
+  readonly description: string | null
+}
+
+const loadError = (cause: unknown) => ({
+  _tag: "RenderNotificationEmailError" as const,
+  message: "Failed to load incident source",
+  cause,
+})
+
+const MISSING: ResolvedIncidentSource = { name: null, description: null }
+
+/** Resolve the source name by `sourceId`, mirroring how the issue name is resolved — the saved search is the source for `savedSearch.*`. */
+export const resolveIncidentSource = (input: { readonly sourceType: string; readonly sourceId: string }) =>
+  Effect.gen(function* () {
+    if (input.sourceType === "savedSearch") {
+      const repo = yield* SavedSearchRepository
+      return yield* repo.findById(SavedSearchId(input.sourceId)).pipe(
+        Effect.map((s): ResolvedIncidentSource => ({ name: s.name, description: null })),
+        Effect.catchTag("SavedSearchNotFoundError", () => Effect.succeed(MISSING)),
+        Effect.catchTag("RepositoryError", (cause) => Effect.fail(loadError(cause))),
+      )
+    }
+    const repo = yield* IssueRepository
+    return yield* repo.findById(IssueId(input.sourceId)).pipe(
+      Effect.map((i): ResolvedIncidentSource => ({ name: i.name, description: i.description ?? null })),
+      Effect.catchTag("NotFoundError", () => Effect.succeed(MISSING)),
+      Effect.catchTag("RepositoryError", (cause) => Effect.fail(loadError(cause))),
+    )
+  })

--- a/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/EmailTemplate.tsx
@@ -1,5 +1,5 @@
 import type { IncidentRecovery } from "@domain/notifications"
-import type { AlertSeverity } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_SOURCE_TYPE, type AlertIncidentKind, type AlertSeverity } from "@domain/shared"
 import { Section } from "@react-email/components"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -23,10 +23,11 @@ import {
 } from "../-incident-components.tsx"
 
 interface IncidentClosedEmailProps {
+  readonly incidentKind: AlertIncidentKind
   readonly severity: AlertSeverity
-  readonly issueId: string
-  readonly issueName: string | undefined
-  readonly issueDescription: string | undefined
+  readonly sourceId: string
+  readonly sourceName: string
+  readonly description: string | undefined
   readonly issueUrl: string | undefined
   readonly chartUrl: string
   readonly notificationCreatedAt: Date
@@ -38,10 +39,11 @@ interface IncidentClosedEmailProps {
 }
 
 export function IncidentClosedEmail({
+  incidentKind,
   severity,
-  issueId,
-  issueName,
-  issueDescription,
+  sourceId,
+  sourceName,
+  description,
   issueUrl,
   chartUrl,
   notificationCreatedAt,
@@ -51,9 +53,17 @@ export function IncidentClosedEmail({
   monitor,
   webAppUrl,
 }: IncidentClosedEmailProps) {
-  const issueRef = issueName ?? "an issue"
+  const isSavedSearch = ALERT_INCIDENT_KIND_SOURCE_TYPE[incidentKind] === "savedSearch"
+  const heading = "Resolved escalation"
+  const subtitle = isSavedSearch
+    ? "We notified everyone watching this project — matching traces have returned below the threshold."
+    : "We notified everyone watching this project — the occurrence rate has returned to baseline."
   const scope = formatScope(organizationName, projectName)
   const duration = humanizeDurationMs(recovery.durationMs)
+  const recoveryLine = isSavedSearch
+    ? `Elevated for ${duration} — no further action needed unless matching traces climb again.`
+    : `Elevated for ${duration} — no further action needed unless the issue regresses again.`
+  const ctaHref = isSavedSearch ? monitor?.url : issueUrl
 
   const metadataRows = [
     { label: "Project", value: scope },
@@ -62,24 +72,21 @@ export function IncidentClosedEmail({
 
   return (
     <ContainerLayout
-      previewText={`Resolved: escalation on ${issueRef}`}
+      previewText={`Resolved: escalation on ${sourceName}`}
       footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
     >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
-        Resolved escalation
+        {heading}
       </EmailText>
-      <EmailText variant="body">
-        We notified everyone watching this project — the occurrence rate has returned to baseline.
-      </EmailText>
+      <EmailText variant="body">{subtitle}</EmailText>
 
       <MonitorAttribution monitor={monitor} />
 
-      <SectionHeader label="Issue" />
-
-      <EmailText variant="heading">{issueRef}</EmailText>
-      {issueDescription ? (
+      <SectionHeader label={isSavedSearch ? "Saved search" : "Issue"} />
+      <EmailText variant="heading">{sourceName}</EmailText>
+      {description ? (
         <EmailText variant="bodySmall" className="text-muted-foreground">
-          {issueDescription}
+          {description}
         </EmailText>
       ) : null}
 
@@ -89,15 +96,18 @@ export function IncidentClosedEmail({
 
       <SectionHeader label="Recovery" />
       <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-        {`Elevated for ${duration} — no further action needed unless the issue regresses again.`}
+        {recoveryLine}
       </EmailText>
-      <IncidentTrendChartImage src={chartUrl} />
+      {isSavedSearch ? null : (
+        <>
+          <IncidentTrendChartImage src={chartUrl} />
+          <IssueIdFooter issueId={sourceId} />
+        </>
+      )}
 
-      <IssueIdFooter issueId={issueId} />
-
-      {issueUrl ? (
+      {ctaHref ? (
         <Section className={emailDesignTokens.spacing.buttonTop}>
-          <EmailButton href={issueUrl} label="View issue" />
+          <EmailButton href={ctaHref} label={isSavedSearch ? "View monitor" : "View issue"} />
         </Section>
       ) : null}
     </ContainerLayout>
@@ -105,10 +115,11 @@ export function IncidentClosedEmail({
 }
 
 IncidentClosedEmail.PreviewProps = {
+  incidentKind: "issue.escalating",
   severity: "high",
-  issueId: "dds0rt8sqgpuku4u4wabze9r",
-  issueName: "Token leakage in responses",
-  issueDescription: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
+  sourceId: "dds0rt8sqgpuku4u4wabze9r",
+  sourceName: "Token leakage in responses",
+  description: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
   issueUrl: "https://console.latitude.so/projects/sample-project/issues?issueId=preview-issue",
   chartUrl: "https://placehold.co/600x200/dbe5ff/3b5bff?text=Trend+chart",
   notificationCreatedAt: new Date("2026-03-18T10:37:00Z"),

--- a/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
@@ -1,5 +1,3 @@
-import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
 import { Effect } from "effect"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -7,10 +5,11 @@ import React from "react"
 import { buildChartUrl } from "../../../helpers/chart-url.ts"
 import { renderEmail } from "../../../utils/render.ts"
 import { buildMonitorAttribution } from "../-incident-components.tsx"
+import { resolveIncidentSource } from "../-incident-source.ts"
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentClosedEmail } from "./EmailTemplate.tsx"
 
-const buildSourceUrl = (
+const buildIssueUrl = (
   ctx: NotificationEmailRenderContext,
   payload: Parameters<NotificationEmailRenderer<"incident.closed">>[0],
 ): string | undefined => {
@@ -20,19 +19,10 @@ const buildSourceUrl = (
 
 export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"> = (payload, ctx) =>
   Effect.gen(function* () {
-    const issues = yield* IssueRepository
-    const issue = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", (cause) =>
-        Effect.fail({
-          _tag: "RenderNotificationEmailError" as const,
-          message: "Failed to load incident source issue",
-          cause,
-        }),
-      ),
-    )
-    const issueRef = issue?.name ?? "an issue"
-    const issueUrl = buildSourceUrl(ctx, payload)
+    const isSavedSearch = payload.sourceType === "savedSearch"
+    const source = yield* resolveIncidentSource(payload)
+    const sourceName = source.name ?? (isSavedSearch ? "a saved search" : "an issue")
+    const issueUrl = isSavedSearch ? undefined : buildIssueUrl(ctx, payload)
 
     const chartUrl = buildChartUrl({
       notificationId: ctx.notificationId,
@@ -46,15 +36,18 @@ export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"
       incidentKind: payload.incidentKind,
       condition: payload.condition,
     })
+    const ctaUrl = isSavedSearch ? monitor?.url : issueUrl
+    const subject = `Resolved: escalation on ${sourceName}`
 
     const html = yield* Effect.tryPromise({
       try: () =>
         renderEmail(
           <IncidentClosedEmail
+            incidentKind={payload.incidentKind}
             severity={payload.severity}
-            issueId={payload.sourceId}
-            issueName={issue?.name ?? undefined}
-            issueDescription={issue?.description ?? undefined}
+            sourceId={payload.sourceId}
+            sourceName={sourceName}
+            description={source.description ?? undefined}
             issueUrl={issueUrl}
             chartUrl={chartUrl}
             notificationCreatedAt={ctx.notificationCreatedAt}
@@ -74,8 +67,8 @@ export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"
 
     return {
       html,
-      subject: `Resolved: escalation on ${issueRef}`,
-      text: `Resolved: escalation on ${issueRef}.${issueUrl ? `\n\n${issueUrl}` : ""}\n\n— Latitude`,
+      subject,
+      text: `${subject}.${ctaUrl ? `\n\n${ctaUrl}` : ""}\n\n— Latitude`,
     }
   })
 

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -1,5 +1,10 @@
 import type { IncidentSampleExcerpt } from "@domain/notifications"
-import { ALERT_INCIDENT_KIND_LABEL, type AlertIncidentKind, type AlertSeverity } from "@domain/shared"
+import {
+  ALERT_INCIDENT_KIND_LABEL,
+  ALERT_INCIDENT_KIND_SOURCE_TYPE,
+  type AlertIncidentKind,
+  type AlertSeverity,
+} from "@domain/shared"
 import { Section } from "@react-email/components"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -37,9 +42,12 @@ const ALERT_KIND_TO_SUBTITLE: Record<AlertIncidentKind, string> = {
 interface IncidentEventEmailProps {
   readonly incidentKind: AlertIncidentKind
   readonly severity: AlertSeverity
-  readonly issueId: string
-  readonly issueName: string | undefined
-  readonly issueDescription: string | undefined
+  /** Source entity id — issue id or saved search id. Surfaced in the footer for issues only. */
+  readonly sourceId: string
+  /** Live-resolved source display name (issue title or saved search name). */
+  readonly sourceName: string
+  /** Issue description; absent for saved-search sources. */
+  readonly description: string | undefined
   readonly issueUrl: string | undefined
   readonly notificationCreatedAt: Date
   readonly organizationName: string
@@ -53,9 +61,9 @@ interface IncidentEventEmailProps {
 export function IncidentEventEmail({
   incidentKind,
   severity,
-  issueId,
-  issueName,
-  issueDescription,
+  sourceId,
+  sourceName,
+  description,
   issueUrl,
   notificationCreatedAt,
   organizationName,
@@ -67,8 +75,9 @@ export function IncidentEventEmail({
 }: IncidentEventEmailProps) {
   const heading = ALERT_INCIDENT_KIND_LABEL[incidentKind]
   const subtitle = ALERT_KIND_TO_SUBTITLE[incidentKind]
-  const issueRef = issueName ?? "an issue"
+  const isSavedSearch = ALERT_INCIDENT_KIND_SOURCE_TYPE[incidentKind] === "savedSearch"
   const scope = formatScope(organizationName, projectName)
+  const ctaHref = isSavedSearch ? monitor?.url : issueUrl
 
   const metadataRows = [
     { label: "Project", value: scope },
@@ -78,7 +87,7 @@ export function IncidentEventEmail({
 
   return (
     <ContainerLayout
-      previewText={`${heading}: ${issueRef}`}
+      previewText={`${heading}: ${sourceName}`}
       footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
     >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
@@ -88,12 +97,11 @@ export function IncidentEventEmail({
 
       <MonitorAttribution monitor={monitor} />
 
-      <SectionHeader label="Issue" />
-
-      <EmailText variant="heading">{issueRef}</EmailText>
-      {issueDescription ? (
+      <SectionHeader label={isSavedSearch ? "Saved search" : "Issue"} />
+      <EmailText variant="heading">{sourceName}</EmailText>
+      {description ? (
         <EmailText variant="bodySmall" className="text-muted-foreground">
-          {issueDescription}
+          {description}
         </EmailText>
       ) : null}
 
@@ -103,11 +111,11 @@ export function IncidentEventEmail({
 
       {sampleExcerpt ? <SampleExcerptCard excerpt={sampleExcerpt} /> : null}
 
-      <IssueIdFooter issueId={issueId} />
+      {isSavedSearch ? null : <IssueIdFooter issueId={sourceId} />}
 
-      {issueUrl ? (
+      {ctaHref ? (
         <Section className={emailDesignTokens.spacing.buttonTop}>
-          <EmailButton href={issueUrl} label="View issue" />
+          <EmailButton href={ctaHref} label={isSavedSearch ? "View monitor" : "View issue"} />
         </Section>
       ) : null}
     </ContainerLayout>
@@ -117,9 +125,9 @@ export function IncidentEventEmail({
 IncidentEventEmail.PreviewProps = {
   incidentKind: "issue.new",
   severity: "medium",
-  issueId: "dds0rt8sqgpuku4u4wabze9r",
-  issueName: "Token leakage in responses",
-  issueDescription: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
+  sourceId: "dds0rt8sqgpuku4u4wabze9r",
+  sourceName: "Token leakage in responses",
+  description: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
   issueUrl: "https://console.latitude.so/projects/sample-project/issues?issueId=preview-issue",
   notificationCreatedAt: new Date("2026-03-18T10:05:00Z"),
   organizationName: "Acme Inc.",

--- a/packages/domain/email/src/templates/notifications/incident-event/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/index.tsx
@@ -1,15 +1,15 @@
-import { IssueRepository } from "@domain/issues"
-import { ALERT_INCIDENT_KIND_LABEL, IssueId } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_LABEL } from "@domain/shared"
 import { Effect } from "effect"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
 import React from "react"
 import { renderEmail } from "../../../utils/render.ts"
 import { buildMonitorAttribution } from "../-incident-components.tsx"
+import { resolveIncidentSource } from "../-incident-source.ts"
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentEventEmail } from "./EmailTemplate.tsx"
 
-const buildSourceUrl = (
+const buildIssueUrl = (
   ctx: NotificationEmailRenderContext,
   payload: Parameters<NotificationEmailRenderer<"incident.event">>[0],
 ): string | undefined => {
@@ -19,19 +19,9 @@ const buildSourceUrl = (
 
 export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> = (payload, ctx) =>
   Effect.gen(function* () {
-    const issues = yield* IssueRepository
-    const issue = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", (cause) =>
-        Effect.fail({
-          _tag: "RenderNotificationEmailError" as const,
-          message: "Failed to load incident source issue",
-          cause,
-        }),
-      ),
-    )
-    const issueRef = issue?.name ?? "an issue"
-    const issueUrl = buildSourceUrl(ctx, payload)
+    const isSavedSearch = payload.sourceType === "savedSearch"
+    const source = yield* resolveIncidentSource(payload)
+    const sourceName = source.name ?? (isSavedSearch ? "a saved search" : "an issue")
     const heading = ALERT_INCIDENT_KIND_LABEL[payload.incidentKind] ?? "Incident"
     const monitor = buildMonitorAttribution({
       webAppUrl: ctx.webAppUrl,
@@ -41,6 +31,9 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
       incidentKind: payload.incidentKind,
       condition: payload.condition,
     })
+    const issueUrl = isSavedSearch ? undefined : buildIssueUrl(ctx, payload)
+    const ctaUrl = isSavedSearch ? monitor?.url : issueUrl
+    const subject = `${heading}: ${sourceName}`
 
     const html = yield* Effect.tryPromise({
       try: () =>
@@ -48,9 +41,9 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
           <IncidentEventEmail
             incidentKind={payload.incidentKind}
             severity={payload.severity}
-            issueId={payload.sourceId}
-            issueName={issue?.name ?? undefined}
-            issueDescription={issue?.description ?? undefined}
+            sourceId={payload.sourceId}
+            sourceName={sourceName}
+            description={source.description ?? undefined}
             issueUrl={issueUrl}
             notificationCreatedAt={ctx.notificationCreatedAt}
             organizationName={ctx.organization.name}
@@ -70,8 +63,8 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
 
     return {
       html,
-      subject: `${heading}: ${issueRef}`,
-      text: `${heading}: ${issueRef}.${issueUrl ? `\n\n${issueUrl}` : ""}\n\n— Latitude`,
+      subject,
+      text: `${subject}.${ctaUrl ? `\n\n${ctaUrl}` : ""}\n\n— Latitude`,
     }
   })
 

--- a/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/EmailTemplate.tsx
@@ -1,5 +1,10 @@
 import type { IncidentBreach, IncidentSampleExcerpt } from "@domain/notifications"
-import type { AlertSeverity } from "@domain/shared"
+import {
+  ALERT_INCIDENT_KIND_LABEL,
+  ALERT_INCIDENT_KIND_SOURCE_TYPE,
+  type AlertIncidentKind,
+  type AlertSeverity,
+} from "@domain/shared"
 import { Section } from "@react-email/components"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -25,10 +30,11 @@ import {
 } from "../-incident-components.tsx"
 
 interface IncidentOpenedEmailProps {
+  readonly incidentKind: AlertIncidentKind
   readonly severity: AlertSeverity
-  readonly issueId: string
-  readonly issueName: string | undefined
-  readonly issueDescription: string | undefined
+  readonly sourceId: string
+  readonly sourceName: string
+  readonly description: string | undefined
   readonly issueUrl: string | undefined
   readonly chartUrl: string
   readonly notificationCreatedAt: Date
@@ -54,10 +60,11 @@ const buildBreachLine = (breach: IncidentBreach | undefined): string | null => {
 }
 
 export function IncidentOpenedEmail({
+  incidentKind,
   severity,
-  issueId,
-  issueName,
-  issueDescription,
+  sourceId,
+  sourceName,
+  description,
   issueUrl,
   chartUrl,
   notificationCreatedAt,
@@ -69,9 +76,14 @@ export function IncidentOpenedEmail({
   monitor,
   webAppUrl,
 }: IncidentOpenedEmailProps) {
-  const issueRef = issueName ?? "an issue"
+  const isSavedSearch = ALERT_INCIDENT_KIND_SOURCE_TYPE[incidentKind] === "savedSearch"
+  const heading = ALERT_INCIDENT_KIND_LABEL[incidentKind]
+  const subtitle = isSavedSearch
+    ? "We notified everyone watching this project — traces matching the search stayed above the threshold for the configured window."
+    : "We notified everyone watching this project — an ongoing issue is being detected more than expected."
   const scope = formatScope(organizationName, projectName)
   const breachLine = buildBreachLine(breach)
+  const ctaHref = isSavedSearch ? monitor?.url : issueUrl
 
   const metadataRows = [
     { label: "Project", value: scope },
@@ -81,24 +93,21 @@ export function IncidentOpenedEmail({
 
   return (
     <ContainerLayout
-      previewText={`Escalating: ${issueRef}`}
+      previewText={`Escalating: ${sourceName}`}
       footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
     >
       <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
-        Issue escalating
+        {heading}
       </EmailText>
-      <EmailText variant="body">
-        We notified everyone watching this project — an ongoing issue is being detected more than expected.
-      </EmailText>
+      <EmailText variant="body">{subtitle}</EmailText>
 
       <MonitorAttribution monitor={monitor} />
 
-      <SectionHeader label="Issue" />
-
-      <EmailText variant="heading">{issueRef}</EmailText>
-      {issueDescription ? (
+      <SectionHeader label={isSavedSearch ? "Saved search" : "Issue"} />
+      <EmailText variant="heading">{sourceName}</EmailText>
+      {description ? (
         <EmailText variant="bodySmall" className="text-muted-foreground">
-          {issueDescription}
+          {description}
         </EmailText>
       ) : null}
 
@@ -106,21 +115,23 @@ export function IncidentOpenedEmail({
 
       <EmailMetadataTable rows={metadataRows} />
 
-      <SectionHeader label="Breach" />
-      {breachLine ? (
-        <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
-          {breachLine}
-        </EmailText>
-      ) : null}
-      <IncidentTrendChartImage src={chartUrl} />
+      {isSavedSearch ? null : (
+        <>
+          <SectionHeader label="Breach" />
+          {breachLine ? (
+            <EmailText variant="body" className={emailDesignTokens.spacing.contentGap}>
+              {breachLine}
+            </EmailText>
+          ) : null}
+          <IncidentTrendChartImage src={chartUrl} />
+          {sampleExcerpt ? <SampleExcerptCard excerpt={sampleExcerpt} /> : null}
+          <IssueIdFooter issueId={sourceId} />
+        </>
+      )}
 
-      {sampleExcerpt ? <SampleExcerptCard excerpt={sampleExcerpt} /> : null}
-
-      <IssueIdFooter issueId={issueId} />
-
-      {issueUrl ? (
+      {ctaHref ? (
         <Section className={emailDesignTokens.spacing.buttonTop}>
-          <EmailButton href={issueUrl} label="View issue" />
+          <EmailButton href={ctaHref} label={isSavedSearch ? "View monitor" : "View issue"} />
         </Section>
       ) : null}
     </ContainerLayout>
@@ -128,10 +139,11 @@ export function IncidentOpenedEmail({
 }
 
 IncidentOpenedEmail.PreviewProps = {
+  incidentKind: "issue.escalating",
   severity: "high",
-  issueId: "dds0rt8sqgpuku4u4wabze9r",
-  issueName: "Token leakage in responses",
-  issueDescription: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
+  sourceId: "dds0rt8sqgpuku4u4wabze9r",
+  sourceName: "Token leakage in responses",
+  description: "Agent occasionally echoes API keys or PII back to the user when summarising prior tool outputs.",
   issueUrl: "https://console.latitude.so/projects/sample-project/issues?issueId=preview-issue",
   chartUrl: "https://placehold.co/600x200/dbe5ff/3b5bff?text=Trend+chart",
   notificationCreatedAt: new Date("2026-03-18T10:05:00Z"),

--- a/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
@@ -1,5 +1,3 @@
-import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
 import { Effect } from "effect"
 // @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
@@ -7,10 +5,11 @@ import React from "react"
 import { buildChartUrl } from "../../../helpers/chart-url.ts"
 import { renderEmail } from "../../../utils/render.ts"
 import { buildMonitorAttribution } from "../-incident-components.tsx"
+import { resolveIncidentSource } from "../-incident-source.ts"
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentOpenedEmail } from "./EmailTemplate.tsx"
 
-const buildSourceUrl = (
+const buildIssueUrl = (
   ctx: NotificationEmailRenderContext,
   payload: Parameters<NotificationEmailRenderer<"incident.opened">>[0],
 ): string | undefined => {
@@ -20,19 +19,10 @@ const buildSourceUrl = (
 
 export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"> = (payload, ctx) =>
   Effect.gen(function* () {
-    const issues = yield* IssueRepository
-    const issue = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", (cause) =>
-        Effect.fail({
-          _tag: "RenderNotificationEmailError" as const,
-          message: "Failed to load incident source issue",
-          cause,
-        }),
-      ),
-    )
-    const issueRef = issue?.name ?? "an issue"
-    const issueUrl = buildSourceUrl(ctx, payload)
+    const isSavedSearch = payload.sourceType === "savedSearch"
+    const source = yield* resolveIncidentSource(payload)
+    const sourceName = source.name ?? (isSavedSearch ? "a saved search" : "an issue")
+    const issueUrl = isSavedSearch ? undefined : buildIssueUrl(ctx, payload)
 
     const chartUrl = buildChartUrl({
       notificationId: ctx.notificationId,
@@ -46,15 +36,18 @@ export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"
       incidentKind: payload.incidentKind,
       condition: payload.condition,
     })
+    const ctaUrl = isSavedSearch ? monitor?.url : issueUrl
+    const subject = `Escalating: ${sourceName}`
 
     const html = yield* Effect.tryPromise({
       try: () =>
         renderEmail(
           <IncidentOpenedEmail
+            incidentKind={payload.incidentKind}
             severity={payload.severity}
-            issueId={payload.sourceId}
-            issueName={issue?.name ?? undefined}
-            issueDescription={issue?.description ?? undefined}
+            sourceId={payload.sourceId}
+            sourceName={sourceName}
+            description={source.description ?? undefined}
             issueUrl={issueUrl}
             chartUrl={chartUrl}
             notificationCreatedAt={ctx.notificationCreatedAt}
@@ -76,8 +69,8 @@ export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"
 
     return {
       html,
-      subject: `Escalating: ${issueRef}`,
-      text: `Escalating issue: ${issueRef}.${issueUrl ? `\n\n${issueUrl}` : ""}\n\n— Latitude`,
+      subject,
+      text: `${subject}.${ctaUrl ? `\n\n${ctaUrl}` : ""}\n\n— Latitude`,
     }
   })
 

--- a/packages/domain/email/src/templates/notifications/types.ts
+++ b/packages/domain/email/src/templates/notifications/types.ts
@@ -1,6 +1,7 @@
 import type { FeatureFlagRepository } from "@domain/feature-flags"
 import type { IssueRepository } from "@domain/issues"
 import type { NOTIFICATION_KIND_META, NotificationKind, RenderNotificationEmailError } from "@domain/notifications"
+import type { SavedSearchRepository } from "@domain/saved-searches"
 import type { SqlClient } from "@domain/shared"
 import type { WrappedReportRepository } from "@domain/spans"
 import type { Effect } from "effect"
@@ -54,9 +55,9 @@ export interface NotificationEmailRenderContext {
  * `never` and stay as trivial `Effect.tryPromise(() => template(...))`.
  */
 export type RenderDepsByKind = {
-  readonly "incident.event": IssueRepository | SqlClient
-  readonly "incident.opened": IssueRepository | SqlClient
-  readonly "incident.closed": IssueRepository | SqlClient
+  readonly "incident.event": IssueRepository | SavedSearchRepository | SqlClient
+  readonly "incident.opened": IssueRepository | SavedSearchRepository | SqlClient
+  readonly "incident.closed": IssueRepository | SavedSearchRepository | SqlClient
   readonly "wrapped.report": WrappedReportRepository | FeatureFlagRepository | SqlClient
   readonly "custom.message": never
 }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -263,6 +263,15 @@ export interface EventPayloads {
     readonly name: string
   }
   /**
+   * Fired when a saved search is (soft-)deleted. Drives the monitors source
+   * cascade: alerts watching it are soft-deleted and now-empty monitors pruned.
+   */
+  SavedSearchDeleted: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly searchId: string
+  }
+  /**
    * Fired the first time an issue is monitored: a brand-new evaluation
    * generation job has been kicked off (no existing evaluation existed for
    * the issue).

--- a/packages/domain/integrations/package.json
+++ b/packages/domain/integrations/package.json
@@ -19,6 +19,7 @@
     "@domain/issues": "workspace:*",
     "@domain/monitors": "workspace:*",
     "@domain/notifications": "workspace:*",
+    "@domain/saved-searches": "workspace:*",
     "@domain/shared": "workspace:*",
     "@slack/web-api": "7.10.0",
     "effect": "catalog:",

--- a/packages/domain/integrations/src/templates/notifications/blocks.ts
+++ b/packages/domain/integrations/src/templates/notifications/blocks.ts
@@ -34,6 +34,16 @@ export const projectOrOrgContext = (
   project: { readonly name: string } | null,
 ): string => (project ? `Project *${project.name}* · ${organization.name}` : `Org *${organization.name}*`)
 
+/** `/projects/<slug>/monitors?monitorSlug=<slug>` deep link; `null` when either slug is missing. */
+export const monitorDeepLink = (input: {
+  readonly webAppUrl: string
+  readonly projectSlug: string | undefined
+  readonly monitorSlug: string | undefined
+}): string | null => {
+  if (!input.projectSlug || !input.monitorSlug) return null
+  return `${input.webAppUrl.replace(/\/$/, "")}/projects/${input.projectSlug}/monitors?monitorSlug=${encodeURIComponent(input.monitorSlug)}`
+}
+
 /** "Created by monitor X" context line (+ humanised rule); `[]` on legacy incidents. Deep-links when the slug resolves, else bold text. */
 export const monitorAttributionBlocks = (input: {
   readonly webAppUrl: string
@@ -44,10 +54,7 @@ export const monitorAttributionBlocks = (input: {
   readonly condition: AlertIncidentCondition | null | undefined
 }): KnownBlock[] => {
   if (!input.monitorName) return []
-  const url =
-    input.projectSlug && input.monitorSlug
-      ? `${input.webAppUrl.replace(/\/$/, "")}/projects/${input.projectSlug}/monitors?monitorSlug=${encodeURIComponent(input.monitorSlug)}`
-      : null
+  const url = monitorDeepLink(input)
   const name = url ? `<${url}|${input.monitorName}>` : `*${input.monitorName}*`
   const blocks: KnownBlock[] = [contextLine(`Created by monitor ${name}`)]
   if (input.condition) {

--- a/packages/domain/integrations/src/templates/notifications/incident-closed.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-closed.ts
@@ -1,31 +1,56 @@
-import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
 import { Effect } from "effect"
 import {
   actionsLink,
   COLORS,
   contextLine,
   monitorAttributionBlocks,
+  monitorDeepLink,
   projectOrOrgContext,
   sectionMarkdown,
   trendChartBlock,
 } from "./blocks.ts"
+import { resolveSourceName } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentClosedRenderer: SlackNotificationRenderer<"incident.closed"> = (payload, ctx) =>
   Effect.gen(function* () {
     const projectName = ctx.project?.name ?? ctx.organization.name
+    const isSavedSearch = payload.sourceType === "savedSearch"
     const issueUrl = ctx.project
       ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/issues?issueId=${payload.sourceId}`
       : ctx.webAppUrl
+    const monitorUrl =
+      monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
+      ctx.webAppUrl
     const duration = humanizeDurationMs(payload.recovery.durationMs)
 
-    const issues = yield* IssueRepository
-    const issueName = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.map((i) => i.name),
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+    const sourceName = yield* resolveSourceName(payload)
+
+    const attribution = monitorAttributionBlocks({
+      webAppUrl: ctx.webAppUrl,
+      projectSlug: ctx.project?.slug,
+      monitorName: payload.monitorName,
+      monitorSlug: payload.monitorSlug,
+      incidentKind: payload.incidentKind,
+      condition: payload.condition,
+    })
+    const context = contextLine(
+      `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
     )
+
+    if (isSavedSearch) {
+      const searchRef = sourceName ?? "a saved search"
+      return {
+        text: `Resolved: escalation on ${searchRef} — elevated for ${duration}`,
+        color: COLORS.resolved,
+        blocks: [
+          sectionMarkdown(`Escalation resolved on *${searchRef}* — elevated for *${duration}*.`),
+          ...attribution,
+          context,
+          actionsLink("View monitor", monitorUrl),
+        ],
+      }
+    }
 
     const chart = trendChartBlock(ctx.notificationId, ctx.webAppUrl)
 
@@ -33,20 +58,11 @@ export const incidentClosedRenderer: SlackNotificationRenderer<"incident.closed"
       text: `Issue recovered in ${projectName} — elevated for ${duration}`,
       color: COLORS.resolved,
       blocks: [
-        ...(issueName ? [sectionMarkdown(`*<${issueUrl}|${issueName}>*`)] : []),
+        ...(sourceName ? [sectionMarkdown(`*<${issueUrl}|${sourceName}>*`)] : []),
         sectionMarkdown(`Elevated for *${duration}*.`),
         ...(chart ? [chart] : []),
-        ...monitorAttributionBlocks({
-          webAppUrl: ctx.webAppUrl,
-          projectSlug: ctx.project?.slug,
-          monitorName: payload.monitorName,
-          monitorSlug: payload.monitorSlug,
-          incidentKind: payload.incidentKind,
-          condition: payload.condition,
-        }),
-        contextLine(
-          `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
-        ),
+        ...attribution,
+        context,
         actionsLink("View issue", issueUrl),
       ],
     }

--- a/packages/domain/integrations/src/templates/notifications/incident-event.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-event.ts
@@ -1,52 +1,68 @@
-import { IssueRepository } from "@domain/issues"
-import { ALERT_INCIDENT_KIND_LABEL, IssueId } from "@domain/shared"
+import { ALERT_INCIDENT_KIND_LABEL } from "@domain/shared"
 import { Effect } from "effect"
 import {
   actionsLink,
   contextLine,
   monitorAttributionBlocks,
+  monitorDeepLink,
   projectOrOrgContext,
   sectionMarkdown,
   severityColor,
 } from "./blocks.ts"
+import { resolveSourceName } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentEventRenderer: SlackNotificationRenderer<"incident.event"> = (payload, ctx) =>
   Effect.gen(function* () {
     const name = ALERT_INCIDENT_KIND_LABEL[payload.incidentKind] ?? "Incident"
     const color = severityColor(payload.severity)
+    const isSavedSearch = payload.sourceType === "savedSearch"
     const issueUrl = ctx.project
       ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/issues?issueId=${payload.sourceId}`
       : ctx.webAppUrl
+    const monitorUrl =
+      monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
+      ctx.webAppUrl
 
-    const issues = yield* IssueRepository
-    const issueName = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.map((i) => i.name),
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+    const sourceName = yield* resolveSourceName(payload)
+
+    const attribution = monitorAttributionBlocks({
+      webAppUrl: ctx.webAppUrl,
+      projectSlug: ctx.project?.slug,
+      monitorName: payload.monitorName,
+      monitorSlug: payload.monitorSlug,
+      incidentKind: payload.incidentKind,
+      condition: payload.condition,
+    })
+    const context = contextLine(
+      `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
     )
 
-    const tags = payload.tags ?? []
+    if (isSavedSearch) {
+      const searchRef = sourceName ?? "a saved search"
+      return {
+        text: `${name} in ${ctx.project?.name ?? ctx.organization.name}: ${searchRef}`,
+        color,
+        blocks: [
+          sectionMarkdown(`A saved search fired an alert: *${searchRef}*.`),
+          ...attribution,
+          context,
+          actionsLink("View monitor", monitorUrl),
+        ],
+      }
+    }
 
+    const tags = payload.tags ?? []
     return {
-      text: `${name} in ${ctx.project?.name ?? ctx.organization.name}${issueName ? `: ${issueName}` : ""}`,
+      text: `${name} in ${ctx.project?.name ?? ctx.organization.name}${sourceName ? `: ${sourceName}` : ""}`,
       color,
       blocks: [
-        ...(issueName ? [sectionMarkdown(`*<${issueUrl}|${issueName}>*`)] : []),
-        sectionMarkdown(issueName ? `A new <${issueUrl}|issue> has been detected.` : `A new issue has been detected.`),
+        ...(sourceName ? [sectionMarkdown(`*<${issueUrl}|${sourceName}>*`)] : []),
+        sectionMarkdown(sourceName ? `A new <${issueUrl}|issue> has been detected.` : `A new issue has been detected.`),
         ...(payload.sampleExcerpt?.text ? [sectionMarkdown(`\`\`\`\n${payload.sampleExcerpt.text}\n\`\`\``)] : []),
         ...(tags.length > 0 ? [sectionMarkdown(tags.map((t) => `\`${t}\``).join("  "))] : []),
-        ...monitorAttributionBlocks({
-          webAppUrl: ctx.webAppUrl,
-          projectSlug: ctx.project?.slug,
-          monitorName: payload.monitorName,
-          monitorSlug: payload.monitorSlug,
-          incidentKind: payload.incidentKind,
-          condition: payload.condition,
-        }),
-        contextLine(
-          `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
-        ),
+        ...attribution,
+        context,
         actionsLink("View issue", issueUrl),
       ],
     }

--- a/packages/domain/integrations/src/templates/notifications/incident-opened.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-opened.ts
@@ -1,30 +1,55 @@
-import { IssueRepository } from "@domain/issues"
-import { IssueId } from "@domain/shared"
 import { Effect } from "effect"
 import {
   actionsLink,
   contextLine,
   monitorAttributionBlocks,
+  monitorDeepLink,
   projectOrOrgContext,
   sectionMarkdown,
   severityColor,
   trendChartBlock,
 } from "./blocks.ts"
+import { resolveSourceName } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentOpenedRenderer: SlackNotificationRenderer<"incident.opened"> = (payload, ctx) =>
   Effect.gen(function* () {
     const projectName = ctx.project?.name ?? ctx.organization.name
+    const isSavedSearch = payload.sourceType === "savedSearch"
     const issueUrl = ctx.project
       ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/issues?issueId=${payload.sourceId}`
       : ctx.webAppUrl
+    const monitorUrl =
+      monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
+      ctx.webAppUrl
 
-    const issues = yield* IssueRepository
-    const issueName = yield* issues.findById(IssueId(payload.sourceId)).pipe(
-      Effect.map((i) => i.name),
-      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-      Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+    const sourceName = yield* resolveSourceName(payload)
+
+    const attribution = monitorAttributionBlocks({
+      webAppUrl: ctx.webAppUrl,
+      projectSlug: ctx.project?.slug,
+      monitorName: payload.monitorName,
+      monitorSlug: payload.monitorSlug,
+      incidentKind: payload.incidentKind,
+      condition: payload.condition,
+    })
+    const context = contextLine(
+      `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
     )
+
+    if (isSavedSearch) {
+      const searchRef = sourceName ?? "a saved search"
+      return {
+        text: `Escalating: ${searchRef} in ${projectName}`,
+        color: severityColor(payload.severity),
+        blocks: [
+          sectionMarkdown(`A saved search started escalating: *${searchRef}*.`),
+          ...attribution,
+          context,
+          actionsLink("View monitor", monitorUrl),
+        ],
+      }
+    }
 
     const breachLine = payload.breach
       ? `Rate climbed to *${formatRate(payload.breach.triggerRate)}/hr* — ${formatMultiple(payload.breach.triggerRate, payload.breach.baselineRate)} the baseline of ${formatRate(payload.breach.baselineRate)}/hr`
@@ -34,25 +59,16 @@ export const incidentOpenedRenderer: SlackNotificationRenderer<"incident.opened"
     const chart = trendChartBlock(ctx.notificationId, ctx.webAppUrl)
 
     return {
-      text: `Issue escalating in ${projectName}${issueName ? `: ${issueName}` : ""}`,
+      text: `Issue escalating in ${projectName}${sourceName ? `: ${sourceName}` : ""}`,
       color: severityColor(payload.severity),
       blocks: [
-        ...(issueName ? [sectionMarkdown(`*<${issueUrl}|${issueName}>*`)] : []),
+        ...(sourceName ? [sectionMarkdown(`*<${issueUrl}|${sourceName}>*`)] : []),
         ...(breachLine ? [sectionMarkdown(breachLine)] : []),
         ...(payload.sampleExcerpt?.text ? [sectionMarkdown(`\`\`\`\n${payload.sampleExcerpt.text}\n\`\`\``)] : []),
         ...(chart ? [chart] : []),
         ...(tags.length > 0 ? [sectionMarkdown(tags.map((t) => `\`${t}\``).join("  "))] : []),
-        ...monitorAttributionBlocks({
-          webAppUrl: ctx.webAppUrl,
-          projectSlug: ctx.project?.slug,
-          monitorName: payload.monitorName,
-          monitorSlug: payload.monitorSlug,
-          incidentKind: payload.incidentKind,
-          condition: payload.condition,
-        }),
-        contextLine(
-          `${payload.severity} · ${payload.sourceType} · ${projectOrOrgContext(ctx.organization, ctx.project)}`,
-        ),
+        ...attribution,
+        context,
         actionsLink("View issue", issueUrl),
       ],
     }

--- a/packages/domain/integrations/src/templates/notifications/source-name.ts
+++ b/packages/domain/integrations/src/templates/notifications/source-name.ts
@@ -1,0 +1,23 @@
+import { IssueRepository } from "@domain/issues"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import { IssueId, SavedSearchId } from "@domain/shared"
+import { Effect } from "effect"
+
+/** Live-resolve the incident source's display name (issue title or saved search name). `null` if missing/deleted. */
+export const resolveSourceName = (input: { readonly sourceType: string; readonly sourceId: string }) =>
+  Effect.gen(function* () {
+    if (input.sourceType === "savedSearch") {
+      const repo = yield* SavedSearchRepository
+      return yield* repo.findById(SavedSearchId(input.sourceId)).pipe(
+        Effect.map((s): string | null => s.name),
+        Effect.catchTag("SavedSearchNotFoundError", () => Effect.succeed(null)),
+        Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+      )
+    }
+    const repo = yield* IssueRepository
+    return yield* repo.findById(IssueId(input.sourceId)).pipe(
+      Effect.map((i): string | null => i.name),
+      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+      Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+    )
+  })

--- a/packages/domain/integrations/src/templates/notifications/types.ts
+++ b/packages/domain/integrations/src/templates/notifications/types.ts
@@ -1,5 +1,6 @@
 import type { IssueRepository } from "@domain/issues"
 import type { NOTIFICATION_KIND_META, NotificationKind } from "@domain/notifications"
+import type { SavedSearchRepository } from "@domain/saved-searches"
 import type { NotificationId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import type { KnownBlock } from "@slack/web-api"
 import { Data, type Effect } from "effect"
@@ -71,13 +72,13 @@ export class RenderSlackError extends Data.TaggedError("RenderSlackError")<{
 
 /**
  * Per-kind Effect service requirements for rendering. Incident kinds
- * look up the issue name from `IssueRepository`; other kinds need
- * nothing beyond the payload + context.
+ * look up the source name (issue or saved search) from its repository;
+ * other kinds need nothing beyond the payload + context.
  */
 export type SlackRenderDepsByKind = {
-  readonly "incident.event": IssueRepository | SqlClient
-  readonly "incident.opened": IssueRepository | SqlClient
-  readonly "incident.closed": IssueRepository | SqlClient
+  readonly "incident.event": IssueRepository | SavedSearchRepository | SqlClient
+  readonly "incident.opened": IssueRepository | SavedSearchRepository | SqlClient
+  readonly "incident.closed": IssueRepository | SavedSearchRepository | SqlClient
   readonly "wrapped.report": never
   readonly "custom.message": never
 }
@@ -85,8 +86,8 @@ export type SlackRenderDepsByKind = {
 export type SlackRenderDepsFor<K extends NotificationKind> = SlackRenderDepsByKind[K]
 
 /**
- * Per-kind renderer signature. Incident kinds have `R = IssueRepository | SqlClient`
- * so they can look up the issue display name. Other kinds use `R = never`.
+ * Per-kind renderer signature. Incident kinds carry the source repositories on `R`
+ * so they can look up the source display name. Other kinds use `R = never`.
  */
 export type SlackNotificationRenderer<K extends NotificationKind> = (
   payload: z.infer<(typeof NOTIFICATION_KIND_META)[K]["payload"]>,

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
@@ -1,4 +1,5 @@
 import { IssueRepository } from "@domain/issues"
+import { SavedSearchRepository } from "@domain/saved-searches"
 import { OrganizationId, ProjectId, SlackIntegrationId, SqlClient, type SqlClientShape } from "@domain/shared"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -18,6 +19,11 @@ const NoopIssueRepository = Layer.succeed(IssueRepository, {
   hardDelete: () => Effect.die(new Error("not expected")),
   existsByName: () => Effect.die(new Error("not expected")),
   countBySlug: () => Effect.die(new Error("not expected")),
+} as never)
+
+// Same rationale as NoopIssueRepository: custom.message never resolves a source name.
+const NoopSavedSearchRepository = Layer.succeed(SavedSearchRepository, {
+  findById: () => Effect.die(new Error("SavedSearchRepository.findById not expected in this test")),
 } as never)
 
 const ORG = OrganizationId("o".repeat(24))
@@ -73,7 +79,12 @@ describe("dispatchSlackNotificationUseCase", () => {
         idempotencyKey: "custom.message:abc",
         context: ctx,
         messenger,
-      }).pipe(Effect.provide(layer), Effect.provide(NoopIssueRepository), Effect.provide(NoopSqlClient)),
+      }).pipe(
+        Effect.provide(layer),
+        Effect.provide(NoopIssueRepository),
+        Effect.provide(NoopSavedSearchRepository),
+        Effect.provide(NoopSqlClient),
+      ),
     )
 
     expect(outcome.status).toBe("delivered")
@@ -94,7 +105,12 @@ describe("dispatchSlackNotificationUseCase", () => {
         idempotencyKey: "custom.message:abc",
         context: ctx,
         messenger,
-      }).pipe(Effect.provide(layer), Effect.provide(NoopIssueRepository), Effect.provide(NoopSqlClient)),
+      }).pipe(
+        Effect.provide(layer),
+        Effect.provide(NoopIssueRepository),
+        Effect.provide(NoopSavedSearchRepository),
+        Effect.provide(NoopSqlClient),
+      ),
     )
 
     expect(outcome.status).toBe("skipped-already-delivered")
@@ -115,7 +131,12 @@ describe("dispatchSlackNotificationUseCase", () => {
         idempotencyKey: "custom.message:xyz",
         context: ctx,
         messenger,
-      }).pipe(Effect.provide(layer), Effect.provide(NoopIssueRepository), Effect.provide(NoopSqlClient)),
+      }).pipe(
+        Effect.provide(layer),
+        Effect.provide(NoopIssueRepository),
+        Effect.provide(NoopSavedSearchRepository),
+        Effect.provide(NoopSqlClient),
+      ),
     )
 
     expect(result._tag).toBe("Failure")

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.ts
@@ -1,5 +1,6 @@
 import type { IssueRepository } from "@domain/issues"
 import { NOTIFICATION_KIND_META, type NotificationKind } from "@domain/notifications"
+import type { SavedSearchRepository } from "@domain/saved-searches"
 import type { RepositoryError, SlackIntegrationId, SqlClient } from "@domain/shared"
 import { Data, Effect } from "effect"
 import { SlackDeliveryRepository } from "../ports/slack-delivery-repository.ts"
@@ -68,7 +69,7 @@ export const dispatchSlackNotificationUseCase = (
 ): Effect.Effect<
   DispatchSlackOutcome,
   DispatchSlackNotificationError,
-  SqlClient | SlackDeliveryRepository | IssueRepository
+  SqlClient | SlackDeliveryRepository | IssueRepository | SavedSearchRepository
 > =>
   Effect.gen(function* () {
     const deliveryRepo = yield* SlackDeliveryRepository

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -130,6 +130,14 @@ export const isIssueNew = (firstSeenAt: Date, now: Date = new Date()): boolean =
 const sigmaEffective = (observed: number, expected: number): number =>
   Math.max(observed, Math.sqrt(Math.max(0, expected)), 1.0)
 
+/**
+ * Seasonal anomaly threshold for a window: `expected + k · σ_effective`. Shared
+ * with `@domain/monitors`' saved-search `expected` mode so both compute the same
+ * band. `k` is the caller's resolved σ-multiplier (sensitivity, sample-adjusted).
+ */
+export const seasonalAnomalyThreshold = (expected: number, stddev: number, k: number): number =>
+  expected + k * sigmaEffective(stddev, expected)
+
 const snapshotFromSignals = (
   signals: IssueEscalationSignals,
   kShort: number,
@@ -273,8 +281,8 @@ export const evaluateSeasonalEscalation = (input: SeasonalEscalationDecisionInpu
   const sigma6hPerHour = sigmaEffective(signals.stddev6hPerHour, signals.expected6hPerHour)
   const recent6hPerHour = signals.recent6h / 6
 
-  const entryBand1h = signals.expected1h + kAdj * sigma1h
-  const entryBand6hPerHour = signals.expected6hPerHour + kLong * sigma6hPerHour
+  const entryBand1h = seasonalAnomalyThreshold(signals.expected1h, signals.stddev1h, kAdj)
+  const entryBand6hPerHour = seasonalAnomalyThreshold(signals.expected6hPerHour, signals.stddev6hPerHour, kLong)
   const exitBand1h = signals.expected1h + ESCALATION_EXIT_THRESHOLD_FACTOR * kAdj * sigma1h
   const exitBand6hPerHour = signals.expected6hPerHour + ESCALATION_EXIT_THRESHOLD_FACTOR * kLong * sigma6hPerHour
 

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -1,3 +1,6 @@
+// Re-exported so `@domain/monitors` can size its saved-search seasonal window
+// to the same history as the issue detector without depending on `@domain/scores`.
+export { SEASONAL_HISTORY_WEEKS } from "@domain/scores"
 export {
   CENTROID_EMBEDDING_DIMENSIONS,
   CENTROID_EMBEDDING_MODEL,
@@ -72,6 +75,7 @@ export {
   type SeasonalEscalationDecisionInput,
   type SeasonalEscalationExitReason,
   type SeasonalEscalationTransition,
+  seasonalAnomalyThreshold,
   type UpdateIssueCentroidInput,
   updateIssueCentroid,
 } from "./helpers.ts"

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -129,6 +129,9 @@ const provideTestLayers = (params: {
       Effect.sync(() => {
         dwellWrites.push(input)
       }),
+    findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
+    existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
+    setEndedAt: () => Effect.die("setEndedAt not used"),
   }
 
   return {

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -1,4 +1,4 @@
-import { AlertIncidentRepository } from "@domain/alerts"
+import { AlertIncidentRepository, isIssueEscalationEntrySignals } from "@domain/alerts"
 import { OutboxEventWriter } from "@domain/events"
 import { ScoreAnalyticsRepository } from "@domain/scores"
 import {
@@ -180,7 +180,9 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
       kShort,
       isNew: isIssueNew(issueWithLifecycle.createdAt, now),
       wasEscalating,
-      entrySignals: openIncident?.entrySignals ?? null,
+      // Narrow the now-polymorphic snapshot to the seasonal shape.
+      entrySignals:
+        openIncident && isIssueEscalationEntrySignals(openIncident.entrySignals) ? openIncident.entrySignals : null,
       startedAt: openIncident?.startedAt ?? null,
       exitEligibleSince: openIncident?.exitEligibleSince ?? null,
       now,

--- a/packages/domain/issues/src/use-cases/sweep-escalating-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/sweep-escalating-issues.test.ts
@@ -56,6 +56,9 @@ const provideRepository = (incidents: readonly AlertIncident[]): AlertIncidentRe
   listByMonitorId: () => Effect.die("listByMonitorId not used"),
   statsByMonitorId: () => Effect.die("statsByMonitorId not used"),
   listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used"),
+  findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
+  existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
+  setEndedAt: () => Effect.die("setEndedAt not used"),
 })
 
 const runSweep = (

--- a/packages/domain/monitors/package.json
+++ b/packages/domain/monitors/package.json
@@ -18,7 +18,11 @@
   },
   "dependencies": {
     "@domain/alerts": "workspace:*",
+    "@domain/events": "workspace:*",
+    "@domain/issues": "workspace:*",
     "@domain/notifications": "workspace:*",
+    "@domain/queue": "workspace:*",
+    "@domain/saved-searches": "workspace:*",
     "@domain/shared": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * The "current activity" window for `savedSearch.threshold` (multiplier mode) and
+ * `savedSearch.match` evaluation. Equals the firing throttle interval — a shorter
+ * window would be evaluated less often than it claims to measure.
+ */
+export const SAVED_SEARCH_CURRENT_WINDOW_MS = 5 * 60 * 1000
+
+/** Trace-end throttle for the per-project `checkSavedSearchMonitors` publish: at most one run per 5 min per project. */
+export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 5 * 60 * 1000
+
+/** BullMQ repeatable-job key for the saved-search sweep (re-registering with the same key replaces the schedule). */
+export const SAVED_SEARCH_MONITORS_SWEEPER_KEY = "monitors:saved-search-sweep"
+
+/** Sweep cron — every 5 minutes (the minimum escalating `window`; coarser would delay closes by more than a tick). */
+export const SAVED_SEARCH_MONITORS_SWEEPER_PATTERN = "*/5 * * * *"

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  SAVED_SEARCH_CURRENT_WINDOW_MS,
+  SAVED_SEARCH_MONITORS_SWEEPER_KEY,
+  SAVED_SEARCH_MONITORS_SWEEPER_PATTERN,
+  SAVED_SEARCH_MONITORS_THROTTLE_MS,
+} from "./constants.ts"
 export type { Monitor, MonitorAlert } from "./entities/monitor.ts"
 export { monitorAlertSchema, monitorSchema } from "./entities/monitor.ts"
 export {
@@ -12,18 +18,33 @@ export {
   type HumanReadableAlertInput,
 } from "./helpers.ts"
 export type {
+  CascadeSourceDeletionResult,
   ListMonitorsRepositoryInput,
   MonitorLastIncident,
   MonitorListPage,
   MonitorRepositoryShape,
   MonitorSearchResult,
+  ProjectWithActiveSavedSearchAlerts,
 } from "./ports/monitor-repository.ts"
 export { MonitorRepository } from "./ports/monitor-repository.ts"
+export type {
+  SavedSearchMatchReaderShape,
+  SavedSearchMatchTarget,
+  SavedSearchMatchWindowInput,
+} from "./ports/saved-search-match-reader.ts"
+export { SavedSearchMatchReader } from "./ports/saved-search-match-reader.ts"
 export type {
   SystemMonitorAlertDefinition,
   SystemMonitorDefinition,
 } from "./system-monitors.ts"
 export { SYSTEM_MONITOR_DEFINITIONS } from "./system-monitors.ts"
+export type { CascadeSourceDeletionInput } from "./use-cases/cascade-source-deletion.ts"
+export { cascadeSourceDeletionUseCase } from "./use-cases/cascade-source-deletion.ts"
+export type {
+  CheckSavedSearchMonitorsInput,
+  CheckSavedSearchMonitorsResult,
+} from "./use-cases/check-saved-search-monitors.ts"
+export { checkSavedSearchMonitorsUseCase } from "./use-cases/check-saved-search-monitors.ts"
 export type { CreateMonitorError, CreateMonitorInput } from "./use-cases/create-monitor.ts"
 export { createMonitorUseCase } from "./use-cases/create-monitor.ts"
 export type {
@@ -37,6 +58,12 @@ export type { DeleteMonitorError, DeleteMonitorInput } from "./use-cases/delete-
 export { deleteMonitorUseCase } from "./use-cases/delete-monitor.ts"
 export type { DeleteMonitorAlertError, DeleteMonitorAlertInput } from "./use-cases/delete-monitor-alert.ts"
 export { deleteMonitorAlertUseCase } from "./use-cases/delete-monitor-alert.ts"
+export type {
+  EvaluateSavedSearchAlertError,
+  EvaluateSavedSearchAlertInput,
+  SavedSearchEvaluation,
+} from "./use-cases/evaluate-saved-search-alert.ts"
+export { evaluateSavedSearchAlert } from "./use-cases/evaluate-saved-search-alert.ts"
 export type { GetMonitorBySlugInput } from "./use-cases/get-monitor-by-slug.ts"
 export { getMonitorBySlugUseCase } from "./use-cases/get-monitor-by-slug.ts"
 export type {
@@ -60,8 +87,28 @@ export type {
 export { buildSystemMonitors, provisionSystemMonitorsUseCase } from "./use-cases/provision-system-monitors.ts"
 export type { ResolveMonitorAlertsForSourceEventInput } from "./use-cases/resolve-monitor-alerts-for-source-event.ts"
 export { resolveMonitorAlertsForSourceEventUseCase } from "./use-cases/resolve-monitor-alerts-for-source-event.ts"
+export type {
+  RunSavedSearchEscalatingAlertError,
+  RunSavedSearchEscalatingAlertResult,
+} from "./use-cases/run-saved-search-escalating-alert.ts"
+export { runSavedSearchEscalatingAlertUseCase } from "./use-cases/run-saved-search-escalating-alert.ts"
+export type {
+  RunSavedSearchMatchAlertError,
+  RunSavedSearchMatchAlertResult,
+} from "./use-cases/run-saved-search-match-alert.ts"
+export { runSavedSearchMatchAlertUseCase } from "./use-cases/run-saved-search-match-alert.ts"
+export type {
+  RunSavedSearchThresholdAlertError,
+  RunSavedSearchThresholdAlertResult,
+} from "./use-cases/run-saved-search-threshold-alert.ts"
+export { runSavedSearchThresholdAlertUseCase } from "./use-cases/run-saved-search-threshold-alert.ts"
 export type { SearchMonitorsInput } from "./use-cases/search-monitors.ts"
 export { searchMonitorsUseCase } from "./use-cases/search-monitors.ts"
+export type {
+  SweepSavedSearchMonitorsPublish,
+  SweepSavedSearchMonitorsResult,
+} from "./use-cases/sweep-saved-search-monitors.ts"
+export { sweepSavedSearchMonitorsUseCase } from "./use-cases/sweep-saved-search-monitors.ts"
 export type { UpdateMonitorError, UpdateMonitorInput } from "./use-cases/update-monitor.ts"
 export { updateMonitorUseCase } from "./use-cases/update-monitor.ts"
 export type { UpdateMonitorAlertError, UpdateMonitorAlertInput } from "./use-cases/update-monitor-alert.ts"

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -6,12 +6,24 @@ import type {
   MonitorAlertId,
   MonitorId,
   NotFoundError,
+  OrganizationId,
   ProjectId,
   RepositoryError,
   SqlClient,
 } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { Monitor, MonitorAlert } from "../entities/monitor.ts"
+
+/** An (org, project) pair holding at least one active saved-search alert — the sweep's fan-out unit. */
+export interface ProjectWithActiveSavedSearchAlerts {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+}
+
+export interface CascadeSourceDeletionResult {
+  readonly deletedAlertCount: number
+  readonly deletedMonitorCount: number
+}
 
 export interface ListMonitorsRepositoryInput {
   readonly projectId: ProjectId
@@ -97,14 +109,14 @@ export interface MonitorRepositoryShape {
   create(monitor: Monitor): Effect.Effect<void, RepositoryError, SqlClient>
   /** Insert a single new alert (org resolved from the client). Used to add an alert to a live monitor. */
   insertAlert(alert: MonitorAlert): Effect.Effect<void, RepositoryError, SqlClient>
-  /** Soft-delete a single live alert. Fails `NotFoundError` if it isn't a live alert. */
+  /** Soft-delete a single live alert + silently close its open incidents (no event). Fails `NotFoundError` if it isn't a live alert. */
   softDeleteAlert(alertId: MonitorAlertId): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
   /** Set or clear `mutedAt` on a live monitor. Fails `NotFoundError` if it doesn't exist. */
   setMuted(input: {
     readonly id: MonitorId
     readonly mutedAt: Date | null
   }): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
-  /** Soft-delete a live monitor and cascade `deletedAt` to its live alerts (so firing stops; incident history stays joinable). */
+  /** Soft-delete a live monitor, cascade `deletedAt` to its live alerts (firing stops; history stays joinable), and silently close those alerts' open incidents. */
   softDelete(id: MonitorId): Effect.Effect<void, NotFoundError | RepositoryError, SqlClient>
   /** Update a live monitor's name/slug/description. Caller resolves the slug. */
   updateMetadata(input: {
@@ -132,6 +144,27 @@ export interface MonitorRepositoryShape {
     readonly sourceType: AlertIncidentSourceType
     readonly sourceId: string
   }): Effect.Effect<readonly MonitorAlert[], RepositoryError, SqlClient>
+  /** `FOR UPDATE` lock on a `monitor_alerts` row inside the caller's transaction — serialises the one-time-threshold read-then-insert against retries. No-ops if the row is gone. */
+  lockAlertForUpdate(alertId: MonitorAlertId): Effect.Effect<void, RepositoryError, SqlClient>
+  /** Active saved-search alerts in a project (live alert + monitor). Org-scoped — the firing orchestrator resolves + evaluates each. */
+  listActiveSavedSearchAlerts(projectId: ProjectId): Effect.Effect<readonly MonitorAlert[], RepositoryError, SqlClient>
+  /** Distinct `(org, project)` pairs with ≥1 active saved-search alert. **Cross-org** (admin client) — backs the 5-minute sweep's per-project fan-out. */
+  listProjectsWithActiveSavedSearchAlerts(): Effect.Effect<
+    readonly ProjectWithActiveSavedSearchAlerts[],
+    RepositoryError,
+    SqlClient
+  >
+  /**
+   * Source-deletion cascade: soft-delete every live alert watching
+   * `(sourceType, sourceId)` in the current org, silently close those alerts'
+   * open incidents, then soft-delete any monitor left with no active alerts (so
+   * firing stops while incident history stays joinable through the soft-deleted
+   * alert). One transaction.
+   */
+  cascadeSourceDeletion(input: {
+    readonly sourceType: AlertIncidentSourceType
+    readonly sourceId: string
+  }): Effect.Effect<CascadeSourceDeletionResult, RepositoryError, SqlClient>
   /** Count live monitors in a project holding `slug`, excluding `excludeId` — backs slug regeneration. */
   countActiveBySlug(input: {
     readonly projectId: ProjectId

--- a/packages/domain/monitors/src/ports/saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/ports/saved-search-match-reader.ts
@@ -1,0 +1,30 @@
+import type { ChSqlClient, FilterSet, OrganizationId, ProjectId, RepositoryError } from "@domain/shared"
+import { Context, type Effect } from "effect"
+
+/** What a saved-search alert counts traces against — its `query` and/or `filterSet` (both empty = every trace). */
+export interface SavedSearchMatchTarget {
+  readonly query: string | null
+  readonly filterSet: FilterSet
+}
+
+export interface SavedSearchMatchWindowInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly target: SavedSearchMatchTarget
+  /** Inclusive lower bound on trace `start_time`. */
+  readonly from: Date
+  /** Exclusive upper bound — the evaluation `now`. */
+  readonly to: Date
+}
+
+/** Windowed match count + first-match for the evaluator. A dedicated port (not a `TraceRepository` widening) keeps the firing concern off the broadly-stubbed trace port. */
+export interface SavedSearchMatchReaderShape {
+  /** Traces matching `target` whose `start_time` falls in `[from, to)`. */
+  countMatches(input: SavedSearchMatchWindowInput): Effect.Effect<number, RepositoryError, ChSqlClient>
+  /** Earliest matching trace `start_time` in `[from, to)`, or `null` when none match. */
+  firstMatchAt(input: SavedSearchMatchWindowInput): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
+}
+
+export class SavedSearchMatchReader extends Context.Service<SavedSearchMatchReader, SavedSearchMatchReaderShape>()(
+  "@domain/monitors/SavedSearchMatchReader",
+) {}

--- a/packages/domain/monitors/src/testing/fake-alert-incident-store.ts
+++ b/packages/domain/monitors/src/testing/fake-alert-incident-store.ts
@@ -1,0 +1,43 @@
+import { type AlertIncident, AlertIncidentRepository, type AlertIncidentRepositoryShape } from "@domain/alerts"
+import { Effect, Layer } from "effect"
+
+/**
+ * In-memory `AlertIncidentRepository` for the saved-search firing tests. Backs
+ * only the methods the state machines touch; everything else dies loudly. Seed
+ * via the argument and assert against the returned `incidents` array.
+ */
+export const createFakeAlertIncidentStore = (seed: readonly AlertIncident[] = []) => {
+  const incidents: AlertIncident[] = [...seed]
+
+  const patch = (id: string, next: Partial<AlertIncident>) => {
+    const index = incidents.findIndex((incident) => incident.id === id)
+    const current = incidents[index]
+    if (current) incidents[index] = { ...current, ...next }
+  }
+
+  const repo: AlertIncidentRepositoryShape = {
+    insert: (incident) =>
+      Effect.sync(() => {
+        incidents.push(incident)
+      }),
+    existsByMonitorAlertId: (monitorAlertId) =>
+      Effect.sync(() => incidents.some((incident) => incident.monitorAlertId === monitorAlertId)),
+    findOpenByMonitorAlertId: (monitorAlertId) =>
+      Effect.sync(
+        () =>
+          incidents.find((incident) => incident.monitorAlertId === monitorAlertId && incident.endedAt === null) ?? null,
+      ),
+    setEndedAt: ({ id, endedAt }) => Effect.sync(() => patch(id, { endedAt })),
+    updateExitDwell: ({ id, exitEligibleSince }) => Effect.sync(() => patch(id, { exitEligibleSince })),
+    findById: () => Effect.die("findById not used by saved-search firing"),
+    findOpen: () => Effect.die("findOpen not used by saved-search firing"),
+    closeOpen: () => Effect.die("closeOpen not used by saved-search firing"),
+    listByProjectId: () => Effect.die("listByProjectId not used by saved-search firing"),
+    listOpenByKind: () => Effect.die("listOpenByKind not used by saved-search firing"),
+    listByMonitorId: () => Effect.die("listByMonitorId not used by saved-search firing"),
+    statsByMonitorId: () => Effect.die("statsByMonitorId not used by saved-search firing"),
+    listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used by saved-search firing"),
+  }
+
+  return { repo, incidents, layer: Layer.succeed(AlertIncidentRepository, repo) }
+}

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -189,6 +189,49 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
               (alert.source.id === null || alert.source.id === sourceId),
           ),
       ),
+    // Lock is a Postgres-transaction concern; the in-memory fake has nothing to lock.
+    lockAlertForUpdate: () => Effect.void,
+    listActiveSavedSearchAlerts: (projectId) =>
+      Effect.sync(() =>
+        monitors
+          .filter((m) => m.projectId === projectId && isLive(m))
+          .flatMap((m) => m.alerts)
+          .filter((alert) => alert.source.type === "savedSearch"),
+      ),
+    listProjectsWithActiveSavedSearchAlerts: () =>
+      Effect.sync(() => {
+        const seen = new Map<string, { organizationId: Monitor["organizationId"]; projectId: Monitor["projectId"] }>()
+        for (const monitor of monitors) {
+          if (!isLive(monitor)) continue
+          if (!monitor.alerts.some((alert) => alert.source.type === "savedSearch")) continue
+          seen.set(`${monitor.organizationId}:${monitor.projectId}`, {
+            organizationId: monitor.organizationId,
+            projectId: monitor.projectId,
+          })
+        }
+        return [...seen.values()]
+      }),
+    cascadeSourceDeletion: ({ sourceType, sourceId }) =>
+      Effect.sync(() => {
+        let deletedAlertCount = 0
+        let deletedMonitorCount = 0
+        const now = new Date()
+        for (const monitor of monitors) {
+          if (!isLive(monitor)) continue
+          const remaining = monitor.alerts.filter(
+            (alert) => !(alert.source.type === sourceType && alert.source.id === sourceId),
+          )
+          if (remaining.length === monitor.alerts.length) continue
+          deletedAlertCount += monitor.alerts.length - remaining.length
+          if (remaining.length === 0) {
+            replace(monitor.id, { ...monitor, alerts: remaining, deletedAt: now, updatedAt: now })
+            deletedMonitorCount += 1
+          } else {
+            replace(monitor.id, { ...monitor, alerts: remaining, updatedAt: now })
+          }
+        }
+        return { deletedAlertCount, deletedMonitorCount }
+      }),
     countActiveBySlug: ({ projectId, slug, excludeId }) =>
       Effect.sync(
         () =>

--- a/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
@@ -1,0 +1,22 @@
+import { Effect, Layer } from "effect"
+import { SavedSearchMatchReader, type SavedSearchMatchWindowInput } from "../ports/saved-search-match-reader.ts"
+
+/**
+ * In-memory `SavedSearchMatchReader` for unit tests: seed matching trace
+ * `start_time`s, and the methods window them by `[from, to)`. `target` is ignored
+ * (match semantics are the reader's job, covered by the platform test).
+ */
+export const createFakeSavedSearchMatchReader = (matchTimestamps: readonly Date[] = []) => {
+  const inWindow = (input: SavedSearchMatchWindowInput) =>
+    matchTimestamps.filter((at) => at.getTime() >= input.from.getTime() && at.getTime() < input.to.getTime())
+
+  const layer = Layer.succeed(SavedSearchMatchReader, {
+    countMatches: (input) => Effect.succeed(inWindow(input).length),
+    firstMatchAt: (input) =>
+      Effect.succeed(
+        inWindow(input).reduce<Date | null>((earliest, at) => (earliest && earliest <= at ? earliest : at), null),
+      ),
+  })
+
+  return { layer }
+}

--- a/packages/domain/monitors/src/testing/index.ts
+++ b/packages/domain/monitors/src/testing/index.ts
@@ -1,1 +1,3 @@
+export { createFakeAlertIncidentStore } from "./fake-alert-incident-store.ts"
 export { createFakeMonitorRepository } from "./fake-monitor-repository.ts"
+export { createFakeSavedSearchMatchReader } from "./fake-saved-search-match-reader.ts"

--- a/packages/domain/monitors/src/use-cases/cascade-source-deletion.test.ts
+++ b/packages/domain/monitors/src/use-cases/cascade-source-deletion.test.ts
@@ -1,0 +1,79 @@
+import { OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Monitor, MonitorAlert } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import { createFakeMonitorRepository } from "../testing/fake-monitor-repository.ts"
+import { cascadeSourceDeletionUseCase } from "./cascade-source-deletion.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const searchX = "x".repeat(24)
+const searchY = "y".repeat(24)
+
+const alert = (id: string, sourceId: string): MonitorAlert => ({
+  id: id.padEnd(24, "0").slice(0, 24) as MonitorAlert["id"],
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.match",
+  source: { type: "savedSearch", id: sourceId },
+  condition: null,
+  severity: "low",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+const monitor = (id: string, alerts: readonly MonitorAlert[]): Monitor => ({
+  id: id.padEnd(24, "0").slice(0, 24) as Monitor["id"],
+  organizationId,
+  projectId,
+  slug: `monitor-${id}`,
+  name: `Monitor ${id}`,
+  description: "",
+  system: false,
+  alerts: alerts.map((a) => ({ ...a, monitorId: id.padEnd(24, "0").slice(0, 24) as MonitorAlert["monitorId"] })),
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+describe("cascadeSourceDeletionUseCase", () => {
+  it("soft-deletes matching alerts and prunes monitors left empty", async () => {
+    const onlyX = monitor("m1", [alert("a1", searchX), alert("a2", searchX)])
+    const mixed = monitor("m2", [alert("a3", searchX), alert("a4", searchY)])
+    const { repo, monitors } = createFakeMonitorRepository([onlyX, mixed])
+
+    const result = await Effect.runPromise(
+      cascadeSourceDeletionUseCase({ sourceType: "savedSearch", sourceId: searchX }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(MonitorRepository, repo),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ deletedAlertCount: 3, deletedMonitorCount: 1 })
+    // m1 (all alerts watched X) is pruned; m2 survives with its searchY alert.
+    expect(monitors.find((m) => m.slug === "monitor-m1")?.deletedAt).not.toBeNull()
+    const survivor = monitors.find((m) => m.slug === "monitor-m2")
+    expect(survivor?.deletedAt).toBeNull()
+    expect(survivor?.alerts.map((a) => a.source.id)).toEqual([searchY])
+  })
+
+  it("is a no-op when nothing watches the source", async () => {
+    const { repo } = createFakeMonitorRepository([monitor("m1", [alert("a1", searchY)])])
+    const result = await Effect.runPromise(
+      cascadeSourceDeletionUseCase({ sourceType: "savedSearch", sourceId: searchX }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(MonitorRepository, repo),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+          ),
+        ),
+      ),
+    )
+    expect(result).toEqual({ deletedAlertCount: 0, deletedMonitorCount: 0 })
+  })
+})

--- a/packages/domain/monitors/src/use-cases/cascade-source-deletion.ts
+++ b/packages/domain/monitors/src/use-cases/cascade-source-deletion.ts
@@ -1,0 +1,24 @@
+import type { AlertIncidentSourceType, RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { type CascadeSourceDeletionResult, MonitorRepository } from "../ports/monitor-repository.ts"
+
+export interface CascadeSourceDeletionInput {
+  readonly sourceType: AlertIncidentSourceType
+  readonly sourceId: string
+}
+
+/**
+ * Handle a deleted source (today: a saved search): soft-delete its alerts, close
+ * their open incidents, and prune emptied monitors (see `cascadeSourceDeletion`).
+ * Idempotent. Issue sources need no cascade — issue alerts are system-only with
+ * `source.id = null`, so deleting one issue never orphans an alert.
+ */
+export const cascadeSourceDeletionUseCase = (
+  input: CascadeSourceDeletionInput,
+): Effect.Effect<CascadeSourceDeletionResult, RepositoryError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("sourceType", input.sourceType)
+    yield* Effect.annotateCurrentSpan("sourceId", input.sourceId)
+    const monitorRepository = yield* MonitorRepository
+    return yield* monitorRepository.cascadeSourceDeletion(input)
+  }).pipe(Effect.withSpan("monitors.cascadeSourceDeletion"))

--- a/packages/domain/monitors/src/use-cases/check-saved-search-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/check-saved-search-monitors.test.ts
@@ -1,0 +1,114 @@
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import { createFakeSavedSearchRepository } from "@domain/saved-searches/testing"
+import { ChSqlClient, OrganizationId, ProjectId, SavedSearchId, SqlClient } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Monitor, MonitorAlert } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import { createFakeAlertIncidentStore } from "../testing/fake-alert-incident-store.ts"
+import { createFakeMonitorRepository } from "../testing/fake-monitor-repository.ts"
+import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
+import { checkSavedSearchMonitorsUseCase } from "./check-saved-search-monitors.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const searchId = "s".repeat(24)
+const now = new Date()
+
+const monitor = (alerts: readonly MonitorAlert[]): Monitor => ({
+  id: "m".repeat(24) as Monitor["id"],
+  organizationId,
+  projectId,
+  slug: "user-monitor",
+  name: "User monitor",
+  description: "",
+  system: false,
+  alerts,
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+const matchAlert: MonitorAlert = {
+  id: "a".repeat(24) as MonitorAlert["id"],
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.match",
+  source: { type: "savedSearch", id: searchId },
+  condition: null,
+  severity: "low",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+}
+
+const savedSearch = {
+  id: SavedSearchId(searchId),
+  organizationId,
+  projectId,
+  slug: "errors",
+  name: "Errors",
+  query: "boom",
+  filterSet: {},
+  assignedUserId: null,
+  createdByUserId: "u".repeat(24) as never,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const run = (params: {
+  readonly monitors: readonly Monitor[]
+  readonly searches: readonly (typeof savedSearch)[]
+  readonly matches: readonly Date[]
+}) => {
+  const { repo: monitorRepo } = createFakeMonitorRepository(params.monitors)
+  const { repository: savedSearchRepo } = createFakeSavedSearchRepository(params.searches)
+  const store = createFakeAlertIncidentStore([])
+  const events: OutboxWriteEvent[] = []
+  return Effect.runPromise(
+    checkSavedSearchMonitorsUseCase({ organizationId, projectId }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MonitorRepository, monitorRepo),
+          Layer.succeed(SavedSearchRepository, savedSearchRepo),
+          store.layer,
+          createFakeSavedSearchMatchReader(params.matches).layer,
+          Layer.succeed(OutboxEventWriter, { write: (event) => Effect.sync(() => void events.push(event)) }),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+          Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  ).then((result) => ({ result, incidents: store.incidents, events }))
+}
+
+describe("checkSavedSearchMonitorsUseCase", () => {
+  it("evaluates active saved-search alerts and fires the matching ones", async () => {
+    const { result, incidents, events } = await run({
+      monitors: [monitor([matchAlert])],
+      searches: [savedSearch],
+      matches: [new Date(now.getTime() - 60 * 1000)],
+    })
+    expect(result).toEqual({ evaluated: 1, failed: 0 })
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({ kind: "savedSearch.match", monitorAlertId: matchAlert.id })
+    expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
+  })
+
+  it("skips an alert whose saved search no longer exists (counts it, fires nothing)", async () => {
+    const { result, incidents } = await run({
+      monitors: [monitor([matchAlert])],
+      searches: [],
+      matches: [new Date(now.getTime() - 60 * 1000)],
+    })
+    expect(result).toEqual({ evaluated: 1, failed: 0 })
+    expect(incidents).toHaveLength(0)
+  })
+
+  it("does nothing when there are no active saved-search alerts", async () => {
+    const { result, incidents } = await run({ monitors: [], searches: [], matches: [] })
+    expect(result).toEqual({ evaluated: 0, failed: 0 })
+    expect(incidents).toHaveLength(0)
+  })
+})

--- a/packages/domain/monitors/src/use-cases/check-saved-search-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/check-saved-search-monitors.ts
@@ -1,0 +1,123 @@
+import type { AlertIncidentRepository } from "@domain/alerts"
+import type { OutboxEventWriter } from "@domain/events"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import {
+  type ChSqlClient,
+  OrganizationId,
+  ProjectId,
+  type RepositoryError,
+  SavedSearchId,
+  type SqlClient,
+} from "@domain/shared"
+import { Effect } from "effect"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
+import type { EvaluateSavedSearchAlertInput } from "./evaluate-saved-search-alert.ts"
+import { runSavedSearchEscalatingAlertUseCase } from "./run-saved-search-escalating-alert.ts"
+import { runSavedSearchMatchAlertUseCase } from "./run-saved-search-match-alert.ts"
+import { runSavedSearchThresholdAlertUseCase } from "./run-saved-search-threshold-alert.ts"
+
+export interface CheckSavedSearchMonitorsInput {
+  readonly organizationId: string
+  readonly projectId: string
+}
+
+export interface CheckSavedSearchMonitorsResult {
+  /** Active saved-search alerts found in the project. */
+  readonly evaluated: number
+  /** Alerts whose individual evaluation threw (isolated, logged by the caller). */
+  readonly failed: number
+}
+
+/**
+ * Firing orchestrator, run per (org, project) by both trigger paths. Resolves
+ * each active saved-search alert's search and dispatches to the kind's state
+ * machine. Per-alert failures are isolated + tallied (not propagated) so one bad
+ * alert can't trigger an at-least-once retry that re-fires already-fired `match`
+ * incidents. Sequential: each alert opens its own transaction.
+ */
+export const checkSavedSearchMonitorsUseCase = (
+  input: CheckSavedSearchMonitorsInput,
+): Effect.Effect<
+  CheckSavedSearchMonitorsResult,
+  RepositoryError,
+  | SqlClient
+  | ChSqlClient
+  | SavedSearchMatchReader
+  | AlertIncidentRepository
+  | OutboxEventWriter
+  | MonitorRepository
+  | SavedSearchRepository
+> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    const organizationId = OrganizationId(input.organizationId)
+    const projectId = ProjectId(input.projectId)
+    const now = new Date()
+
+    const monitorRepository = yield* MonitorRepository
+    const savedSearchRepository = yield* SavedSearchRepository
+    const alerts = yield* monitorRepository.listActiveSavedSearchAlerts(projectId)
+
+    let failed = 0
+    yield* Effect.forEach(
+      alerts,
+      (alert) =>
+        runAlert({ organizationId, projectId, alert, now }).pipe(
+          Effect.catch(() =>
+            Effect.sync(() => {
+              failed += 1
+            }),
+          ),
+        ),
+      { concurrency: 1, discard: true },
+    )
+
+    yield* Effect.annotateCurrentSpan("evaluated", alerts.length)
+    yield* Effect.annotateCurrentSpan("failed", failed)
+    return { evaluated: alerts.length, failed }
+
+    function runAlert(args: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly alert: MonitorAlert
+      readonly now: Date
+    }) {
+      return Effect.gen(function* () {
+        const sourceId = args.alert.source.id
+        if (sourceId === null) return
+        // Skip a since-deleted search (a check can race the delete cascade).
+        const search = yield* savedSearchRepository
+          .findById(SavedSearchId(sourceId))
+          .pipe(Effect.catchTag("SavedSearchNotFoundError", () => Effect.succeed(null)))
+        if (search === null) return
+
+        const evalInput: EvaluateSavedSearchAlertInput = {
+          organizationId: args.organizationId,
+          projectId: args.projectId,
+          alert: args.alert,
+          target: { query: search.query, filterSet: search.filterSet },
+          now: args.now,
+        }
+
+        if (args.alert.kind === "savedSearch.match") {
+          yield* runSavedSearchMatchAlertUseCase(evalInput)
+        } else if (args.alert.kind === "savedSearch.threshold") {
+          yield* runSavedSearchThresholdAlertUseCase(evalInput)
+        } else if (args.alert.kind === "savedSearch.escalating") {
+          yield* runSavedSearchEscalatingAlertUseCase(evalInput)
+        }
+      })
+    }
+  }).pipe(Effect.withSpan("monitors.checkSavedSearchMonitors")) as Effect.Effect<
+    CheckSavedSearchMonitorsResult,
+    RepositoryError,
+    | SqlClient
+    | ChSqlClient
+    | SavedSearchMatchReader
+    | AlertIncidentRepository
+    | OutboxEventWriter
+    | MonitorRepository
+    | SavedSearchRepository
+  >

--- a/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.test.ts
@@ -1,0 +1,202 @@
+import { ChSqlClient, OrganizationId, ProjectId } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
+import { evaluateSavedSearchAlert } from "./evaluate-saved-search-alert.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const savedSearchId = "s".repeat(24)
+const now = new Date("2026-06-01T12:00:00.000Z")
+
+const alert = (overrides: Partial<MonitorAlert>): MonitorAlert => ({
+  id: "a".repeat(24) as MonitorAlert["id"],
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.threshold",
+  source: { type: "savedSearch", id: savedSearchId },
+  condition: null,
+  severity: "medium",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  ...overrides,
+})
+
+const evaluate = (input: { alert: MonitorAlert; matches: readonly Date[] }) =>
+  Effect.runPromise(
+    evaluateSavedSearchAlert({
+      organizationId,
+      projectId,
+      alert: input.alert,
+      target: { query: null, filterSet: {} },
+      now,
+    }).pipe(
+      Effect.provide(createFakeSavedSearchMatchReader(input.matches).layer),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    ),
+  )
+
+// Minutes-before-`now` helper keeps the window arithmetic readable.
+const minsAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000)
+
+describe("evaluateSavedSearchAlert", () => {
+  describe("savedSearch.match", () => {
+    const matchAlert = alert({ kind: "savedSearch.match", condition: null })
+
+    it("fires when any trace matched in the trailing 5 minutes, reporting the first match", async () => {
+      const first = minsAgo(4)
+      const result = await evaluate({ alert: matchAlert, matches: [first, minsAgo(1)] })
+      expect(result.isMet).toBe(true)
+      expect(result.count).toBe(2)
+      expect(result.firstMatchInWindow).toEqual(first)
+    })
+
+    it("does not fire when the window is empty", async () => {
+      const result = await evaluate({ alert: matchAlert, matches: [minsAgo(10)] })
+      expect(result).toMatchObject({ isMet: false, count: 0, firstMatchInWindow: null })
+    })
+  })
+
+  describe("savedSearch.threshold absolute", () => {
+    const absolute = alert({
+      kind: "savedSearch.threshold",
+      condition: { kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 5 } },
+    })
+
+    it("counts cumulatively since the alert was created and fires at the threshold", async () => {
+      // Spread 5 matches across the day (all after createdAt 00:00); cumulative window is [createdAt, now).
+      const matches = [minsAgo(600), minsAgo(400), minsAgo(200), minsAgo(100), minsAgo(10)]
+      const result = await evaluate({ alert: absolute, matches })
+      expect(result).toMatchObject({ isMet: true, count: 5, threshold: 5 })
+    })
+
+    it("does not fire below the threshold", async () => {
+      const result = await evaluate({ alert: absolute, matches: [minsAgo(300), minsAgo(120), minsAgo(30)] })
+      expect(result).toMatchObject({ isMet: false, count: 3, threshold: 5 })
+    })
+  })
+
+  describe("savedSearch.threshold multiplier", () => {
+    it("normalises an average baseline onto the 5-minute current window", async () => {
+      const multiplier = alert({
+        kind: "savedSearch.threshold",
+        condition: {
+          kind: "savedSearch.threshold",
+          threshold: {
+            mode: "multiplier",
+            factor: 3,
+            baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+          },
+        },
+      })
+      // baseline = [now-60m, now): 8 matches outside the current window + 4 inside ⇒ 12.
+      // normalisedBaseline = 12 × (5m / 60m) = 1; threshold = 3 × 1 = 3.
+      const baselineOnly = [55, 50, 45, 40, 35, 30, 20, 10].map(minsAgo)
+      const current = [4, 3, 2, 1].map(minsAgo)
+      const result = await evaluate({ alert: multiplier, matches: [...baselineOnly, ...current] })
+      expect(result).toMatchObject({ isMet: true, count: 4, baselineCount: 12, threshold: 3 })
+    })
+
+    it("uses the immediately-preceding window for a period baseline", async () => {
+      const multiplier = alert({
+        kind: "savedSearch.threshold",
+        condition: {
+          kind: "savedSearch.threshold",
+          threshold: {
+            mode: "multiplier",
+            factor: 2,
+            baseline: { kind: "period", lookback: { unit: "hours", hours: 1 } },
+          },
+        },
+      })
+      // period window = [now-120m, now-60m): 12 matches there; none leak into the current 5m window.
+      // normalisedBaseline = 12 × (5m / 60m) = 1; threshold = 2 × 1 = 2.
+      const periodWindow = [115, 110, 100, 95, 90, 85, 80, 75, 70, 68, 65, 62].map(minsAgo)
+      const current = [4, 2, 1].map(minsAgo)
+      const result = await evaluate({ alert: multiplier, matches: [...periodWindow, ...current] })
+      expect(result).toMatchObject({ isMet: true, count: 3, baselineCount: 12, threshold: 2 })
+    })
+
+    it("never fires on an empty current window even when the baseline is zero", async () => {
+      const multiplier = alert({
+        kind: "savedSearch.threshold",
+        condition: {
+          kind: "savedSearch.threshold",
+          threshold: {
+            mode: "multiplier",
+            factor: 2,
+            baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+          },
+        },
+      })
+      const result = await evaluate({ alert: multiplier, matches: [] })
+      expect(result).toMatchObject({ isMet: false, count: 0, baselineCount: 0, threshold: 0 })
+    })
+  })
+
+  describe("savedSearch.escalating", () => {
+    it("counts over the configured window for an absolute threshold", async () => {
+      const escalating = alert({
+        kind: "savedSearch.escalating",
+        condition: {
+          kind: "savedSearch.escalating",
+          threshold: { mode: "absolute", count: 5 },
+          window: { minutes: 10 },
+        },
+      })
+      const result = await evaluate({ alert: escalating, matches: [9, 8, 6, 4, 2, 1].map(minsAgo) })
+      expect(result).toMatchObject({ isMet: true, count: 6, threshold: 5 })
+    })
+
+    it("normalises the baseline onto the window for a multiplier threshold", async () => {
+      const escalating = alert({
+        kind: "savedSearch.escalating",
+        condition: {
+          kind: "savedSearch.escalating",
+          threshold: {
+            mode: "multiplier",
+            factor: 2,
+            baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+          },
+          window: { minutes: 10 },
+        },
+      })
+      // window = [now-10m, now): 6 matches. baseline = [now-60m, now): 18 (12 older + 6 in window).
+      // normalisedBaseline = 18 × (10m / 60m) = 3; threshold = 2 × 3 = 6 ⇒ met (6 ≥ 6).
+      const baselineOlder = [55, 50, 45, 40, 35, 30, 25, 22, 18, 15, 13, 11].map(minsAgo)
+      const inWindow = [9, 7, 5, 3, 2, 1].map(minsAgo)
+      const result = await evaluate({ alert: escalating, matches: [...baselineOlder, ...inWindow] })
+      expect(result).toMatchObject({ isMet: true, count: 6, baselineCount: 18, threshold: 6 })
+    })
+  })
+
+  describe("savedSearch.threshold expected", () => {
+    const expectedAlert = alert({
+      kind: "savedSearch.threshold",
+      condition: { kind: "savedSearch.threshold", threshold: { mode: "expected", sensitivity: 3 } },
+    })
+    // `count` matches inside the 5-min window ending `anchorMsAgo` before `now`.
+    const windowMatches = (anchorMsAgo: number, count: number): Date[] =>
+      Array.from({ length: count }, (_unused, j) => new Date(now.getTime() - anchorMsAgo - 20_000 * (j + 1)))
+    const weekMatches = (week: number, count: number) => windowMatches(week * 7 * 24 * 60 * 60 * 1000, count)
+
+    it("with no seasonal history, the band is sensitivity × the σ floor (1.0)", async () => {
+      // expected 0, stddev 0 ⇒ σ = max(0, 0, 1) = 1; threshold = sensitivity(3) × 1 = 3.
+      const met = await evaluate({ alert: expectedAlert, matches: windowMatches(0, 5) })
+      expect(met).toMatchObject({ isMet: true, count: 5, threshold: 3 })
+      // Strict `>`: a count of 3 does not exceed the threshold of 3.
+      const notMet = await evaluate({ alert: expectedAlert, matches: windowMatches(0, 3) })
+      expect(notMet).toMatchObject({ isMet: false, count: 3, threshold: 3 })
+    })
+
+    it("learns the band from the same-time-of-week history across prior weeks", async () => {
+      // 4 matches in each of the last 4 weekly windows ⇒ expected 4, stddev 0,
+      // σ = max(0, √4, 1) = 2; threshold = 4 + 3 × 2 = 10.
+      const history = [1, 2, 3, 4].flatMap((week) => weekMatches(week, 4))
+      const met = await evaluate({ alert: expectedAlert, matches: [...windowMatches(0, 12), ...history] })
+      expect(met).toMatchObject({ isMet: true, count: 12, threshold: 10 })
+      const notMet = await evaluate({ alert: expectedAlert, matches: [...windowMatches(0, 8), ...history] })
+      expect(notMet).toMatchObject({ isMet: false, count: 8, threshold: 10 })
+    })
+  })
+})

--- a/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
@@ -1,0 +1,140 @@
+import {
+  DEFAULT_ESCALATION_SENSITIVITY_K,
+  MIN_SEASONAL_SAMPLES,
+  SEASONAL_HISTORY_WEEKS,
+  seasonalAnomalyThreshold,
+} from "@domain/issues"
+import type {
+  AlertBaseline,
+  AlertDuration,
+  ChSqlClient,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { SAVED_SEARCH_CURRENT_WINDOW_MS } from "../constants.ts"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { SavedSearchMatchReader, type SavedSearchMatchTarget } from "../ports/saved-search-match-reader.ts"
+
+/** Verdict + the numbers the state machines snapshot onto the incident. */
+export interface SavedSearchEvaluation {
+  readonly isMet: boolean
+  /** Matches in the current window (cumulative since the alert for absolute mode). */
+  readonly count: number
+  readonly threshold: number
+  /** Backs `startedAt` backtracking; `null` when the window was empty. */
+  readonly firstMatchInWindow: Date | null
+  /** Present only for multiplier mode. */
+  readonly baselineCount?: number
+}
+
+export interface EvaluateSavedSearchAlertInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly alert: MonitorAlert
+  readonly target: SavedSearchMatchTarget
+  readonly now: Date
+}
+
+export type EvaluateSavedSearchAlertError = RepositoryError
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+const durationToMs = (duration: AlertDuration): number =>
+  duration.unit === "hours" ? duration.hours * 60 * 60 * 1000 : duration.days * 24 * 60 * 60 * 1000
+
+const mean = (values: readonly number[]): number =>
+  values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
+
+/** Sample (n−1) standard deviation; `0` for fewer than two points. */
+const sampleStddev = (values: readonly number[], avg: number): number => {
+  if (values.length < 2) return 0
+  const variance = values.reduce((sum, value) => sum + (value - avg) ** 2, 0) / (values.length - 1)
+  return Math.sqrt(variance)
+}
+
+/** `average` = trailing window of length `L`; `period` = the equal-length window just before it (yesterday / last week). */
+const baselineWindow = (baseline: AlertBaseline, now: Date): { from: Date; to: Date; lengthMs: number } => {
+  const lengthMs = durationToMs(baseline.lookback)
+  if (baseline.kind === "average") return { from: new Date(now.getTime() - lengthMs), to: now, lengthMs }
+  return { from: new Date(now.getTime() - 2 * lengthMs), to: new Date(now.getTime() - lengthMs), lengthMs }
+}
+
+/** Evaluate one saved-search alert at `now`. Pure modulo the `SavedSearchMatchReader` IO; window + threshold vary by kind/mode (see branches). */
+export const evaluateSavedSearchAlert = (
+  input: EvaluateSavedSearchAlertInput,
+): Effect.Effect<SavedSearchEvaluation, EvaluateSavedSearchAlertError, SavedSearchMatchReader | ChSqlClient> =>
+  Effect.gen(function* () {
+    const reader = yield* SavedSearchMatchReader
+    const { organizationId, projectId, alert, target, now } = input
+    const countIn = (from: Date, to: Date) => reader.countMatches({ organizationId, projectId, target, from, to })
+
+    // Any match in the trailing window fires; the queue throttle is the rate limiter.
+    if (alert.kind === "savedSearch.match") {
+      const from = new Date(now.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS)
+      const count = yield* countIn(from, now)
+      const firstMatchInWindow =
+        count > 0 ? yield* reader.firstMatchAt({ organizationId, projectId, target, from, to: now }) : null
+      return { isMet: count > 0, count, threshold: 1, firstMatchInWindow } satisfies SavedSearchEvaluation
+    }
+
+    const condition = alert.condition
+    if (condition === null || condition.kind === "issue.escalating") {
+      // The orchestrator only routes threshold/escalating alerts here — a wiring bug, not runtime state.
+      return yield* Effect.die(`evaluateSavedSearchAlert: unexpected condition for alert ${alert.id} (${alert.kind})`)
+    }
+
+    const threshold = condition.threshold
+    const currentWindowMs =
+      condition.kind === "savedSearch.escalating"
+        ? condition.window.minutes * 60 * 1000
+        : threshold.mode === "absolute"
+          ? Math.max(0, now.getTime() - alert.createdAt.getTime())
+          : SAVED_SEARCH_CURRENT_WINDOW_MS
+    const from = new Date(now.getTime() - currentWindowMs)
+    const count = yield* countIn(from, now)
+
+    let thresholdValue: number
+    let baselineCount: number | undefined
+    let isMet: boolean
+    if (threshold.mode === "absolute") {
+      // Positive-integer threshold, so `count === 0` never fires.
+      thresholdValue = threshold.count
+      isMet = count >= thresholdValue
+    } else if (threshold.mode === "multiplier") {
+      const window = baselineWindow(threshold.baseline, now)
+      baselineCount = yield* countIn(window.from, window.to)
+      // Normalise the baseline to a current-window slice so the two counts are comparable rates.
+      thresholdValue = threshold.factor * baselineCount * (currentWindowMs / window.lengthMs)
+      // Zero baseline → zero threshold; require real activity.
+      isMet = count > 0 && count >= thresholdValue
+    } else {
+      // `expected`: σ-band over the same-time-of-week window across the last N weeks
+      // (detector math shared from `@domain/issues`).
+      const sensitivity = threshold.sensitivity ?? DEFAULT_ESCALATION_SENSITIVITY_K
+      const historical = yield* Effect.all(
+        Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
+          const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
+          return countIn(new Date(historyTo.getTime() - currentWindowMs), historyTo)
+        }),
+        { concurrency: "unbounded" },
+      )
+      const expected = mean(historical)
+      // Widen the band when the sample is thin (mirrors the detector).
+      const kAdj = historical.length < MIN_SEASONAL_SAMPLES ? sensitivity + 1 : sensitivity
+      thresholdValue = seasonalAnomalyThreshold(expected, sampleStddev(historical, expected), kAdj)
+      isMet = count > 0 && count > thresholdValue
+    }
+
+    const firstMatchInWindow =
+      count > 0 ? yield* reader.firstMatchAt({ organizationId, projectId, target, from, to: now }) : null
+
+    return {
+      isMet,
+      count,
+      threshold: thresholdValue,
+      firstMatchInWindow,
+      ...(baselineCount !== undefined ? { baselineCount } : {}),
+    } satisfies SavedSearchEvaluation
+  }).pipe(Effect.withSpan("monitors.evaluateSavedSearchAlert"))

--- a/packages/domain/monitors/src/use-cases/get-monitor-incidents.test.ts
+++ b/packages/domain/monitors/src/use-cases/get-monitor-incidents.test.ts
@@ -71,6 +71,9 @@ const buildIncidentRepo = (page: {
   listByMonitorId: () => Effect.succeed(page),
   statsByMonitorId: () => Effect.die("statsByMonitorId not used"),
   listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used"),
+  findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
+  existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
+  setEndedAt: () => Effect.die("setEndedAt not used"),
 })
 
 const provideLayer = (incidentRepo: AlertIncidentRepositoryShape, notificationRepo: NotificationRepositoryShape) =>

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
@@ -1,0 +1,179 @@
+import type { AlertIncident } from "@domain/alerts"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { ChSqlClient, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { createFakeAlertIncidentStore } from "../testing/fake-alert-incident-store.ts"
+import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
+import { runSavedSearchEscalatingAlertUseCase } from "./run-saved-search-escalating-alert.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const savedSearchId = "s".repeat(24)
+const alertId = "a".repeat(24) as MonitorAlert["id"]
+const now = new Date("2026-06-01T12:00:00.000Z")
+const minsAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000)
+
+const absoluteAlert: MonitorAlert = {
+  id: alertId,
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.escalating",
+  source: { type: "savedSearch", id: savedSearchId },
+  condition: { kind: "savedSearch.escalating", threshold: { mode: "absolute", count: 5 }, window: { minutes: 10 } },
+  severity: "high",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+}
+const multiplierAlert: MonitorAlert = {
+  ...absoluteAlert,
+  condition: {
+    kind: "savedSearch.escalating",
+    threshold: { mode: "multiplier", factor: 2, baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } } },
+    window: { minutes: 10 },
+  },
+}
+
+const incident = (overrides: Partial<AlertIncident>): AlertIncident => ({
+  id: "c".repeat(24) as AlertIncident["id"],
+  organizationId,
+  projectId,
+  sourceType: "savedSearch",
+  sourceId: savedSearchId,
+  kind: "savedSearch.escalating",
+  severity: "high",
+  startedAt: minsAgo(60),
+  endedAt: null,
+  createdAt: minsAgo(60),
+  entrySignals: { evaluatedThreshold: 5 },
+  exitEligibleSince: null,
+  monitorAlertId: alertId,
+  condition: absoluteAlert.condition,
+  ...overrides,
+})
+
+const run = (params: {
+  readonly alert: MonitorAlert
+  readonly matches: readonly Date[]
+  readonly seed?: readonly AlertIncident[]
+}) => {
+  const store = createFakeAlertIncidentStore(params.seed ?? [])
+  const events: OutboxWriteEvent[] = []
+  return Effect.runPromise(
+    runSavedSearchEscalatingAlertUseCase({
+      organizationId,
+      projectId,
+      alert: params.alert,
+      target: { query: null, filterSet: {} },
+      now,
+    }).pipe(
+      Effect.provide(createFakeSavedSearchMatchReader(params.matches).layer),
+      Effect.provide(store.layer),
+      Effect.provideService(OutboxEventWriter, { write: (event) => Effect.sync(() => void events.push(event)) }),
+      Effect.provideService(SqlClient, createFakeSqlClient({ organizationId })),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    ),
+  ).then((result) => ({ result, incidents: store.incidents, events }))
+}
+
+// 6 matches inside the 10-minute window clears the absolute threshold of 5.
+const sustainedMatches = [9, 8, 6, 4, 2, 1].map(minsAgo)
+
+describe("runSavedSearchEscalatingAlertUseCase", () => {
+  it("opens with a frozen threshold snapshot and emits IncidentCreated", async () => {
+    const first = minsAgo(9)
+    const { result, incidents, events } = await run({ alert: absoluteAlert, matches: sustainedMatches })
+    expect(result.transition).toBe("opened")
+    expect(incidents[0]).toMatchObject({ startedAt: first, endedAt: null, entrySignals: { evaluatedThreshold: 5 } })
+    expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
+  })
+
+  it("snapshots baseline + baselineCount for a multiplier open", async () => {
+    const { incidents } = await run({ alert: multiplierAlert, matches: sustainedMatches })
+    // window count 6; baseline = same 6 over 1h ⇒ normalised 1 ⇒ threshold 2.
+    expect(incidents[0]?.entrySignals).toEqual({
+      evaluatedThreshold: 2,
+      baselineCount: 6,
+      baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+    })
+  })
+
+  it("is a no-op while the condition keeps holding", async () => {
+    const { result, events } = await run({ alert: absoluteAlert, matches: sustainedMatches, seed: [incident({})] })
+    expect(result.transition).toBe("none")
+    expect(events).toHaveLength(0)
+  })
+
+  it("starts the dwell when the condition first drops", async () => {
+    const { result, incidents } = await run({ alert: absoluteAlert, matches: [minsAgo(2)], seed: [incident({})] })
+    expect(result.transition).toBe("exit-eligible")
+    expect(incidents[0]?.exitEligibleSince).toEqual(now)
+  })
+
+  it("cancels the dwell when the condition returns", async () => {
+    const { result, incidents } = await run({
+      alert: absoluteAlert,
+      matches: sustainedMatches,
+      seed: [incident({ exitEligibleSince: minsAgo(3) })],
+    })
+    expect(result.transition).toBe("exit-cancelled")
+    expect(incidents[0]?.exitEligibleSince).toBeNull()
+  })
+
+  it("keeps waiting while still inside the dwell window", async () => {
+    const { result, events } = await run({
+      alert: absoluteAlert,
+      matches: [minsAgo(1)],
+      seed: [incident({ exitEligibleSince: minsAgo(5) })],
+    })
+    expect(result.transition).toBe("none")
+    expect(events).toHaveLength(0)
+  })
+
+  it("closes and emits IncidentClosed once the dwell elapses", async () => {
+    const { result, incidents, events } = await run({
+      alert: absoluteAlert,
+      matches: [],
+      seed: [incident({ exitEligibleSince: minsAgo(15) })],
+    })
+    expect(result.transition).toBe("closed")
+    expect(incidents[0]?.endedAt).toEqual(now)
+    expect(events.map((event) => event.eventName)).toEqual(["IncidentClosed"])
+  })
+
+  it("opens an expected-mode escalating incident, freezing the seasonal threshold", async () => {
+    const expectedAlert: MonitorAlert = {
+      ...absoluteAlert,
+      condition: {
+        kind: "savedSearch.escalating",
+        threshold: { mode: "expected", sensitivity: 3 },
+        window: { minutes: 10 },
+      },
+    }
+    // No seasonal history ⇒ expected 0, σ floor 1 ⇒ threshold = 3 × 1 = 3.
+    // 5 matches in the 10-min window clears it; the frozen threshold is snapshotted.
+    const { result, incidents } = await run({ alert: expectedAlert, matches: [9, 7, 5, 3, 1].map(minsAgo) })
+    expect(result.transition).toBe("opened")
+    expect(incidents[0]?.entrySignals).toEqual({ evaluatedThreshold: 3 })
+  })
+
+  it("compares the live count against the frozen threshold, not a re-resolved one", async () => {
+    // Frozen threshold 10; only 5 matches now. A fresh multiplier resolve would
+    // produce a tiny threshold the count would clear — the frozen value must win.
+    const { result } = await run({
+      alert: multiplierAlert,
+      matches: [9, 7, 5, 3, 1].map(minsAgo),
+      seed: [
+        incident({
+          kind: "savedSearch.escalating",
+          entrySignals: {
+            evaluatedThreshold: 10,
+            baselineCount: 50,
+            baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+          },
+        }),
+      ],
+    })
+    expect(result.transition).toBe("exit-eligible")
+  })
+})

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
@@ -1,0 +1,104 @@
+import { AlertIncidentRepository, isSavedSearchEntrySignals, type SavedSearchEntrySignals } from "@domain/alerts"
+import type { OutboxEventWriter } from "@domain/events"
+import { type ChSqlClient, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
+import {
+  type EvaluateSavedSearchAlertError,
+  type EvaluateSavedSearchAlertInput,
+  evaluateSavedSearchAlert,
+} from "./evaluate-saved-search-alert.ts"
+import { closeSavedSearchIncident, openSavedSearchIncident } from "./saved-search-incident-writer.ts"
+
+/**
+ * - `opened`        — condition met with no open incident; one opened.
+ * - `exit-eligible` — condition dropped; the dwell timer started.
+ * - `exit-cancelled`— condition returned during the dwell; the timer was cleared.
+ * - `closed`        — condition stayed false for the full `window`; the incident closed.
+ * - `none`          — no transition this tick.
+ */
+export interface RunSavedSearchEscalatingAlertResult {
+  readonly transition: "opened" | "exit-eligible" | "exit-cancelled" | "closed" | "none"
+}
+
+export type RunSavedSearchEscalatingAlertError = EvaluateSavedSearchAlertError | RepositoryError
+
+/**
+ * `savedSearch.escalating` state machine, mirroring `issue.escalating` (`window`
+ * is both the count window and the exit dwell). The threshold is frozen into
+ * `entrySignals` at open time so the incident's own elevated counts can't drift
+ * a multiplier baseline and pin it open.
+ */
+export const runSavedSearchEscalatingAlertUseCase = (input: EvaluateSavedSearchAlertInput) =>
+  Effect.gen(function* () {
+    const { organizationId, projectId, alert, now } = input
+    const condition = alert.condition
+    if (alert.kind !== "savedSearch.escalating" || condition?.kind !== "savedSearch.escalating") {
+      return yield* Effect.die(`runSavedSearchEscalatingAlert: not a savedSearch.escalating alert (${alert.id})`)
+    }
+    const sourceId = alert.source.id
+    if (sourceId === null) return yield* Effect.die(`runSavedSearchEscalatingAlert: alert ${alert.id} has no source id`)
+
+    const sqlClient = yield* SqlClient
+    const alertIncidentRepository = yield* AlertIncidentRepository
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const evaluation = yield* evaluateSavedSearchAlert(input)
+        const open = yield* alertIncidentRepository.findOpenByMonitorAlertId(alert.id)
+
+        if (open === null) {
+          if (!evaluation.isMet) return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+          const entrySignals: SavedSearchEntrySignals =
+            condition.threshold.mode === "multiplier"
+              ? {
+                  evaluatedThreshold: evaluation.threshold,
+                  baselineCount: evaluation.baselineCount ?? 0,
+                  baseline: condition.threshold.baseline,
+                }
+              : { evaluatedThreshold: evaluation.threshold }
+          const startedAt = evaluation.firstMatchInWindow ?? now
+          yield* openSavedSearchIncident({
+            organizationId,
+            projectId,
+            alert,
+            sourceId,
+            startedAt,
+            endedAt: null,
+            entrySignals,
+            now,
+          })
+          return { transition: "opened" } satisfies RunSavedSearchEscalatingAlertResult
+        }
+
+        // Compare against the threshold frozen at entry; fall back to the fresh one for legacy rows without a snapshot.
+        const frozenThreshold = isSavedSearchEntrySignals(open.entrySignals)
+          ? open.entrySignals.evaluatedThreshold
+          : evaluation.threshold
+        const conditionHolds = evaluation.count >= frozenThreshold
+
+        if (conditionHolds) {
+          if (open.exitEligibleSince !== null) {
+            yield* alertIncidentRepository.updateExitDwell({ id: open.id, exitEligibleSince: null })
+            return { transition: "exit-cancelled" } satisfies RunSavedSearchEscalatingAlertResult
+          }
+          return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+        }
+
+        if (open.exitEligibleSince === null) {
+          yield* alertIncidentRepository.updateExitDwell({ id: open.id, exitEligibleSince: now })
+          return { transition: "exit-eligible" } satisfies RunSavedSearchEscalatingAlertResult
+        }
+        const windowMs = condition.window.minutes * 60 * 1000
+        if (now.getTime() - open.exitEligibleSince.getTime() >= windowMs) {
+          yield* closeSavedSearchIncident(open, now)
+          return { transition: "closed" } satisfies RunSavedSearchEscalatingAlertResult
+        }
+        return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+      }),
+    )
+  }).pipe(Effect.withSpan("monitors.runSavedSearchEscalatingAlert")) as Effect.Effect<
+    RunSavedSearchEscalatingAlertResult,
+    RunSavedSearchEscalatingAlertError,
+    SqlClient | ChSqlClient | SavedSearchMatchReader | AlertIncidentRepository | OutboxEventWriter
+  >

--- a/packages/domain/monitors/src/use-cases/run-saved-search-match-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-match-alert.test.ts
@@ -1,0 +1,63 @@
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { ChSqlClient, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { createFakeAlertIncidentStore } from "../testing/fake-alert-incident-store.ts"
+import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
+import { runSavedSearchMatchAlertUseCase } from "./run-saved-search-match-alert.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const savedSearchId = "s".repeat(24)
+const now = new Date("2026-06-01T12:00:00.000Z")
+const minsAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000)
+
+const matchAlert: MonitorAlert = {
+  id: "a".repeat(24) as MonitorAlert["id"],
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.match",
+  source: { type: "savedSearch", id: savedSearchId },
+  condition: null,
+  severity: "low",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+}
+
+const run = (matches: readonly Date[]) => {
+  const store = createFakeAlertIncidentStore([])
+  const events: OutboxWriteEvent[] = []
+  return Effect.runPromise(
+    runSavedSearchMatchAlertUseCase({
+      organizationId,
+      projectId,
+      alert: matchAlert,
+      target: { query: null, filterSet: {} },
+      now,
+    }).pipe(
+      Effect.provide(createFakeSavedSearchMatchReader(matches).layer),
+      Effect.provide(store.layer),
+      Effect.provideService(OutboxEventWriter, { write: (event) => Effect.sync(() => void events.push(event)) }),
+      Effect.provideService(SqlClient, createFakeSqlClient({ organizationId })),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    ),
+  ).then((result) => ({ result, incidents: store.incidents, events }))
+}
+
+describe("runSavedSearchMatchAlertUseCase", () => {
+  it("writes a point-in-time incident at the first match in the window", async () => {
+    const first = minsAgo(4)
+    const { result, incidents, events } = await run([first, minsAgo(1)])
+    expect(result.transition).toBe("fired")
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({ startedAt: first, endedAt: first, severity: "low", condition: null })
+    expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
+  })
+
+  it("does nothing when no trace matched in the window", async () => {
+    const { result, incidents, events } = await run([minsAgo(10)])
+    expect(result.transition).toBe("none")
+    expect(incidents).toHaveLength(0)
+    expect(events).toHaveLength(0)
+  })
+})

--- a/packages/domain/monitors/src/use-cases/run-saved-search-match-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-match-alert.ts
@@ -1,0 +1,56 @@
+import type { AlertIncidentRepository } from "@domain/alerts"
+import type { OutboxEventWriter } from "@domain/events"
+import { type ChSqlClient, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
+import {
+  type EvaluateSavedSearchAlertError,
+  type EvaluateSavedSearchAlertInput,
+  evaluateSavedSearchAlert,
+} from "./evaluate-saved-search-alert.ts"
+import { openSavedSearchIncident } from "./saved-search-incident-writer.ts"
+
+export interface RunSavedSearchMatchAlertResult {
+  readonly transition: "fired" | "none"
+}
+
+export type RunSavedSearchMatchAlertError = EvaluateSavedSearchAlertError | RepositoryError
+
+/**
+ * `savedSearch.match` state machine — no stored state: write one point-in-time
+ * incident at the first match. The queue's `throttleMs` is the entire rate limiter.
+ */
+export const runSavedSearchMatchAlertUseCase = (input: EvaluateSavedSearchAlertInput) =>
+  Effect.gen(function* () {
+    const { organizationId, projectId, alert, now } = input
+    if (alert.kind !== "savedSearch.match") {
+      return yield* Effect.die(`runSavedSearchMatchAlert: not a savedSearch.match alert (${alert.id})`)
+    }
+    const sourceId = alert.source.id
+    if (sourceId === null) return yield* Effect.die(`runSavedSearchMatchAlert: alert ${alert.id} has no source id`)
+
+    const sqlClient = yield* SqlClient
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const evaluation = yield* evaluateSavedSearchAlert(input)
+        if (!evaluation.isMet) return { transition: "none" } satisfies RunSavedSearchMatchAlertResult
+        const startedAt = evaluation.firstMatchInWindow ?? now
+        yield* openSavedSearchIncident({
+          organizationId,
+          projectId,
+          alert,
+          sourceId,
+          startedAt,
+          endedAt: startedAt,
+          entrySignals: null,
+          now,
+        })
+        return { transition: "fired" } satisfies RunSavedSearchMatchAlertResult
+      }),
+    )
+  }).pipe(Effect.withSpan("monitors.runSavedSearchMatchAlert")) as Effect.Effect<
+    RunSavedSearchMatchAlertResult,
+    RunSavedSearchMatchAlertError,
+    SqlClient | ChSqlClient | SavedSearchMatchReader | AlertIncidentRepository | OutboxEventWriter
+  >

--- a/packages/domain/monitors/src/use-cases/run-saved-search-threshold-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-threshold-alert.test.ts
@@ -1,0 +1,153 @@
+import type { AlertIncident } from "@domain/alerts"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { ChSqlClient, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MonitorAlert } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import { createFakeAlertIncidentStore } from "../testing/fake-alert-incident-store.ts"
+import { createFakeMonitorRepository } from "../testing/fake-monitor-repository.ts"
+import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
+import { runSavedSearchThresholdAlertUseCase } from "./run-saved-search-threshold-alert.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const savedSearchId = "s".repeat(24)
+const alertId = "a".repeat(24) as MonitorAlert["id"]
+const now = new Date("2026-06-01T12:00:00.000Z")
+const minsAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000)
+
+const alert = (condition: MonitorAlert["condition"]): MonitorAlert => ({
+  id: alertId,
+  monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
+  kind: "savedSearch.threshold",
+  source: { type: "savedSearch", id: savedSearchId },
+  condition,
+  severity: "medium",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+const incident = (overrides: Partial<AlertIncident>): AlertIncident => ({
+  id: "c".repeat(24) as AlertIncident["id"],
+  organizationId,
+  projectId,
+  sourceType: "savedSearch",
+  sourceId: savedSearchId,
+  kind: "savedSearch.threshold",
+  severity: "medium",
+  startedAt: minsAgo(30),
+  endedAt: null,
+  createdAt: minsAgo(30),
+  entrySignals: null,
+  exitEligibleSince: null,
+  monitorAlertId: alertId,
+  condition: null,
+  ...overrides,
+})
+
+const run = (params: {
+  readonly alert: MonitorAlert
+  readonly matches: readonly Date[]
+  readonly seed?: readonly AlertIncident[]
+}) => {
+  const store = createFakeAlertIncidentStore(params.seed ?? [])
+  const events: OutboxWriteEvent[] = []
+  const { repo: monitorRepo } = createFakeMonitorRepository([])
+  return Effect.runPromise(
+    runSavedSearchThresholdAlertUseCase({
+      organizationId,
+      projectId,
+      alert: params.alert,
+      target: { query: null, filterSet: {} },
+      now,
+    }).pipe(
+      Effect.provide(createFakeSavedSearchMatchReader(params.matches).layer),
+      Effect.provide(store.layer),
+      Effect.provideService(MonitorRepository, monitorRepo),
+      Effect.provideService(OutboxEventWriter, { write: (event) => Effect.sync(() => void events.push(event)) }),
+      Effect.provideService(SqlClient, createFakeSqlClient({ organizationId })),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    ),
+  ).then((result) => ({ result, incidents: store.incidents, events }))
+}
+
+const absoluteAlert = alert({ kind: "savedSearch.threshold", threshold: { mode: "absolute", count: 5 } })
+const multiplierAlert = alert({
+  kind: "savedSearch.threshold",
+  threshold: { mode: "multiplier", factor: 1, baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } } },
+})
+
+describe("runSavedSearchThresholdAlertUseCase", () => {
+  describe("absolute (one-time)", () => {
+    it("fires a point-in-time incident at the first match when the count crosses", async () => {
+      const first = minsAgo(300)
+      const { result, incidents, events } = await run({
+        alert: absoluteAlert,
+        matches: [first, minsAgo(200), minsAgo(100), minsAgo(50), minsAgo(10)],
+      })
+      expect(result.transition).toBe("fired")
+      expect(incidents).toHaveLength(1)
+      expect(incidents[0]).toMatchObject({
+        startedAt: first,
+        endedAt: first,
+        monitorAlertId: alertId,
+        entrySignals: null,
+      })
+      expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
+    })
+
+    it("short-circuits once spent — any prior incident blocks a re-fire", async () => {
+      const { result, incidents, events } = await run({
+        alert: absoluteAlert,
+        matches: [minsAgo(300), minsAgo(200), minsAgo(100), minsAgo(50), minsAgo(10)],
+        seed: [incident({ endedAt: minsAgo(400) })],
+      })
+      expect(result.transition).toBe("none")
+      expect(incidents).toHaveLength(1)
+      expect(events).toHaveLength(0)
+    })
+
+    it("does not fire below the threshold", async () => {
+      const { result, incidents } = await run({ alert: absoluteAlert, matches: [minsAgo(100), minsAgo(10)] })
+      expect(result.transition).toBe("none")
+      expect(incidents).toHaveLength(0)
+    })
+  })
+
+  describe("multiplier (rearm)", () => {
+    it("opens an incident on the rising edge with a single IncidentCreated", async () => {
+      const first = minsAgo(4)
+      const { result, incidents, events } = await run({
+        alert: multiplierAlert,
+        matches: [first, minsAgo(2), minsAgo(1)],
+      })
+      expect(result.transition).toBe("opened")
+      expect(incidents).toHaveLength(1)
+      expect(incidents[0]).toMatchObject({ startedAt: first, endedAt: null, entrySignals: null })
+      expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
+    })
+
+    it("silently closes (no notification) when the condition drops", async () => {
+      const { result, incidents, events } = await run({
+        alert: multiplierAlert,
+        matches: [],
+        seed: [incident({ endedAt: null })],
+      })
+      expect(result.transition).toBe("closed")
+      expect(incidents[0]?.endedAt).toEqual(now)
+      expect(events).toHaveLength(0)
+    })
+
+    it("is a no-op while the spike still holds", async () => {
+      const { result, incidents, events } = await run({
+        alert: multiplierAlert,
+        matches: [minsAgo(2), minsAgo(1)],
+        seed: [incident({ endedAt: null })],
+      })
+      expect(result.transition).toBe("none")
+      expect(incidents).toHaveLength(1)
+      expect(events).toHaveLength(0)
+    })
+  })
+})

--- a/packages/domain/monitors/src/use-cases/run-saved-search-threshold-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-threshold-alert.ts
@@ -1,0 +1,98 @@
+import { AlertIncidentRepository } from "@domain/alerts"
+import type { OutboxEventWriter } from "@domain/events"
+import { type ChSqlClient, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
+import {
+  type EvaluateSavedSearchAlertError,
+  type EvaluateSavedSearchAlertInput,
+  evaluateSavedSearchAlert,
+} from "./evaluate-saved-search-alert.ts"
+import { openSavedSearchIncident } from "./saved-search-incident-writer.ts"
+
+/**
+ * - `fired`  — absolute (one-time) threshold crossed; a point-in-time incident opened.
+ * - `opened` — multiplier rising edge; an incident opened and stays open while the spike holds.
+ * - `closed` — multiplier condition dropped; the open incident was silently closed (no notification).
+ * - `none`   — already spent (absolute), or no transition this tick.
+ */
+export interface RunSavedSearchThresholdAlertResult {
+  readonly transition: "fired" | "opened" | "closed" | "none"
+}
+
+export type RunSavedSearchThresholdAlertError = EvaluateSavedSearchAlertError | RepositoryError
+
+/**
+ * `savedSearch.threshold` state machine. Absolute mode is one-time (a `FOR UPDATE`
+ * lock + prior-incident check absorb retries); multiplier mode rearms via the
+ * incident row — one `IncidentCreated` on the rising edge, silent close on drop.
+ */
+export const runSavedSearchThresholdAlertUseCase = (input: EvaluateSavedSearchAlertInput) =>
+  Effect.gen(function* () {
+    const { organizationId, projectId, alert, now } = input
+    const condition = alert.condition
+    if (alert.kind !== "savedSearch.threshold" || condition?.kind !== "savedSearch.threshold") {
+      return yield* Effect.die(`runSavedSearchThresholdAlert: not a savedSearch.threshold alert (${alert.id})`)
+    }
+    const sourceId = alert.source.id
+    if (sourceId === null) return yield* Effect.die(`runSavedSearchThresholdAlert: alert ${alert.id} has no source id`)
+
+    const sqlClient = yield* SqlClient
+    const monitorRepository = yield* MonitorRepository
+    const alertIncidentRepository = yield* AlertIncidentRepository
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        yield* monitorRepository.lockAlertForUpdate(alert.id)
+
+        if (condition.threshold.mode === "absolute") {
+          // One-time: any prior incident (open or closed) means the alert is spent.
+          const alreadyFired = yield* alertIncidentRepository.existsByMonitorAlertId(alert.id)
+          if (alreadyFired) return { transition: "none" } satisfies RunSavedSearchThresholdAlertResult
+          const evaluation = yield* evaluateSavedSearchAlert(input)
+          if (!evaluation.isMet) return { transition: "none" } satisfies RunSavedSearchThresholdAlertResult
+          const startedAt = evaluation.firstMatchInWindow ?? now
+          yield* openSavedSearchIncident({
+            organizationId,
+            projectId,
+            alert,
+            sourceId,
+            startedAt,
+            endedAt: startedAt,
+            entrySignals: null,
+            now,
+          })
+          return { transition: "fired" } satisfies RunSavedSearchThresholdAlertResult
+        }
+
+        // Multiplier: re-evaluate fresh each tick — the alarm already fired on the
+        // rising edge, so a sliding baseline drifting it closed is intended.
+        const open = yield* alertIncidentRepository.findOpenByMonitorAlertId(alert.id)
+        const evaluation = yield* evaluateSavedSearchAlert(input)
+        if (open === null && evaluation.isMet) {
+          const startedAt = evaluation.firstMatchInWindow ?? now
+          yield* openSavedSearchIncident({
+            organizationId,
+            projectId,
+            alert,
+            sourceId,
+            startedAt,
+            endedAt: null,
+            entrySignals: null,
+            now,
+          })
+          return { transition: "opened" } satisfies RunSavedSearchThresholdAlertResult
+        }
+        if (open !== null && !evaluation.isMet) {
+          yield* alertIncidentRepository.setEndedAt({ id: open.id, endedAt: now })
+          return { transition: "closed" } satisfies RunSavedSearchThresholdAlertResult
+        }
+        return { transition: "none" } satisfies RunSavedSearchThresholdAlertResult
+      }),
+    )
+  }).pipe(Effect.withSpan("monitors.runSavedSearchThresholdAlert")) as Effect.Effect<
+    RunSavedSearchThresholdAlertResult,
+    RunSavedSearchThresholdAlertError,
+    SqlClient | ChSqlClient | SavedSearchMatchReader | AlertIncidentRepository | OutboxEventWriter | MonitorRepository
+  >

--- a/packages/domain/monitors/src/use-cases/saved-search-incident-writer.ts
+++ b/packages/domain/monitors/src/use-cases/saved-search-incident-writer.ts
@@ -1,0 +1,86 @@
+import { type AlertIncident, AlertIncidentRepository, type SavedSearchEntrySignals } from "@domain/alerts"
+import { OutboxEventWriter } from "@domain/events"
+import { AlertIncidentId, generateId, type OrganizationId, type ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MonitorAlert } from "../entities/monitor.ts"
+
+/** Shared incident-row shape for the three state machines — the one thing they share. Callers invoke the writers inside their own transaction. */
+interface OpenSavedSearchIncidentInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly alert: MonitorAlert
+  /** The watched saved search's id (the incident's `sourceId`). */
+  readonly sourceId: string
+  readonly startedAt: Date
+  /** `null` keeps a sustained / rearm incident open; `= startedAt` collapses a point-in-time one. */
+  readonly endedAt: Date | null
+  /** Frozen threshold snapshot for `savedSearch.escalating`; `null` otherwise. */
+  readonly entrySignals: SavedSearchEntrySignals | null
+  readonly now: Date
+}
+
+/** Insert the incident row + emit `IncidentCreated`. Returns the inserted row. */
+export const openSavedSearchIncident = (input: OpenSavedSearchIncidentInput) =>
+  Effect.gen(function* () {
+    const alertIncidentRepository = yield* AlertIncidentRepository
+    const outboxEventWriter = yield* OutboxEventWriter
+
+    const incident: AlertIncident = {
+      id: AlertIncidentId(generateId()),
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      sourceType: "savedSearch",
+      sourceId: input.sourceId,
+      kind: input.alert.kind,
+      severity: input.alert.severity,
+      startedAt: input.startedAt,
+      endedAt: input.endedAt,
+      createdAt: input.now,
+      entrySignals: input.entrySignals,
+      exitEligibleSince: null,
+      monitorAlertId: input.alert.id,
+      condition: input.alert.condition,
+    }
+
+    yield* alertIncidentRepository.insert(incident)
+    yield* outboxEventWriter.write({
+      eventName: "IncidentCreated",
+      aggregateType: "alert_incident",
+      aggregateId: incident.id,
+      organizationId: incident.organizationId,
+      payload: {
+        organizationId: incident.organizationId,
+        projectId: incident.projectId,
+        alertIncidentId: incident.id,
+        kind: incident.kind,
+        sourceType: incident.sourceType,
+        sourceId: incident.sourceId,
+      },
+    })
+
+    return incident
+  })
+
+/** Set `ended_at` + emit `IncidentClosed`. `savedSearch.escalating` only — the multiplier silent close sets `ended_at` directly (no event). */
+export const closeSavedSearchIncident = (incident: AlertIncident, endedAt: Date) =>
+  Effect.gen(function* () {
+    const alertIncidentRepository = yield* AlertIncidentRepository
+    const outboxEventWriter = yield* OutboxEventWriter
+
+    yield* alertIncidentRepository.setEndedAt({ id: incident.id, endedAt })
+    yield* outboxEventWriter.write({
+      eventName: "IncidentClosed",
+      aggregateType: "alert_incident",
+      aggregateId: incident.id,
+      organizationId: incident.organizationId,
+      payload: {
+        organizationId: incident.organizationId,
+        projectId: incident.projectId,
+        alertIncidentId: incident.id,
+        kind: incident.kind,
+        sourceType: incident.sourceType,
+        sourceId: incident.sourceId,
+        reason: "threshold",
+      },
+    })
+  })

--- a/packages/domain/monitors/src/use-cases/sweep-saved-search-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/sweep-saved-search-monitors.test.ts
@@ -1,0 +1,82 @@
+import { QueuePublishError } from "@domain/queue"
+import { OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Monitor, MonitorAlert } from "../entities/monitor.ts"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+import { createFakeMonitorRepository } from "../testing/fake-monitor-repository.ts"
+import { sweepSavedSearchMonitorsUseCase } from "./sweep-saved-search-monitors.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+
+const savedSearchAlert = (monitorId: string): MonitorAlert => ({
+  id: `${monitorId}-alert`.padEnd(24, "0").slice(0, 24) as MonitorAlert["id"],
+  monitorId: monitorId as MonitorAlert["monitorId"],
+  kind: "savedSearch.match",
+  source: { type: "savedSearch", id: "s".repeat(24) },
+  condition: null,
+  severity: "low",
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+const monitor = (id: string, projectId: ProjectId, alerts: readonly MonitorAlert[]): Monitor => ({
+  id: id.padEnd(24, "0").slice(0, 24) as Monitor["id"],
+  organizationId,
+  projectId,
+  slug: `monitor-${id}`,
+  name: `Monitor ${id}`,
+  description: "",
+  system: false,
+  alerts,
+  mutedAt: null,
+  deletedAt: null,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+})
+
+const projectA = ProjectId("a".repeat(24))
+const projectB = ProjectId("b".repeat(24))
+
+const run = (monitors: readonly Monitor[], opts: { failOn?: ReadonlySet<string> } = {}) => {
+  const { repo } = createFakeMonitorRepository(monitors)
+  const published: Array<{ organizationId: string; projectId: string }> = []
+  return Effect.runPromise(
+    sweepSavedSearchMonitorsUseCase({
+      publish: (payload) => {
+        if (opts.failOn?.has(payload.projectId)) {
+          return Effect.fail(new QueuePublishError({ cause: "boom", queue: "monitors" }))
+        }
+        published.push(payload)
+        return Effect.void
+      },
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MonitorRepository, repo),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  ).then((result) => ({ result, published }))
+}
+
+describe("sweepSavedSearchMonitorsUseCase", () => {
+  it("fans out one publish per distinct project holding active saved-search alerts", async () => {
+    const { result, published } = await run([
+      monitor("m1", projectA, [savedSearchAlert("m1")]),
+      monitor("m2", projectA, [savedSearchAlert("m2")]),
+      monitor("m3", projectB, [savedSearchAlert("m3")]),
+    ])
+    expect(result).toEqual({ attempted: 2, published: 2, failed: 0 })
+    expect(published.map((p) => p.projectId).sort()).toEqual([projectA, projectB].sort())
+  })
+
+  it("tallies per-project publish failures without aborting the rest", async () => {
+    const { result } = await run(
+      [monitor("m1", projectA, [savedSearchAlert("m1")]), monitor("m3", projectB, [savedSearchAlert("m3")])],
+      { failOn: new Set([projectA]) },
+    )
+    expect(result).toEqual({ attempted: 2, published: 1, failed: 1 })
+  })
+})

--- a/packages/domain/monitors/src/use-cases/sweep-saved-search-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/sweep-saved-search-monitors.ts
@@ -1,0 +1,56 @@
+import type { QueuePublishError } from "@domain/queue"
+import type { RepositoryError, SqlClient } from "@domain/shared"
+import { Effect, Ref } from "effect"
+import { MonitorRepository } from "../ports/monitor-repository.ts"
+
+const PUBLISH_CONCURRENCY = 10
+
+/** Publish callback, one per (org, project); wired to `QueuePublisher.publish` in the worker. */
+export type SweepSavedSearchMonitorsPublish = (payload: {
+  readonly organizationId: string
+  readonly projectId: string
+}) => Effect.Effect<void, QueuePublishError>
+
+export interface SweepSavedSearchMonitorsResult {
+  readonly attempted: number
+  readonly published: number
+  readonly failed: number
+}
+
+/**
+ * Fan-out side of the 5-minute sweep: enqueues one `checkSavedSearchMonitors` per
+ * (org, project) with an active alert (cross-org, admin client). Catches the
+ * low-traffic case the trace-end check misses — opening incidents and letting
+ * sustained ones close once their dwell elapses. Per-project failures are tallied.
+ */
+export const sweepSavedSearchMonitorsUseCase = (deps: {
+  readonly publish: SweepSavedSearchMonitorsPublish
+}): Effect.Effect<SweepSavedSearchMonitorsResult, RepositoryError, SqlClient | MonitorRepository> =>
+  Effect.gen(function* () {
+    const monitorRepository = yield* MonitorRepository
+    const projects = yield* monitorRepository.listProjectsWithActiveSavedSearchAlerts()
+
+    const failedRef = yield* Ref.make(0)
+    yield* Effect.forEach(
+      projects,
+      (project) =>
+        deps
+          .publish({ organizationId: project.organizationId, projectId: project.projectId })
+          .pipe(Effect.catch(() => Ref.update(failedRef, (n) => n + 1))),
+      { concurrency: PUBLISH_CONCURRENCY, discard: true },
+    )
+
+    const failed = yield* Ref.get(failedRef)
+    const attempted = projects.length
+    const published = attempted - failed
+
+    yield* Effect.annotateCurrentSpan("attempted", attempted)
+    yield* Effect.annotateCurrentSpan("published", published)
+    yield* Effect.annotateCurrentSpan("failed", failed)
+
+    return { attempted, published, failed } satisfies SweepSavedSearchMonitorsResult
+  }).pipe(Effect.withSpan("monitors.sweepSavedSearchMonitors")) as Effect.Effect<
+    SweepSavedSearchMonitorsResult,
+    RepositoryError,
+    SqlClient | MonitorRepository
+  >

--- a/packages/domain/notifications/src/entities/notification.ts
+++ b/packages/domain/notifications/src/entities/notification.ts
@@ -151,7 +151,8 @@ export type IncidentEventPayload = z.infer<typeof incidentEventPayloadSchema>
  */
 export const incidentOpenedPayloadSchema = z.object({
   ...incidentBasePayloadShape,
-  trend: incidentTrendSchema,
+  // Issue trend snapshot — absent for non-issue sources (e.g. `savedSearch.escalating`).
+  trend: incidentTrendSchema.optional(),
   tags: incidentTagsSchema.optional(),
   /**
    * Optional: legacy escalating incidents opened before
@@ -178,7 +179,8 @@ export type IncidentOpenedPayload = z.infer<typeof incidentOpenedPayloadSchema>
  */
 export const incidentClosedPayloadSchema = z.object({
   ...incidentBasePayloadShape,
-  trend: incidentTrendSchema,
+  // Issue trend snapshot — absent for non-issue sources (e.g. `savedSearch.escalating`).
+  trend: incidentTrendSchema.optional(),
   recovery: incidentRecoverySchema,
 })
 export type IncidentClosedPayload = z.infer<typeof incidentClosedPayloadSchema>

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
@@ -90,6 +90,9 @@ function setup(opts: SetupOpts = {}) {
     listByMonitorId: () => Effect.die("listByMonitorId not used"),
     statsByMonitorId: () => Effect.die("statsByMonitorId not used"),
     listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used"),
+    findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
+    existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
+    setEndedAt: () => Effect.die("setEndedAt not used"),
   }
 
   const members: MemberWithUser[] = (opts.memberUserIds ?? [cuid("u1"), cuid("u2")]).map((uid, i) => ({
@@ -260,7 +263,7 @@ describe("requestIncidentNotificationsUseCase", () => {
     expect(result.requests[0]?.kind).toBe("incident.opened")
     expect(result.requests[0]?.idempotencyKey).toBe(`incident.opened:${incidentId}`)
     const payload = result.requests[0]?.payload
-    if (!payload || !("trend" in payload)) throw new Error("expected trend on opened payload")
+    if (!payload || !("trend" in payload) || !payload.trend) throw new Error("expected trend on opened payload")
     expect(payload.trend.bucketDurationMs).toBe(10 * 60 * 1000)
     // NaN thresholds round-trip through the producer as null.
     expect(payload.trend.points.some((p) => p.threshold === null)).toBe(true)
@@ -289,7 +292,7 @@ describe("requestIncidentNotificationsUseCase", () => {
     expect(result.requests[0]?.kind).toBe("incident.closed")
     expect(result.requests[0]?.idempotencyKey).toBe(`incident.closed:${incidentId}`)
     const payload = result.requests[0]?.payload
-    if (!payload || !("trend" in payload)) throw new Error("expected trend on closed payload")
+    if (!payload || !("trend" in payload) || !payload.trend) throw new Error("expected trend on closed payload")
     expect(payload.trend.points.length).toBeGreaterThan(0)
   })
 

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
@@ -1,4 +1,4 @@
-import { type AlertIncident, AlertIncidentRepository } from "@domain/alerts"
+import { type AlertIncident, AlertIncidentRepository, isIssueEscalationEntrySignals } from "@domain/alerts"
 import { EvaluationRepository } from "@domain/evaluations"
 import { DEFAULT_ESCALATION_SENSITIVITY_K } from "@domain/issues"
 import type { MembershipRepository } from "@domain/organizations"
@@ -289,7 +289,9 @@ const snapshotSampleExcerpt = (incident: AlertIncident) =>
  * "climbed to" copy.
  */
 const buildBreach = (incident: AlertIncident, trend: IncidentTrend | null): IncidentBreach | undefined => {
-  if (incident.entrySignals === null || trend === null) return undefined
+  // Seasonal breach scalars only exist on `issue.escalating` snapshots; saved-search
+  // incidents carry a frozen-threshold snapshot instead and have no such copy.
+  if (trend === null || !isIssueEscalationEntrySignals(incident.entrySignals)) return undefined
   const peakCount = trend.points.reduce((m, p) => (p.count > m ? p.count : m), 0)
   const bucketHours = trend.bucketDurationMs / (60 * 60 * 1000)
   const triggerRate = bucketHours > 0 ? peakCount / bucketHours : 0
@@ -344,8 +346,8 @@ const buildPayload = (input: {
       ...(sampleExcerpt ? { sampleExcerpt } : {}),
     }
   }
-  // Sustained kinds must carry the trend snapshot (caller guarantees it).
-  if (trend === null) throw new Error(`Missing trend snapshot for ${kind}`)
+  // Sustained kinds carry an issue trend snapshot when the source is an issue;
+  // saved-search incidents omit it (no issue analytics).
   if (kind === "incident.opened") {
     const breach = buildBreach(incident, trend)
     return {
@@ -355,7 +357,7 @@ const buildPayload = (input: {
       incidentKind: base.incidentKind,
       severity: base.severity,
       ...attribution,
-      trend,
+      ...(trend ? { trend } : {}),
       ...(mutableTags ? { tags: mutableTags } : {}),
       ...(breach ? { breach } : {}),
       ...(sampleExcerpt ? { sampleExcerpt } : {}),
@@ -367,7 +369,8 @@ const buildPayload = (input: {
     sourceId: base.sourceId,
     incidentKind: base.incidentKind,
     severity: base.severity,
-    trend,
+    ...attribution,
+    ...(trend ? { trend } : {}),
     recovery: buildRecovery(incident),
   }
 }
@@ -415,15 +418,17 @@ export const requestIncidentNotificationsUseCase = (input: RequestIncidentNotifi
     const snapshotSensitivity =
       incident.condition?.kind === "issue.escalating" ? incident.condition.sensitivity : undefined
     const kShort = snapshotSensitivity ?? projectSettings?.escalation?.sensitivity ?? DEFAULT_ESCALATION_SENSITIVITY_K
-    // Snapshot trend + tags + sample-excerpt in parallel. Closed kind
-    // skips both: the recovery email focuses on the descent, not the
-    // source context. Event + opened both get the excerpt so the
-    // recipient sees what triggered the alert without clicking through.
+    // Trend / tags / sample-excerpt are all issue-analytics keyed on the issue id,
+    // so they only apply to `issue`-sourced incidents. Saved-search incidents skip
+    // them (the templates render from the kind + monitor attribution + condition).
+    // Closed kind also skips tags/excerpt: the recovery copy focuses on the descent.
+    const isIssueSource = incident.sourceType === "issue"
+    const wantsSourceContext = isIssueSource && notificationKind !== "incident.closed"
     const [trend, tags, sampleExcerpt] = yield* Effect.all(
       [
-        snapshotTrend({ incident, kind: notificationKind, kShort }),
-        notificationKind === "incident.closed" ? Effect.succeed(undefined) : snapshotTags(incident),
-        notificationKind === "incident.closed" ? Effect.succeed(undefined) : snapshotSampleExcerpt(incident),
+        isIssueSource ? snapshotTrend({ incident, kind: notificationKind, kShort }) : Effect.succeed(null),
+        wantsSourceContext ? snapshotTags(incident) : Effect.succeed(undefined),
+        wantsSourceContext ? snapshotSampleExcerpt(incident) : Effect.succeed(undefined),
       ],
       { concurrency: "unbounded" },
     )

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -275,6 +275,31 @@ const _registry = {
     }
   }>(),
 
+  monitors: payloads<{
+    /**
+     * Run the saved-search firing pipeline for one project. Published throttled
+     * (per project) on trace-end and fanned out by the 5-minute sweep. The
+     * handler lists active saved-search alerts and runs each one's state machine.
+     */
+    checkSavedSearchMonitors: {
+      readonly organizationId: string
+      readonly projectId: string
+    }
+    /** Fired by the 5-minute cron — fans out one `checkSavedSearchMonitors` per project with active alerts. */
+    sweepSavedSearchMonitors: Record<string, never>
+    /**
+     * Source-deletion cascade. Fired by the domain-events router on
+     * `SavedSearchDeleted`. Soft-deletes alerts watching the source and prunes
+     * now-empty monitors.
+     */
+    onSourceDeleted: {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly sourceType: "savedSearch" | "issue"
+      readonly sourceId: string
+    }
+  }>(),
+
   evaluations: payloads<{
     automaticRefreshAlignment: {
       readonly organizationId: string

--- a/packages/domain/saved-searches/src/use-cases/delete-saved-search.test.ts
+++ b/packages/domain/saved-searches/src/use-cases/delete-saved-search.test.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import { ProjectId, SavedSearchId, SqlClient, UserId } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -32,6 +33,7 @@ function makeLayer() {
   return Layer.mergeAll(
     Layer.succeed(SavedSearchRepository, repository),
     Layer.succeed(SqlClient, createFakeSqlClient()),
+    Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
   )
 }
 

--- a/packages/domain/saved-searches/src/use-cases/delete-saved-search.ts
+++ b/packages/domain/saved-searches/src/use-cases/delete-saved-search.ts
@@ -1,4 +1,5 @@
-import type { SavedSearchId } from "@domain/shared"
+import { OutboxEventWriter } from "@domain/events"
+import { type SavedSearchId, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { SavedSearchRepository } from "../ports/saved-search-repository.ts"
 
@@ -8,6 +9,26 @@ export const deleteSavedSearch = Effect.fn("savedSearches.deleteSavedSearch")(fu
   yield* Effect.annotateCurrentSpan("savedSearchId", args.savedSearchId)
 
   const repo = yield* SavedSearchRepository
-  yield* repo.findById(args.savedSearchId)
-  yield* repo.softDelete(args.savedSearchId)
+  const sqlClient = yield* SqlClient
+  const existing = yield* repo.findById(args.savedSearchId)
+
+  yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      yield* repo.softDelete(args.savedSearchId)
+
+      // Drives the monitors source cascade; atomic with the delete.
+      const outboxEventWriter = yield* OutboxEventWriter
+      yield* outboxEventWriter.write({
+        eventName: "SavedSearchDeleted",
+        aggregateType: "saved-search",
+        aggregateId: existing.id,
+        organizationId: existing.organizationId,
+        payload: {
+          organizationId: existing.organizationId,
+          projectId: existing.projectId,
+          searchId: existing.id,
+        },
+      })
+    }),
+  )
 })

--- a/packages/platform/db-clickhouse/package.json
+++ b/packages/platform/db-clickhouse/package.json
@@ -32,6 +32,7 @@
     "@domain/ai": "workspace:*",
     "@domain/datasets": "workspace:*",
     "@domain/events": "workspace:*",
+    "@domain/monitors": "workspace:*",
     "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/taxonomy": "workspace:*",

--- a/packages/platform/db-clickhouse/src/index.ts
+++ b/packages/platform/db-clickhouse/src/index.ts
@@ -16,6 +16,7 @@ export { AdminProjectMetricsRepositoryLive } from "./repositories/admin-project-
 export { BehaviorObservationRepositoryLive } from "./repositories/behavior-observation-repository.ts"
 export { ClaudeCodeSpanReaderLive } from "./repositories/claude-code-span-reader.ts"
 export { DatasetRowRepositoryLive } from "./repositories/dataset-row-repository.ts"
+export { SavedSearchMatchReaderLive } from "./repositories/saved-search-match-reader.ts"
 export { ScoreAnalyticsRepositoryLive } from "./repositories/score-analytics-repository.ts"
 export { SessionRepositoryLive } from "./repositories/session-repository.ts"
 export { SpanRepositoryLive } from "./repositories/span-repository.ts"

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
@@ -1,0 +1,148 @@
+import { SavedSearchMatchReader, type SavedSearchMatchReaderShape } from "@domain/monitors"
+import { type ChSqlClient, OrganizationId, ProjectId } from "@domain/shared"
+import { setupTestClickHouse } from "@platform/testkit"
+import { Effect } from "effect"
+import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { ChSqlClientLive } from "../ch-sql-client.ts"
+import type { SpanRow } from "../seeds/spans/span-builders.ts"
+import { insertJsonEachRow } from "../sql.ts"
+import { SavedSearchMatchReaderLive } from "./saved-search-match-reader.ts"
+
+const ORG_ID = OrganizationId("o".repeat(24))
+// A project of its own so seeded fixtures from other suites can't leak into the counts.
+const PROJECT_ID = ProjectId("savedsearchreader00000000")
+const TAG = "ss-match"
+
+const toCh = (value: Date): string => value.toISOString().replace("T", " ").replace("Z", "")
+
+// trace_id / span_id are fixed-width columns (32 / 16 chars); pad to fit.
+const traceId = (n: number) => `tr${n}`.padEnd(32, "0")
+const spanId = (n: number) => `sp${n}`.padEnd(16, "0")
+
+// One span per trace, so `start_time` (min over the trace) is exactly the span's.
+const span = (n: number, startTime: Date, tags: readonly string[] = [TAG]): SpanRow =>
+  ({
+    organization_id: ORG_ID,
+    project_id: PROJECT_ID,
+    session_id: "",
+    user_id: "",
+    trace_id: traceId(n),
+    span_id: spanId(n),
+    parent_span_id: "",
+    api_key_id: "test-api-key",
+    simulation_id: "",
+    start_time: toCh(startTime),
+    end_time: toCh(new Date(startTime.getTime() + 1_000)),
+    name: "ss-match-span",
+    service_name: "ss-match-service",
+    kind: 0,
+    status_code: 0,
+    status_message: "",
+    error_type: "",
+    tags: [...tags],
+    metadata: {},
+    operation: "",
+    provider: "",
+    model: "",
+    response_model: "",
+    tokens_input: 0,
+    tokens_output: 0,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: 0,
+    cost_output_microcents: 0,
+    cost_total_microcents: 0,
+    cost_is_estimated: 0,
+    time_to_first_token_ns: 0,
+    is_streaming: 0,
+    response_id: "",
+    finish_reasons: [],
+    input_messages: "",
+    output_messages: "",
+    system_instructions: "",
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: {},
+    attr_int: {},
+    attr_float: {},
+    attr_bool: {},
+    resource_string: {},
+    scope_name: "",
+    scope_version: "",
+  }) satisfies SpanRow
+
+const t10 = new Date("2026-06-01T10:00:00.000Z")
+const t1030 = new Date("2026-06-01T10:30:00.000Z")
+const t11 = new Date("2026-06-01T11:00:00.000Z")
+
+const ch = setupTestClickHouse()
+const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
+
+describe("SavedSearchMatchReaderLive", () => {
+  let reader: SavedSearchMatchReaderShape
+
+  beforeAll(async () => {
+    reader = await Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* SavedSearchMatchReader
+      }).pipe(Effect.provide(SavedSearchMatchReaderLive)),
+    )
+  })
+
+  beforeEach(async () => {
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [span(1, t10), span(2, t1030), span(3, t11), span(4, t1030, ["other"])]),
+    )
+  })
+
+  const target = { query: null, filterSet: {} }
+
+  it("counts only traces whose start_time falls in [from, to)", async () => {
+    // [10:00, 11:00) includes t10 + t1030 (and the 'other'-tagged trace at t1030); excludes t11.
+    const count = await runCh(
+      reader.countMatches({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t10, to: t11 }),
+    )
+    expect(count).toBe(3)
+  })
+
+  it("excludes the lower bound's predecessor and the upper bound itself", async () => {
+    const count = await runCh(
+      reader.countMatches({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t1030, to: t11 }),
+    )
+    expect(count).toBe(2)
+  })
+
+  it("returns the earliest matching trace start_time", async () => {
+    const first = await runCh(
+      reader.firstMatchAt({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t10, to: t11 }),
+    )
+    expect(first).toEqual(t10)
+  })
+
+  it("returns null when no trace matches the window", async () => {
+    const first = await runCh(
+      reader.firstMatchAt({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        target,
+        from: new Date("2026-06-01T12:00:00.000Z"),
+        to: new Date("2026-06-01T13:00:00.000Z"),
+      }),
+    )
+    expect(first).toBeNull()
+  })
+
+  it("applies the saved search's structured filters", async () => {
+    const tagged = { query: null, filterSet: { tags: [{ op: "in" as const, value: [TAG] }] } }
+    const count = await runCh(
+      reader.countMatches({ organizationId: ORG_ID, projectId: PROJECT_ID, target: tagged, from: t10, to: t11 }),
+    )
+    // Drops the 'other'-tagged trace → t10 + t1030 only.
+    expect(count).toBe(2)
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
@@ -1,0 +1,109 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import {
+  SavedSearchMatchReader,
+  type SavedSearchMatchReaderShape,
+  type SavedSearchMatchWindowInput,
+} from "@domain/monitors"
+import { ChSqlClient, type ChSqlClientShape, toRepositoryError } from "@domain/shared"
+import { parseSearchQuery } from "@domain/spans"
+import { Effect, Layer } from "effect"
+import { isActiveSearch, planSearch } from "./search-plan.ts"
+import { buildTraceFilterClauses, LIST_SELECT } from "./trace-repository.ts"
+
+/** ClickHouse `DateTime64` params take a space-separated, zone-naive string (UTC). */
+const toClickHouseDateTime64 = (value: Date): string => value.toISOString().replace("T", " ").replace("Z", "")
+
+/**
+ * The grouped per-trace subquery the count + first-match queries wrap. The window
+ * is a `HAVING` on the aggregated `start_time` (`min(min_start_time)`), not a
+ * `WHERE` — same as the trace list/count — combined with the search's filters + query.
+ */
+const buildInnerQuery = (
+  input: SavedSearchMatchWindowInput,
+): Effect.Effect<{ readonly sql: string; readonly params: Record<string, unknown> }> =>
+  Effect.gen(function* () {
+    const { havingClauses, whereClauses, params: filterParams } = buildTraceFilterClauses(input.target.filterSet)
+    const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+
+    const parsed = input.target.query ? parseSearchQuery(input.target.query) : undefined
+    let searchCondition = ""
+    let searchParams: Record<string, unknown> = {}
+    if (parsed && isActiveSearch(parsed)) {
+      const plan = yield* planSearch(parsed)
+      searchCondition = `AND trace_id IN (SELECT trace_id FROM (${plan.subquery}))`
+      searchParams = plan.params
+    }
+
+    const having = [
+      "start_time >= toDateTime64({windowFrom:String}, 9, 'UTC')",
+      "start_time < toDateTime64({windowTo:String}, 9, 'UTC')",
+      ...havingClauses,
+    ].join(" AND ")
+
+    return {
+      sql: `SELECT ${LIST_SELECT}
+            FROM traces
+            WHERE organization_id = {organizationId:String}
+              AND project_id = {projectId:String}
+              ${extraWhere}
+              ${searchCondition}
+            GROUP BY organization_id, project_id, trace_id
+            HAVING ${having}`,
+      params: {
+        organizationId: input.organizationId as string,
+        projectId: input.projectId as string,
+        windowFrom: toClickHouseDateTime64(input.from),
+        windowTo: toClickHouseDateTime64(input.to),
+        ...filterParams,
+        ...searchParams,
+      },
+    }
+  })
+
+const make = (): SavedSearchMatchReaderShape => ({
+  countMatches: (input) =>
+    Effect.gen(function* () {
+      const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+      const inner = yield* buildInnerQuery(input)
+      return yield* chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            query: `SELECT count() AS total FROM (${inner.sql})`,
+            query_params: inner.params,
+            format: "JSONEachRow",
+          })
+          return result.json<{ total: string }>()
+        })
+        .pipe(
+          Effect.map((rows) => Number(rows[0]?.total ?? 0)),
+          Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.countMatches")),
+        )
+    }),
+  firstMatchAt: (input) =>
+    Effect.gen(function* () {
+      const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+      const inner = yield* buildInnerQuery(input)
+      return yield* chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            // `count()` guards the empty case — `min()` over zero rows returns the
+            // epoch, not NULL, so we'd otherwise report a bogus 1970 first match.
+            query: `SELECT toString(min(start_time)) AS first_at, count() AS matches FROM (${inner.sql})`,
+            query_params: inner.params,
+            format: "JSONEachRow",
+          })
+          return result.json<{ first_at: string | null; matches: string }>()
+        })
+        .pipe(
+          Effect.map((rows) => {
+            const row = rows[0]
+            if (!row || Number(row.matches) === 0 || !row.first_at) return null
+            const parsed = new Date(row.first_at.includes(" ") ? `${row.first_at.replace(" ", "T")}Z` : row.first_at)
+            return Number.isNaN(parsed.getTime()) ? null : parsed
+          }),
+          Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.firstMatchAt")),
+        )
+    }),
+})
+
+export const SavedSearchMatchReaderLive = Layer.succeed(SavedSearchMatchReader, make())

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -45,7 +45,7 @@ import { TRACE_FIELD_REGISTRY } from "../registries/trace-fields.ts"
 import { buildScoreRollupSubquery, splitScoreFilters } from "../score-filter-subquery.ts"
 import { isActiveSearch, planSearch } from "./search-plan.ts"
 
-const LIST_SELECT = `
+export const LIST_SELECT = `
   organization_id,
   project_id,
   trace_id,
@@ -314,7 +314,7 @@ const SORT_COLUMNS: Record<string, SortColumn> = {
   spans: { expr: "span_count", chType: "UInt64", rowKey: "span_count" },
 }
 
-function buildTraceFilterClauses(
+export function buildTraceFilterClauses(
   filters: FilterSet | undefined,
   options?: {
     readonly paramPrefix?: string

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
@@ -465,3 +465,103 @@ describe("AlertIncidentRepositoryLive.listByMonitorAlertId", () => {
     expect(result.nextCursor).toBeNull()
   })
 })
+
+describe("AlertIncidentRepositoryLive monitor-alert lookups (saved-search firing)", () => {
+  let database: InMemoryPostgres
+  const alertA = MonitorAlertId("1a".padEnd(24, "0"))
+  const alertB = MonitorAlertId("1b".padEnd(24, "0"))
+
+  beforeAll(async () => {
+    database = await createInMemoryPostgres()
+  })
+
+  beforeEach(async () => {
+    await database.db.delete(alertIncidentsTable)
+  })
+
+  afterAll(async () => {
+    await closeInMemoryPostgres(database)
+  })
+
+  it("findOpenByMonitorAlertId returns the open incident and null when only closed rows exist", async () => {
+    const open = makeRow({
+      id: AlertIncidentId("1".repeat(24)),
+      sourceId: "1".repeat(24),
+      monitorAlertId: alertA,
+      endedAt: null,
+    })
+    const closed = makeRow({
+      id: AlertIncidentId("2".repeat(24)),
+      sourceId: "2".repeat(24),
+      monitorAlertId: alertB,
+      endedAt: new Date("2026-05-07T12:00:00.000Z"),
+    })
+    // Another org's open row for the same alert id must stay invisible under RLS.
+    const otherOrg = makeRow({
+      id: AlertIncidentId("3".repeat(24)),
+      sourceId: "3".repeat(24),
+      organizationId: otherOrganizationId,
+      monitorAlertId: alertA,
+      endedAt: null,
+    })
+    await database.db.insert(alertIncidentsTable).values([open, closed, otherOrg])
+
+    const found = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        return yield* repository.findOpenByMonitorAlertId(alertA)
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+    expect(found?.id).toEqual(open.id)
+
+    const none = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        return yield* repository.findOpenByMonitorAlertId(alertB)
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+    expect(none).toBeNull()
+  })
+
+  it("existsByMonitorAlertId is true for any prior incident (open or closed)", async () => {
+    await database.db.insert(alertIncidentsTable).values([
+      makeRow({
+        id: AlertIncidentId("1".repeat(24)),
+        sourceId: "1".repeat(24),
+        monitorAlertId: alertA,
+        endedAt: new Date("2026-05-07T12:00:00.000Z"),
+      }),
+    ])
+
+    const [spent, fresh] = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        return [
+          yield* repository.existsByMonitorAlertId(alertA),
+          yield* repository.existsByMonitorAlertId(alertB),
+        ] as const
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+    expect(spent).toBe(true)
+    expect(fresh).toBe(false)
+  })
+
+  it("setEndedAt closes a specific incident by id", async () => {
+    const open = makeRow({
+      id: AlertIncidentId("1".repeat(24)),
+      sourceId: "1".repeat(24),
+      monitorAlertId: alertA,
+      endedAt: null,
+    })
+    await database.db.insert(alertIncidentsTable).values([open])
+
+    const stillOpen = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        yield* repository.setEndedAt({ id: open.id as AlertIncidentId, endedAt: new Date("2026-05-07T13:00:00.000Z") })
+        return yield* repository.findOpenByMonitorAlertId(alertA)
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+    expect(stillOpen).toBeNull()
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -147,6 +147,52 @@ export const AlertIncidentRepositoryLive = Layer.effect(
               .where(and(eq(alertIncidents.id, id), eq(alertIncidents.organizationId, sqlClient.organizationId))),
           )
         }),
+      findOpenByMonitorAlertId: (monitorAlertId) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select()
+              .from(alertIncidents)
+              .where(
+                and(
+                  eq(alertIncidents.organizationId, sqlClient.organizationId),
+                  eq(alertIncidents.monitorAlertId, monitorAlertId),
+                  isNull(alertIncidents.endedAt),
+                ),
+              )
+              .limit(1),
+          )
+          const row = rows[0]
+          return row ? toDomain(row) : null
+        }),
+      existsByMonitorAlertId: (monitorAlertId) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({ id: alertIncidents.id })
+              .from(alertIncidents)
+              .where(
+                and(
+                  eq(alertIncidents.organizationId, sqlClient.organizationId),
+                  eq(alertIncidents.monitorAlertId, monitorAlertId),
+                ),
+              )
+              .limit(1),
+          )
+          return rows.length > 0
+        }),
+      setEndedAt: ({ id, endedAt }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient.query((db) =>
+            db
+              .update(alertIncidents)
+              .set({ endedAt })
+              .where(and(eq(alertIncidents.id, id), eq(alertIncidents.organizationId, sqlClient.organizationId))),
+          )
+        }),
       listByProjectId: ({ organizationId, projectId, from, to, sourceTypes, sourceId, kinds, severities }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1056,6 +1056,183 @@ describe("MonitorRepositoryLive", () => {
       expect(await resolve({ kind: "issue.new", sourceId: "z".repeat(24) })).toEqual([])
     })
   })
+
+  describe("saved-search firing reads", () => {
+    const searchX = "x".repeat(24)
+    const searchY = "y".repeat(24)
+    const provideAdmin = (database: InMemoryPostgres) =>
+      withPostgres(MonitorRepositoryLive, database.adminPostgresClient)
+
+    it("listActiveSavedSearchAlerts returns only live savedSearch alerts in the project", async () => {
+      const live = generateId()
+      const otherProject = generateId()
+      await database.db
+        .insert(monitorsTable)
+        .values([
+          makeMonitorRow({ id: live, slug: "live", name: "Live" }),
+          makeMonitorRow({ id: otherProject, slug: "other", name: "Other", projectId: otherProjectId as string }),
+        ])
+      await database.db.insert(monitorAlertsTable).values([
+        makeAlertRow({ id: "1".repeat(24), monitorId: live, sourceId: searchX }),
+        // soft-deleted alert — excluded.
+        makeAlertRow({ id: "2".repeat(24), monitorId: live, sourceId: searchY, deletedAt: new Date() }),
+        // issue-kind alert (different source type) — excluded.
+        makeAlertRow({ id: "3".repeat(24), monitorId: live, kind: "issue.new", sourceType: "issue", sourceId: null }),
+        // alert in another project — excluded.
+        makeAlertRow({ id: "4".repeat(24), monitorId: otherProject, sourceId: searchX }),
+      ])
+
+      const alerts = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* repository.listActiveSavedSearchAlerts(projectId)
+        }).pipe(provideRls(database, organizationId)),
+      )
+      expect(alerts.map((a: MonitorAlert) => a.id)).toEqual([MonitorAlertId("1".repeat(24))])
+    })
+
+    it("listProjectsWithActiveSavedSearchAlerts returns distinct (org, project) pairs across orgs", async () => {
+      const a = generateId()
+      const b = generateId()
+      const other = generateId()
+      await database.db.insert(monitorsTable).values([
+        makeMonitorRow({ id: a, slug: "a", name: "A" }),
+        makeMonitorRow({ id: b, slug: "b", name: "B" }), // same org+project as a → de-duped
+        makeMonitorRow({
+          id: other,
+          slug: "c",
+          name: "C",
+          organizationId: otherOrganizationId as string,
+          projectId: otherProjectId as string,
+        }),
+      ])
+      await database.db.insert(monitorAlertsTable).values([
+        makeAlertRow({ id: "1".repeat(24), monitorId: a, sourceId: searchX }),
+        makeAlertRow({ id: "2".repeat(24), monitorId: b, sourceId: searchY }),
+        makeAlertRow({
+          id: "3".repeat(24),
+          monitorId: other,
+          organizationId: otherOrganizationId as string,
+          sourceId: searchX,
+        }),
+      ])
+
+      const pairs = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* repository.listProjectsWithActiveSavedSearchAlerts()
+        }).pipe(provideAdmin(database)),
+      )
+      expect(pairs.map((p) => `${p.organizationId}:${p.projectId}`).sort()).toEqual(
+        [`${organizationId}:${projectId}`, `${otherOrganizationId}:${otherProjectId}`].sort(),
+      )
+    })
+
+    it("cascadeSourceDeletion soft-deletes matching alerts and prunes emptied monitors", async () => {
+      const onlyX = generateId()
+      const mixed = generateId()
+      await database.db
+        .insert(monitorsTable)
+        .values([
+          makeMonitorRow({ id: onlyX, slug: "only-x", name: "Only X" }),
+          makeMonitorRow({ id: mixed, slug: "mixed", name: "Mixed" }),
+        ])
+      await database.db
+        .insert(monitorAlertsTable)
+        .values([
+          makeAlertRow({ id: "1".repeat(24), monitorId: onlyX, sourceId: searchX }),
+          makeAlertRow({ id: "2".repeat(24), monitorId: onlyX, sourceId: searchX }),
+          makeAlertRow({ id: "3".repeat(24), monitorId: mixed, sourceId: searchX }),
+          makeAlertRow({ id: "4".repeat(24), monitorId: mixed, sourceId: searchY }),
+        ])
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          return yield* repository.cascadeSourceDeletion({ sourceType: "savedSearch", sourceId: searchX })
+        }).pipe(provideRls(database, organizationId)),
+      )
+      expect(result).toEqual({ deletedAlertCount: 3, deletedMonitorCount: 1 })
+
+      const onlyXRow = await database.db.select().from(monitorsTable).where(eq(monitorsTable.id, onlyX))
+      const mixedRow = await database.db.select().from(monitorsTable).where(eq(monitorsTable.id, mixed))
+      expect(onlyXRow[0]?.deletedAt).not.toBeNull()
+      expect(mixedRow[0]?.deletedAt).toBeNull()
+    })
+  })
+
+  describe("soft-delete silently closes open incidents", () => {
+    const alertId = MonitorAlertId("aa".padEnd(24, "0"))
+    const openId = AlertIncidentId("1".repeat(24))
+    const closedId = AlertIncidentId("2".repeat(24))
+    const sourceId = "s".repeat(24)
+    const priorEndedAt = new Date("2026-06-01T10:00:00.000Z")
+
+    const incidentRow = (
+      id: typeof openId,
+      monitorAlertId: typeof alertId,
+      endedAt: Date | null,
+    ): typeof alertIncidentsTable.$inferInsert => ({
+      id,
+      organizationId: organizationId as string,
+      projectId: projectId as string,
+      sourceType: "savedSearch",
+      sourceId,
+      kind: "savedSearch.escalating",
+      severity: "high",
+      startedAt: new Date("2026-06-01T09:00:00.000Z"),
+      endedAt,
+      monitorAlertId,
+    })
+
+    const seed = async (monitorId: string) => {
+      await database.db.insert(monitorsTable).values([makeMonitorRow({ id: monitorId, slug: "m", name: "M" })])
+      await database.db.insert(monitorAlertsTable).values([makeAlertRow({ id: alertId, monitorId, sourceId })])
+      await database.db
+        .insert(alertIncidentsTable)
+        .values([incidentRow(openId, alertId, null), incidentRow(closedId, alertId, priorEndedAt)])
+    }
+
+    const endedAtOf = async (id: typeof openId): Promise<Date | null> => {
+      const rows = await database.db.select().from(alertIncidentsTable).where(eq(alertIncidentsTable.id, id))
+      return rows[0]?.endedAt ?? null
+    }
+
+    it("softDeleteAlert closes the alert's open incident and leaves closed ones untouched", async () => {
+      await seed(generateId())
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          yield* repository.softDeleteAlert(alertId)
+        }).pipe(provideRls(database, organizationId)),
+      )
+      expect(await endedAtOf(openId)).not.toBeNull()
+      expect(await endedAtOf(closedId)).toEqual(priorEndedAt)
+    })
+
+    it("softDelete (monitor) closes open incidents of its cascaded alerts", async () => {
+      const monitorId = generateId()
+      await seed(monitorId)
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          yield* repository.softDelete(MonitorId(monitorId))
+        }).pipe(provideRls(database, organizationId)),
+      )
+      expect(await endedAtOf(openId)).not.toBeNull()
+    })
+
+    it("cascadeSourceDeletion closes open incidents of the soft-deleted alerts", async () => {
+      await seed(generateId())
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* MonitorRepository
+          yield* repository.cascadeSourceDeletion({ sourceType: "savedSearch", sourceId })
+        }).pipe(provideRls(database, organizationId)),
+      )
+      expect(await endedAtOf(openId)).not.toBeNull()
+    })
+  })
 })
 
 describe("MonitorRepositoryLive searchOrgWide", () => {

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -6,7 +6,14 @@ import {
   type MonitorSearchResult,
   monitorSchema,
 } from "@domain/monitors"
-import { type MonitorId, NotFoundError, type ProjectId, SqlClient, type SqlClientShape } from "@domain/shared"
+import {
+  type MonitorId,
+  NotFoundError,
+  type OrganizationId,
+  type ProjectId,
+  SqlClient,
+  type SqlClientShape,
+} from "@domain/shared"
 import { and, asc, count, desc, eq, getTableColumns, ilike, inArray, isNull, max, ne, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
@@ -70,6 +77,30 @@ const toMonitorAlertRow = (
   severity: alert.severity,
   createdAt: alert.createdAt,
 })
+
+/**
+ * Silent-close (no `IncidentClosed` event) every open incident fired by the given
+ * alerts, in the caller's soft-delete transaction — otherwise a removed alert's
+ * sustained incident would linger "ongoing" forever (the firing scan skips it).
+ */
+const closeOpenIncidentsForAlerts = async (
+  db: Operator,
+  organizationId: Monitor["organizationId"],
+  alertIds: readonly string[],
+  now: Date,
+): Promise<void> => {
+  if (alertIds.length === 0) return
+  await db
+    .update(alertIncidents)
+    .set({ endedAt: now })
+    .where(
+      and(
+        eq(alertIncidents.organizationId, organizationId),
+        inArray(alertIncidents.monitorAlertId, alertIds),
+        isNull(alertIncidents.endedAt),
+      ),
+    )
+}
 
 const groupAlertsByMonitorId = (
   rows: readonly (typeof monitorAlerts.$inferSelect)[],
@@ -397,10 +428,11 @@ export const MonitorRepositoryLive = Layer.effect(
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const { organizationId } = sqlClient
-          const updated = yield* sqlClient.query((db) =>
-            db
+          const updated = yield* sqlClient.query(async (db) => {
+            const now = new Date()
+            const rows = await db
               .update(monitorAlerts)
-              .set({ deletedAt: new Date() })
+              .set({ deletedAt: now })
               .where(
                 and(
                   eq(monitorAlerts.organizationId, organizationId),
@@ -408,8 +440,10 @@ export const MonitorRepositoryLive = Layer.effect(
                   isNull(monitorAlerts.deletedAt),
                 ),
               )
-              .returning({ id: monitorAlerts.id }),
-          )
+              .returning({ id: monitorAlerts.id })
+            if (rows.length > 0) await closeOpenIncidentsForAlerts(db, organizationId, [alertId], now)
+            return rows
+          })
           if (updated.length === 0) return yield* new NotFoundError({ entity: "MonitorAlert", id: alertId })
         }),
       setMuted: ({ id, mutedAt }) =>
@@ -440,7 +474,7 @@ export const MonitorRepositoryLive = Layer.effect(
               .where(and(eq(monitors.organizationId, organizationId), eq(monitors.id, id), isNull(monitors.deletedAt)))
               .returning({ id: monitors.id })
             if (rows.length > 0) {
-              await db
+              const cascadedAlerts = await db
                 .update(monitorAlerts)
                 .set({ deletedAt: now })
                 .where(
@@ -450,6 +484,13 @@ export const MonitorRepositoryLive = Layer.effect(
                     isNull(monitorAlerts.deletedAt),
                   ),
                 )
+                .returning({ id: monitorAlerts.id })
+              await closeOpenIncidentsForAlerts(
+                db,
+                organizationId,
+                cascadedAlerts.map((alert) => alert.id),
+                now,
+              )
             }
             return rows
           })
@@ -511,6 +552,121 @@ export const MonitorRepositoryLive = Layer.effect(
               ),
           )
           return rows.map(toMonitorAlert)
+        }),
+      lockAlertForUpdate: (alertId) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // FOR UPDATE on the alert row so the one-time-threshold read-then-insert
+          // is serialised against a concurrent worker tick. No row → no lock taken
+          // (the caller already loaded the alert; absence is handled there).
+          yield* sqlClient.query((db) =>
+            db
+              .select({ id: monitorAlerts.id })
+              .from(monitorAlerts)
+              .where(and(eq(monitorAlerts.organizationId, sqlClient.organizationId), eq(monitorAlerts.id, alertId)))
+              .for("update"),
+          )
+        }),
+      listActiveSavedSearchAlerts: (projectId) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // `source_type = 'savedSearch'` already selects exactly the savedSearch.* kinds.
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select(getTableColumns(monitorAlerts))
+              .from(monitorAlerts)
+              .innerJoin(monitors, eq(monitors.id, monitorAlerts.monitorId))
+              .where(
+                and(
+                  eq(monitorAlerts.organizationId, sqlClient.organizationId),
+                  eq(monitors.projectId, projectId),
+                  eq(monitorAlerts.sourceType, "savedSearch"),
+                  isNull(monitorAlerts.deletedAt),
+                  isNull(monitors.deletedAt),
+                ),
+              ),
+          )
+          return rows.map(toMonitorAlert)
+        }),
+      listProjectsWithActiveSavedSearchAlerts: () =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // No org filter — cross-org sweep on the admin client.
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .selectDistinct({ organizationId: monitorAlerts.organizationId, projectId: monitors.projectId })
+              .from(monitorAlerts)
+              .innerJoin(monitors, eq(monitors.id, monitorAlerts.monitorId))
+              .where(
+                and(
+                  eq(monitorAlerts.sourceType, "savedSearch"),
+                  isNull(monitorAlerts.deletedAt),
+                  isNull(monitors.deletedAt),
+                ),
+              ),
+          )
+          return rows.map((row) => ({
+            organizationId: row.organizationId as OrganizationId,
+            projectId: row.projectId as ProjectId,
+          }))
+        }),
+      cascadeSourceDeletion: ({ sourceType, sourceId }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient.transaction(
+            Effect.gen(function* () {
+              const now = new Date()
+              const deleted = yield* sqlClient.query((db) =>
+                db
+                  .update(monitorAlerts)
+                  .set({ deletedAt: now, updatedAt: now })
+                  .where(
+                    and(
+                      eq(monitorAlerts.organizationId, sqlClient.organizationId),
+                      eq(monitorAlerts.sourceType, sourceType),
+                      eq(monitorAlerts.sourceId, sourceId),
+                      isNull(monitorAlerts.deletedAt),
+                    ),
+                  )
+                  .returning({ id: monitorAlerts.id, monitorId: monitorAlerts.monitorId }),
+              )
+
+              yield* sqlClient.query((db) =>
+                closeOpenIncidentsForAlerts(
+                  db,
+                  sqlClient.organizationId,
+                  deleted.map((alert) => alert.id),
+                  now,
+                ),
+              )
+
+              let deletedMonitorCount = 0
+              for (const monitorId of new Set(deleted.map((row) => row.monitorId))) {
+                const remaining = yield* sqlClient.query((db) =>
+                  db
+                    .select({ value: count() })
+                    .from(monitorAlerts)
+                    .where(and(eq(monitorAlerts.monitorId, monitorId), isNull(monitorAlerts.deletedAt))),
+                )
+                if (Number(remaining[0]?.value ?? 0) > 0) continue
+                yield* sqlClient.query((db) =>
+                  db
+                    .update(monitors)
+                    .set({ deletedAt: now, updatedAt: now })
+                    .where(
+                      and(
+                        eq(monitors.id, monitorId),
+                        eq(monitors.organizationId, sqlClient.organizationId),
+                        isNull(monitors.deletedAt),
+                      ),
+                    ),
+                )
+                deletedMonitorCount += 1
+              }
+
+              return { deletedAlertCount: deleted.length, deletedMonitorCount }
+            }),
+          )
         }),
       countActiveBySlug: ({ projectId, slug, excludeId }) =>
         Effect.gen(function* () {

--- a/packages/platform/db-postgres/src/schema/alert-incidents.ts
+++ b/packages/platform/db-postgres/src/schema/alert-incidents.ts
@@ -1,4 +1,4 @@
-import type { AlertIncidentKind, AlertIncidentSourceType, AlertSeverity, EntrySignalsSnapshot } from "@domain/alerts"
+import type { AlertIncidentKind, AlertIncidentSourceType, AlertSeverity, IncidentEntrySignals } from "@domain/alerts"
 import type { AlertIncidentCondition } from "@domain/shared"
 import { sql } from "drizzle-orm"
 import { index, jsonb, varchar } from "drizzle-orm/pg-core"
@@ -17,10 +17,9 @@ export const alertIncidents = latitudeSchema.table(
     startedAt: tzTimestamp("started_at").notNull(),
     endedAt: tzTimestamp("ended_at"),
     createdAt: tzTimestamp("created_at").defaultNow().notNull(),
-    // Frozen at entry for `issue.escalating` incidents so the close-side detector
-    // can compare against the conditions that tripped open. `NULL` for legacy rows
-    // and for kinds that don't escalate (`issue.new`, `issue.regressed`).
-    entrySignals: jsonb("entry_signals").$type<EntrySignalsSnapshot>(),
+    // Entry snapshot for sustained incidents (seasonal for `issue.escalating`,
+    // frozen threshold for `savedSearch.escalating`); `NULL` otherwise. Narrowed per-kind on read.
+    entrySignals: jsonb("entry_signals").$type<IncidentEntrySignals>(),
     // Marks when the band-shape exit condition first started holding. Cleared
     // back to NULL whenever it fails again. Once `now - exitEligibleSince` clears
     // the dwell threshold, the incident is closed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1136,6 +1136,9 @@ importers:
       '@domain/notifications':
         specifier: workspace:*
         version: link:../notifications
+      '@domain/saved-searches':
+        specifier: workspace:*
+        version: link:../saved-searches
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1294,6 +1297,9 @@ importers:
       '@domain/notifications':
         specifier: workspace:*
         version: link:../notifications
+      '@domain/saved-searches':
+        specifier: workspace:*
+        version: link:../saved-searches
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1392,9 +1398,21 @@ importers:
       '@domain/alerts':
         specifier: workspace:*
         version: link:../alerts
+      '@domain/events':
+        specifier: workspace:*
+        version: link:../events
+      '@domain/issues':
+        specifier: workspace:*
+        version: link:../issues
       '@domain/notifications':
         specifier: workspace:*
         version: link:../notifications
+      '@domain/queue':
+        specifier: workspace:*
+        version: link:../queue
+      '@domain/saved-searches':
+        specifier: workspace:*
+        version: link:../saved-searches
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1915,6 +1933,9 @@ importers:
       '@domain/events':
         specifier: workspace:*
         version: link:../../domain/events
+      '@domain/monitors':
+        specifier: workspace:*
+        version: link:../../domain/monitors
       '@domain/scores':
         specifier: workspace:*
         version: link:../../domain/scores

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -1419,26 +1419,40 @@ Scope is intentionally left open — the exact polish items are decided when the
 
 ### Milestone 7 — Saved-search firing pipeline
 
-> Branch: `LAT-630/saved-search-firing` · Estimated size: ~2,800 lines
+> Branch: `LAT-630/saved-search-firing` · One PR (per the milestone-per-PR convention) · ~3,500 lines incl. tests.
 
 **Goal:** With the flag on, a monitor with a `savedSearch.*` alert fires incidents that land in the details panel and route through the notifications pipeline (subject to mute). Three distinct state machines (threshold one-time, escalating sustained, match) on top of one shared pure evaluator. No new columns on `alert_incidents` — the schema additions in M2 cover everything.
 
-- [ ] New worker file `apps/workers/src/workers/monitors.ts`:
-  - `checkSavedSearchMonitorsTask` — orchestrator handler, called by both trigger paths.
-  - Sweep cron registration: 5-minute interval, scans active alerts + open sustained incidents.
-- [ ] Trace-end hook: publish `monitors:checkSavedSearchMonitors` with the queue's `throttleMs: 5 * 60 * 1000` option (per-org throttle key).
-- [ ] `evaluateSavedSearchAlert` in `@domain/monitors` — pure evaluator returning `{ isMet, count, threshold, firstMatchInWindow, baselineCount? }`. Drives all state machines across all three threshold modes (absolute, multiplier, expected). Reuses the trace repo's count + match primitives.
-- [ ] **`expected`-mode threshold**: wire the seasonal detector (`evaluateSeasonalEscalation` from `@domain/issues`) for saved searches — feed it the saved-search match counts (per day-of-week × hour-of-day grid) instead of issue occurrences, tuned by `condition.threshold.sensitivity`. Finalise here how the user-facing "N times more than expected" amount maps onto the detector's σ-multiplier. Works for both threshold (5-min current window) and escalating (sustained `window`). Snapshot the seasonal signals onto `entrySignals` exactly as `issue.escalating` does.
-- [ ] Three state-machine use-cases:
-  - `runSavedSearchThresholdAlert` — handles all modes:
-    - Absolute: one-time. Short-circuits on any prior incident for the monitor alert. Read-then-insert wrapped in a transaction with `SELECT … FOR UPDATE` on the `monitor_alerts` row.
-    - Multiplier / expected: rearming. Reuses `alert_incidents` rows as state — opens with `endedAt = null` on the rising edge (emits `IncidentCreated`); silently closes (`endedAt = now`, no event emit) when the condition stops holding. Single point-in-time notification per rising edge.
-  - `runSavedSearchEscalatingAlert` — sustained, mirrors `issue.escalating`'s open/exit-eligible/reset/close transitions. Snapshots `entrySignals` at the open transition (`{ evaluatedThreshold, baselineCount?, baseline? }` for multiplier; the frozen seasonal signals for expected — baseline frozen at entry either way).
-  - `runSavedSearchMatchAlert` — literal throttle. If `evaluateSavedSearchAlert` reports `count > 0`, insert one point-in-time incident with `startedAt = endedAt = firstMatchInWindow`. No prior-incident check, no new state on `monitor_alerts`. The queue's `throttleMs` is the rate-limiter.
-- [ ] All three writers stamp `monitor_alert_id`, `condition` snapshot, and `severity` on the new `alert_incidents` row; `startedAt` is backtracked to the first matching trace in the look-back window.
-- [ ] `monitors:onSourceDeleted` task — wired from saved-search delete and issue delete events; **soft-deletes** matching `monitor_alerts` (`deleted_at = now()`); soft-deletes the monitor if its active alert list becomes empty.
-- [ ] No abstraction over issue.escalating and saved-search kinds at the use-case level — parallel implementations sharing only the storage shape and trigger plumbing. The one deliberate share is the detector: `evaluateSeasonalEscalation` stays owned by `@domain/issues` and is imported by `@domain/monitors`'s `evaluateSavedSearchAlert` for the `expected` mode (fed saved-search counts instead of issue occurrences).
-- [ ] Backend tests: each state machine and each threshold mode (absolute, multiplier, **expected**) independently; backtracked `startedAt`; multiplier/expected baseline frozen at entry; `isMet` flapping during dwell resets `exitEligibleSince`; threshold short-circuit after prior fire; sweep cron closes incidents in low-traffic orgs.
+**Domain core:**
+
+- [x] `evaluateSavedSearchAlert` in `@domain/monitors` — pure evaluator (modulo the `SavedSearchMatchReader` IO) returning `{ isMet, count, threshold, firstMatchInWindow, baselineCount? }`. Handles all three threshold modes (absolute, multiplier, expected) across `savedSearch.match` / `.threshold` / `.escalating`. Multiplier guards against a zero baseline (`count > 0` required). Current window: 5 min (match / threshold-multiplier), cumulative since the alert (threshold-absolute), or the user `window` (escalating).
+- [x] **`SavedSearchMatchReader`** port (`@domain/monitors`) + `SavedSearchMatchReaderLive` (`@platform/db-clickhouse`) — `countMatches` / `firstMatchAt` over `[from, to)`, reusing the trace count machinery (`LIST_SELECT` + `buildTraceFilterClauses` + `planSearch`) with the window applied as a `HAVING` on the aggregated `start_time`. A dedicated reader port (not a `TraceRepository` widening) keeps the firing concern off the broadly-stubbed trace port — mirrors M6's `IncidentMonitorReader`.
+- [x] Three state-machine use-cases (`runSavedSearchThresholdAlert` / `runSavedSearchEscalatingAlert` / `runSavedSearchMatchAlert`), keyed on **`monitor_alert_id`** (one saved search can back several alerts):
+  - Threshold absolute: one-time; `existsByMonitorAlertId` short-circuit + `MonitorRepository.lockAlertForUpdate` (`FOR UPDATE`) inside one transaction.
+  - Threshold multiplier: rearm via the incident row — opens with `endedAt = null` (one `IncidentCreated`), silently closes (no event) when it drops. Re-evaluated fresh each tick (it's point-in-time; `entrySignals` stays `null`).
+  - Escalating: sustained open/exit-eligible/reset/close; freezes the threshold into `entrySignals` at open and compares the live count against the **frozen** value (never re-resolving `factor × baseline` or the seasonal band).
+  - Match: point-in-time at the first match; no prior-incident check, no new state.
+- [x] Writers stamp `monitor_alert_id`, `condition` snapshot, `severity`; `startedAt` backtracked to `firstMatchInWindow`. Shared `saved-search-incident-writer.ts` does insert + `IncidentCreated`; sustained close emits `IncidentClosed`.
+- [x] `AlertIncidentRepository` lookups: `findOpenByMonitorAlertId`, `existsByMonitorAlertId`, `setEndedAt`; `MonitorRepository.lockAlertForUpdate`.
+- [x] **`entrySignals` polymorphism** — widened the entity column to `issue (seasonal) | savedSearch ({ evaluatedThreshold, baselineCount?, baseline? })`, narrowed per-kind at the read sites (`isIssueEscalationEntrySignals` / `isSavedSearchEntrySignals`).
+
+**`expected`-mode threshold:**
+
+- [x] The seasonally-learned band, reusing the issue detector's threshold math. The evaluator samples the **same-time-of-week** window across the last `SEASONAL_HISTORY_WEEKS` (4) weeks via `countMatches`, computes `expected`/`stddev`/`samplesCount`, then applies `seasonalAnomalyThreshold(expected, stddev, kAdj)` — **extracted from and shared with `@domain/issues`** (the one deliberate cross-domain detector share). `threshold = expected + kAdj·σ`; `isMet = count > threshold` (strict, mirroring the detector entry). Works for threshold (5-min window) and escalating (the `window`); the frozen threshold is snapshotted into `entrySignals` so the close-side compares against the entry band.
+  > **As-built:** the spec originally said "feed saved-search counts into `evaluateSeasonalEscalation`." That function is issue-shaped (dual 1h/6h windows with an AND), so instead the shared piece is the σ-band **threshold formula** (`seasonalAnomalyThreshold`), applied to a single current window aligned to its time-of-week across prior weeks — no new ClickHouse query needed (the existing windowed `countMatches` covers it; the `±hour` pooling grid the issue path uses over `scores_hourly_buckets` is not replicated). The user-facing "N times more than expected" amount maps to the detector's `sensitivity` (σ-multiplier `k`, default 3).
+
+**Pipeline & wiring:**
+
+- [x] New worker file `apps/workers/src/workers/monitors.ts`:
+  - `checkSavedSearchMonitors` — orchestrator handler (org+project scoped, flag-gated): lists active saved-search alerts, resolves each saved search, dispatches to the right state machine. Per-alert failures isolated + tallied so one bad alert can't trigger a retry that re-fires `match` incidents.
+  - `sweepSavedSearchMonitors` — 5-minute cron; fans out one `checkSavedSearchMonitors` per (org, project) holding an active saved-search alert (cross-org via the admin client). Opens incidents in low-traffic orgs and lets sustained ones close on quiet traffic.
+  - `onSourceDeleted` — the source cascade.
+- [x] Trace-end hook: publish `monitors:checkSavedSearchMonitors` with the queue's `throttleMs: 5 * 60 * 1000` option (org-prefixed per-project dedupe key).
+- [x] `monitors:onSourceDeleted` task — wired from a new `SavedSearchDeleted` domain event (emitted by `deleteSavedSearch`, routed in `domain-events.ts`); **soft-deletes** matching `monitor_alerts` (`deleted_at = now()`) and soft-deletes the monitor if its active alert list becomes empty. (Issue-delete needs no cascade: issue alerts are system-only with `source.id = null`.)
+- [x] **Any** alert soft-delete — manual (`deleteMonitorAlert`), monitor-cascade (`deleteMonitor`), or source-cascade (above) — **silently closes that alert's open incidents** in the same repo transaction (`ended_at = now()`, no `IncidentClosed` event, since the alert is gone). Without this a sustained incident would render "ongoing" forever (the firing scan skips soft-deleted alerts, so it'd never re-evaluate to close). Point-in-time incidents already have `ended_at`, so only sustained / rearm-open rows are touched.
+- [x] Backend tests: evaluator (absolute / multiplier average + period normalisation / match / zero-baseline / **expected** cold-start + history), each state machine (short-circuit, rearm, silent close, dwell open/eligible/cancel/close, frozen-threshold comparison, expected-escalating freeze, backtracked `startedAt`), orchestrator dispatch + skip-deleted-source, sweep fan-out + failure tally, source cascade; repo lookups + new `MonitorRepository` reads (PGlite); the windowed reader (chdb).
+
+> **As-built deviations from the original task list:** (1) absolute-threshold "cumulative since creation" anchors on **`alert.createdAt`**, not `monitor.createdAt` — makes "remove and re-add to re-arm" reset the count; (2) match counting goes through a dedicated `SavedSearchMatchReader`, not `TraceRepository` (avoids touching its ~17 stubs); (3) the `monitors` queue carries three tasks (`checkSavedSearchMonitors` / `sweepSavedSearchMonitors` / `onSourceDeleted`); the orchestrator gates on the `monitors` flag in the worker, not the use-case.
 
 ### Milestone 8 — Fold `/search` into the `/` page tabs, retire the standalone route
 


### PR DESCRIPTION
## Milestone 7 — Saved-search firing pipeline [LAT-630]

With the `monitors` flag enabled, a monitor's `savedSearch.*` alert now fires incidents that land in the details panel and route through the existing notifications pipeline (subject to mute). Builds on the issue-event path (M6); no schema changes beyond M2.

> One PR for the whole milestone, as agreed. Safe to merge to `development` to test behind the flag — flag-off orgs are unaffected.

### What's in it

**Evaluator + state machines** (`@domain/monitors`)
- `evaluateSavedSearchAlert` — all three threshold modes (absolute / multiplier / expected) across `match` / `threshold` / `escalating`.
- Three state machines keyed on `monitor_alert_id` (one search can back several alerts):
  - **threshold** — absolute one-time (`FOR UPDATE` lock + prior-incident short-circuit) and multiplier rearm (one `IncidentCreated` on the rising edge, silent close on drop).
  - **escalating** — sustained open / dwell / close mirroring `issue.escalating`; threshold frozen into `entrySignals` at open so a drifting baseline can't pin it open.
  - **match** — point-in-time at the first match; the queue throttle is the rate limiter.

**`expected` mode**
- Reuses the issue detector's σ-band threshold (`seasonalAnomalyThreshold`, extracted from and shared with `@domain/issues`) over the same-time-of-week window across the last `SEASONAL_HISTORY_WEEKS`. No new ClickHouse query.

**Pipeline & wiring**
- New `monitors` worker: throttled `checkSavedSearchMonitors` (published per project on trace-end), a 5-minute `sweepSavedSearchMonitors` cron, and `onSourceDeleted`.
- `SavedSearchMatchReader` (ClickHouse) for windowed match counts + first match.
- `SavedSearchDeleted` event → source cascade: soft-deletes the watching alerts, prunes emptied monitors, and **silently closes their open incidents** (any alert soft-delete now closes open incidents, so nothing lingers "ongoing").

**Misc**
- `alert_incidents.entrySignals` widened to a per-kind union (issue seasonal | saved-search frozen threshold), narrowed at the read site.
- Web: a deleted incident source renders an italic *"Deleted &lt;type&gt;"* in the monitor incidents table instead of a raw id.

### Notable decisions (flagged for review)
- Absolute-threshold cumulative count anchors on **`alert.createdAt`**, not `monitor.createdAt` — makes "remove & re-add to re-arm" reset the count.
- `expected` mode shares the detector's **threshold formula** rather than feeding counts into the issue-shaped `evaluateSeasonalEscalation` (dual-window, doesn't map). See the as-built note in `specs/monitors.md`.
- Match counting uses a dedicated `SavedSearchMatchReader` rather than widening `TraceRepository` (avoids touching its ~17 stubs; mirrors M6's `IncidentMonitorReader`).

### Testing
Backend-only (per the spec). Evaluator (all modes incl. expected cold-start + history), each state machine (short-circuit / rearm / silent close / dwell transitions / frozen-threshold / backtracked `startedAt`), orchestrator / sweep / cascade, incident-close-on-delete; PGlite repo tests + a chdb reader test. Full workspace typecheck, knip, and biome are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
