### PR TITLE
feat(ingest): auto-create project for unrecognized span slug

### DIFF
--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -4,6 +4,7 @@ import { ingestSpansWithBillingUseCase } from "@domain/spans"
 import {
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
+  OutboxEventWriterLive,
   ProjectRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
@@ -27,6 +28,7 @@ interface TracesRouteContext {
 const traceIngestionBillingLayers = Layer.mergeAll(
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
+  OutboxEventWriterLive,
   ProjectRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,

--- a/packages/domain/projects/src/index.ts
+++ b/packages/domain/projects/src/index.ts
@@ -18,6 +18,10 @@ export {
   type CreateProjectInput,
   createProjectUseCase,
 } from "./use-cases/create-project.ts"
+export {
+  type FindOrCreateProjectBySlugInput,
+  findOrCreateProjectBySlugUseCase,
+} from "./use-cases/find-or-create-project-by-slug.ts"
 
 export {
   type ListAllProjectsInput,

--- a/packages/domain/projects/src/use-cases/create-project.ts
+++ b/packages/domain/projects/src/use-cases/create-project.ts
@@ -6,20 +6,34 @@ import {
   type RepositoryError,
   SqlClient,
   toRepositoryError,
+  toSlug,
   type ValidationError,
 } from "@domain/shared"
 import { Effect } from "effect"
 import { createProject } from "../entities/project.ts"
-import { InvalidProjectNameError } from "../errors.ts"
+import { InvalidProjectNameError, InvalidProjectSlugError } from "../errors.ts"
 import { ProjectRepository } from "../ports/project-repository.ts"
 
 export interface CreateProjectInput {
   readonly id?: ProjectId
   readonly name: string
+  /**
+   * Explicit slug to use verbatim (after normalization) instead of deriving a
+   * fresh one from the name. Set this when the slug must stay stable — e.g.
+   * auto-provisioning a project from an ingested span's `latitude.project`
+   * value, where the same slug has to resolve the same project next time.
+   * When omitted, the slug is generated from the name with collision suffixing.
+   */
+  readonly slug?: string
   readonly actorUserId?: string
 }
 
-export type CreateProjectError = RepositoryError | ValidationError | ConflictError | InvalidProjectNameError
+export type CreateProjectError =
+  | RepositoryError
+  | ValidationError
+  | ConflictError
+  | InvalidProjectNameError
+  | InvalidProjectSlugError
 
 export const createProjectUseCase = Effect.fn("projects.createProject")(function* (input: CreateProjectInput) {
   if (input.id) {
@@ -43,19 +57,36 @@ export const createProjectUseCase = Effect.fn("projects.createProject")(function
     })
   }
 
+  // Normalize an explicit slug up front so an unusable one fails before we open
+  // a transaction. The explicit-slug path skips collision suffixing on purpose:
+  // callers (find-or-create) rely on the org-scoped unique constraint to reject
+  // a racing duplicate rather than silently minting a suffixed variant.
+  let explicitSlug: string | undefined
+  if (input.slug !== undefined) {
+    explicitSlug = toSlug(input.slug)
+    if (!explicitSlug) {
+      return yield* new InvalidProjectSlugError({
+        slug: input.slug,
+        reason: "Slug must contain at least one URL-safe character",
+      })
+    }
+  }
+
   return yield* sqlClient.transaction(
     Effect.gen(function* () {
       const repo = yield* ProjectRepository
       const outboxEventWriter = yield* OutboxEventWriter
 
-      const uniqueSlug = yield* generateSlug({
-        name: trimmedName,
-        count: (slug) => repo.countBySlug(slug),
-      }).pipe(
-        Effect.catchTag("InvalidSlugInputError", (error) =>
-          Effect.fail(new InvalidProjectNameError({ field: input.name, message: error.reason })),
-        ),
-      )
+      const uniqueSlug =
+        explicitSlug ??
+        (yield* generateSlug({
+          name: trimmedName,
+          count: (slug) => repo.countBySlug(slug),
+        }).pipe(
+          Effect.catchTag("InvalidSlugInputError", (error) =>
+            Effect.fail(new InvalidProjectNameError({ field: input.name, message: error.reason })),
+          ),
+        ))
 
       const project = createProject({
         id: input.id,

--- a/packages/domain/projects/src/use-cases/find-or-create-project-by-slug.test.ts
+++ b/packages/domain/projects/src/use-cases/find-or-create-project-by-slug.test.ts
@@ -1,0 +1,130 @@
+import { OutboxEventWriter } from "@domain/events"
+import {
+  causesIncludePostgresUniqueViolation,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+  SqlClient,
+} from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { createProject, type Project } from "../entities/project.ts"
+import { ProjectRepository } from "../ports/project-repository.ts"
+import { createFakeProjectRepository } from "../testing/fake-project-repository.ts"
+import { findOrCreateProjectBySlugUseCase } from "./find-or-create-project-by-slug.ts"
+
+const ORG_ID = OrganizationId("o".repeat(24))
+
+const makeProject = (args: { id: ProjectId; slug: string; name: string }): Project =>
+  createProject({ organizationId: ORG_ID, id: args.id, slug: args.slug, name: args.name })
+
+const fakeOutbox = Layer.succeed(OutboxEventWriter, { write: () => Effect.void })
+
+function makeLayer(seed: readonly Project[]) {
+  const { repository, rows } = createFakeProjectRepository(seed)
+  const layer = Layer.mergeAll(
+    Layer.succeed(ProjectRepository, repository),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+    fakeOutbox,
+  )
+  return { layer, rows }
+}
+
+describe("findOrCreateProjectBySlugUseCase", () => {
+  it("returns the existing project when the slug already resolves", async () => {
+    const id = ProjectId("1".repeat(24))
+    const { layer, rows } = makeLayer([makeProject({ id, slug: "checkout-agent", name: "Checkout agent" })])
+
+    const result = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "checkout-agent" }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.id).toBe(id)
+    expect(rows.size).toBe(1)
+  })
+
+  it("creates a project using the slug as its name when the slug is unknown", async () => {
+    const { layer, rows } = makeLayer([])
+
+    const result = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "fresh-project" }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.slug).toBe("fresh-project")
+    expect(result.name).toBe("fresh-project")
+    expect(rows.size).toBe(1)
+  })
+
+  it("normalizes the slug before lookup and storage", async () => {
+    const { layer, rows } = makeLayer([])
+
+    const result = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "My Service" }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.slug).toBe("my-service")
+    expect(result.name).toBe("My Service")
+    expect(rows.size).toBe(1)
+  })
+
+  it("does not create a second project for the same slug (idempotent)", async () => {
+    const { layer, rows } = makeLayer([])
+
+    const first = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "repeat" }).pipe(Effect.provide(layer)),
+    )
+    const second = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "repeat" }).pipe(Effect.provide(layer)),
+    )
+
+    expect(second.id).toBe(first.id)
+    expect(rows.size).toBe(1)
+  })
+
+  it("fails with InvalidProjectSlugError when the slug normalizes to empty", async () => {
+    const { layer, rows } = makeLayer([])
+
+    const result = await Effect.runPromise(
+      Effect.flip(findOrCreateProjectBySlugUseCase({ slug: "###" }).pipe(Effect.provide(layer))),
+    )
+
+    expect(result._tag).toBe("InvalidProjectSlugError")
+    expect(rows.size).toBe(0)
+  })
+
+  it("re-fetches the winner when a concurrent insert lost the unique-constraint race", async () => {
+    // Simulate the race: the first findBySlug misses, the save then fails with a
+    // Postgres 23505, and the retry findBySlug now sees the project a concurrent
+    // ingest committed. The fake's save would otherwise just succeed, so we wrap it.
+    const id = ProjectId("2".repeat(24))
+    const winner = makeProject({ id, slug: "raced", name: "raced" })
+    const { repository } = createFakeProjectRepository([])
+
+    let findCalls = 0
+    const racing = ProjectRepository.of({
+      ...repository,
+      findBySlug: (slug) =>
+        Effect.gen(function* () {
+          findCalls++
+          // Miss on the first lookup, hit on the retry (concurrent commit landed).
+          if (findCalls === 1) return yield* repository.findBySlug(slug)
+          return winner
+        }),
+      save: () => Effect.fail(new RepositoryError({ cause: { code: "23505" }, operation: "insert" })),
+    })
+
+    const layer = Layer.mergeAll(
+      Layer.succeed(ProjectRepository, racing),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      fakeOutbox,
+    )
+
+    const result = await Effect.runPromise(
+      findOrCreateProjectBySlugUseCase({ slug: "raced" }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.id).toBe(id)
+    expect(causesIncludePostgresUniqueViolation({ code: "23505" })).toBe(true)
+  })
+})

