### PR TITLE
fix: demo-project seed resilience (remote-CH batching, parallel trace-search, heartbeat)

### DIFF
--- a/apps/workflows/package.json
+++ b/apps/workflows/package.json
@@ -38,6 +38,7 @@
     "@platform/workflows-temporal": "workspace:*",
     "@repo/observability": "workspace:*",
     "@repo/utils": "workspace:*",
+    "@temporalio/activity": "catalog:",
     "@temporalio/workflow": "catalog:",
     "@temporalio/worker": "catalog:",
     "effect": "catalog:",

--- a/apps/workflows/src/activities/seed-demo-project-activities.ts
+++ b/apps/workflows/src/activities/seed-demo-project-activities.ts
@@ -19,6 +19,7 @@ import {
 } from "@platform/db-clickhouse"
 import { seedDemoProjectClickHouse } from "@platform/db-clickhouse/seeding"
 import { seedDemoProjectPostgres } from "@platform/db-postgres/seeding"
+import { Context as ActivityContext } from "@temporalio/activity"
 import { Effect, Layer } from "effect"
 import { getAdminPostgresClient, getClickhouseClient, getRedisClient } from "../clients.ts"
 
@@ -87,6 +88,37 @@ type DemoTraceRow = {
 // Hardcoded rather than resolved from org settings so demo rows never expire per-tenant config.
 const DEMO_PROJECT_RETENTION_DAYS = 30
 
+/**
+ * Embedding every seeded trace is the long pole of the demo seed. The
+ * production trace-search worker gets parallelism for free (one queue job
+ * per trace, processed across the worker pool); here every trace is indexed
+ * inside a single activity, so we fan out across traces with a bounded
+ * concurrency instead of awaiting each in turn. Chunks within a trace stay
+ * sequential — trace count (hundreds to thousands) dominates, so trace-level
+ * parallelism is where the win is, and processing one chunk at a time per
+ * trace keeps in-flight Voyage calls ~equal to this bound rather than
+ * `bound × chunks`. The Voyage adapter has no rate-limit guard, so this is
+ * the only throttle on the embedding fan-out.
+ */
+const SEED_TRACE_SEARCH_CONCURRENCY = 8
+
+/**
+ * Emit a Temporal activity heartbeat, no-op when not running inside an
+ * activity (unit tests, the local seed-repro path). `Context.current()`
+ * throws outside activity execution, so the guard keeps the same effect
+ * usable in both places. Paired with the workflow's `heartbeatTimeout`, a
+ * heartbeat per completed trace lets Temporal detect a dead worker in
+ * seconds instead of waiting out the 30-minute start-to-close timeout.
+ */
+const heartbeat = (details: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    try {
+      ActivityContext.current().heartbeat(details)
+    } catch {
+      // Not inside a Temporal activity — nothing to heartbeat.
+    }
+  })
+
 const listSeededTraceRows = (input: SeedDemoProjectActivityInput) =>
   queryClickhouse<DemoTraceRow>(
     getClickhouseClient(),
@@ -122,84 +154,95 @@ export const seedDemoProjectTraceSearchActivity = (input: SeedDemoProjectActivit
       const searchRepo = yield* TraceSearchRepository
       const ai = yield* AI
 
-      for (const row of traceRows) {
-        const traceId = TraceId(row.trace_id)
-        const startTimeMs = typeof row.start_time_ms === "string" ? Number(row.start_time_ms) : row.start_time_ms
-        const startTime = new Date(startTimeMs)
-        const trace = yield* traceRepo.findByTraceId({ organizationId, projectId, traceId })
-        if (trace.allMessages.length === 0) continue
+      const indexTrace = (row: DemoTraceRow) =>
+        Effect.gen(function* () {
+          const traceId = TraceId(row.trace_id)
+          const startTimeMs = typeof row.start_time_ms === "string" ? Number(row.start_time_ms) : row.start_time_ms
+          const startTime = new Date(startTimeMs)
+          const trace = yield* traceRepo.findByTraceId({ organizationId, projectId, traceId })
+          if (trace.allMessages.length === 0) {
+            yield* heartbeat(row.trace_id)
+            return
+          }
 
-        const document = yield* buildTraceSearchDocument({
-          traceId,
-          startTime,
-          rootSpanName: row.root_span_name,
-          messages: trace.allMessages,
-        })
-
-        yield* searchRepo.upsertDocument({
-          organizationId,
-          projectId,
-          traceId,
-          startTime,
-          rootSpanName: document.rootSpanName,
-          searchText: document.searchText,
-          contentHash: document.contentHash,
-          retentionDays: DEMO_PROJECT_RETENTION_DAYS,
-        })
-
-        // NOTE: mirrors `prioritizeChunksForEmbedding` in apps/workers/src/workers/trace-search.ts.
-        // Not imported directly because extracting it to @domain/spans is a larger refactor.
-        const eligibleChunks = document.chunks
-          .filter((item) => item.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
-          .sort((a, b) => b.chunkIndex - a.chunkIndex)
-
-        for (const chunk of eligibleChunks) {
-          const hasExisting = yield* searchRepo.hasEmbeddingWithHash(
-            organizationId,
-            projectId,
+          const document = yield* buildTraceSearchDocument({
             traceId,
-            chunk.chunkIndex,
-            chunk.contentHash,
-          )
-          if (hasExisting) continue
-
-          const embedding = yield* ai
-            .embed({
-              text: chunk.text,
-              model: TRACE_SEARCH_EMBEDDING_MODEL,
-              dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
-              telemetry: {
-                spanName: "demo-project.trace-search.embed",
-                name: "demo-project-trace-search-embed",
-                tags: ["demo-project", "trace-search", "embedding"],
-              },
-            })
-            .pipe(
-              Effect.tapError((err) =>
-                Effect.logWarning("demo-project trace-search embed failed — skipping chunk", {
-                  chunkIndex: chunk.chunkIndex,
-                  error: err,
-                }),
-              ),
-              Effect.orElseSucceed(() => null),
-            )
-          if (embedding === null) continue
-
-          yield* searchRepo.upsertEmbedding({
-            organizationId,
-            projectId,
-            traceId,
-            chunkIndex: chunk.chunkIndex,
             startTime,
-            contentHash: chunk.contentHash,
-            embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
-            embedding: embedding.embedding as readonly number[],
-            retentionDays: DEMO_PROJECT_RETENTION_DAYS,
-            firstMessageIndex: chunk.firstMessageIndex,
-            lastMessageIndex: chunk.lastMessageIndex,
+            rootSpanName: row.root_span_name,
+            messages: trace.allMessages,
           })
-        }
-      }
+
+          yield* searchRepo.upsertDocument({
+            organizationId,
+            projectId,
+            traceId,
+            startTime,
+            rootSpanName: document.rootSpanName,
+            searchText: document.searchText,
+            contentHash: document.contentHash,
+            retentionDays: DEMO_PROJECT_RETENTION_DAYS,
+          })
+
+          // NOTE: mirrors `prioritizeChunksForEmbedding` in apps/workers/src/workers/trace-search.ts.
+          // Not imported directly because extracting it to @domain/spans is a larger refactor.
+          const eligibleChunks = document.chunks
+            .filter((item) => item.text.length >= TRACE_SEARCH_EMBEDDING_MIN_LENGTH)
+            .sort((a, b) => b.chunkIndex - a.chunkIndex)
+
+          for (const chunk of eligibleChunks) {
+            const hasExisting = yield* searchRepo.hasEmbeddingWithHash(
+              organizationId,
+              projectId,
+              traceId,
+              chunk.chunkIndex,
+              chunk.contentHash,
+            )
+            if (hasExisting) continue
+
+            const embedding = yield* ai
+              .embed({
+                text: chunk.text,
+                model: TRACE_SEARCH_EMBEDDING_MODEL,
+                dimensions: TRACE_SEARCH_EMBEDDING_DIMENSIONS,
+                telemetry: {
+                  spanName: "demo-project.trace-search.embed",
+                  name: "demo-project-trace-search-embed",
+                  tags: ["demo-project", "trace-search", "embedding"],
+                },
+              })
+              .pipe(
+                Effect.tapError((err) =>
+                  Effect.logWarning("demo-project trace-search embed failed — skipping chunk", {
+                    chunkIndex: chunk.chunkIndex,
+                    error: err,
+                  }),
+                ),
+                Effect.orElseSucceed(() => null),
+              )
+            if (embedding === null) continue
+
+            yield* searchRepo.upsertEmbedding({
+              organizationId,
+              projectId,
+              traceId,
+              chunkIndex: chunk.chunkIndex,
+              startTime,
+              contentHash: chunk.contentHash,
+              embeddingModel: TRACE_SEARCH_EMBEDDING_MODEL,
+              embedding: embedding.embedding as readonly number[],
+              retentionDays: DEMO_PROJECT_RETENTION_DAYS,
+              firstMessageIndex: chunk.firstMessageIndex,
+              lastMessageIndex: chunk.lastMessageIndex,
+            })
+          }
+
+          yield* heartbeat(row.trace_id)
+        })
+
+      yield* Effect.forEach(traceRows, indexTrace, {
+        concurrency: SEED_TRACE_SEARCH_CONCURRENCY,
+        discard: true,
+      })
     }).pipe(
       withClickHouse(Layer.mergeAll(TraceRepositoryLive, TraceSearchRepositoryLive), clickhouse, organizationId),
       withAi(AIEmbedLive, redis),

--- a/apps/workflows/src/activities/seed-demo-project-activities.ts
+++ b/apps/workflows/src/activities/seed-demo-project-activities.ts
@@ -150,6 +150,12 @@ export const seedDemoProjectTraceSearchActivity = (input: SeedDemoProjectActivit
   return Effect.runPromise(
     Effect.gen(function* () {
       const traceRows = yield* listSeededTraceRows(input)
+      // Heartbeat once up front: the per-trace heartbeats below only start
+      // firing after the first trace finishes, so without this the heartbeat
+      // clock would have to cover `listSeededTraceRows` + the first trace's
+      // embeds before any signal — a slow start could trip `heartbeatTimeout`
+      // on attempt 1 even though nothing is wrong.
+      yield* heartbeat("start")
       const traceRepo = yield* TraceRepository
       const searchRepo = yield* TraceSearchRepository
       const ai = yield* AI

--- a/apps/workflows/src/workflows/seed-demo-project-workflow.ts
+++ b/apps/workflows/src/workflows/seed-demo-project-workflow.ts
@@ -41,11 +41,29 @@ import { gardenTaxonomyWorkflow } from "./taxonomy-gardening-workflow.ts"
  * use-case created it) but its content is partial. Operators clean up
  * via the existing `softDeleteProject` admin server function.
  */
-const { seedDemoProjectPostgresActivity, seedDemoProjectClickHouseActivity, seedDemoProjectTraceSearchActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "30 minutes",
-    retry: { ...defaultActivityRetryPolicy, nonRetryableErrorTypes: ["SeedError"] },
-  })
+const { seedDemoProjectPostgresActivity, seedDemoProjectClickHouseActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
+  retry: { ...defaultActivityRetryPolicy, nonRetryableErrorTypes: ["SeedError"] },
+})
+
+/**
+ * The trace-search activity embeds every seeded trace via Voyage and is the
+ * long pole. It heartbeats per trace, so a worker that dies mid-run (in dev
+ * `tsx watch` restarts the worker on every file save) is detected within
+ * `heartbeatTimeout` and the activity is retried in seconds — instead of
+ * sitting orphaned in `Started` until the 30-minute `startToCloseTimeout`
+ * elapses, which is what made the seed appear to "hang". Retries are cheap:
+ * the activity skips already-written documents/embeddings via dedupe-by-hash.
+ *
+ * Kept in its own proxy because the Postgres/ClickHouse activities don't
+ * heartbeat — a shared `heartbeatTimeout` would fail them the moment they ran
+ * longer than the timeout without emitting one.
+ */
+const { seedDemoProjectTraceSearchActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
+  heartbeatTimeout: "2 minutes",
+  retry: { ...defaultActivityRetryPolicy, nonRetryableErrorTypes: ["SeedError"] },
+})
 
 export interface SeedDemoProjectWorkflowInput {
   readonly organizationId: string

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -570,7 +570,19 @@ const seedFixedTraces: Seeder = {
         return
       }
       const allFixedSpans = buildAllFixedSpans(ctx.scope)
-      yield* insertJsonEachRow(ctx.client, "spans", allFixedSpans)
+      // `insertJsonEachRow` chunks large inserts into multiple requests, so a
+      // mid-insert failure can commit some batches but not others. The sentinel
+      // above is read back from the `spans` table, so it must only become
+      // visible once the *whole* fixture set has landed — otherwise a retry
+      // after a partial insert would find the sentinel, skip, and leave spans
+      // permanently missing. Insert every non-sentinel span first and the
+      // sentinel trace's spans last. A retry that re-inserts earlier batches is
+      // safe: `spans` is a ReplacingMergeTree keyed by span_id, so duplicates
+      // collapse on merge.
+      const sentinelSpans = allFixedSpans.filter((span) => span.trace_id === sentinel)
+      const nonSentinelSpans = allFixedSpans.filter((span) => span.trace_id !== sentinel)
+      yield* insertJsonEachRow(ctx.client, "spans", nonSentinelSpans)
+      yield* insertJsonEachRow(ctx.client, "spans", sentinelSpans)
       if (!ctx.quiet) console.log(`  -> spans/fixed-traces: ${allFixedSpans.length} deterministic tau2 spans`)
     }),
 }

--- a/packages/platform/db-clickhouse/src/sql.ts
+++ b/packages/platform/db-clickhouse/src/sql.ts
@@ -48,6 +48,19 @@ export const commandClickhouse = (
     catch: (error) => new ClickhouseCommandError({ cause: error, query }),
   })
 
+/**
+ * Max rows per `client.insert()` HTTP request. Large seed inserts (e.g. the
+ * ~40k deterministic demo spans, whose message blobs alone run to hundreds of
+ * MiB) must be chunked: a single insert of that size completes fine against a
+ * localhost ClickHouse but stalls against a remote/managed one — the giant
+ * HTTP body trips request-size/memory limits or proxy timeouts, the call never
+ * returns, and the Temporal seed activity sits until its start-to-close
+ * timeout. Chunking caps each request's body so the insert stays well within
+ * remote limits. ClickHouse inserts aren't transactional, so splitting one
+ * logical insert into several is behaviourally equivalent here.
+ */
+const INSERT_BATCH_SIZE = 500
+
 export const insertJsonEachRow = <TRow extends Record<string, unknown>>(
   client: ClickHouseClient,
   table: string,
@@ -56,13 +69,16 @@ export const insertJsonEachRow = <TRow extends Record<string, unknown>>(
   Effect.gen(function* () {
     if (values.length === 0) return
 
-    yield* Effect.tryPromise({
-      try: () =>
-        client.insert({
-          table,
-          values,
-          format: "JSONEachRow",
-        }),
-      catch: (error) => new ClickhouseInsertError({ cause: error, table }),
-    })
+    for (let offset = 0; offset < values.length; offset += INSERT_BATCH_SIZE) {
+      const batch = values.slice(offset, offset + INSERT_BATCH_SIZE)
+      yield* Effect.tryPromise({
+        try: () =>
+          client.insert({
+            table,
+            values: batch,
+            format: "JSONEachRow",
+          }),
+        catch: (error) => new ClickhouseInsertError({ cause: error, table }),
+      })
+    }
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,6 +863,9 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@temporalio/activity':
+        specifier: 'catalog:'
+        version: 1.17.0
       '@temporalio/worker':
         specifier: 'catalog:'
         version: 1.17.0(esbuild@0.27.7)(tslib@2.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 'catalog:'
-        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
+        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
       '@platform/testkit':
         specifier: workspace:*
         version: link:../../packages/platform/testkit
@@ -365,7 +365,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/web:
     dependencies:
@@ -863,6 +863,9 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@temporalio/activity':
+        specifier: 'catalog:'
+        version: 1.17.0
       '@temporalio/worker':
         specifier: 'catalog:'
         version: 1.17.0(esbuild@0.27.7)(tslib@2.8.1)
@@ -884,7 +887,7 @@ importers:
         version: link:../../packages/vitest-config
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   examples/sdks/typescript:
     dependencies:
@@ -14951,7 +14954,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@cfworker/json-schema@4.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -14962,7 +14965,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@25.9.1)(typescript@6.0.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -19184,7 +19187,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-    optional: true
 
   '@types/nodemailer@8.0.0':
     dependencies:
@@ -23899,26 +23901,6 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.14.1
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.30
-
   ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.19.17)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23939,6 +23921,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.30
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.9.1)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.30
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -24068,8 +24070,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.24.6:
-    optional: true
+  undici-types@7.24.6: {}
 
   undici@6.26.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,7 +295,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 'catalog:'
-        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
+        version: 0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)
       '@platform/testkit':
         specifier: workspace:*
         version: link:../../packages/platform/testkit
@@ -365,7 +365,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/web:
     dependencies:
@@ -863,9 +863,6 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../../packages/utils
-      '@temporalio/activity':
-        specifier: 'catalog:'
-        version: 1.17.0
       '@temporalio/worker':
         specifier: 'catalog:'
         version: 1.17.0(esbuild@0.27.7)(tslib@2.8.1)
@@ -887,7 +884,7 @@ importers:
         version: link:../../packages/vitest-config
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   examples/sdks/typescript:
     dependencies:
@@ -14954,7 +14951,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
+  '@modelcontextprotocol/inspector@0.21.2(@cfworker/json-schema@4.1.1)(@swc/core@1.15.30)(@types/node@22.14.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(typescript@6.0.3)':
     dependencies:
       '@modelcontextprotocol/inspector-cli': 0.21.2(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@modelcontextprotocol/inspector-client': 0.21.2(@cfworker/json-schema@4.1.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)
@@ -14965,7 +14962,7 @@ snapshots:
       open: 10.2.0
       shell-quote: 1.8.3
       spawn-rx: 5.1.2
-      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@25.9.1)(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -19187,6 +19184,7 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/nodemailer@8.0.0':
     dependencies:
@@ -23901,6 +23899,26 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.14.1)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.14.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.30
+
   ts-node@10.9.2(@swc/core@1.15.30)(@types/node@22.19.17)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23921,26 +23939,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.30
     optional: true
-
-  ts-node@10.9.2(@swc/core@1.15.30)(@types/node@25.9.1)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.1
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.30
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -24070,7 +24068,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   undici@6.26.0: {}
 


### PR DESCRIPTION
## Why

The "Create Demo Project" seed workflow was failing/stalling. Two distinct root causes, surfacing differently by environment:

- **Staging/production: stuck in `seedDemoProjectClickHouseActivity`.** The ClickHouse seed inserts all ~40k deterministic spans in a **single `client.insert()`** — the message blobs alone are ~200 MiB. On a localhost ClickHouse this finishes in seconds; against a remote/managed ClickHouse the giant HTTP body trips request-size/memory limits or proxy timeouts, the call never returns, and the activity sits until its 30-min start-to-close timeout, then retries (CH seeders throw plain *retryable* errors) — i.e. "stuck".
- **Locally: trace-search seeding was slow, and the seed appeared to "hang".** The trace-search step embedded every trace's chunks in one sequential loop (the long pole). Separately, because the long activity had no `heartbeatTimeout`, a worker restart mid-run (in dev `tsx watch` restarts on every file save) left the activity orphaned in `Started` until the 30-min timeout.

## What

1. **`fix(db-clickhouse)`** — chunk `insertJsonEachRow` at 500 rows internally (seed-only helper). Each request body stays small regardless of caller. ClickHouse inserts aren't transactional, so splitting one logical insert into several is equivalent here. This is the direct fix for the staging/prod stall.
2. **`perf(workflows)`** — fan out the demo trace-search seed across traces with bounded concurrency (8); chunks within a trace stay sequential so in-flight Voyage calls stay ~equal to the bound. Cut the step from minutes to well under a minute locally.
3. **`fix(workflows)`** — give the trace-search activity (its own `proxyActivities`, so the short Postgres/ClickHouse activities aren't forced to heartbeat) a `heartbeatTimeout` and a heartbeat per trace. A dead worker is now detected in seconds and the activity retries, skipping already-written rows via dedupe-by-hash, instead of hanging for 30 minutes.

## Testing

- `pnpm --filter @platform/db-clickhouse --filter @app/workflows typecheck` — clean
- `@app/workflows` tests: 70 passed
- `@platform/db-clickhouse` tests: 223 passed
- Verified locally end-to-end: the parallel trace-search seed wrote ~1.2k embeddings in ~30s (vs. 9+ min sequential); the batched CH insert seeds the full ~40k spans without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/7946b56a-7614-456d-9fb8-62ecca810878/pull/3471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->