### PR TITLE
fix(billing): order usage-event inserts by conflict key to break deadlock

### DIFF
--- a/packages/platform/db-postgres/src/repositories/billing-usage-event-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/billing-usage-event-repository.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { billingUsageEvents } from "../schema/billing.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
-import { BillingUsageEventRepositoryLive } from "./billing-usage-event-repository.ts"
+import { BillingUsageEventRepositoryLive, dedupeAndOrderEventsForInsert } from "./billing-usage-event-repository.ts"
 
 const ORGANIZATION_ID = OrganizationId("o".repeat(24))
 const PROJECT_ID = ProjectId("p".repeat(24))
@@ -76,6 +76,75 @@ describe("BillingUsageEventRepositoryLive", () => {
 
     expect(found?.id).toBe(first.id)
     expect(await pg.db.select().from(billingUsageEvents)).toHaveLength(2)
+  })
+
+  // Concurrent same-period batches are written by multiple worker processes
+  // (the in-memory batcher only dedupes within one process). When two such
+  // batches shared idempotency keys but supplied them in different arrival
+  // orders, the multi-row `INSERT ... ON CONFLICT` acquired the unique-index
+  // locks in opposite orders and deadlocked. `insertMany` must therefore emit
+  // rows in a deterministic order keyed on the conflict tuple regardless of
+  // input order, so every transaction takes the locks in the same order.
+  it("orders events deterministically by (billingPeriodStart, idempotencyKey) regardless of input order", () => {
+    const a = makeEvent({ id: "a".repeat(24), idempotencyKey: "trace:org:project:a" })
+    const b = makeEvent({ id: "b".repeat(24), idempotencyKey: "trace:org:project:b" })
+    const c = makeEvent({ id: "c".repeat(24), idempotencyKey: "trace:org:project:c" })
+
+    const keysOf = (events: readonly BillingUsageEvent[]) => events.map((event) => event.idempotencyKey)
+    const expected = ["trace:org:project:a", "trace:org:project:b", "trace:org:project:c"]
+
+    // Two batches with the same keys in opposite arrival orders must converge
+    // to the identical insert order — this is the property that breaks the
+    // AB/BA deadlock cycle.
+    expect(keysOf(dedupeAndOrderEventsForInsert([c, a, b]))).toEqual(expected)
+    expect(keysOf(dedupeAndOrderEventsForInsert([b, c, a]))).toEqual(expected)
+    expect(keysOf(dedupeAndOrderEventsForInsert([a, b, c]))).toEqual(expected)
+  })
+
+  it("orders by billing period before idempotency key, and still dedupes per period", () => {
+    const nextPeriodEarlyKey = makeEvent({
+      id: "x".repeat(24),
+      idempotencyKey: "trace:org:project:a",
+      billingPeriodStart: NEXT_PERIOD_START,
+      billingPeriodEnd: NEXT_PERIOD_END,
+    })
+    const thisPeriodLateKey = makeEvent({ id: "y".repeat(24), idempotencyKey: "trace:org:project:z" })
+    const thisPeriodLateKeyDuplicate = makeEvent({ id: "z".repeat(24), idempotencyKey: "trace:org:project:z" })
+
+    const ordered = dedupeAndOrderEventsForInsert([nextPeriodEarlyKey, thisPeriodLateKeyDuplicate, thisPeriodLateKey])
+
+    // Earlier period sorts first even though its idempotency key sorts later;
+    // the duplicate within the later period collapses to a single row.
+    expect(ordered.map((event) => event.idempotencyKey)).toEqual(["trace:org:project:z", "trace:org:project:a"])
+    expect(ordered.map((event) => event.billingPeriodStart.getTime())).toEqual([
+      PERIOD_START.getTime(),
+      NEXT_PERIOD_START.getTime(),
+    ])
+  })
+
+  it("persists the identical ledger when the same keys arrive in opposite batch orders", async () => {
+    const a = makeEvent({ id: "a".repeat(24), idempotencyKey: "trace:org:project:a" })
+    const b = makeEvent({ id: "b".repeat(24), idempotencyKey: "trace:org:project:b" })
+    const c = makeEvent({ id: "c".repeat(24), idempotencyKey: "trace:org:project:c" })
+
+    const insertedForward = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* BillingUsageEventRepository
+        return yield* repo.insertMany([a, b, c])
+      }),
+    )
+    expect(insertedForward).toBe(3)
+
+    // A concurrent batch carrying the same keys in reverse must be a no-op
+    // (all conflicts), not a second set of rows.
+    const insertedReverse = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* BillingUsageEventRepository
+        return yield* repo.insertMany([c, b, a])
+      }),
+    )
+    expect(insertedReverse).toBe(0)
+    expect(await pg.db.select().from(billingUsageEvents)).toHaveLength(3)
   })
 
   it("allows an idempotency key to be reused in a different billing period", async () => {

--- a/packages/platform/db-postgres/src/repositories/billing-usage-event-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/billing-usage-event-repository.ts
@@ -33,7 +33,27 @@ const toInsertRow = (event: BillingUsageEvent): typeof billingUsageEvents.$infer
   billingPeriodEnd: event.billingPeriodEnd,
 })
 
