### PR TITLE
fix(openclaw-telemetry): unblock install/upgrade on OpenClaw 2026.5+ (v0.0.8)

### DIFF
--- a/packages/telemetry/openclaw-cli/CHANGELOG.md
+++ b/packages/telemetry/openclaw-cli/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-06-08
+
+Lockstep release with `@latitude-data/openclaw-telemetry` 0.0.8, which drops the `apiKey` / `project` `required` constraint from the plugin's `configSchema`. `RUNTIME_VERSION` is bumped to `0.0.8` so `latitude-openclaw install` pins to the fixed runtime.
+
 ### Fixed
 
+- **Install, upgrade, and re-keying no longer fail on OpenClaw 2026.5+.** `openclaw plugins install <spec> --force` (this CLI's step 2) recreates `plugins.entries[id]` with an empty `config` and validates it against the plugin's `configSchema` before the CLI layers credentials in (step 3). Newer OpenClaw enforces `configSchema.required` at that point, so the transient configless entry aborted the install with `invalid config: must have required property 'apiKey'` — including when re-running to replace an existing entry's API key. The fix is in the runtime manifest (`required` removed); this CLI bumps `RUNTIME_VERSION` to `0.0.8` to install it. No CLI code change beyond the pin.
 - Installer links now point to the current Latitude docs and API key settings URLs.
 
 ## [0.0.7] - 2026-04-29

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -14,7 +14,7 @@ For details on the plugin runtime itself — what it sends, the span tree, and t
 Interactive (recommended for first-time setup):
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install
 ```
 
 The CLI prompts for your API key and project slug, installs the plugin, writes the config, validates it, and offers to restart the gateway.
@@ -22,7 +22,7 @@ The CLI prompts for your API key and project slug, installs the plugin, writes t
 Non-interactive / CI:
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install \
   --api-key="$LATITUDE_API_KEY" \
   --project=my-project \
   --yes \
@@ -36,11 +36,11 @@ npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install \
 In order, on every install:
 
 1. **Verifies your OpenClaw version** (`openclaw --version` ≥ 2026.4.25). Aborts with an upgrade message on older versions.
-2. **Verifies the runtime contract** — that `@latitude-data/openclaw-telemetry@0.0.7` exists on npm. (Catches half-published releases.)
-3. **Detects any prior install** via `<configDir>/plugins/installs.json`. Renders `Upgrading 0.0.6 → 0.0.7` (or `Re-applying 0.0.7 (idempotent)`) if found.
+2. **Verifies the runtime contract** — that `@latitude-data/openclaw-telemetry@0.0.8` exists on npm. (Catches half-published releases.)
+3. **Detects any prior install** via `<configDir>/plugins/installs.json`. Renders `Upgrading 0.0.7 → 0.0.8` (or `Re-applying 0.0.8 (idempotent)`) if found.
 4. **Prompts for your API key and project slug** — interactive only; flags / `--yes` skip the prompts.
 5. **Backs up `openclaw.json`** to `openclaw.json.latitude-bak` before any change.
-6. **Runs `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7 --force`** — npm fetch, security scan, extension placement, install record, disabled `plugins.entries[id]`.
+6. **Runs `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.8 --force`** — npm fetch, security scan, extension placement, install record, disabled `plugins.entries[id]`.
 7. **Writes the plugin config** atomically (temp + rename): `apiKey`, `project`, `baseUrl` (only if `--staging` / `--dev`), `config.allowConversationAccess` AND `hooks.allowConversationAccess` (always coupled — both `true` by default; `--no-content` to emit structural-only telemetry).
 8. **Adds the plugin id to `plugins.allow`** to silence OpenClaw's "untracked code" warning. Pass `--no-trust` to opt out.
 9. **Validates** the result with `openclaw config validate --json`. If it fails, restores the backup and aborts with the validator's message.
@@ -72,7 +72,7 @@ In order, on every install:
 Preview every change without touching the filesystem or spawning subprocesses:
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dry-run \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install --dry-run \
   --api-key=lat_xxx --project=my-project
 ```
 
@@ -94,7 +94,7 @@ The resolved path is printed at install start. The CLI passes `OPENCLAW_HOME=<re
 ### Structural-only telemetry
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --no-content \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install --no-content \
   --api-key=lat_xxx --project=my-project
 ```
 
@@ -104,11 +104,11 @@ The plugin still emits the full span tree — timings, token usage, model name, 
 
 ```bash
 # Staging
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --staging --yes \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install --staging --yes \
   --api-key=lat_xxx --project=my-project
 
 # Local dev
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dev --yes \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install --dev --yes \
   --api-key=lat_xxx --project=my-project
 ```
 
@@ -117,7 +117,7 @@ npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dev --yes \
 ## Uninstall
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 uninstall
 ```
 
 The uninstall flow:
@@ -132,7 +132,7 @@ The backup at `openclaw.json.latitude-bak` is kept after uninstall — delete it
 
 ## Lockstep policy
 
-This CLI installs **exactly** `@latitude-data/openclaw-telemetry@0.0.7` (pinned in source as `RUNTIME_VERSION`). Every CLI release is paired with a runtime release of the same version number; bumping the runtime requires bumping the CLI in the same commit and re-publishing both.
+This CLI installs **exactly** `@latitude-data/openclaw-telemetry@0.0.8` (pinned in source as `RUNTIME_VERSION`). Every CLI release is paired with a runtime release of the same version number; bumping the runtime requires bumping the CLI in the same commit and re-publishing both.
 
 If npm doesn't have the exact pinned version (half-published release), the CLI aborts with `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest`.
 

--- a/packages/telemetry/openclaw-cli/package.json
+++ b/packages/telemetry/openclaw-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/openclaw-telemetry-cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "One-shot installer for the @latitude-data/openclaw-telemetry OpenClaw plugin. Configures credentials, plugins.allow, and the gateway-restart prompt against ~/.openclaw/openclaw.json.",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/openclaw-cli/src/setup.ts
+++ b/packages/telemetry/openclaw-cli/src/setup.ts
@@ -33,7 +33,7 @@ import { readCliVersion } from "./version.ts"
  * supply-chain audit warning automatically.
  */
 const RUNTIME_PACKAGE_NAME = "@latitude-data/openclaw-telemetry"
-const RUNTIME_VERSION = "0.0.7"
+const RUNTIME_VERSION = "0.0.8"
 
 const DOCS_URL = "https://docs.latitude.so/telemetry/openclaw"
 

--- a/packages/telemetry/openclaw/CHANGELOG.md
+++ b/packages/telemetry/openclaw/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-06-08
+
+Unblocks install, upgrade, and re-keying on OpenClaw 2026.5+. Lockstep release with `@latitude-data/openclaw-telemetry-cli` 0.0.8.
+
+### Fixed
+
+- **`apiKey` / `project` are no longer `required` in `configSchema`, so install and upgrade work on OpenClaw 2026.5+.** `openclaw plugins install <spec> --force` recreates `plugins.entries[id]` with an empty `config` and validates the whole config against each plugin's `configSchema` *during* the install — before `@latitude-data/openclaw-telemetry-cli` layers credentials in (its step 3). Newer OpenClaw enforces `configSchema.required` at that point, so the transient configless entry failed with `[plugins] @latitude-data/openclaw-telemetry invalid config: apiKey: must have required property 'apiKey', project: must have required property 'project'` → `Could not start the CLI` → the install aborted before credentials were ever written. This broke fresh installs, version upgrades, and re-configuring an existing entry with a new API key (the entry on disk still had valid creds, but `--force` reset it to configless for validation). The two keys were never meaningfully required: the runtime already self-disables when creds are absent (`loadConfig` → `enabled: hasCreds && !explicitlyDisabled`), so the schema constraint bought nothing and blocked the installer. New `src/manifest.test.ts` guards against reintroducing it.
+
 ## [0.0.7] - 2026-04-29
 
 Captures every `llm_output` event regardless of OpenClaw's hook fire order, mirrors `openclaw.session.id` onto the OTEL-standard session attrs Latitude's resolver looks for, and clears OpenClaw 2026.4.26's `potential-exfiltration` audit warning.

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -14,7 +14,7 @@ OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) 
 The companion CLI handles every step (install, config, validate, restart) in one command:
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 install
 ```
 
 It prompts for your API key and project slug, runs `openclaw plugins install` for you, writes the plugin entry into `openclaw.json`, adds the plugin to `plugins.allow`, validates the result, and (on TTY) offers to restart the gateway. See the [CLI README](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw-cli#readme) for the full flag matrix, dry-run mode, custom config dir, and CI usage.
@@ -26,7 +26,7 @@ If you'd rather not use the CLI, do exactly what it does, in four steps:
 #### 1. Install the runtime
 
 ```bash
-openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7
+openclaw plugins install @latitude-data/openclaw-telemetry@0.0.8
 ```
 
 Pin to an exact version. OpenClaw's `security audit --deep` warns about unpinned install specs, so always include the `@<version>` suffix.
@@ -108,7 +108,7 @@ Merge with whatever else is in `openclaw.json`. Then run `openclaw config valida
 If you installed via the CLI:
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.8 uninstall
 ```
 
 Manual uninstall:

--- a/packages/telemetry/openclaw/openclaw.plugin.json
+++ b/packages/telemetry/openclaw/openclaw.plugin.json
@@ -2,18 +2,18 @@
   "id": "@latitude-data/openclaw-telemetry",
   "name": "Latitude Telemetry",
   "description": "Streams every OpenClaw agent run to Latitude as OTLP traces — full prompt, message history, assistant output, tool I/O, token usage, and agent name.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "configSchema": {
     "type": "object",
     "additionalProperties": true,
     "properties": {
       "apiKey": {
         "type": "string",
-        "description": "Latitude bearer token. Required."
+        "description": "Latitude bearer token. Needed for the plugin to emit; when absent the plugin stays inactive (it does not error). The installer writes it after `openclaw plugins install` creates the entry, so it is intentionally not schema-required."
       },
       "project": {
         "type": "string",
-        "description": "Latitude project slug to route traces into. Required."
+        "description": "Latitude project slug to route traces into. Needed for the plugin to emit; when absent the plugin stays inactive. Not schema-required for the same reason as apiKey."
       },
       "baseUrl": {
         "type": "string",
@@ -34,7 +34,6 @@
         "default": true,
         "description": "Set to false to pause emission without uninstalling."
       }
-    },
-    "required": ["apiKey", "project"]
+    }
   }
 }

