### PR TITLE
Fix silent Claude Code issues Linux <20 Node version

### DIFF
--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -20,8 +20,11 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=20.12.0"
+  },
   "bin": {
-    "latitude-claude-code": "./dist/index.js"
+    "latitude-claude-code": "./dist/entry.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/telemetry/claude-code/src/entry.ts
+++ b/packages/telemetry/claude-code/src/entry.ts
@@ -11,4 +11,9 @@ if (error) {
   process.exit(0) // fail-open — do not block Claude Code
 }
 
-await import("./index.js")
+try {
+  await import("./index.js")
+} catch (err) {
+  process.stderr.write(`[latitude-claude-code] failed to load: ${String(err)}\n`)
+  process.exit(0)
+}

--- a/packages/telemetry/claude-code/src/entry.ts
+++ b/packages/telemetry/claude-code/src/entry.ts
@@ -3,18 +3,11 @@
 // In ESM the static imports at the top of index.ts are evaluated before
 // any module body runs, so this file dynamically imports index.js after
 // the check passes.
-const parts = process.versions.node.split(".")
-const major = parseInt(parts[0] ?? "0", 10)
-const minor = parseInt(parts[1] ?? "0", 10)
+import { buildVersionError } from "./node-version.ts"
 
-if (major < 20 || (major === 20 && minor < 12)) {
-  process.stderr.write(
-    `[latitude-claude-code] Node.js ${process.versions.node} is too old — requires >=20.12.\n` +
-      `The Stop hook is failing silently. To fix, ensure the "node" on your PATH is v20.12+\n` +
-      `before Claude Code runs this hook.\n` +
-      `With nvm, update the hook command in ~/.claude/settings.json to prefix the PATH:\n` +
-      `  "command": "PATH=\\"/home/<you>/.nvm/versions/node/v22.x.x/bin:$PATH\\" npx -y @latitude-data/claude-code-telemetry"\n`,
-  )
+const error = buildVersionError(process.versions.node)
+if (error) {
+  process.stderr.write(error)
   process.exit(0) // fail-open — do not block Claude Code
 }
 

--- a/packages/telemetry/claude-code/src/entry.ts
+++ b/packages/telemetry/claude-code/src/entry.ts
@@ -1,0 +1,21 @@
+// Version check must run before any other import — @clack/prompts uses
+// node:util styleText which only exists from Node.js 20.12 onward.
+// In ESM the static imports at the top of index.ts are evaluated before
+// any module body runs, so this file dynamically imports index.js after
+// the check passes.
+const parts = process.versions.node.split(".")
+const major = parseInt(parts[0] ?? "0", 10)
+const minor = parseInt(parts[1] ?? "0", 10)
+
+if (major < 20 || (major === 20 && minor < 12)) {
+  process.stderr.write(
+    `[latitude-claude-code] Node.js ${process.versions.node} is too old — requires >=20.12.\n` +
+      `The Stop hook is failing silently. To fix, ensure the "node" on your PATH is v20.12+\n` +
+      `before Claude Code runs this hook.\n` +
+      `With nvm, update the hook command in ~/.claude/settings.json to prefix the PATH:\n` +
+      `  "command": "PATH=\\"/home/<you>/.nvm/versions/node/v22.x.x/bin:$PATH\\" npx -y @latitude-data/claude-code-telemetry"\n`,
+  )
+  process.exit(0) // fail-open — do not block Claude Code
+}
+
+await import("./index.js")

--- a/packages/telemetry/claude-code/src/node-version.test.ts
+++ b/packages/telemetry/claude-code/src/node-version.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { buildVersionError } from "./node-version.ts"
+
+describe("buildVersionError", () => {
+  it("returns null for current-era Node versions", () => {
+    expect(buildVersionError("22.0.0")).toBeNull()
+    expect(buildVersionError("23.5.0")).toBeNull()
+    expect(buildVersionError("21.0.0")).toBeNull()
+  })
+
+  it("returns null for the minimum supported version (20.12.0)", () => {
+    expect(buildVersionError("20.12.0")).toBeNull()
+  })
+
+  it("returns null for patch releases above the threshold", () => {
+    expect(buildVersionError("20.12.1")).toBeNull()
+    expect(buildVersionError("20.19.0")).toBeNull()
+  })
+
+  it("returns an error for Node 18", () => {
+    const msg = buildVersionError("18.19.1")
+    expect(msg).toContain("18.19.1")
+    expect(msg).toContain("too old")
+    expect(msg).toContain(">=20.12")
+  })
+
+  it("returns an error for Node 20.11 (one minor below the threshold)", () => {
+    const msg = buildVersionError("20.11.9")
+    expect(msg).toContain("too old")
+  })
+
+  it("returns an error for Node 20.0", () => {
+    expect(buildVersionError("20.0.0")).toContain("too old")
+  })
+
+  it("error message includes the nvm PATH fix hint", () => {
+    const msg = buildVersionError("18.0.0")
+    expect(msg).toContain("PATH")
+    expect(msg).toContain("nvm")
+  })
+})

--- a/packages/telemetry/claude-code/src/node-version.ts
+++ b/packages/telemetry/claude-code/src/node-version.ts
@@ -1,0 +1,15 @@
+export function buildVersionError(version: string): string | null {
+  const parts = version.split(".")
+  const major = parseInt(parts[0] ?? "0", 10)
+  const minor = parseInt(parts[1] ?? "0", 10)
+  if (major < 20 || (major === 20 && minor < 12)) {
+    return (
+      `[latitude-claude-code] Node.js ${version} is too old — requires >=20.12.\n` +
+      `The Stop hook is failing silently. To fix, ensure the "node" on your PATH is v20.12+\n` +
+      `before Claude Code runs this hook.\n` +
+      `With nvm, update the hook command in ~/.claude/settings.json to prefix the PATH:\n` +
+      `  "command": "PATH=\\"/home/<you>/.nvm/versions/node/v22.x.x/bin:$PATH\\" npx -y @latitude-data/claude-code-telemetry"\n`
+    )
+  }
+  return null
+}

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -25,6 +25,8 @@ const REQUESTS_DIR = join(STATE_DIR, "requests")
 const STATE_FILE = join(STATE_DIR, "state.json")
 const PLIST_PATH = join(homedir(), "Library", "LaunchAgents", "so.latitude.claude-code-telemetry.plist")
 const PLIST_LABEL = "so.latitude.claude-code-telemetry"
+// Linux: systemd user environment drop-in; mirrors the macOS plist for persistence.
+const ENVIRONMENT_D_CONF_PATH = join(homedir(), ".config", "environment.d", "latitude-telemetry.conf")
 const DEFAULT_HOOK_COMMAND = "npx -y @latitude-data/claude-code-telemetry"
 const DOCS_URL = "https://docs.latitude.so/telemetry/claude-code"
 
@@ -72,6 +74,7 @@ interface InstallFlags {
   project?: string | undefined
   environment?: EnvironmentConfig | undefined
   noLaunchctl?: boolean
+  noSystemd?: boolean
   noPrompt?: boolean
 }
 
@@ -136,19 +139,44 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
     useLaunchctl = answer === true
   }
 
-  await applyChanges({ apiKey, project, envConfig, useLaunchctl, existing, interactive: true })
+  let useSystemd = false
+  if (process.platform === "linux" && !flags.noSystemd && isSystemctlAvailable()) {
+    log.info(
+      [
+        "On Linux, settings.json env vars only reach hook subprocesses — not the",
+        "main claude binary launched by VS Code or a desktop launcher.",
+        "Wiring BUN_OPTIONS via systemd --user covers GUI apps and persists across reboots.",
+        `Writes to: ${ENVIRONMENT_D_CONF_PATH}`,
+      ].join("\n"),
+    )
+    const answer = await confirm({
+      message: "Set up systemd user environment? (recommended)",
+      initialValue: true,
+    })
+    if (isCancel(answer)) return onCancel()
+    useSystemd = answer === true
+  }
 
-  note(
-    [
-      "Quit claude fully and relaunch for the preload to attach.",
-      "",
+  await applyChanges({ apiKey, project, envConfig, useLaunchctl, useSystemd, existing, interactive: true })
+
+  const nextStepLines = ["Quit claude fully and relaunch for the preload to attach.", ""]
+  if (process.platform === "darwin") {
+    nextStepLines.push(
       `${pc.dim("  Terminal       ")}close and reopen your terminal`,
       `${pc.dim("  Claude Desktop ")}⌘Q, then relaunch from Dock / Finder`,
+    )
+  } else if (useSystemd) {
+    nextStepLines.push(
+      `${pc.dim("  VS Code        ")}close and reopen VS Code`,
+      `${pc.dim("  Terminal       ")}close and reopen your terminal`,
       "",
-      `View your traces at  ${pc.cyan(urls.projectView(project))}`,
-    ].join("\n"),
-    "Next step",
-  )
+      "The systemd user environment persists across reboots.",
+    )
+  } else {
+    nextStepLines.push(`${pc.dim("  Terminal       ")}close and reopen your terminal`)
+  }
+  nextStepLines.push("", `View your traces at  ${pc.cyan(urls.projectView(project))}`)
+  note(nextStepLines.join("\n"), "Next step")
 
   outro(pc.green("Installed."))
 }
