### PR TITLE
docs: serve license badge from self-hosted JSON

### DIFF
--- a/.github/badges/license.json
+++ b/.github/badges/license.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "license",
+  "message": "MIT",
+  "color": "blue"
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/latitude-dev/latitude-llm/blob/main/LICENSE"><img src="https://img.shields.io/github/license/latitude-dev/latitude-llm?color=blue" alt="License"></a>
+  <a href="https://github.com/latitude-dev/latitude-llm/blob/main/LICENSE"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/latitude-dev/latitude-llm/development/.github/badges/license.json" alt="License"></a>
   <a href="https://github.com/latitude-dev/latitude-llm/actions/workflows/deploy.yml"><img src="https://img.shields.io/github/actions/workflow/status/latitude-dev/latitude-llm/deploy.yml?branch=development&label=build" alt="Build"></a>
   <a href="https://github.com/latitude-dev/latitude-llm/graphs/commit-activity" target="_blank"><img alt="Commits last month" src="https://img.shields.io/github/commit-activity/m/latitude-dev/latitude-llm?labelColor=%20%2332b583&color=%20%2312b76a"></a>
   <a href="https://www.npmjs.com/org/latitude-data"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/latitude-dev/latitude-llm/development/.github/badges/npm-downloads.json&logo=npm&logoColor=white" alt="npm downloads"></a>


### PR DESCRIPTION
## Summary
- The license badge used shields.io's `github/license` endpoint, which relies on shields.io's shared GitHub API token pool. When that pool is rate-limited, the badge renders as `invalid` (the same class of failure as the `Unable to select next GitHub token from pool` error seen on the stars badge).
- The license is static (MIT), so this serves it from a self-hosted `.github/badges/license.json` endpoint — the same pattern already used for the npm and pypi download badges — removing the external dependency entirely.
- No workflow needed since the value never changes.

## Test plan
- [ ] After merge to `development`, confirm the License badge in the README renders `MIT` (the shields endpoint reads `raw.githubusercontent.com/.../development/.github/badges/license.json`).