### PR TITLE
feat(test-mode): sandbox lifecycle use-cases + active-cap [AGE-103]

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",
+    "@domain/sandboxes": "workspace:*",
     "@domain/saved-searches": "workspace:*",
     "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",

--- a/apps/web/src/domains/sandbox/sandbox-lifecycle.functions.ts
+++ b/apps/web/src/domains/sandbox/sandbox-lifecycle.functions.ts
@@ -1,0 +1,93 @@
+import {
+  archiveSandboxUseCase,
+  createSandboxUseCase,
+  deleteSandboxUseCase,
+  reactivateSandboxUseCase,
+} from "@domain/sandboxes"
+import { OrganizationId } from "@domain/shared"
+import {
+  BillingOverrideRepositoryLive,
+  MembershipRepositoryLive,
+  OrganizationRepositoryLive,
+  OutboxEventWriterLive,
+  ProjectRepositoryLive,
+  SandboxRepositoryLive,
+  SettingsReaderLive,
+  StripeSubscriptionLookupLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect, Layer } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getAdminPostgresClient } from "../../server/clients.ts"
+
+const sandboxWriteLayers = Layer.mergeAll(SandboxRepositoryLive, OrganizationRepositoryLive, MembershipRepositoryLive)
+const sandboxCapLayers = Layer.mergeAll(
+  sandboxWriteLayers,
+  BillingOverrideRepositoryLive,
+  StripeSubscriptionLookupLive,
+  SettingsReaderLive,
+)
+const sandboxDeleteLayers = Layer.mergeAll(sandboxWriteLayers, ProjectRepositoryLive, OutboxEventWriterLive)
+
+const sandboxIdInput = z.object({ sandboxOrganizationId: z.string() })
+
+export const createSandbox = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ name: z.string().min(1).max(256) }))
+  .handler(async ({ data }) => {
+    const { userId, organizationId } = await requireSession()
+    const client = getAdminPostgresClient()
+
+    return await Effect.runPromise(
+      createSandboxUseCase({
+        parentOrganizationId: organizationId,
+        actorUserId: userId,
+        name: data.name,
+      }).pipe(withPostgres(sandboxCapLayers, client, organizationId), withTracing),
+    )
+  })
+
+export const archiveSandbox = createServerFn({ method: "POST" })
+  .inputValidator(sandboxIdInput)
+  .handler(async ({ data }) => {
+    const { userId, organizationId } = await requireSession()
+    const client = getAdminPostgresClient()
+
+    return await Effect.runPromise(
+      archiveSandboxUseCase({
+        sandboxOrganizationId: OrganizationId(data.sandboxOrganizationId),
+        actorUserId: userId,
+      }).pipe(withPostgres(sandboxWriteLayers, client, organizationId), withTracing),
+    )
+  })
+
+export const reactivateSandbox = createServerFn({ method: "POST" })
+  .inputValidator(sandboxIdInput)
+  .handler(async ({ data }) => {
+    const { userId, organizationId } = await requireSession()
+    const client = getAdminPostgresClient()
+
+    return await Effect.runPromise(
+      reactivateSandboxUseCase({
+        sandboxOrganizationId: OrganizationId(data.sandboxOrganizationId),
+        actorUserId: userId,
+      }).pipe(withPostgres(sandboxCapLayers, client, organizationId), withTracing),
+    )
+  })
+
+export const deleteSandbox = createServerFn({ method: "POST" })
+  .inputValidator(sandboxIdInput)
+  .handler(async ({ data }): Promise<void> => {
+    const { userId } = await requireSession()
+    const client = getAdminPostgresClient()
+    const sandboxOrganizationId = OrganizationId(data.sandboxOrganizationId)
+
+    await Effect.runPromise(
+      deleteSandboxUseCase({ sandboxOrganizationId, actorUserId: userId }).pipe(
+        withPostgres(sandboxDeleteLayers, client, sandboxOrganizationId),
+        withTracing,
+      ),
+    )
+  })

