### PR TITLE
feat(observability): attach org + user identity to error spans

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -36,6 +36,7 @@ const oauthContext = (result: OAuthTokenAuthResult): AuthContext => ({
   oauthClientId: result.oauthClientId,
   scopes: result.scopes,
   expiresAt: result.expiresAt,
+  email: result.email,
 })
 
 const authenticateWithApiKey = (

--- a/apps/api/src/middleware/span-enrichment.ts
+++ b/apps/api/src/middleware/span-enrichment.ts
@@ -1,0 +1,39 @@
+import { trace } from "@repo/observability"
+import type { Context, MiddlewareHandler, Next } from "hono"
+
+/**
+ * Attaches tenant/user identity to the active OpenTelemetry span so it shows up
+ * on Datadog Error Tracking issues. The `@hono/otel` middleware records request
+ * exceptions on this same HTTP span, so any attribute set here becomes a
+ * searchable facet on the resulting issue.
+ *
+ * Uses Datadog's reserved user keys (`usr.id`, `usr.email`) so they populate the
+ * native user facet, plus a custom `organization.id` (Datadog has no built-in
+ * org concept) and `auth.method` for filtering.
+ *
+ * Must run AFTER the auth middleware (so `c.get("auth")` is populated). Purely
+ * best-effort: if there's no active span or no auth context it no-ops, and it
+ * never throws — telemetry must not affect request handling.
+ *
+ * Note: on the `api-key` path `usr.id` is the synthetic `api-key:<keyId>`
+ * principal and there is no email; `usr.email` is set only for `oauth` requests.
+ */
+export const createSpanEnrichmentMiddleware = (): MiddlewareHandler => {
+  return async (c: Context, next: Next) => {
+    const auth = c.get("auth")
+    const span = trace.getActiveSpan()
+
+    if (auth && span) {
+      span.setAttributes({
+        "organization.id": auth.organizationId,
+        "usr.id": auth.userId,
+        "auth.method": auth.method,
+      })
+      if (auth.method === "oauth" && auth.email) {
+        span.setAttribute("usr.email", auth.email)
+      }
+    }
+
+    await next()
+  }
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -3,6 +3,7 @@ import { API_VERSION } from "../constants.ts"
 import { registerMcpRoute } from "../mcp/index.ts"
 import { createAuthMiddleware } from "../middleware/auth.ts"
 import { createOrganizationContextMiddleware } from "../middleware/organization-context.ts"
+import { createSpanEnrichmentMiddleware } from "../middleware/span-enrichment.ts"
 import { validationErrorMiddleware } from "../middleware/validation.ts"
 import type { ApiOptions, AppEnv, ProtectedEnv } from "../types.ts"
 import { accountPath, createAccountRoutes } from "./account.ts"
@@ -52,6 +53,7 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
     }),
   )
   routes.use("*", createOrganizationContextMiddleware())
+  routes.use("*", createSpanEnrichmentMiddleware())
 
   routes.route(projectsPath, createProjectsRoutes())
   routes.route(scoresPath, createScoresRoutes())

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -36,6 +36,12 @@ export type AuthContext =
       readonly scopes: ReadonlyArray<string>
       /** Underlying access token's `accessTokenExpiresAt`. */
       readonly expiresAt: Date
