### PR TITLE
fix(issues): close escalation on resolve/ignore and add cold-start exit

### DIFF
--- a/apps/api/src/routes/issues.ts
+++ b/apps/api/src/routes/issues.ts
@@ -193,7 +193,13 @@ const buildLifecycleEndpoint = ({
           })
         }).pipe(
           withPostgres(
-            Layer.mergeAll(ProjectRepositoryLive, IssueRepositoryLive, EvaluationRepositoryLive, SettingsReaderLive),
+            Layer.mergeAll(
+              ProjectRepositoryLive,
+              IssueRepositoryLive,
+              EvaluationRepositoryLive,
+              OutboxEventWriterLive,
+              SettingsReaderLive,
+            ),
             c.var.postgresClient,
             organizationId,
           ),

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -33,6 +33,7 @@ import { ScoreAnalyticsRepositoryLive, TraceRepositoryLive, withClickHouse } fro
 import {
   EvaluationRepositoryLive,
   IssueRepositoryLive,
+  OutboxEventWriterLive,
   ScoreRepositoryLive,
   SettingsReaderLive,
   withPostgres,
@@ -619,7 +620,7 @@ export const applyIssueLifecycleAction = createServerFn({ method: "POST" })
         keepMonitoring: data.keepMonitoring,
       }).pipe(
         withPostgres(
-          Layer.mergeAll(IssueRepositoryLive, EvaluationRepositoryLive, SettingsReaderLive),
+          Layer.mergeAll(IssueRepositoryLive, EvaluationRepositoryLive, OutboxEventWriterLive, SettingsReaderLive),
           pgClient,
           orgId,
         ),
@@ -745,7 +746,7 @@ export const applyBulkIssueLifecycleAction = createServerFn({ method: "POST" })
         keepMonitoring: data.keepMonitoring,
       }).pipe(
         withPostgres(
-          Layer.mergeAll(IssueRepositoryLive, EvaluationRepositoryLive, SettingsReaderLive),
+          Layer.mergeAll(IssueRepositoryLive, EvaluationRepositoryLive, OutboxEventWriterLive, SettingsReaderLive),
           pgClient,
           orgId,
         ),

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -286,6 +286,46 @@ describe("domain-events dispatcher", () => {
     expect(job?.options?.dedupeKey).toBe("notifications:request-incident-closed:ai-1")
   })
 
+  it("still notifies on an organic IncidentClosed (reason=threshold)", async () => {
+    const { consumer, published } = setupDispatcher()
+
+    const envelope = makeEnvelope("IncidentClosed", {
+      organizationId: "org-1",
+      projectId: "proj-1",
+      alertIncidentId: "ai-1",
+      kind: "issue.escalating",
+      sourceType: "issue",
+      sourceId: "issue-1",
+      reason: "threshold",
+    })
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
+
+    expect(published).toHaveLength(1)
+    expect(published[0]?.task).toBe("request-incident-notifications")
+  })
+
+  it.each([
+    "resolved",
+    "ignored",
+  ] as const)("suppresses the recovery notification on a manual IncidentClosed (reason=%s)", async (reason) => {
+    const { consumer, published } = setupDispatcher()
+
+    const envelope = makeEnvelope("IncidentClosed", {
+      organizationId: "org-1",
+      projectId: "proj-1",
+      alertIncidentId: "ai-1",
+      kind: "issue.escalating",
+      sourceType: "issue",
+      sourceId: "issue-1",
+      reason,
+    })
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
+
+    expect(published).toEqual([])
+  })
+
   it("routes ProjectDeleted to notifications:delete-by-project for cascade cleanup", async () => {
     const { consumer, published } = setupDispatcher()
 

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -201,16 +201,22 @@ export const createDomainEventsWorker = ({
       ),
 
     IncidentClosed: (event) =>
-      pub.publish(
-        "notifications",
-        "request-incident-notifications",
-        {
-          organizationId: event.payload.organizationId,
-          alertIncidentId: event.payload.alertIncidentId,
-          transition: "closed",
-        },
-        { dedupeKey: `notifications:request-incident-closed:${event.payload.alertIncidentId}` },
-      ),
+      // Manual lifecycle closes (the user resolved or ignored the issue) close
+      // the escalation silently — the recovery notification is meant for
+      // organic recovery, not a deliberate user action. Organic exits
+      // (threshold/absolute-rate-drop/timeout) still notify.
+      event.payload.reason === "resolved" || event.payload.reason === "ignored"
+        ? Effect.void
+        : pub.publish(
+            "notifications",
+            "request-incident-notifications",
+            {
+              organizationId: event.payload.organizationId,
+              alertIncidentId: event.payload.alertIncidentId,
+              transition: "closed",
+            },
+            { dedupeKey: `notifications:request-incident-closed:${event.payload.alertIncidentId}` },
+          ),
 
     AnnotationDeleted: (event) => {
       const { organizationId, projectId, scoreId, issueId, draftedAt, feedback, source, createdAt } = event.payload

--- a/apps/workers/src/workers/domain-events/alert-incidents.ts
+++ b/apps/workers/src/workers/domain-events/alert-incidents.ts
@@ -95,7 +95,7 @@ const closeIncidentFor = (
     readonly projectId: string
     readonly issueId: string
     readonly endedAt: Date
-    readonly reason?: "threshold" | "absolute-rate-drop" | "timeout"
+    readonly reason?: "threshold" | "absolute-rate-drop" | "timeout" | "resolved" | "ignored"
   },
 ) => {
   const pgClient = getPostgresClient()

--- a/dev-docs/issues.md
+++ b/dev-docs/issues.md
@@ -87,6 +87,9 @@ Lifecycle side effects:
 - manual resolve opens a confirmation modal with a keep-monitoring toggle
 - that toggle defaults from `keepMonitoring`, after project settings fall back to organization settings when project-level `keepMonitoring` is unset, and can be overridden for the specific resolve action
 - the confirmed toggle state decides whether linked evaluations stay active or archive
+- resolving or ignoring an issue closes any open `issue.escalating` incident immediately (emits `IssueEscalationEnded` with reason `resolved`/`ignored`). Ignored and resolved issues no longer drive lifecycle/alerting transitions, so the stale escalation is cleared. This close is silent — unlike an organic de-escalation it does not send a recovery notification
+
+The `escalating` state is backed by an open `issue.escalating` row in `alert_incidents`, not recomputed from the occurrence aggregate. A seasonal detector opens/closes that row; closes fire on the absolute-rate backstop, a band-shape + dwell recovery, or a 72h hard timeout. Issues with no seasonal history (e.g. a normally-silent issue hit by a one-off burst) use the same band-shape + dwell exit on the close side, so they de-escalate shortly after going quiet rather than waiting on the 72h ceiling.
 
 Important state timestamps:
 

--- a/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.ts
+++ b/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.ts
@@ -13,11 +13,11 @@ export interface CloseAlertIncidentFromIssueEventInput {
   /**
    * Forwarded to the `IncidentClosed` outbox event so downstream consumers
    * (notifications copy, dashboards) can tell whether the band exit, the
-   * absolute-rate backstop, or the 72h timeout closed the incident. Optional
-   * because legacy `IssueEscalationEnded` events emitted before the seasonal
-   * detector landed don't carry a reason.
+   * absolute-rate backstop, the 72h timeout, or a manual resolve/ignore
+   * closed the incident. Optional because legacy `IssueEscalationEnded`
+   * events emitted before the seasonal detector landed don't carry a reason.
    */
-  readonly reason?: "threshold" | "absolute-rate-drop" | "timeout"
+  readonly reason?: "threshold" | "absolute-rate-drop" | "timeout" | "resolved" | "ignored"
 }
 
 export type CloseAlertIncidentFromIssueEventError = RepositoryError

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -121,6 +121,10 @@ export interface EventPayloads {
    *     the seasonal baseline caught up — wouldn't close on `threshold` alone).
    *   - `timeout`: the 72h hard ceiling kicked in (backstop against
    *     ghost incidents that never recover their snapshot conditions).
+   *   - `resolved` / `ignored`: the user manually resolved or ignored the
+   *     issue, so the open escalation is stale and closed directly. Emitted
+   *     by `applyIssueLifecycleCommandUseCase` (not the detector); these
+   *     close silently — see the notification gate in `domain-events.ts`.
    *
    * Drives the `issue.escalating` incident's close transition — the
    * alert-incidents worker sets `ended_at` on the open row, which is what
@@ -131,7 +135,7 @@ export interface EventPayloads {
     readonly projectId: string
     readonly issueId: string
     readonly endedAt: string
-    readonly reason: "threshold" | "absolute-rate-drop" | "timeout"
+    readonly reason: "threshold" | "absolute-rate-drop" | "timeout" | "resolved" | "ignored"
   }
   /**
    * Emitted by the alert-incidents worker after an `alert_incidents` row is
@@ -165,7 +169,7 @@ export interface EventPayloads {
     readonly kind: AlertIncidentKind
     readonly sourceType: AlertIncidentSourceType
     readonly sourceId: string
-    readonly reason?: "threshold" | "absolute-rate-drop" | "timeout"
+    readonly reason?: "threshold" | "absolute-rate-drop" | "timeout" | "resolved" | "ignored"
   }
   AnnotationDeleted: {
     readonly organizationId: string

--- a/packages/domain/issues/src/helpers.test.ts
+++ b/packages/domain/issues/src/helpers.test.ts
@@ -601,4 +601,143 @@ describe("evaluateSeasonalEscalation", () => {
     expect(noisy.transition).toBe("enter")
     expect(quiet.transition).toBe("none")
   })
+
+  // Cold-start (samplesCount === 0) active-incident exits. With no seasonal
+  // history kAdj=kShort+1=4, σ_eff floors at 1.0 → exitBand1h = 0.7·4·1 = 2.8
+  // and exitBand6hPerHour = 0.7·3·1 = 2.1. The burst tail keeps recent24h
+  // elevated, so the absolute-rate backstop hasn't tripped yet — the
+  // band-shape exit is what closes these.
+  it("cold-start: starts the band-shape dwell once the 1h/6h windows go quiet", () => {
+    const decision = evaluateSeasonalEscalation({
+      // recent1h/recent6h quiet (< exit bands); recent24h still high so the
+      // backstop (200 < 240·0.5=120) does NOT fire.
+      signals: baseSignals({
+        recent1h: 0,
+        recent6h: 0,
+        recent24h: 200,
+        samplesCount: 0,
+        expected1h: 0,
+        expected6hPerHour: 0,
+        stddev1h: 0,
+        stddev6hPerHour: 0,
+      }),
+      kShort: 3,
+      isNew: false,
+      wasEscalating: true,
+      entrySignals: makeSnapshot({ entryCount24h: 240 }),
+      startedAt: new Date(now.getTime() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: null,
+      now,
+    })
+
+    expect(decision.transition).toBe("none")
+    expect(decision.nextExitEligibleSince).toEqual(now)
+  })
+
+  it("cold-start: closes via threshold once the band-shape dwell is met", () => {
+    const dwellStart = new Date(now.getTime() - ESCALATION_EXIT_DWELL_MS)
+    const decision = evaluateSeasonalEscalation({
+      signals: baseSignals({
+        recent1h: 0,
+        recent6h: 0,
+        recent24h: 200,
+        samplesCount: 0,
+        expected1h: 0,
+        expected6hPerHour: 0,
+        stddev1h: 0,
+        stddev6hPerHour: 0,
+      }),
+      kShort: 3,
+      isNew: false,
+      wasEscalating: true,
+      entrySignals: makeSnapshot({ entryCount24h: 240 }),
+      startedAt: new Date(now.getTime() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: dwellStart,
+      now,
+    })
+
+    expect(decision.transition).toBe("exit")
+    expect(decision.reason).toBe("threshold")
+  })
+
+  it("cold-start: starts the band-shape dwell even without an entry snapshot", () => {
+    // The stuck-incident case: no seasonal history AND no entry snapshot
+    // (legacy / cold-start entry), so the backstop can't fire. Previously the
+    // only exit was the 72h timeout; now the band-shape dwell starts.
+    const decision = evaluateSeasonalEscalation({
+      signals: baseSignals({
+        recent1h: 0,
+        recent6h: 0,
+        recent24h: 0,
+        samplesCount: 0,
+        expected1h: 0,
+        expected6hPerHour: 0,
+        stddev1h: 0,
+        stddev6hPerHour: 0,
+      }),
+      kShort: 3,
+      isNew: false,
+      wasEscalating: true,
+      entrySignals: null,
+      startedAt: new Date(now.getTime() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: null,
+      now,
+    })
+
+    expect(decision.transition).toBe("none")
+    expect(decision.nextExitEligibleSince).toEqual(now)
+  })
+
+  it("cold-start: keeps escalating (clears dwell) while the rate is still elevated", () => {
+    // recent1h=10 > exitBand1h=2.8 → shape doesn't hold.
+    const decision = evaluateSeasonalEscalation({
+      signals: baseSignals({
+        recent1h: 10,
+        recent6h: 60,
+        recent24h: 200,
+        samplesCount: 0,
+        expected1h: 0,
+        expected6hPerHour: 0,
+        stddev1h: 0,
+        stddev6hPerHour: 0,
+      }),
+      kShort: 3,
+      isNew: false,
+      wasEscalating: true,
+      entrySignals: makeSnapshot({ entryCount24h: 240 }),
+      startedAt: new Date(now.getTime() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: new Date(now.getTime() - 10 * 60 * 1000),
+      now,
+    })
+
+    expect(decision.transition).toBe("none")
+    expect(decision.nextExitEligibleSince).toBeNull()
+  })
+
+  it("cold-start: the absolute-rate backstop still takes priority over the band-shape exit", () => {
+    // recent24h=50 < 240·0.5=120 → backstop trips even though the band shape
+    // also holds. Reason must be the backstop, not threshold.
+    const decision = evaluateSeasonalEscalation({
+      signals: baseSignals({
+        recent1h: 0,
+        recent6h: 0,
+        recent24h: 50,
+        samplesCount: 0,
+        expected1h: 0,
+        expected6hPerHour: 0,
+        stddev1h: 0,
+        stddev6hPerHour: 0,
+      }),
+      kShort: 3,
+      isNew: false,
+      wasEscalating: true,
+      entrySignals: makeSnapshot({ entryCount24h: 240 }),
+      startedAt: new Date(now.getTime() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: null,
+      now,
+    })
+
+    expect(decision.transition).toBe("exit")
+    expect(decision.reason).toBe("absolute-rate-drop")
+  })
 })

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -181,7 +181,15 @@ export interface SeasonalEscalationDecisionInput {
 
 export type SeasonalEscalationTransition = "enter" | "exit" | "none"
 
-export type SeasonalEscalationExitReason = "threshold" | "absolute-rate-drop" | "timeout"
+export type SeasonalEscalationExitReason =
+  | "threshold"
+  | "absolute-rate-drop"
+  | "timeout"
+  // Manual lifecycle closes: the user resolved or ignored the issue, so the
+  // open escalation is stale and gets closed directly (no organic recovery).
+  // These are emitted by `applyIssueLifecycleCommandUseCase`, not the detector.
+  | "resolved"
+  | "ignored"
 
 export interface SeasonalEscalationDecision {
   readonly transition: SeasonalEscalationTransition

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -225,8 +225,13 @@ export interface SeasonalEscalationDecision {
  * Below `MIN_SEASONAL_SAMPLES` of contributing prior weeks, `k` is inflated
  * by +1 (wider band where we have less evidence). At zero prior weeks the
  * detector falls back to the floor used pre-rewrite — same `ESCALATION_MIN_OCCURRENCES_THRESHOLD`
- * gate as before. The 7-day issue-age guard makes the zero-history case
- * rare in practice.
+ * gate as before — but for ENTRY only. The EXIT path is unified across all
+ * sample counts: `sigmaEffective` floors σ at 1.0, so the exit band is a
+ * small positive number even with zero seasonal history, and a cold-start
+ * incident de-escalates via band-shape + dwell ~one dwell after it goes quiet
+ * instead of hanging until the 72h timeout (the absolute-rate backstop is the
+ * only other cold-start exit, and it needs a non-null entry snapshot). The
+ * 7-day issue-age guard makes the zero-history case rare in practice.
  */
 export const evaluateSeasonalEscalation = (input: SeasonalEscalationDecisionInput): SeasonalEscalationDecision => {
   const { signals, kShort, isNew, wasEscalating, entrySignals, startedAt, exitEligibleSince, now } = input
@@ -245,35 +250,11 @@ export const evaluateSeasonalEscalation = (input: SeasonalEscalationDecisionInpu
     return { transition: "exit", reason: "timeout", nextExitEligibleSince: null }
   }
 
-  // Deep cold start — no seasonal history at all. Fall back to the
-  // pre-rewrite floor formula.
-  if (signals.samplesCount === 0) {
-    if (!wasEscalating) {
-      const floor1h = ESCALATION_MIN_OCCURRENCES_THRESHOLD / 6
-      if (signals.recent6h >= ESCALATION_MIN_OCCURRENCES_THRESHOLD && signals.recent1h >= floor1h) {
-        // The snapshot has nothing useful to record (no expected/sigma to
-        // freeze) — emit zeros so the column type stays satisfied; the
-        // backstop will simply not fire for these incidents.
-        return {
-          transition: "enter",
-          entrySignalsSnapshot: snapshotFromSignals(signals, kShort, Math.max(1, kShort - 1), 0, 0),
-          nextExitEligibleSince: null,
-        }
-      }
-      return { transition: "none", nextExitEligibleSince: null }
-    }
-    // Active incident with no seasonal context — absolute-rate backstop only.
-    if (
-      entrySignals !== null &&
-      signals.recent24h < entrySignals.entryCount24h * ESCALATION_ABSOLUTE_RATE_EXIT_FACTOR
-    ) {
-      return { transition: "exit", reason: "absolute-rate-drop", nextExitEligibleSince: null }
-    }
-    return { transition: "none", nextExitEligibleSince: exitEligibleSince }
-  }
-
-  // Normal seasonal path. Inflate `k` when the seasonal sample is thin so
-  // the band widens to account for noisy sigma estimates.
+  // Band geometry. `k` is inflated by +1 below `MIN_SEASONAL_SAMPLES`
+  // contributing prior weeks (including the zero-history cold-start case) so
+  // the band widens where the σ estimate is noisy. `sigmaEffective` floors σ
+  // at 1.0, which is what keeps these bands — and so the band-shape exit
+  // below — well-defined even when expected/stddev are zero.
   const kAdj = signals.samplesCount < MIN_SEASONAL_SAMPLES ? kShort + 1 : kShort
   const kLong = Math.max(1, kAdj - 1)
 
@@ -287,6 +268,25 @@ export const evaluateSeasonalEscalation = (input: SeasonalEscalationDecisionInpu
   const exitBand6hPerHour = signals.expected6hPerHour + ESCALATION_EXIT_THRESHOLD_FACTOR * kLong * sigma6hPerHour
 
   if (!wasEscalating) {
+    // Entry. Cold start (no seasonal history) can't trust the bands to size an
+    // entry, so it falls back to the pre-rewrite absolute floor; the seasonal
+    // path uses the multi-window band test.
+    if (signals.samplesCount === 0) {
+      const floor1h = ESCALATION_MIN_OCCURRENCES_THRESHOLD / 6
+      if (signals.recent6h >= ESCALATION_MIN_OCCURRENCES_THRESHOLD && signals.recent1h >= floor1h) {
+        // No real expected/sigma to freeze — record kShort/kLong + zero
+        // thresholds so the snapshot type stays satisfied. `entryCount24h`
+        // is still captured (from `recent24h`), so the absolute-rate backstop
+        // remains usable on the close side.
+        return {
+          transition: "enter",
+          entrySignalsSnapshot: snapshotFromSignals(signals, kShort, Math.max(1, kShort - 1), 0, 0),
+          nextExitEligibleSince: null,
+        }
+      }
+      return { transition: "none", nextExitEligibleSince: null }
+    }
+
     // Multi-window AND: short window proves "now", long window proves "sustained".
     // Both must clear their bands so the short window doesn't trip on a single noisy minute.
     if (signals.recent1h > entryBand1h && recent6hPerHour > entryBand6hPerHour) {
@@ -299,14 +299,21 @@ export const evaluateSeasonalEscalation = (input: SeasonalEscalationDecisionInpu
     return { transition: "none", nextExitEligibleSince: null }
   }
 
-  // wasEscalating === true: try backstop before the band-shape exit. The
-  // backstop catches the "rate has clearly dropped, bands don't matter"
-  // case that the band-shape exit can miss when the seasonal baseline
-  // climbs to meet a declining-but-still-elevated rate.
+  // wasEscalating === true. Exit pipeline — applies to every open incident
+  // regardless of seasonal history (cold-start included). Priority order:
+  //
+  //   1. Absolute-rate backstop: the 24h rate has clearly dropped vs. entry,
+  //      so close regardless of band shape. Catches the case where the
+  //      seasonal baseline climbed to meet a declining-but-still-elevated
+  //      rate. Needs the entry snapshot; skipped when it's null.
   if (entrySignals !== null && signals.recent24h < entrySignals.entryCount24h * ESCALATION_ABSOLUTE_RATE_EXIT_FACTOR) {
     return { transition: "exit", reason: "absolute-rate-drop", nextExitEligibleSince: null }
   }
 
+  //   2. Band-shape + dwell: both windows below the (σ-floored) exit band for
+  //      the full dwell. For a cold-start incident the σ floor keeps the exit
+  //      band a small positive number, so once it goes quiet this fires ~one
+  //      dwell later instead of leaving it stuck until the 72h timeout.
   const exitShapeHolds = signals.recent1h < exitBand1h && recent6hPerHour < exitBand6hPerHour
   if (!exitShapeHolds) {
     return { transition: "none", nextExitEligibleSince: null }

--- a/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.test.ts
+++ b/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.test.ts
@@ -4,6 +4,7 @@ import {
   EvaluationRepository,
   emptyEvaluationAlignment,
 } from "@domain/evaluations"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
 import { EvaluationId, IssueId, OrganizationId, SettingsReader, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -154,6 +155,9 @@ const makeProvider = (input: {
   readonly evaluationRepository: ReturnType<typeof createFakeEvaluationRepository>["repository"]
   readonly organizationKeepMonitoring?: boolean
   readonly projectKeepMonitoring?: boolean
+  // Optional sink that captures every outbox event the use-case writes, so
+  // tests can assert on the emitted `IssueEscalationEnded` events.
+  readonly events?: OutboxWriteEvent[]
 }) => {
   const settingsReaderInput: {
     organizationKeepMonitoring?: boolean
@@ -168,11 +172,19 @@ const makeProvider = (input: {
     settingsReaderInput.projectKeepMonitoring = input.projectKeepMonitoring
   }
 
+  const events = input.events ?? []
+
   return Layer.mergeAll(
     Layer.succeed(IssueRepository, input.issueRepository),
     Layer.succeed(EvaluationRepository, input.evaluationRepository),
     makeSettingsReader(settingsReaderInput),
     Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(organizationId) })),
+    Layer.succeed(OutboxEventWriter, {
+      write: (event: OutboxWriteEvent) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+    }),
   )
 }
 
@@ -380,5 +392,140 @@ describe("applyIssueLifecycleCommandUseCase", () => {
     ).rejects.toMatchObject({
       _tag: "BadRequestError",
     })
+  })
+
+  it("emits IssueEscalationEnded with reason='resolved' when resolving changes the issue", async () => {
+    const now = new Date("2026-04-14T09:00:00.000Z")
+    const issue = makeIssue()
+    const { repository: issueRepository } = createFakeIssueRepository([issue])
+    const { repository: evaluationRepository } = createFakeEvaluationRepository()
+    const events: OutboxWriteEvent[] = []
+
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [issue.id],
+        command: "resolve",
+        keepMonitoring: true,
+        now,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IssueEscalationEnded",
+      aggregateType: "issue",
+      aggregateId: issue.id,
+      organizationId,
+      payload: {
+        organizationId,
+        projectId,
+        issueId: issue.id,
+        endedAt: now.toISOString(),
+        reason: "resolved",
+      },
+    })
+  })
+
+  it("emits IssueEscalationEnded with reason='ignored' when ignoring changes the issue", async () => {
+    const now = new Date("2026-04-14T10:00:00.000Z")
+    const issue = makeIssue()
+    const { repository: issueRepository } = createFakeIssueRepository([issue])
+    const { repository: evaluationRepository } = createFakeEvaluationRepository()
+    const events: OutboxWriteEvent[] = []
+
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [issue.id],
+        command: "ignore",
+        now,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IssueEscalationEnded",
+      payload: { issueId: issue.id, reason: "ignored" },
+    })
+  })
+
+  it("emits no event when the lifecycle command is a no-op (already resolved)", async () => {
+    const issue = makeIssue({ resolvedAt: new Date("2026-04-01T00:00:00.000Z") })
+    const { repository: issueRepository } = createFakeIssueRepository([issue])
+    const { repository: evaluationRepository } = createFakeEvaluationRepository()
+    const events: OutboxWriteEvent[] = []
+
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [issue.id],
+        command: "resolve",
+        keepMonitoring: true,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+
+    expect(events).toEqual([])
+  })
+
+  it("emits no escalation-ended event for unresolve / unignore", async () => {
+    const now = new Date("2026-04-15T09:00:00.000Z")
+    const issue = makeIssue({
+      resolvedAt: new Date("2026-04-01T00:00:00.000Z"),
+      ignoredAt: new Date("2026-04-02T00:00:00.000Z"),
+    })
+    const { repository: issueRepository } = createFakeIssueRepository([issue])
+    const { repository: evaluationRepository } = createFakeEvaluationRepository()
+    const events: OutboxWriteEvent[] = []
+
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [issue.id],
+        command: "unresolve",
+        now,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [issue.id],
+        command: "unignore",
+        now,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+
+    expect(events).toEqual([])
+  })
+
+  it("emits one escalation-ended event per changed issue on a bulk resolve", async () => {
+    const now = new Date("2026-04-16T09:00:00.000Z")
+    const firstIssue = makeIssue({ id: IssueId("aaaaaaaaaaaaaaaaaaaaaaaa") })
+    // Already resolved → no-op → no event.
+    const secondIssue = makeIssue({
+      id: IssueId("bbbbbbbbbbbbbbbbbbbbbbbb"),
+      resolvedAt: new Date("2026-04-01T00:00:00.000Z"),
+    })
+    const thirdIssue = makeIssue({ id: IssueId("cccccccccccccccccccccccc") })
+    const { repository: issueRepository } = createFakeIssueRepository([firstIssue, secondIssue, thirdIssue])
+    const { repository: evaluationRepository } = createFakeEvaluationRepository()
+    const events: OutboxWriteEvent[] = []
+
+    await Effect.runPromise(
+      applyIssueLifecycleCommandUseCase({
+        projectId,
+        issueIds: [firstIssue.id, secondIssue.id, thirdIssue.id],
+        command: "resolve",
+        keepMonitoring: true,
+        now,
+      }).pipe(Effect.provide(makeProvider({ issueRepository, evaluationRepository, events }))),
+    )
+
+    expect(events).toHaveLength(2)
+    expect(events.map((event) => (event.payload as { issueId: string }).issueId)).toEqual([
+      firstIssue.id,
+      thirdIssue.id,
+    ])
+    expect(events.every((event) => event.eventName === "IssueEscalationEnded")).toBe(true)
   })
 })

--- a/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.ts
+++ b/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.ts
@@ -1,4 +1,5 @@
 import { EvaluationRepository } from "@domain/evaluations"
+import { OutboxEventWriter } from "@domain/events"
 import {
   BadRequestError,
   type ConcurrentSqlTransactionError,
@@ -145,13 +146,7 @@ const shouldSoftDeleteLinkedEvaluations = (input: {
   return input.command === "resolve" && input.keepMonitoring === false
 }
 
-export const applyIssueLifecycleCommandUseCase = (
-  input: ApplyIssueLifecycleCommandInput,
-): Effect.Effect<
-  ApplyIssueLifecycleCommandResult,
-  ApplyIssueLifecycleCommandError,
-  EvaluationRepository | IssueRepository | SettingsReader | SqlClient
-> =>
+export const applyIssueLifecycleCommandUseCase = (input: ApplyIssueLifecycleCommandInput) =>
   Effect.gen(function* () {
     const parsed = applyIssueLifecycleCommandInputSchema.parse(input)
     yield* Effect.annotateCurrentSpan("projectId", String(parsed.projectId))
@@ -168,6 +163,7 @@ export const applyIssueLifecycleCommandUseCase = (
       Effect.gen(function* () {
         const issueRepository = yield* IssueRepository
         const evaluationRepository = yield* EvaluationRepository
+        const outboxEventWriter = yield* OutboxEventWriter
         const items: IssueLifecycleCommandItem[] = []
 
         for (const issueId of issueIds) {
@@ -197,6 +193,29 @@ export const applyIssueLifecycleCommandUseCase = (
                 issueId,
               })
             }
+
+            // Resolving or ignoring an issue makes any open `issue.escalating`
+            // incident stale — ignored/resolved issues no longer drive lifecycle
+            // or alerting transitions. Emit `IssueEscalationEnded` so the
+            // alert-incidents worker closes the open row (idempotent no-op when
+            // none is open). The `resolved`/`ignored` reason flows through to
+            // `IncidentClosed`, where the notification fan-out is suppressed —
+            // a manual close shouldn't fire a recovery notification.
+            if (parsed.command === "resolve" || parsed.command === "ignore") {
+              yield* outboxEventWriter.write({
+                eventName: "IssueEscalationEnded",
+                aggregateType: "issue",
+                aggregateId: nextIssue.id,
+                organizationId: nextIssue.organizationId,
+                payload: {
+                  organizationId: nextIssue.organizationId,
+                  projectId: nextIssue.projectId,
+                  issueId: nextIssue.id,
+                  endedAt: now.toISOString(),
+                  reason: parsed.command === "resolve" ? "resolved" : "ignored",
+                },
+              })
+            }
           }
 
           items.push(toLifecycleCommandItem(nextIssue, changed))
@@ -209,4 +228,8 @@ export const applyIssueLifecycleCommandUseCase = (
         } satisfies ApplyIssueLifecycleCommandResult
       }),
     )
-  }).pipe(Effect.withSpan("issues.applyIssueLifecycleCommand"))
+  }).pipe(Effect.withSpan("issues.applyIssueLifecycleCommand")) as Effect.Effect<
+    ApplyIssueLifecycleCommandResult,
+    ApplyIssueLifecycleCommandError,
+    EvaluationRepository | IssueRepository | OutboxEventWriter | SettingsReader | SqlClient
+  >

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -235,7 +235,7 @@ const _registry = {
       readonly projectId: string
       readonly issueId: string
       readonly endedAt: string
-      readonly reason: "threshold" | "absolute-rate-drop" | "timeout"
+      readonly reason: "threshold" | "absolute-rate-drop" | "timeout" | "resolved" | "ignored"
     }
   }>(),
 


### PR DESCRIPTION
## what this fixes

Two reasons an `issue.escalating` incident could stay open long after the issue stopped firing — both observed on a real production issue that sat "Escalating" for ~2 days with ~21h of zero occurrences.

The "Escalating" badge is driven entirely by an open row in `alert_incidents` (`kind = issue.escalating`, `ended_at IS NULL`), surfaced through `deriveIssueLifecycleStates`'s `isEscalating` flag — it is not recomputed from the live occurrence rate. So an incident that never gets its `ended_at` written keeps the issue escalating regardless of current activity.

### 1. resolve / ignore never closed the escalation

`applyIssueLifecycleCommandUseCase` only set `resolvedAt` / `ignoredAt` and emitted nothing, so the open incident was never closed. An issue could show `escalating` and `resolved` at the same time. Ignored and resolved issues already stop driving lifecycle and alerting transitions (the escalation check bails on `ignoredAt`, regression is gated on `ignoredAt === null`), so a lingering open escalation is simply stale.

Now the use-case emits `IssueEscalationEnded` for every issue whose state actually changes on `resolve` / `ignore`. The alert-incidents worker closes the open row idempotently (no-op when none is open), so emitting on a state change is safe; `unresolve` / `unignore` emit nothing. `OutboxEventWriter` is wired into the use-case and its API + web call sites.

Closing an incident normally fans out a "Resolved: escalation" in-app + email notification. That recovery notification is meant for organic recovery, not a deliberate user action, so the `IncidentClosed` handler in `domain-events` skips the notification when the reason is `resolved` or `ignored`. Organic closes (`threshold` / `absolute-rate-drop` / `timeout`) still notify.

### 2. cold-start incidents had no fast exit

An issue with no seasonal history (`samplesCount === 0` — e.g. a normally-silent issue hit by a one-off burst) took the cold-start branch of `evaluateSeasonalEscalation`, whose only active-incident exits were the 72h hard timeout and the absolute-rate backstop (itself gated on a non-null entry snapshot). The fast band-shape + dwell exit was skipped, so a quiet incident could hang until the 72h ceiling instead of recovering shortly after going silent.

The exit path is now unified across all sample counts. Entry stays split (cold start keeps the `ESCALATION_MIN_OCCURRENCES_THRESHOLD` floor; the seasonal path keeps the multi-window band test), but once an incident is open the same pipeline runs regardless of history: absolute-rate backstop first, then band-shape + dwell. `sigmaEffective` floors σ at 1.0, so the exit band stays a small positive number even with zero history and a quiet incident de-escalates ~one dwell after going silent. The 72h timeout and backstop priority are unchanged.

## new exit reasons

`SeasonalEscalationExitReason` (and the `IssueEscalationEnded` / `IncidentClosed` payloads, the close use-case input, the worker handler, and the queue topic registry) gain two manual-lifecycle reasons, `resolved` and `ignored`, alongside the organic `threshold` / `absolute-rate-drop` / `timeout`. No DB migration — `alert_incidents` has no `reason` column; the reason travels on events only and is used to gate the close notification.

## decisions

- Close on both resolve and ignore — ignored issues stop generating incidents, so the open escalation is stale in both cases.
- Suppress the recovery notification for both manual reasons. Easy to flip for `resolved` (drop it from the gate) if we later want resolve to notify.
- Emit `IssueEscalationEnded` unconditionally on a state change rather than first checking for an open incident — `closeOpen` is idempotent, which avoids an extra query and dependency.

## testing

- `@domain/issues`, `@domain/events`, `@domain/alerts`, `@domain/queue`, `@app/api`, `@app/web`, `@app/workers` typecheck clean.
- `@domain/issues` unit tests pass (added: resolve/ignore/no-op/unresolve/unignore/bulk emission cases, and cold-start active-incident exits — dwell start with and without an entry snapshot, threshold close after dwell, dwell cleared while elevated, backstop priority).
- `domain-events.test.ts` passes, including the notification-suppression gate (organic close still notifies; `resolved`/`ignored` do not).