--- a/packages/domain/projects/src/use-cases/find-or-create-project-by-slug.ts
+++ b/packages/domain/projects/src/use-cases/find-or-create-project-by-slug.ts
@@ -1,0 +1,51 @@
+import { causesIncludePostgresUniqueViolation, type RepositoryError, toSlug } from "@domain/shared"
+import { Effect } from "effect"
+import { InvalidProjectSlugError } from "../errors.ts"
+import { ProjectRepository } from "../ports/project-repository.ts"
+import { createProjectUseCase } from "./create-project.ts"
+
+export interface FindOrCreateProjectBySlugInput {
+  /** The raw project slug carried by the request (span attribute / resource attribute / header). */
+  readonly slug: string
+  readonly actorUserId?: string
+}
+
+/**
+ * Resolve a project by slug within the active organization, creating it on the
+ * fly when it doesn't exist yet. Used by span ingestion so an export carrying an
+ * unrecognized `latitude.project` value provisions the project instead of being
+ * rejected.
+ *
+ * The slug is normalized once and used for both the lookup and the created
+ * project so the same value keeps resolving the same project on later exports.
+ * Two ingests racing on the same new slug converge to one project: the loser of
+ * the org-scoped unique constraint (Postgres `23505`) re-fetches the winner.
+ */
+export const findOrCreateProjectBySlugUseCase = Effect.fn("projects.findOrCreateProjectBySlug")(function* (
+  input: FindOrCreateProjectBySlugInput,
+) {
+  const repo = yield* ProjectRepository
+  const normalizedSlug = toSlug(input.slug)
+  if (!normalizedSlug) {
+    return yield* new InvalidProjectSlugError({
+      slug: input.slug,
+      reason: "Slug must contain at least one URL-safe character",
+    })
+  }
+
+  return yield* repo.findBySlug(normalizedSlug).pipe(
+    Effect.catchTag("NotFoundError", () =>
+      createProjectUseCase({
+        name: input.slug.trim(),
+        slug: normalizedSlug,
+        ...(input.actorUserId !== undefined ? { actorUserId: input.actorUserId } : {}),
+      }).pipe(
+        Effect.catchIf(
+          (error): error is RepositoryError =>
+            error._tag === "RepositoryError" && causesIncludePostgresUniqueViolation(error.cause),
+          () => repo.findBySlug(normalizedSlug),
+        ),
+      ),
+    ),
+  )
+})