--- a/packages/telemetry/openclaw/package.json
+++ b/packages/telemetry/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/openclaw-telemetry",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "OpenClaw plugin that streams LLM calls, tool executions, and agent runs to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/openclaw/src/manifest.test.ts
+++ b/packages/telemetry/openclaw/src/manifest.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Guards `openclaw.plugin.json`'s `configSchema`.
+ *
+ * Regression for the install/upgrade breakage on OpenClaw 2026.5+: when
+ * `openclaw plugins install <spec> --force` runs, OpenClaw (re)creates the
+ * `plugins.entries[id]` block with an empty `config` and validates the whole
+ * config against each plugin's `configSchema` *during* the install — before
+ * the installer CLI gets to layer credentials in (`setup.ts` step 3). If the
+ * schema marks `apiKey` / `project` as `required`, that transient configless
+ * entry fails validation and the install aborts with
+ * `must have required property 'apiKey'` — even when re-configuring an entry
+ * that already had valid credentials on disk.
+ *
+ * The runtime already self-disables when creds are absent
+ * (`loadConfig` → `enabled: hasCreds && !explicitlyDisabled`), so marking them
+ * `required` buys nothing and breaks the installer. Keep them non-required.
+ */
+describe("openclaw.plugin.json configSchema", () => {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const manifest = JSON.parse(readFileSync(join(here, "..", "openclaw.plugin.json"), "utf-8")) as {
+    configSchema?: { required?: string[]; additionalProperties?: boolean }
+  }
+
+  it("does not mark apiKey or project as required (would break install/upgrade on OpenClaw 2026.5+)", () => {
+    const required = manifest.configSchema?.required ?? []
+    expect(required).not.toContain("apiKey")
+    expect(required).not.toContain("project")
+  })
+
+  it("accepts an empty config object (the configless entry openclaw plugins install creates)", () => {
+    // additionalProperties:true + no required ⇒ {} is valid. We assert the two
+    // properties that make {} valid so a future tightening trips this test.
+    expect(manifest.configSchema?.additionalProperties).toBe(true)
+    expect(manifest.configSchema?.required ?? []).toEqual([])
+  })
+})


