### PR TITLE
feat(test-mode): sandbox ingest pipeline [AGE-127]

### DIFF
--- a/apps/ingest/package.json
+++ b/apps/ingest/package.json
@@ -15,6 +15,7 @@
     "@domain/api-keys": "workspace:*",
     "@domain/billing": "workspace:*",
     "@domain/queue": "workspace:*",
+    "@domain/sandboxes": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "@hono/node-server": "catalog:",

--- a/apps/ingest/src/middleware/auth.ts
+++ b/apps/ingest/src/middleware/auth.ts
@@ -30,5 +30,6 @@ export const authMiddleware: MiddlewareHandler<IngestEnv> = async (c, next) => {
 
   c.set("organizationId", result.organizationId)
   c.set("apiKeyId", result.keyId)
+  c.set("isSandbox", result.isSandbox)
   await next()
 }

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -1,10 +1,13 @@
 import { NoCreditsRemainingError } from "@domain/billing"
+import { SandboxArchivedError, SandboxQuotaExceededError } from "@domain/sandboxes"
 import { OrganizationId } from "@domain/shared"
 import { ingestSpansWithBillingUseCase } from "@domain/spans"
+import { SandboxSignalsLive } from "@platform/cache-redis"
 import {
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
   ProjectRepositoryLive,
+  SandboxRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
   withPostgres,
@@ -28,6 +31,7 @@ const traceIngestionBillingLayers = Layer.mergeAll(
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
   ProjectRepositoryLive,
+  SandboxRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
 )
@@ -69,6 +73,7 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
 
     const organization = OrganizationId(c.get("organizationId"))
     const apiKeyId = c.get("apiKeyId")
+    const isSandbox = c.get("isSandbox")
     const defaultProjectSlug = c.get("defaultProjectSlug")
 
     const disk = getStorageDisk()
@@ -77,12 +82,15 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
     const ingestionEffect = ingestSpansWithBillingUseCase({
       organizationId: organization,
       apiKeyId,
+      isSandbox,
       payload: new Uint8Array(body),
       contentType,
       ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
     }).pipe(
       withPostgres(traceIngestionBillingLayers, postgresClient, organization),
-      Effect.provide(Layer.mergeAll(StorageDiskLive(disk), QueuePublisherLive(publisher))),
+      Effect.provide(
+        Layer.mergeAll(StorageDiskLive(disk), QueuePublisherLive(publisher), SandboxSignalsLive(getRedisClient())),
+      ),
       withTracing,
     )
 
@@ -93,6 +101,14 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
       if (Option.isSome(failure) && failure.value instanceof NoCreditsRemainingError) {
         const err = failure.value
         return c.json({ error: err.httpMessage, kind: "NoCreditsRemaining" }, err.httpStatus)
+      }
+      if (Option.isSome(failure) && failure.value instanceof SandboxArchivedError) {
+        const err = failure.value
+        return c.json({ error: err.httpMessage, kind: "SandboxArchived" }, err.httpStatus)
+      }
+      if (Option.isSome(failure) && failure.value instanceof SandboxQuotaExceededError) {
+        const err = failure.value
+        return c.json({ error: err.httpMessage, kind: "SandboxQuotaExceeded" }, err.httpStatus)
       }
       if (Option.isSome(failure) && (failure.value as { _tag?: string })._tag === "SpanDecodingError") {
         const err = failure.value as { httpMessage?: string }

--- a/apps/ingest/src/types.ts
+++ b/apps/ingest/src/types.ts
@@ -2,6 +2,7 @@ export interface IngestEnv {
   Variables: {
     organizationId: string
     apiKeyId: string
+    isSandbox: boolean
     /**
      * Optional default project slug from the `X-Latitude-Project` header. The middleware
      * is best-effort — it never fails if the header is missing or the slug doesn't resolve.

--- a/apps/workers/src/workers/billing.test.ts
+++ b/apps/workers/src/workers/billing.test.ts
@@ -399,6 +399,45 @@ describe("billing runtime integration", () => {
     expect(period?.overageCredits).toBe(0)
   })
 
+  it("does not record usage for sandbox traces", async () => {
+    const consumer = new TestQueueConsumer()
+    const organizationId = generateId()
+    const projectId = generateId()
+
+    await pg.db.insert(organizations).values({
+      id: organizationId,
+      name: "Sandbox Billing Skip Org",
+      slug: `sandbox-billing-skip-${organizationId}`,
+    })
+
+    createBillingWorker({ consumer, postgresClient: pg.appPostgresClient })
+
+    await consumer.dispatchTask("billing", "recordTraceUsageBatch", {
+      organizationId,
+      projectId,
+      traceIds: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"],
+      planSlug: "free" as const,
+      planSource: "free-fallback" as const,
+      periodStart: new Date("2026-04-01T00:00:00.000Z").toISOString(),
+      periodEnd: new Date("2026-05-01T00:00:00.000Z").toISOString(),
+      includedCredits: PLAN_CONFIGS.free.includedCredits,
+      overageAllowed: false,
+      isSandbox: true,
+    })
+
+    const events = await pg.db
+      .select()
+      .from(billingUsageEvents)
+      .where(eq(billingUsageEvents.organizationId, organizationId))
+    const periods = await pg.db
+      .select()
+      .from(billingUsagePeriods)
+      .where(eq(billingUsagePeriods.organizationId, organizationId))
+
+    expect(events).toHaveLength(0)
+    expect(periods).toHaveLength(0)
+  })
+
   it("micro-batches trace usage jobs for the same organization period", async () => {
     const consumer = new TestQueueConsumer()
     const organizationId = generateId()

--- a/apps/workers/src/workers/billing.ts
+++ b/apps/workers/src/workers/billing.ts
@@ -38,6 +38,7 @@ interface RecordTraceUsageBatchPayload {
   readonly periodEnd: string
   readonly includedCredits: number
   readonly overageAllowed: boolean
+  readonly isSandbox?: boolean
 }
 
 interface RecordBillableActionPayload {
@@ -222,23 +223,25 @@ export const createBillingWorker = ({ consumer, postgresClient }: BillingDeps) =
         ),
 
       recordTraceUsageBatch: (payload: RecordTraceUsageBatchPayload) =>
-        Effect.tryPromise({
-          try: () => traceUsageBatcher.enqueue(payload),
-          catch: (cause) => cause,
-        }).pipe(
-          withTracing,
-          Effect.tapError((error) =>
-            Effect.sync(() =>
-              logger.error("Billing trace usage batch failed", {
-                organizationId: payload.organizationId,
-                projectId: payload.projectId,
-                traceCount: payload.traceIds.length,
-                error,
-              }),
+        payload.isSandbox
+          ? Effect.void
+          : Effect.tryPromise({
+              try: () => traceUsageBatcher.enqueue(payload),
+              catch: (cause) => cause,
+            }).pipe(
+              withTracing,
+              Effect.tapError((error) =>
+                Effect.sync(() =>
+                  logger.error("Billing trace usage batch failed", {
+                    organizationId: payload.organizationId,
+                    projectId: payload.projectId,
+                    traceCount: payload.traceIds.length,
+                    error,
+                  }),
+                ),
+              ),
+              Effect.asVoid,
             ),
-          ),
-          Effect.asVoid,
-        ),
     },
     { concurrency: 50 },
   )

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -113,12 +113,43 @@ describe("domain-events dispatcher", () => {
       organizationId: "org-1",
       projectId: "proj-1",
       traceId: "trace-abc",
+      isSandbox: false,
     })
     expect(traceEnd?.options).toEqual({
       dedupeKey: "trace-end:run:org-1:proj-1:trace-abc",
       debounceMs: TRACE_END_DEBOUNCE_MS,
     })
     expect(firstTrace?.options?.dedupeKey).toBe("projects:first-trace:proj-1")
+  })
+
+  it("dispatches the full fan-out and carries the sandbox bit into the task payloads", async () => {
+    const { consumer, published } = setupDispatcher()
+
+    // The dispatcher does NOT gatekeep: it fans out unconditionally and stamps
+    // `isSandbox` onto each task payload. The leaf workers (trace-end, billing)
+    // own the skip — see their own tests.
+    const envelope = makeEnvelope("TracesIngested", {
+      organizationId: "org-1",
+      projectId: "proj-1",
+      traceIds: ["trace-abc"],
+      isSandbox: true,
+      billing: {
+        planSlug: "free",
+        planSource: "free-fallback",
+        periodStart: "2026-06-01T00:00:00.000Z",
+        periodEnd: "2026-07-01T00:00:00.000Z",
+        includedCredits: 20_000,
+        overageAllowed: false,
+      },
+    })
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
+
+    const traceEnd = published.find((p) => p.queue === "trace-end")
+    const billing = published.find((p) => p.queue === "billing")
+    expect((traceEnd?.payload as { isSandbox?: boolean }).isSandbox).toBe(true)
+    expect((billing?.payload as { isSandbox?: boolean }).isSandbox).toBe(true)
+    expect(published.map((p) => `${p.queue}:${p.task}`)).toContain("projects:checkFirstTrace")
   })
 
   it("routes TracesIngested billing snapshots to billing:recordTraceUsageBatch", async () => {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -78,6 +78,7 @@ export const createDomainEventsWorker = ({
 
     TracesIngested: (event) => {
       const [firstTraceId] = event.payload.traceIds
+      const isSandbox = event.payload.isSandbox ?? false
       return Effect.all(
         [
           ...event.payload.traceIds.map((traceId) =>
@@ -88,6 +89,7 @@ export const createDomainEventsWorker = ({
                 organizationId: event.payload.organizationId,
                 projectId: event.payload.projectId,
                 traceId,
+                isSandbox,
               },
               {
                 dedupeKey: buildTraceIngestedDedupeKey("trace-end:run", {
@@ -99,6 +101,9 @@ export const createDomainEventsWorker = ({
               },
             ),
           ),
+          // Not gated on `isSandbox`: first-trace detection is onboarding/marketing
+          // telemetry, not LLM work. Outbound marketing/notification suppression for
+          // sandbox orgs is AGE-113's concern (handled downstream), not this PR's.
           ...(firstTraceId
             ? [
                 pub.publish(
@@ -109,7 +114,9 @@ export const createDomainEventsWorker = ({
                     projectId: event.payload.projectId,
                     traceId: firstTraceId,
                   },
-                  { dedupeKey: `projects:first-trace:${event.payload.projectId}` },
+                  {
+                    dedupeKey: `projects:first-trace:${event.payload.projectId}`,
+                  },
                 ),
               ]
             : []),
@@ -128,6 +135,7 @@ export const createDomainEventsWorker = ({
                     periodEnd: event.payload.billing.periodEnd,
                     includedCredits: event.payload.billing.includedCredits,
                     overageAllowed: event.payload.billing.overageAllowed,
+                    isSandbox,
                   },
                   {
                     attempts: 10,
@@ -198,7 +206,9 @@ export const createDomainEventsWorker = ({
           sourceType: "savedSearch",
           sourceId: event.payload.searchId,
         },
-        { dedupeKey: `monitors:on-source-deleted:savedSearch:${event.payload.searchId}` },
+        {
+          dedupeKey: `monitors:on-source-deleted:savedSearch:${event.payload.searchId}`,
+        },
       ),
 
     IncidentCreated: (event) =>
@@ -210,7 +220,9 @@ export const createDomainEventsWorker = ({
           alertIncidentId: event.payload.alertIncidentId,
           transition: "created",
         },
-        { dedupeKey: `notifications:request-incident-created:${event.payload.alertIncidentId}` },
+        {
+          dedupeKey: `notifications:request-incident-created:${event.payload.alertIncidentId}`,
+        },
       ),
 
     IncidentClosed: (event) =>
@@ -228,7 +240,9 @@ export const createDomainEventsWorker = ({
               alertIncidentId: event.payload.alertIncidentId,
               transition: "closed",
             },
-            { dedupeKey: `notifications:request-incident-closed:${event.payload.alertIncidentId}` },
+            {
+              dedupeKey: `notifications:request-incident-closed:${event.payload.alertIncidentId}`,
+            },
           ),
 
     AnnotationDeleted: (event) => {
@@ -245,7 +259,16 @@ export const createDomainEventsWorker = ({
           pub.publish(
             "issues",
             "removeScore",
-            { organizationId, projectId, scoreId, issueId, draftedAt, feedback, source, createdAt },
+            {
+              organizationId,
+              projectId,
+              scoreId,
+              issueId,
+              draftedAt,
+              feedback,
+              source,
+              createdAt,
+            },
             { dedupeKey: `issues:remove-score:${scoreId}` },
           ),
         ],
@@ -270,15 +293,22 @@ export const createDomainEventsWorker = ({
         "marketing-contacts",
         "register-user",
         { userId: event.payload.userId },
-        { dedupeKey: `marketing-contacts:register-user:${event.payload.userId}` },
+        {
+          dedupeKey: `marketing-contacts:register-user:${event.payload.userId}`,
+        },
       ),
 
     UserOnboardingCompleted: (event) =>
       pub.publish(
         "marketing-contacts",
         "update-onboarding",
-        { userId: event.payload.userId, stackChoice: event.payload.stackChoice },
-        { dedupeKey: `marketing-contacts:update-onboarding:${event.payload.userId}` },
+        {
+          userId: event.payload.userId,
+          stackChoice: event.payload.stackChoice,
+        },
+        {
+          dedupeKey: `marketing-contacts:update-onboarding:${event.payload.userId}`,
+        },
       ),
 
     BillingUsagePeriodUpdated: (event) => {
@@ -322,7 +352,9 @@ export const createDomainEventsWorker = ({
         "marketing-contacts",
         "mark-telemetry-enabled",
         { organizationId: event.payload.organizationId },
-        { dedupeKey: `marketing-contacts:mark-telemetry-enabled:${event.payload.organizationId}` },
+        {
+          dedupeKey: `marketing-contacts:mark-telemetry-enabled:${event.payload.organizationId}`,
+        },
       ),
 
     MemberInvited: () => Effect.void,
@@ -336,8 +368,13 @@ export const createDomainEventsWorker = ({
       pub.publish(
         "notifications",
         "delete-by-project",
-        { organizationId: event.payload.organizationId, projectId: event.payload.projectId },
-        { dedupeKey: `notifications:delete-by-project:${event.payload.projectId}` },
+        {
+          organizationId: event.payload.organizationId,
+          projectId: event.payload.projectId,
+        },
+        {
+          dedupeKey: `notifications:delete-by-project:${event.payload.projectId}`,
+        },
       ),
     FlaggerToggled: () => Effect.void,
     SavedSearchCreated: () => Effect.void,
@@ -405,7 +442,9 @@ export const createDomainEventsWorker = ({
           ),
         )
 
-      return Effect.all([primary, analytics], { concurrency: "unbounded" }).pipe(Effect.asVoid, withTracing)
+      return Effect.all([primary, analytics], {
+        concurrency: "unbounded",
+      }).pipe(Effect.asVoid, withTracing)
     },
   })
 }

--- a/apps/workers/src/workers/live-monitoring.test.ts
+++ b/apps/workers/src/workers/live-monitoring.test.ts
@@ -274,6 +274,7 @@ describe("live monitoring integration", () => {
           organizationId: ORGANIZATION_ID,
           projectId: PROJECT_ID,
           traceId: TRACE_ID,
+          isSandbox: false,
         },
         options: {
           dedupeKey: `trace-end:run:${ORGANIZATION_ID}:${PROJECT_ID}:${TRACE_ID}`,
@@ -357,6 +358,7 @@ describe("live monitoring integration", () => {
         organizationId: ORGANIZATION_ID,
         projectId: PROJECT_ID,
         traceId: TRACE_ID,
+        isSandbox: false,
       },
       options: {
         dedupeKey: `trace-end:run:${ORGANIZATION_ID}:${PROJECT_ID}:${TRACE_ID}`,

--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -2,7 +2,7 @@ import type { EventsPublisher } from "@domain/events"
 import type { QueueConsumer, QueuePublishError } from "@domain/queue"
 import { OrganizationId, type StorageDiskPort } from "@domain/shared"
 import { processIngestedSpansUseCase } from "@domain/spans"
-import { RedisCacheStoreLive, type RedisClient } from "@platform/cache-redis"
+import { RedisCacheStoreLive, type RedisClient, SandboxSignalsLive } from "@platform/cache-redis"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import type { PostgresClient } from "@platform/db-postgres"
@@ -63,6 +63,7 @@ export const createSpanIngestionWorker = ({
         const legacy = wire as unknown as { projectId?: string }
         const defaultProjectId = wire.defaultProjectId ?? legacy.projectId ?? null
         const projectIdBySlug = wire.projectIdBySlug ?? {}
+        const isSandbox = wire.isSandbox ?? false
 
         const processEffect = Effect.gen(function* () {
           const orgPlan = yield* resolveEffectivePlanCached(OrganizationId(organizationId)).pipe(
@@ -78,7 +79,11 @@ export const createSpanIngestionWorker = ({
             fileKey: wire.fileKey,
             defaultProjectId,
             projectIdBySlug,
+            isSandbox,
             ...(orgPlan ? { retentionDays: orgPlan.plan.retentionDays } : {}),
+            // Emit the full event (plan snapshot + the `isSandbox` bit). Whether to
+            // bill is the consumer's call — `domain-events` skips the billing fan-out
+            // for sandbox events. See the `TracesIngested` handler there.
             ...(orgPlan
               ? {
                   traceUsage: {
@@ -104,6 +109,7 @@ export const createSpanIngestionWorker = ({
           withTracing,
           Effect.provide(StorageDiskLive(disk)),
           Effect.provide(RedisCacheStoreLive(rdClient)),
+          Effect.provide(SandboxSignalsLive(rdClient)),
         )
 
         return processEffect

--- a/apps/workers/src/workers/trace-end.test.ts
+++ b/apps/workers/src/workers/trace-end.test.ts
@@ -328,6 +328,28 @@ describe("runTraceEndJob", () => {
     })
     expect(published).toEqual([])
   })
+
+  it("skips all LLM work for sandbox traces (before loading the trace)", async () => {
+    const { publisher, published } = createFakeQueuePublisher()
+    const redisClient = createFakeRedisClient()
+
+    const result = await Effect.runPromise(
+      runTraceEndJob({
+        publisher,
+        postgresClient: pg.appPostgresClient,
+        clickhouseClient: ch.client,
+        redisClient,
+      })({
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        isSandbox: true,
+      }),
+    )
+
+    expect(result).toEqual({ action: "skipped", reason: "sandbox", traceId: TRACE_ID })
+    expect(published).toEqual([])
+  })
 })
 
 describe("runTraceEndJob", () => {

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -47,6 +47,7 @@ interface TraceEndPayload {
   readonly organizationId: string
   readonly projectId: string
   readonly traceId: string
+  readonly isSandbox?: boolean
 }
 
 type TraceEndLogger = Pick<ReturnType<typeof createLogger>, "info" | "error">
@@ -90,7 +91,7 @@ type TraceEndRunSummary = {
 type TraceEndRunResult =
   | {
       readonly action: "skipped"
-      readonly reason: "trace-not-found"
+      readonly reason: "trace-not-found" | "sandbox"
       readonly traceId: string
     }
   | {
@@ -110,6 +111,10 @@ export const runTraceEndJob =
   ({ publisher, postgresClient, clickhouseClient, redisClient }: RunTraceEndDeps) =>
   (payload: TraceEndPayload) =>
     Effect.gen(function* () {
+      if (payload.isSandbox) {
+        return { action: "skipped", reason: "sandbox", traceId: payload.traceId } satisfies TraceEndRunResult
+      }
+
       const loaded = yield* loadTraceForTraceEndUseCase(payload)
 
       if (loaded.kind === "skipped") {
@@ -231,6 +236,7 @@ export const runTraceEndJob =
         traceId: payload.traceId,
         startTime: traceDetail.startTime.toISOString(),
         rootSpanName: traceDetail.rootSpanName,
+        isSandbox: payload.isSandbox ?? false,
       })
 
       // Saved-search firing check, throttled to one run per project per 5 min.

--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -37,7 +37,7 @@ vi.mock("../clients.ts", () => ({
   getRedisClient: vi.fn(() => ({})),
 }))
 
-import { prioritizeChunksForEmbedding, resolveTraceSearchRetentionDays } from "./trace-search.ts"
+import { prioritizeChunksForEmbedding, processRefreshTrace, resolveTraceSearchRetentionDays } from "./trace-search.ts"
 
 describe("prioritizeChunksForEmbedding", () => {
   it("prioritizes tail chunks first and skips chunks below the embedding floor", () => {
@@ -76,5 +76,28 @@ describe("resolveTraceSearchRetentionDays", () => {
     )
 
     expect(retentionDays).toBe(30)
+  })
+})
+
+describe("runTraceSearchRefresh sandbox gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("skips embedding/Weaviate work for sandbox traces — no plan lookup, no repos", async () => {
+    const result = await Effect.runPromise(
+      processRefreshTrace({
+        organizationId: "o".repeat(24),
+        projectId: "p".repeat(24),
+        traceId: "t".repeat(32),
+        startTime: "2026-04-16T12:00:00.000Z",
+        rootSpanName: "qa",
+        isSandbox: true,
+      }) as unknown as Effect.Effect<void>,
+    )
+
+    expect(result).toBeUndefined()
+    // The gate returns before resolving retention (the first thing the real path does).
+    expect(resolveEffectivePlanCachedMock).not.toHaveBeenCalled()
   })
 })

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -50,6 +50,7 @@ interface RefreshTracePayload {
   readonly traceId: string
   readonly startTime: string
   readonly rootSpanName: string
+  readonly isSandbox?: boolean
 }
 
 export const resolveTraceSearchRetentionDays = (organizationId: string) =>
@@ -105,8 +106,10 @@ export const prioritizeChunksForEmbedding = (chunks: readonly TraceSearchChunk[]
  *  4. For each chunk above the min-length floor, dedup-by-hash → budget-gate →
  *     embed → upsert one row per chunk.
  */
-const processRefreshTrace = (payload: RefreshTracePayload) =>
+export const processRefreshTrace = (payload: RefreshTracePayload) =>
   Effect.gen(function* () {
+    if (payload.isSandbox) return
+
     const traceRepo = yield* TraceRepository
     const traceSearchRepo = yield* TraceSearchRepository
 

--- a/packages/domain/billing/src/constants.ts
+++ b/packages/domain/billing/src/constants.ts
@@ -29,6 +29,9 @@ export const FREE_PLAN_CONFIG = {
   overageAllowed: false,
   hardCapped: true,
   priceCents: 0,
+  // Per-period sandbox span ceiling (Test Mode abuse guard, not billed). Read
+  // through `resolveEffectivePlan`; enforced as a loud ingest refusal.
+  spanQuotaPerPeriod: 100_000,
 } as const
 
 export const PRO_PLAN_CONFIG = {
@@ -41,6 +44,7 @@ export const PRO_PLAN_CONFIG = {
   priceCents: 9900,
   overageCreditsPerUnit: 10_000,
   overagePriceCentsPerUnit: 2000,
+  spanQuotaPerPeriod: 1_000_000,
 } as const
 
 /** Upper bound for `billing_usage_periods.included_credits` (Postgres `integer`). */
@@ -54,6 +58,7 @@ export const ENTERPRISE_PLAN_CONFIG = {
   overageAllowed: true,
   hardCapped: false,
   priceCents: null as null,
+  spanQuotaPerPeriod: Number.POSITIVE_INFINITY,
 } as const
 
 export type PlanConfig = {
@@ -64,6 +69,7 @@ export type PlanConfig = {
   overageAllowed: boolean
   hardCapped: boolean
   priceCents: number | null
+  spanQuotaPerPeriod: number
 }
 
 export const PLAN_CONFIGS: Record<PlanSlug, PlanConfig> = {

--- a/packages/domain/billing/src/entities/billing-plan.ts
+++ b/packages/domain/billing/src/entities/billing-plan.ts
@@ -10,6 +10,10 @@ export const billingPlanSchema = z.object({
   hardCapped: z.boolean(),
   priceCents: z.number().int().nonnegative().nullable(),
   spendingLimitCents: z.number().int().positive().nullable(),
+  // Per-period sandbox span ceiling. `Number.POSITIVE_INFINITY` for enterprise
+  // (which, like `includedCredits`, simply won't round-trip through the JSON
+  // plan cache — re-resolved on miss).
+  spanQuotaPerPeriod: z.number(),
 })
 
 export type BillingPlan = z.infer<typeof billingPlanSchema>

--- a/packages/domain/billing/src/use-cases/resolve-effective-plan.ts
+++ b/packages/domain/billing/src/use-cases/resolve-effective-plan.ts
@@ -24,6 +24,7 @@ const buildResolvedPlan = (input: {
   readonly hardCapped: boolean
   readonly priceCents: number | null
   readonly spendingLimitCents: number | null
+  readonly spanQuotaPerPeriod: number
 }): EffectivePlanResolution["plan"] => ({
   slug: input.slug,
   includedCredits: input.includedCredits,
@@ -32,6 +33,7 @@ const buildResolvedPlan = (input: {
   hardCapped: input.hardCapped,
   priceCents: input.priceCents,
   spendingLimitCents: input.slug === "pro" ? input.spendingLimitCents : null,
+  spanQuotaPerPeriod: input.spanQuotaPerPeriod,
 })
 
 const resolveOverridePlan = (input: {
@@ -52,6 +54,7 @@ const resolveOverridePlan = (input: {
       hardCapped: plan.hardCapped,
       priceCents: plan.priceCents,
       spendingLimitCents: input.spendingLimitCents,
+      spanQuotaPerPeriod: plan.spanQuotaPerPeriod,
     }),
     source: "override",
     periodStart: currentMonth.start,
@@ -99,6 +102,7 @@ const resolveSubscriptionPlan = Effect.fn("billing.resolveSubscriptionPlan")(fun
       hardCapped: plan.hardCapped,
       priceCents: plan.priceCents,
       spendingLimitCents: input.spendingLimitCents,
+      spanQuotaPerPeriod: plan.spanQuotaPerPeriod,
     }),
     source: "subscription",
     periodStart: subscription.periodStart ?? new Date(),
@@ -123,6 +127,7 @@ const resolveFreeFallbackPlan = (input: {
       hardCapped: freePlan.hardCapped,
       priceCents: freePlan.priceCents,
       spendingLimitCents: input.spendingLimitCents,
+      spanQuotaPerPeriod: freePlan.spanQuotaPerPeriod,
     }),
     source: "free-fallback",
     periodStart: currentMonth.start,
@@ -140,6 +145,7 @@ export interface EffectivePlanResolution {
     readonly hardCapped: boolean
     readonly priceCents: number | null
     readonly spendingLimitCents: number | null
+    readonly spanQuotaPerPeriod: number
   }
   readonly source: "override" | "subscription" | "free-fallback"
   readonly periodStart: Date

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -29,6 +29,12 @@ export interface EventPayloads {
     readonly organizationId: string
     readonly projectId: string
     readonly traceIds: readonly string[]
+    /**
+     * Resolved once at the top of ingest (`parent_org_id != null`). Consumers
+     * branch on it: the LLM fan-out (flaggers, evaluations, issue-clustering)
+     * does not run for sandbox events. Absent on legacy/replayed events ⇒ live.
+     */
+    readonly isSandbox?: boolean
     readonly billing?: {
       readonly planSlug: "free" | "pro" | "enterprise"
       readonly planSource: "override" | "subscription" | "free-fallback"

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -51,19 +51,9 @@ const _registry = {
       readonly organizationId: string
       readonly apiKeyId: string
       readonly ingestedAt: string
-      /**
-       * `projectId` to apply to spans that carry no `latitude.project` attribute on the span or
-       * its OTEL resource. Resolved from the `X-Latitude-Project` header by the ingest route;
-       * `null` when no header was sent (in which case those spans are dropped here).
-       */
       readonly defaultProjectId: string | null
-      /**
-       * Pre-resolved slug → `projectId` map for every distinct `latitude.project` attribute
-       * value seen in the batch (and the header default, if set). The request handler does the
-       * DB lookups once per batch and counts rejected spans for the OTLP `partial_success`
-       * response; the worker uses this map and avoids re-querying Postgres.
-       */
       readonly projectIdBySlug: Readonly<Record<string, string>>
+      readonly isSandbox?: boolean
     }
   }>(),
 
@@ -349,6 +339,7 @@ const _registry = {
       readonly organizationId: string
       readonly projectId: string
       readonly traceId: string
+      readonly isSandbox?: boolean
     }
   }>(),
 
@@ -449,6 +440,7 @@ const _registry = {
       readonly traceId: string
       readonly startTime: string
       readonly rootSpanName: string
+      readonly isSandbox?: boolean
     }
   }>(),
 
@@ -497,6 +489,7 @@ const _registry = {
       readonly periodEnd: string
       readonly includedCredits: number
       readonly overageAllowed: boolean
+      readonly isSandbox?: boolean
     }
   }>(),
 

--- a/packages/domain/sandboxes/package.json
+++ b/packages/domain/sandboxes/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "@platform/cache-redis",
+  "name": "@domain/sandboxes",
   "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "check": "biome check src",
     "format": "biome format --write src && biome check --fix src",
@@ -12,13 +16,8 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
-    "@domain/billing": "workspace:*",
-    "@domain/integrations": "workspace:*",
-    "@domain/sandboxes": "workspace:*",
     "@domain/shared": "workspace:*",
-    "@domain/spans": "workspace:*",
-    "@platform/env": "workspace:*",
     "effect": "catalog:",
-    "ioredis": "catalog:"
+    "zod": "catalog:"
   }
 }

--- a/packages/domain/sandboxes/src/constants.ts
+++ b/packages/domain/sandboxes/src/constants.ts
@@ -1,0 +1,22 @@
+/** Skip the `last_activity_at` write if one already happened within this window. */
+export const SANDBOX_ACTIVITY_STAMP_DEBOUNCE_MS = 5 * 60_000 // 5 minutes
+
+/** Coalesce realtime trace signals (liveness + upsert) to at most one per kind, per trace, per window. */
+export const SANDBOX_TRACE_SIGNAL_COALESCE_MS = 300
+
+/** How long the "last rejected ingest" marker lingers for the sandbox UI to read. */
+export const SANDBOX_LAST_REJECTED_INGEST_TTL_SECONDS = 60 * 60 * 24 // a day
+
+export const buildSandboxQuotaKey = (organizationId: string, periodStart: Date): string =>
+  `org:${organizationId}:sandbox:quota:${periodStart.toISOString()}`
+
+export const buildSandboxRejectedIngestKey = (organizationId: string): string =>
+  `org:${organizationId}:sandbox:last_rejected_ingest`
+
+export const buildSandboxActivityStampKey = (organizationId: string): string =>
+  `org:${organizationId}:sandbox:activity_stamped`
+
+export const buildSandboxTracesChannel = (organizationId: string): string => `org:${organizationId}:sandbox:traces`
+
+export const buildSandboxTraceCoalesceKey = (organizationId: string, kind: string, traceId: string): string =>
+  `org:${organizationId}:sandbox:traces:coalesce:${kind}:${traceId}`

--- a/packages/domain/sandboxes/src/entities/sandbox.ts
+++ b/packages/domain/sandboxes/src/entities/sandbox.ts
@@ -1,0 +1,24 @@
+import { organizationIdSchema } from "@domain/shared"
+import { z } from "zod"
+
+export const sandboxStatusSchema = z.enum(["active", "archived"])
+export type SandboxStatus = z.infer<typeof sandboxStatusSchema>
+
+/**
+ * Sandbox attributes (Test Mode) — the 1:1 row that hangs off a sandbox
+ * organization (an `organizations` row with `parent_org_id IS NOT NULL`).
+ * Carries the sleep/wake lifecycle (`status`, `lastActivityAt`) and creator
+ * attribution. The row's presence is itself the operational signal that an org
+ * is a sandbox.
+ */
+export const sandboxSchema = z.object({
+  id: z.string(),
+  organizationId: organizationIdSchema,
+  status: sandboxStatusSchema,
+  lastActivityAt: z.date(),
+  createdByUserId: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export type Sandbox = z.infer<typeof sandboxSchema>

--- a/packages/domain/sandboxes/src/errors.ts
+++ b/packages/domain/sandboxes/src/errors.ts
@@ -1,0 +1,27 @@
+import { Data } from "effect"
+
+/**
+ * Ingestion refused because the sandbox is archived (asleep). Mirrors billing's
+ * `NoCreditsRemainingError` (402): a loud, pre-persist 4xx. 403 — and crucially
+ * *not* 429 — so OTLP exporters treat it as non-retryable and drop the batch
+ * instead of retry-looping. The `kind` surfaced at the HTTP boundary is
+ * `"SandboxArchived"`.
+ */
+export class SandboxArchivedError extends Data.TaggedError("SandboxArchivedError")<{
+  readonly organizationId: string
+}> {
+  readonly httpStatus = 403
+  readonly httpMessage = "Sandbox is archived (asleep). Reactivate it to resume ingestion."
+}
+
+/**
+ * Ingestion refused because the sandbox exceeded its per-period span quota.
+ * Same loud-refuse path as {@link SandboxArchivedError}; `kind` is
+ * `"SandboxQuotaExceeded"`.
+ */
+export class SandboxQuotaExceededError extends Data.TaggedError("SandboxQuotaExceededError")<{
+  readonly organizationId: string
+}> {
+  readonly httpStatus = 403
+  readonly httpMessage = "Sandbox span quota exceeded for the current period."
+}

--- a/packages/domain/sandboxes/src/index.ts
+++ b/packages/domain/sandboxes/src/index.ts
@@ -1,0 +1,26 @@
+export {
+  buildSandboxActivityStampKey,
+  buildSandboxQuotaKey,
+  buildSandboxRejectedIngestKey,
+  buildSandboxTraceCoalesceKey,
+  buildSandboxTracesChannel,
+  SANDBOX_ACTIVITY_STAMP_DEBOUNCE_MS,
+  SANDBOX_LAST_REJECTED_INGEST_TTL_SECONDS,
+  SANDBOX_TRACE_SIGNAL_COALESCE_MS,
+} from "./constants.ts"
+export type { Sandbox, SandboxStatus } from "./entities/sandbox.ts"
+export { sandboxSchema, sandboxStatusSchema } from "./entities/sandbox.ts"
+export { SandboxArchivedError, SandboxQuotaExceededError } from "./errors.ts"
+export type { SandboxRepositoryShape } from "./ports/sandbox-repository.ts"
+export { SandboxRepository } from "./ports/sandbox-repository.ts"
+export type {
+  SandboxRejectedIngestKind,
+  SandboxRejectedIngestMarker,
+  SandboxSignalsShape,
+} from "./ports/sandbox-signals.ts"
+export { SandboxSignals } from "./ports/sandbox-signals.ts"
+export {
+  publishSandboxTraceSignalsUseCase,
+  type SandboxTraceRef,
+} from "./use-cases/publish-sandbox-trace-signals.ts"
+export { stampSandboxActivityUseCase } from "./use-cases/stamp-sandbox-activity.ts"

--- a/packages/domain/sandboxes/src/ports/sandbox-repository.ts
+++ b/packages/domain/sandboxes/src/ports/sandbox-repository.ts
@@ -1,0 +1,19 @@
+import type { RepositoryError, SqlClient } from "@domain/shared"
+import { Context, type Effect } from "effect"
+import type { Sandbox } from "../entities/sandbox.ts"
+
+export interface SandboxRepositoryShape {
+  /**
+   * The current RLS org's sandbox attributes row, or `null` when the org is not
+   * a sandbox. A `sandboxes` row exists iff `parent_org_id IS NOT NULL`, so this
+   * single scoped read resolves the sandbox bit (and the `status` for the
+   * archived-refusal gate) at the top of ingest.
+   */
+  findOptional(): Effect.Effect<Sandbox | null, RepositoryError, SqlClient>
+  /** Stamp `last_activity_at = now()` for the current RLS org's sandbox row. */
+  stampActivity(): Effect.Effect<void, RepositoryError, SqlClient>
+}
+
+export class SandboxRepository extends Context.Service<SandboxRepository, SandboxRepositoryShape>()(
+  "@domain/sandboxes/SandboxRepository",
+) {}

--- a/packages/domain/sandboxes/src/ports/sandbox-signals.ts
+++ b/packages/domain/sandboxes/src/ports/sandbox-signals.ts
@@ -1,0 +1,73 @@
+import { Context, type Effect } from "effect"
+
+export type SandboxRejectedIngestKind = "SandboxArchived" | "SandboxQuotaExceeded"
+
+export interface SandboxRejectedIngestMarker {
+  readonly kind: SandboxRejectedIngestKind
+  readonly at: string
+  readonly spansDropped: number
+}
+
+/**
+ * Redis-backed, abuse-guard signals for sandbox ingestion: the per-period span
+ * quota counter, the "last rejected ingest" marker, the `last_activity_at`
+ * debounce, and the realtime trace-upsert Pub/Sub pulse.
+ *
+ * Every method **fails open** (errors are swallowed in the adapter) — these are
+ * an abuse guard and a UX nicety, never a reason to drop otherwise-valid traces.
+ */
+export interface SandboxSignalsShape {
+  /**
+   * `INCRBY` the sandbox's per-period span counter and return the new total.
+   * Sets a TTL to `periodEnd` so the window resets itself. Returns 0 on a Redis
+   * error so the caller fails open (allows the ingest).
+   */
+  incrementSpanQuota(input: {
+    readonly organizationId: string
+    readonly periodStart: Date
+    readonly periodEnd: Date
+    readonly spanCount: number
+  }): Effect.Effect<number>
+
+  /** Persist the marker the sandbox UI reads (TTL'd). No-op on Redis error. */
+  recordRejectedIngest(input: {
+    readonly organizationId: string
+    readonly marker: SandboxRejectedIngestMarker
+  }): Effect.Effect<void>
+
+  /**
+   * `SET NX PX` the debounce key; returns `true` when acquired (caller should
+   * write `last_activity_at`), `false` when a recent stamp still holds the key
+   * or on Redis error.
+   */
+  tryAcquireActivityStamp(input: {
+    readonly organizationId: string
+    readonly debounceMs: number
+  }): Effect.Effect<boolean>
+
+  /**
+   * Publish an id-only trace signal to the sandbox's channel, coalesced per
+   * (kind, trace) so each kind pulses at most once per window. Never carries
+   * trace content. The channel itself is `organizationId`-scoped, so the payload
+   * carries that same sandbox-org id (a sandbox is 1:1 with its org) — not a
+   * separate `sandboxes.id`.
+   *
+   * `kind` distinguishes the two signals from `specs/test-mode.md`:
+   *  - `"liveness"` — fired at the HTTP boundary the moment spans arrive, before
+   *    persist, so the UI can react instantly (activity indicator / optimistic
+   *    refetch).
+   *  - `"upsert"` — fired after the span is persisted, the authoritative signal
+   *    to refetch the list (read-after-write safe).
+   */
+  publishTraceSignal(input: {
+    readonly kind: "liveness" | "upsert"
+    readonly organizationId: string
+    readonly traceId: string
+    readonly sessionId: string
+    readonly coalesceMs: number
+  }): Effect.Effect<void>
+}
+
+export class SandboxSignals extends Context.Service<SandboxSignals, SandboxSignalsShape>()(
+  "@domain/sandboxes/SandboxSignals",
+) {}

--- a/packages/domain/sandboxes/src/testing/fake-sandbox-repository.ts
+++ b/packages/domain/sandboxes/src/testing/fake-sandbox-repository.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import type { Sandbox } from "../entities/sandbox.ts"
+import type { SandboxRepository } from "../ports/sandbox-repository.ts"
+
+type SandboxRepositoryShape = (typeof SandboxRepository)["Service"]
+
+export const createFakeSandboxRepository = (overrides?: Partial<SandboxRepositoryShape>) => {
+  let stampCount = 0
+
+  const repository: SandboxRepositoryShape = {
+    findOptional: () => Effect.succeed<Sandbox | null>(null),
+    stampActivity: () =>
+      Effect.sync(() => {
+        stampCount++
+      }),
+    ...overrides,
+  }
+
+  return {
+    repository,
+    get stampCount() {
+      return stampCount
+    },
+  }
+}

--- a/packages/domain/sandboxes/src/testing/fake-sandbox-signals.ts
+++ b/packages/domain/sandboxes/src/testing/fake-sandbox-signals.ts
@@ -1,0 +1,62 @@
+import { Effect } from "effect"
+import type { SandboxRejectedIngestMarker, SandboxSignals } from "../ports/sandbox-signals.ts"
+
+type SandboxSignalsShape = (typeof SandboxSignals)["Service"]
+
+export interface FakeSandboxSignalsState {
+  readonly quotaIncrements: { organizationId: string; spanCount: number }[]
+  readonly rejected: { organizationId: string; marker: SandboxRejectedIngestMarker }[]
+  readonly activityAcquisitions: string[]
+  readonly published: {
+    kind: "liveness" | "upsert"
+    organizationId: string
+    traceId: string
+    sessionId: string
+  }[]
+}
+
+/**
+ * In-memory {@link SandboxSignals}. By default the quota counter accumulates per
+ * org (so `incrementSpanQuota` returns a realistic running total) and the
+ * activity stamp is always acquired. Override `incrementSpanQuota` to force an
+ * over-quota total, or `tryAcquireActivityStamp` to exercise the debounce.
+ */
+export const createFakeSandboxSignals = (overrides?: Partial<SandboxSignalsShape>) => {
+  const counters = new Map<string, number>()
+  const state: FakeSandboxSignalsState = {
+    quotaIncrements: [],
+    rejected: [],
+    activityAcquisitions: [],
+    published: [],
+  }
+
+  const signals: SandboxSignalsShape = {
+    incrementSpanQuota: (input) => {
+      state.quotaIncrements.push({ organizationId: input.organizationId, spanCount: input.spanCount })
+      const next = (counters.get(input.organizationId) ?? 0) + input.spanCount
+      counters.set(input.organizationId, next)
+      return Effect.succeed(next)
+    },
+    recordRejectedIngest: (input) =>
+      Effect.sync(() => {
+        state.rejected.push({ organizationId: input.organizationId, marker: input.marker })
+      }),
+    tryAcquireActivityStamp: (input) =>
+      Effect.sync(() => {
+        state.activityAcquisitions.push(input.organizationId)
+        return true
+      }),
+    publishTraceSignal: (input) =>
+      Effect.sync(() => {
+        state.published.push({
+          kind: input.kind,
+          organizationId: input.organizationId,
+          traceId: input.traceId,
+          sessionId: input.sessionId,
+        })
+      }),
+    ...overrides,
+  }
+
+  return { signals, state }
+}

--- a/packages/domain/sandboxes/src/testing/index.ts
+++ b/packages/domain/sandboxes/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { createFakeSandboxRepository } from "./fake-sandbox-repository.ts"
+export { createFakeSandboxSignals, type FakeSandboxSignalsState } from "./fake-sandbox-signals.ts"

--- a/packages/domain/sandboxes/src/use-cases/publish-sandbox-trace-signals.ts
+++ b/packages/domain/sandboxes/src/use-cases/publish-sandbox-trace-signals.ts
@@ -1,0 +1,42 @@
+import { Effect } from "effect"
+import { SANDBOX_TRACE_SIGNAL_COALESCE_MS } from "../constants.ts"
+import { SandboxSignals } from "../ports/sandbox-signals.ts"
+
+export interface SandboxTraceRef {
+  readonly traceId: string
+  readonly sessionId: string
+}
+
+/**
+ * Publish the realtime per-trace pulse for a sandbox batch — deduped per trace
+ * (first `sessionId` wins) and coalesced per (kind, trace) in the adapter. `kind`
+ * is `"liveness"` (pre-persist, from the HTTP boundary) or `"upsert"`
+ * (post-persist, from the worker). Ids only — never trace content.
+ *
+ * Callers pass the raw trace refs (e.g. one per persisted span); the dedupe lives
+ * here so the call sites stay a single line.
+ */
+export const publishSandboxTraceSignalsUseCase = Effect.fn("sandboxes.publishTraceSignals")(function* (input: {
+  readonly organizationId: string
+  readonly kind: "liveness" | "upsert"
+  readonly traces: readonly SandboxTraceRef[]
+}) {
+  const signals = yield* SandboxSignals
+
+  const sessionByTrace = new Map<string, string>()
+  for (const trace of input.traces) {
+    if (!sessionByTrace.has(trace.traceId)) {
+      sessionByTrace.set(trace.traceId, trace.sessionId)
+    }
+  }
+
+  for (const [traceId, sessionId] of sessionByTrace) {
+    yield* signals.publishTraceSignal({
+      kind: input.kind,
+      organizationId: input.organizationId,
+      traceId,
+      sessionId,
+      coalesceMs: SANDBOX_TRACE_SIGNAL_COALESCE_MS,
+    })
+  }
+})

--- a/packages/domain/sandboxes/src/use-cases/stamp-sandbox-activity.ts
+++ b/packages/domain/sandboxes/src/use-cases/stamp-sandbox-activity.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import { SANDBOX_ACTIVITY_STAMP_DEBOUNCE_MS } from "../constants.ts"
+import { SandboxRepository } from "../ports/sandbox-repository.ts"
+import { SandboxSignals } from "../ports/sandbox-signals.ts"
+
+/**
+ * Stamp the sandbox's `last_activity_at` on ingest, debounced: a Redis `SET NX`
+ * gate keeps the hot-path Postgres write rate to at most once per
+ * {@link SANDBOX_ACTIVITY_STAMP_DEBOUNCE_MS}. A live org never reaches this.
+ */
+export const stampSandboxActivityUseCase = Effect.fn("sandboxes.stampActivity")(function* (input: {
+  readonly organizationId: string
+  readonly debounceMs?: number
+}) {
+  const signals = yield* SandboxSignals
+  const acquired = yield* signals.tryAcquireActivityStamp({
+    organizationId: input.organizationId,
+    debounceMs: input.debounceMs ?? SANDBOX_ACTIVITY_STAMP_DEBOUNCE_MS,
+  })
+
+  if (!acquired) return
+
+  const repo = yield* SandboxRepository
+  yield* repo.stampActivity()
+})

--- a/packages/domain/sandboxes/tsconfig.json
+++ b/packages/domain/sandboxes/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/domain/spans/package.json
+++ b/packages/domain/spans/package.json
@@ -30,6 +30,7 @@
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",
+    "@domain/sandboxes": "workspace:*",
     "@domain/shared": "workspace:*",
     "effect": "catalog:",
     "protobufjs": "catalog:",

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -157,7 +157,7 @@ export { getTraceAnalyticsUseCase } from "./use-cases/get-trace-analytics.ts"
 export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
 export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
 export { getTraceSearchHighlightsUseCase } from "./use-cases/get-trace-search-highlights.ts"
-export type { IngestSpansInput } from "./use-cases/ingest-spans.ts"
+export type { IngestSpansInput, IngestSpansResult } from "./use-cases/ingest-spans.ts"
 export { ingestSpansUseCase } from "./use-cases/ingest-spans.ts"
 export { ingestSpansWithBillingUseCase } from "./use-cases/ingest-spans-with-billing.ts"
 export type {

--- a/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
@@ -1,29 +1,97 @@
+import { checkTraceIngestionBillingUseCase, resolveEffectivePlan } from "@domain/billing"
 import {
-  checkTraceIngestionBillingUseCase,
-  type NoCreditsRemainingError,
-  type UnknownStripePlanError,
-} from "@domain/billing"
-import type { ProjectRepository } from "@domain/projects"
-import type { QueuePublishError, QueuePublisher } from "@domain/queue"
-import type { RepositoryError, SettingsReader, SqlClient, StorageDisk, StorageError } from "@domain/shared"
+  publishSandboxTraceSignalsUseCase,
+  type Sandbox,
+  SandboxArchivedError,
+  SandboxQuotaExceededError,
+  SandboxRepository,
+  SandboxSignals,
+  stampSandboxActivityUseCase,
+} from "@domain/sandboxes"
 import { Effect } from "effect"
-import type { SpanDecodingError } from "../errors.ts"
-import { type IngestSpansInput, type IngestSpansResult, ingestSpansUseCase } from "./ingest-spans.ts"
+import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
+import { decodeOtlpRequest, type IngestSpansInput, ingestSpansUseCase, inspectOtlpForSandbox } from "./ingest-spans.ts"
+
+/**
+ * Pre-enqueue guard for a sandbox ingest (never billed): the loud, pre-persist
+ * refusals that mirror billing's 402 — archived (403 `SandboxArchived`) and
+ * over-quota (403 `SandboxQuotaExceeded`), each leaving a "last rejected ingest"
+ * marker for the sandbox UI — plus the debounced `last_activity_at` stamp and the
+ * earliest realtime "liveness" pulse (before enqueue, skipping queue + worker
+ * latency). Operates on the request decoded once by the caller. `sandbox` is `null`
+ * only on the rare data-inconsistency where a sandbox org has no attributes row —
+ * treated as active (no archived refusal). Fails before any span is enqueued.
+ */
+const guardSandboxIngestion = Effect.fn("spans.guardSandboxIngestion")(function* (
+  input: IngestSpansInput,
+  sandbox: Sandbox | null,
+  decoded: OtlpExportTraceServiceRequest | null,
+) {
+  const signals = yield* SandboxSignals
+  const inspection = inspectOtlpForSandbox(decoded)
+
+  if (sandbox?.status === "archived") {
+    yield* signals.recordRejectedIngest({
+      organizationId: input.organizationId,
+      marker: {
+        kind: "SandboxArchived",
+        at: new Date().toISOString(),
+        spansDropped: inspection.totalSpans,
+      },
+    })
+    return yield* Effect.fail(new SandboxArchivedError({ organizationId: input.organizationId }))
+  }
+
+  // Active sandbox receiving traffic — keep it awake (debounced) before the
+  // volume guard, which is a separate concern from sleep.
+  yield* stampSandboxActivityUseCase({
+    organizationId: input.organizationId,
+  })
+
+  const plan = yield* resolveEffectivePlan(input.organizationId)
+  if (inspection.totalSpans > 0) {
+    const periodTotal = yield* signals.incrementSpanQuota({
+      organizationId: input.organizationId,
+      periodStart: plan.periodStart,
+      periodEnd: plan.periodEnd,
+      spanCount: inspection.totalSpans,
+    })
+    if (periodTotal > plan.plan.spanQuotaPerPeriod) {
+      yield* signals.recordRejectedIngest({
+        organizationId: input.organizationId,
+        marker: {
+          kind: "SandboxQuotaExceeded",
+          at: new Date().toISOString(),
+          spansDropped: inspection.totalSpans,
+        },
+      })
+      return yield* Effect.fail(
+        new SandboxQuotaExceededError({
+          organizationId: input.organizationId,
+        }),
+      )
+    }
+  }
+
+  yield* publishSandboxTraceSignalsUseCase({
+    organizationId: input.organizationId,
+    kind: "liveness",
+    traces: inspection.traceSignals,
+  })
+})
 
 export const ingestSpansWithBillingUseCase = Effect.fn("spans.ingestSpansWithBilling")(function* (
   input: IngestSpansInput,
 ) {
-  yield* checkTraceIngestionBillingUseCase(input.organizationId)
-  return yield* ingestSpansUseCase(input)
-}) as (
-  input: IngestSpansInput,
-) => Effect.Effect<
-  IngestSpansResult,
-  | NoCreditsRemainingError
-  | QueuePublishError
-  | RepositoryError
-  | SpanDecodingError
-  | StorageError
-  | UnknownStripePlanError,
-  ProjectRepository | QueuePublisher | StorageDisk | SettingsReader | SqlClient
->
+  const decoded = decodeOtlpRequest(input.payload, input.contentType)
+
+  if (input.isSandbox) {
+    const sandboxRepo = yield* SandboxRepository
+    const sandbox = yield* sandboxRepo.findOptional()
+    yield* guardSandboxIngestion(input, sandbox, decoded)
+  } else {
+    yield* checkTraceIngestionBillingUseCase(input.organizationId)
+  }
+
+  return yield* ingestSpansUseCase({ ...input, decoded })
+})

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -15,6 +15,14 @@ import type { QueuePublisherShape } from "@domain/queue"
 import { QueuePublishError, QueuePublisher } from "@domain/queue"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
 import {
+  type Sandbox,
+  SandboxArchivedError,
+  SandboxQuotaExceededError,
+  SandboxRepository,
+  SandboxSignals,
+} from "@domain/sandboxes"
+import { createFakeSandboxRepository, createFakeSandboxSignals } from "@domain/sandboxes/testing"
+import {
   generateId,
   NotFoundError,
   OrganizationId,
@@ -29,7 +37,7 @@ import { createFakeSqlClient, createFakeStorageDisk } from "@domain/shared/testi
 import { base64Decode } from "@repo/utils"
 import { Effect, Layer, Result } from "effect"
 import { describe, expect, it } from "vitest"
-import { ingestSpansUseCase } from "./ingest-spans.ts"
+import { decodeOtlpRequest, ingestSpansUseCase } from "./ingest-spans.ts"
 import { ingestSpansWithBillingUseCase } from "./ingest-spans-with-billing.ts"
 
 // Branded IDs are CUID2s — 24 characters exactly.
@@ -121,9 +129,10 @@ const makeProjectRepository = (
     countBySlug: () => Effect.die("not used"),
   })
 
-const makeInput = (payload: Uint8Array, opts: { defaultProjectSlug?: string } = {}) => ({
+const makeInput = (payload: Uint8Array, opts: { defaultProjectSlug?: string; isSandbox?: boolean } = {}) => ({
   organizationId: ORGANIZATION_ID,
   apiKeyId: "key-1",
+  isSandbox: opts.isSandbox ?? false,
   payload,
   contentType: "application/json",
   ...(opts.defaultProjectSlug ? { defaultProjectSlug: opts.defaultProjectSlug } : {}),
@@ -136,7 +145,7 @@ const runUseCase = (
   resolutions: Record<string, string | null> = { primary: PRIMARY_PROJECT_ID },
   settingsBySlug: Record<string, ProjectSettings> = {},
 ) =>
-  ingestSpansUseCase(input).pipe(
+  ingestSpansUseCase({ ...input, decoded: decodeOtlpRequest(input.payload, input.contentType) }).pipe(
     Effect.provide(
       Layer.mergeAll(
         Layer.succeed(StorageDisk, diskPort),
@@ -147,19 +156,37 @@ const runUseCase = (
     ),
   )
 
-const createBillingLayer = () => {
+const makeSandbox = (status: Sandbox["status"]): Sandbox => ({
+  id: generateId(),
+  organizationId: ORGANIZATION_ID,
+  status,
+  lastActivityAt: new Date("2026-01-01T00:00:00Z"),
+  createdByUserId: generateId(),
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+})
+
+const createBillingLayer = (
+  opts: { sandbox?: Sandbox | null; signalsOverrides?: Parameters<typeof createFakeSandboxSignals>[0] } = {},
+) => {
   const { repository: billingOverrides } = createFakeBillingOverrideRepository()
   const { repository: billingPeriods } = createFakeBillingUsagePeriodRepository()
   const { service: stripeSubscriptions } = createFakeStripeSubscriptionLookup()
+  const sandboxRepo = createFakeSandboxRepository({ findOptional: () => Effect.succeed(opts.sandbox ?? null) })
+  const sandboxSignals = createFakeSandboxSignals(opts.signalsOverrides)
 
   return {
     billingPeriods,
+    sandboxRepo,
+    sandboxSignals,
     layer: Layer.mergeAll(
       Layer.succeed(BillingOverrideRepository, billingOverrides),
       Layer.succeed(BillingUsagePeriodRepository, billingPeriods),
       Layer.succeed(StripeSubscriptionLookup, stripeSubscriptions),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
       Layer.succeed(ProjectRepository, makeProjectRepository({ primary: PRIMARY_PROJECT_ID })),
+      Layer.succeed(SandboxRepository, sandboxRepo.repository),
+      Layer.succeed(SandboxSignals, sandboxSignals.signals),
       Layer.succeed(SettingsReader, {
         getOrganizationSettings: () => Effect.succeed(null),
         getProjectSettings: () => Effect.die("ingestSpansWithBillingUseCase tests do not read project settings"),
@@ -389,7 +416,13 @@ describe("ingestSpansUseCase project scoping", () => {
       }),
     )
 
-    await Effect.runPromise(ingestSpansUseCase(makeInput(manySpans)).pipe(Effect.provide(layer)))
+    const manySpansInput = makeInput(manySpans)
+    await Effect.runPromise(
+      ingestSpansUseCase({
+        ...manySpansInput,
+        decoded: decodeOtlpRequest(manySpansInput.payload, manySpansInput.contentType),
+      }).pipe(Effect.provide(layer)),
+    )
 
     expect(findBySlugCalls).toBe(2)
   })
@@ -660,5 +693,143 @@ describe("ingestSpansWithBillingUseCase", () => {
       expect(result.failure).toBeInstanceOf(NoCreditsRemainingError)
     }
     expect(published).toHaveLength(0)
+  })
+})
+
+describe("ingestSpansWithBillingUseCase sandbox path", () => {
+  const seedExhaustedFreePeriod = (billingPeriods: ReturnType<typeof createBillingLayer>["billingPeriods"]) =>
+    Effect.runPromise(
+      billingPeriods
+        .upsert(
+          seedBillingUsagePeriod({
+            organizationId: ORGANIZATION_ID,
+            planSlug: "free",
+            periodStart: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)),
+            periodEnd: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 1)),
+            includedCredits: 20_000,
+            consumedCredits: 20_000,
+          }),
+        )
+        .pipe(Effect.provideService(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID }))),
+    )
+
+  it("active sandbox: no billing, quota incremented, activity stamped, liveness pulsed, enqueued with isSandbox", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const { billingPeriods, sandboxRepo, sandboxSignals, layer } = createBillingLayer({
+      sandbox: makeSandbox("active"),
+    })
+    // Exhaust the free credits: a live org would be refused here. The sandbox is
+    // never billed, so this must be ignored.
+    await seedExhaustedFreePeriod(billingPeriods)
+
+    await Effect.runPromise(
+      ingestSpansWithBillingUseCase(
+        makeInput(buildOtlpJson(), { defaultProjectSlug: "primary", isSandbox: true }),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
+        ),
+      ),
+    )
+
+    expect(published).toHaveLength(1)
+    expect((published[0]?.payload as { isSandbox: boolean }).isSandbox).toBe(true)
+    expect(sandboxSignals.state.quotaIncrements).toEqual([{ organizationId: ORGANIZATION_ID, spanCount: 1 }])
+    expect(sandboxRepo.stampCount).toBe(1)
+    expect(sandboxSignals.state.rejected).toHaveLength(0)
+    // Earliest signal: a pre-persist liveness pulse for the arriving trace.
+    expect(sandboxSignals.state.published).toEqual([
+      {
+        kind: "liveness",
+        organizationId: ORGANIZATION_ID,
+        traceId: "0af7651916cd43dd8448eb211c80319c",
+        sessionId: "",
+      },
+    ])
+  })
+
+  it("archived sandbox: refuses with SandboxArchived before persist and records the marker", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const { sandboxSignals, layer } = createBillingLayer({ sandbox: makeSandbox("archived") })
+
+    const result = await Effect.runPromise(
+      Effect.result(
+        ingestSpansWithBillingUseCase(
+          makeInput(buildOtlpJson(), { defaultProjectSlug: "primary", isSandbox: true }),
+        ).pipe(
+          Effect.provide(
+            Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
+          ),
+        ),
+      ),
+    )
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(SandboxArchivedError)
+    }
+    expect(published).toHaveLength(0)
+    expect(sandboxSignals.state.quotaIncrements).toHaveLength(0)
+    expect(sandboxSignals.state.published).toHaveLength(0)
+    expect(sandboxSignals.state.rejected).toEqual([
+      { organizationId: ORGANIZATION_ID, marker: { kind: "SandboxArchived", at: expect.any(String), spansDropped: 1 } },
+    ])
+  })
+
+  it("over-quota sandbox: refuses with SandboxQuotaExceeded and records the marker", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const { sandboxSignals, layer } = createBillingLayer({
+      sandbox: makeSandbox("active"),
+      // Force the running total past any plan ceiling.
+      signalsOverrides: { incrementSpanQuota: () => Effect.succeed(Number.MAX_SAFE_INTEGER) },
+    })
+
+    const result = await Effect.runPromise(
+      Effect.result(
+        ingestSpansWithBillingUseCase(
+          makeInput(buildOtlpJson(), { defaultProjectSlug: "primary", isSandbox: true }),
+        ).pipe(
+          Effect.provide(
+            Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
+          ),
+        ),
+      ),
+    )
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(SandboxQuotaExceededError)
+    }
+    expect(published).toHaveLength(0)
+    expect(sandboxSignals.state.published).toHaveLength(0)
+    expect(sandboxSignals.state.rejected).toEqual([
+      {
+        organizationId: ORGANIZATION_ID,
+        marker: { kind: "SandboxQuotaExceeded", at: expect.any(String), spansDropped: 1 },
+      },
+    ])
+  })
+
+  it("live org: billing checked, enqueued without the sandbox bit, quota untouched", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const { sandboxSignals, sandboxRepo, layer } = createBillingLayer({ sandbox: null })
+
+    await Effect.runPromise(
+      ingestSpansWithBillingUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" })).pipe(
+        Effect.provide(
+          Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
+        ),
+      ),
+    )
+
+    expect(published).toHaveLength(1)
+    expect((published[0]?.payload as { isSandbox: boolean }).isSandbox).toBe(false)
+    expect(sandboxSignals.state.quotaIncrements).toHaveLength(0)
+    expect(sandboxSignals.state.published).toHaveLength(0)
+    expect(sandboxRepo.stampCount).toBe(0)
   })
 })

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -14,6 +14,8 @@ import { base64Encode } from "@repo/utils"
 import { Effect } from "effect"
 import { SpanDecodingError } from "../errors.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
+import { sessionIdCandidates } from "../otlp/resolvers/identity.ts"
+import { first } from "../otlp/resolvers/utils.ts"
 import { resolveSpanProjectSlug } from "../otlp/transform.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
 import { deterministicSample } from "../sampling/deterministic-sampler.ts"
@@ -26,11 +28,7 @@ export interface IngestSpansInput {
   readonly apiKeyId: string
   readonly payload: Uint8Array
   readonly contentType: string
-  /**
-   * Project slug from the `X-Latitude-Project` header. Used as the fallback for spans that
-   * carry no `latitude.project` attribute on the span or its OTEL resource. Optional — when
-   * absent, spans without a per-span / resource attribute are rejected.
-   */
+  readonly isSandbox: boolean
   readonly defaultProjectSlug?: string
 }
 
@@ -44,7 +42,13 @@ export interface IngestSpansResult {
   readonly rejectedSpans: number
 }
 
-function decodeRequest(value: Uint8Array, contentType: string): OtlpExportTraceServiceRequest | null {
+/**
+ * Decode an OTLP payload (protobuf or JSON) to a request, or `null` if it can't be
+ * parsed. The single decode site for the hot path: `ingestSpansWithBillingUseCase`
+ * decodes once here and hands the result to both the sandbox guard and
+ * `ingestSpansUseCase` — the use case itself never decodes.
+ */
+export function decodeOtlpRequest(value: Uint8Array, contentType: string): OtlpExportTraceServiceRequest | null {
   try {
     if (contentType.includes("application/x-protobuf")) {
       return decodeOtlpProtobuf(value)
@@ -81,14 +85,60 @@ function inspectPayload(request: OtlpExportTraceServiceRequest): PayloadInspecti
   return { totalSpans, spanSlugs, uniqueSlugs }
 }
 
+/** Earliest id-only view of a trace, for the pre-persist sandbox liveness pulse. */
+interface OtlpTraceSignal {
+  readonly traceId: string
+  readonly sessionId: string
+}
+
+interface OtlpSandboxInspection {
+  readonly totalSpans: number
+  /** One entry per distinct trace in the batch (first span wins for `sessionId`). */
+  readonly traceSignals: readonly OtlpTraceSignal[]
+}
+
+export const inspectOtlpForSandbox = (decoded: OtlpExportTraceServiceRequest | null): OtlpSandboxInspection => {
+  if (!decoded) return { totalSpans: 0, traceSignals: [] }
+
+  let totalSpans = 0
+  const sessionByTrace = new Map<string, string>()
+  for (const resourceSpans of decoded.resourceSpans ?? []) {
+    for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
+      for (const span of scopeSpans.spans ?? []) {
+        totalSpans++
+        const traceId = span.traceId
+        if (traceId && !sessionByTrace.has(traceId)) {
+          sessionByTrace.set(traceId, first(sessionIdCandidates, span.attributes ?? []) ?? "")
+        }
+      }
+    }
+  }
+
+  return {
+    totalSpans,
+    traceSignals: [...sessionByTrace].map(([traceId, sessionId]) => ({
+      traceId,
+      sessionId,
+    })),
+  }
+}
+
 const resolveProject = (slug: string): Effect.Effect<Project | null, RepositoryError, ProjectRepository | SqlClient> =>
   Effect.gen(function* () {
     const repo = yield* ProjectRepository
     return yield* repo.findBySlug(slug).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
   })
 
+interface IngestSpansUseCaseInput extends IngestSpansInput {
+  /**
+   * The OTLP request decoded once by `ingestSpansWithBillingUseCase`. The use case
+   * never decodes itself — `null` means the payload was undecodable.
+   */
+  readonly decoded: OtlpExportTraceServiceRequest | null
+}
+
 export const ingestSpansUseCase = (
-  input: IngestSpansInput,
+  input: IngestSpansUseCaseInput,
 ): Effect.Effect<
   IngestSpansResult,
   StorageError | QueuePublishError | RepositoryError | SpanDecodingError,
@@ -97,9 +147,11 @@ export const ingestSpansUseCase = (
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
 
-    const decoded = decodeRequest(input.payload, input.contentType)
+    const decoded = input.decoded
     if (!decoded) {
-      return yield* new SpanDecodingError({ reason: "failed to decode OTLP message" })
+      return yield* new SpanDecodingError({
+        reason: "failed to decode OTLP message",
+      })
     }
 
     const { totalSpans, spanSlugs, uniqueSlugs } = inspectPayload(decoded)
@@ -203,6 +255,7 @@ export const ingestSpansUseCase = (
       ingestedAt: new Date().toISOString(),
       defaultProjectId,
       projectIdBySlug,
+      isSandbox: input.isSandbox ?? false,
     })
 
     return { totalSpans, acceptedSpans, rejectedSpans }

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.test.ts
@@ -1,0 +1,110 @@
+import type { DomainEvent, EventsPublisher } from "@domain/events"
+import type { QueuePublishError } from "@domain/queue"
+import { SandboxSignals } from "@domain/sandboxes"
+import { createFakeSandboxSignals } from "@domain/sandboxes/testing"
+import { ChSqlClient, type ChSqlClientShape, OrganizationId, StorageDisk } from "@domain/shared"
+import { createFakeStorageDisk } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { SpanRepository } from "../ports/span-repository.ts"
+import { createFakeSpanRepository } from "../testing/fake-span-repository.ts"
+import { processIngestedSpansUseCase } from "./process-ingested-spans.ts"
+
+const ORGANIZATION_ID = OrganizationId("org_realtime_sandbox_test_aaa")
+
+const validRequest = {
+  resourceSpans: [
+    {
+      resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+      scopeSpans: [
+        {
+          scope: { name: "test", version: "1.0.0" },
+          spans: [
+            {
+              traceId: "0af7651916cd43dd8448eb211c80319c",
+              spanId: "b7ad6b7169203331",
+              name: "test-span",
+              startTimeUnixNano: "1710590400000000000",
+              endTimeUnixNano: "1710590401000000000",
+              attributes: [],
+              status: { code: 1 },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const inlinePayload = Buffer.from(JSON.stringify(validRequest), "utf-8").toString("base64")
+
+const createFakeEventsPublisher = (): EventsPublisher<QueuePublishError> & { readonly published: DomainEvent[] } => {
+  const published: DomainEvent[] = []
+  return {
+    published,
+    publish: (event) => {
+      published.push(event)
+      return Effect.void
+    },
+  }
+}
+
+const run = (isSandbox: boolean) => {
+  const eventsPublisher = createFakeEventsPublisher()
+  const { signals, state } = createFakeSandboxSignals()
+  const { repository: spanRepo } = createFakeSpanRepository()
+
+  const effect = processIngestedSpansUseCase({ eventsPublisher })({
+    organizationId: ORGANIZATION_ID,
+    apiKeyId: "key-1",
+    contentType: "application/json",
+    ingestedAt: new Date("2026-03-18T10:00:00.000Z"),
+    isSandbox,
+    inlinePayload,
+    fileKey: null,
+    defaultProjectId: "proj_realtime_sandbox_test",
+    projectIdBySlug: {},
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        Layer.succeed(SpanRepository, spanRepo),
+        Layer.succeed(StorageDisk, createFakeStorageDisk().disk),
+        Layer.succeed(SandboxSignals, signals),
+        Layer.succeed(ChSqlClient, {} as ChSqlClientShape),
+      ),
+    ),
+  )
+
+  return { effect, eventsPublisher, signalsState: state }
+}
+
+describe("processIngestedSpansUseCase realtime publish", () => {
+  it("publishes a coalesced trace-upsert pulse and stamps the sandbox bit for sandbox orgs", async () => {
+    const { effect, eventsPublisher, signalsState } = run(true)
+    await Effect.runPromise(effect)
+
+    expect(signalsState.published).toEqual([
+      {
+        kind: "upsert",
+        organizationId: ORGANIZATION_ID,
+        traceId: "0af7651916cd43dd8448eb211c80319c",
+        sessionId: expect.any(String),
+      },
+    ])
+    expect(eventsPublisher.published[0]).toMatchObject({
+      name: "TracesIngested",
+      payload: { isSandbox: true },
+    })
+  })
+
+  it("never publishes a realtime pulse for live orgs", async () => {
+    const { effect, eventsPublisher, signalsState } = run(false)
+    await Effect.runPromise(effect)
+
+    expect(signalsState.published).toHaveLength(0)
+    expect(eventsPublisher.published[0]).toMatchObject({
+      name: "TracesIngested",
+      payload: { isSandbox: false },
+    })
+  })
+})

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -1,4 +1,5 @@
 import type { DomainEvent, EventsPublisher } from "@domain/events"
+import { publishSandboxTraceSignalsUseCase, type SandboxSignals } from "@domain/sandboxes"
 import {
   type ChSqlClient,
   getFromDisk,
@@ -66,6 +67,7 @@ export interface ProcessIngestedSpansInput {
   readonly apiKeyId: string
   readonly contentType: string
   readonly ingestedAt: Date
+  readonly isSandbox?: boolean
   readonly retentionDays?: number
   readonly traceUsage?: {
     readonly context?: {
@@ -118,7 +120,11 @@ function resolvePayload(
     })
   }
 
-  return Effect.fail(new SpanDecodingError({ reason: "no inline payload or fileKey in message" }))
+  return Effect.fail(
+    new SpanDecodingError({
+      reason: "no inline payload or fileKey in message",
+    }),
+  )
 }
 
 function decodeAndTransform(
@@ -128,7 +134,9 @@ function decodeAndTransform(
   return Effect.gen(function* () {
     const request = decodeRequest(payload, input.contentType)
     if (!request) {
-      return yield* new SpanDecodingError({ reason: "failed to decode OTLP message" })
+      return yield* new SpanDecodingError({
+        reason: "failed to decode OTLP message",
+      })
     }
 
     if (!request.resourceSpans?.length) {
@@ -158,7 +166,7 @@ export const processIngestedSpansUseCase =
   ): Effect.Effect<
     void,
     SpanDecodingError | StorageError | RepositoryError | TPublishError,
-    ChSqlClient | SpanRepository | StorageDisk
+    ChSqlClient | SpanRepository | StorageDisk | SandboxSignals
   > =>
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
@@ -179,6 +187,17 @@ export const processIngestedSpansUseCase =
 
       const repo = yield* SpanRepository
       yield* repo.insert(persistedSpans)
+
+      if (input.isSandbox) {
+        yield* publishSandboxTraceSignalsUseCase({
+          organizationId: input.organizationId,
+          kind: "upsert",
+          traces: persistedSpans.map((span) => ({
+            traceId: span.traceId,
+            sessionId: span.sessionId,
+          })),
+        })
+      }
 
       // Spans in a single OTLP batch may now belong to different projects (per-span scoping).
       // Group by projectId so each TracesIngested event addresses one project at a time —
@@ -202,6 +221,7 @@ export const processIngestedSpansUseCase =
             organizationId: input.organizationId,
             projectId: ProjectId(projectIdRaw),
             traceIds: [...traceIdSet],
+            isSandbox: input.isSandbox === true,
             ...(input.traceUsage?.context
               ? {
                   billing: {

--- a/packages/platform/api-key-auth/package.json
+++ b/packages/platform/api-key-auth/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@domain/api-keys": "workspace:*",
+    "@domain/organizations": "workspace:*",
+    "@domain/shared": "workspace:*",
     "@platform/cache-redis": "workspace:*",
     "@platform/db-postgres": "workspace:*",
     "@repo/utils": "workspace:*",

--- a/packages/platform/api-key-auth/src/validate-api-key.test.ts
+++ b/packages/platform/api-key-auth/src/validate-api-key.test.ts
@@ -65,7 +65,7 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateApiKey (integration, Node 25+)",
       }),
     )
 
-    expect(result).toEqual({ organizationId: apiKey.organizationId, keyId: apiKey.id })
+    expect(result).toEqual({ organizationId: apiKey.organizationId, keyId: apiKey.id, isSandbox: false })
     expect(touched).toEqual([apiKey.id])
   })
 
@@ -96,6 +96,6 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateApiKey (integration, Node 25+)",
       }),
     )
 
-    expect(result).toEqual({ organizationId: apiKey.organizationId, keyId: apiKey.id })
+    expect(result).toEqual({ organizationId: apiKey.organizationId, keyId: apiKey.id, isSandbox: false })
   })
 })

--- a/packages/platform/api-key-auth/src/validate-api-key.ts
+++ b/packages/platform/api-key-auth/src/validate-api-key.ts
@@ -1,7 +1,9 @@
 import { ApiKeyCacheInvalidator, ApiKeyRepository } from "@domain/api-keys"
+import { isSandbox, OrganizationRepository } from "@domain/organizations"
+import { OrganizationId } from "@domain/shared"
 import type { RedisClient } from "@platform/cache-redis"
 import type { PostgresClient } from "@platform/db-postgres"
-import { ApiKeyRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { ApiKeyRepositoryLive, OrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { hash } from "@repo/utils"
 import { Effect, Layer, Option } from "effect"
 
@@ -57,7 +59,7 @@ export const ApiKeyCacheInvalidatorLive = (redis: RedisClient) =>
       }).pipe(Effect.orDie),
   })
 
-export type ApiKeyAuthResult = { organizationId: string; keyId: string }
+export type ApiKeyAuthResult = { organizationId: string; keyId: string; isSandbox: boolean }
 
 const isCachedApiKeyResult = (value: unknown): value is ApiKeyAuthResult | null => {
   if (value === null) {
@@ -68,11 +70,13 @@ const isCachedApiKeyResult = (value: unknown): value is ApiKeyAuthResult | null 
     return false
   }
 
-  if (!("organizationId" in value) || !("keyId" in value)) {
+  if (!("organizationId" in value) || !("keyId" in value) || !("isSandbox" in value)) {
     return false
   }
 
-  return typeof value.organizationId === "string" && typeof value.keyId === "string"
+  return (
+    typeof value.organizationId === "string" && typeof value.keyId === "string" && typeof value.isSandbox === "boolean"
+  )
 }
 
 const getCachedApiKey = (
@@ -154,14 +158,18 @@ export const validateApiKey = (
 
     const apiKey = apiKeyOption.value
 
+    const organizationRepository = yield* OrganizationRepository
+    const organization = yield* Effect.option(organizationRepository.findById(OrganizationId(apiKey.organizationId)))
+
     const result: ApiKeyAuthResult = {
       organizationId: apiKey.organizationId,
       keyId: apiKey.id,
+      isSandbox: Option.isSome(organization) ? isSandbox(organization.value) : false,
     }
 
     yield* cacheApiKeyResult(redis, tokenHash, result, VALID_KEY_TTL_SECONDS)
     onKeyValidated?.(apiKey.id)
     yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
     return result
-  }).pipe(withPostgres(ApiKeyRepositoryLive, adminClient), Effect.orDie)
+  }).pipe(withPostgres(Layer.mergeAll(ApiKeyRepositoryLive, OrganizationRepositoryLive), adminClient), Effect.orDie)
 }

--- a/packages/platform/cache-redis/src/index.ts
+++ b/packages/platform/cache-redis/src/index.ts
@@ -3,6 +3,7 @@ export { RedisCacheStoreLive } from "./ai-cache.ts"
 export { RedisBillingSpendReservationLive } from "./billing-spend-reservation.ts"
 export { RedisDistributedLockRepositoryLive } from "./distributed-lock.ts"
 export { EmbedBudgetResolverLive } from "./embed-budget-resolver.ts"
+export { SandboxSignalsLive } from "./sandbox-signals.ts"
 export { RedisSlackRefreshLockRepositoryLive } from "./slack-refresh-lock.ts"
 export { TraceSearchBudgetLive } from "./trace-search-budget.ts"
 

--- a/packages/platform/cache-redis/src/sandbox-signals.ts
+++ b/packages/platform/cache-redis/src/sandbox-signals.ts
@@ -1,0 +1,85 @@
+import {
+  buildSandboxActivityStampKey,
+  buildSandboxQuotaKey,
+  buildSandboxRejectedIngestKey,
+  buildSandboxTraceCoalesceKey,
+  buildSandboxTracesChannel,
+  SANDBOX_LAST_REJECTED_INGEST_TTL_SECONDS,
+  SandboxSignals,
+} from "@domain/sandboxes"
+import { Effect, Layer } from "effect"
+import type { RedisClient } from "./client.ts"
+
+const secondsUntil = (date: Date): number => Math.max(1, Math.ceil((date.getTime() - Date.now()) / 1000))
+
+/**
+ * Redis-backed {@link SandboxSignals}. Every method fails open: a Redis outage
+ * must never drop an otherwise-valid sandbox trace, so quota errors allow the
+ * ingest, the activity debounce skips the write, and marker/publish become
+ * no-ops.
+ */
+export const SandboxSignalsLive = (redis: RedisClient): Layer.Layer<SandboxSignals> =>
+  Layer.succeed(SandboxSignals, {
+    incrementSpanQuota: (input) =>
+      Effect.tryPromise({
+        try: async () => {
+          const key = buildSandboxQuotaKey(input.organizationId, input.periodStart)
+          const total = await redis.incrby(key, input.spanCount)
+          // First write into a fresh period key: pin the TTL to the period end so
+          // the counter resets itself. `-1` means "set but no expiry yet".
+          if (total === input.spanCount || (await redis.ttl(key)) === -1) {
+            await redis.expire(key, secondsUntil(input.periodEnd))
+          }
+          return total
+        },
+        catch: (error) => error,
+      }).pipe(Effect.catch(() => Effect.succeed(0))),
+
+    recordRejectedIngest: (input) =>
+      Effect.tryPromise({
+        try: () =>
+          redis.set(
+            buildSandboxRejectedIngestKey(input.organizationId),
+            JSON.stringify(input.marker),
+            "EX",
+            SANDBOX_LAST_REJECTED_INGEST_TTL_SECONDS,
+          ),
+        catch: (error) => error,
+      }).pipe(Effect.catch(() => Effect.void)),
+
+    tryAcquireActivityStamp: (input) =>
+      Effect.tryPromise({
+        try: () => redis.set(buildSandboxActivityStampKey(input.organizationId), "1", "PX", input.debounceMs, "NX"),
+        catch: (error) => error,
+      }).pipe(
+        Effect.map((result) => result === "OK"),
+        Effect.catch(() => Effect.succeed(false)),
+      ),
+
+    publishTraceSignal: (input) =>
+      Effect.tryPromise({
+        try: async () => {
+          // Coalesce per (kind, trace): only the window winner publishes, so a
+          // chatty trace pulses ~once per `coalesceMs` per kind instead of once
+          // per span — and a liveness pulse never suppresses the later upsert.
+          const won = await redis.set(
+            buildSandboxTraceCoalesceKey(input.organizationId, input.kind, input.traceId),
+            "1",
+            "PX",
+            input.coalesceMs,
+            "NX",
+          )
+          if (won !== "OK") return
+          await redis.publish(
+            buildSandboxTracesChannel(input.organizationId),
+            JSON.stringify({
+              kind: input.kind,
+              organizationId: input.organizationId,
+              traceId: input.traceId,
+              sessionId: input.sessionId,
+            }),
+          )
+        },
+        catch: (error) => error,
+      }).pipe(Effect.catch(() => Effect.void)),
+  })

--- a/packages/platform/db-postgres/package.json
+++ b/packages/platform/db-postgres/package.json
@@ -47,6 +47,7 @@
     "@domain/oauth-keys": "workspace:*",
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
+    "@domain/sandboxes": "workspace:*",
     "@domain/saved-searches": "workspace:*",
     "@domain/scores": "workspace:*",
     "@domain/integrations": "workspace:*",

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -51,6 +51,7 @@ export { NotificationRepositoryLive } from "./repositories/notification-reposito
 export { OAuthKeyRepositoryLive } from "./repositories/oauth-key-repository.ts"
 export { OrganizationRepositoryLive } from "./repositories/organization-repository.ts"
 export { ProjectRepositoryLive } from "./repositories/project-repository.ts"
+export { SandboxRepositoryLive } from "./repositories/sandbox-repository.ts"
 export { SavedSearchRepositoryLive } from "./repositories/saved-search-repository.ts"
 export { ScoreRepositoryLive } from "./repositories/score-repository.ts"
 export { SettingsReaderLive } from "./repositories/settings-reader-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/sandbox-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/sandbox-repository.ts
@@ -1,0 +1,46 @@
+import type { Sandbox } from "@domain/sandboxes"
+import { SandboxRepository } from "@domain/sandboxes"
+import { OrganizationId, SqlClient, type SqlClientShape } from "@domain/shared"
+import { eq } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import type { Operator } from "../client.ts"
+import { sandboxes } from "../schema/sandboxes.ts"
+
+const toDomainSandbox = (row: typeof sandboxes.$inferSelect): Sandbox => ({
+  id: row.id,
+  organizationId: OrganizationId(row.organizationId),
+  status: row.status,
+  lastActivityAt: row.lastActivityAt,
+  createdByUserId: row.createdByUserId,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+})
+
+export const SandboxRepositoryLive = Layer.effect(
+  SandboxRepository,
+  Effect.gen(function* () {
+    return {
+      findOptional: () =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient
+            .query((db, organizationId) =>
+              db.select().from(sandboxes).where(eq(sandboxes.organizationId, organizationId)).limit(1),
+            )
+            .pipe(Effect.map((results) => (results[0] ? toDomainSandbox(results[0]) : null)))
+        }),
+
+      stampActivity: () =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const now = new Date()
+          yield* sqlClient.query((db, organizationId) =>
+            db
+              .update(sandboxes)
+              .set({ lastActivityAt: now, updatedAt: now })
+              .where(eq(sandboxes.organizationId, organizationId)),
+          )
+        }),
+    }
+  }),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -311,6 +311,9 @@ importers:
       '@domain/queue':
         specifier: workspace:*
         version: link:../../packages/domain/queue