--- a/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
@@ -3,6 +3,7 @@ import {
   type NoCreditsRemainingError,
   type UnknownStripePlanError,
 } from "@domain/billing"
+import type { OutboxEventWriter } from "@domain/events"
 import type { ProjectRepository } from "@domain/projects"
 import type { QueuePublishError, QueuePublisher } from "@domain/queue"
 import type { RepositoryError, SettingsReader, SqlClient, StorageDisk, StorageError } from "@domain/shared"
@@ -25,5 +26,5 @@ export const ingestSpansWithBillingUseCase = Effect.fn("spans.ingestSpansWithBil
   | SpanDecodingError
   | StorageError
   | UnknownStripePlanError,
-  ProjectRepository | QueuePublisher | StorageDisk | SettingsReader | SqlClient
+  ProjectRepository | QueuePublisher | StorageDisk | SettingsReader | SqlClient | OutboxEventWriter
 >

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -10,7 +10,8 @@ import {
   createFakeStripeSubscriptionLookup,
   seedBillingUsagePeriod,
 } from "@domain/billing/testing"
-import { createProject, ProjectRepository } from "@domain/projects"
+import { OutboxEventWriter } from "@domain/events"
+import { createProject, type Project, ProjectRepository } from "@domain/projects"
 import type { QueuePublisherShape } from "@domain/queue"
 import { QueuePublishError, QueuePublisher } from "@domain/queue"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
@@ -101,25 +102,47 @@ const makeProject = (slug: string, id: string, settings: ProjectSettings = {}) =
     lastEditedAt: new Date("2026-01-01T00:00:00Z"),
   })
 