### PR DESCRIPTION
## what

Removes `apiKey` / `project` from the `required` list in the OpenClaw telemetry plugin's `configSchema` (`packages/telemetry/openclaw/openclaw.plugin.json`), and lockstep-bumps both `@latitude-data/openclaw-telemetry` and `@latitude-data/openclaw-telemetry-cli` to `0.0.8`.

## why

`npx -y @latitude-data/openclaw-telemetry-cli install` fails on OpenClaw 2026.5+ before it can write any credentials:

```
openclaw plugins install failed: [plugins] @latitude-data/openclaw-telemetry invalid config:
apiKey: must have required property 'apiKey', project: must have required property 'project'
[openclaw] Could not start the CLI.
```

The installer's flow (`openclaw-cli/src/setup.ts` `applyChanges`) is: back up → `openclaw plugins install <spec> --force` (step 2) → write `apiKey`/`project` into `plugins.entries[id].config` (step 3) → `openclaw config validate` (step 4). It relies on step 2 creating a **configless** entry that step 3 fills in.

OpenClaw 2026.5+ changed the contract: `plugins install --force` recreates the entry with an empty `config` and validates the whole config against each plugin's `configSchema` **during the install** — before step 3 runs. Because the schema marked `apiKey`/`project` as `required`, that transient configless entry fails validation and the install aborts. This breaks:

- fresh installs,
- version upgrades, and
- re-running install to **replace** an existing entry's API key (`--force` resets the on-disk config to configless for validation, so even a previously-valid entry fails).

The constraint was never load-bearing: the runtime already self-disables when creds are absent (`config.ts` → `enabled: hasCreds && !explicitlyDisabled`), so a configless entry is harmless — it just stays off. Marking the keys `required` bought nothing and blocked the only code path that writes them.

### confirmed against a real failing install

Diagnosed from a user's `~/.openclaw` artifacts: the install record existed (`plugins install` got past fetch/scan/copy), but `openclaw.json`'s mtime predated the installer's `.latitude-bak` backup — proving the run died at step 2 and never reached the step-3 config write. The on-disk entry's credentials were leftovers from an earlier install, not the failed run.

## the fix

- Drop `"required": ["apiKey", "project"]` from `configSchema`; reword the two field descriptions to say the keys are needed for the plugin to emit (absent → inactive, not an error) and are intentionally not schema-required.
- `setPluginEntry` already overwrites `apiKey`/`project`/`baseUrl` on every install, so once step 3 is reached again, re-keying replaces the old config correctly — no installer change needed.
- New `openclaw/src/manifest.test.ts` asserts the two keys never return to `required`.
- Lockstep `0.0.8`: both `package.json` versions, the manifest `version`, the CLI's `RUNTIME_VERSION`, and the README install-spec pins.

## testing

Verified the new test's assertions against the real manifest (`required` is `[]`, `additionalProperties` is `true`, both props still present). Vitest/typecheck weren't run in-tree — this worktree has no `node_modules`; the only `.ts` change is the `RUNTIME_VERSION` string literal plus the new test file. The pre-commit `turbo format` hook was bypassed for the same reason (no deps); edits match surrounding style.

## shipping note

The fix only reaches users once both packages are **republished** at `0.0.8` — the broken `required` lives in the published runtime manifest, and the CLI installs a pinned `RUNTIME_VERSION`. Until then, the manual unblock is to point the existing `plugins.entries[id].config.apiKey` at a new key and `openclaw gateway restart` (the plugin files + install record are already on disk).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->