+      '@domain/sandboxes':
+        specifier: workspace:*
+        version: link:../../packages/domain/sandboxes
       '@domain/shared':
         specifier: workspace:*
         version: link:../../packages/domain/shared
@@ -1550,6 +1553,18 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/domain/sandboxes:
+    dependencies:
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../shared
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.57
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+
   packages/domain/saved-searches:
     dependencies:
       '@domain/events':
@@ -1643,6 +1658,9 @@ importers:
       '@domain/queue':
         specifier: workspace:*
         version: link:../queue
+      '@domain/sandboxes':
+        specifier: workspace:*
+        version: link:../sandboxes
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1857,6 +1875,12 @@ importers:
       '@domain/api-keys':
         specifier: workspace:*
         version: link:../../domain/api-keys
+      '@domain/organizations':
+        specifier: workspace:*
+        version: link:../../domain/organizations
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../../domain/shared
       '@platform/cache-redis':
         specifier: workspace:*
         version: link:../cache-redis
@@ -1888,6 +1912,9 @@ importers:
       '@domain/integrations':
         specifier: workspace:*
         version: link:../../domain/integrations
+      '@domain/sandboxes':
+        specifier: workspace:*
+        version: link:../../domain/sandboxes
       '@domain/shared':
         specifier: workspace:*
         version: link:../../domain/shared
