### PR TITLE
feat(test-mode): sandbox routing + middleware scaffold + seed fixtures [AGE-102, AGE-126]

### DIFF
--- a/apps/web/src/domains/sandbox/sandbox-access.functions.ts
+++ b/apps/web/src/domains/sandbox/sandbox-access.functions.ts
@@ -1,0 +1,94 @@
+import { isSandbox, MembershipRepository, OrganizationRepository } from "@domain/organizations"
+import { NotFoundError, type OrganizationId, organizationIdSchema, UnauthorizedError, UserId } from "@domain/shared"
+import { MembershipRepositoryLive, OrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { getAdminPostgresClient, getPostgresClient } from "../../server/clients.ts"
+import { getFreshSession } from "../sessions/session.functions.ts"
+
+/**
+ * Server-side resolution of "is the caller allowed to act on this sandbox?".
+ *
+ * Lives in a `.functions.ts` so the TanStack Start Vite compiler can strip
+ * its Node-only transitive imports (`@platform/db-postgres`,
+ * `@repo/observability`, `server/clients.ts`) from the browser bundle.
+ * `sandbox-middleware.ts` would leak them if it owned this logic directly,
+ * which is why `adminMiddleware` similarly delegates session work to the
+ * `getFreshSession` server fn instead of importing DB modules itself.
+ */
+
+interface SandboxAccessDto {
+  readonly userId: string
+  readonly sandbox: {
+    readonly organizationId: string
+    readonly name: string
+    readonly parentOrgId: string
+  }
+}
+
+const inputSchema = z.object({ sandboxOrgId: z.unknown() })
+
+export const authorizeSandboxAccess = createServerFn({ method: "GET" })
+  .inputValidator(inputSchema)
+  .handler(async ({ data }): Promise<SandboxAccessDto> => {
+    const session = await getFreshSession()
+    if (!session) {
+      throw new UnauthorizedError({ message: "Unauthorized" })
+    }
+    const userId = UserId(session.user.id)
+
+    const parsed = organizationIdSchema.safeParse(data.sandboxOrgId)
+    if (!parsed.success) {
+      throw new NotFoundError({ entity: "Sandbox", id: String(data.sandboxOrgId ?? "") })
+    }
+    const sandboxOrgId: OrganizationId = parsed.data
+
+    // The org lookup uses the admin client so it works at any RLS scope —
+    // `organizations` has no policy, but `withPostgres`'s default "system"
+    // scope is only sanctioned for the admin connection.
+    const sandbox = await Effect.runPromise(
+      Effect.gen(function* () {
+        const orgRepo = yield* OrganizationRepository
+        const org = yield* orgRepo
+          .findById(sandboxOrgId)
+          .pipe(
+            Effect.catchTag("NotFoundError", () =>
+              Effect.fail(new NotFoundError({ entity: "Sandbox", id: sandboxOrgId })),
+            ),
+          )
+        if (!isSandbox(org)) {
+          return yield* Effect.fail(new NotFoundError({ entity: "Sandbox", id: sandboxOrgId }))
+        }
+        return {
+          organizationId: org.id,
+          name: org.name,
+          parentOrgId: org.parentOrgId,
+        }
+      }).pipe(withPostgres(OrganizationRepositoryLive, getAdminPostgresClient()), withTracing),
+    )
+
+    // Membership check is scoped to the PARENT org (whose `members` rows are
+    // RLS-protected) — never the sandbox, never the session's active org. We
+    // can only scope here, after the org load told us the parent id.
+    const isMember = await Effect.runPromise(
+      Effect.gen(function* () {
+        const memberRepo = yield* MembershipRepository
+        return yield* memberRepo.isMember(sandbox.parentOrgId, userId)
+      }).pipe(withPostgres(MembershipRepositoryLive, getPostgresClient(), sandbox.parentOrgId), withTracing),
+    )
+
+    if (!isMember) {
+      throw new NotFoundError({ entity: "Sandbox", id: sandboxOrgId })
+    }
+
+    return {
+      userId,
+      sandbox: {
+        organizationId: sandbox.organizationId,
+        name: sandbox.name,
+        parentOrgId: sandbox.parentOrgId,
+      },
+    }
+  })

--- a/apps/web/src/domains/sandbox/sandbox.functions.ts
+++ b/apps/web/src/domains/sandbox/sandbox.functions.ts
@@ -1,0 +1,21 @@
+import { organizationIdSchema } from "@domain/shared"
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { sandboxMiddleware } from "../../server/sandbox-middleware.ts"
+
+interface SandboxSummaryDto {
+  readonly organizationId: string
+  readonly name: string
+  readonly parentOrgId: string
+}
+
+export const getSandbox = createServerFn({ method: "GET" })
+  .middleware([sandboxMiddleware])
+  .inputValidator(z.object({ sandboxOrgId: organizationIdSchema }))
+  .handler(
+    async ({ context }): Promise<SandboxSummaryDto> => ({
+      organizationId: context.sandbox.organizationId,
+      name: context.sandbox.name,
+      parentOrgId: context.sandbox.parentOrgId,
+    }),
+  )

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -22,7 +22,7 @@ interface ServerError {
  * Returns `{ _tag, message, status }` when the error was produced by
  * `errorHandler`, otherwise falls back to the raw error message with no tag.
  */
-function parseServerError(err: unknown): ServerError {
+export function parseServerError(err: unknown): ServerError {
   const raw = err instanceof Error ? err.message : String(err)
   try {
     const parsed = JSON.parse(raw)

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -30,6 +30,8 @@ import { Route as AuthConsentRouteImport } from './routes/auth/consent'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as Char91DotwellKnownChar93OpenidConfigurationRouteImport } from './routes/[.well-known]/openid-configuration'
 import { Route as Char91DotwellKnownChar93OauthAuthorizationServerRouteImport } from './routes/[.well-known]/oauth-authorization-server'
+import { Route as SandboxSandboxOrgIdRouteRouteImport } from './routes/sandbox/$sandboxOrgId/route'
+import { Route as SandboxSandboxOrgIdIndexRouteImport } from './routes/sandbox/$sandboxOrgId/index'
 import { Route as BackofficeOrganizationsIndexRouteImport } from './routes/backoffice/organizations/index'
 import { Route as BackofficeFeatureFlagsIndexRouteImport } from './routes/backoffice/feature-flags/index'
 import { Route as ApiObservabilityTestIndexRouteImport } from './routes/api/observability-test/index'
@@ -173,6 +175,18 @@ const Char91DotwellKnownChar93OauthAuthorizationServerRoute =
     id: '/.well-known/oauth-authorization-server',
     path: '/.well-known/oauth-authorization-server',
     getParentRoute: () => rootRouteImport,
+  } as any)
+const SandboxSandboxOrgIdRouteRoute =
+  SandboxSandboxOrgIdRouteRouteImport.update({
+    id: '/sandbox/$sandboxOrgId',
+    path: '/sandbox/$sandboxOrgId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const SandboxSandboxOrgIdIndexRoute =
+  SandboxSandboxOrgIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => SandboxSandboxOrgIdRouteRoute,
   } as any)
 const BackofficeOrganizationsIndexRoute =
   BackofficeOrganizationsIndexRouteImport.update({
@@ -396,6 +410,7 @@ export interface FileRoutesByFullPath {
   '/design-system': typeof DesignSystemRouteRouteWithChildren
   '/': typeof AuthenticatedIndexRoute
   '/login': typeof LoginRoute
+  '/sandbox/$sandboxOrgId': typeof SandboxSandboxOrgIdRouteRouteWithChildren
   '/.well-known/oauth-authorization-server': typeof Char91DotwellKnownChar93OauthAuthorizationServerRouteWithChildren
   '/.well-known/openid-configuration': typeof Char91DotwellKnownChar93OpenidConfigurationRouteWithChildren
   '/api/health': typeof ApiHealthRoute
@@ -425,6 +440,7 @@ export interface FileRoutesByFullPath {
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/backoffice/feature-flags/': typeof BackofficeFeatureFlagsIndexRoute
   '/backoffice/organizations/': typeof BackofficeOrganizationsIndexRoute
+  '/sandbox/$sandboxOrgId/': typeof SandboxSandboxOrgIdIndexRoute
   '/projects/$projectSlug/onboarding': typeof AuthenticatedProjectsProjectSlugOnboardingRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRouteWithChildren
   '/api/auth/$provider/start': typeof ApiAuthProviderStartRoute
@@ -481,6 +497,7 @@ export interface FileRoutesByTo {
   '/api/observability-test': typeof ApiObservabilityTestIndexRoute
   '/backoffice/feature-flags': typeof BackofficeFeatureFlagsIndexRoute
   '/backoffice/organizations': typeof BackofficeOrganizationsIndexRoute
+  '/sandbox/$sandboxOrgId': typeof SandboxSandboxOrgIdIndexRoute
   '/projects/$projectSlug/onboarding': typeof AuthenticatedProjectsProjectSlugOnboardingRoute
   '/api/auth/$provider/start': typeof ApiAuthProviderStartRoute
   '/api/auth/mcp/authorize': typeof ApiAuthMcpAuthorizeRoute
@@ -511,6 +528,7 @@ export interface FileRoutesById {
   '/design-system': typeof DesignSystemRouteRouteWithChildren
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
+  '/sandbox/$sandboxOrgId': typeof SandboxSandboxOrgIdRouteRouteWithChildren
   '/.well-known/oauth-authorization-server': typeof Char91DotwellKnownChar93OauthAuthorizationServerRouteWithChildren
   '/.well-known/openid-configuration': typeof Char91DotwellKnownChar93OpenidConfigurationRouteWithChildren
   '/api/health': typeof ApiHealthRoute
@@ -541,6 +559,7 @@ export interface FileRoutesById {
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/backoffice/feature-flags/': typeof BackofficeFeatureFlagsIndexRoute
   '/backoffice/organizations/': typeof BackofficeOrganizationsIndexRoute
+  '/sandbox/$sandboxOrgId/': typeof SandboxSandboxOrgIdIndexRoute
   '/_authenticated/projects/$projectSlug/onboarding': typeof AuthenticatedProjectsProjectSlugOnboardingRoute
   '/_authenticated/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRouteWithChildren
   '/api/auth/$provider/start': typeof ApiAuthProviderStartRoute
@@ -573,6 +592,7 @@ export interface FileRouteTypes {
     | '/design-system'
     | '/'
     | '/login'
+    | '/sandbox/$sandboxOrgId'
     | '/.well-known/oauth-authorization-server'
     | '/.well-known/openid-configuration'
     | '/api/health'
@@ -602,6 +622,7 @@ export interface FileRouteTypes {
     | '/api/observability-test/'
     | '/backoffice/feature-flags/'
     | '/backoffice/organizations/'
+    | '/sandbox/$sandboxOrgId/'
     | '/projects/$projectSlug/onboarding'
     | '/projects/$projectSlug/settings'
     | '/api/auth/$provider/start'
@@ -658,6 +679,7 @@ export interface FileRouteTypes {
     | '/api/observability-test'
     | '/backoffice/feature-flags'
     | '/backoffice/organizations'
+    | '/sandbox/$sandboxOrgId'
     | '/projects/$projectSlug/onboarding'
     | '/api/auth/$provider/start'
     | '/api/auth/mcp/authorize'
@@ -687,6 +709,7 @@ export interface FileRouteTypes {
     | '/design-system'
     | '/_authenticated'
     | '/login'
+    | '/sandbox/$sandboxOrgId'
     | '/.well-known/oauth-authorization-server'
     | '/.well-known/openid-configuration'
     | '/api/health'
@@ -717,6 +740,7 @@ export interface FileRouteTypes {
     | '/api/observability-test/'
     | '/backoffice/feature-flags/'
     | '/backoffice/organizations/'
+    | '/sandbox/$sandboxOrgId/'
     | '/_authenticated/projects/$projectSlug/onboarding'
     | '/_authenticated/projects/$projectSlug/settings'
     | '/api/auth/$provider/start'
@@ -748,6 +772,7 @@ export interface RootRouteChildren {
   DesignSystemRouteRoute: typeof DesignSystemRouteRouteWithChildren
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoginRoute: typeof LoginRoute
+  SandboxSandboxOrgIdRouteRoute: typeof SandboxSandboxOrgIdRouteRouteWithChildren
   Char91DotwellKnownChar93OauthAuthorizationServerRoute: typeof Char91DotwellKnownChar93OauthAuthorizationServerRouteWithChildren
   Char91DotwellKnownChar93OpenidConfigurationRoute: typeof Char91DotwellKnownChar93OpenidConfigurationRouteWithChildren
   ApiHealthRoute: typeof ApiHealthRoute
@@ -915,6 +940,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/.well-known/oauth-authorization-server'
       preLoaderRoute: typeof Char91DotwellKnownChar93OauthAuthorizationServerRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/sandbox/$sandboxOrgId': {
+      id: '/sandbox/$sandboxOrgId'
+      path: '/sandbox/$sandboxOrgId'
+      fullPath: '/sandbox/$sandboxOrgId'
+      preLoaderRoute: typeof SandboxSandboxOrgIdRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sandbox/$sandboxOrgId/': {
+      id: '/sandbox/$sandboxOrgId/'
+      path: '/'
+      fullPath: '/sandbox/$sandboxOrgId/'
+      preLoaderRoute: typeof SandboxSandboxOrgIdIndexRouteImport
+      parentRoute: typeof SandboxSandboxOrgIdRouteRoute
     }
     '/backoffice/organizations/': {
       id: '/backoffice/organizations/'
@@ -1317,6 +1356,20 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
   AuthenticatedRouteChildren,
 )
 
+interface SandboxSandboxOrgIdRouteRouteChildren {
+  SandboxSandboxOrgIdIndexRoute: typeof SandboxSandboxOrgIdIndexRoute
+}
+
+const SandboxSandboxOrgIdRouteRouteChildren: SandboxSandboxOrgIdRouteRouteChildren =
+  {
+    SandboxSandboxOrgIdIndexRoute: SandboxSandboxOrgIdIndexRoute,
+  }
+
+const SandboxSandboxOrgIdRouteRouteWithChildren =
+  SandboxSandboxOrgIdRouteRoute._addFileChildren(
+    SandboxSandboxOrgIdRouteRouteChildren,
+  )
+
 interface Char91DotwellKnownChar93OauthAuthorizationServerRouteChildren {
   Char91DotwellKnownChar93OauthAuthorizationServerSplatRoute: typeof Char91DotwellKnownChar93OauthAuthorizationServerSplatRoute
 }
@@ -1376,6 +1429,7 @@ const rootRouteChildren: RootRouteChildren = {
   DesignSystemRouteRoute: DesignSystemRouteRouteWithChildren,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoginRoute: LoginRoute,
+  SandboxSandboxOrgIdRouteRoute: SandboxSandboxOrgIdRouteRouteWithChildren,
   Char91DotwellKnownChar93OauthAuthorizationServerRoute:
     Char91DotwellKnownChar93OauthAuthorizationServerRouteWithChildren,
   Char91DotwellKnownChar93OpenidConfigurationRoute:

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/index.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/index.tsx
@@ -1,0 +1,34 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { ArrowLeft } from "lucide-react"
+
+const sandboxRoute = getRouteApi("/sandbox/$sandboxOrgId")
+
+/**
+ * Stub landing page for a Test Mode sandbox. Proves the
+ * `/sandbox/:sandboxOrgId` parent-route gate (`route.tsx`) wires the
+ * `sandboxMiddleware`-authorized `getSandbox` result into route context;
+ * the real sandbox UI (traces list, settings, Live ⇄ Sandbox switch)
+ * lands in later Test Mode tickets and reads the same context.
+ */
+export const Route = createFileRoute("/sandbox/$sandboxOrgId/")({
+  component: SandboxStubPage,
+})
+
+function SandboxStubPage() {
+  const sandbox = sandboxRoute.useRouteContext({ select: (c) => c.sandbox })
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <Text.H3>Sandbox: {sandbox.name}</Text.H3>
+      <div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/">
+            <Icon icon={ArrowLeft} size="sm" />
+            Back to live
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/route.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/route.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute, notFound, Outlet, redirect } from "@tanstack/react-router"
+import { getSandbox } from "../../../domains/sandbox/sandbox.functions.ts"
+import { parseServerError } from "../../../lib/errors.ts"
+
+/**
+ * Parent route for the `/sandbox/:sandboxOrgId/*` subtree.
+ *
+ * `beforeLoad` is the single structural gate for everything under
+ * `/sandbox/:sandboxOrgId` — it fires before any child loader, so a
+ * descendant route (settings, traces, …) literally cannot be reached
+ * without it. The resolved sandbox is returned into the route context so
+ * child routes read it via `useRouteContext` without re-fetching, and
+ * `getSandbox` only hits the DB once per page load.
+ *
+ * Failure mapping is the same shape used in the backoffice layout:
+ * `NotFoundError` collapses to `notFound()` (no fingerprint of whether
+ * the id is unknown vs. forbidden), `UnauthorizedError` redirects to
+ * `/login`. Anything else bubbles to the router error boundary.
+ */
+export const Route = createFileRoute("/sandbox/$sandboxOrgId")({
+  ssr: "data-only",
+  beforeLoad: async ({ params }) => {
+    try {
+      const sandbox = await getSandbox({ data: { sandboxOrgId: params.sandboxOrgId } })
+      return { sandbox }
+    } catch (error) {
+      const { _tag } = parseServerError(error)
+      if (_tag === "NotFoundError") throw notFound()
+      if (_tag === "UnauthorizedError") throw redirect({ to: "/login" })
+      throw error
+    }
+  },
+  component: SandboxLayout,
+})
+
+function SandboxLayout() {
+  return <Outlet />
+}

--- a/apps/web/src/server/sandbox-middleware.ts
+++ b/apps/web/src/server/sandbox-middleware.ts
@@ -1,0 +1,69 @@
+import { OrganizationId, UserId } from "@domain/shared"
+import { createMiddleware } from "@tanstack/react-start"
+import { authorizeSandboxAccess } from "../domains/sandbox/sandbox-access.functions.ts"
+
+/**
+ * Test Mode sandbox guard for `/sandbox/:sandboxOrgId` server functions.
+ *
+ * Mirrors `adminMiddleware` (see `admin-middleware.ts`): the heavy lifting
+ * (session, DB lookups, membership check) lives in a server fn
+ * (`authorizeSandboxAccess`) whose body the TanStack Start Vite compiler
+ * strips on the client, so this file stays free of Node-only module-level
+ * imports — exactly the leak `.agents/skills/backoffice/SKILL.md` warns
+ * against. `adminMiddleware` similarly delegates session work to
+ * `getFreshSession` rather than importing `@platform/db-postgres` directly.
+ *
+ * The "createSandboxServerFn wrapper" from the spec is realised as this
+ * middleware, exactly as the "createAdminServerFn pattern" is realised as
+ * `adminMiddleware` — a `createServerFn` factory cannot be used because the
+ * Vite plugin only recognises the literal `createServerFn(...).handler(...)`
+ * chain at the call site; hiding it behind a factory leaks server-only
+ * imports into the client bundle. Handlers attach the middleware at the
+ * call site:
+ *
+ * ```ts
+ * createServerFn({ method: "GET" })
+ *   .middleware([sandboxMiddleware])
+ *   .inputValidator(z.object({ sandboxOrgId: organizationIdSchema }))
+ *   .handler(async ({ context }) => context.sandbox.name)
+ * ```
+ *
+ * The structural guarantee: the handler's `context` carries only the
+ * resolved, sandbox-scoped `sandbox` (plus the requesting `userId`). The
+ * browser session's `activeOrganizationId` is never injected and never
+ * changes, so a handler in this namespace cannot accidentally act on the
+ * live parent org — it has no handle to reach it.
+ */
+
+interface ResolvedSandbox {
+  readonly organizationId: OrganizationId
+  readonly name: string
+  readonly parentOrgId: OrganizationId
+}
+
+interface SandboxAccess {
+  readonly userId: UserId
+  readonly sandbox: ResolvedSandbox
+}
+
+export const sandboxMiddleware = createMiddleware({ type: "function" }).server(async (rawArgs) => {
+  const data = (
+    rawArgs as unknown as {
+      readonly data?: { readonly sandboxOrgId?: unknown }
+    }
+  ).data
+  const dto = await authorizeSandboxAccess({
+    data: { sandboxOrgId: data?.sandboxOrgId },
+  })
+  const access: SandboxAccess = {
+    userId: UserId(dto.userId),
+    sandbox: {
+      organizationId: OrganizationId(dto.sandbox.organizationId),
+      name: dto.sandbox.name,
+      parentOrgId: OrganizationId(dto.sandbox.parentOrgId),
+    },
+  }
+  return rawArgs.next({
+    context: { userId: access.userId, sandbox: access.sandbox },
+  })
+})

--- a/packages/domain/organizations/src/entities/organization.ts
+++ b/packages/domain/organizations/src/entities/organization.ts
@@ -57,7 +57,9 @@ export const createOrganization = (params: {
 /**
  * Whether this org is a Test Mode sandbox (sibling tenant of a live parent).
  *
- * @knipignore — consumed by sandbox use-cases landing in later Test Mode PRs
- * (AGE-103+); this PR only seats the schema + predicate.
+ * Type predicate so callers can use the narrowed `parentOrgId` without a
+ * redundant null check (the sandbox middleware relies on this).
  */
-export const isSandbox = (org: Pick<Organization, "parentOrgId">): boolean => org.parentOrgId !== null
+export const isSandbox = <T extends Pick<Organization, "parentOrgId">>(
+  org: T,
+): org is T & { readonly parentOrgId: OrganizationId } => org.parentOrgId !== null

--- a/packages/domain/shared/src/seeds.ts
+++ b/packages/domain/shared/src/seeds.ts
@@ -334,3 +334,50 @@ export const SEED_API_KEY_TOKEN = "lat_seed_default_api_key_token"
 export const SEED_LATITUDE_TELEMETRY_PROJECT_ID = ProjectId("rvknrpb3afjbcb7gzw3wlbvf")
 export const SEED_LATITUDE_TELEMETRY_PROJECT_NAME = "Latitude Telemetry"
 export const SEED_LATITUDE_TELEMETRY_PROJECT_SLUG = "latitude-telemetry"
+
+// ---------------------------------------------------------------------------
+// Test Mode — second org (empty-sandbox state) and Acme sandboxes
+// ---------------------------------------------------------------------------
+
+/**
+ * Second top-level org with no sandboxes. Exercises the "create your first
+ * sandbox" empty state distinct from Acme (which has two sandboxes seeded
+ * below) so Wave 2 UI work can demo both branches against `pnpm db:seed`.
+ */
+export const SEED_BETA_ORG_ID = OrganizationId("bet4c00rg1seed00000000ab")
+export const SEED_BETA_ORG_NAME = "Beta Co."
+export const SEED_BETA_ORG_SLUG = "beta"
+
+export const SEED_BETA_OWNER_USER_ID = UserId("bet4ownr0user000000000ab")
+export const SEED_BETA_OWNER_EMAIL = "owner@beta.com"
+export const SEED_BETA_OWNER_MEMBERSHIP_ID = MembershipId("bet4ownr0memb000000000ab")
+
+export const SEED_BETA_MEMBER_USER_ID = UserId("bet4mbr10user000000000ab")
+export const SEED_BETA_MEMBER_EMAIL = "alex@beta.com"
+export const SEED_BETA_MEMBER_MEMBERSHIP_ID = MembershipId("bet4mbr10memb000000000ab")
+
+export const SEED_BETA_PROJECT_ID = ProjectId("bet4pr0j0default00000ab1")
+export const SEED_BETA_PROJECT_NAME = "Support Agent"
+export const SEED_BETA_PROJECT_SLUG = "default-project"
+
+/**
+ * Acme sandbox #1 — `active`. Has one linked sandbox project pointing at
+ * Acme's default project by stable id.
+ */
+export const SEED_ACME_SANDBOX_ACTIVE_ORG_ID = OrganizationId("acmesbx1act000000000000a")
+export const SEED_ACME_SANDBOX_ACTIVE_NAME = "Dev sandbox"
+export const SEED_ACME_SANDBOX_ACTIVE_SLUG = "acme-dev-sandbox"
+/** PK of the 1:1 sandbox-attrs row keyed to `SEED_ACME_SANDBOX_ACTIVE_ORG_ID`. */
+export const SEED_ACME_SANDBOX_ACTIVE_ATTRS_ID = "acmesbx1act0attrs00000a1"
+/** Sandbox project under the active sandbox, linked to `SEED_PROJECT_ID`. */
+export const SEED_ACME_SANDBOX_ACTIVE_PROJECT_ID = ProjectId("acmesbx1act0proj000000a1")
+
+/**
+ * Acme sandbox #2 — `archived`. Idle past the 7-day threshold; surfaces the
+ * "asleep / reactivate" branch in the UI.
+ */
+export const SEED_ACME_SANDBOX_ARCHIVED_ORG_ID = OrganizationId("acmesbx2arc000000000000a")
+export const SEED_ACME_SANDBOX_ARCHIVED_NAME = "Old sandbox"
+export const SEED_ACME_SANDBOX_ARCHIVED_SLUG = "acme-old-sandbox"
+export const SEED_ACME_SANDBOX_ARCHIVED_ATTRS_ID = "acmesbx2arc0attrs00000a2"
+export const SEED_ACME_SANDBOX_ARCHIVED_PROJECT_ID = ProjectId("acmesbx2arc0proj000000a2")

--- a/packages/platform/db-postgres/src/seeds/organizations/index.ts
+++ b/packages/platform/db-postgres/src/seeds/organizations/index.ts
@@ -28,6 +28,7 @@ import {
 import { Effect } from "effect"
 import { users as usersTable } from "../../schema/better-auth.ts"
 import { type SeedContext, SeedError, type Seeder } from "../types.ts"
+import { sandboxOrganizationSeeders } from "./sandboxes.ts"
 
 const seedUsers: Seeder = {
   name: "organizations/users",
@@ -161,4 +162,12 @@ const seedMemberships: Seeder = {
     }),
 }
 
-export const organizationSeeders: readonly Seeder[] = [seedUsers, seedOrganizations, seedMemberships]
+export const organizationSeeders: readonly Seeder[] = [
+  seedUsers,
+  seedOrganizations,
+  seedMemberships,
+  // Test Mode fixtures: second top-level org (empty-sandbox state) + two
+  // sandboxes (active, archived) under Acme so Wave 2 UI demos against
+  // real data on a fresh `pnpm db:seed`. See AGE-126.
+  ...sandboxOrganizationSeeders,
+]

--- a/packages/platform/db-postgres/src/seeds/organizations/sandboxes.ts
+++ b/packages/platform/db-postgres/src/seeds/organizations/sandboxes.ts
@@ -1,0 +1,209 @@
+import { createMembership, createOrganization } from "@domain/organizations"
+import { createProject } from "@domain/projects"
+import {
+  SEED_ACME_SANDBOX_ACTIVE_ATTRS_ID,
+  SEED_ACME_SANDBOX_ACTIVE_NAME,
+  SEED_ACME_SANDBOX_ACTIVE_ORG_ID,
+  SEED_ACME_SANDBOX_ACTIVE_PROJECT_ID,
+  SEED_ACME_SANDBOX_ACTIVE_SLUG,
+  SEED_ACME_SANDBOX_ARCHIVED_ATTRS_ID,
+  SEED_ACME_SANDBOX_ARCHIVED_NAME,
+  SEED_ACME_SANDBOX_ARCHIVED_ORG_ID,
+  SEED_ACME_SANDBOX_ARCHIVED_PROJECT_ID,
+  SEED_ACME_SANDBOX_ARCHIVED_SLUG,
+  SEED_BETA_MEMBER_EMAIL,
+  SEED_BETA_MEMBER_MEMBERSHIP_ID,
+  SEED_BETA_MEMBER_USER_ID,
+  SEED_BETA_ORG_ID,
+  SEED_BETA_ORG_NAME,
+  SEED_BETA_ORG_SLUG,
+  SEED_BETA_OWNER_EMAIL,
+  SEED_BETA_OWNER_MEMBERSHIP_ID,
+  SEED_BETA_OWNER_USER_ID,
+  SEED_BETA_PROJECT_ID,
+  SEED_BETA_PROJECT_NAME,
+  SEED_BETA_PROJECT_SLUG,
+  SEED_ORG_ID,
+  SEED_OWNER_USER_ID,
+  SEED_PROJECT_ID,
+} from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { users as usersTable } from "../../schema/better-auth.ts"
+import { projects as projectsTable } from "../../schema/projects.ts"
+import { sandboxes as sandboxesTable } from "../../schema/sandboxes.ts"
+import { type SeedContext, SeedError, type Seeder } from "../types.ts"
+
+/**
+ * Second top-level org for Test Mode QA. No sandboxes — exercises the
+ * empty-state / "create your first sandbox" branch of the Wave 2 UI.
+ */
+const seedBetaOrganization: Seeder = {
+  name: "organizations/beta-organization",
+  run: (ctx: SeedContext) =>
+    Effect.gen(function* () {
+      yield* Effect.tryPromise({
+        try: async () => {
+          const betaUsers = [
+            {
+              id: SEED_BETA_OWNER_USER_ID,
+              email: SEED_BETA_OWNER_EMAIL,
+              name: "Beta Owner",
+              emailVerified: true,
+              role: "user" as const,
+            },
+            {
+              id: SEED_BETA_MEMBER_USER_ID,
+              email: SEED_BETA_MEMBER_EMAIL,
+              name: "Alex (Beta)",
+              emailVerified: true,
+              role: "user" as const,
+            },
+          ]
+          for (const u of betaUsers) {
+            await ctx.db
+              .insert(usersTable)
+              .values(u)
+              .onConflictDoUpdate({
+                target: usersTable.id,
+                set: { email: u.email, name: u.name, emailVerified: u.emailVerified, role: u.role },
+              })
+          }
+        },
+        catch: (error) => new SeedError({ reason: "Failed to seed Beta users", cause: error }),
+      })
+
+      const org = createOrganization({
+        id: SEED_BETA_ORG_ID,
+        name: SEED_BETA_ORG_NAME,
+        slug: SEED_BETA_ORG_SLUG,
+      })
+      yield* ctx.repositories.organization.save(org)
+
+      yield* ctx.repositories.membership.save(
+        createMembership({
+          id: SEED_BETA_OWNER_MEMBERSHIP_ID,
+          organizationId: SEED_BETA_ORG_ID,
+          userId: SEED_BETA_OWNER_USER_ID,
+          role: "owner",
+        }),
+      )
+      yield* ctx.repositories.membership.save(
+        createMembership({
+          id: SEED_BETA_MEMBER_MEMBERSHIP_ID,
+          organizationId: SEED_BETA_ORG_ID,
+          userId: SEED_BETA_MEMBER_USER_ID,
+          role: "member",
+        }),
+      )
+
+      const project = createProject({
+        id: SEED_BETA_PROJECT_ID,
+        organizationId: SEED_BETA_ORG_ID,
+        name: SEED_BETA_PROJECT_NAME,
+        slug: SEED_BETA_PROJECT_SLUG,
+      })
+      yield* ctx.repositories.project.save(project)
+
+      console.log(`  -> organization: ${org.name} (${org.slug}) — owner@beta.com, alex@beta.com`)
+    }),
+}
+
+/**
+ * Two sandbox orgs under Acme — one `active`, one `archived` — so Wave 2 UI
+ * (switcher / list / settings) demos both lifecycle states. Sandbox orgs are
+ * sibling tenants: a real `organizations` row with `parent_org_id = acme.id`,
+ * a 1:1 `sandboxes` attrs row, and (per spec) **no `members` rows** — access
+ * resolves through the parent's membership via `sandboxMiddleware`.
+ *
+ * Each sandbox owns one linked sandbox project pointing at an Acme project by
+ * stable id (`projects.linked_project_id`). The `linkedProjectId` column is
+ * not yet exposed through the domain `Project` entity, so the linked row is
+ * inserted directly via the drizzle table.
+ */
+const seedAcmeSandboxes: Seeder = {
+  name: "organizations/acme-sandboxes",
+  run: (ctx: SeedContext) =>
+    Effect.gen(function* () {
+      const activeOrg = createOrganization({
+        id: SEED_ACME_SANDBOX_ACTIVE_ORG_ID,
+        name: SEED_ACME_SANDBOX_ACTIVE_NAME,
+        slug: SEED_ACME_SANDBOX_ACTIVE_SLUG,
+        parentOrgId: SEED_ORG_ID,
+      })
+      yield* ctx.repositories.organization.save(activeOrg)
+
+      const archivedOrg = createOrganization({
+        id: SEED_ACME_SANDBOX_ARCHIVED_ORG_ID,
+        name: SEED_ACME_SANDBOX_ARCHIVED_NAME,
+        slug: SEED_ACME_SANDBOX_ARCHIVED_SLUG,
+        parentOrgId: SEED_ORG_ID,
+      })
+      yield* ctx.repositories.organization.save(archivedOrg)
+
+      yield* Effect.tryPromise({
+        try: async () => {
+          // Both timestamps anchor on `SEED_TIMELINE_ANCHOR` (via the seed
+          // scope) so Postgres and ClickHouse seeds agree and re-running
+          // `pnpm db:seed` doesn't drift the values.
+          const lastActiveAt = ctx.scope.dateDaysAgo(0, 9, 0)
+          // 30 days ago — well past the 7-day idle threshold so the
+          // archived sandbox surfaces as "asleep" in the UI.
+          const archivedSince = ctx.scope.dateDaysAgo(30, 9, 0)
+
+          // Sandbox attrs + linked-project rows use `onConflictDoNothing`
+          // (rather than the `onConflictDoUpdate` we use for users) so that
+          // local QA tweaks to status / last_activity_at survive a re-seed.
+          // User rows are upserted to keep email/name aligned with the seed
+          // constants in `@domain/shared/seeding`.
+          await ctx.db
+            .insert(sandboxesTable)
+            .values({
+              id: SEED_ACME_SANDBOX_ACTIVE_ATTRS_ID,
+              organizationId: SEED_ACME_SANDBOX_ACTIVE_ORG_ID,
+              status: "active",
+              lastActivityAt: lastActiveAt,
+              createdByUserId: SEED_OWNER_USER_ID,
+            })
+            .onConflictDoNothing({ target: sandboxesTable.organizationId })
+
+          await ctx.db
+            .insert(sandboxesTable)
+            .values({
+              id: SEED_ACME_SANDBOX_ARCHIVED_ATTRS_ID,
+              organizationId: SEED_ACME_SANDBOX_ARCHIVED_ORG_ID,
+              status: "archived",
+              lastActivityAt: archivedSince,
+              createdByUserId: SEED_OWNER_USER_ID,
+            })
+            .onConflictDoNothing({ target: sandboxesTable.organizationId })
+
+          await ctx.db
+            .insert(projectsTable)
+            .values({
+              id: SEED_ACME_SANDBOX_ACTIVE_PROJECT_ID,
+              organizationId: SEED_ACME_SANDBOX_ACTIVE_ORG_ID,
+              name: "Support Agent",
+              slug: "support-agent",
+              linkedProjectId: SEED_PROJECT_ID,
+            })
+            .onConflictDoNothing({ target: projectsTable.id })
+
+          await ctx.db
+            .insert(projectsTable)
+            .values({
+              id: SEED_ACME_SANDBOX_ARCHIVED_PROJECT_ID,
+              organizationId: SEED_ACME_SANDBOX_ARCHIVED_ORG_ID,
+              name: "Support Agent",
+              slug: "support-agent",
+              linkedProjectId: SEED_PROJECT_ID,
+            })
+            .onConflictDoNothing({ target: projectsTable.id })
+        },
+        catch: (error) => new SeedError({ reason: "Failed to seed Acme sandboxes", cause: error }),
+      })
+
+      console.log(`  -> sandboxes (acme): "${activeOrg.name}" [active], "${archivedOrg.name}" [archived]`)
+    }),
+}
+
+export const sandboxOrganizationSeeders: readonly Seeder[] = [seedBetaOrganization, seedAcmeSandboxes]


### PR DESCRIPTION
Bundles [AGE-102](https://linear.app/latitude/issue/AGE-102/test-mode-sandbox-routing-middleware-scaffold) (sandbox routing + middleware) and [AGE-126](https://linear.app/latitude/issue/AGE-126/test-mode-seed-data-second-org-sandboxes-for-the-acme-org) (seed fixtures) so the new `/sandbox/:sandboxOrgId` page is QA-able locally without hand-rolling rows.

Spec: `specs/test-mode.md` → *How isolation works*, *Access without membership*, *What a sandbox is*.

## Summary

**Routing & middleware (AGE-102)**
- **`sandboxMiddleware`** (`apps/web/src/server/sandbox-middleware.ts`) — guard for `createServerFn` handlers under the `/sandbox/:sandboxOrgId` namespace. Authorizes the caller iff the resolved sandbox's `parent_org_id` is an org they're a member of (membership check is an ordinary RLS-scoped read against the **parent** — no bypass), then injects a sandbox-scoped `context.sandbox` (organizationId / name / parentOrgId) + `userId`. The browser session's `activeOrganizationId` is never seen by the handler, structurally preventing it from acting on the live parent by accident.
- **`createSandboxServerFn` is realised as the middleware**, not a factory. The TanStack Start Vite plugin only recognises the literal `createServerFn(...).handler(...)` chain at the call site — hiding it behind a factory leaks Node-only imports into the browser bundle (see `.agents/skills/backoffice/SKILL.md`). Same shape as the admin pattern: there is no `createAdminServerFn` either.
- **`authorizeSandboxAccess`** (`apps/web/src/domains/sandbox/sandbox-access.functions.ts`) — server fn that owns the DB-heavy auth path so its Node-only imports are stripped by the compiler on the client (the original draft had them in the middleware file directly and CI flagged the leak; mirrors how `adminMiddleware` delegates to `getFreshSession`).
- **`getSandbox` server fn** (`apps/web/src/domains/sandbox/sandbox.functions.ts`) — first consumer of `sandboxMiddleware`, returns the sandbox's display attributes.
- **Stub page** at `/sandbox/:sandboxOrgId` — loader fetches via `getSandbox`, renders `Sandbox: $name` + a *Back to live* `Link`. Loader maps `NotFoundError` → `notFound()` and `UnauthorizedError` → `/login` redirect via `parseServerError`.
- **`isSandbox` is now a type predicate** so callers don't need a redundant `parentOrgId !== null` check.

**Seed fixtures (AGE-126)**
- **Beta Co.** — second top-level org (owner@beta.com, alex@beta.com, default project) with **no sandboxes**, exercising the empty-state branch for the Wave 2 sandbox UI.
- **Two Acme sandboxes** — one `active` ("Dev sandbox") and one `archived` ("Old sandbox", last activity ~30 days ago). Each sandbox is a sibling-tenant `organizations` row with `parent_org_id = SEED_ORG_ID`, a 1:1 `sandboxes` attrs row (status / last_activity_at / created_by = Acme owner), and one linked sandbox project pointing at `SEED_PROJECT_ID` via `projects.linked_project_id`. **No `members` rows** for sandbox orgs (by design — spec: *Access without membership*).
- Idempotent: deterministic ids + `onConflictDoNothing` on direct inserts so `pnpm db:seed` is safely rerunnable.

## Non-goals (deferred to follow-up tickets)

- No traces UI, settings UI, or Live↔Sandbox switcher.
- No `members` rows for sandbox orgs — by design.
- No span seeding inside the sandboxes — comes with the ingestion path (AGE-105+).
- **`resolveEffectivePlan` parent-follow** lands with AGE-127 (sandbox ingest pipeline running in parallel), where it becomes load-bearing.

## QA recipe

```bash
pnpm db:seed     # idempotent — safe to re-run
# log in as owner@acme.com (mailpit magic-link)
```

Then visit:

- `/sandbox/acmesbx1act000000000000a` → renders `Sandbox: Dev sandbox` + *Back to live*
- `/sandbox/acmesbx2arc000000000000a` → renders `Sandbox: Old sandbox`
- `/sandbox/notarealsandboxidaaaaaaa` → 404
- `/sandbox/iapkf6osmlm7mbw9kulosua4` (the live Acme org id, not a sandbox) → 404

Then sign out and back in as `owner@beta.com`:

- `/sandbox/acmesbx1act000000000000a` → 404 (Beta is not a parent of Acme's sandbox — no fingerprint of existence)

## Test plan

- [x] `pnpm --filter @app/web typecheck` (clean)
- [x] `pnpm --filter @app/web build` (clean — reproduces the original CI MISSING_EXPORT before the `.functions.ts` refactor, succeeds after)
- [x] `pnpm --filter @platform/db-postgres --filter @domain/shared typecheck` (clean)
- [x] `pnpm knip` (clean)
- [ ] Dev-server smoke (reviewer to verify after `pnpm db:seed`):
  - [ ] Routes resolve per the QA recipe above
  - [ ] Re-running `pnpm db:seed` is idempotent (no duplicate-key errors)