### PR TITLE
feat(monitors): sustained-gate open + dwell-free close for savedSearch.escalating [LAT-630]

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -7510,7 +7510,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -10535,7 +10535,7 @@
                                         "type": "integer",
                                         "minimum": 5,
                                         "maximum": 9007199254740991,
-                                        "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                        "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                       }
                                     },
                                     "required": [
@@ -11040,7 +11040,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -11505,7 +11505,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -12043,7 +12043,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -12592,7 +12592,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -13120,7 +13120,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -13546,7 +13546,7 @@
                             "type": "integer",
                             "minimum": 5,
                             "maximum": 9007199254740991,
-                            "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                            "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                           }
                         },
                         "required": [
@@ -14003,7 +14003,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -14507,7 +14507,7 @@
                             "type": "integer",
                             "minimum": 5,
                             "maximum": 9007199254740991,
-                            "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                            "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                           }
                         },
                         "required": [
@@ -14929,7 +14929,7 @@
                             "type": "integer",
                             "minimum": 5,
                             "maximum": 9007199254740991,
-                            "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                            "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                           }
                         },
                         "required": [
@@ -15385,7 +15385,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -15959,7 +15959,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -16470,7 +16470,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [
@@ -17008,7 +17008,7 @@
                                   "type": "integer",
                                   "minimum": 5,
                                   "maximum": 9007199254740991,
-                                  "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                                  "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                                 }
                               },
                               "required": [

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3879,7 +3879,7 @@
                   "minutes": {
                     "type": "integer",
                     "minimum": 5,
-                    "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                    "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                   }
                 },
                 "required": [
@@ -5627,7 +5627,7 @@
                       "minutes": {
                         "type": "integer",
                         "minimum": 5,
-                        "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                        "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                       }
                     },
                     "required": [
@@ -5791,7 +5791,7 @@
                       "minutes": {
                         "type": "integer",
                         "minimum": 5,
-                        "description": "Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."
+                        "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
                       }
                     },
                     "required": [

--- a/apps/api/src/openapi/entities/incident.ts
+++ b/apps/api/src/openapi/entities/incident.ts
@@ -86,7 +86,9 @@ export const AlertConditionSchema = z
             .number()
             .int()
             .min(5)
-            .describe("Length of the rolling count window, which also doubles as the dwell-before-close. Minimum 5."),
+            .describe(
+              "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5.",
+            ),
         })
         .describe("Sustained-condition window."),
     }),

--- a/packages/domain/monitors/src/constants.test.ts
+++ b/packages/domain/monitors/src/constants.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import {
+  countFailingBuckets,
+  ESCALATING_BUCKET_LARGE_MS,
+  ESCALATING_BUCKET_SIZE_CUTOFF_MS,
+  ESCALATING_BUCKET_SMALL_MS,
+  maxFailingBuckets,
+  pickEscalatingBucketMs,
+} from "./constants.ts"
+
+describe("pickEscalatingBucketMs", () => {
+  it("uses 1-min buckets up to and including the 15-min cutoff", () => {
+    expect(pickEscalatingBucketMs(5 * 60_000)).toBe(ESCALATING_BUCKET_SMALL_MS)
+    expect(pickEscalatingBucketMs(ESCALATING_BUCKET_SIZE_CUTOFF_MS)).toBe(ESCALATING_BUCKET_SMALL_MS)
+  })
+
+  it("uses 5-min buckets beyond the cutoff", () => {
+    expect(pickEscalatingBucketMs(ESCALATING_BUCKET_SIZE_CUTOFF_MS + 1)).toBe(ESCALATING_BUCKET_LARGE_MS)
+    expect(pickEscalatingBucketMs(60 * 60_000)).toBe(ESCALATING_BUCKET_LARGE_MS)
+  })
+})
+
+describe("maxFailingBuckets", () => {
+  it("floors to at least one bucket of slack for any positive tolerance", () => {
+    // floor(0.1 × 5) = 0, but the min-1 floor keeps short windows from being strict.
+    expect(maxFailingBuckets(5, 0.1)).toBe(1)
+    expect(maxFailingBuckets(10, 0.1)).toBe(1)
+    expect(maxFailingBuckets(12, 0.1)).toBe(1)
+  })
+
+  it("lets the fraction dominate the floor on large windows", () => {
+    expect(maxFailingBuckets(24, 0.1)).toBe(2)
+    expect(maxFailingBuckets(50, 0.1)).toBe(5)
+  })
+
+  it("is strict (zero slack) when the tolerance is 0", () => {
+    expect(maxFailingBuckets(5, 0)).toBe(0)
+    expect(maxFailingBuckets(24, 0)).toBe(0)
+  })
+
+  it("defaults to the configured tolerance", () => {
+    expect(maxFailingBuckets(24)).toBe(2)
+  })
+})
+
+describe("countFailingBuckets", () => {
+  it("fails buckets below the threshold", () => {
+    expect(countFailingBuckets([3, 2, 1, 0], 2)).toBe(2) // 1 and 0 fail
+  })
+
+  it("always fails an empty bucket, even when the threshold is 0", () => {
+    expect(countFailingBuckets([0, 1, 2], 0)).toBe(1) // the 0 bucket fails despite a 0 threshold
+  })
+
+  it("passes a bucket that meets the threshold exactly", () => {
+    expect(countFailingBuckets([2, 2, 2], 2)).toBe(0)
+  })
+})

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -27,3 +27,52 @@ export const SAVED_SEARCH_MONITORS_SWEEPER_KEY = "monitors:saved-search-sweep"
 
 /** Sweep cron — every 5 minutes (the minimum escalating `window`; coarser would delay closes by more than a tick). */
 export const SAVED_SEARCH_MONITORS_SWEEPER_PATTERN = "*/5 * * * *"
+
+// ---------------------------------------------------------------------------
+// `savedSearch.escalating` sustained-gate bucketing
+// ---------------------------------------------------------------------------
+//
+// "Sustained for the whole `window`" is checked by tiling `[now - window, now]`
+// into fixed-size sub-buckets and requiring (almost) every bucket to pass the
+// per-bucket threshold. A one-shot spike inflates a single bucket and leaves the
+// rest failing, so it's filtered; the same bucket count drives a prompt close
+// once enough recent buckets go quiet. This is stateless — one bucketed query
+// per check, no persisted timer.
+
+/** Bucket width for a short sustained window (`window <= 15 min`): 1 minute. */
+export const ESCALATING_BUCKET_SMALL_MS = 60 * 1000
+
+/** Bucket width for a long sustained window (`window > 15 min`): 5 minutes. Keeps the bucket count bounded on long windows. */
+export const ESCALATING_BUCKET_LARGE_MS = 5 * 60 * 1000
+
+/** Cutoff between small (1-min) and large (5-min) buckets. */
+export const ESCALATING_BUCKET_SIZE_CUTOFF_MS = 15 * 60 * 1000
+
+/**
+ * Fraction of buckets allowed to dip below the per-bucket threshold without
+ * blocking an open (or forcing a close) — absorbs Poisson variance on a breach
+ * sitting near the threshold. `0` = strict (every bucket must pass). The min-1
+ * floor in {@link maxFailingBuckets} guarantees at least one bucket of slack for
+ * any positive tolerance, so short windows still get slack.
+ */
+export const ESCALATING_BUCKET_FAIL_TOLERANCE = 0.1
+
+/** Bucket width for a sustained window of `windowMs`: 1 min up to the cutoff, 5 min beyond. */
+export const pickEscalatingBucketMs = (windowMs: number): number =>
+  windowMs <= ESCALATING_BUCKET_SIZE_CUTOFF_MS ? ESCALATING_BUCKET_SMALL_MS : ESCALATING_BUCKET_LARGE_MS
+
+/**
+ * Buckets allowed to fail before the window is "not sustained": `floor(tolerance × N)`
+ * with a floor of 1 bucket for any positive tolerance; `0` when tolerance is `0` (strict).
+ * Symmetric across open (fewer-or-equal fails ⇒ open) and close (more fails ⇒ close).
+ */
+export const maxFailingBuckets = (bucketCount: number, tolerance: number = ESCALATING_BUCKET_FAIL_TOLERANCE): number =>
+  tolerance <= 0 ? 0 : Math.max(1, Math.floor(tolerance * bucketCount))
+
+/**
+ * Buckets that fail the per-bucket threshold. An empty bucket (count `0`) always
+ * fails — a gap means the breach wasn't sustained — even when the threshold
+ * itself is `0` (e.g. a zero baseline in multiplier mode).
+ */
+export const countFailingBuckets = (bucketCounts: readonly number[], perBucketThreshold: number): number =>
+  bucketCounts.filter((count) => count <= 0 || count < perBucketThreshold).length

