### PR TITLE
feat(monitors,issues): backtrace sustained-incident close (ended_at) [LAT-630]

### DIFF
--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -402,6 +402,92 @@ describe("checkIssueEscalationUseCase", () => {
     })
   })
 
+  it("backtracks IssueEscalationEnded.endedAt to the last bucket still above the threshold", async () => {
+    const issue = makeIssue()
+    const events: OutboxWriteEvent[] = []
+    const dwellStart = new Date(Date.now() - ESCALATION_EXIT_DWELL_MS - 1000)
+    const openIncident = makeOpenIncident({
+      entrySignals: {
+        expected1h: 10,
+        expected6hPerHour: 10,
+        stddev1h: 2,
+        stddev6hPerHour: 2,
+        kShort: 3,
+        kLong: 2,
+        entryThreshold1h: 16,
+        entryThreshold6hPerHour: 14,
+        entryCount24h: 600,
+      },
+      startedAt: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: dwellStart,
+    })
+    const { apply } = provideTestLayers({
+      issue,
+      isEscalating: true,
+      signals: makeSignals({ recent1h: 5, recent6h: 30, recent24h: 400 }),
+      events,
+      openIncident,
+      occurrenceBuckets: [
+        { bucket: "2026-05-07T07:00:00.000Z", count: 12 }, // crossing
+        { bucket: "2026-05-07T08:00:00.000Z", count: 9 }, // last crossing — escalation subsided after this
+        { bucket: "2026-05-07T09:00:00.000Z", count: 2 }, // below threshold
+      ],
+      thresholdBuckets: [
+        { bucket: "2026-05-07T07:00:00.000Z", thresholdCount: 5 },
+        { bucket: "2026-05-07T08:00:00.000Z", thresholdCount: 5 },
+        { bucket: "2026-05-07T09:00:00.000Z", thresholdCount: 5 },
+      ],
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("exited")
+    const payload = events[0]?.payload as { endedAt: string }
+    expect(payload.endedAt).toBe("2026-05-07T08:00:00.000Z") // last crossing bucket, NOT the detection time (now)
+  })
+
+  it("falls back to the event time for endedAt when no bucket crossed in the window", async () => {
+    const issue = makeIssue()
+    const events: OutboxWriteEvent[] = []
+    const before = Date.now()
+    const openIncident = makeOpenIncident({
+      entrySignals: {
+        expected1h: 10,
+        expected6hPerHour: 10,
+        stddev1h: 2,
+        stddev6hPerHour: 2,
+        kShort: 3,
+        kLong: 2,
+        entryThreshold1h: 16,
+        entryThreshold6hPerHour: 14,
+        entryCount24h: 600,
+      },
+      startedAt: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      exitEligibleSince: new Date(Date.now() - ESCALATION_EXIT_DWELL_MS - 1000),
+    })
+    const { apply } = provideTestLayers({
+      issue,
+      isEscalating: true,
+      signals: makeSignals({ recent1h: 5, recent6h: 30, recent24h: 400 }),
+      events,
+      openIncident,
+      occurrenceBuckets: [
+        { bucket: "2026-05-07T08:00:00.000Z", count: 2 },
+        { bucket: "2026-05-07T09:00:00.000Z", count: 3 },
+      ],
+      thresholdBuckets: [
+        { bucket: "2026-05-07T08:00:00.000Z", thresholdCount: 5 },
+        { bucket: "2026-05-07T09:00:00.000Z", thresholdCount: 5 },
+      ],
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("exited")
+    const payload = events[0]?.payload as { endedAt: string }
+    expect(new Date(payload.endedAt).getTime()).toBeGreaterThanOrEqual(before)
+  })
+
   it("forwards reason='absolute-rate-drop' when the 24h backstop trips", async () => {
     const issue = makeIssue()
     const events: OutboxWriteEvent[] = []

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -28,22 +28,20 @@ export interface CheckIssueEscalationInput {
   readonly escalationSensitivity?: number
 }
 
-/** Look-back window + bucket for `startedAt` backtracking on the escalation `enter` transition. */
+/** Look-back window + bucket for `started_at` / `ended_at` backtracking on the escalation enter/exit transitions. */
 const BACKTRACK_WINDOW_MS = 24 * 60 * 60 * 1000
 const BACKTRACK_BUCKET_SECONDS = 60 * 60
 
-/**
- * The detector flags late (the band must hold a while), so backtrack: return the
- * first bucket whose count cleared the seasonal threshold (same `kShort`). No
- * crossing in the window → the event time (`now`).
- */
-const backtrackEscalationStart = (input: {
+interface BacktrackInput {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
   readonly issueId: IssueId
   readonly kShort: number
   readonly now: Date
-}) =>
+}
+
+/** The issue's occurrence histogram over the backtrack window as ascending `{bucket,count}` rows, paired with a per-bucket seasonal-threshold lookup (same `kShort`). */
+const escalationCrossingBuckets = (input: BacktrackInput) =>
   Effect.gen(function* () {
     const analytics = yield* ScoreAnalyticsRepository
     const to = input.now
@@ -75,7 +73,36 @@ const backtrackEscalationStart = (input: {
     }
 
     const ascending = [...counts].sort((a, b) => a.bucket.localeCompare(b.bucket))
+    return { ascending, thresholdByBucket }
+  })
+
+/**
+ * The detector flags late (the band must hold a while), so backtrack: return the
+ * first bucket whose count cleared the seasonal threshold (same `kShort`). No
+ * crossing in the window → the event time (`now`).
+ */
+const backtrackEscalationStart = (input: BacktrackInput) =>
+  Effect.gen(function* () {
+    const { ascending, thresholdByBucket } = yield* escalationCrossingBuckets(input)
     for (const bucket of ascending) {
+      const threshold = thresholdByBucket.get(bucket.bucket)
+      if (threshold !== undefined && bucket.count >= threshold) {
+        const ts = new Date(bucket.bucket)
+        if (!Number.isNaN(ts.getTime())) return ts
+      }
+    }
+    return input.now
+  })
+
+/**
+ * Mirror of {@link backtrackEscalationStart} for the close: the detector exits late
+ * (dwell), so backtrack `ended_at` to the **last** bucket whose count was still above
+ * the seasonal threshold. No crossing in the window → the event time (`now`).
+ */
+const backtrackEscalationEnd = (input: BacktrackInput) =>
+  Effect.gen(function* () {
+    const { ascending, thresholdByBucket } = yield* escalationCrossingBuckets(input)
+    for (const bucket of [...ascending].reverse()) {
       const threshold = thresholdByBucket.get(bucket.bucket)
       if (threshold !== undefined && bucket.count >= threshold) {
         const ts = new Date(bucket.bucket)
@@ -227,6 +254,17 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
     }
 
     if (decision.transition === "exit") {
+      // Backtrack the end to the last bucket still above the seasonal threshold (mirror of the
+      // enter-side backtrack), so the incident's `ended_at` reflects when the escalation actually
+      // subsided rather than the dwell-delayed detection tick.
+      const endedAt = yield* backtrackEscalationEnd({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        issueId: IssueId(input.issueId),
+        kShort,
+        now,
+      })
+
       yield* outboxEventWriter.write({
         eventName: "IssueEscalationEnded",
         aggregateType: "issue",
@@ -236,7 +274,7 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
           organizationId: issueWithLifecycle.organizationId,
           projectId: issueWithLifecycle.projectId,
           issueId: issueWithLifecycle.id,
-          endedAt: now.toISOString(),
+          endedAt: endedAt.toISOString(),
           reason: decision.reason ?? "threshold",
         },
       })

--- a/packages/domain/monitors/src/ports/saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/ports/saved-search-match-reader.ts
@@ -28,6 +28,8 @@ export interface SavedSearchMatchReaderShape {
   countMatches(input: SavedSearchMatchWindowInput): Effect.Effect<number, RepositoryError, ChSqlClient>
   /** Earliest matching trace `start_time` in `[from, to)`, or `null` when none match. */
   firstMatchAt(input: SavedSearchMatchWindowInput): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
+  /** Latest matching trace `start_time` in `[from, to)`, or `null` when none match. Mirror of {@link firstMatchAt}; backs the escalating incident's backtraced `ended_at`. */
+  lastMatchAt(input: SavedSearchMatchWindowInput): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
   /**
    * Per-bucket match counts over `[from, to)`, tiled into `N = floor((to - from) / bucketMs)`
    * fixed-width buckets aligned to `to`. Returns exactly `N` counts, **newest-first**

--- a/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
+++ b/packages/domain/monitors/src/testing/fake-saved-search-match-reader.ts
@@ -32,6 +32,8 @@ export const createFakeSavedSearchMatchReader = (matchTimestamps: readonly Date[
       Effect.succeed(
         inWindow(input).reduce<Date | null>((earliest, at) => (earliest && earliest <= at ? earliest : at), null),
       ),
+    lastMatchAt: (input) =>
+      Effect.succeed(inWindow(input).reduce<Date | null>((latest, at) => (latest && latest >= at ? latest : at), null)),
     countMatchesPerBucket: (input) => Effect.succeed(bucketCounts(input)),
   })
 

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.test.ts
@@ -154,16 +154,35 @@ describe("runSavedSearchEscalatingAlertUseCase", () => {
     expect(events).toHaveLength(0)
   })
 
-  it("closes and emits IncidentClosed once enough buckets drop below the frozen threshold", async () => {
-    // Only buckets 0..1 still have matches ⇒ 3 empty ⇒ failing 3 > maxFail 1.
+  it("closes, emits IncidentClosed, and backtraces ended_at to the last matching trace", async () => {
+    // Buckets 2..4 empty ⇒ failing 3 > maxFail 1 ⇒ close; the last match is in bucket 0.
     const { result, incidents, events } = await run({
       alert: absoluteAlert,
       matches: [0, 1].map((b) => inBucket(b)),
       seed: [incident({})],
     })
     expect(result.transition).toBe("closed")
-    expect(incidents[0]?.endedAt).toEqual(now)
+    expect(incidents[0]?.endedAt).toEqual(inBucket(0)) // last matching trace, NOT the detection time (now)
     expect(events.map((event) => event.eventName)).toEqual(["IncidentClosed"])
+  })
+
+  it("backtraces ended_at to the last match even when traffic stopped before the window", async () => {
+    // All matches predate the 5-min window ⇒ every bucket empty ⇒ close. ended_at must be the
+    // most recent past match (when traffic actually stopped), not the detection time (now).
+    const lastTrace = minsAgo(7)
+    const { result, incidents } = await run({
+      alert: absoluteAlert,
+      matches: [lastTrace, minsAgo(8), minsAgo(9)],
+      seed: [incident({})],
+    })
+    expect(result.transition).toBe("closed")
+    expect(incidents[0]?.endedAt).toEqual(lastTrace)
+  })
+
+  it("falls back to now for ended_at when the incident has no matching traces in its lifetime", async () => {
+    const { result, incidents } = await run({ alert: absoluteAlert, matches: [], seed: [incident({})] })
+    expect(result.transition).toBe("closed")
+    expect(incidents[0]?.endedAt).toEqual(now)
   })
 
   it("counts failing buckets against the frozen threshold, not a re-resolved one", async () => {
@@ -183,6 +202,7 @@ describe("runSavedSearchEscalatingAlertUseCase", () => {
       ],
     })
     expect(result.transition).toBe("closed")
-    expect(incidents[0]?.endedAt).toEqual(now)
+    // Backtraced to the last matching trace of the sustained set, not the detection time.
+    expect(incidents[0]?.endedAt).toEqual(inBucket(0))
   })
 })

--- a/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-saved-search-escalating-alert.ts
@@ -3,7 +3,7 @@ import type { OutboxEventWriter } from "@domain/events"
 import { type ChSqlClient, type RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { countFailingBuckets, maxFailingBuckets } from "../constants.ts"
-import type { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
+import { SavedSearchMatchReader } from "../ports/saved-search-match-reader.ts"
 import {
   type EvaluateSavedSearchAlertError,
   type EvaluateSavedSearchAlertInput,
@@ -89,7 +89,20 @@ export const runSavedSearchEscalatingAlertUseCase = (input: EvaluateSavedSearchA
         const failing = countFailingBuckets(evaluation.bucketCounts, frozenThreshold)
         if (failing <= maxFail) return { transition: "none" } satisfies RunSavedSearchEscalatingAlertResult
 
-        yield* closeSavedSearchIncident(open, now)
+        // Backtrace ended_at to the incident's last matching trace (mirror of the started_at
+        // backtrace) so the recorded close reflects when traffic actually stopped, not the
+        // detection tick. `[startedAt, now)` is bounded + guaranteed to contain the last match
+        // (the current window is empty — that's why we're closing). Falls back to `now` only if
+        // the lifetime window is somehow empty.
+        const reader = yield* SavedSearchMatchReader
+        const lastMatch = yield* reader.lastMatchAt({
+          organizationId,
+          projectId,
+          target: input.target,
+          from: open.startedAt,
+          to: now,
+        })
+        yield* closeSavedSearchIncident(open, lastMatch ?? now)
         return { transition: "closed" } satisfies RunSavedSearchEscalatingAlertResult
       }),
     )

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.test.ts
@@ -138,6 +138,27 @@ describe("SavedSearchMatchReaderLive", () => {
     expect(first).toBeNull()
   })
 
+  it("returns the latest matching trace start_time", async () => {
+    // [10:00, 11:00) includes t10 + t1030; t11 == the exclusive upper bound is excluded ⇒ latest is t1030.
+    const last = await runCh(
+      reader.lastMatchAt({ organizationId: ORG_ID, projectId: PROJECT_ID, target, from: t10, to: t11 }),
+    )
+    expect(last).toEqual(t1030)
+  })
+
+  it("returns null from lastMatchAt when no trace matches the window", async () => {
+    const last = await runCh(
+      reader.lastMatchAt({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        target,
+        from: new Date("2026-06-01T12:00:00.000Z"),
+        to: new Date("2026-06-01T13:00:00.000Z"),
+      }),
+    )
+    expect(last).toBeNull()
+  })
+
   it("applies the saved search's structured filters", async () => {
     const tagged = { query: null, filterSet: { tags: [{ op: "in" as const, value: [TAG] }] } }
     const count = await runCh(

--- a/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/saved-search-match-reader.ts
@@ -105,6 +105,31 @@ const make = (): SavedSearchMatchReaderShape => ({
           Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.firstMatchAt")),
         )
     }),
+  lastMatchAt: (input) =>
+    Effect.gen(function* () {
+      const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+      const inner = yield* buildInnerQuery(input)
+      return yield* chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            // `count()` guards the empty case — `max()` over zero rows returns the
+            // epoch, not NULL, so we'd otherwise report a bogus 1970 last match.
+            query: `SELECT toString(max(start_time)) AS last_at, count() AS matches FROM (${inner.sql})`,
+            query_params: inner.params,
+            format: "JSONEachRow",
+          })
+          return result.json<{ last_at: string | null; matches: string }>()
+        })
+        .pipe(
+          Effect.map((rows) => {
+            const row = rows[0]
+            if (!row || Number(row.matches) === 0 || !row.last_at) return null
+            const parsed = new Date(row.last_at.includes(" ") ? `${row.last_at.replace(" ", "T")}Z` : row.last_at)
+            return Number.isNaN(parsed.getTime()) ? null : parsed
+          }),
+          Effect.mapError((error) => toRepositoryError(error, "SavedSearchMatchReader.lastMatchAt")),
+        )
+    }),
   countMatchesPerBucket: (input: SavedSearchMatchBucketInput) =>
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>

--- a/specs/monitors.md
+++ b/specs/monitors.md
@@ -640,6 +640,8 @@ Note: the `entrySignals` snapshot holds only scalar stats (expected / σ / thres
 
 The natural home for this is the producer side (`checkIssueEscalationUseCase`, which already has `ScoreAnalyticsRepository` + `ChSqlClient`): it resolves the backtracked timestamp and forwards it on the `IssueEscalated` event, which the alert-incidents worker passes through as `occurredAt`. Because it changes the existing **non-flag-gated** escalation path, it lands in **M6** alongside the rest of the issue-event work, not in M3.
 
+**`endedAt` backtracking (symmetric to the above).** The detector also exits *late* (the band-shape exit holds for a dwell before closing), so on the organic exit we backtrack `endedAt` to the **last** bucket whose count was still above the seasonal threshold — `backtrackEscalationEnd`, the exact mirror of `backtrackEscalationStart` (same 24h/1h-bucket histogram + threshold series, scanned newest→oldest). The backtracked timestamp rides the existing `IssueEscalationEnded.endedAt` payload through to `closeAlertIncidentFromIssueEventUseCase`, which already writes it to `ended_at` — so only the *value* computed in `checkIssueEscalationUseCase` changed. No crossing in the window → the event time (`now`). This applies **only to the organic detector exit**; a **manual** resolve/ignore close (`applyIssueLifecycleCommandUseCase`) keeps `endedAt = now` (the user closed it now), mirroring that the open side never backtracks a manual action.
+
 For other kinds, behaviour is unchanged (`issue.new` / `issue.regressed` are eventful — `startedAt = endedAt = occurredAt` stays correct).
 
 #### Escalation sensitivity sourcing
@@ -839,7 +841,10 @@ At evaluation:
     // CLOSE TRANSITION — once too many buckets drop below the FROZEN threshold
     let thr = open.entrySignals.evaluatedThreshold ?? v.perBucketThreshold   // legacy rows: fresh threshold
     if failing(thr) > maxFail:
-      UPDATE alert_incidents SET endedAt = now
+      // Backtrace ended_at to the last matching trace of the incident (mirror of started_at),
+      // so the recorded close reflects when traffic actually stopped, not the detection tick.
+      endedAt = lastMatchAt(open.startedAt, now) ?? now
+      UPDATE alert_incidents SET endedAt = endedAt
       emit IncidentClosed
 ```
 
@@ -847,6 +852,7 @@ Notes:
 
 - **Per-bucket threshold is frozen at entry.** The per-bucket threshold (and, for multiplier, the supporting `baselineCount`) is snapshotted into `entrySignals` on open. The close-side does NOT re-resolve `factor × baseline` or the seasonal band — it counts how many buckets fall below `entrySignals.evaluatedThreshold`. This prevents the open incident's own elevated counts from drifting a sliding baseline and pinning the incident open.
 - **Stateless — no `exitEligibleSince`, no dwell.** Open and close are both pure functions of the current bucketed query against the (live, then frozen) per-bucket threshold. The `exit_eligible_since` column stays in the schema but is unused by escalating now; a stale value on a legacy open incident is ignored, and that incident closes on the next check where failing buckets exceed the tolerance.
+- **`ended_at` is backtraced (mirror of `started_at`).** On close, `ended_at = SavedSearchMatchReader.lastMatchAt(startedAt, now) ?? now` — the last matching trace of the incident, so the recorded close reflects when traffic actually stopped, not the (cadence-delayed) detection tick. The lookup runs only on the close transition. `[startedAt, now)` is the lower bound because the *current* window is empty at close (that's why it closes), so the last match usually predates it.
 - **Anti-flap via the shared tolerance.** Because the same `maxFail` applies on close, a brief single-bucket dip won't close a noisy-but-sustained breach. Re-opening after a genuine close still requires a fresh sustained window.
 - **No 72h backstop.** Saved-search conditions are deterministic and user-configured; if the user said "alert me when 5xx > 100 for 1 hour" and it's been holding for a week, that's the system working as designed.
 - **Spikes are filtered by construction.** A 1-second burst fills a single bucket and leaves the other `N - 1` buckets failing, so `failing` far exceeds `maxFail` and nothing opens — the sustained-for-the-window semantics, not a rolling-count aging trick.


### PR DESCRIPTION
## What & why

Sustained incidents already backtrace **`started_at`** to when the breach really began (the first matching trace / first threshold-crossing bucket), so an incident detected mid-breach is dated correctly instead of to "now". The **close** side did not do the symmetric thing — both sustained kinds set `ended_at = now` (the detection moment), which lags the real end by the check cadence + dwell + the trailing empty buckets needed to trip the close (≈8 min in the E2E below). This PR backtraces `ended_at` to when matching activity actually ended, **using the same data source each kind uses for its `started_at` backtrace**.

Applied to **every kind that backtraces `started_at`** (the two sustained kinds); point-in-time kinds are unchanged.

| Kind | `started_at` (existing) | `ended_at` (this PR) |
|---|---|---|
| `savedSearch.escalating` | `firstMatchAt` — first matching trace | **`lastMatchAt`** — last matching trace |
| `issue.escalating` (organic exit) | `backtrackEscalationStart` — first crossing bucket | **`backtrackEscalationEnd`** — last crossing bucket |
| `issue.escalating` (manual resolve/ignore) | — | `now` (unchanged — user closed it now) |
| `issue.new` / `issue.regressed` / `savedSearch.match` / `savedSearch.threshold` | — | `started_at` (unchanged — already collapsed at creation) |

## How

- **`savedSearch.escalating`** — new `SavedSearchMatchReader.lastMatchAt` (`max(start_time)`, exact mirror of `firstMatchAt`; port + ClickHouse impl + fake). The close branch sets `ended_at = lastMatchAt(open.startedAt, now) ?? now`. `[startedAt, now)` is the lower bound because the current window is empty at close (that's *why* it closes), so the last match usually predates it; the lookup runs **only on the close transition**.
- **`issue.escalating`** — extracted the shared histogram fetch into `escalationCrossingBuckets`, then added `backtrackEscalationEnd` (scans newest→oldest for the last bucket still ≥ the seasonal threshold), the exact mirror of `backtrackEscalationStart`. Only the **organic detector exit** backtraces; the `IssueEscalationEnded → worker → closeAlertIncidentFromIssueEventUseCase → closeOpen` plumbing already threads `endedAt`, so only the value computed in `checkIssueEscalationUseCase` changed. **Manual** resolve/ignore (`applyIssueLifecycleCommandUseCase`) keeps `ended_at = now`.

**No migration, no schema change, no API/MCP/SDK change** (`ended_at` is a value-only change; the OpenAPI description stays accurate, mirroring how `started_at` never spelled out its backtrace). The outbox `IncidentClosed` event still fires at detection time; only the persisted `ended_at` is backtraced (exactly as `started_at < created_at` already holds for opens).

## Verification

**Unit / typecheck:** clean across monitors / issues / db-clickhouse.
- `@domain/monitors` 117 — close cases: last-match backtrace, traffic-stopped-before-window, null fallback, frozen-threshold updated.
- `@domain/issues` 154 — exit backtraces to the last crossing bucket; no-crossing → `now`; existing reason cases (threshold / absolute-rate-drop / timeout) intact.
- `@platform/db-clickhouse` 218 — `lastMatchAt` against real chdb (latest match; null on empty window).

**Live E2E via Latitude MCP + live-seeds** (project `escalating-close-backtrace-e2e`; one escalating alert, absolute `count:1`, `window:5min`; trickled ~2 traces/min for ~7 min, then stopped):

| | Backtraced (recorded) | Detection tick |
|---|---|---|
| **open** | `started_at` **10:45:12.479** — first *in-window* trace | `created_at` 10:50:00.138 (first sweep after 5-min coverage) |
| **close** | `ended_at` **10:51:55.958** — last matching trace | close detected ~**11:00:00** (sweep) |

The last `live-seed` trace's `startTime` via MCP (`10:51:55.958Z`) equals `ended_at` **to the millisecond**. Single incident, no flap. The ~8-min close-detection lag (cadence/throttle) no longer pollutes the recorded `ended_at` — recorded lifetime is the real `[10:45:12 → 10:51:55]` instead of the detection ticks `[10:50:00 → 11:00:00]`.

`issue.escalating` is covered by unit tests (driving a real seasonal escalation+de-escalation via live-seeds is impractical in a short run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->