--- a/knip.json
+++ b/knip.json
@@ -21,7 +21,12 @@
       "ignoreDependencies": ["@temporalio/worker", "voyageai"]
     },
     "apps/web": {
-      "entry": ["src/router.tsx", "src/start.ts", "src/routes/**/*.tsx"],
+      "entry": [
+        "src/router.tsx",
+        "src/start.ts",
+        "src/routes/**/*.tsx",
+        "src/domains/sandbox/sandbox-lifecycle.functions.ts"
+      ],
       "project": ["src/**/*.ts", "src/**/*.tsx"],
       "ignore": [
         "src/domains/feature-flags/feature-flags.collection.ts"

--- a/packages/domain/billing/src/constants.ts
+++ b/packages/domain/billing/src/constants.ts
@@ -21,6 +21,13 @@ export const ACTION_CREDITS: Record<ChargeableAction, number> = {
   "eval-generation": 1000,
 } as const
 
+/**
+ * Test Mode active-sandbox cap for Enterprise. A finite "high number" rather
+ * than `Infinity` so it round-trips through the integer plan schema; no real
+ * org approaches it, so it acts as effectively unbounded.
+ */
+export const ENTERPRISE_SANDBOX_ACTIVE_CAP = 1000
+
 export const FREE_PLAN_CONFIG = {
   slug: "free" as const,
   selfServe: false,
@@ -32,6 +39,7 @@ export const FREE_PLAN_CONFIG = {
   // Per-period sandbox span ceiling (Test Mode abuse guard, not billed). Read
   // through `resolveEffectivePlan`; enforced as a loud ingest refusal.
   spanQuotaPerPeriod: 100_000,
+  sandboxActiveCap: 1,
 } as const
 
 export const PRO_PLAN_CONFIG = {
@@ -45,6 +53,7 @@ export const PRO_PLAN_CONFIG = {
   overageCreditsPerUnit: 10_000,
   overagePriceCentsPerUnit: 2000,
   spanQuotaPerPeriod: 1_000_000,
+  sandboxActiveCap: 15,
 } as const
 
 /** Upper bound for `billing_usage_periods.included_credits` (Postgres `integer`). */
@@ -59,6 +68,7 @@ export const ENTERPRISE_PLAN_CONFIG = {
   hardCapped: false,
   priceCents: null as null,
   spanQuotaPerPeriod: Number.POSITIVE_INFINITY,
+  sandboxActiveCap: ENTERPRISE_SANDBOX_ACTIVE_CAP,
 } as const
 
 export type PlanConfig = {
@@ -70,6 +80,8 @@ export type PlanConfig = {
   hardCapped: boolean
   priceCents: number | null
   spanQuotaPerPeriod: number
+  /** Max number of *active* sandboxes an org on this plan may have. */
+  sandboxActiveCap: number
 }
 
 export const PLAN_CONFIGS: Record<PlanSlug, PlanConfig> = {

--- a/packages/domain/billing/src/entities/billing-plan.ts
+++ b/packages/domain/billing/src/entities/billing-plan.ts
@@ -14,6 +14,7 @@ export const billingPlanSchema = z.object({
   // (which, like `includedCredits`, simply won't round-trip through the JSON
   // plan cache — re-resolved on miss).
   spanQuotaPerPeriod: z.number(),
+  sandboxActiveCap: z.number().int().nonnegative(),
 })
 
 export type BillingPlan = z.infer<typeof billingPlanSchema>

--- a/packages/domain/billing/src/index.ts
+++ b/packages/domain/billing/src/index.ts
@@ -13,6 +13,7 @@ export {
   calculateOverageAmountMills,
   calculatePlanSpendMills,
   ENTERPRISE_PLAN_CONFIG,
+  ENTERPRISE_SANDBOX_ACTIVE_CAP,
   FREE_PLAN_CONFIG,
   OverageCreditUnit,
   PLAN_CONFIGS,

--- a/packages/domain/billing/src/use-cases/resolve-effective-plan.ts
+++ b/packages/domain/billing/src/use-cases/resolve-effective-plan.ts
@@ -34,6 +34,7 @@ const buildResolvedPlan = (input: {
   priceCents: input.priceCents,
   spendingLimitCents: input.slug === "pro" ? input.spendingLimitCents : null,
   spanQuotaPerPeriod: input.spanQuotaPerPeriod,
+  sandboxActiveCap: PLAN_CONFIGS[input.slug].sandboxActiveCap,
 })
 
 const resolveOverridePlan = (input: {
@@ -146,6 +147,7 @@ export interface EffectivePlanResolution {
     readonly priceCents: number | null
     readonly spendingLimitCents: number | null
     readonly spanQuotaPerPeriod: number
+    readonly sandboxActiveCap: number
   }
   readonly source: "override" | "subscription" | "free-fallback"
   readonly periodStart: Date
@@ -164,7 +166,11 @@ export const resolveEffectivePlan = Effect.fn("billing.resolveEffectivePlan")(fu
   const spendingLimitCents = settings.billing?.spendingLimitCents ?? null
 
   if (override) {
-    return resolveOverridePlan({ organizationId, override, spendingLimitCents })
+    return resolveOverridePlan({
+      organizationId,
+      override,
+      spendingLimitCents,
+    })
   }
 
   const subLookup = yield* StripeSubscriptionLookup

--- a/packages/domain/sandboxes/package.json
+++ b/packages/domain/sandboxes/package.json
@@ -16,6 +16,9 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@domain/billing": "workspace:*",
+    "@domain/organizations": "workspace:*",
+    "@domain/projects": "workspace:*",
     "@domain/shared": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"

--- a/packages/domain/sandboxes/src/entities/sandbox.ts
+++ b/packages/domain/sandboxes/src/entities/sandbox.ts
@@ -1,24 +1,50 @@
-import { organizationIdSchema } from "@domain/shared"
+import {
+  generateId,
+  type OrganizationId,
+  organizationIdSchema,
+  type SandboxId,
+  sandboxIdSchema,
+  type UserId,
+  userIdSchema,
+} from "@domain/shared"
 import { z } from "zod"
 
 export const sandboxStatusSchema = z.enum(["active", "archived"])
 export type SandboxStatus = z.infer<typeof sandboxStatusSchema>
 
-/**
- * Sandbox attributes (Test Mode) — the 1:1 row that hangs off a sandbox
- * organization (an `organizations` row with `parent_org_id IS NOT NULL`).
- * Carries the sleep/wake lifecycle (`status`, `lastActivityAt`) and creator
- * attribution. The row's presence is itself the operational signal that an org
- * is a sandbox.
- */
 export const sandboxSchema = z.object({
-  id: z.string(),
+  id: sandboxIdSchema,
   organizationId: organizationIdSchema,
   status: sandboxStatusSchema,
   lastActivityAt: z.date(),
-  createdByUserId: z.string(),
+  createdByUserId: userIdSchema,
   createdAt: z.date(),
   updatedAt: z.date(),
 })
 
 export type Sandbox = z.infer<typeof sandboxSchema>
+
+/**
+ * Factory for a freshly-created sandbox attributes row — starts `active` with
+ * `lastActivityAt` stamped now.
+ */
+export const createSandbox = (params: {
+  id?: SandboxId | undefined
+  organizationId: OrganizationId
+  createdByUserId: UserId
+  status?: SandboxStatus
+  lastActivityAt?: Date
+  createdAt?: Date
+  updatedAt?: Date
+}): Sandbox => {
+  const now = new Date()
+  return sandboxSchema.parse({
+    id: params.id ?? generateId<"SandboxId">(),
+    organizationId: params.organizationId,
+    status: params.status ?? "active",
+    lastActivityAt: params.lastActivityAt ?? now,
+    createdByUserId: params.createdByUserId,
+    createdAt: params.createdAt ?? now,
+    updatedAt: params.updatedAt ?? now,
+  })
+}

--- a/packages/domain/sandboxes/src/errors.ts
+++ b/packages/domain/sandboxes/src/errors.ts
@@ -1,12 +1,5 @@
 import { Data } from "effect"
 
-/**
- * Ingestion refused because the sandbox is archived (asleep). Mirrors billing's
- * `NoCreditsRemainingError` (402): a loud, pre-persist 4xx. 403 — and crucially
- * *not* 429 — so OTLP exporters treat it as non-retryable and drop the batch
- * instead of retry-looping. The `kind` surfaced at the HTTP boundary is
- * `"SandboxArchived"`.
- */
 export class SandboxArchivedError extends Data.TaggedError("SandboxArchivedError")<{
   readonly organizationId: string
 }> {
@@ -14,14 +7,40 @@ export class SandboxArchivedError extends Data.TaggedError("SandboxArchivedError
   readonly httpMessage = "Sandbox is archived (asleep). Reactivate it to resume ingestion."
 }
 
-/**
- * Ingestion refused because the sandbox exceeded its per-period span quota.
- * Same loud-refuse path as {@link SandboxArchivedError}; `kind` is
- * `"SandboxQuotaExceeded"`.
- */
 export class SandboxQuotaExceededError extends Data.TaggedError("SandboxQuotaExceededError")<{
   readonly organizationId: string
 }> {
   readonly httpStatus = 403
   readonly httpMessage = "Sandbox span quota exceeded for the current period."
+}
+
+export class NotSandboxError extends Data.TaggedError("NotSandboxError")<{
+  readonly organizationId: string
+}> {
+  readonly httpStatus = 400
+  readonly httpMessage = "This organization is not a sandbox."
+}
+
+export class SandboxAccessDeniedError extends Data.TaggedError("SandboxAccessDeniedError")<{
+  readonly organizationId: string
+  readonly userId: string
+}> {
+  readonly httpStatus = 403
+  readonly httpMessage = "You must be a member of the parent organization to manage its sandboxes."
+}
+export class SandboxNotFoundError extends Data.TaggedError("SandboxNotFoundError")<{
+  readonly organizationId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "Sandbox not found"
+}
+
+export class SandboxActiveCapReachedError extends Data.TaggedError("SandboxActiveCapReachedError")<{
+  readonly cap: number
+  readonly planSlug: string
+}> {
+  readonly httpStatus = 403
+  get httpMessage() {
+    return `Active sandbox limit reached (${this.cap}). Archive or delete a sandbox before adding another.`
+  }
 }

--- a/packages/domain/sandboxes/src/helpers.ts
+++ b/packages/domain/sandboxes/src/helpers.ts
@@ -1,0 +1,34 @@
+import { isSandbox, MembershipRepository, type Organization, OrganizationRepository } from "@domain/organizations"
+import type { OrganizationId, UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { NotSandboxError, SandboxAccessDeniedError, SandboxNotFoundError } from "./errors.ts"
+
+/**
+ * Resolve an existing sandbox org and authorize the actor against its *parent*
+ * org membership — any member of the parent may manage its sandboxes. Shared by
+ * the archive/reactivate/delete sandbox use-cases.
+ */
+export const loadAuthorizedSandboxOrg = (sandboxOrganizationId: OrganizationId, actorUserId: UserId) =>
+  Effect.gen(function* () {
+    const organizations = yield* OrganizationRepository
+    const org: Organization = yield* organizations
+      .findById(sandboxOrganizationId)
+      .pipe(
+        Effect.catchTag("NotFoundError", () =>
+          Effect.fail(new SandboxNotFoundError({ organizationId: sandboxOrganizationId })),
+        ),
+      )
+
+    if (!isSandbox(org)) {
+      return yield* new NotSandboxError({ organizationId: sandboxOrganizationId })
+    }
+    const parentOrgId = org.parentOrgId
+
+    const memberships = yield* MembershipRepository
+    const isMember = yield* memberships.isMember(parentOrgId, actorUserId)
+    if (!isMember) {
+      return yield* new SandboxAccessDeniedError({ organizationId: parentOrgId, userId: actorUserId })
+    }
+
+    return { organization: org, parentOrgId }
+  })

--- a/packages/domain/sandboxes/src/index.ts
+++ b/packages/domain/sandboxes/src/index.ts
@@ -9,9 +9,19 @@ export {
   SANDBOX_TRACE_SIGNAL_COALESCE_MS,
 } from "./constants.ts"
 export type { Sandbox, SandboxStatus } from "./entities/sandbox.ts"
-export { sandboxSchema, sandboxStatusSchema } from "./entities/sandbox.ts"
-export { SandboxArchivedError, SandboxQuotaExceededError } from "./errors.ts"
-export type { SandboxRepositoryShape } from "./ports/sandbox-repository.ts"
+export {
+  createSandbox,
+  sandboxSchema,
+  sandboxStatusSchema,
+} from "./entities/sandbox.ts"
+export {
+  NotSandboxError,
+  SandboxAccessDeniedError,
+  SandboxActiveCapReachedError,
+  SandboxArchivedError,
+  SandboxNotFoundError,
+  SandboxQuotaExceededError,
+} from "./errors.ts"
 export { SandboxRepository } from "./ports/sandbox-repository.ts"
 export type {
   SandboxRejectedIngestKind,
@@ -20,7 +30,24 @@ export type {
 } from "./ports/sandbox-signals.ts"
 export { SandboxSignals } from "./ports/sandbox-signals.ts"
 export {
+  type ArchiveSandboxInput,
+  archiveSandboxUseCase,
+} from "./use-cases/archive-sandbox.ts"
+export {
+  type CreateSandboxInput,
+  type CreateSandboxResult,
+  createSandboxUseCase,
+} from "./use-cases/create-sandbox.ts"
+export {
+  type DeleteSandboxInput,
+  deleteSandboxUseCase,
+} from "./use-cases/delete-sandbox.ts"
+export {
   publishSandboxTraceSignalsUseCase,
   type SandboxTraceRef,
 } from "./use-cases/publish-sandbox-trace-signals.ts"
+export {
+  type ReactivateSandboxInput,
+  reactivateSandboxUseCase,
+} from "./use-cases/reactivate-sandbox.ts"
 export { stampSandboxActivityUseCase } from "./use-cases/stamp-sandbox-activity.ts"

--- a/packages/domain/sandboxes/src/ports/sandbox-repository.ts
+++ b/packages/domain/sandboxes/src/ports/sandbox-repository.ts
@@ -1,19 +1,39 @@
-import type { RepositoryError, SqlClient } from "@domain/shared"
+import type { NotFoundError, OrganizationId, RepositoryError, SqlClient } from "@domain/shared"
 import { Context, type Effect } from "effect"
-import type { Sandbox } from "../entities/sandbox.ts"
+import type { Sandbox, SandboxStatus } from "../entities/sandbox.ts"
 
-export interface SandboxRepositoryShape {
-  /**
-   * The current RLS org's sandbox attributes row, or `null` when the org is not
-   * a sandbox. A `sandboxes` row exists iff `parent_org_id IS NOT NULL`, so this
-   * single scoped read resolves the sandbox bit (and the `status` for the
-   * archived-refusal gate) at the top of ingest.
-   */
-  findOptional(): Effect.Effect<Sandbox | null, RepositoryError, SqlClient>
-  /** Stamp `last_activity_at = now()` for the current RLS org's sandbox row. */
-  stampActivity(): Effect.Effect<void, RepositoryError, SqlClient>
-}
-
-export class SandboxRepository extends Context.Service<SandboxRepository, SandboxRepositoryShape>()(
-  "@domain/sandboxes/SandboxRepository",
-) {}
+/**
+ * Sandbox lifecycle is *cross-org* management: a parent live org owns sibling
+ * sandbox orgs, and the per-plan cap counts sandboxes across that family. The
+ * `sandboxes` table's RLS scopes each row to its *own* sandbox org, so no
+ * single live-org RLS context can see a parent's sandboxes. These methods are
+ * therefore scoped by explicit `organizationId` / `parentOrgId` arguments and
+ * run on an RLS-bypassing (admin) `SqlClient`, mirroring the cross-org reads in
+ * `@domain/admin`. Authorization is the caller's responsibility (the use-cases
+ * gate every call on parent-org membership before touching this port).
+ */
+export class SandboxRepository extends Context.Service<
+  SandboxRepository,
+  {
+    findOptional(): Effect.Effect<Sandbox | null, RepositoryError, SqlClient>
+    stampActivity(): Effect.Effect<void, RepositoryError, SqlClient>
+    create: (sandbox: Sandbox) => Effect.Effect<void, RepositoryError, SqlClient>
+    findByOrganizationId: (
+      organizationId: OrganizationId,
+    ) => Effect.Effect<Sandbox, NotFoundError | RepositoryError, SqlClient>
+    countActiveByParentOrgId: (parentOrgId: OrganizationId) => Effect.Effect<number, RepositoryError, SqlClient>
+    /**
+     * Take a transaction-scoped advisory lock keyed on the parent org, so the
+     * active-cap "count then write" sequence is serialized per parent and two
+     * concurrent create/reactivate calls can't both pass the cap. Must be called
+     * inside a `SqlClient.transaction` — the lock releases when that tx ends.
+     */
+    lockParentForCapCheck: (parentOrgId: OrganizationId) => Effect.Effect<void, RepositoryError, SqlClient>
+    setStatus: (
+      organizationId: OrganizationId,
+      status: SandboxStatus,
+    ) => Effect.Effect<void, RepositoryError, SqlClient>
+    /** Remove the attributes row (the org row + cascade is handled separately). */
+    delete: (organizationId: OrganizationId) => Effect.Effect<void, RepositoryError, SqlClient>
+  }
+>()("@domain/sandboxes/SandboxRepository") {}

--- a/packages/domain/sandboxes/src/testing/fake-sandbox-repository.ts
+++ b/packages/domain/sandboxes/src/testing/fake-sandbox-repository.ts
@@ -1,10 +1,18 @@
+import { NotFoundError, type OrganizationId } from "@domain/shared"
 import { Effect } from "effect"
 import type { Sandbox } from "../entities/sandbox.ts"
 import type { SandboxRepository } from "../ports/sandbox-repository.ts"
 
 type SandboxRepositoryShape = (typeof SandboxRepository)["Service"]
 
+/**
+ * In-memory fake keyed by the sandbox org id. `parentByOrganizationId` lets a
+ * test attach a sandbox to a parent so `countActiveByParentOrgId` can resolve
+ * the family without a real `organizations` join.
+ */
 export const createFakeSandboxRepository = (overrides?: Partial<SandboxRepositoryShape>) => {
+  const sandboxes = new Map<OrganizationId, Sandbox>()
+  const parentByOrganizationId = new Map<OrganizationId, OrganizationId>()
   let stampCount = 0
 
   const repository: SandboxRepositoryShape = {
@@ -13,11 +21,45 @@ export const createFakeSandboxRepository = (overrides?: Partial<SandboxRepositor
       Effect.sync(() => {
         stampCount++
       }),
+    create: (sandbox) =>
+      Effect.sync(() => {
+        sandboxes.set(sandbox.organizationId, sandbox)
+      }),
+
+    findByOrganizationId: (organizationId) => {
+      const sandbox = sandboxes.get(organizationId)
+      if (!sandbox) return Effect.fail(new NotFoundError({ entity: "Sandbox", id: organizationId }))
+      return Effect.succeed(sandbox)
+    },
+
+    countActiveByParentOrgId: (parentOrgId) =>
+      Effect.succeed(
+        [...sandboxes.values()].filter(
+          (sandbox) =>
+            sandbox.status === "active" && parentByOrganizationId.get(sandbox.organizationId) === parentOrgId,
+        ).length,
+      ),
+
+    // No-op: in-memory tests are single-threaded, so there's no lock to take.
+    lockParentForCapCheck: () => Effect.void,
+
+    setStatus: (organizationId, status) =>
+      Effect.sync(() => {
+        const sandbox = sandboxes.get(organizationId)
+        if (sandbox) sandboxes.set(organizationId, { ...sandbox, status })
+      }),
+
+    delete: (organizationId) =>
+      Effect.sync(() => {
+        sandboxes.delete(organizationId)
+      }),
     ...overrides,
   }
 
   return {
     repository,
+    sandboxes,
+    parentByOrganizationId,
     get stampCount() {
       return stampCount
     },

--- a/packages/domain/sandboxes/src/use-cases/archive-sandbox.ts
+++ b/packages/domain/sandboxes/src/use-cases/archive-sandbox.ts
@@ -1,0 +1,30 @@
+import type { OrganizationId, UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { loadAuthorizedSandboxOrg } from "../helpers.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+
+export interface ArchiveSandboxInput {
+  readonly sandboxOrganizationId: OrganizationId
+  readonly actorUserId: UserId
+}
+
+/**
+ * Put a sandbox to sleep. Archiving frees a slot toward the per-plan active
+ * cap; it is non-destructive (data ages out via retention). Idempotent on an
+ * already-archived sandbox.
+ */
+export const archiveSandboxUseCase = Effect.fn("sandboxes.archiveSandbox")(function* (input: ArchiveSandboxInput) {
+  yield* Effect.annotateCurrentSpan("organization.id", input.sandboxOrganizationId)
+
+  yield* loadAuthorizedSandboxOrg(input.sandboxOrganizationId, input.actorUserId)
+
+  const sandboxes = yield* SandboxRepository
+  const sandbox = yield* sandboxes.findByOrganizationId(input.sandboxOrganizationId)
+  if (sandbox.status === "archived") {
+    return sandbox
+  }
+
+  yield* sandboxes.setStatus(input.sandboxOrganizationId, "archived")
+  // Re-read so the returned entity carries the DB-updated `updatedAt`.
+  return yield* sandboxes.findByOrganizationId(input.sandboxOrganizationId)
+})

--- a/packages/domain/sandboxes/src/use-cases/create-sandbox.ts
+++ b/packages/domain/sandboxes/src/use-cases/create-sandbox.ts
@@ -1,0 +1,69 @@
+import { resolveEffectivePlan } from "@domain/billing"
+import {
+  createOrganization,
+  generateUniqueOrganizationSlugUseCase,
+  MembershipRepository,
+  type Organization,
+  OrganizationRepository,
+} from "@domain/organizations"
+import { generateId, type OrganizationId, SqlClient, type UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { createSandbox, type Sandbox } from "../entities/sandbox.ts"
+import { SandboxAccessDeniedError, SandboxActiveCapReachedError } from "../errors.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+
+export interface CreateSandboxInput {
+  /** The live org the sandbox is a sibling of. Authz is evaluated against it. */
+  readonly parentOrganizationId: OrganizationId
+  readonly actorUserId: UserId
+  readonly name: string
+}
+
+export interface CreateSandboxResult {
+  readonly organization: Organization
+  readonly sandbox: Sandbox
+}
+
+export const createSandboxUseCase = Effect.fn("sandboxes.createSandbox")(function* (input: CreateSandboxInput) {
+  yield* Effect.annotateCurrentSpan("organization.id", input.parentOrganizationId)
+
+  const memberships = yield* MembershipRepository
+  const isMember = yield* memberships.isMember(input.parentOrganizationId, input.actorUserId)
+  if (!isMember) {
+    return yield* new SandboxAccessDeniedError({
+      organizationId: input.parentOrganizationId,
+      userId: input.actorUserId,
+    })
+  }
+
+  const { plan } = yield* resolveEffectivePlan(input.parentOrganizationId)
+
+  const slug = yield* generateUniqueOrganizationSlugUseCase({ name: input.name })
+  const organizationId = generateId<"OrganizationId">()
+  const organization = createOrganization({
+    id: organizationId,
+    name: input.name,
+    slug,
+    parentOrgId: input.parentOrganizationId,
+  })
+  const sandbox = createSandbox({ organizationId, createdByUserId: input.actorUserId })
+
+  const sqlClient = yield* SqlClient
+  yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const organizationRepository = yield* OrganizationRepository
+      const sandboxRepository = yield* SandboxRepository
+      // Lock + count + insert in one tx so concurrent creates can't both pass
+      // the cap (the lock serializes this section per parent org).
+      yield* sandboxRepository.lockParentForCapCheck(input.parentOrganizationId)
+      const activeCount = yield* sandboxRepository.countActiveByParentOrgId(input.parentOrganizationId)
+      if (activeCount >= plan.sandboxActiveCap) {
+        return yield* new SandboxActiveCapReachedError({ cap: plan.sandboxActiveCap, planSlug: plan.slug })
+      }
+      yield* organizationRepository.save(organization)
+      yield* sandboxRepository.create(sandbox)
+    }),
+  )
+
+  return { organization, sandbox } satisfies CreateSandboxResult
+})

--- a/packages/domain/sandboxes/src/use-cases/delete-sandbox.ts
+++ b/packages/domain/sandboxes/src/use-cases/delete-sandbox.ts
@@ -1,0 +1,36 @@
+import { OrganizationRepository } from "@domain/organizations"
+import { purgeOrganizationProjectsUseCase } from "@domain/projects"
+import { type OrganizationId, SqlClient, type UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { loadAuthorizedSandboxOrg } from "../helpers.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+
+export interface DeleteSandboxInput {
+  readonly sandboxOrganizationId: OrganizationId
+  readonly actorUserId: UserId
+}
+
+export const deleteSandboxUseCase = Effect.fn("sandboxes.deleteSandbox")(function* (input: DeleteSandboxInput) {
+  yield* Effect.annotateCurrentSpan("organization.id", input.sandboxOrganizationId)
+
+  yield* loadAuthorizedSandboxOrg(input.sandboxOrganizationId, input.actorUserId)
+
+  const sqlClient = yield* SqlClient
+  if (sqlClient.organizationId !== input.sandboxOrganizationId) {
+    return yield* Effect.die(
+      `deleteSandbox must run scoped to the sandbox org (${input.sandboxOrganizationId}), got ${sqlClient.organizationId}`,
+    )
+  }
+
+  yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const sandboxes = yield* SandboxRepository
+      const organizations = yield* OrganizationRepository
+      yield* purgeOrganizationProjectsUseCase({
+        actorUserId: input.actorUserId,
+      })
+      yield* sandboxes.delete(input.sandboxOrganizationId)
+      yield* organizations.delete(input.sandboxOrganizationId)
+    }),
+  )
+})

--- a/packages/domain/sandboxes/src/use-cases/reactivate-sandbox.ts
+++ b/packages/domain/sandboxes/src/use-cases/reactivate-sandbox.ts
@@ -1,0 +1,48 @@
+import { resolveEffectivePlan } from "@domain/billing"
+import { type OrganizationId, SqlClient, type UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { SandboxActiveCapReachedError } from "../errors.ts"
+import { loadAuthorizedSandboxOrg } from "../helpers.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+
+export interface ReactivateSandboxInput {
+  readonly sandboxOrganizationId: OrganizationId
+  readonly actorUserId: UserId
+}
+
+/**
+ * Wake a sleeping sandbox back to `active`, iff doing so won't exceed the
+ * parent plan's active-sandbox cap. Idempotent on an already-active sandbox.
+ */
+export const reactivateSandboxUseCase = Effect.fn("sandboxes.reactivateSandbox")(function* (
+  input: ReactivateSandboxInput,
+) {
+  yield* Effect.annotateCurrentSpan("organization.id", input.sandboxOrganizationId)
+
+  const { parentOrgId } = yield* loadAuthorizedSandboxOrg(input.sandboxOrganizationId, input.actorUserId)
+
+  const sandboxes = yield* SandboxRepository
+  const sandbox = yield* sandboxes.findByOrganizationId(input.sandboxOrganizationId)
+  if (sandbox.status === "active") {
+    return sandbox
+  }
+
+  const { plan } = yield* resolveEffectivePlan(parentOrgId)
+
+  const sqlClient = yield* SqlClient
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const sandboxRepository = yield* SandboxRepository
+      // Lock + count + flip in one tx so reactivation can't race creation (or
+      // another reactivation) past the cap.
+      yield* sandboxRepository.lockParentForCapCheck(parentOrgId)
+      const activeCount = yield* sandboxRepository.countActiveByParentOrgId(parentOrgId)
+      if (activeCount + 1 > plan.sandboxActiveCap) {
+        return yield* new SandboxActiveCapReachedError({ cap: plan.sandboxActiveCap, planSlug: plan.slug })
+      }
+      yield* sandboxRepository.setStatus(input.sandboxOrganizationId, "active")
+      // Re-read so the returned entity carries the DB-updated `updatedAt`.
+      return yield* sandboxRepository.findByOrganizationId(input.sandboxOrganizationId)
+    }),
+  )
+})

--- a/packages/domain/sandboxes/src/use-cases/sandbox-lifecycle.test.ts
+++ b/packages/domain/sandboxes/src/use-cases/sandbox-lifecycle.test.ts
@@ -1,0 +1,143 @@
+import { BillingOverrideRepository, StripeSubscriptionLookup } from "@domain/billing"
+import { createFakeBillingOverrideRepository, createFakeStripeSubscriptionLookup } from "@domain/billing/testing"
+import { createOrganization, MembershipRepository, OrganizationRepository } from "@domain/organizations"
+import { createFakeMembershipRepository, createFakeOrganizationRepository } from "@domain/organizations/testing"
+import { generateId, OrganizationId, SettingsReader, SqlClient, UserId } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { createSandbox } from "../entities/sandbox.ts"
+import { SandboxAccessDeniedError, SandboxActiveCapReachedError } from "../errors.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+import { createFakeSandboxRepository } from "../testing/fake-sandbox-repository.ts"
+import { archiveSandboxUseCase } from "./archive-sandbox.ts"
+import { createSandboxUseCase } from "./create-sandbox.ts"
+import { reactivateSandboxUseCase } from "./reactivate-sandbox.ts"
+
+const PARENT_ORG_ID = OrganizationId(generateId())
+const ADMIN_USER_ID = UserId(generateId())
+
+const failure = <A, E>(exit: Exit.Exit<A, E>): E | undefined =>
+  Exit.isFailure(exit) ? exit.cause.reasons.find(Cause.isFailReason)?.error : undefined
+
+/**
+ * Wire every sandbox-use-case dependency with in-memory fakes. The actor is a
+ * member of the parent org and the plan is Free (no override/subscription) →
+ * active cap of 1, unless `plan: "pro"` is passed.
+ */
+const buildLayer = (input?: {
+  readonly plan?: "pro"
+  readonly isMember?: boolean
+  readonly seedSandbox?: { readonly organizationId: OrganizationId; readonly status: "active" | "archived" }
+}) => {
+  const sandbox = createFakeSandboxRepository()
+  const organization = createFakeOrganizationRepository()
+  const membership = createFakeMembershipRepository({
+    isMember: () => Effect.succeed(input?.isMember ?? true),
+  })
+  const override = createFakeBillingOverrideRepository()
+  const subscription = createFakeStripeSubscriptionLookup()
+
+  if (input?.plan === "pro") {
+    subscription.subscriptionsByOrganizationId.set(String(PARENT_ORG_ID), {
+      plan: "pro",
+      status: "active",
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+      stripeCustomerId: "cus_test",
+      stripeSubscriptionId: "sub_test",
+    })
+  }
+
+  if (input?.seedSandbox) {
+    const seeded = input.seedSandbox
+    sandbox.sandboxes.set(
+      seeded.organizationId,
+      createSandbox({ organizationId: seeded.organizationId, createdByUserId: ADMIN_USER_ID, status: seeded.status }),
+    )
+    sandbox.parentByOrganizationId.set(seeded.organizationId, PARENT_ORG_ID)
+    organization.organizations.set(
+      seeded.organizationId,
+      createOrganization({
+        id: seeded.organizationId,
+        name: "Seeded",
+        slug: `seeded-${seeded.organizationId}`,
+        parentOrgId: PARENT_ORG_ID,
+      }),
+    )
+  }
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(SandboxRepository, sandbox.repository),
+    Layer.succeed(OrganizationRepository, organization.repository),
+    Layer.succeed(MembershipRepository, membership.repository),
+    Layer.succeed(BillingOverrideRepository, override.repository),
+    Layer.succeed(StripeSubscriptionLookup, subscription.service),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: PARENT_ORG_ID })),
+    Layer.succeed(SettingsReader, {
+      getOrganizationSettings: () => Effect.succeed(null),
+      getProjectSettings: () => Effect.die("sandbox use-cases do not read project settings"),
+    }),
+  )
+
+  return { layer, sandbox }
+}
+
+describe("sandbox lifecycle (unit)", () => {
+  it("creates an active sandbox under the parent org", async () => {
+    const { layer, sandbox } = buildLayer()
+
+    const result = await Effect.runPromise(
+      createSandboxUseCase({ parentOrganizationId: PARENT_ORG_ID, actorUserId: ADMIN_USER_ID, name: "Debug" }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(result.organization.parentOrgId).toBe(PARENT_ORG_ID)
+    expect(result.sandbox.status).toBe("active")
+    expect(sandbox.sandboxes.get(result.organization.id)?.createdByUserId).toBe(ADMIN_USER_ID)
+  })
+
+  it("refuses a non-member of the parent org", async () => {
+    const { layer } = buildLayer({ isMember: false })
+
+    const exit = await Effect.runPromiseExit(
+      createSandboxUseCase({ parentOrganizationId: PARENT_ORG_ID, actorUserId: ADMIN_USER_ID, name: "Nope" }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(failure(exit)).toBeInstanceOf(SandboxAccessDeniedError)
+  })
+
+  it("refuses creation once the Free active cap of 1 is reached", async () => {
+    const existing = OrganizationId(generateId())
+    const { layer } = buildLayer({ seedSandbox: { organizationId: existing, status: "active" } })
+
+    const exit = await Effect.runPromiseExit(
+      createSandboxUseCase({ parentOrganizationId: PARENT_ORG_ID, actorUserId: ADMIN_USER_ID, name: "Second" }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(failure(exit)).toBeInstanceOf(SandboxActiveCapReachedError)
+  })
+
+  it("archiving frees a slot, then reactivation fits within the cap", async () => {
+    const existing = OrganizationId(generateId())
+    const { layer } = buildLayer({ seedSandbox: { organizationId: existing, status: "active" } })
+
+    await Effect.runPromise(
+      archiveSandboxUseCase({ sandboxOrganizationId: existing, actorUserId: ADMIN_USER_ID }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    const reactivated = await Effect.runPromise(
+      reactivateSandboxUseCase({ sandboxOrganizationId: existing, actorUserId: ADMIN_USER_ID }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+    expect(reactivated.status).toBe("active")
+  })
+})

--- a/packages/domain/shared/src/id.ts
+++ b/packages/domain/shared/src/id.ts
@@ -30,6 +30,8 @@ export type UserId = Id<"UserId">
 export type OrganizationId = Id<"OrganizationId">
 export type MembershipId = Id<"MembershipId">
 export type InvitationId = Id<"InvitationId">
+// Test Mode sandbox-attributes row id (1:1 with a sandbox organization)
+export type SandboxId = Id<"SandboxId">
 
 // Project-related IDs
 export type ProjectId = Id<"ProjectId">
@@ -82,6 +84,7 @@ export const SessionId = (value: string): SessionId => value as SessionId
 export const OrganizationId = (value: string): OrganizationId => value as OrganizationId
 export const MembershipId = (value: string): MembershipId => value as MembershipId
 export const InvitationId = (value: string): InvitationId => value as InvitationId
+export const SandboxId = (value: string): SandboxId => value as SandboxId
 export const ProjectId = (value: string): ProjectId => value as ProjectId
 export const ApiKeyId = (value: string): ApiKeyId => value as ApiKeyId
 export const OrganizationFeatureFlagId = (value: string): OrganizationFeatureFlagId =>
@@ -117,6 +120,7 @@ export const userIdSchema = cuidSchema.transform(UserId)
 export const organizationIdSchema = cuidSchema.transform(OrganizationId)
 export const membershipIdSchema = cuidSchema.transform(MembershipId)
 export const invitationIdSchema = cuidSchema.transform(InvitationId)
+export const sandboxIdSchema = cuidSchema.transform(SandboxId)
 export const projectIdSchema = cuidSchema.transform(ProjectId)
 export const apiKeyIdSchema = cuidSchema.transform(ApiKeyId)
 export const organizationFeatureFlagIdSchema = cuidSchema.transform(OrganizationFeatureFlagId)

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -157,11 +157,11 @@ const runUseCase = (
   )
 
 const makeSandbox = (status: Sandbox["status"]): Sandbox => ({
-  id: generateId(),
+  id: generateId<"SandboxId">(),
   organizationId: ORGANIZATION_ID,
   status,
   lastActivityAt: new Date("2026-01-01T00:00:00Z"),
-  createdByUserId: generateId(),
+  createdByUserId: generateId<"UserId">(),
   createdAt: new Date("2026-01-01T00:00:00Z"),
   updatedAt: new Date("2026-01-01T00:00:00Z"),
 })

--- a/packages/platform/db-postgres/src/repositories/sandbox-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/sandbox-repository.test.ts
@@ -1,0 +1,277 @@
+import type { BillingOverrideRepository, StripeSubscriptionLookup } from "@domain/billing"
+import type { OutboxEventWriter } from "@domain/events"
+import type { MembershipRepository, OrganizationRepository } from "@domain/organizations"
+import type { ProjectRepository } from "@domain/projects"
+import {
+  archiveSandboxUseCase,
+  createSandboxUseCase,
+  deleteSandboxUseCase,
+  reactivateSandboxUseCase,
+  SandboxAccessDeniedError,
+  SandboxActiveCapReachedError,
+  type SandboxRepository,
+} from "@domain/sandboxes"
+import { generateId, OrganizationId, type SettingsReader, type SqlClient, UserId } from "@domain/shared"
+import { withTracing } from "@repo/observability"
+import { eq } from "drizzle-orm"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { OutboxEventWriterLive } from "../outbox-writer.ts"
+import { members, organizations, subscriptions, users } from "../schema/better-auth.ts"
+import { projects } from "../schema/projects.ts"
+import { sandboxes } from "../schema/sandboxes.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { BillingOverrideRepositoryLive } from "./billing-override-repository.ts"
+import { MembershipRepositoryLive } from "./membership-repository.ts"
+import { OrganizationRepositoryLive } from "./organization-repository.ts"
+import { ProjectRepositoryLive } from "./project-repository.ts"
+import { SandboxRepositoryLive } from "./sandbox-repository.ts"
+import { SettingsReaderLive } from "./settings-reader-repository.ts"
+import { StripeSubscriptionLookupLive } from "./stripe-subscription-lookup.ts"
+
+const pg = setupTestPostgres()
+
+const sandboxLayers = Layer.mergeAll(
+  SandboxRepositoryLive,
+  OrganizationRepositoryLive,
+  MembershipRepositoryLive,
+  BillingOverrideRepositoryLive,
+  StripeSubscriptionLookupLive,
+  SettingsReaderLive,
+  ProjectRepositoryLive,
+  OutboxEventWriterLive,
+)
+
+type SandboxEnv =
+  | SandboxRepository
+  | OrganizationRepository
+  | MembershipRepository
+  | BillingOverrideRepository
+  | StripeSubscriptionLookup
+  | SettingsReader
+  | ProjectRepository
+  | OutboxEventWriter
+  | SqlClient
+
+// Sandbox lifecycle is cross-org management, so the use-cases run on the
+// RLS-bypassing admin client scoped to the parent live org (the active org the
+// user manages sandboxes from).
+const runScoped = <A, E>(parentOrgId: OrganizationId, effect: Effect.Effect<A, E, SandboxEnv>) =>
+  Effect.runPromise(effect.pipe(withPostgres(sandboxLayers, pg.adminPostgresClient, parentOrgId), withTracing))
+
+const runScopedExit = <A, E>(parentOrgId: OrganizationId, effect: Effect.Effect<A, E, SandboxEnv>) =>
+  Effect.runPromiseExit(effect.pipe(withPostgres(sandboxLayers, pg.adminPostgresClient, parentOrgId), withTracing))
+
+interface ParentOrg {
+  readonly parentOrgId: OrganizationId
+  readonly memberUserId: UserId
+}
+
+const seedParentOrg = async (input?: { readonly plan?: "free" | "pro" }): Promise<ParentOrg> => {
+  const parentOrgId = generateId()
+  const memberUserId = generateId()
+
+  await pg.db.insert(users).values({ id: memberUserId, name: "Member", email: `member-${memberUserId}@example.com` })
+  await pg.db.insert(organizations).values({ id: parentOrgId, name: "Parent", slug: `parent-${parentOrgId}` })
+  await pg.db
+    .insert(members)
+    .values({ id: generateId(), organizationId: parentOrgId, userId: memberUserId, role: "member" })
+
+  if (input?.plan === "pro") {
+    await pg.db.insert(subscriptions).values({
+      id: generateId(),
+      plan: "pro",
+      referenceId: parentOrgId,
+      stripeCustomerId: `cus_${parentOrgId}`,
+      stripeSubscriptionId: `sub_${parentOrgId}`,
+      status: "active",
+      periodStart: new Date("2026-06-01T00:00:00.000Z"),
+      periodEnd: new Date("2026-07-01T00:00:00.000Z"),
+    })
+  }
+
+  return { parentOrgId: OrganizationId(parentOrgId), memberUserId: UserId(memberUserId) }
+}
+
+/** Directly seed an active/archived sandbox org + attrs row under a parent. */
+const seedSandbox = async (parent: ParentOrg, status: "active" | "archived"): Promise<OrganizationId> => {
+  const sandboxOrgId = generateId()
+  await pg.db
+    .insert(organizations)
+    .values({ id: sandboxOrgId, name: "Sandbox", slug: `sandbox-${sandboxOrgId}`, parentOrgId: parent.parentOrgId })
+  await pg.db
+    .insert(sandboxes)
+    .values({ id: generateId(), organizationId: sandboxOrgId, status, createdByUserId: parent.memberUserId })
+  return OrganizationId(sandboxOrgId)
+}
+
+const failure = <A, E>(exit: Exit.Exit<A, E>): E | undefined =>
+  Exit.isFailure(exit) ? exit.cause.reasons.find(Cause.isFailReason)?.error : undefined
+
+describe("sandbox lifecycle use-cases", () => {
+  beforeEach(async () => {
+    await pg.db.delete(sandboxes)
+    await pg.db.delete(subscriptions)
+    await pg.db.delete(members)
+    await pg.db.delete(organizations)
+    await pg.db.delete(users)
+  })
+
+  it("createSandbox provisions a sandbox org and its attributes row", async () => {
+    const parent = await seedParentOrg()
+
+    const result = await runScoped(
+      parent.parentOrgId,
+      createSandboxUseCase({
+        parentOrganizationId: parent.parentOrgId,
+        actorUserId: parent.memberUserId,
+        name: "Debug",
+      }),
+    )
+
+    expect(result.organization.parentOrgId).toBe(parent.parentOrgId)
+    expect(result.sandbox.organizationId).toBe(result.organization.id)
+    expect(result.sandbox.status).toBe("active")
+    expect(result.sandbox.createdByUserId).toBe(parent.memberUserId)
+
+    const orgRows = await pg.db.select().from(organizations).where(eq(organizations.id, result.organization.id))
+    expect(orgRows[0]?.parentOrgId).toBe(parent.parentOrgId)
+
+    const sandboxRows = await pg.db.select().from(sandboxes).where(eq(sandboxes.organizationId, result.organization.id))
+    expect(sandboxRows[0]?.status).toBe("active")
+    expect(sandboxRows[0]?.createdByUserId).toBe(parent.memberUserId)
+  })
+
+  it("rejects creation for a non-member of the parent org", async () => {
+    const parent = await seedParentOrg()
+    const outsiderUserId = UserId(generateId())
+
+    const exit = await runScopedExit(
+      parent.parentOrgId,
+      createSandboxUseCase({ parentOrganizationId: parent.parentOrgId, actorUserId: outsiderUserId, name: "Nope" }),
+    )
+
+    expect(failure(exit)).toBeInstanceOf(SandboxAccessDeniedError)
+  })
+
+  it("enforces the Free plan active cap of 1 and frees a slot on archive", async () => {
+    const parent = await seedParentOrg()
+
+    const first = await runScoped(
+      parent.parentOrgId,
+      createSandboxUseCase({ parentOrganizationId: parent.parentOrgId, actorUserId: parent.memberUserId, name: "One" }),
+    )
+
+    const secondExit = await runScopedExit(
+      parent.parentOrgId,
+      createSandboxUseCase({ parentOrganizationId: parent.parentOrgId, actorUserId: parent.memberUserId, name: "Two" }),
+    )
+    expect(failure(secondExit)).toBeInstanceOf(SandboxActiveCapReachedError)
+
+    // Archiving frees the single slot.
+    await runScoped(
+      parent.parentOrgId,
+      archiveSandboxUseCase({ sandboxOrganizationId: first.organization.id, actorUserId: parent.memberUserId }),
+    )
+
+    const third = await runScoped(
+      parent.parentOrgId,
+      createSandboxUseCase({
+        parentOrganizationId: parent.parentOrgId,
+        actorUserId: parent.memberUserId,
+        name: "Three",
+      }),
+    )
+    expect(third.sandbox.status).toBe("active")
+  })
+
+  it("allows up to the Pro plan active cap of 15", async () => {
+    const parent = await seedParentOrg({ plan: "pro" })
+
+    // Seed 14 active sandboxes directly, then a 15th via the use-case succeeds.
+    for (let i = 0; i < 14; i++) {
+      await seedSandbox(parent, "active")
+    }
+    const fifteenth = await runScoped(
+      parent.parentOrgId,
+      createSandboxUseCase({
+        parentOrganizationId: parent.parentOrgId,
+        actorUserId: parent.memberUserId,
+        name: "Fifteen",
+      }),
+    )
+    expect(fifteenth.sandbox.status).toBe("active")
+
+    // The 16th exceeds the cap.
+    const sixteenthExit = await runScopedExit(
+      parent.parentOrgId,
+      createSandboxUseCase({
+        parentOrganizationId: parent.parentOrgId,
+        actorUserId: parent.memberUserId,
+        name: "Sixteen",
+      }),
+    )
+    expect(failure(sixteenthExit)).toBeInstanceOf(SandboxActiveCapReachedError)
+  })
+
+  it("reactivates an archived sandbox only within the cap", async () => {
+    const parent = await seedParentOrg()
+    const archived = await seedSandbox(parent, "archived")
+
+    // Free cap is 1 and there are no active sandboxes, so reactivation fits.
+    const reactivated = await runScoped(
+      parent.parentOrgId,
+      reactivateSandboxUseCase({ sandboxOrganizationId: archived, actorUserId: parent.memberUserId }),
+    )
+    expect(reactivated.status).toBe("active")
+
+    // Archive it again, fill the single slot with another active sandbox, and
+    // reactivation must now be refused.
+    await runScoped(
+      parent.parentOrgId,
+      archiveSandboxUseCase({ sandboxOrganizationId: archived, actorUserId: parent.memberUserId }),
+    )
+    await seedSandbox(parent, "active")
+
+    const refusedExit = await runScopedExit(
+      parent.parentOrgId,
+      reactivateSandboxUseCase({ sandboxOrganizationId: archived, actorUserId: parent.memberUserId }),
+    )
+    expect(failure(refusedExit)).toBeInstanceOf(SandboxActiveCapReachedError)
+  })
+
+  it("deleteSandbox removes the org + attrs row and tears down the sandbox's projects", async () => {
+    const parent = await seedParentOrg()
+    const created = await runScoped(
+      parent.parentOrgId,
+      createSandboxUseCase({
+        parentOrganizationId: parent.parentOrgId,
+        actorUserId: parent.memberUserId,
+        name: "Doomed",
+      }),
+    )
+    const projectId = generateId()
+    await pg.db.insert(projects).values({
+      id: projectId,
+      organizationId: created.organization.id,
+      name: "Sandbox project",
+      slug: "sandbox-project",
+    })
+
+    await runScoped(
+      created.organization.id,
+      deleteSandboxUseCase({ sandboxOrganizationId: created.organization.id, actorUserId: parent.memberUserId }),
+    )
+
+    const orgRows = await pg.db.select().from(organizations).where(eq(organizations.id, created.organization.id))
+    expect(orgRows).toHaveLength(0)
+    const sandboxRows = await pg.db
+      .select()
+      .from(sandboxes)
+      .where(eq(sandboxes.organizationId, created.organization.id))
+    expect(sandboxRows).toHaveLength(0)
+    const projectRows = await pg.db.select().from(projects).where(eq(projects.id, projectId))
+    expect(projectRows[0]?.deletedAt).not.toBeNull()
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/sandbox-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/sandbox-repository.ts
@@ -1,19 +1,35 @@
 import type { Sandbox } from "@domain/sandboxes"
 import { SandboxRepository } from "@domain/sandboxes"
-import { OrganizationId, SqlClient, type SqlClientShape } from "@domain/shared"
-import { eq } from "drizzle-orm"
+import {
+  NotFoundError,
+  OrganizationId,
+  type OrganizationId as OrganizationIdType,
+  SandboxId,
+  SqlClient,
+  type SqlClientShape,
+  UserId,
+} from "@domain/shared"
+import { and, eq, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
+import { organizations } from "../schema/better-auth.ts"
 import { sandboxes } from "../schema/sandboxes.ts"
 
 const toDomainSandbox = (row: typeof sandboxes.$inferSelect): Sandbox => ({
-  id: row.id,
+  id: SandboxId(row.id),
   organizationId: OrganizationId(row.organizationId),
   status: row.status,
   lastActivityAt: row.lastActivityAt,
-  createdByUserId: row.createdByUserId,
+  createdByUserId: UserId(row.createdByUserId),
   createdAt: row.createdAt,
   updatedAt: row.updatedAt,
+})
+const toSandboxInsertRow = (sandbox: ReturnType<typeof toDomainSandbox>) => ({
+  id: sandbox.id,
+  organizationId: sandbox.organizationId,
+  status: sandbox.status,
+  lastActivityAt: sandbox.lastActivityAt,
+  createdByUserId: sandbox.createdByUserId,
 })
 
 export const SandboxRepositoryLive = Layer.effect(
@@ -40,6 +56,71 @@ export const SandboxRepositoryLive = Layer.effect(
               .set({ lastActivityAt: now, updatedAt: now })
               .where(eq(sandboxes.organizationId, organizationId)),
           )
+        }),
+      create: (sandbox) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient.query((db) => db.insert(sandboxes).values(toSandboxInsertRow(sandbox)))
+        }),
+
+      findByOrganizationId: (organizationId: OrganizationIdType) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient
+            .query((db) => db.select().from(sandboxes).where(eq(sandboxes.organizationId, organizationId)).limit(1))
+            .pipe(
+              Effect.flatMap((rows) => {
+                const [row] = rows
+                if (!row) {
+                  return Effect.fail(
+                    new NotFoundError({
+                      entity: "Sandbox",
+                      id: organizationId,
+                    }),
+                  )
+                }
+                return Effect.succeed(toDomainSandbox(row))
+              }),
+            )
+        }),
+
+      countActiveByParentOrgId: (parentOrgId: OrganizationIdType) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient
+            .query((db) =>
+              db
+                .select({ count: sql<number>`count(*)::int` })
+                .from(sandboxes)
+                .innerJoin(organizations, eq(organizations.id, sandboxes.organizationId))
+                .where(and(eq(organizations.parentOrgId, parentOrgId), eq(sandboxes.status, "active"))),
+            )
+            .pipe(Effect.map((rows) => rows[0]?.count ?? 0))
+        }),
+
+      lockParentForCapCheck: (parentOrgId: OrganizationIdType) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          // Transaction-scoped advisory lock keyed on the parent org id; blocks
+          // until any concurrent holder's tx ends, serializing the cap check.
+          yield* sqlClient.query((db) => db.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${parentOrgId}))`))
+        }),
+
+      setStatus: (organizationId: OrganizationIdType, status) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient.query((db) =>
+            db
+              .update(sandboxes)
+              .set({ status, updatedAt: new Date() })
+              .where(eq(sandboxes.organizationId, organizationId)),
+          )
+        }),
+
+      delete: (organizationId: OrganizationIdType) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient.query((db) => db.delete(sandboxes).where(eq(sandboxes.organizationId, organizationId)))
         }),
     }
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -432,6 +432,9 @@ importers:
       '@domain/queue':
         specifier: workspace:*
         version: link:../../packages/domain/queue
+      '@domain/sandboxes':
+        specifier: workspace:*
+        version: link:../../packages/domain/sandboxes
       '@domain/saved-searches':
         specifier: workspace:*
         version: link:../../packages/domain/saved-searches
@@ -1558,6 +1561,15 @@ importers:
 
   packages/domain/sandboxes:
     dependencies:
+      '@domain/billing':
+        specifier: workspace:*
+        version: link:../billing
+      '@domain/organizations':
+        specifier: workspace:*
+        version: link:../organizations
+      '@domain/projects':
+        specifier: workspace:*
+        version: link:../projects
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -4210,21 +4222,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
-    engines: {node: '>=12.10.0'}
-
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  '@grpc/proto-loader@0.8.0':
-    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -11046,14 +11049,8 @@ packages:
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
-  pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
-
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
-
-  pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
 
   pg-connection-string@2.13.0:
     resolution: {integrity: sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==}
@@ -11062,18 +11059,10 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
-    peerDependencies:
-      pg: '>=8.0'
-
   pg-pool@3.14.0:
     resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
     peerDependencies:
       pg: '>=8.0'
-
-  pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
   pg-protocol@1.14.0:
     resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
@@ -13819,7 +13808,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -14399,7 +14388,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -14435,24 +14424,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@grpc/grpc-js@1.14.3':
-    dependencies:
-      '@grpc/proto-loader': 0.8.0
-      '@js-sdsl/ordered-map': 4.4.2
-
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
 
   '@grpc/proto-loader@0.7.15':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 8.0.2
-      yargs: 17.7.2
-
-  '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
@@ -14880,7 +14857,7 @@ snapshots:
       '@modelcontextprotocol/ext-apps': 1.7.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -14893,7 +14870,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@modelcontextprotocol/inspector-cli@0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -14930,7 +14907,7 @@ snapshots:
       pkce-challenge: 4.1.0
       prismjs: 1.30.0
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-simple-code-editor: 0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       serve-handler: 6.1.7
       tailwind-merge: 2.6.1
@@ -16562,7 +16539,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16587,7 +16564,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16615,7 +16592,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16672,7 +16649,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -16720,7 +16697,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16771,7 +16748,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16809,7 +16786,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16866,7 +16843,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -16908,7 +16885,7 @@ snapshots:
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/rect': 1.1.1
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16936,7 +16913,7 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16956,7 +16933,7 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16975,7 +16952,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -16993,7 +16970,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17019,7 +16996,7 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17064,7 +17041,7 @@ snapshots:
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       aria-hidden: 1.2.6
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -17156,7 +17133,7 @@ snapshots:
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17187,7 +17164,7 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17207,7 +17184,7 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17247,7 +17224,7 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -17384,7 +17361,7 @@ snapshots:
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -18821,7 +18798,7 @@ snapshots:
 
   '@temporalio/client@1.17.0':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@temporalio/common': 1.17.0
       '@temporalio/proto': 1.17.0
       abort-controller: 3.0.0
@@ -18869,7 +18846,7 @@ snapshots:
 
   '@temporalio/worker@1.17.0(esbuild@0.27.7)(tslib@2.8.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@swc/core': 1.15.30
       '@temporalio/activity': 1.17.0
       '@temporalio/client': 1.17.0
@@ -19212,13 +19189,13 @@ snapshots:
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 22.19.17
-      pg-protocol: 1.13.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.16.0':
     dependencies:
       '@types/node': 22.19.17
-      pg-protocol: 1.13.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pluralize@0.0.33': {}
@@ -19993,7 +19970,7 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@18.3.1)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -22629,20 +22606,14 @@ snapshots:
 
   peberminta@0.9.0: {}
 
-  pg-cloudflare@1.3.0:
-    optional: true
-
   pg-cloudflare@1.4.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
-
-  pg-connection-string@2.13.0:
-    optional: true
+  pg-connection-string@2.13.0: {}
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.13.0(pg@8.16.0):
+  pg-pool@3.14.0(pg@8.16.0):
     dependencies:
       pg: 8.16.0
 
@@ -22651,10 +22622,7 @@ snapshots:
       pg: 8.20.0
     optional: true
 
-  pg-protocol@1.13.0: {}
-
-  pg-protocol@1.14.0:
-    optional: true
+  pg-protocol@1.14.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -22666,13 +22634,13 @@ snapshots:
 
   pg@8.16.0:
     dependencies:
-      pg-connection-string: 2.12.0
-      pg-pool: 3.13.0(pg@8.16.0)
-      pg-protocol: 1.13.0
+      pg-connection-string: 2.13.0
+      pg-pool: 3.14.0(pg@8.16.0)
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
-      pg-cloudflare: 1.3.0
+      pg-cloudflare: 1.4.0
 
   pg@8.20.0:
     dependencies:
@@ -22868,10 +22836,10 @@ snapshots:
       date-fns: 3.6.0
       react: 19.2.5
 
-  react-dom@18.3.1(react@19.2.5):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
-      react: 19.2.5
+      react: 18.3.1
       scheduler: 0.23.2
 
   react-dom@19.2.5(react@19.2.5):
@@ -22969,7 +22937,7 @@ snapshots:
   react-simple-code-editor@0.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-dom: 18.3.1(react@19.2.5)
+      react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
@@ -23974,7 +23942,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.16
       rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.16)(typescript@6.0.3)
-      semver: 7.7.4
+      semver: 7.8.1
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
@@ -24001,7 +23969,7 @@ snapshots:
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.16
       rolldown-plugin-dts: 0.23.2(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rolldown@1.0.0-rc.16)(typescript@6.0.3)
-      semver: 7.7.4
+      semver: 7.8.1
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tree-kill: 1.2.2


### PR DESCRIPTION
## Summary

- Adds a new **`@domain/sandboxes`** package with the Test Mode sandbox lifecycle: `createSandbox`, `archiveSandbox`, `reactivateSandbox`, `deleteSandbox` use-cases, plus the `Sandbox` entity (Zod-first), `SandboxRepository` port, and tagged errors.
- Enforces a **per-plan active-sandbox cap** resolved via `resolveEffectivePlan` — a new `sandboxActiveCap` on each `PlanConfig` (Free **1**, Pro **15**, Enterprise **1000**). Archiving frees a slot; reactivation is allowed only when `active + 1 ≤ cap`; deleting is the only destructive path.
- Authorization reuses the main org's admin check (`isAdminRole` via `MembershipRepository.isAdmin`), evaluated against the **parent** org membership (sandboxes have no member rows).
- Adds the Postgres adapter **`SandboxRepositoryLive`** (`toDomainSandbox` / `toSandboxInsertRow`, round-tripping every field). Because the `sandboxes` RLS scopes each row to its *own* sandbox org, lifecycle is cross-org management and runs on the RLS-bypassing admin client with explicit id predicates — mirroring `AdminOrganizationRepository`.
- Wires `apps/web` server functions (`createSandbox` / `archiveSandbox` / `reactivateSandbox` / `deleteSandbox`) on the admin client scoped to the active parent org. **No UI consumer yet** (Wave 2).

## Out of scope (per ticket)

No idle sweep (AGE-110), no downgrade auto-archive (AGE-114), no UI, no feature flags.

## Test plan

- [x] `@domain/sandboxes` unit tests (fakes): create, authz refusal, Free cap, archive→reactivate.
- [x] `@platform/db-postgres` PGlite integration tests (real DB, real repos): provisioning + field round-trip, non-admin refusal, **Free cap = 1** with slot freed on archive, **Pro cap = 15** (16th refused), reactivation cap, delete removes org + attrs row.
- [x] `pnpm --filter <pkg> typecheck` passes for `@domain/{shared,billing,organizations,sandboxes}`, `@platform/db-postgres`, `@app/web`.
- [x] `pnpm knip` clean.

Linear: https://linear.app/latitude/issue/AGE-103

🤖 Generated with [Claude Code](https://claude.com/claude-code)