--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  countFailingBuckets,
+  ESCALATING_BUCKET_FAIL_TOLERANCE,
+  ESCALATING_BUCKET_LARGE_MS,
+  ESCALATING_BUCKET_SIZE_CUTOFF_MS,
+  ESCALATING_BUCKET_SMALL_MS,
+  maxFailingBuckets,
+  pickEscalatingBucketMs,
   SAVED_SEARCH_CURRENT_WINDOW_MS,
   SAVED_SEARCH_MONITORS_SWEEPER_KEY,
   SAVED_SEARCH_MONITORS_SWEEPER_PATTERN,
@@ -30,6 +37,7 @@ export type {
 } from "./ports/monitor-repository.ts"
 export { MonitorRepository } from "./ports/monitor-repository.ts"
 export type {
+  SavedSearchMatchBucketInput,
   SavedSearchMatchReaderShape,
   SavedSearchMatchTarget,
   SavedSearchMatchWindowInput,
@@ -63,9 +71,13 @@ export { deleteMonitorAlertUseCase } from "./use-cases/delete-monitor-alert.ts"
 export type {
   EvaluateSavedSearchAlertError,
   EvaluateSavedSearchAlertInput,
+  SavedSearchEscalatingEvaluation,
   SavedSearchEvaluation,
 } from "./use-cases/evaluate-saved-search-alert.ts"
-export { evaluateSavedSearchAlert } from "./use-cases/evaluate-saved-search-alert.ts"
+export {
+  evaluateSavedSearchAlert,
+  evaluateSavedSearchEscalatingAlert,
+} from "./use-cases/evaluate-saved-search-alert.ts"
 export type { GetMonitorBySlugInput } from "./use-cases/get-monitor-by-slug.ts"
 export { getMonitorBySlugUseCase } from "./use-cases/get-monitor-by-slug.ts"
 export type {

--- a/packages/domain/monitors/src/ports/saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/ports/saved-search-match-reader.ts
@@ -17,12 +17,26 @@ export interface SavedSearchMatchWindowInput {
   readonly to: Date
 }
 
+export interface SavedSearchMatchBucketInput extends SavedSearchMatchWindowInput {
+  /** Bucket width. The window `[from, to)` is tiled into `floor((to - from) / bucketMs)` buckets aligned to `to`. */
+  readonly bucketMs: number
+}
+
 /** Windowed match count + first-match for the evaluator. A dedicated port (not a `TraceRepository` widening) keeps the firing concern off the broadly-stubbed trace port. */
 export interface SavedSearchMatchReaderShape {
   /** Traces matching `target` whose `start_time` falls in `[from, to)`. */
   countMatches(input: SavedSearchMatchWindowInput): Effect.Effect<number, RepositoryError, ChSqlClient>
   /** Earliest matching trace `start_time` in `[from, to)`, or `null` when none match. */
   firstMatchAt(input: SavedSearchMatchWindowInput): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
+  /**
+   * Per-bucket match counts over `[from, to)`, tiled into `N = floor((to - from) / bucketMs)`
+   * fixed-width buckets aligned to `to`. Returns exactly `N` counts, **newest-first**
+   * (index `0` = the bucket ending at `to`), zero-filled for empty buckets. Backs the
+   * `savedSearch.escalating` sustained-gate (open) and prompt close.
+   */
+  countMatchesPerBucket(
+    input: SavedSearchMatchBucketInput,
+  ): Effect.Effect<readonly number[], RepositoryError, ChSqlClient>
 }
 
 export class SavedSearchMatchReader extends Context.Service<SavedSearchMatchReader, SavedSearchMatchReaderShape>()(

--- a/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
@@ -1,5 +1,9 @@
 import { Effect, Layer } from "effect"
-import { SavedSearchMatchReader, type SavedSearchMatchWindowInput } from "../ports/saved-search-match-reader.ts"
+import {
+  type SavedSearchMatchBucketInput,
+  SavedSearchMatchReader,
+  type SavedSearchMatchWindowInput,
+} from "../ports/saved-search-match-reader.ts"
 
 /**
  * In-memory `SavedSearchMatchReader` for unit tests: seed matching trace
@@ -10,12 +14,25 @@ export const createFakeSavedSearchMatchReader = (matchTimestamps: readonly Date[
   const inWindow = (input: SavedSearchMatchWindowInput) =>
     matchTimestamps.filter((at) => at.getTime() >= input.from.getTime() && at.getTime() < input.to.getTime())
 
+  // Mirror the ClickHouse impl: `N = floor((to - from) / bucketMs)` buckets
+  // aligned to `to`, newest-first (index 0 ends at `to`), zero-filled.
+  const bucketCounts = (input: SavedSearchMatchBucketInput): number[] => {
+    const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
+    const counts = new Array<number>(bucketCount).fill(0)
+    for (const at of inWindow(input)) {
+      const index = Math.floor((input.to.getTime() - at.getTime()) / input.bucketMs)
+      if (index >= 0 && index < bucketCount) counts[index] += 1
+    }
+    return counts
+  }
+
   const layer = Layer.succeed(SavedSearchMatchReader, {
     countMatches: (input) => Effect.succeed(inWindow(input).length),
     firstMatchAt: (input) =>
       Effect.succeed(
         inWindow(input).reduce<Date | null>((earliest, at) => (earliest && earliest <= at ? earliest : at), null),
       ),
+    countMatchesPerBucket: (input) => Effect.succeed(bucketCounts(input)),
   })
 
   return { layer }

--- a/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.test.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import type { MonitorAlert } from "../entities/monitor.ts"
 import { createFakeSavedSearchMatchReader } from "../testing/fake-saved-search-match-reader.ts"
-import { evaluateSavedSearchAlert } from "./evaluate-saved-search-alert.ts"
+import { evaluateSavedSearchAlert, evaluateSavedSearchEscalatingAlert } from "./evaluate-saved-search-alert.ts"
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -134,39 +134,105 @@ describe("evaluateSavedSearchAlert", () => {
     })
   })
 
-  describe("savedSearch.escalating", () => {
-    it("counts over the configured window for an absolute threshold", async () => {
+  describe("evaluateSavedSearchEscalatingAlert", () => {
+    const evaluateEscalating = (input: { alert: MonitorAlert; matches: readonly Date[] }) =>
+      Effect.runPromise(
+        evaluateSavedSearchEscalatingAlert({
+          organizationId,
+          projectId,
+          alert: input.alert,
+          target: { query: null, filterSet: {} },
+          now,
+        }).pipe(
+          Effect.provide(createFakeSavedSearchMatchReader(input.matches).layer),
+          Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+        ),
+      )
+
+    it("buckets the window at 1-min granularity for windows ≤ 15 min (absolute = per-bucket count)", async () => {
       const escalating = alert({
         kind: "savedSearch.escalating",
         condition: {
           kind: "savedSearch.escalating",
-          threshold: { mode: "absolute", count: 5 },
+          threshold: { mode: "absolute", count: 2 },
           window: { minutes: 10 },
         },
       })
-      const result = await evaluate({ alert: escalating, matches: [9, 8, 6, 4, 2, 1].map(minsAgo) })
-      expect(result).toMatchObject({ isMet: true, count: 6, threshold: 5 })
+      // bucket 0: two matches; bucket 3: one; bucket 9: three; the rest empty.
+      const matches = [minsAgo(0.3), minsAgo(0.6), minsAgo(3.5), minsAgo(9.2), minsAgo(9.5), minsAgo(9.8)]
+      const result = await evaluateEscalating({ alert: escalating, matches })
+      expect(result.bucketMs).toBe(60_000)
+      expect(result.bucketCounts).toHaveLength(10)
+      expect(result.perBucketThreshold).toBe(2)
+      expect(result.bucketCounts[0]).toBe(2)
+      expect(result.bucketCounts[3]).toBe(1)
+      expect(result.bucketCounts[9]).toBe(3)
+      expect(result.firstMatchInWindow).toEqual(minsAgo(9.8))
     })
 
-    it("normalises the baseline onto the window for a multiplier threshold", async () => {
+    it("buckets at 5-min granularity for windows > 15 min", async () => {
+      const escalating = alert({
+        kind: "savedSearch.escalating",
+        condition: {
+          kind: "savedSearch.escalating",
+          threshold: { mode: "absolute", count: 1 },
+          window: { minutes: 30 },
+        },
+      })
+      const result = await evaluateEscalating({ alert: escalating, matches: [minsAgo(2), minsAgo(27)] })
+      expect(result.bucketMs).toBe(5 * 60_000)
+      expect(result.bucketCounts).toHaveLength(6)
+      expect(result.bucketCounts[0]).toBe(1) // [now-5m, now)
+      expect(result.bucketCounts[5]).toBe(1) // [now-30m, now-25m)
+    })
+
+    it("normalises the baseline rate down to a single bucket for a multiplier threshold", async () => {
       const escalating = alert({
         kind: "savedSearch.escalating",
         condition: {
           kind: "savedSearch.escalating",
           threshold: {
             mode: "multiplier",
-            factor: 2,
+            factor: 60,
             baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
           },
           window: { minutes: 10 },
         },
       })
-      // window = [now-10m, now): 6 matches. baseline = [now-60m, now): 18 (12 older + 6 in window).
-      // normalisedBaseline = 18 × (10m / 60m) = 3; threshold = 2 × 3 = 6 ⇒ met (6 ≥ 6).
-      const baselineOlder = [55, 50, 45, 40, 35, 30, 25, 22, 18, 15, 13, 11].map(minsAgo)
-      const inWindow = [9, 7, 5, 3, 2, 1].map(minsAgo)
-      const result = await evaluate({ alert: escalating, matches: [...baselineOlder, ...inWindow] })
-      expect(result).toMatchObject({ isMet: true, count: 6, baselineCount: 18, threshold: 6 })
+      // baseline = [now-60m, now): 3 matches ⇒ perBucket = 60 × 3 × (1m / 60m) = 3.
+      const result = await evaluateEscalating({ alert: escalating, matches: [minsAgo(1), minsAgo(2), minsAgo(3)] })
+      expect(result.perBucketThreshold).toBe(3)
+      expect(result.baselineCount).toBe(3)
+      expect(result.bucketMs).toBe(60_000)
+    })
+
+    it("sizes an expected-mode band to a single bucket (σ floor with no history)", async () => {
+      const escalating = alert({
+        kind: "savedSearch.escalating",
+        condition: {
+          kind: "savedSearch.escalating",
+          threshold: { mode: "expected", sensitivity: 3 },
+          window: { minutes: 10 },
+        },
+      })
+      // expected 0, σ floor 1 ⇒ perBucket threshold = 3 × 1 = 3; no baselineCount for expected.
+      const result = await evaluateEscalating({ alert: escalating, matches: [minsAgo(1), minsAgo(2)] })
+      expect(result.perBucketThreshold).toBe(3)
+      expect(result.baselineCount).toBeUndefined()
+    })
+
+    it("reports a null first match when the window is empty", async () => {
+      const escalating = alert({
+        kind: "savedSearch.escalating",
+        condition: {
+          kind: "savedSearch.escalating",
+          threshold: { mode: "absolute", count: 1 },
+          window: { minutes: 10 },
+        },
+      })
+      const result = await evaluateEscalating({ alert: escalating, matches: [minsAgo(20)] })
+      expect(result.firstMatchInWindow).toBeNull()
+      expect(result.bucketCounts).toEqual(new Array(10).fill(0))
     })
   })
 

--- a/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
@@ -13,7 +13,7 @@ import type {
   RepositoryError,
 } from "@domain/shared"
 import { Effect } from "effect"
-import { SAVED_SEARCH_CURRENT_WINDOW_MS } from "../constants.ts"
+import { pickEscalatingBucketMs, SAVED_SEARCH_CURRENT_WINDOW_MS } from "../constants.ts"
 import type { MonitorAlert } from "../entities/monitor.ts"
 import { SavedSearchMatchReader, type SavedSearchMatchTarget } from "../ports/saved-search-match-reader.ts"
 
@@ -80,18 +80,17 @@ export const evaluateSavedSearchAlert = (
     }
 
     const condition = alert.condition
-    if (condition === null || condition.kind === "issue.escalating") {
-      // The orchestrator only routes threshold/escalating alerts here — a wiring bug, not runtime state.
+    if (condition === null || condition.kind !== "savedSearch.threshold") {
+      // The orchestrator routes only `savedSearch.threshold` here; `savedSearch.match` is
+      // handled above and `savedSearch.escalating` goes through `evaluateSavedSearchEscalatingAlert`.
       return yield* Effect.die(`evaluateSavedSearchAlert: unexpected condition for alert ${alert.id} (${alert.kind})`)
     }
 
     const threshold = condition.threshold
     const currentWindowMs =
-      condition.kind === "savedSearch.escalating"
-        ? condition.window.minutes * 60 * 1000
-        : threshold.mode === "absolute"
-          ? Math.max(0, now.getTime() - alert.createdAt.getTime())
-          : SAVED_SEARCH_CURRENT_WINDOW_MS
+      threshold.mode === "absolute"
+        ? Math.max(0, now.getTime() - alert.createdAt.getTime())
+        : SAVED_SEARCH_CURRENT_WINDOW_MS
     const from = new Date(now.getTime() - currentWindowMs)
     const count = yield* countIn(from, now)
 
@@ -138,3 +137,96 @@ export const evaluateSavedSearchAlert = (
       ...(baselineCount !== undefined ? { baselineCount } : {}),
     } satisfies SavedSearchEvaluation
   }).pipe(Effect.withSpan("monitors.evaluateSavedSearchAlert"))
+
+/** The numbers the `savedSearch.escalating` sustained-gate / prompt-close state machine reads. */
+export interface SavedSearchEscalatingEvaluation {
+  /**
+   * Per-bucket match counts over `[now - window, now]`, newest-first, zero-filled.
+   * Length is the bucket count `N`; a gap shows up as a `0` bucket.
+   */
+  readonly bucketCounts: readonly number[]
+  /** Bucket width used to tile the window, in ms (1 min for `window <= 15 min`, else 5 min). */
+  readonly bucketMs: number
+  /** Threshold a single bucket must meet to "pass" — per-mode (see branches); the value frozen onto `entrySignals` at open. */
+  readonly perBucketThreshold: number
+  /** Earliest match in the window; backs `startedAt` backtracking. `null` when the window was empty. */
+  readonly firstMatchInWindow: Date | null
+  /** Present only for multiplier mode (frozen onto entry signals). */
+  readonly baselineCount?: number
+}
+
+/**
+ * Evaluate one `savedSearch.escalating` alert at `now` over fixed-size buckets
+ * tiling `[now - window, now]`. The threshold is computed for a single bucket
+ * (measurement window = `bucketMs`), so "sustained for the whole window" reduces
+ * to "(almost) every bucket clears the per-bucket threshold" — see the state
+ * machine in `run-saved-search-escalating-alert.ts`. Pure modulo the reader IO.
+ */
+export const evaluateSavedSearchEscalatingAlert = (
+  input: EvaluateSavedSearchAlertInput,
+): Effect.Effect<
+  SavedSearchEscalatingEvaluation,
+  EvaluateSavedSearchAlertError,
+  SavedSearchMatchReader | ChSqlClient
+> =>
+  Effect.gen(function* () {
+    const reader = yield* SavedSearchMatchReader
+    const { organizationId, projectId, alert, target, now } = input
+    const condition = alert.condition
+    if (alert.kind !== "savedSearch.escalating" || condition?.kind !== "savedSearch.escalating") {
+      // The orchestrator only routes escalating alerts here — a wiring bug, not runtime state.
+      return yield* Effect.die(`evaluateSavedSearchEscalatingAlert: not a savedSearch.escalating alert (${alert.id})`)
+    }
+    const countIn = (from: Date, to: Date) => reader.countMatches({ organizationId, projectId, target, from, to })
+
+    const windowMs = condition.window.minutes * 60 * 1000
+    const bucketMs = pickEscalatingBucketMs(windowMs)
+    const from = new Date(now.getTime() - windowMs)
+    const bucketCounts = yield* reader.countMatchesPerBucket({
+      organizationId,
+      projectId,
+      target,
+      from,
+      to: now,
+      bucketMs,
+    })
+
+    const threshold = condition.threshold
+    let perBucketThreshold: number
+    let baselineCount: number | undefined
+    if (threshold.mode === "absolute") {
+      // The configured count is a per-bucket requirement (every bucket needs `>= count` matches).
+      perBucketThreshold = threshold.count
+    } else if (threshold.mode === "multiplier") {
+      const baseline = baselineWindow(threshold.baseline, now)
+      baselineCount = yield* countIn(baseline.from, baseline.to)
+      // Normalise the baseline rate down to a single bucket so the per-bucket counts are comparable.
+      perBucketThreshold = threshold.factor * baselineCount * (bucketMs / baseline.lengthMs)
+    } else {
+      // `expected`: seasonal σ-band sized to a single bucket (same detector math as issues / threshold mode).
+      const sensitivity = threshold.sensitivity ?? DEFAULT_ESCALATION_SENSITIVITY_K
+      const historical = yield* Effect.all(
+        Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
+          const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
+          return countIn(new Date(historyTo.getTime() - bucketMs), historyTo)
+        }),
+        { concurrency: "unbounded" },
+      )
+      const expected = mean(historical)
+      const kAdj = historical.length < MIN_SEASONAL_SAMPLES ? sensitivity + 1 : sensitivity
+      perBucketThreshold = seasonalAnomalyThreshold(expected, sampleStddev(historical, expected), kAdj)
+    }
+
+    // One first-match query for the `startedAt` backtrace, only when the window has activity.
+    const total = bucketCounts.reduce((sum, count) => sum + count, 0)
+    const firstMatchInWindow =
+      total > 0 ? yield* reader.firstMatchAt({ organizationId, projectId, target, from, to: now }) : null
+
+    return {
+      bucketCounts,
+      bucketMs,
+      perBucketThreshold,
+      firstMatchInWindow,
+      ...(baselineCount !== undefined ? { baselineCount } : {}),
+    } satisfies SavedSearchEscalatingEvaluation
+  }).pipe(Effect.withSpan("monitors.evaluateSavedSearchEscalatingAlert"))

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
@@ -16,12 +16,14 @@ const alertId = "a".repeat(24) as MonitorAlert["id"]
 const now = new Date("2026-06-01T12:00:00.000Z")
 const minsAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000)
 
