### PR TITLE
feat(notifications): align incident-trend chart with the issue-detail drawer

### DIFF
--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -17,6 +17,18 @@ export const INCIDENT_SEVERITY_COLOR: Record<AlertSeverity, string> = {
   high: "hsl(0 84% 60%)",
 }
 
+/**
+ * Concrete hex equivalents of {@link INCIDENT_SEVERITY_COLOR}, for renderers that can't rely on
+ * CSS `hsl()` parsing. usvg (the SVG parser behind the server-side Resvg incident-trend PNG)
+ * does not reliably parse the space-separated `hsl(H S% L%)` syntax used above, so the hand-built
+ * SVG markup references these instead. Values are the same Tailwind-500 colors (blue/amber/red).
+ */
+export const INCIDENT_SEVERITY_HEX: Record<AlertSeverity, string> = {
+  low: "#3b82f6",
+  medium: "#f59e0b",
+  high: "#ef4444",
+}
+
 type TopSymbol = NonNullable<BarChartOverlayLine["topSymbol"]>
 
 // Markers are paint-only — interactivity lives at the bucket level via the histogram's hover

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -3,9 +3,11 @@ import { exportSelectionSchema } from "@domain/exports"
 import {
   type ApplyIssueLifecycleCommandResult,
   applyIssueLifecycleCommandUseCase,
+  buildHistogramBucketScaffold,
   DEFAULT_ESCALATION_SENSITIVITY_K,
   deriveIssueLifecycleStates,
   embedIssueSearchQueryUseCase,
+  fillBuckets,
   getEscalationOccurrenceThreshold,
   type Issue,
   type IssueListItem,
@@ -21,12 +23,7 @@ import {
   searchOrgIssuesUseCase,
   TAG_AGGREGATION_FALLBACK_DAYS,
 } from "@domain/issues"
-import {
-  type IssueEscalationThresholdBucket,
-  type IssueOccurrenceBucket,
-  ScoreAnalyticsRepository,
-  ScoreRepository,
-} from "@domain/scores"
+import { type IssueEscalationThresholdBucket, ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
 import { IssueId, OrganizationId, ProjectId, resolveSettings, SettingsReader } from "@domain/shared"
 import type { TraceDetail } from "@domain/spans"
 import { withAi } from "@platform/ai"
@@ -162,39 +159,7 @@ const issueTracesCountInputSchema = z.object({
 const toUtcDayEnd = (value: Date): Date =>
   new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 23, 59, 59, 999))
 
-/**
- * Sub-day-aware scaffold producing ISO-8601 UTC bucket-start timestamps. Used by the issue
- * detail trend (12h buckets) — the wider per-bucket precision lets incident overlays land in
- * the right half-day rather than collapsing to the calendar date.
- */
-const buildHistogramBucketScaffold = (input: {
-  readonly from: Date
-  readonly to: Date
-  readonly bucketSeconds: number
-}): readonly string[] => {
-  const widthMs = input.bucketSeconds * 1000
-  if (widthMs <= 0) return []
-  const startMs = Math.floor(input.from.getTime() / widthMs) * widthMs
-  const endMs = input.to.getTime()
-  const out: string[] = []
-  for (let cursor = startMs; cursor <= endMs; cursor += widthMs) {
-    out.push(new Date(cursor).toISOString())
-  }
-  return out
-}
-
 const ISSUE_DETAIL_TREND_BUCKET_SECONDS = 12 * 60 * 60 // 12h
-
-const fillBuckets = (input: {
-  readonly scaffold: readonly string[]
-  readonly buckets: readonly IssueOccurrenceBucket[]
-}): readonly { readonly bucket: string; readonly count: number }[] => {
-  const countsByBucket = new Map(input.buckets.map((bucket) => [bucket.bucket, bucket.count] as const))
-  return input.scaffold.map((bucket) => ({
-    bucket,
-    count: countsByBucket.get(bucket) ?? 0,
-  }))
-}
 
 const toIssueDetailRecord = (input: {
   readonly issue: Issue

--- a/apps/web/src/domains/issues/trend-chart/trend-geometry.test.ts
+++ b/apps/web/src/domains/issues/trend-chart/trend-geometry.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildSmoothThresholdPath,
+  buildThresholdSegments,
+  computeTrendMaxCount,
+  MAX_VISIBLE_BAR_HEIGHT_PERCENT,
+  MIN_VISIBLE_BAR_HEIGHT_PERCENT,
+  type TrendGeometryPoint,
+  toVisibleHeightPercent,
+} from "./trend-geometry.ts"
+
+describe("toVisibleHeightPercent", () => {
+  it("maps zero to zero (no bar)", () => {
+    expect(toVisibleHeightPercent(0, 10)).toBe(0)
+  })
+
+  it("clamps any positive count up to the minimum visible height", () => {
+    // 1/100 would be 0.88% — clamped up so the bar stays legible.
+    expect(toVisibleHeightPercent(1, 100)).toBe(MIN_VISIBLE_BAR_HEIGHT_PERCENT)
+  })
+
+  it("scales the max count to the ceiling", () => {
+    expect(toVisibleHeightPercent(10, 10)).toBe(MAX_VISIBLE_BAR_HEIGHT_PERCENT)
+  })
+})
+
+describe("computeTrendMaxCount", () => {
+  it("takes the largest of counts and thresholds", () => {
+    const points: TrendGeometryPoint[] = [
+      { count: 3, threshold: 9 },
+      { count: 5, threshold: null },
+    ]
+    expect(computeTrendMaxCount(points)).toBe(9)
+  })
+
+  it("floors at 1 for an all-zero window", () => {
+    expect(computeTrendMaxCount([{ count: 0, threshold: null }])).toBe(1)
+  })
+})
+
+describe("buildThresholdSegments", () => {
+  it("breaks the line across null thresholds and centers x on the bucket", () => {
+    const points: TrendGeometryPoint[] = [
+      { count: 0, threshold: 5 },
+      { count: 0, threshold: null },
+      { count: 0, threshold: 7 },
+      { count: 0, threshold: 7 },
+    ]
+    const segments = buildThresholdSegments(points, 10)
+    expect(segments).toHaveLength(2)
+    expect(segments[0]).toHaveLength(1)
+    expect(segments[1]).toHaveLength(2)
+    // x = index + 0.5
+    expect(segments[0]?.[0]?.x).toBe(0.5)
+    expect(segments[1]?.[0]?.x).toBe(2.5)
+    // y = 100 - heightPercent, so a higher threshold sits higher (smaller y).
+    expect(segments[1]?.[0]?.y).toBeLessThan(100)
+  })
+
+  it("returns no segments when every threshold is null", () => {
+    const points: TrendGeometryPoint[] = [
+      { count: 3, threshold: null },
+      { count: 4, threshold: null },
+    ]
+    expect(buildThresholdSegments(points, 10)).toEqual([])
+  })
+})
+
+describe("buildSmoothThresholdPath", () => {
+  it("returns an empty string for no points", () => {
+    expect(buildSmoothThresholdPath([])).toBe("")
+  })
+
+  it("draws a tiny horizontal dash for a single point", () => {
+    const d = buildSmoothThresholdPath([{ x: 2, y: 50 }])
+    expect(d.startsWith("M ")).toBe(true)
+    expect(d).toContain("L ")
+  })
+
+  it("emits a cubic Bezier spline for multiple points", () => {
+    const d = buildSmoothThresholdPath([
+      { x: 0, y: 50 },
+      { x: 1, y: 40 },
+      { x: 2, y: 45 },
+    ])
+    expect(d.startsWith("M ")).toBe(true)
+    expect(d).toContain("C ")
+  })
+})

--- a/apps/web/src/domains/issues/trend-chart/trend-geometry.ts
+++ b/apps/web/src/domains/issues/trend-chart/trend-geometry.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure geometry helpers for the issue occurrence-trend chart, shared between the live
+ * in-app drawer chart (`IssueTrendBar`) and the server-side incident-trend PNG renderer
+ * (`render-incident-trend.tsx`) so both produce the same bar heights and the same
+ * seasonal-expectation dashed curve.
+ *
+ * Everything here is framework-agnostic (no React, no SVG strings) — just the math that maps
+ * `{ count, threshold }` series into a `0..100` vertical space and a smooth path.
+ */
+
+/** Floor so a non-zero bucket always shows at least a sliver. */
+export const MIN_VISIBLE_BAR_HEIGHT_PERCENT = 12
+/** Ceiling so the tallest bar / threshold never touches the top edge. */
+export const MAX_VISIBLE_BAR_HEIGHT_PERCENT = 88
+
+/** One bucket of the trend: its occurrence count and the seasonal threshold (`null` = no history). */
+export interface TrendGeometryPoint {
+  readonly count: number
+  readonly threshold: number | null
+}
+
+/** A point in the `0..N` (x, bucket index) × `0..100` (y) chart space used by the threshold path. */
+export interface ThresholdPoint {
+  readonly x: number
+  readonly y: number
+}
+
+/**
+ * Map a count to a visible height percentage in `[0, MAX]`. Zero stays zero (no bar); anything
+ * positive is clamped up to `MIN` so it stays legible.
+ */
+export function toVisibleHeightPercent(count: number, maxCount: number): number {
+  if (count === 0) {
+    return 0
+  }
+  return Math.max(MIN_VISIBLE_BAR_HEIGHT_PERCENT, (count / maxCount) * MAX_VISIBLE_BAR_HEIGHT_PERCENT)
+}
+
+/**
+ * The scale denominator: the largest of all counts AND thresholds (so the dashed line never
+ * clips off the top), floored at 1 so a flat-zero window doesn't divide by zero.
+ */
+export function computeTrendMaxCount(points: readonly TrendGeometryPoint[]): number {
+  return Math.max(...points.map((point) => Math.max(point.count, point.threshold ?? 0)), 1)
+}
+
+/**
+ * Group consecutive buckets that carry a threshold into smoothable segments. A `null` threshold
+ * breaks the line — that span had no contributing prior history, so any "expected" value would be
+ * misleading. Coordinates use the chart-wide space: `x = bucket center (i + 0.5)` in `0..N`,
+ * `y = 100 − heightPercent` in `0..100`.
+ */
+export function buildThresholdSegments(points: readonly TrendGeometryPoint[], maxCount: number): ThresholdPoint[][] {
+  const segments: ThresholdPoint[][] = []
+  let active: ThresholdPoint[] = []
+  points.forEach((point, index) => {
+    if (point.threshold === null) {
+      if (active.length > 0) {
+        segments.push(active)
+        active = []
+      }
+      return
+    }
+    const heightPercent = toVisibleHeightPercent(point.threshold, maxCount)
+    active.push({ x: index + 0.5, y: 100 - heightPercent })
+  })
+  if (active.length > 0) segments.push(active)
+  return segments
+}
+
+/**
+ * Build a single SVG `<path>` `d` attribute that smoothly connects the given points using a
+ * Catmull-Rom spline expressed as cubic Bezier segments. Endpoints duplicate themselves as
+ * virtual neighbours so the curve doesn't accelerate at the boundary. Coordinates are emitted
+ * with 3 decimals — enough for sub-pixel placement when the SVG scales to its container.
+ */
+export function buildSmoothThresholdPath(points: readonly ThresholdPoint[]): string {
+  if (points.length === 0) return ""
+  const first = points[0]
+  if (!first) return ""
+  if (points.length === 1) {
+    // Single point inside an otherwise-broken segment: draw a tiny horizontal dash so the
+    // datum is still visible (otherwise an isolated bucket would render as nothing).
+    return `M ${(first.x - 0.3).toFixed(3)} ${first.y.toFixed(3)} L ${(first.x + 0.3).toFixed(3)} ${first.y.toFixed(3)}`
+  }
+
+  const parts: string[] = [`M ${first.x.toFixed(3)} ${first.y.toFixed(3)}`]
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i]
+    const p2 = points[i + 1]
+    if (!p1 || !p2) continue
+    const p0 = points[i - 1] ?? p1
+    const p3 = points[i + 2] ?? p2
+    const cp1x = p1.x + (p2.x - p0.x) / 6
+    const cp1y = p1.y + (p2.y - p0.y) / 6
+    const cp2x = p2.x - (p3.x - p1.x) / 6
+    const cp2y = p2.y - (p3.y - p1.y) / 6
+    parts.push(
+      `C ${cp1x.toFixed(3)} ${cp1y.toFixed(3)}, ${cp2x.toFixed(3)} ${cp2y.toFixed(3)}, ${p2.x.toFixed(3)} ${p2.y.toFixed(3)}`,
+    )
+  }
+  return parts.join(" ")
+}

--- a/apps/web/src/domains/notifications/email-chart/fonts.ts
+++ b/apps/web/src/domains/notifications/email-chart/fonts.ts
@@ -11,6 +11,10 @@
  * doesn't hang an inbound chart request indefinitely — the caller
  * catches the throw and degrades to the 1×1 transparent PNG fallback.
  */
+import { writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 const FONT_URL = "https://cdn.jsdelivr.net/npm/@expo-google-fonts/source-serif-pro@0.2.3/SourceSerifPro_400Regular.ttf"
 const FONT_FETCH_TIMEOUT_MS = 5_000
 
@@ -23,7 +27,7 @@ const fetchFont = async (): Promise<ArrayBuffer> => {
   return res.arrayBuffer()
 }
 
-export const getChartFont = async (): Promise<ArrayBuffer> => {
+const getChartFont = async (): Promise<ArrayBuffer> => {
   if (cached) return cached
   if (!inFlight) {
     inFlight = fetchFont()
@@ -36,4 +40,29 @@ export const getChartFont = async (): Promise<ArrayBuffer> => {
       })
   }
   return inFlight
+}
+
+/**
+ * Path to the chart font on disk, for Resvg's `font.fontFiles` option (resvg-js 2.6.2 has no
+ * in-memory `fontBuffers`, so the buffer is materialised to a temp file once and the path is
+ * cached). The hand-built incident-trend SVG uses Resvg to lay out `<text>` axis labels, which
+ * needs a real font file — unlike the prior Satori path that vectorised glyphs in-process.
+ */
+let fontFilePromise: Promise<string> | null = null
+
+export const getChartFontFile = async (): Promise<string> => {
+  if (!fontFilePromise) {
+    fontFilePromise = (async () => {
+      const buffer = await getChartFont()
+      const filePath = join(tmpdir(), "latitude-incident-trend-source-serif-pro-400.ttf")
+      await writeFile(filePath, Buffer.from(buffer))
+      return filePath
+    })().catch((error) => {
+      // Reset so a transient fs/CDN failure can be retried on the next render instead of
+      // poisoning the cache permanently.
+      fontFilePromise = null
+      throw error
+    })
+  }
+  return fontFilePromise
 }

--- a/apps/web/src/domains/notifications/email-chart/render-incident-trend.test.ts
+++ b/apps/web/src/domains/notifications/email-chart/render-incident-trend.test.ts
@@ -1,0 +1,62 @@
+import type { IncidentTrend } from "@domain/notifications"
+import { describe, expect, it } from "vitest"
+import { INCIDENT_SEVERITY_HEX } from "../../alerts/incident-markers.ts"
+import { buildIncidentTrendSvg } from "./render-incident-trend.tsx"
+
+const HOUR_12_MS = 12 * 60 * 60 * 1000
+
+const baseTrend = (overrides: Partial<IncidentTrend> = {}): IncidentTrend => ({
+  bucketDurationMs: HOUR_12_MS,
+  points: [
+    { t: "2026-05-06T00:00:00.000Z", count: 2, threshold: 3 },
+    { t: "2026-05-06T12:00:00.000Z", count: 5, threshold: null },
+    { t: "2026-05-07T00:00:00.000Z", count: 9, threshold: 7 },
+    { t: "2026-05-07T12:00:00.000Z", count: 4, threshold: 6 },
+  ],
+  marker: { startedAt: "2026-05-07T00:00:00.000Z", endedAt: null, severity: "high" },
+  ...overrides,
+})
+
+describe("buildIncidentTrendSvg", () => {
+  it("renders an empty-state frame when there are no points", () => {
+    const svg = buildIncidentTrendSvg(baseTrend({ points: [], marker: undefined }))
+    expect(svg).toContain("No trend data")
+    expect(svg).not.toContain("<rect x=")
+  })
+
+  it("renders bars, the dashed expectation curve, and day-axis labels", () => {
+    const svg = buildIncidentTrendSvg(baseTrend())
+    expect(svg).not.toContain("No trend data")
+    // Occurrence bars.
+    expect(svg).toContain("<rect x=")
+    // Threshold curve uses the dedicated "4 3" dash (distinct from the "3 3" guide lines).
+    expect(svg).toContain('stroke-dasharray="4 3"')
+    expect(svg).toContain("<path d=")
+    // Day-axis labels.
+    expect(svg).toContain("<text")
+  })
+
+  it("draws the incident severity band and start dot in the severity color", () => {
+    const svg = buildIncidentTrendSvg(baseTrend())
+    expect(svg).toContain(INCIDENT_SEVERITY_HEX.high)
+    // Band tint.
+    expect(svg).toContain('fill-opacity="0.16"')
+    // Start dot.
+    expect(svg).toContain("<circle")
+  })
+
+  it("omits the dashed curve for a brand-new issue with no seasonal history", () => {
+    const svg = buildIncidentTrendSvg(
+      baseTrend({
+        points: [
+          { t: "2026-05-06T00:00:00.000Z", count: 2, threshold: null },
+          { t: "2026-05-07T00:00:00.000Z", count: 9, threshold: null },
+        ],
+      }),
+    )
+    // No threshold curve…
+    expect(svg).not.toContain('stroke-dasharray="4 3"')
+    // …but the bars still render.
+    expect(svg).toContain("<rect x=")
+  })
+})

--- a/apps/web/src/domains/notifications/email-chart/render-incident-trend.tsx
+++ b/apps/web/src/domains/notifications/email-chart/render-incident-trend.tsx
@@ -1,270 +1,245 @@
-import type { IncidentBreach, IncidentTrend } from "@domain/notifications"
+import type { IncidentTrend } from "@domain/notifications"
 import { Resvg } from "@resvg/resvg-js"
-// @ts-expect-error TS6133 - React required at runtime for JSX
-// biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX
-import React from "react"
-import satori from "satori"
-import { getChartFont } from "./fonts.ts"
+import { INCIDENT_SEVERITY_HEX } from "../../alerts/incident-markers.ts"
+import {
+  buildSmoothThresholdPath,
+  buildThresholdSegments,
+  computeTrendMaxCount,
+  type ThresholdPoint,
+  toVisibleHeightPercent,
+} from "../../issues/trend-chart/trend-geometry.ts"
+import { getChartFontFile } from "./fonts.ts"
 
-const CHART_WIDTH = 600
-const CHART_HEIGHT = 200
+/**
+ * Server-side renderer for the incident-trend chart embedded in the escalating-incident Slack
+ * message and email. It mirrors the in-app issue-detail drawer chart (`IssueTrendBar`) — same
+ * 14-day / 12h window, same gray occurrence bars, the same smooth dashed seasonal-expectation
+ * curve, and a severity band + start dot for the triggering incident — so the notification and
+ * the issue page read as the same chart.
+ *
+ * Built as a hand-authored SVG string rasterised by Resvg (not Satori): Satori can't render SVG
+ * `stroke-dasharray`, which the expectation curve needs. Resvg/usvg renders `<path>` dashes,
+ * `<rect>`, `<circle>`, `<line>`, and `<text>` faithfully; the geometry/segmentation math is the
+ * exact same pure helpers the drawer uses, so the two stay visually in sync.
+ *
+ * 600×200 px PNG (matches the email `<Img>` aspect ratio), light theme only.
+ */
+
+const WIDTH = 600
+const HEIGHT = 200
 const PADDING_X = 16
-const PADDING_TOP = 14
-const PADDING_BOTTOM = 22
+const CHART_TOP = 12
+const CHART_BOTTOM = 28 // room for the day-axis labels
 
+const CHART_LEFT = PADDING_X
+const CHART_RIGHT = WIDTH - PADDING_X
+const CHART_TOP_Y = CHART_TOP
+const CHART_BOTTOM_Y = HEIGHT - CHART_BOTTOM
+const INNER_W = CHART_RIGHT - CHART_LEFT
+const INNER_H = CHART_BOTTOM_Y - CHART_TOP_Y
+
+const GUIDE_LINE_COUNT = 5
+const MAX_AXIS_LABELS = 6
+
+/** Light-theme palette mapping the drawer's Tailwind tokens to concrete colors usvg can parse. */
 const COLORS = {
   background: "#ffffff",
-  bar: "#dbe5ff",
-  barEmphasis: "#3b5bff",
-  threshold: "#dc2626",
-  baseline: "#9ca3af",
-  axis: "#e5e7eb",
-  label: "#6b7280",
+  bar: "#66727f", // muted-foreground
+  guide: "#e5e5e5", // border
+  threshold: "#66727f", // muted-foreground (dashed expectation curve)
+  label: "#66727f", // muted-foreground
 } as const
+const BAR_OPACITY = 0.6
+const GUIDE_OPACITY = 0.6
+const THRESHOLD_OPACITY = 0.6
+const SEVERITY_BAND_OPACITY = 0.16
+
+const fmt = (value: number): string => value.toFixed(2)
+
+const escapeXml = (value: string): string =>
+  value.replace(/[<>&'"]/g, (char) =>
+    char === "<" ? "&lt;" : char === ">" ? "&gt;" : char === "&" ? "&amp;" : char === "'" ? "&apos;" : "&quot;",
+  )
+
+const formatDayLabel = (iso: string): string => {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ""
+  // UTC so the label matches the bucket's UTC-aligned start regardless of server timezone.
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" })
+}
 
 /**
- * Server-side renderer for the email's incident trend chart. Bars are
- * the per-bucket occurrence counts; a dashed red threshold line traces
- * the seasonal entry band per-bucket (broken across `null` thresholds
- * the same way the bell sparkline / `IssueTrendBar` does). Optional
- * baseline reference line for sustained-opened renders.
- *
- * 600×200 px PNG, no axis ticks — meant for an at-a-glance email read.
+ * Same even-spread label selection the drawer uses (`getVisibleBucketLabelIndices`): show every
+ * bucket up to the cap, otherwise pick `MAX_AXIS_LABELS` evenly-spaced indices including both ends.
  */
-export const renderIncidentTrendPng = async (input: {
-  readonly trend: IncidentTrend
-  readonly breach?: IncidentBreach
-}): Promise<Buffer> => {
-  const font = await getChartFont()
-  const points = input.trend.points
-  if (points.length === 0) {
-    // Render an empty chart frame so the email still has something
-    // visually anchored where the chart would be.
-    return renderEmpty(font)
+const pickLabelIndices = (total: number): ReadonlySet<number> => {
+  if (total <= 0) return new Set()
+  if (total <= MAX_AXIS_LABELS) return new Set(Array.from({ length: total }, (_, index) => index))
+  const count = Math.max(2, MAX_AXIS_LABELS)
+  return new Set(Array.from({ length: count }, (_, index) => Math.round((index * (total - 1)) / (count - 1))))
+}
+
+/** Snap a timestamp to the bucket index whose `[start, start + width)` range contains it. */
+const snapToBucketIndex = (ms: number, firstStartMs: number, widthMs: number, lastIndex: number): number | null => {
+  if (!Number.isFinite(ms) || widthMs <= 0) return null
+  const index = Math.floor((ms - firstStartMs) / widthMs)
+  if (index < 0 || index > lastIndex) return null
+  return index
+}
+
+interface IncidentSpan {
+  /** Bucket the band starts at (clamped to 0 when the incident opened before the window). */
+  readonly bandStart: number
+  /** Bucket the band ends at (clamped to the last bucket while the incident is still open). */
+  readonly bandEnd: number
+  /** Bucket the start dot sits in, or `null` when the incident opened outside the window. */
+  readonly dotBucket: number | null
+  readonly color: string
+}
+
+/** Resolve the severity band span + start-dot bucket from the trend's incident marker. */
+const resolveIncidentSpan = (trend: IncidentTrend, bucketStartsMs: readonly number[]): IncidentSpan | null => {
+  const marker = trend.marker
+  const firstStartMs = bucketStartsMs[0]
+  if (!marker || firstStartMs === undefined || !Number.isFinite(firstStartMs)) return null
+
+  const widthMs = trend.bucketDurationMs
+  const lastIndex = bucketStartsMs.length - 1
+  const startedMs = Date.parse(marker.startedAt)
+  const endedMs = marker.endedAt !== null ? Date.parse(marker.endedAt) : Number.NaN
+
+  const dotBucket = snapToBucketIndex(startedMs, firstStartMs, widthMs, lastIndex)
+  // Band start: snapped bucket, or 0 when the incident opened before the window but is active in it.
+  const bandStart = dotBucket ?? (Number.isFinite(startedMs) && startedMs < firstStartMs ? 0 : null)
+  if (bandStart === null) return null
+
+  let bandEnd: number
+  if (marker.endedAt !== null) {
+    const snapped = snapToBucketIndex(endedMs, firstStartMs, widthMs, lastIndex)
+    bandEnd = snapped ?? (Number.isFinite(endedMs) && endedMs >= firstStartMs ? lastIndex : bandStart)
+  } else {
+    // Still open → paint to the right edge, matching the drawer's ongoing-range behaviour.
+    bandEnd = lastIndex
   }
 
-  // Scale: bars + threshold both participate. Floor at 1 so a flat-zero
-  // window doesn't blow up to NaN.
-  const maxCount = Math.max(1, ...points.map((p) => Math.max(p.count, p.threshold !== null ? p.threshold : 0)))
+  return { bandStart, bandEnd, dotBucket, color: INCIDENT_SEVERITY_HEX[marker.severity] }
+}
 
-  const innerWidth = CHART_WIDTH - PADDING_X * 2
-  const innerHeight = CHART_HEIGHT - PADDING_TOP - PADDING_BOTTOM
-  const barSlot = innerWidth / points.length
-  const barWidth = Math.max(2, barSlot * 0.7)
-  const barGap = barSlot - barWidth
+/** Map a threshold point from the drawer's `0..N × 0..100` space into this chart's pixel space. */
+const toPixel = (point: ThresholdPoint, barSlot: number): ThresholdPoint => ({
+  x: CHART_LEFT + point.x * barSlot,
+  y: CHART_TOP_Y + (point.y / 100) * INNER_H,
+})
 
-  const yForValue = (value: number) => PADDING_TOP + (1 - value / maxCount) * innerHeight
-
-  const peakCount = points.reduce((m, p) => (p.count > m ? p.count : m), 0)
-  // Group consecutive points with non-null thresholds. Each segment
-  // becomes one dashed run.
-  const segments: { start: number; end: number; values: number[] }[] = []
-  let activeStart: number | null = null
-  let activeValues: number[] = []
-  points.forEach((p, idx) => {
-    if (p.threshold !== null) {
-      if (activeStart === null) {
-        activeStart = idx
-        activeValues = []
-      }
-      activeValues.push(p.threshold)
-    } else if (activeStart !== null) {
-      segments.push({ start: activeStart, end: activeStart + activeValues.length - 1, values: activeValues })
-      activeStart = null
-      activeValues = []
-    }
+const renderToPng = (svg: string, fontFile: string): Buffer =>
+  new Resvg(svg, {
+    fitTo: { mode: "width", value: WIDTH },
+    font: { fontFiles: [fontFile], defaultFontFamily: "Source Serif Pro", loadSystemFonts: false },
   })
-  if (activeStart !== null) {
-    segments.push({ start: activeStart, end: activeStart + activeValues.length - 1, values: activeValues })
+    .render()
+    .asPng()
+
+export const renderIncidentTrendPng = async (input: { readonly trend: IncidentTrend }): Promise<Buffer> => {
+  const fontFile = await getChartFontFile()
+  return renderToPng(buildIncidentTrendSvg(input.trend), fontFile)
+}
+
+/**
+ * Build the chart SVG markup. Pure (no font fetch, no rasterisation) so it can be unit-tested
+ * directly. Returns an empty-state frame when the trend carries no points.
+ */
+export const buildIncidentTrendSvg = (trend: IncidentTrend): string => {
+  const points = trend.points
+  if (points.length === 0) {
+    return EMPTY_SVG
   }
 
-  const baselineY = input.breach ? yForValue(input.breach.baselineRate) : null
-  const showBaseline = baselineY !== null && baselineY > PADDING_TOP && baselineY < CHART_HEIGHT - PADDING_BOTTOM
+  const maxCount = computeTrendMaxCount(points)
+  const bucketCount = points.length
+  const barSlot = INNER_W / bucketCount
+  const barWidth = Math.max(2, barSlot * 0.7)
+  const barInset = (barSlot - barWidth) / 2
 
-  const svg = await satori(
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        width: "100%",
-        height: "100%",
-        backgroundColor: COLORS.background,
-        fontFamily: "Source Serif Pro",
-        position: "relative",
-      }}
-    >
-      {/* Chart frame */}
-      <div
-        style={{
-          position: "absolute",
-          left: PADDING_X,
-          right: PADDING_X,
-          top: PADDING_TOP,
-          bottom: PADDING_BOTTOM,
-          display: "flex",
-          alignItems: "flex-end",
-          gap: `${barGap}px`,
-        }}
-      >
-        {points.map((p, idx) => {
-          const heightPx = (p.count / maxCount) * innerHeight
-          const isPeak = p.count === peakCount && peakCount > 0
-          return (
-            <div
-              key={`${p.t}-${idx}`}
-              style={{
-                width: `${barWidth}px`,
-                height: `${Math.max(heightPx, 1)}px`,
-                backgroundColor: isPeak ? COLORS.barEmphasis : COLORS.bar,
-                borderRadius: "2px",
-                display: "flex",
-              }}
-            />
-          )
-        })}
-      </div>
-      {/* Baseline reference line */}
-      {showBaseline ? (
-        <div
-          style={{
-            position: "absolute",
-            left: PADDING_X,
-            right: PADDING_X,
-            top: baselineY - 0.5,
-            height: "1px",
-            backgroundColor: COLORS.baseline,
-            display: "flex",
-          }}
-        />
-      ) : null}
-      {/* Threshold segments — render each contiguous run as a dashed line built from short bars */}
-      {segments.map((segment) => (
-        <ThresholdSegment
-          key={`${segment.start}-${segment.end}`}
-          segment={segment}
-          barSlot={barSlot}
-          paddingX={PADDING_X}
-          yForValue={yForValue}
-        />
-      ))}
-      {/* Caption: peak count + breach context when available */}
-      <div
-        style={{
-          position: "absolute",
-          left: PADDING_X,
-          right: PADDING_X,
-          bottom: 4,
-          display: "flex",
-          justifyContent: "space-between",
-          color: COLORS.label,
-          fontSize: 11,
-        }}
-      >
-        <span>peak {peakCount}/bucket</span>
-        {input.breach ? (
-          <span>
-            baseline {Math.round(input.breach.baselineRate)}/hr · threshold {Math.round(input.breach.threshold)}/hr
-          </span>
-        ) : (
-          <span />
-        )}
-      </div>
-    </div>,
-    {
-      width: CHART_WIDTH,
-      height: CHART_HEIGHT,
-      fonts: [{ name: "Source Serif Pro", data: font, weight: 400, style: "normal" }],
-    },
-  )
+  const bucketStartsMs = points.map((point) => Date.parse(point.t))
+  const span = resolveIncidentSpan(trend, bucketStartsMs)
 
-  return new Resvg(svg, { fitTo: { mode: "width", value: CHART_WIDTH } }).render().asPng()
+  const parts: string[] = []
+
+  // Guide lines — dashed, with a solid baseline at the bottom (like the drawer's mini histogram).
+  for (let i = 0; i < GUIDE_LINE_COUNT; i++) {
+    const y = CHART_TOP_Y + (i * INNER_H) / (GUIDE_LINE_COUNT - 1)
+    const isBaseline = i === GUIDE_LINE_COUNT - 1
+    parts.push(
+      `<line x1="${CHART_LEFT}" y1="${fmt(y)}" x2="${CHART_RIGHT}" y2="${fmt(y)}" stroke="${COLORS.guide}" stroke-opacity="${GUIDE_OPACITY}" stroke-width="1"${isBaseline ? "" : ' stroke-dasharray="3 3"'} />`,
+    )
+  }
+
+  // Severity band behind the bars.
+  if (span) {
+    const bandX = CHART_LEFT + span.bandStart * barSlot
+    const bandW = (span.bandEnd - span.bandStart + 1) * barSlot
+    parts.push(
+      `<rect x="${fmt(bandX)}" y="${CHART_TOP_Y}" width="${fmt(bandW)}" height="${INNER_H}" fill="${span.color}" fill-opacity="${SEVERITY_BAND_OPACITY}" rx="2" />`,
+    )
+  }
+
+  // Occurrence bars.
+  for (let i = 0; i < bucketCount; i++) {
+    const count = points[i]?.count ?? 0
+    if (count <= 0) continue
+    const heightPx = (toVisibleHeightPercent(count, maxCount) / 100) * INNER_H
+    const x = CHART_LEFT + i * barSlot + barInset
+    const y = CHART_BOTTOM_Y - heightPx
+    parts.push(
+      `<rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(barWidth)}" height="${fmt(Math.max(heightPx, 1))}" rx="1.5" fill="${COLORS.bar}" fill-opacity="${BAR_OPACITY}" />`,
+    )
+  }
+
+  // Dashed seasonal-expectation curve (one path per contiguous run of non-null thresholds).
+  for (const segment of buildThresholdSegments(points, maxCount)) {
+    const path = buildSmoothThresholdPath(segment.map((point) => toPixel(point, barSlot)))
+    if (!path) continue
+    parts.push(
+      `<path d="${path}" fill="none" stroke="${COLORS.threshold}" stroke-opacity="${THRESHOLD_OPACITY}" stroke-width="1.5" stroke-dasharray="4 3" stroke-linecap="round" />`,
+    )
+  }
+
+  // Incident start tick + dot.
+  if (span && span.dotBucket !== null) {
+    const cx = CHART_LEFT + (span.dotBucket + 0.5) * barSlot
+    parts.push(
+      `<line x1="${fmt(cx)}" y1="${CHART_TOP_Y}" x2="${fmt(cx)}" y2="${CHART_BOTTOM_Y}" stroke="${span.color}" stroke-width="1.5" />`,
+      `<circle cx="${fmt(cx)}" cy="${CHART_TOP_Y}" r="3" fill="${span.color}" />`,
+    )
+  }
+
+  // Day-axis labels.
+  const labelIndices = pickLabelIndices(bucketCount)
+  for (let i = 0; i < bucketCount; i++) {
+    if (!labelIndices.has(i)) continue
+    const label = formatDayLabel(points[i]?.t ?? "")
+    if (!label) continue
+    const cx = CHART_LEFT + (i + 0.5) * barSlot
+    const anchor = i === 0 ? "start" : i === bucketCount - 1 ? "end" : "middle"
+    const x = i === 0 ? CHART_LEFT : i === bucketCount - 1 ? CHART_RIGHT : cx
+    parts.push(
+      `<text x="${fmt(x)}" y="${HEIGHT - 9}" font-family="Source Serif Pro" font-size="11" fill="${COLORS.label}" text-anchor="${anchor}">${escapeXml(label)}</text>`,
+    )
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}"><rect width="${WIDTH}" height="${HEIGHT}" fill="${COLORS.background}" />${parts.join("")}</svg>`
 }
 
 /**
- * Per-segment dashed line drawn as a row of short filled rects. Satori
- * doesn't render SVG `stroke-dasharray`, and CSS `border-style: dashed`
- * inside satori produces inconsistent results across renders, so the
- * dashes are emitted as positioned divs.
+ * Empty-state frame so the email/Slack `<Img>` still renders something anchored where the chart
+ * would be when a notification row carries no trend points.
  */
-function ThresholdSegment({
-  segment,
-  barSlot,
-  paddingX,
-  yForValue,
-}: {
-  readonly segment: { start: number; end: number; values: number[] }
-  readonly barSlot: number
-  readonly paddingX: number
-  readonly yForValue: (value: number) => number
-}) {
-  const dashEvery = 8
-  const dashLen = 4
-  const startX = paddingX + segment.start * barSlot + barSlot / 2
-  const endX = paddingX + segment.end * barSlot + barSlot / 2
-  const widthPx = Math.max(2, endX - startX)
-  // Average the threshold within the segment for the y position. Most
-  // segments are flat in practice (the seasonal grid changes hourly).
-  const avgThreshold = segment.values.reduce((s, v) => s + v, 0) / segment.values.length
-  const y = yForValue(avgThreshold)
-  const dashCount = Math.max(1, Math.floor(widthPx / dashEvery))
-  return (
-    <div
-      style={{
-        position: "absolute",
-        left: startX,
-        top: y - 0.75,
-        width: widthPx,
-        height: 1.5,
-        display: "flex",
-        gap: `${dashEvery - dashLen}px`,
-      }}
-    >
-      {Array.from({ length: dashCount }).map((_, i) => (
-        <div
-          key={i}
-          style={{
-            width: `${dashLen}px`,
-            height: "1.5px",
-            backgroundColor: COLORS.threshold,
-            display: "flex",
-          }}
-        />
-      ))}
-    </div>
-  )
-}
-
-const renderEmpty = async (font: ArrayBuffer): Promise<Buffer> => {
-  const svg = await satori(
-    <div
-      style={{
-        display: "flex",
-        width: "100%",
-        height: "100%",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: COLORS.background,
-        color: COLORS.label,
-        fontFamily: "Source Serif Pro",
-        fontSize: 13,
-      }}
-    >
-      No trend data
-    </div>,
-    {
-      width: CHART_WIDTH,
-      height: CHART_HEIGHT,
-      fonts: [{ name: "Source Serif Pro", data: font, weight: 400, style: "normal" }],
-    },
-  )
-  return new Resvg(svg, { fitTo: { mode: "width", value: CHART_WIDTH } }).render().asPng()
-}
+const EMPTY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}"><rect width="${WIDTH}" height="${HEIGHT}" fill="${COLORS.background}" /><text x="${WIDTH / 2}" y="${HEIGHT / 2}" font-family="Source Serif Pro" font-size="13" fill="${COLORS.label}" text-anchor="middle" dominant-baseline="middle">No trend data</text></svg>`
 
 /**
- * 1×1 transparent PNG used as the fallback when the request hits a
- * notification row that doesn't have a trend (e.g. `incident.event`)
- * or the row was deleted. Returning a real PNG keeps the email's
- * `<Img>` tag from breaking into an alt-text fallback.
+ * 1×1 transparent PNG used as the fallback when the request hits a notification row that doesn't
+ * have a trend (e.g. `incident.event`) or the row was deleted. Returning a real PNG keeps the
+ * email's `<Img>` tag from breaking into an alt-text fallback.
  */
 export const TRANSPARENT_1x1_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGD4DwABBAEAfbLI3wAAAABJRU5ErkJggg==",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-trend-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-trend-bar.tsx
@@ -9,14 +9,18 @@ import {
   INCIDENT_SEVERITY_COLOR,
 } from "../../../../../../domains/alerts/incident-markers.ts"
 import {
+  buildSmoothThresholdPath,
+  buildThresholdSegments,
+  computeTrendMaxCount,
+  toVisibleHeightPercent,
+} from "../../../../../../domains/issues/trend-chart/trend-geometry.ts"
+import {
   formatHistogramBucketDayLabel,
   formatHistogramBucketLabel,
   formatHistogramBucketTooltipLabel,
 } from "./issue-formatters.ts"
 
 const DEFAULT_MAX_VISIBLE_BUCKET_LABELS = 6
-const MIN_VISIBLE_BAR_HEIGHT_PERCENT = 12
-const MAX_VISIBLE_BAR_HEIGHT_PERCENT = 88
 const MINI_HISTOGRAM_GUIDE_LINE_COUNT = 5
 const MINI_HISTOGRAM_TOP_INSET_PX = 6
 const REGRESSED_BAR_CLASSES = "bg-rose-700 dark:bg-rose-400"
@@ -62,40 +66,6 @@ function resolveBarClasses(input: {
   return DEFAULT_ROW_BAR_CLASSES
 }
 
-/**
- * Build a single SVG `<path>` `d` attribute that smoothly connects the given points using a
- * Catmull-Rom spline expressed as cubic Bezier segments. Endpoints duplicate themselves as
- * virtual neighbours so the curve doesn't accelerate at the boundary. Coordinates are emitted
- * with 3 decimals — enough for sub-pixel placement when the SVG scales to its container.
- */
-function buildSmoothThresholdPath(points: readonly { readonly x: number; readonly y: number }[]): string {
-  if (points.length === 0) return ""
-  const first = points[0]
-  if (!first) return ""
-  if (points.length === 1) {
-    // Single point inside an otherwise-broken segment: draw a tiny horizontal dash so the
-    // datum is still visible (otherwise an isolated bucket would render as nothing).
-    return `M ${(first.x - 0.3).toFixed(3)} ${first.y.toFixed(3)} L ${(first.x + 0.3).toFixed(3)} ${first.y.toFixed(3)}`
-  }
-
-  const parts: string[] = [`M ${first.x.toFixed(3)} ${first.y.toFixed(3)}`]
-  for (let i = 0; i < points.length - 1; i++) {
-    const p1 = points[i]
-    const p2 = points[i + 1]
-    if (!p1 || !p2) continue
-    const p0 = points[i - 1] ?? p1
-    const p3 = points[i + 2] ?? p2
-    const cp1x = p1.x + (p2.x - p0.x) / 6
-    const cp1y = p1.y + (p2.y - p0.y) / 6
-    const cp2x = p2.x - (p3.x - p1.x) / 6
-    const cp2y = p2.y - (p3.y - p1.y) / 6
-    parts.push(
-      `C ${cp1x.toFixed(3)} ${cp1y.toFixed(3)}, ${cp2x.toFixed(3)} ${cp2y.toFixed(3)}, ${p2.x.toFixed(3)} ${p2.y.toFixed(3)}`,
-    )
-  }
-  return parts.join(" ")
-}
-
 function getVisibleBucketLabelIndices(totalBuckets: number, maxVisibleBucketLabels: number): ReadonlySet<number> {
   if (totalBuckets <= 0) {
     return new Set()
@@ -109,14 +79,6 @@ function getVisibleBucketLabelIndices(totalBuckets: number, maxVisibleBucketLabe
   return new Set(
     Array.from({ length: labelCount }, (_, index) => Math.round((index * (totalBuckets - 1)) / (labelCount - 1))),
   )
-}
-
-function toVisibleHeightPercent(count: number, maxCount: number): number {
-  if (count === 0) {
-    return 0
-  }
-
-  return Math.max(MIN_VISIBLE_BAR_HEIGHT_PERCENT, (count / maxCount) * MAX_VISIBLE_BAR_HEIGHT_PERCENT)
 }
 
 interface IncidentBucketInfo {
@@ -340,33 +302,20 @@ export function IssueTrendBar({
     [chartBuckets.length, maxVisibleBucketLabels],
   )
 
-  // Threshold values participate in the scale so the dashed line never clips off the top.
-  const maxCount = useMemo(
-    () => Math.max(...chartBuckets.map((bucket) => Math.max(bucket.count, bucket.thresholdCount ?? 0)), 1),
+  // Shared shape `{ count, threshold }` consumed by the geometry helpers (the renderer side uses
+  // the same helpers against the notification payload), so bars + the dashed curve stay in sync.
+  const trendPoints = useMemo(
+    () => chartBuckets.map((bucket) => ({ count: bucket.count, threshold: bucket.thresholdCount })),
     [chartBuckets],
   )
 
-  // Group consecutive buckets that carry a threshold into smoothable segments. A null
-  // breaks the line — that span had no contributing prior history, so any "expected" value
-  // would be misleading. SVG coordinates use the chart-wide viewBox set on the overlay below:
-  // x = bucket center (i + 0.5) in 0..N space, y = 100 − heightPercent in 0..100 space.
-  const thresholdSegments = useMemo<{ readonly x: number; readonly y: number }[][]>(() => {
-    const segments: { x: number; y: number }[][] = []
-    let active: { x: number; y: number }[] = []
-    chartBuckets.forEach((bucket, index) => {
-      if (bucket.thresholdCount === null) {
-        if (active.length > 0) {
-          segments.push(active)
-          active = []
-        }
-        return
-      }
-      const heightPercent = toVisibleHeightPercent(bucket.thresholdCount, maxCount)
-      active.push({ x: index + 0.5, y: 100 - heightPercent })
-    })
-    if (active.length > 0) segments.push(active)
-    return segments
-  }, [chartBuckets, maxCount])
+  // Threshold values participate in the scale so the dashed line never clips off the top.
+  const maxCount = useMemo(() => computeTrendMaxCount(trendPoints), [trendPoints])
+
+  // Group consecutive buckets that carry a threshold into smoothable segments (the helper breaks
+  // the line across `null` thresholds). Coordinates use the chart-wide viewBox set on the overlay
+  // below: x = bucket center (i + 0.5) in 0..N space, y = 100 − heightPercent in 0..100 space.
+  const thresholdSegments = useMemo(() => buildThresholdSegments(trendPoints, maxCount), [trendPoints, maxCount])
 
   if (isLoading) {
     return <ChartSkeleton minHeight={height} className="border-0 bg-transparent p-0" />

--- a/apps/web/src/routes/api/notifications/$nid/incident-trend[.]png.ts
+++ b/apps/web/src/routes/api/notifications/$nid/incident-trend[.]png.ts
@@ -87,12 +87,8 @@ export const Route = createFileRoute("/api/notifications/$nid/incident-trend.png
         const trend = parsed.data.trend
         if (!trend) return respondTransparent()
 
-        const breach = "breach" in parsed.data ? parsed.data.breach : undefined
         try {
-          const png = await renderIncidentTrendPng({
-            trend,
-            ...(breach ? { breach } : {}),
-          })
+          const png = await renderIncidentTrendPng({ trend })
           return respondPng(png)
         } catch (cause) {
           logger.error(`charts.incident-trend: render failed for ${params.nid}`, cause)

--- a/packages/domain/issues/src/histogram-buckets.ts
+++ b/packages/domain/issues/src/histogram-buckets.ts
@@ -1,0 +1,42 @@
+import type { IssueOccurrenceBucket } from "@domain/scores"
+
+/**
+ * Sub-day-aware scaffold aligned to UTC bucket boundaries. Emits ISO-8601 UTC timestamps
+ * (`YYYY-MM-DDTHH:MM:SS.000Z`) — the same shape the ClickHouse analytics histogram returns.
+ * The scaffold starts at `floor(from / bucketWidth) * bucketWidth` and steps by `bucketSeconds`
+ * up to and including the bucket containing `to`.
+ *
+ * Shared by every surface that renders an occurrence histogram (issues list mini-bar, the issue
+ * detail trend, and the incident-notification trend snapshot) so empty buckets render as gaps
+ * consistently instead of collapsing the time axis.
+ */
+export const buildHistogramBucketScaffold = (input: {
+  readonly from: Date
+  readonly to: Date
+  readonly bucketSeconds: number
+}): readonly string[] => {
+  const widthMs = input.bucketSeconds * 1000
+  if (widthMs <= 0) return []
+  const startMs = Math.floor(input.from.getTime() / widthMs) * widthMs
+  const endMs = input.to.getTime()
+  const out: string[] = []
+  for (let cursor = startMs; cursor <= endMs; cursor += widthMs) {
+    out.push(new Date(cursor).toISOString())
+  }
+  return out
+}
+
+/**
+ * Zero-fills a sparse histogram against a scaffold so every bucket in the window has an entry.
+ * Buckets present in `buckets` keep their count; the rest default to `0`.
+ */
+export const fillBuckets = (input: {
+  readonly scaffold: readonly string[]
+  readonly buckets: readonly IssueOccurrenceBucket[]
+}): readonly IssueOccurrenceBucket[] => {
+  const countsByBucket = new Map(input.buckets.map((bucket) => [bucket.bucket, bucket.count] as const))
+  return input.scaffold.map((bucket) => ({
+    bucket,
+    count: countsByBucket.get(bucket) ?? 0,
+  }))
+}

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -79,6 +79,7 @@ export {
   type UpdateIssueCentroidInput,
   updateIssueCentroid,
 } from "./helpers.ts"
+export { buildHistogramBucketScaffold, fillBuckets } from "./histogram-buckets.ts"
 export { type IssueDiscoveryLockInput, issueDiscoveryLockKey, withIssueDiscoveryLock } from "./locks.ts"
 export {
   type IssueLifecycleFlags,

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -25,6 +25,7 @@ import { Effect } from "effect"
 import { z } from "zod"
 import { type IssueSource, IssueState } from "../entities/issue.ts"
 import { deriveIssueLifecycleStates, getEscalationOccurrenceThreshold } from "../helpers.ts"
+import { buildHistogramBucketScaffold, fillBuckets } from "../histogram-buckets.ts"
 import { IssueRepository, type IssueSearchCandidate, type IssueWithLifecycle } from "../ports/issue-repository.ts"
 
 export const issuesLifecycleGroupSchema = z.enum(["active", "archived"])
@@ -253,40 +254,6 @@ const buildBucketScaffold = (input: { readonly from: Date; readonly to: Date }):
   }
 
   return buckets
-}
-
-/**
- * Sub-day-aware scaffold aligned to UTC bucket boundaries. Emits ISO-8601 UTC timestamps
- * (`YYYY-MM-DDTHH:MM:SS.000Z`) — same shape the CH layer returns for the analytics histogram.
- * The scaffold starts at `floor(from / bucketWidth) * bucketWidth` and steps by `bucketSeconds`
- * up to and including the bucket containing `to`.
- */
-const buildHistogramBucketScaffold = (input: {
-  readonly from: Date
-  readonly to: Date
-  readonly bucketSeconds: number
-}): readonly string[] => {
-  const widthMs = input.bucketSeconds * 1000
-  if (widthMs <= 0) return []
-  const startMs = Math.floor(input.from.getTime() / widthMs) * widthMs
-  const endMs = input.to.getTime()
-  const out: string[] = []
-  for (let cursor = startMs; cursor <= endMs; cursor += widthMs) {
-    out.push(new Date(cursor).toISOString())
-  }
-  return out
-}
-
-const fillBuckets = (input: {
-  readonly scaffold: readonly string[]
-  readonly buckets: readonly IssueOccurrenceBucket[]
-}): readonly IssueOccurrenceBucket[] => {
-  const countsByBucket = new Map(input.buckets.map((bucket) => [bucket.bucket, bucket.count] as const))
-
-  return input.scaffold.map((bucket) => ({
-    bucket,
-    count: countsByBucket.get(bucket) ?? 0,
-  }))
 }
 
 const matchesLifecycleGroup = (

--- a/packages/domain/notifications/src/entities/notification.ts
+++ b/packages/domain/notifications/src/entities/notification.ts
@@ -26,14 +26,30 @@ export const incidentTrendPointSchema = z.object({
 })
 
 /**
- * Bucketed trend window snapshotted at incident-transition time. Window is
- * 3h ending at `startedAt` (`incident.opened`) or `endedAt`
- * (`incident.closed`); bucket size is currently 10 min (18 buckets), bumped
- * via `bucketDurationMs` so consumers don't hardcode it.
+ * The triggering incident, snapshotted onto the trend so the chart can draw a severity band
+ * (the incident's active span) and a start dot — mirroring the in-app issue-detail drawer. The
+ * window/anchor live on the trend itself; this just carries the incident's own timestamps and
+ * severity. Optional so payloads written before this field still parse.
+ */
+const incidentTrendMarkerSchema = z.object({
+  startedAt: z.iso.datetime(),
+  /** `null` while the incident is still open (e.g. `incident.opened`). */
+  endedAt: z.iso.datetime().nullable(),
+  severity: alertSeveritySchema,
+})
+export type IncidentTrendMarker = z.infer<typeof incidentTrendMarkerSchema>
+
+/**
+ * Bucketed trend window snapshotted at incident-transition time, frozen so the immutable PNG
+ * matches what the issue-detail drawer showed at that moment. Window is 14 days of UTC-aligned
+ * 12h buckets (~28 points) anchored at `startedAt` (`incident.opened`) or `endedAt`
+ * (`incident.closed`) — the same range + granularity the drawer renders. `bucketDurationMs` is
+ * carried so consumers don't hardcode it (older payloads still carry their 10-min value).
  */
 export const incidentTrendSchema = z.object({
   bucketDurationMs: z.number().int().positive(),
   points: z.array(incidentTrendPointSchema).max(64),
+  marker: incidentTrendMarkerSchema.optional(),
 })
 export type IncidentTrend = z.infer<typeof incidentTrendSchema>
 

--- a/packages/domain/notifications/src/index.ts
+++ b/packages/domain/notifications/src/index.ts
@@ -10,6 +10,7 @@ export type {
   IncidentSampleAuthor,
   IncidentSampleExcerpt,
   IncidentTrend,
+  IncidentTrendMarker,
   Notification,
   NotificationKind,
   WrappedReportPayload,

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
@@ -138,15 +138,17 @@ function setup(opts: SetupOpts = {}) {
     getProjectSettings: (_pid: ProjectId) => Effect.succeed(opts.projectSettings ?? null),
   })
 
+  // Keys are UTC-aligned to the 12h trend grid and fall inside the snapshot's 14d window
+  // (anchored at the incident's 2026-05-07 start) so they zip against the bucket scaffold.
   const occurrenceBuckets = opts.occurrenceBuckets ?? [
-    { bucket: "2026-05-07T07:10:00.000Z", count: 1 },
-    { bucket: "2026-05-07T08:10:00.000Z", count: 4 },
-    { bucket: "2026-05-07T09:10:00.000Z", count: 9 },
+    { bucket: "2026-05-06T00:00:00.000Z", count: 1 },
+    { bucket: "2026-05-06T12:00:00.000Z", count: 4 },
+    { bucket: "2026-05-07T00:00:00.000Z", count: 9 },
   ]
   const thresholdBuckets = opts.thresholdBuckets ?? [
-    { bucket: "2026-05-07T07:10:00.000Z", thresholdCount: 5 },
-    { bucket: "2026-05-07T08:10:00.000Z", thresholdCount: Number.NaN },
-    { bucket: "2026-05-07T09:10:00.000Z", thresholdCount: 7 },
+    { bucket: "2026-05-06T00:00:00.000Z", thresholdCount: 5 },
+    { bucket: "2026-05-06T12:00:00.000Z", thresholdCount: Number.NaN },
+    { bucket: "2026-05-07T00:00:00.000Z", thresholdCount: 7 },
   ]
 
   // Stub only the methods the producer calls; the rest stay as the
@@ -264,10 +266,17 @@ describe("requestIncidentNotificationsUseCase", () => {
     expect(result.requests[0]?.idempotencyKey).toBe(`incident.opened:${incidentId}`)
     const payload = result.requests[0]?.payload
     if (!payload || !("trend" in payload) || !payload.trend) throw new Error("expected trend on opened payload")
-    expect(payload.trend.bucketDurationMs).toBe(10 * 60 * 1000)
+    // 12h buckets over a 14-day window — matches the in-app issue-detail drawer grid.
+    expect(payload.trend.bucketDurationMs).toBe(12 * 60 * 60 * 1000)
+    // 14 days of UTC-aligned 12h buckets = 28 points.
+    expect(payload.trend.points).toHaveLength(28)
     // NaN thresholds round-trip through the producer as null.
     expect(payload.trend.points.some((p) => p.threshold === null)).toBe(true)
     expect(payload.trend.points.some((p) => typeof p.threshold === "number")).toBe(true)
+    // The triggering incident is snapshotted as a marker for the chart's band + start dot.
+    expect(payload.trend.marker?.severity).toBe("high")
+    expect(payload.trend.marker?.startedAt).toBe(startedAt.toISOString())
+    expect(payload.trend.marker?.endedAt).toBeNull()
   })
 
   it("derives incident.closed regardless of endedAt shape when transition='closed'", async () => {
@@ -665,7 +674,8 @@ describe("requestIncidentNotificationsUseCase", () => {
     if (!payload || !("breach" in payload)) throw new Error("expected breach on opened payload")
     expect(payload.breach?.baselineRate).toBe(4.2)
     expect(payload.breach?.threshold).toBe(7.5)
-    // triggerRate is derived from peak trend count × per-hour scale; verify it's a positive number.
+    // triggerRate is the fine-grained recent peak/hour (decoupled from the 12h display trend);
+    // verify it's a positive number.
     expect(payload.breach?.triggerRate).toBeGreaterThan(0)
   })
 

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
@@ -1,6 +1,6 @@
 import { type AlertIncident, AlertIncidentRepository, isIssueEscalationEntrySignals } from "@domain/alerts"
 import { EvaluationRepository } from "@domain/evaluations"
-import { DEFAULT_ESCALATION_SENSITIVITY_K } from "@domain/issues"
+import { buildHistogramBucketScaffold, DEFAULT_ESCALATION_SENSITIVITY_K, fillBuckets } from "@domain/issues"
 import type { MembershipRepository } from "@domain/organizations"
 import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
 import {
@@ -70,15 +70,27 @@ export type RequestIncidentNotificationsResult =
 export type RequestIncidentNotificationsError = RepositoryError | NotFoundError
 
 /**
- * Window/bucket size used for the trend snapshot on sustained kinds.
- * 18 buckets × 10 min = 3h, sized to fit comfortably in an email-width
- * chart and a bell sparkline while keeping enough resolution to read
- * the climb (opened) or descent (closed). Hourly seasonal-grid projection
- * still works at 10-min buckets — each bucket's threshold is roughly the
- * 1h figure pro-rated, computed inside the analytics repo.
+ * Window/bucket size for the trend snapshot on sustained kinds. 14 days of UTC-aligned 12h
+ * buckets (~28 points) — identical to the in-app issue-detail drawer (`getIssueDetail`) so the
+ * Slack/email chart shows the same data at the same granularity instead of a divergent 3h zoom.
+ * The window is frozen at incident time (the PNG is immutable/cached), UTC-day-aligned the same
+ * way the drawer aligns to "now".
  */
-const TREND_BUCKET_SECONDS = 600
-const TREND_WINDOW_MS = 3 * 60 * 60 * 1000
+const TREND_BUCKET_SECONDS = 12 * 60 * 60
+const TREND_LOOKBACK_DAYS = 14
+
+/**
+ * Separate fine-grained window used ONLY to derive the breach "rate climbed to X/hr" copy. The
+ * 12h display buckets above are too coarse to read an hourly peak from, so the rate is computed
+ * from a short recent window at 10-min resolution (the historical behaviour) — independent of the
+ * widened display trend.
+ */
+const RATE_PEAK_WINDOW_MS = 3 * 60 * 60 * 1000
+const RATE_PEAK_BUCKET_SECONDS = 600
+
+/** End-of-UTC-day for the anchor, matching the drawer's `toUtcDayEnd` window alignment. */
+const toUtcDayEnd = (value: Date): Date =>
+  new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 23, 59, 59, 999))
 
 /** Cap on sample-excerpt text length; truncated longer feedback gets `truncated: true`. */
 const SAMPLE_EXCERPT_MAX_CHARS = 200
@@ -99,9 +111,11 @@ const resolveKind = (incident: AlertIncident, transition: IncidentTransition): I
 }
 
 /**
- * Snapshot a 3h trend window ending at the relevant transition timestamp.
- * Returns `null` for `incident.event` (one-shot kinds have nothing to
- * trend at notification time) and for missing analytics data.
+ * Snapshot the 14d/12h trend window for sustained kinds, frozen at the relevant transition
+ * timestamp and UTC-day-aligned exactly like the issue-detail drawer. Zero-fills the window so
+ * empty buckets render as gaps, zips in the per-bucket seasonal threshold, and carries the
+ * triggering incident as a `marker` for the chart's severity band + start dot. Returns `null`
+ * for `incident.event` (one-shot kinds have nothing to trend at notification time).
  */
 const snapshotTrend = (input: {
   readonly incident: AlertIncident
@@ -112,12 +126,13 @@ const snapshotTrend = (input: {
     const { incident, kind, kShort } = input
     if (kind === "incident.event") return null
 
-    const anchorMs =
-      kind === "incident.closed" && incident.endedAt !== null
-        ? incident.endedAt.getTime()
-        : incident.startedAt.getTime()
-    const to = new Date(anchorMs)
-    const from = new Date(anchorMs - TREND_WINDOW_MS)
+    const anchor = kind === "incident.closed" && incident.endedAt !== null ? incident.endedAt : incident.startedAt
+    const to = toUtcDayEnd(anchor)
+    const from = new Date(to)
+    from.setUTCDate(from.getUTCDate() - (TREND_LOOKBACK_DAYS - 1))
+    from.setUTCHours(0, 0, 0, 0)
+
+    const scaffold = buildHistogramBucketScaffold({ from, to, bucketSeconds: TREND_BUCKET_SECONDS })
 
     const analytics = yield* ScoreAnalyticsRepository
     const [counts, thresholds] = yield* Effect.all([
@@ -149,13 +164,41 @@ const snapshotTrend = (input: {
       thresholdByBucket.set(entry.bucket, Number.isFinite(entry.thresholdCount) ? entry.thresholdCount : null)
     }
 
-    const points: IncidentTrend["points"] = counts.map((bucket) => ({
+    const points: IncidentTrend["points"] = fillBuckets({ scaffold, buckets: counts }).map((bucket) => ({
       t: bucket.bucket,
       count: bucket.count,
       threshold: thresholdByBucket.get(bucket.bucket) ?? null,
     }))
 
-    return { bucketDurationMs: TREND_BUCKET_SECONDS * 1000, points } as const
+    const marker: IncidentTrend["marker"] = {
+      startedAt: incident.startedAt.toISOString(),
+      endedAt: incident.endedAt !== null ? incident.endedAt.toISOString() : null,
+      severity: incident.severity,
+    }
+
+    return { bucketDurationMs: TREND_BUCKET_SECONDS * 1000, points, marker } as const
+  })
+
+/**
+ * Peak occurrences/hour over a short recent window at 10-min resolution, used solely for the
+ * breach "rate climbed to X/hr" copy (the 12h display trend is too coarse to read an hourly rate
+ * from). Anchored at incident open. Returns `0` when there's no data in the window.
+ */
+const snapshotTriggerRatePerHour = (incident: AlertIncident) =>
+  Effect.gen(function* () {
+    const to = incident.startedAt
+    const from = new Date(to.getTime() - RATE_PEAK_WINDOW_MS)
+    const analytics = yield* ScoreAnalyticsRepository
+    const counts = yield* analytics.histogramByIssues({
+      organizationId: incident.organizationId,
+      projectId: incident.projectId,
+      issueIds: [IssueId(incident.sourceId)],
+      timeRange: { from, to },
+      bucketSeconds: RATE_PEAK_BUCKET_SECONDS,
+    })
+    const peakCount = counts.reduce((max, bucket) => (bucket.count > max ? bucket.count : max), 0)
+    const bucketHours = RATE_PEAK_BUCKET_SECONDS / (60 * 60)
+    return bucketHours > 0 ? peakCount / bucketHours : 0
   })
 
 /**
@@ -282,21 +325,17 @@ const snapshotSampleExcerpt = (incident: AlertIncident) =>
  * `undefined` for legacy escalating incidents that don't have
  * `entrySignals` — those predate the seasonal detector's snapshot.
  *
- * `triggerRate` is derived from the snapshotted trend: the peak
- * per-bucket count converted to per-hour. The exact instantaneous rate
- * that tripped entry isn't preserved on the incident row, but the trend
- * peak is the rate the user would see in the chart and matches the
- * "climbed to" copy.
+ * `triggerRate` is the recent fine-grained peak/hour from
+ * {@link snapshotTriggerRatePerHour} (the display trend is now 12h-bucketed and too coarse for
+ * an hourly rate). The exact instantaneous rate that tripped entry isn't preserved on the
+ * incident row, but this peak is the "climbed to" figure the copy describes.
  */
-const buildBreach = (incident: AlertIncident, trend: IncidentTrend | null): IncidentBreach | undefined => {
+const buildBreach = (incident: AlertIncident, triggerRatePerHour: number | null): IncidentBreach | undefined => {
   // Seasonal breach scalars only exist on `issue.escalating` snapshots; saved-search
   // incidents carry a frozen-threshold snapshot instead and have no such copy.
-  if (trend === null || !isIssueEscalationEntrySignals(incident.entrySignals)) return undefined
-  const peakCount = trend.points.reduce((m, p) => (p.count > m ? p.count : m), 0)
-  const bucketHours = trend.bucketDurationMs / (60 * 60 * 1000)
-  const triggerRate = bucketHours > 0 ? peakCount / bucketHours : 0
+  if (!isIssueEscalationEntrySignals(incident.entrySignals)) return undefined
   return {
-    triggerRate,
+    triggerRate: triggerRatePerHour ?? 0,
     baselineRate: incident.entrySignals.expected1h,
     threshold: incident.entrySignals.entryThreshold1h,
   }
@@ -315,11 +354,12 @@ const buildPayload = (input: {
   readonly incident: AlertIncident
   readonly kind: IncidentNotificationKind
   readonly trend: IncidentTrend | null
+  readonly triggerRatePerHour: number | null
   readonly tags: readonly string[] | undefined
   readonly sampleExcerpt: IncidentSampleExcerpt | undefined
   readonly monitor: IncidentMonitorInfo | null
 }): IncidentEventPayload | IncidentOpenedPayload | IncidentClosedPayload => {
-  const { incident, kind, trend, tags, sampleExcerpt, monitor } = input
+  const { incident, kind, trend, triggerRatePerHour, tags, sampleExcerpt, monitor } = input
   const base = {
     alertIncidentId: incident.id,
     sourceType: incident.sourceType,
@@ -349,7 +389,7 @@ const buildPayload = (input: {
   // Sustained kinds carry an issue trend snapshot when the source is an issue;
   // saved-search incidents omit it (no issue analytics).
   if (kind === "incident.opened") {
-    const breach = buildBreach(incident, trend)
+    const breach = buildBreach(incident, triggerRatePerHour)
     return {
       alertIncidentId: base.alertIncidentId,
       sourceType: base.sourceType,
@@ -424,9 +464,13 @@ export const requestIncidentNotificationsUseCase = (input: RequestIncidentNotifi
     // Closed kind also skips tags/excerpt: the recovery copy focuses on the descent.
     const isIssueSource = incident.sourceType === "issue"
     const wantsSourceContext = isIssueSource && notificationKind !== "incident.closed"
-    const [trend, tags, sampleExcerpt] = yield* Effect.all(
+    const [trend, triggerRatePerHour, tags, sampleExcerpt] = yield* Effect.all(
       [
         isIssueSource ? snapshotTrend({ incident, kind: notificationKind, kShort }) : Effect.succeed(null),
+        // Only the opened-side breach copy needs the fine-grained hourly rate (issue sources only).
+        isIssueSource && notificationKind === "incident.opened"
+          ? snapshotTriggerRatePerHour(incident)
+          : Effect.succeed(null),
         wantsSourceContext ? snapshotTags(incident) : Effect.succeed(undefined),
         wantsSourceContext ? snapshotSampleExcerpt(incident) : Effect.succeed(undefined),
       ],
@@ -443,7 +487,15 @@ export const requestIncidentNotificationsUseCase = (input: RequestIncidentNotifi
       return { status: "skipped", reason: "no-recipients" } as const
     }
 
-    const payload = buildPayload({ incident, kind: notificationKind, trend, tags, sampleExcerpt, monitor })
+    const payload = buildPayload({
+      incident,
+      kind: notificationKind,
+      trend,
+      triggerRatePerHour,
+      tags,
+      sampleExcerpt,
+      monitor,
+    })
     // Per-kind switch preserves the discriminated-union narrowing
     // `buildIdempotencyKey`'s input requires. A widening cast would
     // silently lose exhaustiveness if a future kind keys off a


### PR DESCRIPTION
Two related changes to the escalating-incident notifications surface.

## incident-trend chart parity

The escalating-incident Slack message and email embed a trend PNG (`/api/notifications/{id}/incident-trend.png`). It used a 3h window at 10-min buckets with its own visual style, so it looked nothing like the in-app issue-detail drawer trend and didn't match what someone sees after clicking through. Both render real ClickHouse occurrence data — they just disagreed on window, granularity, and design.

<img width="600" height="200" alt="dyn-7afb87d0e994af941ecfd3157c132ee6" src="https://github.com/user-attachments/assets/c86d5e28-749c-4938-a7e5-612883e9e983" />

The snapshot now mirrors the drawer: a 14-day window of UTC-aligned 12h buckets (~28 points), the seasonal-expectation threshold series, gray occurrence bars, a dashed expectation curve, and a severity band + start dot for the triggering incident. The window is frozen at incident time (the PNG is immutable/cached, so it can't drift like the live drawer).

Notable decisions:

- **Dropped Satori for the chart, render via Resvg.** Satori can't render SVG `stroke-dasharray`, which the dashed expectation curve needs; the prior renderer faked it with positioned divs and omitted the smooth curve. The chart is now a hand-authored SVG string rasterized by Resvg. resvg-js 2.6.2 has no in-memory `fontBuffers`, so the chart font is materialized to a temp file and passed via `fontFiles`.
- **Shared geometry.** The drawer's pure geometry (Catmull-Rom path, height scaling, threshold segmentation) is extracted into a shared module used by both the live `IssueTrendBar` and the server renderer, so the two stay in sync. The triplicated histogram bucket scaffold/fill helper is consolidated into `@domain/issues`.
- **Payload.** Added an optional `marker` (`startedAt`/`endedAt`/`severity`) to the trend payload for the band + dot. Optional, so notifications written before this change still parse — no migration.
- **Breach copy decoupled.** The "rate climbed to X/hr" line is derived from a separate fine-grained recent peak rather than the display trend, since 12h buckets are too coarse to read an hourly rate from.
- Brand-new issues with no seasonal history render bars but no dashed curve (no contributing prior weeks) — matching the drawer.

## Button asChild label fix

The filled `Button` variants (default/destructive/secondary) draw their surface with an `::after` overlay. The non-`asChild` path lifts the label into a `relative z-1` wrapper so it paints above that overlay; the `asChild`/`Slot` path rendered the label as a bare child with no such wrapper, so the fill covered it. The "Connect Slack" buttons (Integrations settings + Slack onboarding) are the only `asChild` usages on a filled variant, so they showed as blue buttons with no text. Fixed by pushing the overlay behind the slotted content with `after:-z-10` in the `asChild` branch.

## testing

- Unit tests for the extracted geometry helpers and the SVG builder (including the no-history and empty-trend cases); updated the producer snapshot test for the 14d/12h window + marker.
- Rendered a real PNG through the Resvg + font pipeline and eyeballed it against the drawer; drove a full escalation end to end locally (issue + a month of synthetic history → real detector → incident → notification) to confirm the workflow path.
- Button fix verified live in the running app.