@@ -2036,6 +2063,9 @@ importers:
       '@domain/projects':
         specifier: workspace:*
         version: link:../../domain/projects
+      '@domain/sandboxes':
+        specifier: workspace:*
+        version: link:../../domain/sandboxes
       '@domain/saved-searches':
         specifier: workspace:*
         version: link:../../domain/saved-searches
@@ -2414,13 +2444,13 @@ importers:
         version: 7.0.0-dev.20260421.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/telemetry/claude-code:
     dependencies:
@@ -17644,14 +17674,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -19284,14 +19306,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -23174,30 +23188,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
-    dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -24276,25 +24266,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.14.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.2
-      tsx: 4.21.0
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
@@ -24320,35 +24291,6 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.14.1
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
# 🏖️ Test Mode: the sandbox ingest pipeline — AGE-127

> Like Stripe's test mode, but for traces. Point your dev app at a **sandbox**, watch your traces stream in live, and never page a teammate or burn a credit doing it.

## The whole thing in one sentence

When traces arrive we ask **one** question — *"is this org a sandbox?"* (`parent_org_id != null`) — answer it **once** at the front door, stamp the answer on the event, and let every step downstream branch on that single bit. No flag threaded through ten functions.

## A sandbox stores & shows your traces. Everything else is off.

Five things change the moment the sandbox bit is `true`. Here's the before/after:

