### PR TITLE
fix(monitors): leading-edge throttle + savedSearch.threshold notification rendering [LAT-630]

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/index.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/renderers/incident/index.tsx
@@ -16,10 +16,10 @@ import { IssueRegressedNotification } from "./issue-regressed.tsx"
 import { SavedSearchIncidentNotification } from "./saved-search.tsx"
 
 /**
- * Notification kinds map 1:1 to lifecycle events:
- * - `incident.event`  → one-shot (issue.new, issue.regressed, savedSearch.match, savedSearch.threshold)
- * - `incident.opened` → sustained start (issue.escalating, savedSearch.escalating)
- * - `incident.closed` → sustained close (issue.escalating, savedSearch.escalating)
+ * Notification kinds map to lifecycle events:
+ * - `incident.event`  → one-shot (issue.new, issue.regressed, savedSearch.match, and savedSearch.threshold in `absolute` mode — a point-in-time breach)
+ * - `incident.opened` → sustained start (issue.escalating, savedSearch.escalating, and savedSearch.threshold in `multiplier`/`expected` mode — these open with `endedAt = null` and close later)
+ * - `incident.closed` → sustained close (issue.escalating, savedSearch.escalating, savedSearch.threshold multiplier/expected)
  */
 export type IncidentEvent = "event" | "opened" | "closed"
 