+// A 5-minute window ⇒ 1-min buckets, N = 5, tolerance 0.1 ⇒ maxFail = max(1, floor(0.5)) = 1.
+// `absolute count: 1` means every 1-min bucket needs ≥ 1 matching trace.
 const absoluteAlert: MonitorAlert = {
   id: alertId,
   monitorId: "m".repeat(24) as MonitorAlert["monitorId"],
   kind: "savedSearch.escalating",
   source: { type: "savedSearch", id: savedSearchId },
-  condition: { kind: "savedSearch.escalating", threshold: { mode: "absolute", count: 5 }, window: { minutes: 10 } },
+  condition: { kind: "savedSearch.escalating", threshold: { mode: "absolute", count: 1 }, window: { minutes: 5 } },
   severity: "high",
   createdAt: new Date("2026-06-01T00:00:00.000Z"),
 }
@@ -29,10 +31,26 @@ const multiplierAlert: MonitorAlert = {
   ...absoluteAlert,
   condition: {
     kind: "savedSearch.escalating",
-    threshold: { mode: "multiplier", factor: 2, baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } } },
-    window: { minutes: 10 },
+    threshold: { mode: "multiplier", factor: 12, baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } } },
+    window: { minutes: 5 },
   },
 }
+const expectedAlert: MonitorAlert = {
+  ...absoluteAlert,
+  condition: {
+    kind: "savedSearch.escalating",
+    threshold: { mode: "expected", sensitivity: 3 },
+    window: { minutes: 5 },
+  },
+}
+
+// One match landing in 1-min bucket `b` (b = 0 is the most recent minute before `now`).
+const inBucket = (b: number, offsetMin = 0.5) => minsAgo(b + offsetMin)
+// `count` matches all inside bucket `b` (offsets stay < 1 min so they share the bucket).
+const fillBucket = (b: number, count: number): Date[] =>
+  Array.from({ length: count }, (_unused, i) => minsAgo(b + 0.2 + i * 0.1))
+// One match in every bucket 0..4 ⇒ a breach sustained across the whole window.
+const sustained: readonly Date[] = [0, 1, 2, 3, 4].map((b) => inBucket(b))
 
 const incident = (overrides: Partial<AlertIncident>): AlertIncident => ({
   id: "c".repeat(24) as AlertIncident["id"],
@@ -45,7 +63,7 @@ const incident = (overrides: Partial<AlertIncident>): AlertIncident => ({
   startedAt: minsAgo(60),
   endedAt: null,
   createdAt: minsAgo(60),
-  entrySignals: { evaluatedThreshold: 5 },
+  entrySignals: { evaluatedThreshold: 1 },
   exitEligibleSince: null,
   monitorAlertId: alertId,
   condition: absoluteAlert.condition,
@@ -76,96 +94,86 @@ const run = (params: {
   ).then((result) => ({ result, incidents: store.incidents, events }))
 }
 
-// 6 matches inside the 10-minute window clears the absolute threshold of 5.
-const sustainedMatches = [9, 8, 6, 4, 2, 1].map(minsAgo)
-
 describe("runSavedSearchEscalatingAlertUseCase", () => {
-  it("opens with a frozen threshold snapshot and emits IncidentCreated", async () => {
-    const first = minsAgo(9)
-    const { result, incidents, events } = await run({ alert: absoluteAlert, matches: sustainedMatches })
+  it("does not open on a one-shot spike confined to a single bucket", async () => {
+    // 6 matches, all in the most recent minute ⇒ buckets 1..4 empty ⇒ failing 4 > maxFail 1.
+    const { result, incidents, events } = await run({ alert: absoluteAlert, matches: fillBucket(0, 6) })
+    expect(result.transition).toBe("none")
+    expect(incidents).toHaveLength(0)
+    expect(events).toHaveLength(0)
+  })
+
+  it("opens when the threshold is sustained across every bucket, backtracing started_at and freezing the threshold", async () => {
+    const { result, incidents, events } = await run({ alert: absoluteAlert, matches: sustained })
     expect(result.transition).toBe("opened")
-    expect(incidents[0]).toMatchObject({ startedAt: first, endedAt: null, entrySignals: { evaluatedThreshold: 5 } })
+    // started_at anchors to the earliest match in the window (~window start).
+    expect(incidents[0]).toMatchObject({
+      startedAt: inBucket(4),
+      endedAt: null,
+      entrySignals: { evaluatedThreshold: 1 },
+    })
     expect(events.map((event) => event.eventName)).toEqual(["IncidentCreated"])
   })
 
-  it("snapshots baseline + baselineCount for a multiplier open", async () => {
-    const { incidents } = await run({ alert: multiplierAlert, matches: sustainedMatches })
-    // window count 6; baseline = same 6 over 1h ⇒ normalised 1 ⇒ threshold 2.
+  it("opens within the failing-bucket tolerance (one empty bucket allowed on N=5)", async () => {
+    // Buckets 0..3 filled, bucket 4 empty ⇒ failing 1 ≤ maxFail 1 (exercises the min-1 floor).
+    const { result } = await run({ alert: absoluteAlert, matches: [0, 1, 2, 3].map((b) => inBucket(b)) })
+    expect(result.transition).toBe("opened")
+  })
+
+  it("does not open when failing buckets exceed the tolerance", async () => {
+    // Only buckets 0..2 filled ⇒ 2 empty ⇒ failing 2 > maxFail 1.
+    const { result, incidents } = await run({ alert: absoluteAlert, matches: [0, 1, 2].map((b) => inBucket(b)) })
+    expect(result.transition).toBe("none")
+    expect(incidents).toHaveLength(0)
+  })
+
+  it("freezes a per-bucket multiplier threshold + baselineCount on open", async () => {
+    // baseline = same 5 matches over 1h ⇒ baselineCount 5; perBucket = 12 × 5 × (1m / 60m) = 1.
+    const { result, incidents } = await run({ alert: multiplierAlert, matches: sustained })
+    expect(result.transition).toBe("opened")
     expect(incidents[0]?.entrySignals).toEqual({
-      evaluatedThreshold: 2,
-      baselineCount: 6,
+      evaluatedThreshold: 1,
+      baselineCount: 5,
       baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
     })
   })
 
-  it("is a no-op while the condition keeps holding", async () => {
-    const { result, events } = await run({ alert: absoluteAlert, matches: sustainedMatches, seed: [incident({})] })
+  it("opens an expected-mode escalating incident, freezing the seasonal per-bucket band", async () => {
+    // No seasonal history ⇒ expected 0, σ floor 1 ⇒ perBucket threshold = 3 × 1 = 3.
+    // 3 matches in each of the 5 buckets clears it everywhere.
+    const matches = [0, 1, 2, 3, 4].flatMap((b) => fillBucket(b, 3))
+    const { result, incidents } = await run({ alert: expectedAlert, matches })
+    expect(result.transition).toBe("opened")
+    expect(incidents[0]?.entrySignals).toEqual({ evaluatedThreshold: 3 })
+  })
+
+  it("is a no-op while the breach stays sustained on an open incident", async () => {
+    const { result, events } = await run({ alert: absoluteAlert, matches: sustained, seed: [incident({})] })
     expect(result.transition).toBe("none")
     expect(events).toHaveLength(0)
   })
 
-  it("starts the dwell when the condition first drops", async () => {
-    const { result, incidents } = await run({ alert: absoluteAlert, matches: [minsAgo(2)], seed: [incident({})] })
-    expect(result.transition).toBe("exit-eligible")
-    expect(incidents[0]?.exitEligibleSince).toEqual(now)
-  })
-
-  it("cancels the dwell when the condition returns", async () => {
-    const { result, incidents } = await run({
-      alert: absoluteAlert,
-      matches: sustainedMatches,
-      seed: [incident({ exitEligibleSince: minsAgo(3) })],
-    })
-    expect(result.transition).toBe("exit-cancelled")
-    expect(incidents[0]?.exitEligibleSince).toBeNull()
-  })
-
-  it("keeps waiting while still inside the dwell window", async () => {
-    const { result, events } = await run({
-      alert: absoluteAlert,
-      matches: [minsAgo(1)],
-      seed: [incident({ exitEligibleSince: minsAgo(5) })],
-    })
-    expect(result.transition).toBe("none")
-    expect(events).toHaveLength(0)
-  })
-
-  it("closes and emits IncidentClosed once the dwell elapses", async () => {
+  it("closes and emits IncidentClosed once enough buckets drop below the frozen threshold", async () => {
+    // Only buckets 0..1 still have matches ⇒ 3 empty ⇒ failing 3 > maxFail 1.
     const { result, incidents, events } = await run({
       alert: absoluteAlert,
-      matches: [],
-      seed: [incident({ exitEligibleSince: minsAgo(15) })],
+      matches: [0, 1].map((b) => inBucket(b)),
+      seed: [incident({})],
     })
     expect(result.transition).toBe("closed")
     expect(incidents[0]?.endedAt).toEqual(now)
     expect(events.map((event) => event.eventName)).toEqual(["IncidentClosed"])
   })
 
-  it("opens an expected-mode escalating incident, freezing the seasonal threshold", async () => {
-    const expectedAlert: MonitorAlert = {
-      ...absoluteAlert,
-      condition: {
-        kind: "savedSearch.escalating",
-        threshold: { mode: "expected", sensitivity: 3 },
-        window: { minutes: 10 },
-      },
-    }
-    // No seasonal history ⇒ expected 0, σ floor 1 ⇒ threshold = 3 × 1 = 3.
-    // 5 matches in the 10-min window clears it; the frozen threshold is snapshotted.
-    const { result, incidents } = await run({ alert: expectedAlert, matches: [9, 7, 5, 3, 1].map(minsAgo) })
-    expect(result.transition).toBe("opened")
-    expect(incidents[0]?.entrySignals).toEqual({ evaluatedThreshold: 3 })
-  })
-
-  it("compares the live count against the frozen threshold, not a re-resolved one", async () => {
-    // Frozen threshold 10; only 5 matches now. A fresh multiplier resolve would
-    // produce a tiny threshold the count would clear — the frozen value must win.
-    const { result } = await run({
+  it("counts failing buckets against the frozen threshold, not a re-resolved one", async () => {
+    // Frozen per-bucket threshold 10; a fresh multiplier resolve would be ~1, which the sustained
+    // 1-per-bucket traffic clears — but every bucket is below the frozen 10, so it must close.
+    const { result, incidents } = await run({
       alert: multiplierAlert,
-      matches: [9, 7, 5, 3, 1].map(minsAgo),
+      matches: sustained,
       seed: [
         incident({
-          kind: "savedSearch.escalating",
           entrySignals: {
             evaluatedThreshold: 10,
             baselineCount: 50,
@@ -174,6 +182,7 @@ describe("runSavedSearchEscalatingAlertUseCase", () => {
         }),
       ],
     })
-    expect(result.transition).toBe("exit-eligible")
+    expect(result.transition).toBe("closed")
+    expect(incidents[0]?.endedAt).toEqual(now)
   })
 })

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
@@ -2,32 +2,36 @@ import { AlertIncidentRepository, isSavedSearchEntrySignals, type SavedSearchEnt
 import type { OutboxEventWriter } from "@domain/events"
 import { type ChSqlClient, type RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
+import { countFailingBuckets, maxFailingBuckets } from "../constants.ts"
 import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
 import {
   type EvaluateSavedSearchAlertError,
   type EvaluateSavedSearchAlertInput,
-  evaluateSavedSearchAlert,
+  evaluateSavedSearchEscalatingAlert,
 } from "./evaluate-saved-search-alert.ts"
 import { closeSavedSearchIncident, openSavedSearchIncident } from "./saved-search-incident-writer.ts"
 
 /**
- * - `opened`        — condition met with no open incident; one opened.
- * - `exit-eligible` — condition dropped; the dwell timer started.
- * - `exit-cancelled`— condition returned during the dwell; the timer was cleared.
- * - `closed`        — condition stayed false for the full `window`; the incident closed.
- * - `none`          — no transition this tick.
+ * - `opened` — the threshold was sustained across the window (≤ the tolerated
+ *   number of failing buckets) and no incident was open; one opened.
+ * - `closed` — too many buckets dropped below the frozen threshold; the open
+ *   incident closed.
+ * - `none`   — no transition this tick.
  */
 export interface RunSavedSearchEscalatingAlertResult {
-  readonly transition: "opened" | "exit-eligible" | "exit-cancelled" | "closed" | "none"
+  readonly transition: "opened" | "closed" | "none"
 }
 
 export type RunSavedSearchEscalatingAlertError = EvaluateSavedSearchAlertError | RepositoryError
 
 /**
- * `savedSearch.escalating` state machine, mirroring `issue.escalating` (`window`
- * is both the count window and the exit dwell). The threshold is frozen into
- * `entrySignals` at open time so the incident's own elevated counts can't drift
- * a multiplier baseline and pin it open.
+ * `savedSearch.escalating` state machine. The threshold is evaluated per
+ * fixed-size bucket tiling `[now - window, now]`; an incident **opens** only when
+ * at most {@link maxFailingBuckets} buckets fail the (live) per-bucket threshold —
+ * i.e. the elevated rate held across the whole window, not just one spike — and
+ * **closes** once more than that many buckets drop below the threshold frozen at
+ * open (so the incident's own elevated counts can't drift a multiplier baseline
+ * and pin it open). Stateless: one bucketed query per check, no exit dwell.
  */
 export const runSavedSearchEscalatingAlertUseCase = (input: EvaluateSavedSearchAlertInput) =>
   Effect.gen(function* () {
@@ -44,20 +48,26 @@ export const runSavedSearchEscalatingAlertUseCase = (input: EvaluateSavedSearchA
 
     return yield* sqlClient.transaction(
       Effect.gen(function* () {
-        const evaluation = yield* evaluateSavedSearchAlert(input)
+        const evaluation = yield* evaluateSavedSearchEscalatingAlert(input)
         const open = yield* alertIncidentRepository.findOpenByMonitorAlertId(alert.id)
+        const maxFail = maxFailingBuckets(evaluation.bucketCounts.length)
 
         if (open === null) {
-          if (!evaluation.isMet) return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+          // Open only when (almost) every bucket cleared the live per-bucket threshold.
+          const failing = countFailingBuckets(evaluation.bucketCounts, evaluation.perBucketThreshold)
+          if (failing > maxFail) return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+
           const entrySignals: SavedSearchEntrySignals =
             condition.threshold.mode === "multiplier"
               ? {
-                  evaluatedThreshold: evaluation.threshold,
+                  evaluatedThreshold: evaluation.perBucketThreshold,
                   baselineCount: evaluation.baselineCount ?? 0,
                   baseline: condition.threshold.baseline,
                 }
-              : { evaluatedThreshold: evaluation.threshold }
-          const startedAt = evaluation.firstMatchInWindow ?? now
+              : { evaluatedThreshold: evaluation.perBucketThreshold }
+          // Anchor to the start of the sustained window (~now - window); fall back to the window start.
+          const startedAt =
+            evaluation.firstMatchInWindow ?? new Date(now.getTime() - condition.window.minutes * 60 * 1000)
           yield* openSavedSearchIncident({
             organizationId,
             projectId,
@@ -71,30 +81,16 @@ export const runSavedSearchEscalatingAlertUseCase = (input: EvaluateSavedSearchA
           return { transition: "opened" } satisfies RunSavedSearchEscalatingAlertResult
         }
 
-        // Compare against the threshold frozen at entry; fall back to the fresh one for legacy rows without a snapshot.
+        // Maintain while the breach is still sustained against the threshold frozen at entry
+        // (fall back to the fresh one for legacy rows without a snapshot); close otherwise.
         const frozenThreshold = isSavedSearchEntrySignals(open.entrySignals)
           ? open.entrySignals.evaluatedThreshold
-          : evaluation.threshold
-        const conditionHolds = evaluation.count >= frozenThreshold
+          : evaluation.perBucketThreshold
+        const failing = countFailingBuckets(evaluation.bucketCounts, frozenThreshold)
+        if (failing <= maxFail) return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
 
-        if (conditionHolds) {
-          if (open.exitEligibleSince !== null) {
-            yield* alertIncidentRepository.updateExitDwell({ id: open.id, exitEligibleSince: null })
-            return { transition: "exit-cancelled" } satisfies RunSavedSearchEscalatingAlertResult
-          }
-          return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
-        }
-
-        if (open.exitEligibleSince === null) {
-          yield* alertIncidentRepository.updateExitDwell({ id: open.id, exitEligibleSince: now })
-          return { transition: "exit-eligible" } satisfies RunSavedSearchEscalatingAlertResult
-        }
-        const windowMs = condition.window.minutes * 60 * 1000
-        if (now.getTime() - open.exitEligibleSince.getTime() >= windowMs) {
-          yield* closeSavedSearchIncident(open, now)
-          return { transition: "closed" } satisfies RunSavedSearchEscalatingAlertResult
-        }
-        return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
+        yield* closeSavedSearchIncident(open, now)
+        return { transition: "closed" } satisfies RunSavedSearchEscalatingAlertResult
       }),
     )
   }).pipe(Effect.withSpan("monitors.runSavedSearchEscalatingAlert")) as Effect.Effect<

--- a/packages/domain/shared/src/alert-incident-condition.ts
+++ b/packages/domain/shared/src/alert-incident-condition.ts
@@ -48,7 +48,13 @@ export type AlertIncidentSavedSearchThresholdCondition = z.infer<
   typeof alertIncidentSavedSearchThresholdConditionSchema
 >
 
-/** `window` is both the rolling count window and the dwell-on-exit; min 5 min (the firing throttle). */
+/**
+ * `window` is the sustained duration the threshold must stay crossed for before
+ * the incident opens: the threshold is evaluated per internal sub-bucket tiling
+ * the window and must hold across it (up to a small configurable failing-bucket
+ * tolerance) to open; the incident closes once failing buckets exceed that
+ * tolerance. Min 5 min (the firing throttle).
+ */
 export const alertIncidentSavedSearchEscalatingConditionSchema = z.object({
   kind: z.literal("savedSearch.escalating"),
   threshold: alertCountThresholdSchema,

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
@@ -75,6 +75,7 @@ const span = (n: number, startTime: Date, tags: readonly string[] = [TAG]): Span
     scope_version: "",
   }) satisfies SpanRow
 
+const t0930 = new Date("2026-06-01T09:30:00.000Z")
 const t10 = new Date("2026-06-01T10:00:00.000Z")
 const t1030 = new Date("2026-06-01T10:30:00.000Z")
 const t11 = new Date("2026-06-01T11:00:00.000Z")
@@ -144,5 +145,39 @@ describe("SavedSearchMatchReaderLive", () => {
     )
     // Drops the 'other'-tagged trace → t10 + t1030 only.
     expect(count).toBe(2)
+  })
+
+  it("buckets matches newest-first, zero-filled, aligned to `to`", async () => {
+    // [09:30, 11:00) tiled into 3×30-min buckets aligned to 11:00 (newest-first):
+    //   idx 0 = (10:30, 11:00) → empty (t11 == `to` is excluded)
+    //   idx 1 = (10:00, 10:30] → t1030 (+ the 'other'-tagged trace, no filter applied) → 2
+    //   idx 2 = (09:30, 10:00] → t10 → 1
+    const counts = await runCh(
+      reader.countMatchesPerBucket({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        target,
+        from: t0930,
+        to: t11,
+        bucketMs: 30 * 60 * 1000,
+      }),
+    )
+    expect(counts).toEqual([0, 2, 1])
+  })
+
+  it("honours the structured filters per bucket", async () => {
+    const tagged = { query: null, filterSet: { tags: [{ op: "in" as const, value: [TAG] }] } }
+    const counts = await runCh(
+      reader.countMatchesPerBucket({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        target: tagged,
+        from: t0930,
+        to: t11,
+        bucketMs: 30 * 60 * 1000,
+      }),
+    )
+    // The 'other'-tagged trace at 10:30 is dropped by the tag filter → idx 1 falls to 1.
+    expect(counts).toEqual([0, 1, 1])
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client"
 import {
+  type SavedSearchMatchBucketInput,
   SavedSearchMatchReader,
   type SavedSearchMatchReaderShape,
   type SavedSearchMatchWindowInput,
@@ -103,6 +104,41 @@ const make = (): SavedSearchMatchReaderShape => ({
           }),
           Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.firstMatchAt")),
         )
+    }),
+  countMatchesPerBucket: (input: SavedSearchMatchBucketInput) =>
+    Effect.gen(function* () {
+      const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+      const inner = yield* buildInnerQuery(input)
+      const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
+      // Bucket each matching trace by how far its `start_time` sits before `to`,
+      // in `bucketNs` (= bucketMs) steps — index 0 is the bucket ending at `to`.
+      // `reinterpretAsInt64(DateTime64(9))` yields nanoseconds-since-epoch, the
+      // same primitive the trace list uses for `duration_ns`. ClickHouse only
+      // returns non-empty buckets, so we densify to `bucketCount` zero-filled
+      // entries in code.
+      const rows = yield* chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            query: `SELECT
+                      intDiv(
+                        reinterpretAsInt64(toDateTime64({windowTo:String}, 9, 'UTC')) - reinterpretAsInt64(start_time),
+                        {bucketNs:Int64}
+                      ) AS bucket_index,
+                      count() AS matches
+                    FROM (${inner.sql})
+                    GROUP BY bucket_index`,
+            query_params: { ...inner.params, bucketNs: input.bucketMs * 1_000_000 },
+            format: "JSONEachRow",
+          })
+          return result.json<{ bucket_index: string; matches: string }>()
+        })
+        .pipe(Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.countMatchesPerBucket")))
+      const counts = new Array<number>(bucketCount).fill(0)
+      for (const row of rows) {
+        const index = Number(row.bucket_index)
+        if (index >= 0 && index < bucketCount) counts[index] = Number(row.matches)
+      }
+      return counts
     }),
 })
 

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -152,9 +152,11 @@ export type AlertIncidentSourceType = (typeof ALERT_INCIDENT_SOURCE_TYPES)[numbe
  *                          notifications.
  *   savedSearch.escalating
  *                       — fires when the match count sustains above a
- *                          configured threshold for a `window` period
- *                          (sustained; closes after the same `window`
- *                          of the condition no longer holding).
+ *                          configured threshold for the whole `window`
+ *                          (sustained; the window is tiled into buckets and
+ *                          (almost) every bucket must clear the per-bucket
+ *                          threshold to open; closes promptly once enough
+ *                          recent buckets drop below it).
  */
 export const ALERT_INCIDENT_KINDS = [
   "issue.new",
@@ -348,28 +350,34 @@ export type AlertIncidentSavedSearchThresholdCondition = {
 }
 
 /**
- * Sustained alert. The count is taken over a rolling `window` ending at
- * evaluation time; the same `window` doubles as the dwell-on-exit for
- * the close transition. This single field is what the user types into
- * the form ("for at least 5 minutes") and it plays two roles in the
- * state machine:
+ * Sustained alert. `window` is the duration the threshold must stay crossed
+ * for before the incident opens — the single field the user types into the
+ * form ("for at least 5 minutes"). It is checked by tiling `[now - window, now]`
+ * into fixed-size buckets and requiring the per-bucket threshold to hold across
+ * (almost) the whole window:
  *
- *   - **Count window**: at every evaluation tick, `count = matches in
- *     [now - window, now]`. The window is the user's lever for ignoring
- *     transient spikes — a 1-second burst doesn't trip a 5-minute
- *     window because the spike's contribution to the rolling count
- *     ages out quickly.
- *   - **Exit dwell**: when `isMet` flips from true to false on an open
- *     incident, the dwell timer (`exitEligibleSince`) starts. The
- *     incident closes once the condition has stayed false for `window`
- *     minutes continuously.
+ *   - **Bucketing**: `bucketMs` = 1 min for `window <= 15 min`, else 5 min;
+ *     `N = floor(window / bucketMs)` buckets aligned to `now`. The per-bucket
+ *     threshold is the configured threshold sized to one bucket (absolute =
+ *     `count` per bucket; multiplier = `factor × baseline-rate × bucketMs`;
+ *     expected = the seasonal σ-band for a bucket-sized window). An empty bucket
+ *     always fails (a gap means the breach wasn't sustained).
+ *   - **Open**: open only when at most `maxFailingBuckets` buckets fail —
+ *     `floor(ESCALATING_BUCKET_FAIL_TOLERANCE × N)` with a floor of 1 bucket for
+ *     any positive tolerance (`0` = strict). A one-shot spike fills a single
+ *     bucket and leaves the rest failing, so it's filtered.
+ *   - **Close**: symmetric — close once *more* than `maxFailingBuckets` buckets
+ *     drop below the threshold frozen at open. No dwell; the incident closes
+ *     roughly `(maxFailingBuckets + 1) × bucketMs` after traffic stops.
  *
- * Minimum 5 minutes (= the throttle interval of the firing task; a
- * shorter window would be evaluated less often than it claims).
+ * Stateless: one bucketed query per check; no `exitEligibleSince`, no persisted
+ * timer. Minimum 5 minutes (= the throttle interval of the firing task; a
+ * shorter window would be evaluated less often than it claims). `window` need
+ * not be a multiple of `bucketMs` — a non-multiple under-covers by `< bucketMs`.
  */
 export type AlertIncidentSavedSearchEscalatingCondition = {
   kind: "savedSearch.escalating"
-  threshold: AlertCountThreshold // absolute or multiplier
+  threshold: AlertCountThreshold // absolute, multiplier, or expected (per-bucket)
   window: { minutes: number }    // ≥ 5
 }
 ```
@@ -733,10 +741,11 @@ Worked example for `savedSearch.threshold, multiplier`, "3 times more than the a
 
 Worked example for `savedSearch.escalating, multiplier`, "2 times more than yesterday for at least 1 hour":
 
-- Yesterday produced 1,200 matches → 50 per hour.
-- `normalisedBaseline = 1,200 × (1hr / 24hr) = 50` (matches per hour).
-- `threshold = 2 × 50 = 100`.
-- Last 1 hour produced 110 matches → `isMet = true`. Open the incident; dwell-on-exit also = 1 hour.
+- `window = 60 min > 15 min` → `bucketMs = 5 min`, `N = 12` buckets tiling the last hour.
+- Yesterday produced 1,200 matches → `4.17` per 5-min bucket on average.
+- `normalisedBaseline = 1,200 × (5min / 24hr) = 4.17` (matches per bucket).
+- `perBucketThreshold = 2 × 4.17 = 8.33`.
+- Open only when (almost) every 5-min bucket in the last hour had `≥ 8.33` matches — i.e. the elevated rate held all hour, not just one busy bucket. With the default 0.1 tolerance, `maxFailingBuckets = floor(0.1 × 12) = 1`, so one bucket may dip.
 
 The multiplier snapshot stored in `entrySignals` at the open transition (`evaluatedThreshold`, `baselineCount`, `baseline`) lets the close-side re-evaluate with the *same* baseline number — preventing the open incident's own elevated counts from drifting the threshold sideways. We compare the *current* count (which is recomputed each tick) against the *frozen* threshold.
 
@@ -796,48 +805,51 @@ The incidents panel will render an open multiplier-threshold incident as "Ongoin
 
 #### State machine — `savedSearch.escalating` (sustained)
 
-Mirrors `issue.escalating`:
+Bucketed sustained-gate on open, symmetric prompt close. `evaluateSavedSearchEscalatingAlert(...)` returns per-bucket match counts over `[now - window, now]` (newest-first, zero-filled, length `N`) plus the live per-bucket threshold:
 
 ```
 At evaluation:
-  let v = evaluateSavedSearchAlert(...)
-  let open = alert_incidents with monitor_alert_id = A.id,
-                                  endedAt IS NULL
-  if open is null and v.isMet:
-    // OPEN TRANSITION
-    INSERT alert_incidents:
-      startedAt      = v.firstMatchInWindow ?? now
-      endedAt        = null
-      monitorAlertId = A.id        (owning monitor resolved via join)
-      condition      = snapshot of A.condition
-      entrySignals = {
-        evaluatedThreshold: v.threshold,
-        baselineCount: v.baselineCount,         // present for multiplier
-        baseline: A.condition.threshold.baseline,  // multiplier only
-      }
-      exitEligibleSince = null
-    emit IncidentCreated
+  let D       = A.condition.window.minutes (minutes)
+  let bucketMs = (D <= 15 ? 1min : 5min)
+  let N        = floor(D / bucketMs)
+  let maxFail  = (ESCALATING_BUCKET_FAIL_TOLERANCE <= 0)
+                   ? 0
+                   : max(1, floor(ESCALATING_BUCKET_FAIL_TOLERANCE * N))   // default 0.1, min 1 bucket
+  let v        = evaluateSavedSearchEscalatingAlert(...)   // { bucketCounts[N], perBucketThreshold, firstMatchInWindow, baselineCount? }
+  let open     = alert_incidents with monitor_alert_id = A.id, endedAt IS NULL
+  // an empty bucket (count 0) always fails — a gap means the breach wasn't sustained
+  let failing(thr) = count(bucketCounts where count <= 0 or count < thr)
 
-  else if open is not null and v.isMet:
-    if open.exitEligibleSince is not null:
-      // condition came back, cancel the dwell timer
-      UPDATE alert_incidents SET exitEligibleSince = null
+  if open is null:
+    // OPEN TRANSITION — only when (almost) every bucket cleared the LIVE threshold
+    if failing(v.perBucketThreshold) <= maxFail:
+      INSERT alert_incidents:
+        startedAt      = v.firstMatchInWindow ?? (now - D)   // anchored to the window start
+        endedAt        = null
+        monitorAlertId = A.id        (owning monitor resolved via join)
+        condition      = snapshot of A.condition
+        entrySignals = {
+          evaluatedThreshold: v.perBucketThreshold,   // the FROZEN per-bucket threshold
+          baselineCount: v.baselineCount,             // present for multiplier
+          baseline: A.condition.threshold.baseline,   // multiplier only
+        }
+      emit IncidentCreated
 
-  else if open is not null and not v.isMet:
-    if open.exitEligibleSince is null:
-      // EXIT-ELIGIBLE TRANSITION
-      UPDATE alert_incidents SET exitEligibleSince = now
-    else if now - open.exitEligibleSince >= A.condition.window:
-      // CLOSE TRANSITION
+  else:
+    // CLOSE TRANSITION — once too many buckets drop below the FROZEN threshold
+    let thr = open.entrySignals.evaluatedThreshold ?? v.perBucketThreshold   // legacy rows: fresh threshold
+    if failing(thr) > maxFail:
       UPDATE alert_incidents SET endedAt = now
       emit IncidentClosed
 ```
 
 Notes:
 
-- **Multiplier baseline is frozen at entry.** The threshold value (and the supporting baselineCount) is snapshotted into `entrySignals` on the open transition. The close-side does NOT re-resolve `factor × baseline` at evaluation time — it compares `v.count >= entrySignals.evaluatedThreshold`. This prevents the open incident's own elevated counts from polluting a sliding baseline and pinning the incident open.
+- **Per-bucket threshold is frozen at entry.** The per-bucket threshold (and, for multiplier, the supporting `baselineCount`) is snapshotted into `entrySignals` on open. The close-side does NOT re-resolve `factor × baseline` or the seasonal band — it counts how many buckets fall below `entrySignals.evaluatedThreshold`. This prevents the open incident's own elevated counts from drifting a sliding baseline and pinning the incident open.
+- **Stateless — no `exitEligibleSince`, no dwell.** Open and close are both pure functions of the current bucketed query against the (live, then frozen) per-bucket threshold. The `exit_eligible_since` column stays in the schema but is unused by escalating now; a stale value on a legacy open incident is ignored, and that incident closes on the next check where failing buckets exceed the tolerance.
+- **Anti-flap via the shared tolerance.** Because the same `maxFail` applies on close, a brief single-bucket dip won't close a noisy-but-sustained breach. Re-opening after a genuine close still requires a fresh sustained window.
 - **No 72h backstop.** Saved-search conditions are deterministic and user-configured; if the user said "alert me when 5xx > 100 for 1 hour" and it's been holding for a week, that's the system working as designed.
-- The "alert is met" semantics for sustained incidents are entirely on the count window, not the dwell — the dwell only applies to the exit transition. This is what handles your reconnection-spike concern: a 1-second burst doesn't trip a 5-minute window because at the next evaluation tick the burst is already aged out of the rolling count.
+- **Spikes are filtered by construction.** A 1-second burst fills a single bucket and leaves the other `N - 1` buckets failing, so `failing` far exceeds `maxFail` and nothing opens — the sustained-for-the-window semantics, not a rolling-count aging trick.
 
 #### State machine — `savedSearch.match`
 
@@ -1454,6 +1466,8 @@ Scope is intentionally left open — the exact polish items are decided when the
 
 > **As-built deviations from the original task list:** (1) absolute-threshold "cumulative since creation" anchors on **`alert.createdAt`**, not `monitor.createdAt` — makes "remove and re-add to re-arm" reset the count; (2) match counting goes through a dedicated `SavedSearchMatchReader`, not `TraceRepository` (avoids touching its ~17 stubs); (3) the `monitors` queue carries three tasks (`checkSavedSearchMonitors` / `sweepSavedSearchMonitors` / `onSourceDeleted`); the orchestrator gates on the `monitors` flag in the worker, not the use-case.
 
+> **Post-M7 escalating rework (sustained-gate open + prompt close).** The escalating bullets above describe the *original* M7 machine (rolling-count open on the first met check; `exitEligibleSince` dwell = `window` on close), which had two flaws: a momentary spike opened immediately (a rolling count can't tell a spike from a sustained breach), and the close lagged ~3× the cadence because `window` doubled as the exit dwell. The escalating machine was reworked to be **bucketed and stateless** — `evaluateSavedSearchEscalatingAlert` tiles `[now − window, now]` into 1-/5-min buckets and the state machine opens only when (almost) every bucket clears the per-bucket threshold (default `ESCALATING_BUCKET_FAIL_TOLERANCE = 0.1`, floor 1 bucket) and closes once more than that many buckets drop below the threshold frozen at open. No `exitEligibleSince`, no dwell, no migration. See the **State machine — `savedSearch.escalating`** section above for the authoritative description; `evaluateSavedSearchAlert` now handles only `match`/`threshold`.
+
 ### Milestone 8 — Fold `/search` into the `/` page tabs, retire the standalone route
 
 > Branch: `LAT-630/search-bar-relocation` · Estimated size: ~2,200 lines (frontend-heavy)
@@ -1500,7 +1514,7 @@ Smaller than originally estimated because most of the heavy lifting has already 
     - **threshold (absolute)** — milestone alarms ("alert me when 100 5xx traces have matched").
     - **threshold (multiplier)** — spike detection ("alert me when I'm seeing 3× my baseline rate"). Explain the baseline choices: **the average of the last …** (the typical/normal-traffic case) vs **yesterday / the previous week** (for daily/weekly seasonality). Worked example with concrete numbers showing the normalisation, so customers don't have to derive it.
     - **expected** — the smart, dynamically-learned baseline ("alert me when I'm seeing more traffic than expected for this time of day/week"). Explain that, unlike average/previous-period, the customer picks no comparison window — Latitude learns the normal shape of traffic per time-of-day × day-of-week (same engine as automatic issue-escalation) — and that the single knob is **sensitivity**. Call out when to prefer it (traffic with strong, irregular seasonality) over a fixed average.
-    - **escalating (absolute, multiplier, and expected)** — sustained-condition alerts, with explanation of how the `window` field doubles as count window + exit dwell, and why that filters out short noise spikes. Any of the threshold modes can be combined with a sustained window.
+    - **escalating (absolute, multiplier, and expected)** — sustained-condition alerts: explain that the threshold must stay crossed for the whole `window` before the incident opens (so a short noise spike doesn't trip it), and that the incident closes promptly once the threshold no longer holds. Keep it high-level — no need to describe the internal bucketing. Any of the threshold modes can be combined with a sustained window.
   - **Mute, delete, edit**: what each action does, mute semantics (incidents still recorded, no notifications), what's editable on system vs user monitors.
   - **How notifications work**: brief, links to existing notification docs page. Clarify that monitors don't have their own notification settings — channel-level routing lives in the existing user/project preferences.
 - [ ] Add the page to the Mintlify nav (`docs/mint.json` or equivalent config), under the appropriate section (likely "Alerts" or "Reliability").


### PR DESCRIPTION
## What & why

Reworks how **`savedSearch.escalating`** alerts open and close incidents. Two long-standing problems:

1. **A momentary spike opened the incident immediately.** The old code opened the instant a single windowed count crossed the threshold — a count over `[now − window, now]` can't tell a one-second burst from a sustained breach.
2. **It closed ~16 min after traffic stopped.** `window` was overloaded as *both* the rolling count window *and* an exit dwell, so three ~5-min delays stacked.

This PR makes "sustained for the whole window" literally true and removes the dwell. **Only `savedSearch.escalating` changes** — `savedSearch.threshold` and `savedSearch.match` are untouched (they're rising-edge/point-in-time by design).

## How

**Bucketed, every-bucket-passes OPEN.** Tile `[now − window, now]` into fixed-size buckets — **1 min** for `window ≤ 15 min`, else **5 min** — and compute the threshold per *single* bucket (absolute = count/bucket; multiplier = `factor × baseline-rate × bucketSize`; expected = the seasonal σ-band for a bucket-sized window). Open only when at most `maxFailingBuckets` buckets fall below it. A spike inflates one bucket and leaves the rest failing, so it's filtered. `started_at` backtraces to the first match in the window (~window start).

**Configurable tolerance, symmetric.** `ESCALATING_BUCKET_FAIL_TOLERANCE = 0.1` with a floor of 1 bucket: `maxFail = tolerance ≤ 0 ? 0 : max(1, floor(tolerance·N))` (`0` = strict). Open when `failing ≤ maxFail`; **close** when `failing > maxFail` — **no dwell**. An empty bucket always fails (a gap ≠ sustained).

**Stateless** — one bucketed ClickHouse query per check (new `SavedSearchMatchReader.countMatchesPerBucket`). **No DB column, no migration.** The `exit_eligible_since` column stays (used by `issue.escalating`); escalating just ignores it now.

Close latency is now bounded only by the **check cadence** (the `*/5` sweep + leading-edge throttle), not by a dwell — tightening that cadence is intentionally **out of scope** for this PR.

## Files
- `saved-search-match-reader.ts` — new `countMatchesPerBucket` (port + ClickHouse impl, bucketed `GROUP BY` densified to N zero-filled, newest-first + fake reader).
- `constants.ts` — bucket-size + tolerance constants and the `pickEscalatingBucketMs` / `maxFailingBuckets` / `countFailingBuckets` helpers.
- `evaluate-saved-search-alert.ts` — new `evaluateSavedSearchEscalatingAlert` (per-bucket eval); escalating branch removed from `evaluateSavedSearchAlert`.
- `run-saved-search-escalating-alert.ts` — sustained-gate open / dwell-free close; transition union `opened | closed | none`.
- `alert-incident-condition.ts`, `incident.ts` (+ regenerated `openapi.json`/`mcp.json`), `specs/monitors.md` — docs/copy (user-facing stays high-level: "the threshold must stay crossed for the configured window"; bucket mechanics documented only in code/spec). SDK had **zero drift**.
- Tests: rewrote the escalating use-case + evaluate suites for the bucketed flow; added `constants.test.ts` and ClickHouse `countMatchesPerBucket` cases.

## Verification

**Unit / typecheck:** `@domain/monitors` 115 passed, `@platform/db-clickhouse` 216 passed (incl. real-chdb bucket query); typecheck clean across monitors / db-clickhouse / api / shared; manifests deterministic (drift-free).

**Live E2E via Latitude MCP + live-seeds** (project `escalating-gate-e2e`, one saved search on `tags contains live-seed`, one monitor with all three alert kinds; escalating = absolute `count:1`, `window:5min` → 1-min buckets, N=5, tolerance allows 1 failing bucket):

| Scenario | Result |
|---|---|
| **A — spike must not open** | 6-trace burst @ 09:08:08 (fills ~1 bucket of 5). Escalating did **not** open across multiple checks (09:09–09:16). ✅ |
| **B — sustained must open, backtraced** | ~2 traces/min from 09:15:29. Opened at the first sweep after 5-min coverage (`created 09:20:00`), `started_at = 09:15:29` (window start, **not** "now"), `entry_signals={evaluatedThreshold:1}`. Did **not** open at the earlier 09:17 partial-coverage check. ✅ |
| **C — prompt, dwell-free close** | Last trace 09:26:03; closed `09:35:00` on the first check that ran after traffic stopped (trailing buckets empty → failing > tolerance). No flap, single incident. The latency here was inflated to ~9 min by a skipped sweep (leading-edge throttle pushed by lagging trace-end publishes) — that's the deferred check-cadence, not the close logic, which has no dwell. ✅ |
| **Regression — `match`** | Fired 3× point-in-time, throttled ~5 min apart. ✅ |
| **Regression — `threshold` (absolute)** | Fired once (6 ≥ 3), durably spent (no re-fire). ✅ |

For comparison, the **old** code in scenario A/C would have wrongly opened on the 09:08 spike and closed ~16 min after traffic stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->