### PR TITLE
fix(monitors): align "last incident" / "detected at" with the incidents table [LAT-630]

### DIFF
--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -178,6 +178,7 @@ interface MonitorIncidentStats {
   readonly total: number
   readonly firstStartedAtIso: string | null
   readonly lastStartedAtIso: string | null
+  readonly lastEndedAtIso: string | null
 }
 
 export function useMonitorIncidentStats(input: {

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -430,6 +430,7 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
       readonly total: number
       readonly firstStartedAtIso: string | null
       readonly lastStartedAtIso: string | null
+      readonly lastEndedAtIso: string | null
     }> => {
       const { organizationId } = await requireSession()
       const orgId = OrganizationId(organizationId)
@@ -445,6 +446,7 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
         total: stats.total,
         firstStartedAtIso: stats.firstStartedAt?.toISOString() ?? null,
         lastStartedAtIso: stats.lastStartedAt?.toISOString() ?? null,
+        lastEndedAtIso: stats.lastEndedAt?.toISOString() ?? null,
       }
     },
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
@@ -79,21 +79,21 @@ const elapsedSince = (iso: string): number => Math.max(0, Date.now() - Date.pars
 
 // Flex `div` so the `gap-*` around the separator holds; bare `<span>` triggers so Radix's hover handlers land on a real DOM node.
 function MonitorDetectedAtValue({
-  lastStartedAtIso,
+  lastDetectedAtIso,
   firstStartedAtIso,
 }: {
-  readonly lastStartedAtIso: string
+  readonly lastDetectedAtIso: string
   readonly firstStartedAtIso: string
 }) {
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5 text-sm leading-5">
       <Tooltip
         asChild
-        trigger={<span className="break-words">{`${formatCompactElapsed(elapsedSince(lastStartedAtIso))} ago`}</span>}
+        trigger={<span className="break-words">{`${formatCompactElapsed(elapsedSince(lastDetectedAtIso))} ago`}</span>}
       >
         <div className="flex flex-col gap-0.5">
           <Text.H6 color="foregroundMuted">Last detected at</Text.H6>
-          <Text.H6B>{new Date(lastStartedAtIso).toLocaleString()}</Text.H6B>
+          <Text.H6B>{new Date(lastDetectedAtIso).toLocaleString()}</Text.H6B>
         </div>
       </Tooltip>
       <span className="shrink-0 text-muted-foreground">/</span>
@@ -419,7 +419,9 @@ export function MonitorDetailDrawer({
                     <Skeleton className="h-5 w-32" />
                   ) : incidentStats?.lastStartedAtIso && incidentStats.firstStartedAtIso ? (
                     <MonitorDetectedAtValue
-                      lastStartedAtIso={incidentStats.lastStartedAtIso}
+                      // "Last detected at" is the last incident's close time, falling back to its
+                      // start while it's still ongoing.
+                      lastDetectedAtIso={incidentStats.lastEndedAtIso ?? incidentStats.lastStartedAtIso}
                       firstStartedAtIso={incidentStats.firstStartedAtIso}
                     />
                   ) : (

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -93,8 +93,12 @@ export interface AlertIncidentListPage {
 
 export interface MonitorIncidentStats {
   readonly total: number
+  /** `started_at` of the first (oldest) incident — "first detected at". */
   readonly firstStartedAt: Date | null
+  /** Last incident's `started_at` (ongoing-first pick); the fallback for "last detected at" when it's still open. */
   readonly lastStartedAt: Date | null
+  /** Last incident's `ended_at` — "last detected at"; `null` while that incident is ongoing. */
+  readonly lastEndedAt: Date | null
 }
 
 export interface AlertIncidentRepositoryShape {

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
@@ -342,7 +342,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
     await closeInMemoryPostgres(database)
   })
 
-  it("aggregates total + earliest/latest startedAt across the monitor's alerts (soft-deleted included)", async () => {
+  it("aggregates total + first startedAt, and picks the ongoing incident as last (soft-deleted included)", async () => {
     await database.db
       .insert(monitorAlertsTable)
       .values([
@@ -352,17 +352,20 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
       ])
 
     await database.db.insert(alertIncidentsTable).values([
+      // Ongoing — wins `lastStartedAt` even though a closed incident started later.
       makeRow({
         id: AlertIncidentId("1".repeat(24)),
         sourceId: "1".repeat(24),
         monitorAlertId: alertA1,
         startedAt: new Date("2026-05-07T10:00:00.000Z"),
+        endedAt: null,
       }),
       makeRow({
         id: AlertIncidentId("2".repeat(24)),
         sourceId: "2".repeat(24),
         monitorAlertId: alertA1,
         startedAt: new Date("2026-05-07T12:00:00.000Z"),
+        endedAt: new Date("2026-05-07T12:30:00.000Z"),
       }),
       // Soft-deleted alert's incident still counts toward history.
       makeRow({
@@ -370,6 +373,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
         sourceId: "3".repeat(24),
         monitorAlertId: alertA2Deleted,
         startedAt: new Date("2026-05-07T09:00:00.000Z"),
+        endedAt: new Date("2026-05-07T09:30:00.000Z"),
       }),
       makeRow({
         id: AlertIncidentId("4".repeat(24)),
@@ -393,7 +397,42 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
 
     expect(result.total).toBe(3)
     expect(result.firstStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
-    expect(result.lastStartedAt?.toISOString()).toBe("2026-05-07T12:00:00.000Z")
+    // Last incident is ongoing, so "last detected at" has no close time and falls back to its start.
+    expect(result.lastStartedAt?.toISOString()).toBe("2026-05-07T10:00:00.000Z")
+    expect(result.lastEndedAt).toBeNull()
+  })
+
+  it("uses the latest-ended incident's endedAt as lastEndedAt when none are ongoing", async () => {
+    await database.db.insert(monitorAlertsTable).values([makeAlertRow({ id: alertA1, monitorId: monitorIdA })])
+    await database.db.insert(alertIncidentsTable).values([
+      makeRow({
+        id: AlertIncidentId("1".repeat(24)),
+        sourceId: "1".repeat(24),
+        monitorAlertId: alertA1,
+        startedAt: new Date("2026-05-07T10:00:00.000Z"),
+        endedAt: new Date("2026-05-07T10:30:00.000Z"),
+      }),
+      // Latest close — wins the pick even though it started earlier.
+      makeRow({
+        id: AlertIncidentId("2".repeat(24)),
+        sourceId: "2".repeat(24),
+        monitorAlertId: alertA1,
+        startedAt: new Date("2026-05-07T09:00:00.000Z"),
+        endedAt: new Date("2026-05-07T11:00:00.000Z"),
+      }),
+    ])
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        return yield* repository.statsByMonitorId(monitorIdA)
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+
+    expect(result.total).toBe(2)
+    expect(result.firstStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
+    expect(result.lastStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
+    expect(result.lastEndedAt?.toISOString()).toBe("2026-05-07T11:00:00.000Z")
   })
 
   it("returns zero/null for a monitor with no incidents", async () => {
@@ -409,6 +448,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
     expect(result.total).toBe(0)
     expect(result.firstStartedAt).toBeNull()
     expect(result.lastStartedAt).toBeNull()
+    expect(result.lastEndedAt).toBeNull()
   })
 })
 

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -19,7 +19,6 @@ import {
   isNull,
   lt,
   lte,
-  max,
   min,
   or,
   type SQL,
@@ -258,22 +257,31 @@ export const AlertIncidentRepositoryLive = Layer.effect(
             eq(alertIncidents.organizationId, sqlClient.organizationId),
             eq(monitorAlerts.monitorId, monitorId),
           )
-          const rows = yield* sqlClient.query((db) =>
-            db
-              .select({
-                total: count(),
-                firstStartedAt: min(alertIncidents.startedAt),
-                lastStartedAt: max(alertIncidents.startedAt),
-              })
+          const [aggRows, lastRows] = yield* sqlClient.query((db) => {
+            const aggPromise = db
+              .select({ total: count(), firstStartedAt: min(alertIncidents.startedAt) })
               .from(alertIncidents)
               .innerJoin(monitorAlerts, eq(monitorAlerts.id, alertIncidents.monitorAlertId))
-              .where(where),
-          )
-          const row = rows[0]
+              .where(where)
+            // The "last incident" is the same ongoing-first row as `listByMonitorId`, not
+            // the latest-started one. We surface both ends: `ended_at` is "last detected at"
+            // (the close time), `started_at` is the fallback while it's still ongoing.
+            const lastPromise = db
+              .select({ startedAt: alertIncidents.startedAt, endedAt: alertIncidents.endedAt })
+              .from(alertIncidents)
+              .innerJoin(monitorAlerts, eq(monitorAlerts.id, alertIncidents.monitorAlertId))
+              .where(where)
+              .orderBy(desc(alertIncidents.endedAt), desc(alertIncidents.id))
+              .limit(1)
+            return Promise.all([aggPromise, lastPromise])
+          })
+          const agg = aggRows[0]
+          const last = lastRows[0]
           return {
-            total: row?.total ?? 0,
-            firstStartedAt: row?.firstStartedAt ? new Date(row.firstStartedAt) : null,
-            lastStartedAt: row?.lastStartedAt ? new Date(row.lastStartedAt) : null,
+            total: agg?.total ?? 0,
+            firstStartedAt: agg?.firstStartedAt ? new Date(agg.firstStartedAt) : null,
+            lastStartedAt: last?.startedAt ? new Date(last.startedAt) : null,
+            lastEndedAt: last?.endedAt ? new Date(last.endedAt) : null,
           }
         }),
       listByMonitorAlertId: ({ monitorAlertId, limit, cursor }) =>

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -217,6 +217,20 @@ describe("MonitorRepositoryLive", () => {
           endedAt: olderEndedAt,
           monitorAlertId: olderAlertId,
         },
+        {
+          // Closed but started AFTER the ongoing one — the ongoing incident still wins the
+          // "last incident" pick (ended_at DESC NULLS FIRST), not the latest-started.
+          id: AlertIncidentId(generateId()),
+          organizationId: organizationId as string,
+          projectId: projectId as string,
+          sourceType: "savedSearch",
+          sourceId: "s".repeat(24),
+          kind: "savedSearch.match",
+          severity: "medium",
+          startedAt: new Date("2026-06-02T09:00:00.000Z"),
+          endedAt: new Date("2026-06-02T09:30:00.000Z"),
+          monitorAlertId: recentAlertId,
+        },
       ])
 
       const result = await Effect.runPromise(

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -219,7 +219,8 @@ export const MonitorRepositoryLive = Layer.effect(
 
           const ids = rows.map((r) => r.id)
 
-          // Ordered so the first row per monitor is the latest; deduped in JS (DISTINCT ON isn't ergonomic via the query builder).
+          // Ongoing-first (ended_at DESC NULLS FIRST), matching the incidents table, so the
+          // first row per monitor is the displayed "last incident"; deduped in JS.
           const incidentRows = yield* sqlClient.query((db) =>
             db
               .select({
@@ -230,7 +231,7 @@ export const MonitorRepositoryLive = Layer.effect(
               .from(alertIncidents)
               .innerJoin(monitorAlerts, eq(monitorAlerts.id, alertIncidents.monitorAlertId))
               .where(and(eq(alertIncidents.organizationId, organizationId), inArray(monitorAlerts.monitorId, ids)))
-              .orderBy(asc(monitorAlerts.monitorId), desc(alertIncidents.startedAt), desc(alertIncidents.id)),
+              .orderBy(asc(monitorAlerts.monitorId), desc(alertIncidents.endedAt), desc(alertIncidents.id)),
           )
           const lastIncidentByMonitorId = new Map<string, MonitorLastIncident>()
           for (const row of incidentRows) {


### PR DESCRIPTION
## Problem

The monitors-list **"Last incident"** column and the monitor-details **"Detected at"** stat selected the *latest-started* incident, which diverges from the monitor-details **incidents table** — that orders ongoing-first (`ended_at DESC NULLS FIRST, id DESC`). So a monitor with an ongoing incident that started *before* a more-recently-started closed one would show a different (or differently-timed) incident in the list/drawer than in the table.

## Fix

Align both display paths to the table's ordering, and reframe the drawer's "detected at" as a span:

- **`MonitorRepository.list`** — the per-monitor displayed "last incident" pick now orders by `ended_at DESC` (ongoing first), matching `listByMonitorId`.
- **`AlertIncidentRepository.statsByMonitorId`** — picks the same ongoing-first incident and returns its `started_at` **and** `ended_at`. `total` + `firstStartedAt` stay aggregates.
- **Drawer "Detected at"**:
  - *First detected at* = first (oldest) incident's `started_at` (unchanged).
  - *Last detected at* = the last incident's **`ended_at`** (its close time, so it lines up with the table's "Closed Xm ago"), falling back to its `started_at` while that incident is still ongoing.

So for a monitor whose latest incident started 56m ago and closed 37m ago, the drawer now reads **37m** (matching the table) instead of 56m.

## Tests

- `statsByMonitorId`: updated the ongoing-pick case (asserts `lastEndedAt` is null) and added a closed-pick case (asserts `lastEndedAt` = the latest close, even when it started earlier).
- `MonitorRepository.list`: strengthened to prove the ongoing incident wins the "last incident" pick even when a closed incident started later.
- db-postgres suite (58 repo tests) + typecheck across `@domain/alerts`, `@domain/monitors`, `@platform/db-postgres`, `@app/web`; biome + knip clean.

## Note (out of scope)

The "Last incident" column's *sort* still ranks by `max(started_at)`, so in the rare case of an ongoing incident plus a later-started closed one it can sort by the closed one's start while displaying the ongoing one. Matching the sort exactly needs a `DISTINCT ON`-style subquery — happy to follow up if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