+      /**
+       * Granting user's email, for telemetry enrichment only (`usr.email` span
+       * attribute). Optional — absent for tokens cached before the field
+       * existed or whose user row is missing.
+       */
+      readonly email?: string | undefined
     }
 
 /**

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -9,6 +9,7 @@ import {
 } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
 import { createMiddleware, createStart } from "@tanstack/react-start"
+import { getSession } from "./domains/sessions/session.functions.ts"
 
 type Logger = ReturnType<typeof createLogger>
 
@@ -119,6 +120,25 @@ export const tracingFnMiddleware = ({ tracer, logger }: { tracer: Tracer; logger
       if (traceId) span.setAttribute("trace.trace_id", traceId)
       if (issueId) span.setAttribute("issue.id", issueId)
       if (datasetId) span.setAttribute("dataset.id", datasetId)
+
+      // Best-effort tenant/user enrichment so Datadog error issues carry the
+      // affected org + user. Uses Datadog's reserved `usr.*` keys (native user
+      // facet) plus a custom `organization.id`. `getSession()` rides Better
+      // Auth's 5-min cookie cache (cheap) and calling this server fn from the
+      // global fn-middleware does not recurse — TanStack does not re-apply
+      // global middleware to nested server-fn calls. Never affects handling.
+      try {
+        const session = await getSession()
+        if (session) {
+          span.setAttribute("usr.id", session.user.id)
+          if (session.user.email) span.setAttribute("usr.email", session.user.email)
+          if (session.user.name) span.setAttribute("usr.name", session.user.name)
+          const organizationId = session.session.activeOrganizationId
+          if (organizationId) span.setAttribute("organization.id", organizationId)
+        }
+      } catch {
+        // Unauthenticated request or session lookup failed — skip enrichment.
+      }
 
       try {
         const result = await rawArgs.next()

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
@@ -41,6 +41,7 @@ interface OAuthSetup {
   readonly tokenRowId: string
   readonly clientId: string
   readonly userId: string
+  readonly email: string
   readonly organizationId: string
 }
 
@@ -60,6 +61,7 @@ interface InsertOAuthSetupOptions {
 const insertOAuthSetup = async (db: PostgresDb, options: InsertOAuthSetupOptions): Promise<OAuthSetup> => {
   const userFixture = await Effect.runPromise(createUserFixture(db))
   const userId = userFixture.id
+  const email = userFixture.email
   const clientId = `client-${generateId()}`
   const accessToken = `${generateId()}_${generateId()}`
   const refreshToken = `${generateId()}_${generateId()}`
@@ -96,6 +98,7 @@ const insertOAuthSetup = async (db: PostgresDb, options: InsertOAuthSetupOptions
     tokenRowId,
     clientId,
     userId,
+    email,
     organizationId: options.organizationId ?? "",
   }
 }
@@ -139,6 +142,7 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, N
     expect(result?.organizationId).toBe(organization.id)
     expect(result?.oauthClientId).toBe(setup.clientId)
     expect(result?.scopes).toEqual(["openid", "profile"])
+    expect(result?.email).toBe(setup.email)
     expect(touched).toEqual([setup.tokenRowId])
   })
 
@@ -234,6 +238,7 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, N
     // Second call — cache hit, no second touch.
     const cached = await Effect.runPromise(validateOAuthAccessToken(setup.accessToken, deps))
     expect(cached?.userId).toBe(setup.userId)
+    expect(cached?.email).toBe(setup.email)
     expect(touched).toEqual([setup.tokenRowId])
   })
 })

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
@@ -4,7 +4,7 @@ import type { RedisClient } from "@platform/cache-redis"
 // drizzle-orm version (peer-dep collisions cause private-property typecheck
 // errors otherwise).
 import { eq, type PostgresClient } from "@platform/db-postgres"
-import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { oauthAccessTokens, oauthApplications, users } from "@platform/db-postgres/schema/better-auth"
 import { hash } from "@repo/utils"
 import { Effect, Layer } from "effect"
 
@@ -42,6 +42,12 @@ export interface OAuthTokenAuthResult {
   readonly scopes: ReadonlyArray<string>
   /** Token's `accessTokenExpiresAt`. Cached entries re-check this on hit. */
   readonly expiresAt: Date
