### PR TITLE
fix(monitors): re-fire throttled saved-search checks [LAT-630]

### DIFF
--- a/apps/workers/src/workers/monitors.ts
+++ b/apps/workers/src/workers/monitors.ts
@@ -2,6 +2,8 @@ import { hasFeatureFlagUseCase } from "@domain/feature-flags"
 import {
   cascadeSourceDeletionUseCase,
   checkSavedSearchMonitorsUseCase,
+  SAVED_SEARCH_MONITORS_THROTTLE_MS,
+  savedSearchMonitorsCheckDedupeKey,
   sweepSavedSearchMonitorsUseCase,
 } from "@domain/monitors"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
@@ -84,9 +86,11 @@ export const createMonitorsWorker = ({
       ),
     sweepSavedSearchMonitors: () =>
       sweepSavedSearchMonitorsUseCase({
+        // Same throttled key as trace-end so both triggers coalesce into one check per project.
         publish: (target) =>
           publisher.publish("monitors", "checkSavedSearchMonitors", target, {
-            dedupeKey: `monitors:check-saved-search-sweep:${target.organizationId}:${target.projectId}`,
+            dedupeKey: savedSearchMonitorsCheckDedupeKey(target),
+            throttleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
           }),
       }).pipe(
         withPostgres(MonitorRepositoryLive, adminPgClient),

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -8,7 +8,7 @@ import {
   listAllActiveEvaluations,
   orchestrateTraceEndLiveEvaluationExecutesUseCase,
 } from "@domain/evaluations"
-import { SAVED_SEARCH_MONITORS_THROTTLE_MS } from "@domain/monitors"
+import { SAVED_SEARCH_MONITORS_THROTTLE_MS, savedSearchMonitorsCheckDedupeKey } from "@domain/monitors"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import {
@@ -240,7 +240,10 @@ export const runTraceEndJob =
           "checkSavedSearchMonitors",
           { organizationId: payload.organizationId, projectId: payload.projectId },
           {
-            dedupeKey: `org:${payload.organizationId}:monitors:check-saved-search:${payload.projectId}`,
+            dedupeKey: savedSearchMonitorsCheckDedupeKey({
+              organizationId: payload.organizationId,
+              projectId: payload.projectId,
+            }),
             throttleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
           },
         )

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -8,6 +8,15 @@ export const SAVED_SEARCH_CURRENT_WINDOW_MS = 5 * 60 * 1000
 /** Trace-end throttle for the per-project `checkSavedSearchMonitors` publish: at most one run per 5 min per project. */
 export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 5 * 60 * 1000
 
+/** Per-project `checkSavedSearchMonitors` dedupe key, shared by trace-end + the sweep so the two triggers coalesce into one throttled check stream. */
+export const savedSearchMonitorsCheckDedupeKey = ({
+  organizationId,
+  projectId,
+}: {
+  readonly organizationId: string
+  readonly projectId: string
+}): string => `org:${organizationId}:monitors:check-saved-search:${projectId}`
+
 /** BullMQ repeatable-job key for the saved-search sweep (re-registering with the same key replaces the schedule). */
 export const SAVED_SEARCH_MONITORS_SWEEPER_KEY = "monitors:saved-search-sweep"
 

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -3,6 +3,7 @@ export {
   SAVED_SEARCH_MONITORS_SWEEPER_KEY,
   SAVED_SEARCH_MONITORS_SWEEPER_PATTERN,
   SAVED_SEARCH_MONITORS_THROTTLE_MS,
+  savedSearchMonitorsCheckDedupeKey,
 } from "./constants.ts"
 export type { Monitor, MonitorAlert } from "./entities/monitor.ts"
 export { monitorAlertSchema, monitorSchema } from "./entities/monitor.ts"

--- a/packages/platform/queue-bullmq/src/adapter.test.ts
+++ b/packages/platform/queue-bullmq/src/adapter.test.ts
@@ -1,0 +1,64 @@
+import { base64urlEncode } from "@repo/utils"
+import { describe, expect, it } from "vitest"
+import { buildBullMqJobOptions } from "./adapter.ts"
+
+const LABEL = "publish(monitors, checkSavedSearchMonitors)"
+
+describe("buildBullMqJobOptions", () => {
+  it("rides a custom jobId for a bare dedupeKey (process-once idempotency)", () => {
+    const opts = buildBullMqJobOptions(LABEL, { dedupeKey: "org:1:flaggers:trace-9" })
+    expect(opts.jobId).toBe(base64urlEncode("org:1:flaggers:trace-9"))
+    expect(opts.deduplication).toBeUndefined()
+    expect(opts.delay).toBeUndefined()
+  })
+
+  it("sets no jobId at all when there is no dedupeKey", () => {
+    expect(buildBullMqJobOptions(LABEL, {})).toEqual({})
+    expect(buildBullMqJobOptions(LABEL, undefined)).toEqual({})
+  })
+
+  // Guards the shadow regression: a recurring throttle must not set a jobId (it would be
+  // retained by removeOnComplete and shadow later publishes); coalescing rides `deduplication`.
+  it("does NOT set a custom jobId for a throttled publish; drives the window via deduplication", () => {
+    const opts = buildBullMqJobOptions(LABEL, { dedupeKey: "org:1:monitors:check:proj-2", throttleMs: 300_000 })
+    expect(opts.jobId).toBeUndefined()
+    expect(opts.delay).toBe(300_000)
+    expect(opts.deduplication).toEqual({
+      id: "org:1:monitors:check:proj-2",
+      ttl: 300_000,
+      extend: false,
+      replace: false,
+    })
+  })
+
+  it("does NOT set a custom jobId for a debounced publish; extends + replaces", () => {
+    const opts = buildBullMqJobOptions(LABEL, { dedupeKey: "k", debounceMs: 5_000 })
+    expect(opts.jobId).toBeUndefined()
+    expect(opts.delay).toBe(5_000)
+    expect(opts.deduplication).toEqual({ id: "k", ttl: 5_000, extend: true, replace: true })
+  })
+
+  it("does NOT set a custom jobId for a latest-throttle publish; replaces without extending", () => {
+    const opts = buildBullMqJobOptions(LABEL, { dedupeKey: "k", latestThrottleMs: 2_000 })
+    expect(opts.jobId).toBeUndefined()
+    expect(opts.delay).toBe(2_000)
+    expect(opts.deduplication).toEqual({ id: "k", ttl: 2_000, extend: false, replace: true })
+  })
+
+  it("maps attempts + exponential backoff", () => {
+    const opts = buildBullMqJobOptions(LABEL, { attempts: 3, backoff: { type: "exponential", delayMs: 1_000 } })
+    expect(opts.attempts).toBe(3)
+    expect(opts.backoff).toEqual({ type: "exponential", delay: 1_000 })
+  })
+
+  it("rejects mutually-exclusive coalescing options", () => {
+    expect(() => buildBullMqJobOptions(LABEL, { dedupeKey: "k", throttleMs: 1, debounceMs: 1 })).toThrow(
+      /mutually exclusive/,
+    )
+  })
+
+  it("requires a dedupeKey for throttle / latest-throttle", () => {
+    expect(() => buildBullMqJobOptions(LABEL, { throttleMs: 1 })).toThrow(/require a dedupeKey/)
+    expect(() => buildBullMqJobOptions(LABEL, { latestThrottleMs: 1 })).toThrow(/require a dedupeKey/)
+  })
+})

--- a/packages/platform/queue-bullmq/src/adapter.ts
+++ b/packages/platform/queue-bullmq/src/adapter.ts
@@ -31,6 +31,66 @@ const toError = (value: unknown): Error => (value instanceof Error ? value : new
  */
 const toSafeJobId = (dedupeKey: string): string => base64urlEncode(dedupeKey)
 
+/**
+ * Translate {@link PublishOptions} into BullMQ job options. Pure + exported so the
+ * mapping (especially the jobId-vs-deduplication split) can be unit-tested without Redis.
+ * Throws on mutually-exclusive or incomplete coalescing options.
+ */
+export const buildBullMqJobOptions = (label: string, options?: PublishOptions): Record<string, unknown> => {
+  const coalescingOptions = [options?.debounceMs, options?.throttleMs, options?.latestThrottleMs].filter(
+    (value) => value !== undefined,
+  )
+  if (coalescingOptions.length > 1) {
+    throw new Error(`${label}: debounceMs, throttleMs and latestThrottleMs are mutually exclusive`)
+  }
+  if ((options?.throttleMs !== undefined || options?.latestThrottleMs !== undefined) && !options.dedupeKey) {
+    throw new Error(`${label}: throttleMs and latestThrottleMs require a dedupeKey`)
+  }
+
+  const bullmqOptions: Record<string, unknown> = {}
+  // Delayed coalescing options map to BullMQ's `delay` + `deduplication`,
+  // but the dedup flags differ by semantic:
+  //   - debounce: `extend: true, replace: true` — each publish within the TTL
+  //     pushes the fire time forward and overwrites the payload. Fires after
+  //     `debounceMs` of quiet.
+  //   - throttle: `extend: false, replace: false` — the first publish wins.
+  //     Subsequent publishes within the TTL are dropped by BullMQ. Fires
+  //     exactly `throttleMs` after the first publish.
+  //   - latest-throttle: `extend: false, replace: true` — the first publish
+  //     sets the fire time, later publishes update the payload only.
+  const delayMs = options?.debounceMs ?? options?.throttleMs ?? options?.latestThrottleMs
+  // Custom jobId is for bare-dedupeKey idempotency only. Coalescing relies on the
+  // TTL-based `deduplication` marker instead — a jobId would be retained by
+  // removeOnComplete and shadow later publishes, so a recurring throttle/debounce would
+  // fire once and go dormant.
+  if (options?.dedupeKey && delayMs === undefined) {
+    bullmqOptions.jobId = toSafeJobId(options.dedupeKey)
+  }
+  if (delayMs !== undefined) {
+    bullmqOptions.delay = delayMs
+    if (options?.dedupeKey) {
+      const extendsWindow = options.debounceMs !== undefined
+      const replacesPayload = options.throttleMs === undefined
+      bullmqOptions.deduplication = {
+        id: options.dedupeKey,
+        ttl: delayMs,
+        extend: extendsWindow,
+        replace: replacesPayload,
+      }
+    }
+  }
+  if (options?.attempts !== undefined && options.attempts > 0) {
+    bullmqOptions.attempts = options.attempts
+  }
+  if (options?.backoff) {
+    bullmqOptions.backoff = {
+      type: options.backoff.type,
+      delay: options.backoff.delayMs,
+    }
+  }
+  return bullmqOptions
+}
+
 const incidentToLogFields = (incident: BullMqWorkerIncident) => {
   if (incident.kind === "worker_error") {
     return {
@@ -111,55 +171,7 @@ export const createBullMqQueuePublisher = (
       ) =>
         Effect.tryPromise({
           try: async () => {
-            const coalescingOptions = [options?.debounceMs, options?.throttleMs, options?.latestThrottleMs].filter(
-              (value) => value !== undefined,
-            )
-            if (coalescingOptions.length > 1) {
-              throw new Error(
-                `publish(${queue}, ${String(task)}): debounceMs, throttleMs and latestThrottleMs are mutually exclusive`,
-              )
-            }
-            if ((options?.throttleMs !== undefined || options?.latestThrottleMs !== undefined) && !options.dedupeKey) {
-              throw new Error(`publish(${queue}, ${String(task)}): throttleMs and latestThrottleMs require a dedupeKey`)
-            }
-
-            const bullmqOptions: Record<string, unknown> = {}
-            if (options?.dedupeKey) {
-              bullmqOptions.jobId = toSafeJobId(options.dedupeKey)
-            }
-            // Delayed coalescing options map to BullMQ's `delay` + `deduplication`,
-            // but the dedup flags differ by semantic:
-            //   - debounce: `extend: true, replace: true` — each publish within the TTL
-            //     pushes the fire time forward and overwrites the payload. Fires after
-            //     `debounceMs` of quiet.
-            //   - throttle: `extend: false, replace: false` — the first publish wins.
-            //     Subsequent publishes within the TTL are dropped by BullMQ. Fires
-            //     exactly `throttleMs` after the first publish.
-            //   - latest-throttle: `extend: false, replace: true` — the first publish
-            //     sets the fire time, later publishes update the payload only.
-            const delayMs = options?.debounceMs ?? options?.throttleMs ?? options?.latestThrottleMs
-            if (delayMs !== undefined) {
-              bullmqOptions.delay = delayMs
-              if (options?.dedupeKey) {
-                const extendsWindow = options.debounceMs !== undefined
-                const replacesPayload = options.throttleMs === undefined
-                bullmqOptions.deduplication = {
-                  id: options.dedupeKey,
-                  ttl: delayMs,
-                  extend: extendsWindow,
-                  replace: replacesPayload,
-                }
-              }
-            }
-            if (options?.attempts !== undefined && options.attempts > 0) {
-              bullmqOptions.attempts = options.attempts
-            }
-            if (options?.backoff) {
-              bullmqOptions.backoff = {
-                type: options.backoff.type,
-                delay: options.backoff.delayMs,
-              }
-            }
+            const bullmqOptions = buildBullMqJobOptions(`publish(${queue}, ${String(task)})`, options)
             const readyQueue = await getReadyQueue(queue)
             await readyQueue.add(task, { payload } satisfies BullMqJobData, bullmqOptions)
           },


### PR DESCRIPTION
## Problem

With the `monitors` flag on, `savedSearch.match` and `savedSearch.escalating` alerts didn't fire from live traffic, while the one-time absolute `savedSearch.threshold` eventually did. The check task (`checkSavedSearchMonitors`) ran **once per project and then went dormant** — so the recent-window evaluators never got a second look.

## Root cause

The BullMQ adapter set a custom `jobId = base64(dedupeKey)` for **every** dedupeKey publish. Combined with the worker's `removeOnComplete: { count: 1000 }`, the *completed* job's jobId is retained in Redis and shadows every later publish with the same key (`addStandardJob` returns early on `EXISTS jobIdKey`). So a recurring throttled publish with a constant key fires once, then is silently dropped until the completed job is evicted (~1000 jobs later).

This **self-heals on high-volume queues** (e.g. `issues`, where eviction is fast) but **starves low-volume ones** (`monitors`), which is why it reproduced cleanly on the saved-search checks. Confirmed end-to-end with a Redis probe.

## Fix

- **`@platform/queue-bullmq`** — coalescing publishes (`throttleMs` / `debounceMs` / `latestThrottleMs`) no longer set a custom `jobId`; they rely solely on BullMQ's TTL-based `deduplication` marker, which auto-expires so the next window re-fires. A bare `dedupeKey` (no delay) keeps the jobId for process-once idempotency. The option mapping is extracted into the pure, exported `buildBullMqJobOptions` and unit-tested. This also un-breaks other recurring throttled/debounced publishers.
- **`@domain/monitors` + workers** — the trace-end and sweep `checkSavedSearchMonitors` publishes now share one throttled key (`savedSearchMonitorsCheckDedupeKey`), so the two triggers coalesce into a single per-project check stream (active projects fire via trace-end, quiet ones via the sweep).

## Verification

- `buildBullMqJobOptions` unit tests (8) + a real-Redis probe: throttle without a jobId coalesces within the window **and** re-fires across windows.
- `@domain/monitors` (103) and `@platform/queue-bullmq` (28) suites pass; typecheck + biome + knip clean.
- **Live**: with the flag on and sustained traffic, `savedSearch.match` fires and `savedSearch.escalating` opens and closes through its dwell.

## Follow-up (not in this PR)

`throttleMs` is a *trailing* coalescer, so on a quiet project the sweep-triggered check lands up to ~5 min late (bounded: checks every <10 min, escalating close ~15-20 min worst case). A snappier design — run the sweep check promptly and move match's rate-limit into the match state machine (dedupe by recent incident) — is a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
