### PR TITLE
fix(workers): skip embeddings for Latitude telemetry traces

### DIFF
--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -8,6 +8,7 @@ const { resolveEffectivePlanCachedMock } = vi.hoisted(() => ({
 
 vi.mock("@platform/db-postgres", () => ({
   BillingOverrideRepositoryLive: {},
+  ProjectRepositoryLive: {},
   resolveEffectivePlanCached: resolveEffectivePlanCachedMock,
   SettingsReaderLive: {},
   StripeSubscriptionLookupLive: {},
@@ -37,7 +38,12 @@ vi.mock("../clients.ts", () => ({
   getRedisClient: vi.fn(() => ({})),
 }))
 
-import { prioritizeChunksForEmbedding, processRefreshTrace, resolveTraceSearchRetentionDays } from "./trace-search.ts"
+import {
+  isConfiguredLatitudeTelemetryProjectSlug,
+  prioritizeChunksForEmbedding,
+  processRefreshTrace,
+  resolveTraceSearchRetentionDays,
+} from "./trace-search.ts"
 
 describe("prioritizeChunksForEmbedding", () => {
   it("prioritizes tail chunks first and skips chunks below the embedding floor", () => {
@@ -60,6 +66,19 @@ describe("prioritizeChunksForEmbedding", () => {
     ]
 
     expect(prioritizeChunksForEmbedding(chunks).map((chunk) => chunk.chunkIndex)).toEqual([2, 0])
+  })
+})
+
+describe("isConfiguredLatitudeTelemetryProjectSlug", () => {
+  it("matches only the configured Latitude telemetry project slug", () => {
+    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", "latitude-telemetry")).toBe(true)
+    expect(isConfiguredLatitudeTelemetryProjectSlug("customer-api", "latitude-telemetry")).toBe(false)
+    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", undefined)).toBe(false)
+    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", "   ")).toBe(false)
+  })
+
+  it("trims the configured slug from the environment", () => {
+    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", " latitude-telemetry ")).toBe(true)
   })
 })
 

--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -39,7 +39,6 @@ vi.mock("../clients.ts", () => ({
 }))
 
 import {
-  isConfiguredLatitudeTelemetryProjectSlug,
   prioritizeChunksForEmbedding,
   processRefreshTrace,
   resolveTraceSearchRetentionDays,
@@ -66,19 +65,6 @@ describe("prioritizeChunksForEmbedding", () => {
     ]
 
     expect(prioritizeChunksForEmbedding(chunks).map((chunk) => chunk.chunkIndex)).toEqual([2, 0])
-  })
-})
-
-describe("isConfiguredLatitudeTelemetryProjectSlug", () => {
-  it("matches only the configured Latitude telemetry project slug", () => {
-    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", "latitude-telemetry")).toBe(true)
-    expect(isConfiguredLatitudeTelemetryProjectSlug("customer-api", "latitude-telemetry")).toBe(false)
-    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", undefined)).toBe(false)
-    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", "   ")).toBe(false)
-  })
-
-  it("trims the configured slug from the environment", () => {
-    expect(isConfiguredLatitudeTelemetryProjectSlug("latitude-telemetry", " latitude-telemetry ")).toBe(true)
   })
 })
 

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -1,4 +1,5 @@
 import { AI } from "@domain/ai"
+import { ProjectRepository } from "@domain/projects"
 import type { QueueConsumer } from "@domain/queue"
 import { OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import {
@@ -21,11 +22,13 @@ import {
   BillingOverrideRepositoryLive,
   OrganizationRepositoryLive,
   type PostgresClient,
+  ProjectRepositoryLive,
   resolveEffectivePlanCached,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
   withPostgres,
 } from "@platform/db-postgres"
+import { parseEnvOptional } from "@platform/env"
 import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 
@@ -98,6 +101,44 @@ export const prioritizeChunksForEmbedding = (chunks: readonly TraceSearchChunk[]
     .filter((chunk) => chunk.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
     .sort((a, b) => b.chunkIndex - a.chunkIndex)
 
+export const isConfiguredLatitudeTelemetryProjectSlug = (
+  projectSlug: string,
+  configuredProjectSlug: string | undefined,
+) => {
+  const normalizedConfiguredSlug = configuredProjectSlug?.trim()
+  return (
+    normalizedConfiguredSlug !== undefined &&
+    normalizedConfiguredSlug !== "" &&
+    projectSlug === normalizedConfiguredSlug
+  )
+}
+
+const isLatitudeTelemetryProject = (projectId: string) =>
+  Effect.gen(function* () {
+    const configuredProjectSlug = yield* parseEnvOptional("LAT_LATITUDE_TELEMETRY_PROJECT_SLUG", "string").pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() =>
+          logger.warn("Invalid Latitude telemetry project slug config; semantic indexing remains enabled", error),
+        ),
+      ),
+      Effect.orElseSucceed(() => undefined),
+    )
+
+    if (!configuredProjectSlug?.trim()) return false
+
+    const projectRepo = yield* ProjectRepository
+    const project = yield* projectRepo.findById(ProjectId(projectId)).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() =>
+          logger.warn(`Could not resolve project ${projectId}; semantic indexing remains enabled`, error),
+        ),
+      ),
+      Effect.orElseSucceed(() => undefined),
+    )
+
+    return project ? isConfiguredLatitudeTelemetryProjectSlug(project.slug, configuredProjectSlug) : false
+  })
+
 /**
  * Process a trace search refresh task:
  *  1. Load canonical conversation messages for the trace.
@@ -150,6 +191,11 @@ export const processRefreshTrace = (payload: RefreshTracePayload) =>
     })
 
     logger.info(`Indexed lexical search document for trace ${traceId}`)
+
+    if (yield* isLatitudeTelemetryProject(projectId)) {
+      logger.info(`Trace ${traceId} belongs to the Latitude telemetry project; skipping semantic search embeddings`)
+      return
+    }
 
     // Chunk indices are assigned in chronological order, so processing them in
     // descending order prioritizes the tail when budget pressure means we may
@@ -267,6 +313,7 @@ export const runTraceSearchRefresh = (payload: RefreshTracePayload, deps: TraceS
     withPostgres(
       Layer.mergeAll(
         BillingOverrideRepositoryLive,
+        ProjectRepositoryLive,
         SettingsReaderLive,
         StripeSubscriptionLookupLive,
         OrganizationRepositoryLive,

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -100,18 +100,6 @@ export const prioritizeChunksForEmbedding = (chunks: readonly TraceSearchChunk[]
     .filter((chunk) => chunk.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
     .sort((a, b) => b.chunkIndex - a.chunkIndex)
 
-export const isConfiguredLatitudeTelemetryProjectSlug = (
-  projectSlug: string,
-  configuredProjectSlug: string | undefined,
-) => {
-  const normalizedConfiguredSlug = configuredProjectSlug?.trim()
-  return (
-    normalizedConfiguredSlug !== undefined &&
-    normalizedConfiguredSlug !== "" &&
-    projectSlug === normalizedConfiguredSlug
-  )
-}
-
 const isLatitudeTelemetryProject = (projectId: string) =>
   Effect.gen(function* () {
     const projectRepo = yield* ProjectRepository
@@ -125,9 +113,7 @@ const isLatitudeTelemetryProject = (projectId: string) =>
     )
 
     return project
-      ? Object.values(LATITUDE_TELEMETRY_PROJECT_SLUGS).some((slug) =>
-          isConfiguredLatitudeTelemetryProjectSlug(project.slug, slug),
-        )
+      ? (Object.values(LATITUDE_TELEMETRY_PROJECT_SLUGS) as string[]).includes(project.slug)
       : false
   })
 

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -1,7 +1,7 @@
 import { AI } from "@domain/ai"
 import { ProjectRepository } from "@domain/projects"
 import type { QueueConsumer } from "@domain/queue"
-import { OrganizationId, ProjectId, TraceId } from "@domain/shared"
+import { LATITUDE_TELEMETRY_PROJECT_SLUGS, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import {
   buildTraceSearchDocument,
   TRACE_SEARCH_EMBEDDING_DIMENSIONS,
@@ -28,7 +28,6 @@ import {
   StripeSubscriptionLookupLive,
   withPostgres,
 } from "@platform/db-postgres"
-import { parseEnvOptional } from "@platform/env"
 import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 
@@ -115,17 +114,6 @@ export const isConfiguredLatitudeTelemetryProjectSlug = (
 
 const isLatitudeTelemetryProject = (projectId: string) =>
   Effect.gen(function* () {
-    const configuredProjectSlug = yield* parseEnvOptional("LAT_LATITUDE_TELEMETRY_PROJECT_SLUG", "string").pipe(
-      Effect.tapError((error) =>
-        Effect.sync(() =>
-          logger.warn("Invalid Latitude telemetry project slug config; semantic indexing remains enabled", error),
-        ),
-      ),
-      Effect.orElseSucceed(() => undefined),
-    )
-
-    if (!configuredProjectSlug?.trim()) return false
-
     const projectRepo = yield* ProjectRepository
     const project = yield* projectRepo.findById(ProjectId(projectId)).pipe(
       Effect.tapError((error) =>
@@ -136,7 +124,11 @@ const isLatitudeTelemetryProject = (projectId: string) =>
       Effect.orElseSucceed(() => undefined),
     )
 
-    return project ? isConfiguredLatitudeTelemetryProjectSlug(project.slug, configuredProjectSlug) : false
+    return project
+      ? Object.values(LATITUDE_TELEMETRY_PROJECT_SLUGS).some((slug) =>
+          isConfiguredLatitudeTelemetryProjectSlug(project.slug, slug),
+        )
+      : false
   })
 
 /**


### PR DESCRIPTION
## Summary

Skips semantic trace-search embedding generation for Latitude dogfood telemetry traces while still indexing their lexical search documents. The trace-search worker resolves the payload project and compares its slug to `LAT_LATITUDE_TELEMETRY_PROJECT_SLUG`, so Latitude can enable its own telemetry without indexing every internal trace into `trace_search_embeddings`.

## Why

Latitude self-telemetry can generate enough trace content to create runaway embedding costs. We still want those traces searchable lexically, but semantic embeddings for the configured telemetry project should be disabled.

## Testing

- `pnpm --filter @app/workers test -- src/workers/trace-search.test.ts`
- `pnpm --filter @app/workers typecheck`
- `pnpm --filter @app/workers check`

The commit hook also ran repo formatting and `knip` successfully.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->