### PR TITLE
feat(test-mode): block outbound notifications for sandbox orgs [AGE-113]

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
@@ -18,7 +18,9 @@ beforeEach(() => {
 
 describe("sessionTracesQueryOptions queryFn", () => {
   it("fetches a single-trace session by a one-element `traceId in` filter", async () => {
-    listTracesByProject.mockResolvedValueOnce({ traces: [trace("t1", "2024-01-01T00:00:00Z")] })
+    listTracesByProject.mockResolvedValueOnce({
+      traces: [trace("t1", "2024-01-01T00:00:00Z")],
+    })
 
     const result = await sessionTracesQueryOptions("p1", "t1", ["t1"]).queryFn()
 
@@ -42,8 +44,8 @@ describe("sessionTracesQueryOptions queryFn", () => {
     await sessionTracesQueryOptions("p1", "s1", ids).queryFn()
 
     expect(listTracesByProject).toHaveBeenCalledTimes(2)
-    const firstChunk = listTracesByProject.mock.calls[0]![0].data.filters.traceId[0].value
-    const secondChunk = listTracesByProject.mock.calls[1]![0].data.filters.traceId[0].value
+    const firstChunk = listTracesByProject.mock.calls[0]?.[0]?.data.filters.traceId[0].value
+    const secondChunk = listTracesByProject.mock.calls[1]?.[0]?.data.filters.traceId[0].value
     expect(firstChunk).toHaveLength(100)
     expect(secondChunk).toHaveLength(50)
   })
@@ -57,10 +59,9 @@ describe("sessionTracesQueryOptions queryFn", () => {
 
   it("merges chunks and sorts by startTime then traceId", async () => {
     const ids = Array.from({ length: 101 }, (_, i) => `t${i}`)
-    // Second chunk's trace is chronologically earlier than the first chunk's.
-    listTracesByProject
-      .mockResolvedValueOnce({ traces: [trace("t0", "2024-01-02T00:00:00Z")] })
-      .mockResolvedValueOnce({ traces: [trace("t100", "2024-01-01T00:00:00Z")] })
+    listTracesByProject.mockResolvedValueOnce({ traces: [trace("t0", "2024-01-02T00:00:00Z")] }).mockResolvedValueOnce({
+      traces: [trace("t100", "2024-01-01T00:00:00Z")],
+    })
 
     const result = await sessionTracesQueryOptions("p1", "s1", ids).queryFn()
 

--- a/packages/domain/integrations/package.json
+++ b/packages/domain/integrations/package.json
@@ -19,6 +19,7 @@
     "@domain/issues": "workspace:*",
     "@domain/monitors": "workspace:*",
     "@domain/notifications": "workspace:*",
+    "@domain/organizations": "workspace:*",
     "@domain/saved-searches": "workspace:*",
     "@domain/shared": "workspace:*",
     "@slack/web-api": "7.10.0",

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
@@ -1,6 +1,14 @@
 import { IssueRepository } from "@domain/issues"
+import { type Organization, OrganizationRepository } from "@domain/organizations"
 import { SavedSearchRepository } from "@domain/saved-searches"
-import { OrganizationId, ProjectId, SlackIntegrationId, SqlClient, type SqlClientShape } from "@domain/shared"
+import {
+  NotFoundError,
+  OrganizationId,
+  ProjectId,
+  SlackIntegrationId,
+  SqlClient,
+  type SqlClientShape,
+} from "@domain/shared"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { InMemorySlackDeliveryRepositoryLive } from "../testing/in-memory-slack-delivery-repository.ts"
@@ -29,6 +37,35 @@ const NoopSavedSearchRepository = Layer.succeed(SavedSearchRepository, {
 const ORG = OrganizationId("o".repeat(24))
 const PROJECT = ProjectId("p".repeat(24))
 const INTEGRATION = SlackIntegrationId("i".repeat(24))
+
+// Org-repo layer for the test-mode guard the use case now resolves up
+// front. `parentOrgId` decides sandbox-ness: null = live, set = sandbox.
+const orgRepoLayer = (parentOrgId: OrganizationId | null) =>
+  Layer.succeed(
+    OrganizationRepository,
+    OrganizationRepository.of({
+      findById: (id) =>
+        id === ORG
+          ? Effect.succeed({
+              id: ORG,
+              name: "Acme",
+              slug: "acme",
+              logo: null,
+              metadata: null,
+              settings: null,
+              parentOrgId,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            } satisfies Organization)
+          : Effect.fail(new NotFoundError({ entity: "Organization", id })),
+      listByUserId: () => Effect.die("not used"),
+      save: () => Effect.die("not used"),
+      delete: () => Effect.die("not used"),
+      countBySlug: () => Effect.die("not used"),
+    }),
+  )
+
+const LiveOrg = orgRepoLayer(null)
 
 const ctx = {
   webAppUrl: "https://app.example.com",
@@ -84,6 +121,7 @@ describe("dispatchSlackNotificationUseCase", () => {
         Effect.provide(NoopIssueRepository),
         Effect.provide(NoopSavedSearchRepository),
         Effect.provide(NoopSqlClient),
+        Effect.provide(LiveOrg),
       ),
     )
 
@@ -110,10 +148,39 @@ describe("dispatchSlackNotificationUseCase", () => {
         Effect.provide(NoopIssueRepository),
         Effect.provide(NoopSavedSearchRepository),
         Effect.provide(NoopSqlClient),
+        Effect.provide(LiveOrg),
       ),
     )
 
     expect(outcome.status).toBe("skipped-already-delivered")
+    expect(messenger.calls).toHaveLength(0)
+  })
+
+  it("short-circuits for a sandbox org — no claim, no post", async () => {
+    const messenger = fakeMessenger()
+    const layer = InMemorySlackDeliveryRepositoryLive()
+    const sandboxOrg = orgRepoLayer(OrganizationId("parent".padEnd(24, "0")))
+
+    const outcome = await Effect.runPromise(
+      dispatchSlackNotificationUseCase({
+        integrationId: INTEGRATION,
+        botToken: "xoxb-test",
+        channelId: "C123",
+        kind: "custom.message",
+        payload: customMessagePayload,
+        idempotencyKey: "custom.message:sandbox",
+        context: ctx,
+        messenger,
+      }).pipe(
+        Effect.provide(layer),
+        Effect.provide(NoopIssueRepository),
+        Effect.provide(NoopSavedSearchRepository),
+        Effect.provide(NoopSqlClient),
+        Effect.provide(sandboxOrg),
+      ),
+    )
+
+    expect(outcome.status).toBe("skipped-sandbox")
     expect(messenger.calls).toHaveLength(0)
   })
 
@@ -136,6 +203,7 @@ describe("dispatchSlackNotificationUseCase", () => {
         Effect.provide(NoopIssueRepository),
         Effect.provide(NoopSavedSearchRepository),
         Effect.provide(NoopSqlClient),
+        Effect.provide(LiveOrg),
       ),
     )
 

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.ts
@@ -1,7 +1,8 @@
 import type { IssueRepository } from "@domain/issues"
 import { NOTIFICATION_KIND_META, type NotificationKind } from "@domain/notifications"
+import { isSandbox, OrganizationRepository } from "@domain/organizations"
 import type { SavedSearchRepository } from "@domain/saved-searches"
-import type { RepositoryError, SlackIntegrationId, SqlClient } from "@domain/shared"
+import type { NotFoundError, RepositoryError, SlackIntegrationId, SqlClient } from "@domain/shared"
 import { Data, Effect } from "effect"
 import { SlackDeliveryRepository } from "../ports/slack-delivery-repository.ts"
 import { NOTIFICATION_SLACK_RENDERERS } from "../templates/notifications/registry.ts"
@@ -37,6 +38,7 @@ export class SlackMessengerError extends Data.TaggedError("SlackMessengerError")
 export type DispatchSlackOutcome =
   | { readonly status: "delivered"; readonly messageTs: string }
   | { readonly status: "skipped-already-delivered" }
+  | { readonly status: "skipped-sandbox" }
 
 export interface DispatchSlackNotificationInput {
   readonly integrationId: SlackIntegrationId
@@ -49,7 +51,7 @@ export interface DispatchSlackNotificationInput {
   readonly messenger: SlackMessenger
 }
 
-export type DispatchSlackNotificationError = SlackMessengerError | RenderSlackError | RepositoryError
+export type DispatchSlackNotificationError = SlackMessengerError | RenderSlackError | RepositoryError | NotFoundError
 
 /**
  * Claim-then-render-then-post-then-stamp. Idempotency comes from the
@@ -69,9 +71,15 @@ export const dispatchSlackNotificationUseCase = (
 ): Effect.Effect<
   DispatchSlackOutcome,
   DispatchSlackNotificationError,
-  SqlClient | SlackDeliveryRepository | IssueRepository | SavedSearchRepository
+  SqlClient | SlackDeliveryRepository | IssueRepository | SavedSearchRepository | OrganizationRepository
 > =>
   Effect.gen(function* () {
+    const organizations = yield* OrganizationRepository
+    const organization = yield* organizations.findById(input.context.organization.id)
+    if (isSandbox(organization)) {
+      return { status: "skipped-sandbox" as const }
+    }
+
     const deliveryRepo = yield* SlackDeliveryRepository
     const claim = yield* deliveryRepo.claim({
       integrationId: input.integrationId,
@@ -87,7 +95,11 @@ export const dispatchSlackNotificationUseCase = (
     const parsed = payloadSchema.safeParse(input.payload)
     if (!parsed.success) {
       return yield* Effect.fail(
-        new RenderSlackError({ kind: input.kind, reason: "invalid-payload", cause: parsed.error }),
+        new RenderSlackError({
+          kind: input.kind,
+          reason: "invalid-payload",
+          cause: parsed.error,
+        }),
       )
     }
 

--- a/packages/domain/notifications/src/use-cases/send-notification-email.test.ts
+++ b/packages/domain/notifications/src/use-cases/send-notification-email.test.ts
@@ -20,7 +20,9 @@ const cuid = (seed: string) => seed.padEnd(24, "0")
 
 const DEFAULT_PROJECT_SENTINEL = Symbol("default-project")
 
-function setup(opts: { readonly project?: Project | null | typeof DEFAULT_PROJECT_SENTINEL } = {}) {
+function setup(
+  opts: { readonly project?: Project | null | typeof DEFAULT_PROJECT_SENTINEL; readonly sandbox?: boolean } = {},
+) {
   const orgId = OrganizationId(cuid("o"))
   const userId = UserId(cuid("u"))
   const projectIdValue = ProjectId(cuid("p"))
@@ -68,7 +70,7 @@ function setup(opts: { readonly project?: Project | null | typeof DEFAULT_PROJEC
     logo: null,
     metadata: null,
     settings: null,
-    parentOrgId: null,
+    parentOrgId: opts.sandbox ? OrganizationId(cuid("parent")) : null,
     createdAt: new Date("2026-05-01T00:00:00Z"),
     updatedAt: new Date("2026-05-01T00:00:00Z"),
   }
@@ -220,6 +222,27 @@ describe("sendNotificationEmailUseCase", () => {
 
     expect(result.sent).toBe(true)
     expect(ctx.renderedCalls[0]?.project).toBeNull()
+  })
+
+  it("short-circuits for a sandbox org — no claim, no render, no send", async () => {
+    const ctx = setup({ sandbox: true })
+    const stored = makeStoredNotification({ organizationId: ctx.orgId, userId: ctx.userId })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* NotificationRepository
+        yield* repo.insertIfAbsent(stored)
+      }).pipe(Effect.provide(ctx.layer)),
+    )
+
+    const send = sendNotificationEmailUseCase({ renderEmail: ctx.renderEmail, sendEmail: ctx.sendEmail })
+    const result = await Effect.runPromise(send({ notificationId: stored.id }).pipe(Effect.provide(ctx.layer)))
+
+    expect(result.sent).toBe(false)
+    expect(ctx.sentMessages).toHaveLength(0)
+    expect(ctx.renderedCalls).toHaveLength(0)
+    // In-app row is untouched: the guard short-circuits before the claim,
+    // so emailed_at stays null (the notification still surfaces in-app).
+    expect(ctx.rows.find((r) => r.id === stored.id)?.emailedAt).toBeNull()
   })
 
   it("fails with NotFoundError when the row is missing", async () => {

--- a/packages/domain/notifications/src/use-cases/send-notification-email.ts
+++ b/packages/domain/notifications/src/use-cases/send-notification-email.ts
@@ -1,4 +1,4 @@
-import { OrganizationRepository } from "@domain/organizations"
+import { isSandbox, OrganizationRepository } from "@domain/organizations"
 import { ProjectRepository } from "@domain/projects"
 import type { NotFoundError, NotificationId, RepositoryError, SqlClient } from "@domain/shared"
 import { UserRepository } from "@domain/users"
@@ -134,6 +134,18 @@ export const sendNotificationEmailUseCase =
 
       const notification: Notification = yield* notifications.findById(input.notificationId)
 
+      if (notification.emailedAt !== null) {
+        yield* Effect.annotateCurrentSpan("skipped", "already-emailed")
+        return { sent: false as const }
+      }
+
+      const organizationEntity = yield* organizations.findById(notification.organizationId)
+
+      if (isSandbox(organizationEntity)) {
+        yield* Effect.annotateCurrentSpan("skipped", "sandbox")
+        return { sent: false as const }
+      }
+
       // Claim. If the row is already stamped, somebody else already (or
       // is about to) send the email and we exit.
       const claimed = yield* notifications.markEmailed(notification.id)
@@ -144,9 +156,6 @@ export const sendNotificationEmailUseCase =
 
       const user = yield* users.findById(notification.userId)
 
-      // Organization snapshot. Required (every notification has an org)
-      // — fail loud if the row disappears between create and send.
-      const organizationEntity = yield* organizations.findById(notification.organizationId)
       const organization: NotificationEmailOrganization = {
         id: organizationEntity.id,
         name: organizationEntity.name,
@@ -156,7 +165,13 @@ export const sendNotificationEmailUseCase =
       // deletion between request and send doesn't break the email.
       const project: NotificationEmailProject | null = notification.projectId
         ? yield* projects.findById(notification.projectId).pipe(
-            Effect.map((p): NotificationEmailProject => ({ id: p.id, name: p.name, slug: p.slug })),
+            Effect.map(
+              (p): NotificationEmailProject => ({
+                id: p.id,
+                name: p.name,
+                slug: p.slug,
+              }),
+            ),
             Effect.catchTag("NotFoundError", () => Effect.succeed<NotificationEmailProject | null>(null)),
           )
         : null

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -355,6 +355,26 @@ export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
       tags: ["support", "annotation", "tau2-retail"],
       metadata: { seed: "tau2-compatibility", story: "annotation-ui-polish" },
     },
+    {
+      traceKey: "code-block-demo",
+      index: 0,
+      daysAgo: 1,
+      userPrompt: "How do I fetch a trace with the Latitude Node SDK?",
+      assistantResponse:
+        "Set your API key in the `Authorization` header, then call the SDK. Here's a minimal example:\n\n" +
+        "```ts\n" +
+        'import { Latitude } from "@latitude-data/sdk"\n\n' +
+        "const sdk = new Latitude(process.env.LATITUDE_API_KEY!)\n" +
+        'const trace = await sdk.traces.get("trace-id")\n' +
+        "console.log(trace.spans.length)\n" +
+        "```\n\n" +
+        "Keep the key in an environment variable — never hard-code it.",
+      tags: ["support", "developer", "code-example"],
+      metadata: { seed: "tau2-compatibility", story: "code-block-rendering" },
+      serviceName: "developer-support-agent",
+      systemInstruction:
+        "You are a developer support AI agent. Help users integrate the Latitude SDK and API, and include short, correct code examples when useful.",
+    },
   ] as const
 
   return specs.map((spec) => createCompatibilityChatSpan({ scope, ...spec }))

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,6 +24,7 @@
     "@codemirror/language": "6.12.3",
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.41.1",
+    "@domain/models": "workspace:*",
     "@radix-ui/react-checkbox": "1.3.3",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-dropdown-menu": "2.1.16",
@@ -35,7 +36,6 @@
     "@radix-ui/react-switch": "1.2.6",
     "@radix-ui/react-toast": "1.2.15",
     "@radix-ui/react-tooltip": "1.2.8",
-    "@domain/models": "workspace:*",
     "@repo/utils": "workspace:*",
     "@tanstack/react-virtual": "3.13.24",
     "class-variance-authority": "0.7.1",
@@ -54,20 +54,22 @@
     "remark-emoji": "5.0.2",
     "remark-gfm": "4.0.1",
     "tailwind-merge": "2.6.1",
+    "unist-util-visit": "5.1.0",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.4",
     "@tailwindcss/typography": "0.5.19",
+    "@types/mdast": "4.0.4",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "postcss": "8.5.14",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rosetta-ai": "catalog:",
     "tailwindcss": "4.2.4",
     "tw-animate-css": "1.4.0",
-    "@typescript/native-preview": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/ui/src/components/genai-conversation/parts/remark-code-content-positions.ts
+++ b/packages/ui/src/components/genai-conversation/parts/remark-code-content-positions.ts
@@ -1,26 +1,16 @@
-// Attaches `data-code-content-start/end` to HAST <code> elements so that
-// sourceMappedTextPlugin can map code-block text to source offsets.
-// remark-to-hast doesn't propagate positions for code-fence text nodes, so we
-// find the content verbatim in the source string and store the character range.
-
-function visitCode(node: any, callback: (node: any) => void): void {
-  if (!node) return
-  if (node.type === "code") callback(node)
-  if (Array.isArray(node.children)) {
-    for (const child of node.children) visitCode(child, callback)
-  }
-}
+import type { Code, Root } from "mdast"
+import { visit } from "unist-util-visit"
 
 export function remarkCodeContentPositions() {
-  return (tree: any, file: any) => {
-    const source: string = String(file)
+  return (tree: Root, file: unknown) => {
+    const source = String(file)
     if (!source) return
 
-    visitCode(tree, (node) => {
-      if (!node.position || typeof node.value !== "string" || node.value === "") return
+    visit(tree, "code", (node: Code) => {
+      if (!node.position || node.value === "") return
 
-      const fenceStart: number | undefined = node.position.start?.offset
-      const fenceEnd: number | undefined = node.position.end?.offset
+      const fenceStart = node.position.start?.offset
+      const fenceEnd = node.position.end?.offset
       if (fenceStart == null || fenceEnd == null) return
 
       // Start search after the opening fence line to avoid matching the lang id.
@@ -28,7 +18,7 @@ export function remarkCodeContentPositions() {
       if (firstNewline < 0 || firstNewline >= fenceEnd) return
       const searchFrom = firstNewline + 1
 
-      const content: string = node.value
+      const content = node.value
       const contentIdx = source.indexOf(content, searchFrom)
       if (contentIdx < 0 || contentIdx >= fenceEnd) return
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -1297,6 +1297,9 @@ importers:
       '@domain/notifications':
         specifier: workspace:*
         version: link:../notifications
+      '@domain/organizations':
+        specifier: workspace:*
+        version: link:../organizations
       '@domain/saved-searches':
         specifier: workspace:*
         version: link:../saved-searches
@@ -2411,13 +2414,13 @@ importers:
         version: 7.0.0-dev.20260421.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/telemetry/claude-code:
     dependencies:
@@ -2742,6 +2745,9 @@ importers:
       tailwind-merge:
         specifier: 2.6.1
         version: 2.6.1
+      unist-util-visit:
+        specifier: 5.1.0
+        version: 5.1.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -2752,6 +2758,9 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
+      '@types/mdast':
+        specifier: 4.0.4
+        version: 4.0.4
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -17635,6 +17644,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -19267,6 +19284,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -23149,6 +23174,30 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -24227,6 +24276,25 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.14.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
@@ -24252,6 +24320,35 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.14.1
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

Test Mode hard guarantee: **a sandbox org never reaches an external notification channel.** A developer's experiments must never page teammates or hit customers' alert channels. In-app notification surfacing is unaffected — only outbound transports are blocked.

Each channel adapter resolves its target org and short-circuits dispatch when `isSandbox(org)` (the shared predicate from `@domain/organizations`, where a non-null `organizations.parent_org_id` ⇒ sandbox), **before** any send. The guard is placed in each channel's dispatch use case so it's a single, unit-testable point per channel, and it must hold even once LLM-driven feedback is enabled per-sandbox in the future.

### Channels guarded

| Channel | Guard point | Behavior for a sandbox org |
| --- | --- | --- |
| **Email** | `sendNotificationEmailUseCase` (`@domain/notifications`) | Guards **before** the `markEmailed` claim — the notification row stays unstamped (`emailed_at` null) and nothing is rendered or sent. Returns `{ sent: false }`. |
| **Slack** | `dispatchSlackNotificationUseCase` (`@domain/integrations`) | Guards **before** the `slack_deliveries` claim and the post — no delivery row, no message. Returns the new `{ status: "skipped-sandbox" }` outcome. |

Email and Slack are the only outbound notification channels implemented today; webhook/SMS/push channels do not exist yet, so there is nothing to guard for them. When one is added, it should resolve its target org and apply the same `isSandbox` guard at its dispatch point.

In-app rows (the `notifications` table + bell feed) are written by the upstream creator step and are intentionally **not** touched — only the outbound transports short-circuit.

## Test plan

- `pnpm --filter @domain/notifications --filter @domain/integrations --filter @domain/organizations typecheck` ✅
- `pnpm --filter @domain/notifications test` ✅ (34 passed)
- `pnpm --filter @domain/integrations test` ✅ (21 passed)
- `pnpm --filter ... check` (Biome) ✅

New tests, per channel, exercising sandbox vs. live:
- **Email** — `send-notification-email.test.ts`: sandbox org → no claim, no render, no send, `emailed_at` stays null; live org cases (send / idempotent / project lookup) still pass.
- **Slack** — `dispatch-slack-notification.test.ts`: sandbox org → `skipped-sandbox`, messenger never called; live org cases (delivered / dedupe / render error) still pass.

## Linear

[AGE-113 — Test Mode: block all outbound notifications for sandbox orgs](https://linear.app/latitude/issue/AGE-113)

Spec: `specs/test-mode.md` → "A sandbox never sends external notifications".

🤖 Generated with [Claude Code](https://claude.com/claude-code)