### PR TITLE
feat(web): filter behaviour sessions by trajectory turns

### DIFF
--- a/apps/web/src/domains/taxonomy/taxonomy.collection.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.collection.ts
@@ -1,5 +1,6 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import {
+  type BehaviourMomentRangeRecord,
   type BehaviourSessionFilter,
   type BehaviourTimeRangeRecord,
   type BehaviourTrajectoryAxis,
@@ -16,6 +17,8 @@ type BehaviourSortBy = "category" | "volume" | "trend" | "first_seen" | "last_se
 
 const timeRangeKey = (timeRange: BehaviourTimeRangeRecord | undefined) =>
   `${timeRange?.fromIso ?? ""}:${timeRange?.toIso ?? ""}`
+const momentRangeKey = (momentRange: BehaviourMomentRangeRecord | undefined) =>
+  momentRange ? `${momentRange.metric}:${momentRange.fromTurn}:${momentRange.toTurn}` : ""
 
 const clusterProfileQueryKey = (
   projectId: string,
@@ -27,7 +30,8 @@ const behaviourSessionsQueryKey = (
   clusterId: string,
   filter: BehaviourSessionFilter,
   timeRange: BehaviourTimeRangeRecord | undefined,
-) => ["behaviourSessions", projectId, clusterId, filter, timeRangeKey(timeRange)] as const
+  momentRange: BehaviourMomentRangeRecord | undefined,
+) => ["behaviourSessions", projectId, clusterId, filter, timeRangeKey(timeRange), momentRangeKey(momentRange)] as const
 const behaviourTrajectoryQueryKey = (
   projectId: string,
   categoryClusterIds: readonly string[],
@@ -70,9 +74,10 @@ export function useBehaviourSessions(
   clusterId: string | undefined,
   filter: BehaviourSessionFilter,
   timeRange: BehaviourTimeRangeRecord | undefined,
+  momentRange: BehaviourMomentRangeRecord | undefined,
 ) {
   return useInfiniteQuery({
-    queryKey: behaviourSessionsQueryKey(projectId, clusterId ?? "", filter, timeRange),
+    queryKey: behaviourSessionsQueryKey(projectId, clusterId ?? "", filter, timeRange, momentRange),
     queryFn: ({ pageParam }) =>
       getBehaviourSessions({
         data: {
@@ -82,6 +87,7 @@ export function useBehaviourSessions(
           offset: pageParam,
           limit: 50,
           ...(timeRange ? { timeRange } : {}),
+          ...(momentRange ? { momentRange } : {}),
         },
       }),
     initialPageParam: 0,

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -84,6 +84,13 @@ export interface BehaviourTimeRangeRecord {
 }
 
 export type BehaviourSessionFilter = "all" | MomentKind
+export type BehaviourTrajectoryMetric = "frequency" | "escalation" | "resolution" | "churnRisk" | "wins"
+
+export interface BehaviourMomentRangeRecord {
+  readonly metric: BehaviourTrajectoryMetric
+  readonly fromTurn: number
+  readonly toTurn: number
+}
 
 export interface BehaviourSessionRecord {
   readonly sessionId: string
@@ -146,6 +153,17 @@ const behaviourTimeRangeSchema = z
     fromIso: z.string().optional(),
     toIso: z.string().optional(),
   })
+  .optional()
+
+const behaviourTrajectoryMetricSchema = z.enum(["frequency", "escalation", "resolution", "churnRisk", "wins"])
+
+const behaviourMomentRangeSchema = z
+  .object({
+    metric: behaviourTrajectoryMetricSchema,
+    fromTurn: z.number().int().min(0),
+    toTurn: z.number().int().min(0),
+  })
+  .refine((range) => range.toTurn >= range.fromTurn, "toTurn must be greater than or equal to fromTurn")
   .optional()
 
 const parseBehaviourTimeRange = (timeRange: BehaviourTimeRangeRecord | undefined) => ({
@@ -585,11 +603,29 @@ const behaviourSessionFilterSql = `
     OR ({filter:String} NOT IN ('all', 'resolution', 'abandonment') AND has(momentKinds, {filter:String})))
 `
 
+const behaviourMetricMomentSql = `
+  (({momentMetric:String} = 'frequency' AND m.kind != '')
+    OR ({momentMetric:String} = 'escalation' AND m.kind = 'escalation')
+    OR ({momentMetric:String} = 'resolution' AND m.kind = 'resolution')
+    OR ({momentMetric:String} = 'churnRisk' AND m.kind IN ('abandonment', 'user_frustration'))
+    OR ({momentMetric:String} = 'wins' AND m.kind IN ('resolution', 'user_satisfaction')))
+`
+
+const behaviourMomentRangeSql = `
+  ${behaviourMetricMomentSql}
+  AND m.first_message_index >= {turnFrom:UInt16}
+  AND m.first_message_index <= {turnTo:UInt16}
+`
+
 // Observations are pinned to each session's CURRENT analysis: superseded
 // analysis generations are never deleted, so an unscoped read unions every
 // re-analysis and \`any(analysis_hash)\` could pick a stale hash, breaking the
 // trace link and silently dropping every moment label.
-const behaviourClusterSessionsCte = (timeFromClause = "", timeToClause = "") => `
+const behaviourClusterSessionsCte = (
+  timeFromClause = "",
+  timeToClause = "",
+  momentRange: BehaviourMomentRangeRecord | undefined = undefined,
+) => `
   WITH latest_analyses AS (
     SELECT organization_id, project_id, session_id, analysis_hash, trace_ids
     FROM session_analyses FINAL
@@ -624,10 +660,12 @@ const behaviourClusterSessionsCte = (timeFromClause = "", timeToClause = "") => 
     SELECT
       cs.session_id AS sessionId,
       any(cs.traceId) AS traceId,
-      any(cs.momentId) AS momentId,
+      ${momentRange ? `argMinIf(m.moment_id, m.first_message_index, ${behaviourMomentRangeSql})` : "any(cs.momentId)"}
+        AS momentId,
       any(cs.summary) AS summary,
       any(cs.startTime) AS startTime,
       any(cs.endTime) AS endTime,
+      ${momentRange ? `countIf(${behaviourMomentRangeSql})` : "toUInt64(0)"} AS selectedMomentCount,
       groupUniqArrayIf(m.kind, m.kind != '') AS momentKinds
     FROM cluster_sessions AS cs
     LEFT JOIN session_moment_labels AS m FINAL
@@ -648,6 +686,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
       limit: z.number().int().min(1).max(100).optional(),
       filter: z.enum(["all", ...MOMENT_KINDS]).optional(),
       timeRange: behaviourTimeRangeSchema,
+      momentRange: behaviourMomentRangeSchema,
     }),
   )
   .handler(async ({ data }): Promise<BehaviourSessionsRecord> => {
@@ -657,6 +696,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
     const limit = data.limit ?? 50
     const filter = data.filter ?? "all"
     const timeRange = parseBehaviourTimeRange(data.timeRange)
+    const momentRange = data.momentRange
     // Tree node: sessions assigned anywhere in its subtree belong to it.
     const clusterIds = await Effect.runPromise(
       Effect.gen(function* () {
@@ -673,11 +713,16 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
       ...(timeRange.from ? { startTimeFrom: timeRange.from.toISOString().replace("Z", "") } : {}),
       ...(timeRange.to ? { startTimeTo: timeRange.to.toISOString().replace("Z", "") } : {}),
     }
+    const momentRangeClause = momentRange ? "AND selectedMomentCount > 0" : ""
+    const momentRangeQueryParams = momentRange
+      ? { momentMetric: momentRange.metric, turnFrom: momentRange.fromTurn, turnTo: momentRange.toTurn }
+      : {}
     const result = await getClickhouseClient().query({
-      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause)}
+      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, momentRange)}
               SELECT sessionId, traceId, momentId, summary, startTime, endTime, momentKinds
               FROM enriched_sessions
               WHERE ${behaviourSessionFilterSql}
+              ${momentRangeClause}
               ORDER BY endTime DESC
               LIMIT {pageSize:UInt32}
               OFFSET {offset:UInt32}`,
@@ -689,6 +734,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
         pageSize: limit + 1,
         offset,
         ...timeQueryParams,
+        ...momentRangeQueryParams,
       },
       format: "JSONEachRow",
     })
@@ -706,15 +752,23 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
         ? "1 HOUR"
         : "1 DAY"
     const histogramResult = await getClickhouseClient().query({
-      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause)}
+      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, momentRange)}
               SELECT
                 toStartOfInterval(endTime, INTERVAL ${histogramInterval}) AS startTime,
                 count() AS count
               FROM enriched_sessions
               WHERE ${behaviourSessionFilterSql}
+              ${momentRangeClause}
               GROUP BY startTime
               ORDER BY startTime ASC`,
-      query_params: { organizationId, projectId: data.projectId, clusterIds, filter, ...timeQueryParams },
+      query_params: {
+        organizationId,
+        projectId: data.projectId,
+        clusterIds,
+        filter,
+        ...timeQueryParams,
+        ...momentRangeQueryParams,
+      },
       format: "JSONEachRow",
     })
     const histogram = (await histogramResult.json()) as Array<{

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-trajectory-chart.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-trajectory-chart.tsx
@@ -6,9 +6,9 @@ import { useBehaviourTrajectory } from "../../../../../../domains/taxonomy/taxon
 import type {
   BehaviourNodeRecord,
   BehaviourTimeRangeRecord,
+  BehaviourTrajectoryMetric,
 } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
 
-type TrajectoryMetric = "frequency" | "escalation" | "resolution" | "churnRisk" | "wins"
 type TrajectoryAxis = "day" | "turn"
 
 const MAX_COLLAPSED_ROWS = 3
@@ -18,7 +18,7 @@ const ROW_HEIGHT_PX = 48
 const MAX_TURN_BUCKETS = 14
 const CHART_X_PADDING_PERCENT = 2.5
 
-const metricOptions: ReadonlyArray<{ readonly id: TrajectoryMetric; readonly label: string }> = [
+const metricOptions: ReadonlyArray<{ readonly id: BehaviourTrajectoryMetric; readonly label: string }> = [
   { id: "frequency", label: "Frequency" },
   { id: "escalation", label: "Escalation" },
   { id: "resolution", label: "Resolution" },
@@ -91,7 +91,7 @@ const coarsenTrajectoryRows = (
     maxWinsLastMessageIndex: number
   }[],
   axis: TrajectoryAxis,
-  metric: TrajectoryMetric,
+  metric: BehaviourTrajectoryMetric,
 ) => {
   if (axis === "day") {
     return {
@@ -175,7 +175,7 @@ const coarsenTrajectoryRows = (
 
 const metricValue = (
   row: { frequency: number; escalation: number; resolution: number; churnRisk: number; wins: number },
-  metric: TrajectoryMetric,
+  metric: BehaviourTrajectoryMetric,
 ) => row[metric]
 
 const maxLastMessageIndexForMetric = (
@@ -186,7 +186,7 @@ const maxLastMessageIndexForMetric = (
     maxChurnRiskLastMessageIndex: number
     maxWinsLastMessageIndex: number
   },
-  metric: TrajectoryMetric,
+  metric: BehaviourTrajectoryMetric,
 ) => {
   if (metric === "escalation") return row.maxEscalationLastMessageIndex
   if (metric === "resolution") return row.maxResolutionLastMessageIndex
@@ -207,15 +207,23 @@ export function BehavioursTrajectoryChart({
   selectedPath,
   timeRange,
   onSelectPath,
+  onSelectPoint,
 }: {
   readonly projectId: string
   readonly topics: readonly BehaviourNodeRecord[]
   readonly selectedPath: readonly string[]
   readonly timeRange: BehaviourTimeRangeRecord | undefined
   readonly onSelectPath: (path: readonly string[]) => void
+  readonly onSelectPoint: (selection: {
+    readonly path: readonly string[]
+    readonly axis: TrajectoryAxis
+    readonly metric: BehaviourTrajectoryMetric
+    readonly bucket: string
+    readonly maxTurn: number
+  }) => void
 }) {
-  const [metric, setMetric] = useState<TrajectoryMetric>("frequency")
-  const [axis, setAxis] = useState<TrajectoryAxis>("day")
+  const [metric, setMetric] = useState<BehaviourTrajectoryMetric>("frequency")
+  const [axis, setAxis] = useState<TrajectoryAxis>("turn")
   const [showAll, setShowAll] = useState(false)
   const visibleLevel = useMemo(() => resolveVisibleLevel(topics, selectedPath), [topics, selectedPath])
   const visibleNodes = showAll ? visibleLevel.nodes : visibleLevel.nodes.slice(0, MAX_COLLAPSED_ROWS)
@@ -227,6 +235,10 @@ export function BehavioursTrajectoryChart({
   const buckets = trajectory.buckets
   const maxCount = Math.max(...rows.map((row) => metricValue(row, metric)), 0)
   const rowsByCategoryAndBucket = new Map(rows.map((row) => [`${row.categoryClusterId}:${row.bucket}`, row]))
+  const maxTurn =
+    axis === "turn"
+      ? Math.max(...buckets.map((candidate) => Number(candidate.split(":")[1] ?? candidate)).filter(Number.isFinite), 0)
+      : 0
   const chartHeight = Math.max(visibleNodes.length * ROW_HEIGHT_PX, ROW_HEIGHT_PX)
   const canGoBack = visibleLevel.trail.length > 0
   const currentPath = visibleLevel.trail.map((node) => node.cluster.id)
@@ -349,7 +361,15 @@ export function BehavioursTrajectoryChart({
                             marginTop: -size / 2,
                             backgroundColor: rowColors[rowIndex % rowColors.length],
                           }}
-                          onClick={() => onSelectPath([...currentPath, node.cluster.id])}
+                          onClick={() =>
+                            onSelectPoint({
+                              path: [...currentPath, node.cluster.id],
+                              axis,
+                              metric,
+                              bucket,
+                              maxTurn,
+                            })
+                          }
                         />
                       }
                     >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -282,7 +282,14 @@ export function BehaviourDetailDrawer({
     setSessionFilter("all")
     setSessionOverlayId(null)
     setSessionPanelEntered(false)
-  }, [cluster.id, timeRange, momentRange])
+  }, [cluster.id, timeRange])
+
+  useEffect(() => {
+    if (!momentRange) return
+    setSessionFilter("all")
+    setSessionOverlayId(null)
+    setSessionPanelEntered(false)
+  }, [momentRange])
 
   const openSessionOverlay = (session: BehaviourSessionRecord) => {
     setSessionOverlayId(session.sessionId)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -9,6 +9,7 @@ import {
   InfiniteTable,
   type InfiniteTableColumn,
   Skeleton,
+  Slider,
   Tabs,
   TagList,
   Text,
@@ -16,7 +17,16 @@ import {
 } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { ArrowDownIcon, ArrowUpIcon, ChevronRightIcon, FlameIcon, MinusIcon, SparklesIcon, TagIcon } from "lucide-react"
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ChevronRightIcon,
+  FlameIcon,
+  MinusIcon,
+  SparklesIcon,
+  TagIcon,
+  XIcon,
+} from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
 import {
   type BehaviourSegment,
@@ -24,16 +34,17 @@ import {
   useClusterProfile,
 } from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
 import type {
+  BehaviourMomentRangeRecord,
   BehaviourNodeRecord,
   BehaviourSessionFilter,
   BehaviourSessionRecord,
   BehaviourTimeRangeRecord,
+  BehaviourTrajectoryMetric,
 } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
 import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
-import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { SessionDetailDrawer } from "../../-components/session-detail-drawer.tsx"
 import { BehavioursTrajectoryChart } from "./behaviours-trajectory-chart.tsx"
 
@@ -51,6 +62,50 @@ interface BehaviourTableRow {
 
 const formatDate = (iso: string) => new Date(iso).toLocaleDateString()
 const signalLabel = (kind: string) => kind.replaceAll("_", " ").replace(/^./, (char) => char.toUpperCase())
+const metricLabel = (metric: BehaviourTrajectoryMetric) =>
+  metric === "churnRisk" ? "Churn risk" : metric === "wins" ? "Wins" : signalLabel(metric)
+
+const momentKindsForTrajectoryMetric = (metric: BehaviourTrajectoryMetric): readonly MomentKind[] => {
+  switch (metric) {
+    case "escalation":
+      return ["escalation"]
+    case "resolution":
+      return ["resolution"]
+    case "churnRisk":
+      return ["abandonment", "user_frustration"]
+    case "wins":
+      return ["resolution", "user_satisfaction"]
+    case "frequency":
+      return []
+  }
+}
+
+const selectedMomentRangeLabel = (range: BehaviourMomentRangeRecord) =>
+  `${metricLabel(range.metric)} moments in turns ${range.fromTurn + 1}${
+    range.toTurn === range.fromTurn ? "" : `-${range.toTurn + 1}`
+  }`
+
+const parseTurnBucket = (bucket: string): { readonly fromTurn: number; readonly toTurn: number } | undefined => {
+  const [rawStart, rawEnd] = bucket.split(":")
+  const fromTurn = Number(rawStart)
+  const toTurn = rawEnd === undefined ? fromTurn : Number(rawEnd)
+  if (!Number.isInteger(fromTurn) || !Number.isInteger(toTurn) || fromTurn < 0 || toTurn < fromTurn) return undefined
+  return { fromTurn, toTurn }
+}
+
+const findBehaviourPath = (
+  nodes: readonly BehaviourNodeRecord[],
+  clusterId: string,
+  ancestors: readonly string[] = [],
+): readonly string[] | undefined => {
+  for (const node of nodes) {
+    const path = [...ancestors, node.cluster.id]
+    if (node.cluster.id === clusterId) return path
+    const childPath = findBehaviourPath(node.children, clusterId, path)
+    if (childPath) return childPath
+  }
+  return undefined
+}
 
 const trendLabel = (status: BehaviourNodeRecord["trend"]["status"]): string => {
   switch (status) {
@@ -177,12 +232,18 @@ export function BehaviourDetailDrawer({
   parentName,
   projectId,
   timeRange,
+  momentRange,
+  momentRangeMaxTurn,
+  onMomentRangeChange,
   onClose,
 }: {
   readonly node: BehaviourNodeRecord
   readonly parentName: string | null
   readonly projectId: string
   readonly timeRange: BehaviourTimeRangeRecord | undefined
+  readonly momentRange: BehaviourMomentRangeRecord | undefined
+  readonly momentRangeMaxTurn: number
+  readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
   readonly onClose: () => void
 }) {
   const cluster = node.cluster
@@ -197,10 +258,16 @@ export function BehaviourDetailDrawer({
     fetchNextPage: fetchNextBehaviourSessionsPage,
     hasNextPage: hasNextBehaviourSessionsPage,
     isFetchingNextPage: isFetchingNextBehaviourSessionsPage,
-  } = useBehaviourSessions(projectId, cluster.id, sessionFilter, timeRange)
+  } = useBehaviourSessions(projectId, cluster.id, sessionFilter, timeRange, momentRange)
   const behaviourSessions = behaviourSessionsData?.pages.flatMap((page) => page.sessions) ?? []
   const behaviourSessionHistogram = behaviourSessionsData?.pages[0]?.histogram ?? []
   const detectedSignals = intelligence?.topMoments ?? []
+  const activeMomentKinds = momentRange
+    ? momentKindsForTrajectoryMetric(momentRange.metric)
+    : sessionFilter === "all"
+      ? []
+      : [sessionFilter]
+  const hasSessionFilters = sessionFilter !== "all" || Boolean(momentRange)
   const sessionFilterOptions = detectedSignals
     .filter((signal): signal is { readonly kind: MomentKind; readonly count: number } =>
       (MOMENT_KINDS as readonly string[]).includes(signal.kind),
@@ -215,7 +282,7 @@ export function BehaviourDetailDrawer({
     setSessionFilter("all")
     setSessionOverlayId(null)
     setSessionPanelEntered(false)
-  }, [cluster.id, timeRange])
+  }, [cluster.id, timeRange, momentRange])
 
   const openSessionOverlay = (session: BehaviourSessionRecord) => {
     setSessionOverlayId(session.sessionId)
@@ -275,10 +342,13 @@ export function BehaviourDetailDrawer({
                     {sessionFilterOptions.map((option) => (
                       <MetricButton
                         key={option.id}
-                        active={sessionFilter === option.id}
+                        active={activeMomentKinds.includes(option.id)}
                         label={option.label}
                         valueText={option.valueText}
-                        onClick={() => setSessionFilter((current) => (current === option.id ? "all" : option.id))}
+                        onClick={() => {
+                          onMomentRangeChange(undefined)
+                          setSessionFilter((current) => (current === option.id && !momentRange ? "all" : option.id))
+                        }}
                       />
                     ))}
                   </div>
@@ -286,11 +356,29 @@ export function BehaviourDetailDrawer({
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center justify-between gap-2">
                     <Text.H5>Associated sessions</Text.H5>
+                    {hasSessionFilters ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setSessionFilter("all")
+                          onMomentRangeChange(undefined)
+                        }}
+                      >
+                        <Icon icon={XIcon} size="xs" />
+                        Clear filters
+                      </Button>
+                    ) : null}
                   </div>
+                  {momentRange ? (
+                    <TurnRangeSlider range={momentRange} maxTurn={momentRangeMaxTurn} onChange={onMomentRangeChange} />
+                  ) : null}
                   <Text.H6 color="foregroundMuted">
-                    {sessionFilter === "all"
-                      ? "All sessions for this behaviour"
-                      : `Sessions matching ${sessionFilter.replaceAll("_", " ")}`}
+                    {momentRange
+                      ? selectedMomentRangeLabel(momentRange)
+                      : sessionFilter === "all"
+                        ? "All sessions for this behaviour"
+                        : `Sessions matching ${sessionFilter.replaceAll("_", " ")}`}
                   </Text.H6>
                   {behaviourSessionsLoading ? (
                     <Skeleton className="h-16 rounded-xl" />
@@ -344,6 +432,63 @@ export function BehaviourDetailDrawer({
         </>
       ) : null}
     </>
+  )
+}
+
+function TurnRangeSlider({
+  range,
+  maxTurn,
+  onChange,
+}: {
+  readonly range: BehaviourMomentRangeRecord
+  readonly maxTurn: number
+  readonly onChange: (range: BehaviourMomentRangeRecord, maxTurn: number) => void
+}) {
+  const sliderMax = Math.max(maxTurn, range.toTurn, 1)
+  const committedValue = [range.fromTurn, range.toTurn] as const
+  const [draftValue, setDraftValue] = useState<readonly [number, number]>(committedValue)
+
+  useEffect(() => {
+    setDraftValue(committedValue)
+  }, [range.fromTurn, range.toTurn])
+
+  const [draftFrom, draftTo] = draftValue
+
+  const normalizeRange = (values: readonly number[]) => {
+    const first = values[0] ?? range.fromTurn
+    const second = values[1] ?? range.toTurn
+    const fromTurn = Math.max(0, Math.min(first, second))
+    const toTurn = Math.min(sliderMax, Math.max(first, second))
+    return [fromTurn, toTurn] as const
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg bg-secondary px-3 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <Text.H6 color="foregroundMuted">Turn range</Text.H6>
+        <Text.H6B className="tabular-nums">
+          {draftFrom + 1}
+          {draftTo === draftFrom ? "" : `-${draftTo + 1}`}
+        </Text.H6B>
+      </div>
+      <Slider
+        aria-label="Selected turn range"
+        min={0}
+        max={sliderMax}
+        step={1}
+        minStepsBetweenThumbs={0}
+        value={[draftFrom, draftTo]}
+        onValueChange={(values) => setDraftValue(normalizeRange(values))}
+        onValueCommit={(values) => {
+          const [fromTurn, toTurn] = normalizeRange(values)
+          onChange({ ...range, fromTurn, toTurn }, sliderMax)
+        }}
+      />
+      <div className="flex items-center justify-between text-muted-foreground text-xs tabular-nums">
+        <span>1</span>
+        <span>{sliderMax + 1}</span>
+      </div>
+    </div>
   )
 }
 
@@ -597,22 +742,27 @@ export function BehavioursView({
   projectId,
   isLoading,
   segment,
-  activeBehaviourId,
+  behaviourPath,
   timeFilter,
   timeRange,
+  momentRange,
   onSegmentChange,
-  onActiveBehaviourChange,
+  onBehaviourPathChange,
+  onMomentRangeChange,
 }: {
   readonly topics: readonly BehaviourNodeRecord[]
   readonly projectId: string
   readonly isLoading: boolean
   readonly segment: BehaviourSegment
-  readonly activeBehaviourId: string | undefined
+  readonly behaviourPath: readonly string[]
   readonly timeFilter: ReactNode
   readonly timeRange: BehaviourTimeRangeRecord | undefined
+  readonly momentRange: BehaviourMomentRangeRecord | undefined
   readonly onSegmentChange: (segment: BehaviourSegment) => void
-  readonly onActiveBehaviourChange: (behaviourId: string | undefined) => void
+  readonly onBehaviourPathChange: (path: readonly string[]) => void
+  readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
 }) {
+  const activeBehaviourId = behaviourPath.at(-1)
   const expandableKeys = useMemo(() => {
     const keys = new Set<string>()
     const walk = (nodes: readonly BehaviourNodeRecord[]) => {
@@ -624,25 +774,62 @@ export function BehavioursView({
     walk(topics)
     return keys
   }, [topics])
-  const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(new Set())
-  // The drill path lives in the URL with push-history semantics so the
-  // browser back/forward buttons step through chart selections instead of
-  // leaving the page.
-  const [dotChartPathParam, setDotChartPathParam] = useParamState("behaviourPath", "", { history: "push" })
-  const dotChartPath: readonly string[] = useMemo(
-    () => (dotChartPathParam ? dotChartPathParam.split(".") : []),
-    [dotChartPathParam],
-  )
+  const defaultCollapsedKeys = useMemo(() => {
+    const keys = new Set<string>()
+    const walk = (nodes: readonly BehaviourNodeRecord[], depth: number) => {
+      for (const node of nodes) {
+        if (depth > 0 && node.children.length > 0) keys.add(node.cluster.id)
+        walk(node.children, depth + 1)
+      }
+    }
+    walk(topics, 0)
+    return keys
+  }, [topics])
+  const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(() => defaultCollapsedKeys)
+
+  useEffect(() => {
+    setCollapsedKeys((previous) => {
+      const next = new Set([...previous].filter((key) => expandableKeys.has(key)))
+      for (const key of defaultCollapsedKeys) next.add(key)
+      return next.size === previous.size && [...next].every((key) => previous.has(key)) ? previous : next
+    })
+  }, [defaultCollapsedKeys, expandableKeys])
 
   // Chart clicks drive the table selection too: the path tail becomes the
   // active behaviour (highlighted row + detail drawer). Clearing the path
   // closes the drawer.
   const handleDotChartPathChange = useCallback(
     (path: readonly string[]) => {
-      setDotChartPathParam(path.join("."))
-      onActiveBehaviourChange(path.length > 0 ? path[path.length - 1] : undefined)
+      onBehaviourPathChange(path)
+      onMomentRangeChange(undefined)
     },
-    [setDotChartPathParam, onActiveBehaviourChange],
+    [onBehaviourPathChange, onMomentRangeChange],
+  )
+
+  const handleDotChartPointSelect = useCallback(
+    ({
+      path,
+      axis,
+      metric,
+      bucket,
+      maxTurn,
+    }: {
+      readonly path: readonly string[]
+      readonly axis: "day" | "turn"
+      readonly metric: BehaviourTrajectoryMetric
+      readonly bucket: string
+      readonly maxTurn: number
+    }) => {
+      onBehaviourPathChange(path)
+      if (axis !== "turn") {
+        onMomentRangeChange(undefined)
+        return
+      }
+
+      const turnRange = parseTurnBucket(bucket)
+      onMomentRangeChange(turnRange ? { metric, ...turnRange } : undefined, maxTurn)
+    },
+    [onBehaviourPathChange, onMomentRangeChange],
   )
 
   // The dot chart selection narrows the table to the deepest *drilled*
@@ -653,7 +840,7 @@ export function BehavioursView({
   const tableTopics: readonly BehaviourNodeRecord[] = useMemo(() => {
     let nodes = topics
     let subtreeRoot: BehaviourNodeRecord | undefined
-    for (const id of dotChartPath) {
+    for (const id of behaviourPath) {
       const node = nodes.find((candidate) => candidate.cluster.id === id)
       if (!node) return topics
       if (node.children.length > 0) {
@@ -662,7 +849,7 @@ export function BehavioursView({
       }
     }
     return subtreeRoot ? [subtreeRoot] : topics
-  }, [topics, dotChartPath])
+  }, [topics, behaviourPath])
 
   // The visible rows are a depth-first walk that stops at collapsed nodes.
   const rows: readonly BehaviourTableRow[] = useMemo(() => {
@@ -706,10 +893,15 @@ export function BehavioursView({
   const setActiveByOffset = useCallback(
     (offset: number) => {
       const next = rows[activeIndex + offset]
-      if (next) onActiveBehaviourChange(next.node.cluster.id)
-      else if (activeIndex === -1 && rows[0]) onActiveBehaviourChange(rows[0].node.cluster.id)
+      if (next) {
+        onBehaviourPathChange(findBehaviourPath(topics, next.node.cluster.id) ?? [next.node.cluster.id])
+        onMomentRangeChange(undefined)
+      } else if (activeIndex === -1 && rows[0]) {
+        onBehaviourPathChange(findBehaviourPath(topics, rows[0].node.cluster.id) ?? [rows[0].node.cluster.id])
+        onMomentRangeChange(undefined)
+      }
     },
-    [activeIndex, rows, onActiveBehaviourChange],
+    [activeIndex, rows, topics, onBehaviourPathChange, onMomentRangeChange],
   )
 
   useHotkeys([
@@ -803,12 +995,21 @@ export function BehavioursView({
               active={segment}
               onSelect={(value) => onSegmentChange(value)}
             />
-            {dotChartPath.length > 0 ? (
-              // Resets the drill filter without touching the behaviour selection.
-              <Button variant="ghost" size="sm" className="whitespace-nowrap" onClick={() => setDotChartPathParam("")}>
-                Clear filter
+            {behaviourPath.length > 0 || momentRange ? (
+              // Clears the path-driven selection and any chart-derived filters.
+              <Button
+                variant="ghost"
+                size="sm"
+                className="whitespace-nowrap"
+                onClick={() => {
+                  onBehaviourPathChange([])
+                  onMomentRangeChange(undefined)
+                }}
+              >
+                Clear selection
               </Button>
             ) : null}
+            {momentRange ? <BehaviourBadge label={selectedMomentRangeLabel(momentRange)} icon={TagIcon} /> : null}
           </Layout.ActionRowItem>
         </Layout.ActionsRow>
       </Layout.Actions>
@@ -825,9 +1026,10 @@ export function BehavioursView({
               <BehavioursTrajectoryChart
                 projectId={projectId}
                 topics={topics}
-                selectedPath={dotChartPath}
+                selectedPath={behaviourPath}
                 timeRange={timeRange}
                 onSelectPath={handleDotChartPathChange}
+                onSelectPoint={handleDotChartPointSelect}
               />
               <InfiniteTable
                 {...listingLayoutIntrinsicScroll.infiniteTable}
@@ -851,7 +1053,12 @@ export function BehavioursView({
                       return next
                     })
                   }
-                  onActiveBehaviourChange(row.node.cluster.id === activeBehaviourId ? undefined : row.node.cluster.id)
+                  onBehaviourPathChange(
+                    row.node.cluster.id === activeBehaviourId
+                      ? []
+                      : (findBehaviourPath(topics, row.node.cluster.id) ?? [row.node.cluster.id]),
+                  )
+                  onMomentRangeChange(undefined)
                 }}
                 {...(activeBehaviourId ? { activeRowKey: activeBehaviourId, activeRowAutoScroll: true } : {})}
                 blankSlate="No behaviours match the current filters"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -4,13 +4,50 @@ import { LockIcon, TagsIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { type BehaviourSegment, useProjectBehaviours } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
-import type { BehaviourNodeRecord } from "../../../../../domains/taxonomy/taxonomy.functions.ts"
+import type {
+  BehaviourMomentRangeRecord,
+  BehaviourNodeRecord,
+  BehaviourTrajectoryMetric,
+} from "../../../../../domains/taxonomy/taxonomy.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { BehaviourDetailDrawer, BehavioursView } from "./-components/behaviours-view.tsx"
+
+const isBehaviourTrajectoryMetric = (value: string): value is BehaviourTrajectoryMetric =>
+  value === "frequency" || value === "escalation" || value === "resolution" || value === "churnRisk" || value === "wins"
+
+const findNodeByPath = (
+  topics: readonly BehaviourNodeRecord[],
+  path: readonly string[],
+): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
+  let nodes = topics
+  let parent: BehaviourNodeRecord | null = null
+  let selected: { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null = null
+  for (const id of path) {
+    const node = nodes.find((candidate) => candidate.cluster.id === id)
+    if (!node) return null
+    selected = { node, parent }
+    nodes = node.children
+    parent = node
+  }
+  return selected
+}
+
+const findNodeById = (
+  nodes: readonly BehaviourNodeRecord[],
+  clusterId: string,
+  parent: BehaviourNodeRecord | null = null,
+): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
+  for (const node of nodes) {
+    if (node.cluster.id === clusterId) return { node, parent }
+    const found = findNodeById(node.children, clusterId, node)
+    if (found) return found
+  }
+  return null
+}
 
 function BehavioursBreadcrumb() {
   return (
@@ -50,9 +87,13 @@ function BehavioursPageContent() {
     validate: (value): value is BehaviourSegment =>
       value === "all" || value === "new_this_week" || value === "spiking" || value === "high_escalation",
   })
-  const [activeBehaviourId, setActiveBehaviourId] = useParamState("behaviourId", "")
+  const [behaviourPathParam, setBehaviourPathParam] = useParamState("behaviourPath", "", { history: "push" })
   const [timeFrom, setTimeFrom] = useParamState("behaviourTimeFrom", "")
   const [timeTo, setTimeTo] = useParamState("behaviourTimeTo", "")
+  const [momentMetric, setMomentMetric] = useParamState("behaviourMomentMetric", "")
+  const [momentTurnFrom, setMomentTurnFrom] = useParamState("behaviourMomentTurnFrom", "")
+  const [momentTurnTo, setMomentTurnTo] = useParamState("behaviourMomentTurnTo", "")
+  const [momentTurnMax, setMomentTurnMax] = useParamState("behaviourMomentTurnMax", "")
   const timeRange = useMemo(
     () =>
       timeFrom || timeTo
@@ -70,22 +111,38 @@ function BehavioursPageContent() {
     sortBy: "category",
     ...(timeRange ? { timeRange } : {}),
   })
+  const momentRange = useMemo((): BehaviourMomentRangeRecord | undefined => {
+    if (!isBehaviourTrajectoryMetric(momentMetric)) return undefined
+    const fromTurn = Number(momentTurnFrom)
+    const toTurn = Number(momentTurnTo)
+    if (!Number.isInteger(fromTurn) || !Number.isInteger(toTurn) || fromTurn < 0 || toTurn < fromTurn) return undefined
+    return { metric: momentMetric, fromTurn, toTurn }
+  }, [momentMetric, momentTurnFrom, momentTurnTo])
+  const setMomentRange = (range: BehaviourMomentRangeRecord | undefined) => {
+    setMomentMetric(range?.metric ?? "")
+    setMomentTurnFrom(range ? String(range.fromTurn) : "")
+    setMomentTurnTo(range ? String(range.toTurn) : "")
+  }
+  const parsedMomentTurnMax = Number(momentTurnMax)
+  const momentRangeMaxTurn =
+    momentRange && Number.isInteger(parsedMomentTurnMax) && parsedMomentTurnMax >= momentRange.toTurn
+      ? parsedMomentTurnMax
+      : (momentRange?.toTurn ?? 0)
+  const setMomentRangeWithMax = (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => {
+    setMomentRange(range)
+    setMomentTurnMax(range && maxTurn !== undefined ? String(Math.max(maxTurn, range.toTurn)) : "")
+  }
   const topics = data?.topics ?? []
+  const behaviourPath = useMemo(
+    () => (behaviourPathParam ? behaviourPathParam.split(".").filter(Boolean) : []),
+    [behaviourPathParam],
+  )
+  const activeBehaviourId = behaviourPath.at(-1)
   const activeNode = useMemo(() => {
     if (!activeBehaviourId) return null
-    const walk = (
-      nodes: readonly BehaviourNodeRecord[],
-      parent: BehaviourNodeRecord | null,
-    ): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
-      for (const node of nodes) {
-        if (node.cluster.id === activeBehaviourId) return { node, parent }
-        const found = walk(node.children, node)
-        if (found) return found
-      }
-      return null
-    }
-    return walk(topics, null)
-  }, [activeBehaviourId, topics])
+    return findNodeByPath(topics, behaviourPath) ?? findNodeById(topics, activeBehaviourId)
+  }, [activeBehaviourId, behaviourPath, topics])
+  const setBehaviourPath = (path: readonly string[]) => setBehaviourPathParam(path.join("."))
   const hasNoBehaviours = !isLoading && topics.length === 0 && segment === "all" && !timeRange
 
   if (hasNoBehaviours) {
@@ -112,7 +169,7 @@ function BehavioursPageContent() {
           projectId={project.id}
           isLoading={isLoading}
           segment={segment}
-          activeBehaviourId={activeBehaviourId || undefined}
+          behaviourPath={behaviourPath}
           timeFilter={
             <TimeFilterDropdown
               {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
@@ -125,7 +182,9 @@ function BehavioursPageContent() {
           }
           timeRange={timeRange}
           onSegmentChange={setSegment}
-          onActiveBehaviourChange={(behaviourId) => setActiveBehaviourId(behaviourId ?? "")}
+          onBehaviourPathChange={setBehaviourPath}
+          momentRange={momentRange}
+          onMomentRangeChange={setMomentRangeWithMax}
         />
       </Layout.Content>
       {activeNode ? (
@@ -135,7 +194,13 @@ function BehavioursPageContent() {
             parentName={activeNode.parent?.cluster.name ?? null}
             projectId={project.id}
             timeRange={timeRange}
-            onClose={() => setActiveBehaviourId("")}
+            momentRange={momentRange}
+            momentRangeMaxTurn={momentRangeMaxTurn}
+            onMomentRangeChange={setMomentRangeWithMax}
+            onClose={() => {
+              setBehaviourPath([])
+              setMomentRangeWithMax(undefined)
+            }}
           />
         </Layout.Aside>
       ) : null}


### PR DESCRIPTION
## What does this PR do?

Adds turn-axis trajectory selection on the behaviours page so dot clicks select a behaviour path and filter associated sessions to moments that happened in the selected turn range.
The behaviour detail drawer now shows the matching signal chips, a two-thumb turn range slider, and a clear control for chart-derived filters.
Behaviour selection is governed by `behaviourPath` instead of a separate `behaviourId` search param, and the table now opens with only first-level behaviour nodes unfolded.

## Related issue (if applicable)

N/A

## How was this tested?

- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`
- `git diff --check`
- Commit hook ran workspace format and `knip`

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA
