### PR TITLE
fix(clickhouse): aggregate metadata in session search rollup

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -289,6 +289,7 @@ const TRACE_ROLLUP_BODY = `
     argMaxIfMerge(t.user_id)                       AS user_id,
     argMaxIfMerge(t.simulation_id)                 AS simulation_id,
     groupUniqArrayArray(t.tags)                    AS tags,
+    maxMap(t.metadata)                             AS metadata,
     groupUniqArrayIfMerge(t.models)                AS models,
     groupUniqArrayIfMerge(t.providers)             AS providers,
     groupUniqArrayIfMerge(t.service_names)         AS service_names,

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -46,6 +46,7 @@ interface SpanOverrides {
   readonly tokensInput?: number
   readonly tokensOutput?: number
   readonly costTotalMicrocents?: number
+  readonly metadata?: Record<string, string>
   readonly inputMessages?: string
   readonly outputMessages?: string
   readonly systemInstructions?: string
@@ -75,7 +76,7 @@ const makeSpanRow = (overrides: SpanOverrides): SpanRow => {
     status_message: "",
     error_type: "",
     tags: [],
-    metadata: {},
+    metadata: overrides.metadata ?? {},
     operation: "",
     provider: overrides.provider ?? "",
     model: overrides.model ?? "",
@@ -1229,6 +1230,58 @@ describe("SessionRepository", () => {
       expect(match.matchingTraceCount).toBe(1)
       expect(match.matchingTraceIds).toEqual([traces[2]])
       expect(match.bestTraceId).toBe(traces[2])
+    })
+
+    it("metadata filters are applied per-trace inside trace_rollup", async () => {
+      const start = new Date(Date.UTC(2026, 0, 3, 11, 0, 0))
+      const sessionId = "metadata-having-session"
+      const traces = ["m1", "m2", "m3"].map(padTrace)
+      const filters = { "metadata.environment": [{ op: "eq" as const, value: "production" }] }
+
+      await insertSpans(
+        traces.map((t, i) =>
+          makeSpanRow({
+            traceId: t,
+            spanId: padSpan(`m${i + 1}`),
+            sessionId,
+            startTime: new Date(start.getTime() + i * 1_000),
+            metadata: { environment: i === 1 ? "production" : "staging" },
+          }),
+        ),
+      )
+      await insertSearchDocs(
+        traces.map((t, i) => ({
+          traceId: t,
+          text: `metadata needle trace ${i}`,
+          startTime: start,
+          contentHashSuffix: `m${i}`,
+        })),
+      )
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { searchQuery: '"metadata needle"', limit: 10, filters },
+        }),
+      )
+
+      expect(page.items).toHaveLength(1)
+      const match = nonNull(page.searchMatches?.[sessionId])
+      expect(match.matchingTraceCount).toBe(1)
+      expect(match.matchingTraceIds).toEqual([traces[1]])
+      expect(match.bestTraceId).toBe(traces[1])
+
+      const count = await runCh(
+        repo.countByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          searchQuery: '"metadata needle"',
+          filters,
+        }),
+      )
+      expect(count.totalCount).toBe(1)
+      expect(count.matchingTraceCount).toBe(1)
     })
 
     // 4) Cursor stability: paginate ten matching sessions across one project.


### PR DESCRIPTION
Fixes a Datadog Error Tracking issue where session search with `metadata.*` filters failed in ClickHouse:

https://app.datadoghq.eu/error-tracking/issues/12afb340-63ee-11f1-aef6-da7ad0900005

The search-mode session rollup grouped traces by organization, project, and trace id, but metadata filters compile to `metadata[...]` expressions in the CTE `HAVING`. Because the rollup did not project an aggregate-safe `metadata` alias, ClickHouse resolved that expression as raw `t.metadata` and rejected the query with `Column 't.metadata' is not under aggregate function and not in GROUP BY keys`.

This PR adds `maxMap(t.metadata) AS metadata` to the trace rollup, matching the normal session/trace projections, so metadata filters can be applied per trace before session aggregation.

The regression was introduced with the session search rollup in `fda5c09ed8` (`feat(sessions): session-level search rollup (LAT-599 part 2/4)`).

Validation:

- Added a ClickHouse regression test for search + `metadata.environment = production`, covering both list and count paths.
- Confirmed the new test failed before the fix with the same ClickHouse aggregate error.
- `pnpm --filter @platform/db-clickhouse test -- session-repository.test.ts -t "metadata filters are applied per-trace inside trace_rollup"`
- `pnpm --filter @platform/db-clickhouse typecheck`
- `pnpm exec biome check packages/platform/db-clickhouse/src/repositories/search-by-project.ts packages/platform/db-clickhouse/src/repositories/session-repository.test.ts`