+  /**
+   * Email of the granting user, for telemetry/observability enrichment only
+   * (e.g. the `usr.email` span attribute). Optional: cache entries written
+   * before this field existed omit it, so consumers must tolerate `undefined`.
+   */
+  readonly email?: string | undefined
 }
 
 /**
@@ -55,6 +61,7 @@ interface CachedOAuthTokenAuthResult {
   readonly oauthClientId: string
   readonly scopes: ReadonlyArray<string>
   readonly expiresAt: string
+  readonly email?: string | undefined
 }
 
 const isCachedOAuthResult = (value: unknown): value is CachedOAuthTokenAuthResult | null => {
@@ -67,7 +74,10 @@ const isCachedOAuthResult = (value: unknown): value is CachedOAuthTokenAuthResul
     typeof v.oauthClientId === "string" &&
     Array.isArray(v.scopes) &&
     v.scopes.every((s) => typeof s === "string") &&
-    typeof v.expiresAt === "string"
+    typeof v.expiresAt === "string" &&
+    // `email` is optional: legacy cache entries (written before it existed)
+    // simply omit it. Reject only a present-but-non-string value.
+    (v.email === undefined || typeof v.email === "string")
   )
 }
 
@@ -88,6 +98,7 @@ const getCached = (
         oauthClientId: parsed.oauthClientId,
         scopes: parsed.scopes,
         expiresAt: new Date(parsed.expiresAt),
+        email: parsed.email,
       } satisfies OAuthTokenAuthResult
     },
     catch: () => undefined,
@@ -108,6 +119,7 @@ const cache = (
           oauthClientId: result.oauthClientId,
           scopes: result.scopes,
           expiresAt: result.expiresAt.toISOString(),
+          email: result.email,
         } satisfies CachedOAuthTokenAuthResult)
   return Effect.tryPromise({
     try: () => withTimeout(redis.setex(getCacheKey(tokenHash), ttl, JSON.stringify(payload)), undefined),
@@ -167,6 +179,7 @@ interface DbRow {
   readonly accessTokenExpiresAt: Date | null
   readonly applicationDisabled: boolean | null
   readonly organizationId: string | null
+  readonly email: string | null
 }
 
 const lookupByToken = (client: PostgresClient, token: string): Promise<DbRow | undefined> =>
@@ -179,9 +192,16 @@ const lookupByToken = (client: PostgresClient, token: string): Promise<DbRow | u
       accessTokenExpiresAt: oauthAccessTokens.accessTokenExpiresAt,
       applicationDisabled: oauthApplications.disabled,
       organizationId: oauthApplications.organizationId,
+      // For telemetry enrichment only (`usr.email` span attribute). The join
+      // is on the user the token was issued to; rides along on the cache-miss
+      // path, so it adds no per-request cost beyond the existing 5-min cache.
+      email: users.email,
     })
     .from(oauthAccessTokens)
     .innerJoin(oauthApplications, eq(oauthApplications.clientId, oauthAccessTokens.clientId))
+    // LEFT join: `email` is telemetry-only, so a missing/deleted user must not
+    // change token validity. A null email just means no `usr.email` attribute.
+    .leftJoin(users, eq(users.id, oauthAccessTokens.userId))
     .where(eq(oauthAccessTokens.accessToken, token))
     .limit(1)
     .then((rows) => rows[0])
@@ -294,6 +314,7 @@ export const validateOAuthAccessToken = (
       oauthClientId: row.clientId,
       scopes: parseScopes(row.scopes),
       expiresAt: row.accessTokenExpiresAt,
+      email: row.email ?? undefined,
     }
 
     yield* cache(redis, tokenHash, result, ttlFromExpiry(row.accessTokenExpiresAt))


### PR DESCRIPTION
## what this does

Error Tracking issues in Datadog now carry the **organization** and **user** an error affected, so on-call can immediately see which tenant/user hit a problem and filter or group issues by them.

There's no native `dd-trace` SDK — errors reach Datadog as OpenTelemetry span exceptions, and any attribute on the erroring span becomes a searchable facet on the issue. This PR attaches identity attributes to those spans at the points where auth is already resolved. It uses Datadog's reserved user keys (`usr.id`, `usr.email`, `usr.name`) so they populate the native user facet, plus a custom `organization.id` and an `auth.method` tag.

## coverage

- `organization.id` + `usr.id` + `auth.method`: everywhere (the data is already on the request context, so this is free).
- `usr.email`: the web session path and the API OAuth path. The API **api-key** path has no real user — `usr.id` there is the synthetic `api-key:<keyId>` principal and there is no email.

## changes

**API (`apps/api`)** — new `middleware/span-enrichment.ts`, registered right after the org-context middleware. It sets the attributes on the active `@hono/otel` HTTP span, which is the same span `@hono/otel` records request exceptions on, so the attributes land on whatever becomes the Datadog issue. Best-effort: no-ops if there's no active span or auth context, and never throws.

**`@platform/oauth-token-auth`** — the validator now LEFT-joins `users` to surface the granting user's email. It's a left join on purpose: email is telemetry-only and must never change whether a token validates (a deleted user still authenticates, just without an email). The email rides the existing 5-minute Redis token cache, so there's no extra per-request DB hit, and the cached payload tolerates legacy entries written before the field existed. Email is threaded through `OAuthTokenAuthResult` → the OAuth `AuthContext` variant → the enrichment middleware.

**Web (`apps/web`)** — `tracingFnMiddleware` in `start.ts` reads the session (via `getSession()`, which rides Better Auth's 5-minute cookie cache) and sets `organization.id` / `usr.id` / `usr.email` / `usr.name` on the server-fn span. Calling `getSession()` from the global function middleware does not recurse — TanStack does not re-apply global middleware to nested server-fn calls.

## testing

- `@platform/oauth-token-auth`: 7 tests pass, including new assertions that email is returned and survives the cache round-trip.
- Typecheck clean: `@platform/oauth-token-auth`, `@app/api`, `@app/web`. `@app/web` build succeeds (the new `session.functions` import splits correctly — only a stripped client stub reaches the browser bundle).

## follow-up

One deploy-side check remains: confirm Datadog's OTLP ingestion maps `usr.*` onto the native user facet on a real authenticated error. If it doesn't auto-map, a single tag-remap rule at the agent/ingestion layer handles it — the attributes are emitted either way.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->