### PR TITLE
fix(taxonomy): sanitize lone UTF-16 surrogates before embedding and ClickHouse insert

### DIFF
--- a/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/online-observation.test.ts
@@ -522,4 +522,57 @@ describe("online taxonomy observation use-cases", () => {
     expect(row?.assignedClusterId).toBe(clusterId)
     expect(clusters.clusters.get(clusterId)?.observationCount).toBe(2)
   })
+
+  it("sanitises lone UTF-16 surrogates before embedding and persisting the summary", async () => {
+    // Regression: arbitrary LLM I/O (and length-sliced previews) can carry
+    // unpaired surrogates. ClickHouse's JSON insert rejects them with "missing
+    // second part of surrogate pair" and the Voyage embeddings API returns a
+    // 400 for invalid UTF-8. Both inputs must be canonicalised first.
+    const observations = createFakeBehaviorObservationRepository()
+    const clusters = createFakeTaxonomyClusterRepository([])
+    const locks = createFakeDistributedLockRepository()
+    const loneSurrogateRegex = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+    // High surrogate (leading half of an emoji) with no trailing low surrogate.
+    const dirty = `I want to cancel my subscription \uD83D and confirm the billing stops. `.repeat(6)
+    expect(dirty).toMatch(loneSurrogateRegex)
+    const dirtySession = makeSession({
+      traceIds: [],
+      lastInputMessages: [{ role: "user", parts: [{ type: "text", content: dirty }] }],
+      outputMessages: [{ role: "assistant", parts: [{ type: "text", content: dirty }] }],
+    })
+
+    const embedInputs: string[] = []
+    const capturingAi = Layer.succeed(AI, {
+      embed: (input) =>
+        Effect.sync(() => {
+          embedInputs.push(input.text)
+          return { embedding: [...embedding(0)] }
+        }),
+      generate: () => Effect.die("generate must not be called under embed_direct"),
+      rerank: () => Effect.succeed([]),
+    })
+
+    await Effect.runPromise(
+      recordSessionObservationUseCase({ organizationId, projectId, sessionId }).pipe(
+        Effect.provide(makeSessionRepository(dirtySession)),
+        Effect.provide(makeTraceRepository([])),
+        Effect.provide(capturingAi),
+        Effect.provide(Layer.succeed(BehaviorObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(DistributedLockRepository, locks.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    expect(embedInputs).toHaveLength(1)
+    expect(embedInputs[0]).not.toMatch(loneSurrogateRegex)
+    expect(embedInputs[0]).toContain("�")
+
+    const storedSummary = [...observations.rows.values()][0]?.summary
+    expect(storedSummary).toBeDefined()
+    expect(storedSummary).not.toMatch(loneSurrogateRegex)
+    expect(storedSummary).toContain("�")
+  })
 })

--- a/packages/domain/taxonomy/src/use-cases/record-session-observation.ts
+++ b/packages/domain/taxonomy/src/use-cases/record-session-observation.ts
@@ -1,5 +1,5 @@
 import { OrganizationId, ProjectId, SessionId, TaxonomyClusterId, TraceId } from "@domain/shared"
-import { SessionRepository, TraceRepository } from "@domain/spans"
+import { SessionRepository, stripLoneSurrogates, TraceRepository } from "@domain/spans"
 import { hash } from "@repo/utils"
 import { Effect } from "effect"
 import {
@@ -152,7 +152,9 @@ export const recordSessionObservationUseCase = Effect.fn("taxonomy.recordSession
       startTime: session.startTime,
       endTime: session.endTime,
       traceIds,
-      summary: document.summaryPreview,
+      // Slicing the conversation into a preview can split an emoji's surrogate
+      // pair; ClickHouse's strict JSON parser rejects lone surrogates on insert.
+      summary: stripLoneSurrogates(document.summaryPreview),
       summaryHash,
       // Deliberately excluded from gardening birth sweeps: short sessions do
       // not have enough behavioral signal to justify an embedding.
@@ -193,6 +195,14 @@ export const recordSessionObservationUseCase = Effect.fn("taxonomy.recordSession
       textToEmbed = generated.summary
     }
   }
+
+  // The summary/embedding inputs derive from arbitrary LLM I/O (and from
+  // length-sliced previews), so they can carry unpaired UTF-16 surrogates.
+  // Both downstream sinks reject them: ClickHouse's JSON insert fails with
+  // "missing second part of surrogate pair", and the Voyage embeddings API
+  // returns a 400 for invalid UTF-8. Canonicalise before either is reached.
+  summary = stripLoneSurrogates(summary)
+  textToEmbed = stripLoneSurrogates(textToEmbed)
 
   const embedded = yield* embedBehaviorSummaryUseCase({
     organizationId: input.organizationId,


### PR DESCRIPTION
A production crash in the taxonomy `observeSession` job (`workers`). Two Datadog Error Tracking issues share one root cause.

## datadog issues

- **ClickHouse insert** — `RepositoryError: BehaviorObservationRepository.upsert failed … Cannot parse escape sequence: missing second part of surrogate pair … (while reading the value of key summary)` (~3/7d)
  https://app.datadoghq.eu/error-tracking/issues/8746e240-5ba7-11f1-b9fd-da7ad0900005
- **Voyage embedding** — `AIError: Embedding failed (voyage-4-large): 400 … ensure that your input is encoded in valid UTF-8 …` (~15/7d)
  https://app.datadoghq.eu/error-tracking/issues/7c752078-5a69-11f1-b37e-da7ad0900005
  This issue also groups the unrelated `429` rate-limit failures (~17/7d); those are a separate concern and are **not** addressed here. This PR removes the `400` invalid-UTF-8 occurrences only.

## root cause

`record-session-observation` builds a `summary` (and `textToEmbed`) from session conversation text — arbitrary LLM I/O, plus a length-sliced `summaryPreview` that can split an emoji's surrogate pair. The result can contain unpaired UTF-16 surrogates, which are sent to two sinks that both reject them: the Voyage embeddings API (HTTP 400) and the ClickHouse JSON insert ("missing second part of surrogate pair"). Present since the pipeline was introduced in #3280 (`ba2da03e8`).

## fix

Canonicalize `summary` and `textToEmbed` with the existing `stripLoneSurrogates` helper (`@domain/spans`) in `record-session-observation`, covering both the short- and long-session paths. Fixing at the source closes both symptoms rather than patching each sink. This mirrors `build-trace-search-document`, which already does the same for the identical ClickHouse constraint.

## tests

`online-observation.test.ts` gains a case that feeds lone surrogates and asserts both the embed input and the persisted summary are sanitized. It fails without the fix (verified by reverting). Full suite: `pnpm --filter @domain/taxonomy test` — 58 passing; typecheck and biome clean.

## verification

After deploy, occurrences of `8746e240-…` should stop, and the `400` invalid-UTF-8 share of `7c752078-…` should drop to zero (429s will continue).

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->