### PR TITLE
fix(sso): order tanstackStartCookies last in better-auth plugins

### DIFF
--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -208,7 +208,6 @@ export const getBetterAuth = () => {
           ),
         ),
       extraPlugins: [
-        tanstackStartCookies(),
         // OAuth2/OIDC authorization server for MCP clients (Claude Code,
         // Cursor, …). Issues opaque random access + refresh tokens that the
         // API resource server validates via `@platform/oauth-token-auth`.
@@ -240,6 +239,12 @@ export const getBetterAuth = () => {
             allowDynamicClientRegistration: true,
           },
         }),
+        // Cookie integration MUST be the last plugin in the array. Better Auth
+        // only forwards `Set-Cookie` headers into the TanStack Start cookie
+        // store for plugins whose `hooks.after` run *before* it; any plugin
+        // placed after this one could set cookies that never reach the
+        // framework (BA logs a warning when it isn't last).
+        tanstackStartCookies(),
       ],
       onUserCreated: async (user) => {
         await Effect.runPromise(

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -370,7 +370,6 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
             }),
           ]
         : []),
-      ...(config.extraPlugins ?? []),
       ...(stripeClient && stripeWebhookSecret
         ? [
             stripe({
@@ -442,6 +441,11 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
             }) as StripePlugin<StripeOptions>,
           ]
         : []),
+      // Caller-provided plugins are spread LAST so a cookie-integration plugin
+      // (e.g. `tanstackStartCookies`) lands at the very end of the array.
+      // Better Auth forwards `Set-Cookie` headers from plugins whose
+      // `hooks.after` run before the cookie plugin, so it must come last.
+      ...(config.extraPlugins ?? []),
     ],
   })
 }


### PR DESCRIPTION
## What

Make the Better Auth cookie-integration plugin (`tanstackStartCookies`) the **last** entry in the plugins array.

## Why

Better Auth only forwards `Set-Cookie` headers into the TanStack Start cookie store for plugins whose `hooks.after` run **before** the cookie plugin. `tanstackStartCookies()` was sitting *first* in `extraPlugins`, with `mcp()` and `stripe()` after it — so cookies those later plugins set (e.g. on the post-SSO-callback session) could be silently dropped. Better Auth logged a warning on every boot:

> Cookie integration plugin "tanstack-start-cookies" should be placed last in the plugins array.

Surfaced during local QA of the enterprise SSO feature (#3434).

## Changes

- `apps/web/src/server/clients.ts` — move `tanstackStartCookies()` to the end of `extraPlugins` (after `mcp()`).
- `packages/platform/db-postgres/src/create-better-auth.ts` — spread `config.extraPlugins` **last** in the plugins array (after the `stripe` block), so a caller-provided cookie plugin always lands at the very end.

## Verification

- `pnpm --filter @platform/db-postgres typecheck` ✅
- `pnpm --filter @app/web typecheck` ✅
- Boot no longer emits the "should be placed last" warning.

No behavior change beyond cookie-header forwarding correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)