+// In-memory project repository: spans ingestion now provisions a project when a
+// slug doesn't resolve, so the fake must support findBySlug + save + countBySlug
+// (not just lookup). Seed it from `resolutions` and inspect `rows` for creates.
 const makeProjectRepository = (
-  resolutions: Record<string, string | null>,
+  resolutions: Record<string, string | null> = { primary: PRIMARY_PROJECT_ID },
   settingsBySlug: Record<string, ProjectSettings> = {},
-) =>
-  ProjectRepository.of({
+) => {
+  const rows = new Map<string, Project>()
+  for (const [slug, id] of Object.entries(resolutions)) {
+    if (id) rows.set(id, makeProject(slug, id, settingsBySlug[slug] ?? {}))
+  }
+  const isLive = (p: Project | undefined): p is Project => p !== undefined && p.deletedAt === null
+
+  const repository = ProjectRepository.of({
     findById: () => Effect.die("not used"),
-    findBySlug: (slug: string) => {
-      const id = resolutions[slug]
-      if (!id) return Effect.fail(new NotFoundError({ entity: "Project", id: slug }))
-      return Effect.succeed(makeProject(slug, id, settingsBySlug[slug] ?? {}))
-    },
+    findBySlug: (slug: string) =>
+      Effect.gen(function* () {
+        for (const row of rows.values()) {
+          if (isLive(row) && row.slug === slug) return row
+        }
+        return yield* new NotFoundError({ entity: "Project", id: slug })
+      }),
     list: () => Effect.die("not used"),
     listIncludingDeleted: () => Effect.die("not used"),
-    save: () => Effect.die("not used"),
+    save: (project: Project) =>
+      Effect.sync(() => {
+        rows.set(project.id, project)
+      }),
     softDelete: () => Effect.die("not used"),
     hardDelete: () => Effect.die("not used"),
     existsByName: () => Effect.die("not used"),
-    countBySlug: () => Effect.die("not used"),
+    countBySlug: (slug: string, excludeProjectId?: string) =>
+      Effect.sync(
+        () => [...rows.values()].filter((r) => isLive(r) && r.slug === slug && r.id !== excludeProjectId).length,
+      ),
   })
+
+  return { repository, rows }
+}
+
+const fakeOutbox = Layer.succeed(OutboxEventWriter, { write: () => Effect.void })
 
 const makeInput = (payload: Uint8Array, opts: { defaultProjectSlug?: string } = {}) => ({
   organizationId: ORGANIZATION_ID,
@@ -141,8 +164,9 @@ const runUseCase = (
       Layer.mergeAll(
         Layer.succeed(StorageDisk, diskPort),
         Layer.succeed(QueuePublisher, publisher),
-        Layer.succeed(ProjectRepository, makeProjectRepository(resolutions, settingsBySlug)),
+        Layer.succeed(ProjectRepository, makeProjectRepository(resolutions, settingsBySlug).repository),
         Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+        fakeOutbox,
       ),
     ),
   )
@@ -159,7 +183,8 @@ const createBillingLayer = () => {
       Layer.succeed(BillingUsagePeriodRepository, billingPeriods),
       Layer.succeed(StripeSubscriptionLookup, stripeSubscriptions),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
-      Layer.succeed(ProjectRepository, makeProjectRepository({ primary: PRIMARY_PROJECT_ID })),
+      Layer.succeed(ProjectRepository, makeProjectRepository({ primary: PRIMARY_PROJECT_ID }).repository),
+      fakeOutbox,
       Layer.succeed(SettingsReader, {
         getOrganizationSettings: () => Effect.succeed(null),
         getProjectSettings: () => Effect.die("ingestSpansWithBillingUseCase tests do not read project settings"),
@@ -288,9 +313,10 @@ describe("ingestSpansUseCase project scoping", () => {
     expect(published).toHaveLength(0)
   })
 
-  it("rejects spans whose latitude.project slug isn't in the org and keeps the rest", async () => {
+  it("auto-creates a project for an unrecognized slug and accepts its spans", async () => {
     const { disk } = createFakeStorageDisk()
     const { publisher, published } = createFakeQueuePublisher()
+    const { repository, rows } = makeProjectRepository({ primary: PRIMARY_PROJECT_ID })
 
     const twoSpans = new TextEncoder().encode(
       JSON.stringify({
@@ -312,10 +338,10 @@ describe("ingestSpansUseCase project scoping", () => {
                   {
                     traceId: "0af7651916cd43dd8448eb211c80319c",
                     spanId: "0000000000000002",
-                    name: "reject",
+                    name: "new-project",
                     startTimeUnixNano: "1710590400000000000",
                     endTimeUnixNano: "1710590401000000000",
-                    attributes: [{ key: "latitude.project", value: { stringValue: "other-org-project" } }],
+                    attributes: [{ key: "latitude.project", value: { stringValue: "freshly-seen" } }],
                     status: { code: 1 },
                   },
                 ],
@@ -327,13 +353,28 @@ describe("ingestSpansUseCase project scoping", () => {
     )
 
     const result = await Effect.runPromise(
-      runUseCase(makeInput(twoSpans), disk, publisher, { primary: PRIMARY_PROJECT_ID }),
+      ingestSpansUseCase(makeInput(twoSpans)).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(StorageDisk, disk),
+            Layer.succeed(QueuePublisher, publisher),
+            Layer.succeed(ProjectRepository, repository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+            fakeOutbox,
+          ),
+        ),
+      ),
     )
 
-    expect(result).toEqual({ totalSpans: 2, acceptedSpans: 1, rejectedSpans: 1 })
+    expect(result).toEqual({ totalSpans: 2, acceptedSpans: 2, rejectedSpans: 0 })
     expect(published).toHaveLength(1)
     const payload = published[0]?.payload as { projectIdBySlug: Record<string, string> }
-    expect(payload.projectIdBySlug).toEqual({ primary: PRIMARY_PROJECT_ID })
+    expect(payload.projectIdBySlug.primary).toBe(PRIMARY_PROJECT_ID)
+    expect(payload.projectIdBySlug["freshly-seen"]).toBeDefined()
+
+    const created = [...rows.values()].find((p) => p.slug === "freshly-seen")
+    expect(created).toBeDefined()
+    expect(created?.name).toBe("freshly-seen")
   })
 
   it("resolves each unique slug exactly once even across many spans", async () => {
@@ -362,6 +403,7 @@ describe("ingestSpansUseCase project scoping", () => {
           countBySlug: () => Effect.die("not used"),
         }),
       ),
+      fakeOutbox,
     )
 
     const manySpans = new TextEncoder().encode(
@@ -392,6 +434,91 @@ describe("ingestSpansUseCase project scoping", () => {
     await Effect.runPromise(ingestSpansUseCase(makeInput(manySpans)).pipe(Effect.provide(layer)))
 
     expect(findBySlugCalls).toBe(2)
+  })
+
+  it("reuses the auto-created project on a later export with the same slug", async () => {
+    const { repository, rows } = makeProjectRepository({})
+    const layerFor = (diskPort: StorageDiskPort, publisher: QueuePublisherShape) =>
+      Layer.mergeAll(
+        Layer.succeed(StorageDisk, diskPort),
+        Layer.succeed(QueuePublisher, publisher),
+        Layer.succeed(ProjectRepository, repository),
+        Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+        fakeOutbox,
+      )
+
+    const first = createFakeQueuePublisher()
+    await Effect.runPromise(
+      ingestSpansUseCase(makeInput(buildOtlpJson("fresh"))).pipe(
+        Effect.provide(layerFor(createFakeStorageDisk().disk, first.publisher)),
+      ),
+    )
+    expect(rows.size).toBe(1)
+
+    const second = createFakeQueuePublisher()
+    const result = await Effect.runPromise(
+      ingestSpansUseCase(makeInput(buildOtlpJson("fresh"))).pipe(
+        Effect.provide(layerFor(createFakeStorageDisk().disk, second.publisher)),
+      ),
+    )
+
+    expect(result).toEqual({ totalSpans: 1, acceptedSpans: 1, rejectedSpans: 0 })
+    expect(rows.size).toBe(1)
+  })
+
+  it("rejects a span whose slug normalizes to empty without creating a project", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+    const { repository, rows } = makeProjectRepository({})
+
+    const result = await Effect.runPromise(
+      ingestSpansUseCase(makeInput(buildOtlpJson("###"))).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(StorageDisk, disk),
+            Layer.succeed(QueuePublisher, publisher),
+            Layer.succeed(ProjectRepository, repository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+            fakeOutbox,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ totalSpans: 1, acceptedSpans: 0, rejectedSpans: 1 })
+    expect(published).toHaveLength(0)
+    expect(rows.size).toBe(0)
+  })
+
+  it("creates an independent project per organization for the same slug", async () => {
+    const idFor = async (
+      rows: Map<string, Project>,
+      repository: ReturnType<typeof makeProjectRepository>["repository"],
+    ) => {
+      await Effect.runPromise(
+        ingestSpansUseCase(makeInput(buildOtlpJson("shared-slug"))).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(StorageDisk, createFakeStorageDisk().disk),
+              Layer.succeed(QueuePublisher, createFakeQueuePublisher().publisher),
+              Layer.succeed(ProjectRepository, repository),
+              Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+              fakeOutbox,
+            ),
+          ),
+        ),
+      )
+      return [...rows.values()].find((p) => p.slug === "shared-slug")?.id
+    }
+
+    const orgA = makeProjectRepository({})
+    const orgB = makeProjectRepository({})
+    const idA = await idFor(orgA.rows, orgA.repository)
+    const idB = await idFor(orgB.rows, orgB.repository)
+
+    expect(idA).toBeDefined()
+    expect(idB).toBeDefined()
+    expect(idA).not.toBe(idB)
   })
 })
 

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -1,4 +1,5 @@
-import { type Project, ProjectRepository } from "@domain/projects"
+import type { OutboxEventWriter } from "@domain/events"
+import { findOrCreateProjectBySlugUseCase, type Project, type ProjectRepository } from "@domain/projects"
 import type { QueuePublishError } from "@domain/queue"
 import { QueuePublisher } from "@domain/queue"
 import {
@@ -81,18 +82,27 @@ function inspectPayload(request: OtlpExportTraceServiceRequest): PayloadInspecti
   return { totalSpans, spanSlugs, uniqueSlugs }
 }
 
-const resolveProject = (slug: string): Effect.Effect<Project | null, RepositoryError, ProjectRepository | SqlClient> =>
-  Effect.gen(function* () {
-    const repo = yield* ProjectRepository
-    return yield* repo.findBySlug(slug).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-  })
+// Resolve the project for a slug, provisioning one on first sight. A slug that
+// can't be turned into a usable project (empty/invalid) resolves to `null` so
+// the span is rejected gracefully, exactly as an unresolved slug was before —
+// only genuine infrastructure failures (RepositoryError) abort the batch.
+const resolveProject = (
+  slug: string,
+): Effect.Effect<Project | null, RepositoryError, ProjectRepository | SqlClient | OutboxEventWriter> =>
+  findOrCreateProjectBySlugUseCase({ slug }).pipe(
+    Effect.catchTags({
+      NotFoundError: () => Effect.succeed(null),
+      InvalidProjectNameError: () => Effect.succeed(null),
+      InvalidProjectSlugError: () => Effect.succeed(null),
+    }),
+  )
 
 export const ingestSpansUseCase = (
   input: IngestSpansInput,
 ): Effect.Effect<
   IngestSpansResult,
   StorageError | QueuePublishError | RepositoryError | SpanDecodingError,
-  StorageDisk | QueuePublisher | ProjectRepository | SqlClient
+  StorageDisk | QueuePublisher | ProjectRepository | SqlClient | OutboxEventWriter
 > =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)


### PR DESCRIPTION
## what this does

Spans ingested with a project slug that doesn't exist in the org are no longer rejected. The slug is provisioned as a new project (using the slug as the project name) and the spans are ingested against it.

Previously, an unrecognized slug meant `findBySlug` missed, the slug was swallowed to `null`, and every span carrying it was counted as rejected. A batch where *all* spans carried an unknown slug returned HTTP 400 and the data was lost; mixed batches returned a `partialSuccess` accounting for the dropped spans. Now those slugs resolve to a freshly created project.

## how it works

- **`createProjectUseCase` gains an optional `slug`.** When supplied, it's normalized with `toSlug` and used verbatim — the name-derived `generateSlug` (which lowercases, collapses, and adds a random collision suffix) is skipped. This keeps the slug stable, which is the whole point: the same slug has to resolve the same project on the next export.
- **`findOrCreateProjectBySlugUseCase`** (new) normalizes the slug, looks it up, and on a miss creates the project — name = the raw slug, slug = the normalized form — by reusing `createProjectUseCase`, so the `ProjectCreated` event still fires for downstream provisioning. It's idempotent, and safe under concurrency: two ingests racing on the same new slug converge to one project, because the loser of the org-scoped unique constraint (Postgres `23505`) re-fetches the winner.
- **`ingestSpansUseCase`** resolves slugs through that use-case. A slug that can't become a usable project (empty after normalization) still rejects its span gracefully — only a genuine `RepositoryError` aborts the batch, same as before. `OutboxEventWriter` is added to its requirements, and the ingest route provides `OutboxEventWriterLive`.

## decisions worth a look

- **Normalized, not raw.** The stored slug is `toSlug(incoming)`, matching how `updateProjectUseCase` already handles explicit slugs. Storing raw would let spaces/uppercase into the slug column and break URL routing; and since every existing project slug is already normalized, normalizing the lookup also lets a malformed incoming slug correctly match a pre-existing project. The project's display **name** keeps the raw slug.
- **No creation cap.** Every novel slug creates a project, so a misbehaving exporter spraying random slugs could create unbounded projects in an org. Shipping without a guardrail for now; if we want one (per-org cap or slug allowlist) it slots into `findOrCreateProjectBySlugUseCase`.

## tests

- New unit suite for `findOrCreateProjectBySlugUseCase`: existing/unknown/normalize/idempotent/invalid-slug, plus the concurrent unique-constraint re-fetch path.
- Updated `ingest-spans` suite: auto-creation accepts the span, idempotency across two exports, empty-normalized slug still rejects, and the same slug under two orgs yields two distinct projects.
- Typecheck + Biome clean across `@domain/projects`, `@domain/spans`, `@app/ingest`. Full suites green (projects 12, spans 638).