@@ -205,12 +233,13 @@ interface ApplyArgs {
   project: string
   envConfig: EnvironmentConfig
   useLaunchctl: boolean
+  useSystemd: boolean
   existing: ClaudeSettings
   interactive: boolean
 }
 
 async function applyChanges(args: ApplyArgs): Promise<void> {
-  const { apiKey, project, envConfig, useLaunchctl, existing, interactive } = args
+  const { apiKey, project, envConfig, useLaunchctl, useSystemd, existing, interactive } = args
 
   let next = existing
   if (apiKey) next = setEnv(next, "LATITUDE_API_KEY", apiKey)
@@ -221,7 +250,10 @@ async function applyChanges(args: ApplyArgs): Promise<void> {
   if (envConfig.name === "production") next = removeEnv(next, "LATITUDE_BASE_URL")
   else next = setEnv(next, "LATITUDE_BASE_URL", envConfig.ingest)
 
-  if (useLaunchctl) next = removeEnv(next, "BUN_OPTIONS")
+  // When using an OS-level env mechanism (launchctl on macOS, systemd on Linux)
+  // the BUN_OPTIONS value reaches the main claude binary directly, so we don't
+  // need it in settings.json (which only reaches hook subprocesses).
+  if (useLaunchctl || useSystemd) next = removeEnv(next, "BUN_OPTIONS")
   else next = setEnv(next, "BUN_OPTIONS", `--preload=${INTERCEPT_INSTALL_PATH}`)
 
   const hookAlreadyThere = hasLatitudeStopHook(next)
@@ -251,6 +283,13 @@ async function applyChanges(args: ApplyArgs): Promise<void> {
     setLaunchctlBunOptions()
     writePlist()
     step.stop(`launchctl env set (persisted via ${PLIST_PATH})`)
+  }
+
+  if (useSystemd) {
+    step.start("Setting BUN_OPTIONS via systemd --user + writing environment.d conf")
+    setSystemdBunOptions()
+    writeEnvironmentDConf()
+    step.stop(`systemd user env set (persisted via ${ENVIRONMENT_D_CONF_PATH})`)
   }
 }
 
@@ -298,9 +337,10 @@ async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
 
   const envConfig = flags.environment ?? PRODUCTION_ENV
   const useLaunchctl = process.platform === "darwin" && !flags.noLaunchctl
+  const useSystemd = process.platform === "linux" && !flags.noSystemd && isSystemctlAvailable()
 
   process.stdout.write(`Installing Latitude Claude Code telemetry (${envConfig.label})…\n`)
-  await applyChanges({ apiKey, project, envConfig, useLaunchctl, existing, interactive: false })
+  await applyChanges({ apiKey, project, envConfig, useLaunchctl, useSystemd, existing, interactive: false })
   process.stdout.write(`\nInstalled. Quit claude and relaunch (new terminal, or ⌘Q + relaunch Claude Desktop).\n`)
 }
 