| # | Concern | 🟢 Live org | 🏖️ Sandbox |
|---|---------|------------|-----------|
| 1 | **LLM fan-out** (flaggers, evals, issue-clustering) | runs | **skipped** — none of it runs |
| 2 | **Archived (asleep) sandbox** | n/a | **403 `SandboxArchived`** before a single span is stored |
| 3 | **Per-period span quota** | n/a | Redis counter; over the line → **403 `SandboxQuotaExceeded`** |
| 4 | **`last_activity_at`** | n/a | stamped on ingest (debounced, ~once / 5 min) to power idle-sleep |
| 5 | **Realtime** | n/a | spans pulse to the UI over Redis Pub/Sub |
| 💸 | **Billing** | metered & charged | **never** — sandboxes are free |

Both refusals (2 & 3) mirror billing's existing `402 NoCreditsRemaining`: a **loud, pre-persist 4xx** (and *not* a 429, so OTLP exporters drop the batch instead of retry-looping). Each one drops a tiny `last_rejected_ingest` marker in Redis so the sandbox UI can say *"hey, your traces are bouncing"* (AGE-123).

## Realtime, the part that makes it feel alive ✨

You type a message in your dev app → you want to see *something* in the sandbox UI **now**. So there are **two** signals, not one:

```
span arrives ──▶ ⚡ "liveness" pulse   (at the HTTP door, BEFORE persist — instant)
             │
             └──▶ 💾 persist to ClickHouse
                        └──▶ ✅ "upsert" pulse   (AFTER persist — safe to refetch)
```