@@ -59,7 +59,9 @@ const renderOpened = (notification: NotificationRecord, payload: IncidentOpenedP
   if (payload.incidentKind === "issue.escalating") {
     return <IssueEscalatingNotification notification={notification} payload={payload} event="opened" />
   }
-  if (payload.incidentKind === "savedSearch.escalating") {
+  // savedSearch.threshold in `multiplier`/`expected` mode is sustained (opens with `endedAt = null`),
+  // so it lands here alongside savedSearch.escalating. (`absolute` mode is one-shot → incident.event.)
+  if (payload.incidentKind === "savedSearch.escalating" || payload.incidentKind === "savedSearch.threshold") {
     return <SavedSearchIncidentNotification notification={notification} payload={payload} event="opened" />
   }
   // Eventful kinds shouldn't land as opened; defensive fallback.
@@ -70,7 +72,8 @@ const renderClosed = (notification: NotificationRecord, payload: IncidentClosedP
   if (payload.incidentKind === "issue.escalating") {
     return <IssueEscalatingNotification notification={notification} payload={payload} event="closed" />
   }
-  if (payload.incidentKind === "savedSearch.escalating") {
+  // savedSearch.threshold in `multiplier`/`expected` mode is sustained, so its close lands here too.
+  if (payload.incidentKind === "savedSearch.escalating" || payload.incidentKind === "savedSearch.threshold") {
     return <SavedSearchIncidentNotification notification={notification} payload={payload} event="closed" />
   }
   // Eventful kinds shouldn't land as closed; defensive fallback.

--- a/apps/workers/src/workers/monitors.ts
+++ b/apps/workers/src/workers/monitors.ts
@@ -86,11 +86,11 @@ export const createMonitorsWorker = ({
       ),
     sweepSavedSearchMonitors: () =>
       sweepSavedSearchMonitorsUseCase({
-        // Same throttled key as trace-end so both triggers coalesce into one check per project.
+        // Same leading-edge throttle + key as trace-end so both triggers coalesce into one check per project.
         publish: (target) =>
           publisher.publish("monitors", "checkSavedSearchMonitors", target, {
             dedupeKey: savedSearchMonitorsCheckDedupeKey(target),
-            throttleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
+            leadingThrottleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
           }),
       }).pipe(
         withPostgres(MonitorRepositoryLive, adminPgClient),

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -234,6 +234,8 @@ export const runTraceEndJob =
       })
 
       // Saved-search firing check, throttled to one run per project per 5 min.
+      // Leading-edge: runs immediately so its trailing evaluation window covers
+      // the traces that triggered it, instead of sliding 5 min past them.
       yield* publisher
         .publish(
           "monitors",
@@ -244,7 +246,7 @@ export const runTraceEndJob =
               organizationId: payload.organizationId,
               projectId: payload.projectId,
             }),
-            throttleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
+            leadingThrottleMs: SAVED_SEARCH_MONITORS_THROTTLE_MS,
           },
         )
         .pipe(

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -5,7 +5,12 @@
  */
 export const SAVED_SEARCH_CURRENT_WINDOW_MS = 5 * 60 * 1000
 
-/** Trace-end throttle for the per-project `checkSavedSearchMonitors` publish: at most one run per 5 min per project. */
+/**
+ * Leading-edge throttle window for the per-project `checkSavedSearchMonitors` publish:
+ * the first publish runs immediately, then at most one run per 5 min per project. Leading
+ * (not trailing) so the check's trailing evaluation window still covers the traces that
+ * triggered it — a `throttleMs` delay would slide that window 5 min past the burst.
+ */
 export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 5 * 60 * 1000
 
 /** Per-project `checkSavedSearchMonitors` dedupe key, shared by trace-end + the sweep so the two triggers coalesce into one throttled check stream. */

--- a/packages/domain/queue/src/index.ts
+++ b/packages/domain/queue/src/index.ts
@@ -89,7 +89,7 @@ export interface PublishOptions {
    * of quiet on this `dedupeKey`. Appropriate when you want to wait for a
    * stream of events to settle (e.g. `trace-end:run` after `TracesIngested`).
    *
-   * Mutually exclusive with `throttleMs` and `latestThrottleMs`.
+   * Mutually exclusive with `throttleMs`, `latestThrottleMs` and `leadingThrottleMs`.
    */
   readonly debounceMs?: number
   /**
@@ -101,7 +101,7 @@ export interface PublishOptions {
    * when you want a predictable "at most once per N" cadence even under a
    * constant flow of publishes (e.g. annotation-driven alignment refresh).
    *
-   * Requires `dedupeKey`. Mutually exclusive with `debounceMs` and `latestThrottleMs`.
+   * Requires `dedupeKey`. Mutually exclusive with `debounceMs`, `latestThrottleMs` and `leadingThrottleMs`.
    */
   readonly throttleMs?: number
   /**
@@ -111,9 +111,25 @@ export interface PublishOptions {
    * upper bound of `latestThrottleMs` on fire latency from the first publish,
    * while using the latest payload seen in that window.
    *
-   * Requires `dedupeKey`. Mutually exclusive with `debounceMs` and `throttleMs`.
+   * Requires `dedupeKey`. Mutually exclusive with `debounceMs`, `throttleMs` and `leadingThrottleMs`.
    */
   readonly latestThrottleMs?: number
+  /**
+   * Leading-edge throttle window in ms. The first publish fires the task
+   * *immediately* (no delay), then suppresses subsequent publishes for
+   * `leadingThrottleMs` per `dedupeKey` (clock not extended, payload not
+   * replaced). Same "at most once per N" rate as `throttleMs`, but the run
+   * happens at the *start* of the window instead of the end.
+   *
+   * Use this when the task evaluates a trailing time window ending at run
+   * time: with `throttleMs` the `throttleMs` delay slides that window past
+   * the very activity that triggered the publish, so a discrete burst can be
+   * missed (the saved-search monitor firing check). Firing on the leading
+   * edge keeps the triggering activity inside the evaluated window.
+   *
+   * Requires `dedupeKey`. Mutually exclusive with `debounceMs`, `throttleMs` and `latestThrottleMs`.
+   */
+  readonly leadingThrottleMs?: number
   /**
    * Total attempts BullMQ should make before the job is considered failed
    * (inclusive of the first try). Set alongside `backoff` to get bounded

--- a/packages/platform/queue-bullmq/src/adapter.test.ts
+++ b/packages/platform/queue-bullmq/src/adapter.test.ts
@@ -45,6 +45,21 @@ describe("buildBullMqJobOptions", () => {
     expect(opts.deduplication).toEqual({ id: "k", ttl: 2_000, extend: false, replace: true })
   })
 
+  // Leading-edge throttle: fire immediately (no delay), then drop re-adds for the window.
+  // The TTL marker rate-limits like throttle, but the run lands at the start of the window
+  // so a trailing-window evaluation still covers the activity that triggered it.
+  it("does NOT set a custom jobId or delay for a leading-throttle publish; drops re-adds via deduplication", () => {
+    const opts = buildBullMqJobOptions(LABEL, { dedupeKey: "org:1:monitors:check:proj-2", leadingThrottleMs: 300_000 })
+    expect(opts.jobId).toBeUndefined()
+    expect(opts.delay).toBeUndefined()
+    expect(opts.deduplication).toEqual({
+      id: "org:1:monitors:check:proj-2",
+      ttl: 300_000,
+      extend: false,
+      replace: false,
+    })
+  })
+
   it("maps attempts + exponential backoff", () => {
     const opts = buildBullMqJobOptions(LABEL, { attempts: 3, backoff: { type: "exponential", delayMs: 1_000 } })
     expect(opts.attempts).toBe(3)
@@ -55,10 +70,14 @@ describe("buildBullMqJobOptions", () => {
     expect(() => buildBullMqJobOptions(LABEL, { dedupeKey: "k", throttleMs: 1, debounceMs: 1 })).toThrow(
       /mutually exclusive/,
     )
+    expect(() => buildBullMqJobOptions(LABEL, { dedupeKey: "k", leadingThrottleMs: 1, throttleMs: 1 })).toThrow(
+      /mutually exclusive/,
+    )
   })
 
-  it("requires a dedupeKey for throttle / latest-throttle", () => {
+  it("requires a dedupeKey for throttle / latest-throttle / leading-throttle", () => {
     expect(() => buildBullMqJobOptions(LABEL, { throttleMs: 1 })).toThrow(/require a dedupeKey/)
     expect(() => buildBullMqJobOptions(LABEL, { latestThrottleMs: 1 })).toThrow(/require a dedupeKey/)
+    expect(() => buildBullMqJobOptions(LABEL, { leadingThrottleMs: 1 })).toThrow(/require a dedupeKey/)
   })
 })

--- a/packages/platform/queue-bullmq/src/adapter.ts
+++ b/packages/platform/queue-bullmq/src/adapter.ts
@@ -37,14 +37,22 @@ const toSafeJobId = (dedupeKey: string): string => base64urlEncode(dedupeKey)
  * Throws on mutually-exclusive or incomplete coalescing options.
  */
 export const buildBullMqJobOptions = (label: string, options?: PublishOptions): Record<string, unknown> => {
-  const coalescingOptions = [options?.debounceMs, options?.throttleMs, options?.latestThrottleMs].filter(
-    (value) => value !== undefined,
-  )
+  const coalescingOptions = [
+    options?.debounceMs,
+    options?.throttleMs,
+    options?.latestThrottleMs,
+    options?.leadingThrottleMs,
+  ].filter((value) => value !== undefined)
   if (coalescingOptions.length > 1) {
-    throw new Error(`${label}: debounceMs, throttleMs and latestThrottleMs are mutually exclusive`)
+    throw new Error(`${label}: debounceMs, throttleMs, latestThrottleMs and leadingThrottleMs are mutually exclusive`)
   }
-  if ((options?.throttleMs !== undefined || options?.latestThrottleMs !== undefined) && !options.dedupeKey) {
-    throw new Error(`${label}: throttleMs and latestThrottleMs require a dedupeKey`)
+  if (
+    (options?.throttleMs !== undefined ||
+      options?.latestThrottleMs !== undefined ||
+      options?.leadingThrottleMs !== undefined) &&
+    !options.dedupeKey
+  ) {
+    throw new Error(`${label}: throttleMs, latestThrottleMs and leadingThrottleMs require a dedupeKey`)
   }
 
   const bullmqOptions: Record<string, unknown> = {}
@@ -58,12 +66,17 @@ export const buildBullMqJobOptions = (label: string, options?: PublishOptions): 
   //     exactly `throttleMs` after the first publish.
   //   - latest-throttle: `extend: false, replace: true` — the first publish
   //     sets the fire time, later publishes update the payload only.
+  //   - leading-throttle: same flags as throttle (`extend: false, replace: false`)
+  //     but with NO delay — the first publish fires immediately and the TTL
+  //     marker drops re-adds for the window. The run lands at the *start* of the
+  //     window, so a trailing-window evaluation still covers the triggering activity.
   const delayMs = options?.debounceMs ?? options?.throttleMs ?? options?.latestThrottleMs
+  const isCoalescing = delayMs !== undefined || options?.leadingThrottleMs !== undefined
   // Custom jobId is for bare-dedupeKey idempotency only. Coalescing relies on the
   // TTL-based `deduplication` marker instead — a jobId would be retained by
   // removeOnComplete and shadow later publishes, so a recurring throttle/debounce would
   // fire once and go dormant.
-  if (options?.dedupeKey && delayMs === undefined) {
+  if (options?.dedupeKey && !isCoalescing) {
     bullmqOptions.jobId = toSafeJobId(options.dedupeKey)
   }
   if (delayMs !== undefined) {
@@ -77,6 +90,13 @@ export const buildBullMqJobOptions = (label: string, options?: PublishOptions): 
         extend: extendsWindow,
         replace: replacesPayload,
       }
+    }
+  } else if (options?.leadingThrottleMs !== undefined && options?.dedupeKey) {
+    bullmqOptions.deduplication = {
+      id: options.dedupeKey,
+      ttl: options.leadingThrottleMs,
+      extend: false,
+      replace: false,
     }
   }
   if (options?.attempts !== undefined && options.attempts > 0) {


### PR DESCRIPTION
## Summary

Two related monitors/incidents fixes, found while exhaustively testing the monitors & incidents surface through the Latitude MCP.

### 1. `fix(monitors)` — leading-edge throttle for the saved-search firing check

The per-project `checkSavedSearchMonitors` publish used `throttleMs`, which in the BullMQ adapter maps to a `delay` of `throttleMs` **plus** a TTL dedup marker. So the first publish ran 5 minutes *later* and then evaluated a **trailing** 5-minute window that had already slid past the traces that triggered it. Net effect: a discrete burst into a previously-idle project opened **no** `savedSearch.match` / `.threshold` / `.escalating` incident (all trailing-window modes), even though the saved search clearly matched. (`threshold.absolute` was unaffected — its window is cumulative since alert creation.)

**Fix:** add a `leadingThrottleMs` publish option — **no `delay`**, plus a TTL dedup marker (`extend:false, replace:false`) that drops re-adds for the window — and switch both the trace-end and the `*/5` sweep publishers to it. The check now runs at the **start** of the window, so its trailing evaluation covers the triggering activity. Same "at most once per 5 min per project" rate.

### 2. `fix(web)` — render `savedSearch.threshold` sustained incident notifications

`savedSearch.threshold` in `multiplier`/`expected` mode opens a **sustained** incident (`endedAt = null`), so it emits `incident.opened` / `incident.closed` notifications. The in-app incident renderer's `renderOpened` / `renderClosed` only routed `issue.escalating` and `savedSearch.escalating`, so these fell through to the **"Unsupported notification"** fallback in the bell. Route `savedSearch.threshold` through `SavedSearchIncidentNotification` in the opened/closed paths too (it already supports those events). `threshold.absolute` is point-in-time (`incident.event`) and was already handled. Email and Slack templates were already correct (lookup-map + humanizer / `sourceType` branch).

## Verification

- **Live MCP, previously-idle project + one-shot burst (no trickle):** now opens `savedSearch.match`, `savedSearch.escalating`, and `savedSearch.threshold` (`absolute`, `multiplier`, `expected`) incidents, each attributed to its monitor — the exact case that produced nothing before. Issue-pipeline (`issue.new`) attribution and the per-monitor/incident output schemas all still validate.
- **Unit:** `@platform/queue-bullmq` 29 passed; typechecks pass for `@domain/queue`, `@platform/queue-bullmq`, `@domain/monitors`, `@app/workers`, `@app/web`.

## Known follow-up (NOT in this PR)

`savedSearch.escalating` (and `threshold` multiplier/expected) currently **open immediately** when the windowed count first crosses the threshold — the `window` is the rolling count window + the dwell-before-close, not a pre-fire "stay-crossed-for-the-whole-window" gate. The schema description ("opens only when the threshold stays crossed for the whole window") and the "sustained for at least N minutes" copy imply a pending/debounce gate that isn't implemented. A follow-up will add a `pendingSince` open-gate (symmetric to the existing close-dwell) so transient spikes are filtered before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