@@ -437,6 +477,40 @@ function writePlist(): void {
   }
 }
 
+function isSystemctlAvailable(): boolean {
+  const res = spawnSync("systemctl", ["--user", "--version"], { stdio: "ignore" })
+  return res.status === 0
+}
+
+function setSystemdBunOptions(): void {
+  const value = `--preload=${INTERCEPT_INSTALL_PATH}`
+  const res = spawnSync("systemctl", ["--user", "set-environment", `BUN_OPTIONS=${value}`], { encoding: "utf-8" })
+  if (res.status !== 0) {
+    const details = [res.stderr, res.stdout]
+      .filter((s) => s && s.trim().length > 0)
+      .join(" ")
+      .trim()
+    process.stderr.write(
+      `[latitude-claude-code] systemctl set-environment failed (exit ${res.status})${details ? `: ${details}` : ""}. Continuing.\n`,
+    )
+  }
+}
+
+function writeEnvironmentDConf(): void {
+  mkdirSync(dirname(ENVIRONMENT_D_CONF_PATH), { recursive: true })
+  writeFileSync(ENVIRONMENT_D_CONF_PATH, `BUN_OPTIONS=--preload=${INTERCEPT_INSTALL_PATH}\n`, "utf-8")
+}
+
+function readSystemdBunOptions(): string | undefined {
+  if (process.platform !== "linux") return undefined
+  const res = spawnSync("systemctl", ["--user", "show-environment"], { encoding: "utf-8" })
+  if (res.status !== 0) return undefined
+  for (const line of (res.stdout ?? "").split("\n")) {
+    if (line.startsWith("BUN_OPTIONS=")) return line.slice("BUN_OPTIONS=".length).trim()
+  }
+  return undefined
+}
+
 function printMinimalInstallInstructions(): void {
   process.stdout.write(
     [
@@ -506,6 +580,28 @@ function buildUninstallPlan(): UninstallPlan {
       spawnSync("launchctl", ["unload", PLIST_PATH], { stdio: "ignore" })
       try {
         unlinkSync(PLIST_PATH)
+      } catch {
+        // already gone
+      }
+    })
+  }
+
+  // Linux: systemd user environment
+  const currentSystemd = readSystemdBunOptions()
+  if (currentSystemd?.includes(INTERCEPT_INSTALL_PATH)) {
+    description.push(`systemd user: unset-environment BUN_OPTIONS (currently: ${currentSystemd})`)
+    steps.push(() => {
+      spawnSync("systemctl", ["--user", "unset-environment", "BUN_OPTIONS"], { stdio: "ignore" })
+    })
+  } else if (currentSystemd) {
+    description.push(`systemd user BUN_OPTIONS is set to something else (${currentSystemd}); leaving it alone`)
+  }
+
+  if (existsSync(ENVIRONMENT_D_CONF_PATH)) {
+    description.push(`${ENVIRONMENT_D_CONF_PATH}: remove`)
+    steps.push(() => {
+      try {
+        unlinkSync(ENVIRONMENT_D_CONF_PATH)
       } catch {
         // already gone
       }
@@ -585,6 +681,7 @@ export function normalizeInstallFlags(flags: Record<string, string | boolean>): 
 
   const result: InstallFlags = {
     noLaunchctl: flags["no-launchctl"] === true || flags.no_launchctl === true,
+    noSystemd: flags["no-systemd"] === true || flags.no_systemd === true,
     noPrompt: flags["no-prompt"] === true || flags.no_prompt === true || flags.yes === true,
   }
   const apiKey = str(flags["api-key"] ?? flags.api_key)

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -498,7 +498,7 @@ function setSystemdBunOptions(): void {
 
 function writeEnvironmentDConf(): void {
   mkdirSync(dirname(ENVIRONMENT_D_CONF_PATH), { recursive: true })
-  writeFileSync(ENVIRONMENT_D_CONF_PATH, `BUN_OPTIONS=--preload=${INTERCEPT_INSTALL_PATH}\n`, "utf-8")
+  writeFileSync(ENVIRONMENT_D_CONF_PATH, `BUN_OPTIONS="--preload=${INTERCEPT_INSTALL_PATH}"\n`, "utf-8")
 }
 
 function readSystemdBunOptions(): string | undefined {

--- a/packages/telemetry/claude-code/tsdown.config.ts
+++ b/packages/telemetry/claude-code/tsdown.config.ts
@@ -2,9 +2,7 @@ import { defineConfig } from "tsdown"
 
 export default defineConfig([
   {
-    // Thin entry-point that checks the Node.js version before loading index.ts.
-    // Carries the shebang; index.ts is imported dynamically so the version check
-    // runs before any module with Node 20+ APIs is evaluated.
+    // Bin entry: version-checks before dynamically loading index.ts.
     entry: ["src/entry.ts"],
     format: ["esm"],
     dts: false,

--- a/packages/telemetry/claude-code/tsdown.config.ts
+++ b/packages/telemetry/claude-code/tsdown.config.ts
@@ -2,14 +2,26 @@ import { defineConfig } from "tsdown"
 
 export default defineConfig([
   {
-    entry: ["src/index.ts"],
+    // Thin entry-point that checks the Node.js version before loading index.ts.
+    // Carries the shebang; index.ts is imported dynamically so the version check
+    // runs before any module with Node 20+ APIs is evaluated.
+    entry: ["src/entry.ts"],
     format: ["esm"],
-    dts: true,
+    dts: false,
     sourcemap: true,
     clean: true,
     target: "node20",
     fixedExtension: false,
     banner: { js: "#!/usr/bin/env node" },
+  },
+  {
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "node20",
+    fixedExtension: false,
   },
   {
     // The intercept runs as a Bun --preload inside the claude process, so it must


### PR DESCRIPTION
## What does this PR do?

Fixes two silent failures in the @latitude-data/claude-code-telemetry Stop hook that caused traces to never arrive in Latitude with no visible error to the user:

Node.js version check — on systems where the system node is < v20.12 (common on Ubuntu LTS), the hook crashed at load time because @clack/prompts uses node:util styleText which doesn't exist in older Node. Since the hook is async: true + fail-open, the crash was invisible. Fixes this by introducing a thin entry.ts wrapper that checks the Node version before any imports load, and prints a clear error with the nvm fix if too old.

Linux BUN_OPTIONS not reaching Claude — settings.json env vars only reach hook subprocesses, not the main claude binary. On macOS this was already solved via launchctl setenv. On Linux there was no equivalent, so the intercept preload never loaded when Claude was launched from VS Code. Fixes this by adding a systemd user environment path during install: systemctl --user set-environment for the current session + ~/.config/environment.d/latitude-telemetry.conf for persistence across reboots.

## Related issue (if applicable)

Closes #3404 

## How was this tested?

For Fix 1 we ran two tests:

Happy path — piped {} into dist/entry.js on Node 22, verified it exited 0 with no crash.
Error path — monkey-patched process.versions.node to '18.19.1' before the dynamic import, verified the clear error message printed to stderr and the process still exited 0 (fail-open).

For Fix 2 we only verified the file-writing logic (writeEnvironmentDConf) in isolation — confirmed the correct content gets written to ~/.config/environment.d/latitude-telemetry.conf. The actual systemd integration (systemctl --user set-environment and VS Code picking it up) was not tested and needs verification on a real Linux desktop.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
