### PR TITLE
fix(sessions): show Spans tab for single-trace sessions

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -52,7 +52,7 @@ export function SessionDetailDrawer({
     projectId,
     sessionId,
   })
-  const { traces } = useSessionTraces({ projectId, sessionId })
+  const { traces } = useSessionTraces({ projectId, sessionId, traceIds: session?.traceIds ?? [] })
 
   // The session search returns hits from the trace search index, which can
   // reference traces that have no row in the `sessions` table. Two cases

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -182,7 +182,7 @@ export function SessionSlot({
             tooltip="Copy session ID"
           />
         </div>
-        <Tabs options={tabs} active={effectiveActiveTab} onSelect={selectTab} />
+        <Tabs options={tabs} active={effectiveActiveTab} onSelect={selectTab} wrap />
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+
+const listTracesByProject = vi.fn()
+
+vi.mock("../../../../../../domains/traces/traces.functions.ts", () => ({
+  listTracesByProject: (...args: unknown[]) => listTracesByProject(...args),
+}))
+
+// Imported after the mock is registered.
+const { sessionTracesQueryOptions } = await import("./use-session-traces.ts")
+
+const trace = (traceId: string, startTime: string): TraceRecord => ({ traceId, startTime }) as unknown as TraceRecord
+
+beforeEach(() => {
+  listTracesByProject.mockReset()
+})
+
+describe("sessionTracesQueryOptions queryFn", () => {
+  it("fetches a single-trace session by a one-element `traceId in` filter", async () => {
+    listTracesByProject.mockResolvedValueOnce({ traces: [trace("t1", "2024-01-01T00:00:00Z")] })
+
+    const result = await sessionTracesQueryOptions("p1", "t1", ["t1"]).queryFn()
+
+    expect(listTracesByProject).toHaveBeenCalledTimes(1)
+    expect(listTracesByProject).toHaveBeenCalledWith({
+      data: {
+        projectId: "p1",
+        limit: 1,
+        sortBy: "startTime",
+        sortDirection: "asc",
+        filters: { traceId: [{ op: "in", value: ["t1"] }] },
+      },
+    })
+    expect(result.map((t) => t.traceId)).toEqual(["t1"])
+  })
+
+  it("chunks trace ids into batches of 100", async () => {
+    const ids = Array.from({ length: 150 }, (_, i) => `t${i}`)
+    listTracesByProject.mockResolvedValue({ traces: [] })
+
+    await sessionTracesQueryOptions("p1", "s1", ids).queryFn()
+
+    expect(listTracesByProject).toHaveBeenCalledTimes(2)
+    const firstChunk = listTracesByProject.mock.calls[0]![0].data.filters.traceId[0].value
+    const secondChunk = listTracesByProject.mock.calls[1]![0].data.filters.traceId[0].value
+    expect(firstChunk).toHaveLength(100)
+    expect(secondChunk).toHaveLength(50)
+  })
+
+  it("returns early without a fetch when there are no trace ids", async () => {
+    const result = await sessionTracesQueryOptions("p1", "s1", []).queryFn()
+
+    expect(listTracesByProject).not.toHaveBeenCalled()
+    expect(result).toEqual([])
+  })
+
+  it("merges chunks and sorts by startTime then traceId", async () => {
+    const ids = Array.from({ length: 101 }, (_, i) => `t${i}`)
+    // Second chunk's trace is chronologically earlier than the first chunk's.
+    listTracesByProject
+      .mockResolvedValueOnce({ traces: [trace("t0", "2024-01-02T00:00:00Z")] })
+      .mockResolvedValueOnce({ traces: [trace("t100", "2024-01-01T00:00:00Z")] })
+
+    const result = await sessionTracesQueryOptions("p1", "s1", ids).queryFn()
+
+    expect(result.map((t) => t.traceId)).toEqual(["t100", "t0"])
+  })
+
+  it("caps the fetched set at 500 trace ids", async () => {
+    const ids = Array.from({ length: 650 }, (_, i) => `t${i}`)
+    listTracesByProject.mockResolvedValue({ traces: [] })
+
+    await sessionTracesQueryOptions("p1", "s1", ids).queryFn()
+
+    // 500 ids / 100 per chunk = 5 calls (the 150 overflow is dropped).
+    expect(listTracesByProject).toHaveBeenCalledTimes(5)
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
@@ -4,65 +4,62 @@ import { listTracesByProject, type TraceRecord } from "../../../../../../domains
 const EMPTY: readonly TraceRecord[] = []
 
 /**
- * Per-request page size when walking a session's traces. Each ClickHouse page
- * is bounded; we chain up to {@link SESSION_TRACES_HARD_CAP} traces total.
- */
-const PAGE_SIZE = 250
-
-/**
  * Upper bound on traces fetched per session. Both the session panel (which
  * needs the full ordered list for "Trace N" labels) and the inline expanded
  * row in the sessions table share this cap so a single TanStack-Query entry
  * serves both — without it the same ClickHouse query fired twice when a row
  * was expanded with the panel open.
- *
- * The cap also fixes a search-mode regression: `match.matchingTraceIds`
- * (server-side, ordered by relevance) and the per-session trace list
- * (client-side, ordered by `startTime` asc) used to disagree at the page
- * boundary — a match landing after the first page rendered as a "Show N
- * non-matching traces" toggle with no matching row above. Walking the full
- * session up to this cap removes the boundary so every match shows up.
  */
 const SESSION_TRACES_HARD_CAP = 500
+
+/**
+ * Max ids per `traceId IN (...)` filter. `filterValueSchema` caps array filter
+ * values at `MAX_ARRAY_LENGTH = 100` (packages/domain/shared/src/filter.ts), so
+ * a session's trace ids are fetched in chunks of this size.
+ */
+const TRACE_ID_CHUNK_SIZE = 100
 
 const sessionTracesQueryKey = (projectId: string, sessionId: string) =>
   ["session-traces", projectId, sessionId] as const
 
-export const sessionTracesQueryOptions = (projectId: string, sessionId: string) => ({
+/**
+ * Fetches a session's traces by its authoritative `traceIds` (from the
+ * `sessions_mv` `groupUniqArray(trace_id)`), NOT by filtering the traces table
+ * on `session_id`. A trace ingested without an explicit `session_id` is
+ * materialized into a session whose id is `toString(trace_id)` (the MV
+ * coalesces), yet the traces table keeps the raw, empty `session_id` — so a
+ * `session_id = {id}` filter would miss it and single-trace sessions would show
+ * no traces (and no "Spans" tab). Fetching by trace id sidesteps that mismatch.
+ *
+ * The query key stays `(projectId, sessionId)` only — `traceIds` is left out so
+ * the session panel and the inline expanded row keep sharing one cache entry.
+ */
+export const sessionTracesQueryOptions = (projectId: string, sessionId: string, traceIds: readonly string[]) => ({
   queryKey: sessionTracesQueryKey(projectId, sessionId),
   queryFn: async () => {
-    // Child traces are always shown in chronological order — they form a
-    // conversation, and reading order is what users want regardless of how
-    // the parent sessions list is sorted.
-    const filters = { sessionId: [{ op: "eq" as const, value: sessionId }] }
-    const traces: TraceRecord[] = []
-    let cursor: { sortValue: string; secondaryValue?: string; traceId: string } | undefined
+    const ordered = traceIds.slice(0, SESSION_TRACES_HARD_CAP)
+    if (ordered.length === 0) return [] as TraceRecord[]
 
-    while (traces.length < SESSION_TRACES_HARD_CAP) {
-      const remaining = SESSION_TRACES_HARD_CAP - traces.length
+    const traces: TraceRecord[] = []
+    for (let i = 0; i < ordered.length; i += TRACE_ID_CHUNK_SIZE) {
+      const chunk = ordered.slice(i, i + TRACE_ID_CHUNK_SIZE)
       const page = await listTracesByProject({
         data: {
           projectId,
-          limit: Math.min(PAGE_SIZE, remaining),
+          limit: chunk.length,
           sortBy: "startTime",
           sortDirection: "asc",
-          filters,
-          ...(cursor ? { cursor } : {}),
+          filters: { traceId: [{ op: "in" as const, value: chunk }] },
         },
       })
-      if (!page || page.traces.length === 0) break
-      traces.push(...page.traces)
-      if (!page.hasMore || !page.nextCursor) break
-      // Re-pack the cursor: the response type has `secondaryValue?: string | undefined`
-      // but the request schema (under exactOptionalPropertyTypes) wants the key
-      // absent when there's no value.
-      cursor = {
-        sortValue: page.nextCursor.sortValue,
-        traceId: page.nextCursor.traceId,
-        ...(page.nextCursor.secondaryValue !== undefined ? { secondaryValue: page.nextCursor.secondaryValue } : {}),
-      }
+      if (page?.traces.length) traces.push(...page.traces)
     }
 
+    // Child traces are shown in chronological order — they form a conversation,
+    // and reading order is what users want. Each chunk is fetched asc, but the
+    // chunks are independent queries, so re-sort the merged set (tiebreak on
+    // traceId for deterministic "Trace N" labels).
+    traces.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.traceId.localeCompare(b.traceId))
     return traces
   },
   staleTime: 30_000,
@@ -71,15 +68,17 @@ export const sessionTracesQueryOptions = (projectId: string, sessionId: string) 
 export function useSessionTraces({
   projectId,
   sessionId,
+  traceIds,
   enabled = true,
 }: {
   readonly projectId: string
   readonly sessionId: string
+  readonly traceIds: readonly string[]
   readonly enabled?: boolean
 }) {
   const query = useQuery({
-    ...sessionTracesQueryOptions(projectId, sessionId),
-    enabled: enabled && projectId.length > 0 && sessionId.length > 0,
+    ...sessionTracesQueryOptions(projectId, sessionId, traceIds),
+    enabled: enabled && projectId.length > 0 && sessionId.length > 0 && traceIds.length > 0,
   })
 
   return {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -69,29 +69,26 @@ function useExpandedSessionTraces(
   expandedIds: ReadonlySet<string>,
   sessions: readonly SessionRecord[],
 ) {
-  const expandedSessionIds = useMemo(
-    () => sessions.filter((s) => expandedIds.has(s.sessionId)).map((s) => s.sessionId),
-    [sessions, expandedIds],
-  )
+  const expandedSessions = useMemo(() => sessions.filter((s) => expandedIds.has(s.sessionId)), [sessions, expandedIds])
 
   // Shared cache with the session panel's `useSessionTraces` — same key, same
-  // query function, same limit. With the panel open on an expanded row the
-  // ClickHouse query runs once and both surfaces read from it.
+  // query function. With the panel open on an expanded row the ClickHouse query
+  // runs once and both surfaces read from it.
   const results = useQueries({
-    queries: expandedSessionIds.map((sessionId) => sessionTracesQueryOptions(projectId, sessionId)),
+    queries: expandedSessions.map((s) => sessionTracesQueryOptions(projectId, s.sessionId, s.traceIds)),
   })
 
   return useMemo(() => {
     const traceMap = new Map<string, { data: readonly TraceRecord[]; isLoading: boolean }>()
     for (let i = 0; i < results.length; i++) {
       const r = results[i]
-      const sessionId = expandedSessionIds[i]
-      if (!r || !sessionId) continue
+      const session = expandedSessions[i]
+      if (!r || !session) continue
       const isLoading = r.isPending || (r.isFetching && r.data === undefined)
-      traceMap.set(sessionId, { data: r.data ?? [], isLoading })
+      traceMap.set(session.sessionId, { data: r.data ?? [], isLoading })
     }
     return traceMap
-  }, [results, expandedSessionIds])
+  }, [results, expandedSessions])
 }
 
 interface SessionsViewProps {

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -15,6 +15,13 @@ const tabsListVariants = cva("relative flex flex-row", {
       md: "gap-2",
       sm: "gap-1",
     },
+    // Lets tabs flow onto a second row instead of overflowing a narrow
+    // container (e.g. the session detail drawer). The sliding indicator already
+    // tracks the active tab's x/y, so it animates to the wrapped row correctly.
+    wrap: {
+      true: "flex-wrap",
+      false: "",
+    },
   },
   compoundVariants: [
     { variant: "bordered", size: "md", className: "rounded-lg p-1" },
@@ -23,6 +30,7 @@ const tabsListVariants = cva("relative flex flex-row", {
   defaultVariants: {
     variant: "secondary",
     size: "md",
+    wrap: false,
   },
 })
 
@@ -241,6 +249,7 @@ export function Tabs<T extends string>({
   hideLabels = false,
   variant = "secondary",
   size = "md",
+  wrap = false,
 }: TabsProps<T>) {
   const resolvedVariant = variant ?? "secondary"
   const resolvedSize = size ?? "md"
@@ -284,7 +293,7 @@ export function Tabs<T extends string>({
 
   return (
     <div
-      className={cn(tabsListVariants({ variant: resolvedVariant, size: resolvedSize }))}
+      className={cn(tabsListVariants({ variant: resolvedVariant, size: resolvedSize, wrap }))}
       role="tablist"
       onKeyDown={onKeyDown}
       ref={listRef}


### PR DESCRIPTION
## what

Single-trace sessions now show the **Spans** tab in the session detail panel, and their traces render in the inline expanded row of the sessions table. Both were silently empty before.

The session-traces query now fetches by the session's authoritative `traceIds` (`{ traceId: [{ op: "in", value: ... }] }`) instead of filtering the traces table on `session_id`.

## why

The Spans tab is gated on `traces.length === 1` in `session-slot.tsx`, but `traces` came back empty for the common single-trace case.

`useSessionTraces` filtered the `traces` table by `session_id`. The `sessions_mv` synthesizes a session id with `coalesce(nullIf(s.session_id, ''), toString(s.trace_id))` — so a trace ingested **without** an explicit `session_id` becomes a session whose id is its `trace_id`. The drawer opens with that id, `findBySessionId` finds the session row (it's not an orphan), and `SessionSlot` renders. But the `traces` table stores the *raw* `session_id` (`argMaxIfState(session_id, …, session_id != '')`), which is empty for those traces — so `WHERE session_id = <trace_id>` matched nothing. Result: no traces, no Spans tab, and broken "Trace N" labels / empty inline-expand rows.

Fetching by `traceId` (which always matches the trace row regardless of its `session_id`) sidesteps the mismatch.

## notes

- Array filter values are capped at 100 (`MAX_ARRAY_LENGTH` in `@domain/shared`), and a session can carry up to 500 trace ids, so the query fetches in chunks of 100 (up to the 500 cap) and re-sorts the merged set by `startTime` (tiebreak `traceId`) to keep chronological order. Cursor pagination is dropped — the full id set is known up front.
- The query key stays `(projectId, sessionId)`, so the drawer and the sessions-table inline expand keep sharing one cache entry. Both call sites already had the session record(s) with `traceIds` in hand.
- Chose this over coalescing the trace `sessionId` filter at the repository level, which would change semantics across trace search, MCP `listTraces`, and exports.

## testing

- New `use-session-traces.test.ts`: single-id `in` filter, 100-item chunking (150 ids → 2 calls), empty-ids early return, cross-chunk `startTime`/`traceId` sort, and the 500 cap (650 ids → 5 calls).
- `pnpm --filter @app/web typecheck` clean.