- **liveness** = *"activity! something's arriving"* → UI lights up immediately. Fired before the span is even stored, so it skips the entire queue + worker delay.
- **upsert** = *"the row exists now, go refetch the list"* → only after persist, so a refetch is guaranteed to actually find the data (read-after-write).

Both are **id-only** (`{ kind, sandboxId, traceId, sessionId }` — never trace content) and coalesced per trace so a chatty trace pulses ~once every few hundred ms instead of once per span.

> 📝 Heads-up for the "why isn't it *instant*?" question: the dominant latency is your app's OTLP `BatchSpanProcessor` (5s default flush), which lives client-side — no server trick beats it. The fix is a realtime-tuned exporter preset for sandbox keys (short flush / `SimpleSpanProcessor`), shipped via the onboarding snippet. That's SDK/onboarding work (AGE-104), **out of scope here** — this PR makes *our* half near-zero-latency.

## Who decides what? (the design rule)

The event carries **facts** (`isSandbox` + a plan snapshot); the **consumer** owns the policy. The producer stays dumb and emits the same full `TracesIngested` for everyone — then the `domain-events` worker decides, in one place, to skip both the LLM fan-out **and** billing for sandbox events. (Matches the repo's "payload carries facts, not routing hints" convention.)

## Under the hood

- 🆕 **`@domain/sandboxes`** package — `Sandbox` entity, `SandboxRepository` (Postgres) + `SandboxSignals` (Redis) ports, the two refusal errors, constants/keys, the debounced activity-stamp use-case, and test fakes.
- 🔌 Adapters: `SandboxRepositoryLive` (`@platform/db-postgres`), `SandboxSignalsLive` (`@platform/cache-redis`) — every Redis op **fails open**, so a cache hiccup never drops a real trace.
- 🧭 One resolution point: a single scoped read of the `sandboxes` row at the top of ingest (its presence ⇔ `parent_org_id != null`). The bit then rides the queue message and the `TracesIngested` event.
- 🧱 `spanQuotaPerPeriod` added to each `PlanConfig`, read via `resolveEffectivePlan` (Free/Pro finite, Enterprise ∞).

## Test plan ✅

- **Typecheck** clean across all touched packages.
- `@domain/spans` (641) · `@domain/billing` (29) · `domain-events` worker (22) — all green. They cover the four headline scenarios:
  - 🟢 **Live** → full fan-out, billing checked, quota untouched, no pulse, queued without the bit.
  - 🏖️ **Active sandbox** → no billing, quota++, activity stamped, **liveness pulse fires**, spans persisted + **upsert pulse**, queued with the bit.
  - 😴 **Archived** → `403 SandboxArchived` before persist, marker stored, nothing else fires (no pulse).
  - 🚧 **Over quota** → `403 SandboxQuotaExceeded`, marker stored, no pulse.
- ClickHouse-backed integration tests are behavior-unchanged on the live path (they need the native `chdb` binary → CI).

📋 Linear: https://linear.app/latitude/issue/AGE-127

🤖 Generated with [Claude Code](https://claude.com/claude-code)