### PR TITLE
fix(datasets): accept all JSON value types in dataset row cells

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -8262,17 +8262,21 @@
                       "type": "string"
                     },
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
                       },
                       "additionalProperties": {}
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
                     },
                     {
                       "type": "null"
@@ -8287,17 +8291,21 @@
                       "type": "string"
                     },
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
                       },
                       "additionalProperties": {}
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
                     },
                     {
                       "type": "null"
@@ -8311,17 +8319,21 @@
                       "type": "string"
                     },
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
                       },
                       "additionalProperties": {}
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
                     },
                     {
                       "type": "null"
@@ -8335,17 +8347,21 @@
                       "type": "string"
                     },
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
                       },
                       "additionalProperties": {}
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "boolean"
                     },
                     {
                       "type": "null"

--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -8085,19 +8085,14 @@
                       "type": "string"
                     },
                     {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
-                      "additionalProperties": {}
-                    }
-                  ],
-                  "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
-                },
-                "output": {
-                  "anyOf": [
+                      "type": "number"
+                    },
                     {
-                      "type": "string"
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
                     },
                     {
                       "type": "object",
@@ -8107,12 +8102,47 @@
                       "additionalProperties": {}
                     }
                   ],
-                  "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
+                  "description": "Free-form cell value: any JSON scalar, array, or object."
+                },
+                "output": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {}
+                    }
+                  ],
+                  "description": "Free-form cell value: any JSON scalar, array, or object."
                 },
                 "expectedOutput": {
                   "anyOf": [
                     {
                       "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
                     },
                     {
                       "type": "object",
@@ -8130,6 +8160,16 @@
                       "type": "string"
                     },
                     {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -8137,7 +8177,7 @@
                       "additionalProperties": {}
                     }
                   ],
-                  "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
+                  "description": "Free-form cell value: any JSON scalar, array, or object."
                 },
                 "createdAt": {
                   "type": "string",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4198,14 +4198,18 @@
                       "type": "string"
                     },
                     {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    {
                       "type": "number"
                     },
                     {
                       "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {}
                     },
                     {
                       "type": "null"
@@ -4219,14 +4223,18 @@
                       "type": "string"
                     },
                     {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    {
                       "type": "number"
                     },
                     {
                       "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {}
                     },
                     {
                       "type": "null"
@@ -4240,14 +4248,18 @@
                       "type": "string"
                     },
                     {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    {
                       "type": "number"
                     },
                     {
                       "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {}
                     },
                     {
                       "type": "null"
@@ -4261,14 +4273,18 @@
                       "type": "string"
                     },
                     {
-                      "type": "object",
-                      "additionalProperties": {}
-                    },
-                    {
                       "type": "number"
                     },
                     {
                       "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "items": {}
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {}
                     },
                     {
                       "type": "null"

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4049,11 +4049,21 @@
                 "type": "string"
               },
               {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {}
+              },
+              {
                 "type": "object",
                 "additionalProperties": {}
               }
             ],
-            "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
+            "description": "Free-form cell value: any JSON scalar, array, or object."
           },
           "output": {
             "anyOf": [
@@ -4061,16 +4071,36 @@
                 "type": "string"
               },
               {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {}
+              },
+              {
                 "type": "object",
                 "additionalProperties": {}
               }
             ],
-            "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
+            "description": "Free-form cell value: any JSON scalar, array, or object."
           },
           "expectedOutput": {
             "anyOf": [
               {
                 "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {}
               },
               {
                 "type": "object",
@@ -4085,11 +4115,21 @@
                 "type": "string"
               },
               {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {}
+              },
+              {
                 "type": "object",
                 "additionalProperties": {}
               }
             ],
-            "description": "Free-form cell value. Either a plain string or an arbitrary JSON object."
+            "description": "Free-form cell value: any JSON scalar, array, or object."
           },
           "createdAt": {
             "type": "string",

--- a/apps/api/src/openapi/entities/dataset-row.test.ts
+++ b/apps/api/src/openapi/entities/dataset-row.test.ts
@@ -3,11 +3,8 @@ import { DatasetId, DatasetRowId } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { DatasetRowSchema, toDatasetRowResponse } from "./dataset-row.ts"
 
-// The MCP server validates a tool's `structuredContent` against the
-// `outputSchema` it derives from this exact schema (see mcp/server.ts).
-// A cell can round-trip out of ClickHouse as any JSON value safeParseJson
-// emits, so the schema must accept all of them or the MCP call fails with
-// `-32602 Output validation error`.
+// MCP validates structuredContent against this schema (see mcp/server.ts), so it
+// must accept every JSON value a cell can round-trip as, or the call fails -32602.
 const baseRow: Omit<DatasetRow, "input" | "output"> = {
   rowId: DatasetRowId("row-1"),
   datasetId: DatasetId("cm000000000000000000ds01"),

--- a/apps/api/src/openapi/entities/dataset-row.test.ts
+++ b/apps/api/src/openapi/entities/dataset-row.test.ts
@@ -1,0 +1,38 @@
+import type { DatasetRow } from "@domain/datasets"
+import { DatasetId, DatasetRowId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { DatasetRowSchema, toDatasetRowResponse } from "./dataset-row.ts"
+
+// The MCP server validates a tool's `structuredContent` against the
+// `outputSchema` it derives from this exact schema (see mcp/server.ts).
+// A cell can round-trip out of ClickHouse as any JSON value safeParseJson
+// emits, so the schema must accept all of them or the MCP call fails with
+// `-32602 Output validation error`.
+const baseRow: Omit<DatasetRow, "input" | "output"> = {
+  rowId: DatasetRowId("row-1"),
+  datasetId: DatasetId("cm000000000000000000ds01"),
+  expectedOutput: "",
+  metadata: {},
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  version: 1,
+}
+
+describe("DatasetRowSchema", () => {
+  it.each([
+    ["string", "hello"],
+    ["number", 42],
+    ["boolean", true],
+    ["array", [{ role: "user", content: "hi" }]],
+    ["object", { question: "weather" }],
+  ])("accepts a %s cell value through toDatasetRowResponse", (_label, value) => {
+    const response = toDatasetRowResponse({
+      ...baseRow,
+      input: value as DatasetRow["input"],
+      output: value as DatasetRow["output"],
+    })
+
+    const result = DatasetRowSchema.safeParse(response)
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/apps/api/src/openapi/entities/dataset-row.ts
+++ b/apps/api/src/openapi/entities/dataset-row.ts
@@ -3,8 +3,14 @@ import { cuidSchema } from "@domain/shared"
 import { z } from "@hono/zod-openapi"
 
 const RowFieldValueSchema = z
-  .union([z.string(), z.record(z.string(), z.unknown())])
-  .describe("Free-form cell value. Either a plain string or an arbitrary JSON object.")
+  .union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.array(z.unknown()),
+    z.record(z.string(), z.unknown()),
+  ])
+  .describe("Free-form cell value: any JSON scalar, array, or object.")
 
 export const DatasetRowSchema = z
   .object({

--- a/apps/api/src/openapi/entities/dataset-row.ts
+++ b/apps/api/src/openapi/entities/dataset-row.ts
@@ -3,13 +3,7 @@ import { cuidSchema } from "@domain/shared"
 import { z } from "@hono/zod-openapi"
 
 const RowFieldValueSchema = z
-  .union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.array(z.unknown()),
-    z.record(z.string(), z.unknown()),
-  ])
+  .union([z.string(), z.number(), z.boolean(), z.array(z.unknown()), z.record(z.string(), z.unknown())])
   .describe("Free-form cell value: any JSON scalar, array, or object.")
 
 export const DatasetRowSchema = z

--- a/apps/api/src/routes/datasets.ts
+++ b/apps/api/src/routes/datasets.ts
@@ -362,8 +362,7 @@ const deleteDatasetEndpoint = datasetEndpoint({
 
 // ─── Rows ────────────────────────────────────────────────────────────────────
 
-// Mirrors the read-side RowFieldValue (string | number | boolean | array |
-// object) plus null, so anything the API accepts on insert can also be read back.
+// Mirrors the read-side RowFieldValue, plus null (coerced to "" on storage).
 const InsertRowCellSchema = z.union([
   z.string(),
   z.number(),

--- a/apps/api/src/routes/datasets.ts
+++ b/apps/api/src/routes/datasets.ts
@@ -362,7 +362,16 @@ const deleteDatasetEndpoint = datasetEndpoint({
 
 // ─── Rows ────────────────────────────────────────────────────────────────────
 
-const InsertRowCellSchema = z.union([z.string(), z.record(z.string(), z.unknown()), z.number(), z.boolean(), z.null()])
+// Mirrors the read-side RowFieldValue (string | number | boolean | array |
+// object) plus null, so anything the API accepts on insert can also be read back.
+const InsertRowCellSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.unknown()),
+  z.record(z.string(), z.unknown()),
+  z.null(),
+])
 
 const PaginatedDatasetRowsSchema = Paginated(DatasetRowSchema, "PaginatedDatasetRows")
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
@@ -22,7 +22,7 @@ function extractException(eventsJson: string): ExceptionInfo | undefined {
   const events = safeParseJson(eventsJson)
   if (!Array.isArray(events)) return undefined
 
-  for (const event of events) {
+  for (const event of events as Array<{ name?: unknown; attributes?: unknown }>) {
     if (event?.name !== "exception" || !event.attributes) continue
     const attrs = event.attributes as Array<{ key: string; value?: { stringValue?: string } }>
     const info: ExceptionInfo = {}

--- a/packages/domain/datasets/src/entities/dataset-row.ts
+++ b/packages/domain/datasets/src/entities/dataset-row.ts
@@ -1,17 +1,24 @@
 import { datasetIdSchema, datasetRowIdSchema } from "@domain/shared"
 import { z } from "zod"
 
-const rowFieldValueSchema: z.ZodType<string | Record<string, unknown>> = z.union([
+// Any JSON value a cell can round-trip through ClickHouse via safeParseJson.
+// `null` is intentionally absent: serializeField stores it as "" and it reads
+// back as an empty string, so a stored cell never surfaces as null.
+const rowFieldValueSchema: z.ZodType<
+  string | number | boolean | Record<string, unknown> | unknown[]
+> = z.union([
   z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.unknown()),
   z.record(z.string(), z.unknown()),
 ])
 
 export type RowFieldValue = z.infer<typeof rowFieldValueSchema>
 
-const insertRowFieldValueSchema: z.ZodType<RowFieldValue | number | boolean | null> = z.union([
+// Insert accepts the same shapes as read, plus null (coerced to "" on storage).
+const insertRowFieldValueSchema: z.ZodType<RowFieldValue | null> = z.union([
   rowFieldValueSchema,
-  z.number(),
-  z.boolean(),
   z.null(),
 ])
 

--- a/packages/domain/datasets/src/entities/dataset-row.ts
+++ b/packages/domain/datasets/src/entities/dataset-row.ts
@@ -1,9 +1,7 @@
 import { datasetIdSchema, datasetRowIdSchema } from "@domain/shared"
 import { z } from "zod"
 
-// Any JSON value a cell can round-trip through ClickHouse via safeParseJson.
-// `null` is intentionally absent: serializeField stores it as "" and it reads
-// back as an empty string, so a stored cell never surfaces as null.
+// Any JSON value a cell round-trips as. No null: it's stored as "" and reads back as "".
 const rowFieldValueSchema: z.ZodType<string | number | boolean | Record<string, unknown> | unknown[]> = z.union([
   z.string(),
   z.number(),
@@ -14,7 +12,7 @@ const rowFieldValueSchema: z.ZodType<string | number | boolean | Record<string, 
 
 export type RowFieldValue = z.infer<typeof rowFieldValueSchema>
 
-// Insert accepts the same shapes as read, plus null (coerced to "" on storage).
+// Read shapes plus null (coerced to "" on storage).
 const insertRowFieldValueSchema: z.ZodType<RowFieldValue | null> = z.union([rowFieldValueSchema, z.null()])
 
 export type InsertRowFieldValue = z.infer<typeof insertRowFieldValueSchema>

--- a/packages/domain/datasets/src/entities/dataset-row.ts
+++ b/packages/domain/datasets/src/entities/dataset-row.ts
@@ -4,9 +4,7 @@ import { z } from "zod"
 // Any JSON value a cell can round-trip through ClickHouse via safeParseJson.
 // `null` is intentionally absent: serializeField stores it as "" and it reads
 // back as an empty string, so a stored cell never surfaces as null.
-const rowFieldValueSchema: z.ZodType<
-  string | number | boolean | Record<string, unknown> | unknown[]
-> = z.union([
+const rowFieldValueSchema: z.ZodType<string | number | boolean | Record<string, unknown> | unknown[]> = z.union([
   z.string(),
   z.number(),
   z.boolean(),
@@ -17,10 +15,7 @@ const rowFieldValueSchema: z.ZodType<
 export type RowFieldValue = z.infer<typeof rowFieldValueSchema>
 
 // Insert accepts the same shapes as read, plus null (coerced to "" on storage).
-const insertRowFieldValueSchema: z.ZodType<RowFieldValue | null> = z.union([
-  rowFieldValueSchema,
-  z.null(),
-])
+const insertRowFieldValueSchema: z.ZodType<RowFieldValue | null> = z.union([rowFieldValueSchema, z.null()])
 
 export type InsertRowFieldValue = z.infer<typeof insertRowFieldValueSchema>
 

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.test.ts
@@ -288,6 +288,44 @@ describe("DatasetRowClickHouseRepository", () => {
       expect(row.input).toEqual({ code: "yellow72", nested: { a: 1 } })
       expect(row.output).toEqual({ answer: 42 })
     })
+
+    it("preserves JSON arrays through round-trip", async () => {
+      const rowId = DatasetRowId("json-arr-1")
+      const conversation = [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ]
+
+      await runCh(
+        repo.insertBatch({
+          datasetId: DATASET_ID,
+          version: 1,
+          rows: [{ id: rowId, input: conversation, output: ["a", "b"] }],
+        }),
+      )
+
+      const row = await runCh(repo.findById({ datasetId: DATASET_ID, rowId }))
+
+      expect(row.input).toEqual(conversation)
+      expect(row.output).toEqual(["a", "b"])
+    })
+
+    it("preserves scalar number and boolean values through round-trip", async () => {
+      const rowId = DatasetRowId("json-scalar-1")
+
+      await runCh(
+        repo.insertBatch({
+          datasetId: DATASET_ID,
+          version: 1,
+          rows: [{ id: rowId, input: 42, output: true }],
+        }),
+      )
+
+      const row = await runCh(repo.findById({ datasetId: DATASET_ID, rowId }))
+
+      expect(row.input).toBe(42)
+      expect(row.output).toBe(true)
+    })
   })
 
   describe("findById", () => {

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.test.ts
@@ -310,6 +310,23 @@ describe("DatasetRowClickHouseRepository", () => {
       expect(row.output).toEqual(["a", "b"])
     })
 
+    it("preserves empty arrays through round-trip without collapsing to ''", async () => {
+      const rowId = DatasetRowId("json-empty-arr-1")
+
+      await runCh(
+        repo.insertBatch({
+          datasetId: DATASET_ID,
+          version: 1,
+          rows: [{ id: rowId, input: [], output: { key: "value" } }],
+        }),
+      )
+
+      const row = await runCh(repo.findById({ datasetId: DATASET_ID, rowId }))
+
+      expect(row.input).toEqual([])
+      expect(row.output).toEqual({ key: "value" })
+    })
+
     it("preserves scalar number and boolean values through round-trip", async () => {
       const rowId = DatasetRowId("json-scalar-1")
 

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
@@ -6,8 +6,7 @@ import { parseCHDate, safeParseJson, safeStringifyJson } from "@repo/utils"
 import { Effect, Layer } from "effect"
 
 const serializeField = (value: unknown): string => {
-  // Collapse empty plain objects to "" — but NOT empty arrays, which must
-  // round-trip back as [] rather than an empty string.
+  // Collapse empty plain objects to "", but not empty arrays (must round-trip as []).
   if (
     value !== null &&
     typeof value === "object" &&

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
@@ -6,7 +6,14 @@ import { parseCHDate, safeParseJson, safeStringifyJson } from "@repo/utils"
 import { Effect, Layer } from "effect"
 
 const serializeField = (value: unknown): string => {
-  if (value !== null && typeof value === "object" && Object.keys(value as Record<string, unknown>).length === 0) {
+  // Collapse empty plain objects to "" — but NOT empty arrays, which must
+  // round-trip back as [] rather than an empty string.
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  ) {
     return ""
   }
   return safeStringifyJson(value)

--- a/packages/sdk/typescript/src/api/resources/datasets/client/requests/InsertDatasetRowsBody.ts
+++ b/packages/sdk/typescript/src/api/resources/datasets/client/requests/InsertDatasetRowsBody.ts
@@ -32,19 +32,19 @@ export namespace InsertDatasetRowsBody {
             /**
              * Row input cell.
              */
-            export type Input = string | Record<string, unknown> | number | boolean;
+            export type Input = string | number | boolean | unknown[] | Record<string, unknown>;
             /**
              * Row output cell.
              */
-            export type Output = string | Record<string, unknown> | number | boolean;
+            export type Output = string | number | boolean | unknown[] | Record<string, unknown>;
             /**
              * Correct answer for this row. Filled in by curators; usually distinct from `output`.
              */
-            export type ExpectedOutput = string | Record<string, unknown> | number | boolean;
+            export type ExpectedOutput = string | number | boolean | unknown[] | Record<string, unknown>;
             /**
              * Row metadata cell.
              */
-            export type Metadata = string | Record<string, unknown> | number | boolean;
+            export type Metadata = string | number | boolean | unknown[] | Record<string, unknown>;
         }
     }
 }

--- a/packages/sdk/typescript/src/api/types/DatasetRow.ts
+++ b/packages/sdk/typescript/src/api/types/DatasetRow.ts
@@ -5,13 +5,13 @@ export interface DatasetRow {
     rowId: string;
     /** Dataset this row belongs to. */
     datasetId: string;
-    /** Free-form cell value. Either a plain string or an arbitrary JSON object. */
+    /** Free-form cell value: any JSON scalar, array, or object. */
     input: DatasetRow.Input;
-    /** Free-form cell value. Either a plain string or an arbitrary JSON object. */
+    /** Free-form cell value: any JSON scalar, array, or object. */
     output: DatasetRow.Output;
     /** The correct answer for this row. Curators fill this in by hand; it is not derived from `output`. */
     expectedOutput: DatasetRow.ExpectedOutput;
-    /** Free-form cell value. Either a plain string or an arbitrary JSON object. */
+    /** Free-form cell value: any JSON scalar, array, or object. */
     metadata: DatasetRow.Metadata;
     /** ISO-8601 timestamp at which the row was inserted. */
     createdAt: string;
@@ -21,19 +21,19 @@ export interface DatasetRow {
 
 export namespace DatasetRow {
     /**
-     * Free-form cell value. Either a plain string or an arbitrary JSON object.
+     * Free-form cell value: any JSON scalar, array, or object.
      */
-    export type Input = string | Record<string, unknown>;
+    export type Input = string | number | boolean | unknown[] | Record<string, unknown>;
     /**
-     * Free-form cell value. Either a plain string or an arbitrary JSON object.
+     * Free-form cell value: any JSON scalar, array, or object.
      */
-    export type Output = string | Record<string, unknown>;
+    export type Output = string | number | boolean | unknown[] | Record<string, unknown>;
     /**
      * The correct answer for this row. Curators fill this in by hand; it is not derived from `output`.
      */
-    export type ExpectedOutput = string | Record<string, unknown>;
+    export type ExpectedOutput = string | number | boolean | unknown[] | Record<string, unknown>;
     /**
-     * Free-form cell value. Either a plain string or an arbitrary JSON object.
+     * Free-form cell value: any JSON scalar, array, or object.
      */
-    export type Metadata = string | Record<string, unknown>;
+    export type Metadata = string | number | boolean | unknown[] | Record<string, unknown>;
 }

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -107,12 +107,7 @@ export function safeParseJson(
   if (value === "") return fallback === "string" ? "" : {}
 
   try {
-    return (JSON.parse(value || "{}") ?? {}) as
-      | string
-      | number
-      | boolean
-      | Record<string, unknown>
-      | unknown[]
+    return (JSON.parse(value || "{}") ?? {}) as string | number | boolean | Record<string, unknown> | unknown[]
   } catch {
     return fallback === "string" ? value : {}
   }

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -103,11 +103,16 @@ export function formatDuration(ns: number): string {
 export function safeParseJson(
   value: string,
   { fallback = "object" }: { fallback?: "object" | "string" } = {},
-): string | Record<string, unknown> {
+): string | number | boolean | Record<string, unknown> | unknown[] {
   if (value === "") return fallback === "string" ? "" : {}
 
   try {
-    return (JSON.parse(value || "{}") ?? {}) as Record<string, unknown>
+    return (JSON.parse(value || "{}") ?? {}) as
+      | string
+      | number
+      | boolean
+      | Record<string, unknown>
+      | unknown[]
   } catch {
     return fallback === "string" ? value : {}
   }


### PR DESCRIPTION
## TL;DR

`listDatasetRows` crashed with `MCP error -32602: Output validation error` whenever a
dataset cell held a JSON **array** (e.g. a conversation history). The MCP/OpenAPI schema
only allowed `string | object`, but cells can round-trip out of ClickHouse as any JSON
value. Widened the schema to accept the full set and aligned the read/insert contracts.

## Problem

Dataset cells are stored as strings in ClickHouse and parsed back via `safeParseJson` on
read. That parser faithfully returns whatever JSON was stored — including arrays, numbers,
and booleans — but `RowFieldValueSchema` only permitted `string | record`. The MCP SDK
validates a tool's `structuredContent` against this schema, so any row with an array cell
made `listDatasetRows` fail validation.

The root cause was **schema drift**: the insert schema already accepted
`number | boolean | null`, but the read schema didn't — so numbers and booleans were
latent crashes waiting for a different user, not just arrays.

## Fix

- Widened the cell value schema to `string | number | boolean | array | object` in three
  places that must agree: the domain entity, the OpenAPI/MCP entity, and the `safeParseJson`
  return type.
- Defined insert as `read + null` so the two schemas can't drift apart again.
- Regenerated `openapi.json` and `mcp.json`.
- `null` still round-trips to `""` (existing `serializeField` behaviour) — left as-is and
  documented in a code comment.

## Tests

- **Schema test** (`dataset-row.test.ts`): validates the exact schema the MCP SDK uses
  against string/number/boolean/array/object cells.
- **ClickHouse round-trip test**: proves arrays and scalar number/boolean survive
  insert → storage → read.