-const uniqueByPeriodAndIdempotencyKey = (events: readonly BillingUsageEvent[]): readonly BillingUsageEvent[] => {
+/**
+ * Dedupe a batch of usage events by their conflict-target tuple
+ * `(billingPeriodStart, idempotencyKey)` — the columns of the
+ * `billing_usage_events_period_idempotency_key_idx` unique index — and return
+ * them in a deterministic order keyed on that same tuple.
+ *
+ * The ordering matters for concurrency, not just tidiness. `insertMany` issues
+ * a single multi-row `INSERT ... ON CONFLICT DO NOTHING`, and Postgres acquires
+ * the unique-index locks row-by-row in the order rows are supplied. Trace usage
+ * is flushed by an in-memory batcher that only dedupes within one worker
+ * process, so the same org/period is written concurrently by multiple workers.
+ * When two such batches shared idempotency keys but supplied them in different
+ * arrival orders, they grabbed the index locks in opposite orders and deadlocked
+ * each other (Postgres "deadlock detected", observed on the `billing` queue).
+ *
+ * Sorting by the conflict key before insert makes every concurrent transaction
+ * take the locks in the same order, so the AB/BA cycle is impossible. The order
+ * only has to be *consistent* across transactions — it need not match the btree
+ * collation — so a plain value sort is sufficient.
+ */
+export const dedupeAndOrderEventsForInsert = (events: readonly BillingUsageEvent[]): readonly BillingUsageEvent[] => {
   const eventsByKey = new Map<string, BillingUsageEvent>()
 
   for (const event of events) {
@@ -43,7 +63,13 @@ const uniqueByPeriodAndIdempotencyKey = (events: readonly BillingUsageEvent[]): 
     }
   }
 
-  return [...eventsByKey.values()]
+  return [...eventsByKey.values()].sort((a, b) => {
+    const periodDelta = a.billingPeriodStart.getTime() - b.billingPeriodStart.getTime()
+    if (periodDelta !== 0) return periodDelta
+    if (a.idempotencyKey < b.idempotencyKey) return -1
+    if (a.idempotencyKey > b.idempotencyKey) return 1
+    return 0
+  })
 }
 
 export const BillingUsageEventRepositoryLive = Layer.succeed(BillingUsageEventRepository, {
@@ -68,7 +94,7 @@ export const BillingUsageEventRepositoryLive = Layer.succeed(BillingUsageEventRe
     const inserted = yield* sqlClient.query((db) =>
       db
         .insert(billingUsageEvents)
-        .values(uniqueByPeriodAndIdempotencyKey(events).map(toInsertRow))
+        .values(dedupeAndOrderEventsForInsert(events).map(toInsertRow))
         .onConflictDoNothing({ target: [billingUsageEvents.billingPeriodStart, billingUsageEvents.idempotencyKey] })
         .returning({ id: billingUsageEvents.id }),
     )


### PR DESCRIPTION
## Summary

Fixes a Postgres **`deadlock detected`** error on the `billing` worker queue, surfaced by Datadog Error Tracking in production.

- **Datadog issue:** `f8243366-5dd5-11f1-b879-da7ad0900005` — `RepositoryError: Repository query failed: Database query failed Caused by: deadlock detected`, resource `process billing` (task `recordTraceUsageBatch`), `service:workers`, `env:production`.
- **Volume / trend:** 68 occurrences in the last 7d; `first_seen` ≈ Jun 1 (a fresh regression), daily trend spiked Jun 3 (46) then 10 / 8. Deadlocking spans were observed on **two different worker hosts simultaneously**, confirming cross-process concurrency.

## Root cause

`recordTraceUsageBatchUseCase` opens one transaction that `insertMany`s billing usage events, then upserts the single period row. In the platform adapter, `insertMany` issued a single multi-row `INSERT … ON CONFLICT (billing_period_start, idempotency_key) DO NOTHING` with rows in **batch-arrival order**.

Trace usage is flushed by an in-memory batcher that only dedupes **within one worker process**, so the same org/period is written concurrently by multiple workers. When two such batches shared idempotency keys but supplied them in different orders, Postgres acquired the unique-index locks row-by-row in **opposite orders** → classic AB/BA deadlock. The period upsert runs last in both transactions, so it serialises cleanly and is not the culprit; the deadlock is purely the event-insert lock ordering.

## Fix

Sort the deduped events by the conflict-target tuple `(billingPeriodStart, idempotencyKey)` before insert, so every concurrent transaction takes the index locks in the same order and the AB/BA cycle becomes impossible. The order only has to be *consistent* across transactions (not match the btree collation), so a plain value sort suffices.

The fix lives in the platform adapter (`billing-usage-event-repository.ts`), next to the existing dedupe helper — lock ordering is a Postgres concern. **No schema/migration, no behaviour change beyond row ordering.** Blast radius: one helper.

**Sibling call sites checked:** other multi-row `onConflict` inserts (`monitor-repository` alerts, `taxonomy-lineage-repository`) are scoped to a single aggregate, so cross-transaction key overlap in different orders is unlikely — left unchanged to keep this PR tight.

## Tests

A true deadlock isn't reproducible under PGlite (single connection), so the tests pin the **deterministic-ordering invariant** that breaks the cycle:

- `dedupeAndOrderEventsForInsert` orders by `(billingPeriodStart, idempotencyKey)` regardless of input order — two batches with the same keys in opposite orders converge to the identical sequence.
- Period takes precedence over idempotency key, and per-period dedupe still holds.
- Integration: the same keys arriving in opposite batch orders persist an identical 3-row ledger (second batch is a full no-op).

Confirmed the two ordering tests **fail without the sort** and **pass with it**. `@platform/db-postgres` billing repo (5) and `@domain/billing` (29) suites pass; typecheck/biome clean on the changed files (pre-existing unrelated `sandbox-repository.test.ts` type errors and the `@domain/organizations` workspace-link issue are not touched by this PR).

## Verification

- After deploy, occurrences of Datadog issue `f8243366-5dd5-11f1-b879-da7ad0900005` should drop to zero.
- Locally: `pnpm --filter @platform/db-postgres test billing-usage-event-repository`.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->