### PR TITLE
fix(web): apply search query to traces/sessions analytics

### DIFF
--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -253,21 +253,24 @@ export function useSessionCohortSummary({ projectId }: { readonly projectId: str
 export function useSessionMetrics({
   projectId,
   filters,
+  searchQuery,
 }: {
   readonly projectId: string
   readonly filters?: FilterSet
+  readonly searchQuery?: string
 }) {
   const scope = use(TraceScopeContext)
   const effectiveFilters = useMemo(() => withSessionDefaults(filters), [filters])
 
   return useQuery({
-    queryKey: [...traceScopeKey(scope), "sessions-metrics", projectId, effectiveFilters],
+    queryKey: [...traceScopeKey(scope), "sessions-metrics", projectId, effectiveFilters, searchQuery],
     queryFn: () =>
       getSessionMetricsByProject({
         data: {
           ...traceScopeData(scope),
           projectId,
           filters: effectiveFilters,
+          ...(searchQuery ? { searchQuery } : {}),
         },
       }),
     staleTime: 30_000,
@@ -278,11 +281,13 @@ export function useSessionMetrics({
 export function useSessionTimeHistogram({
   projectId,
   filters,
+  searchQuery,
   rangeStartIso: rangeStartIsoOverride,
   rangeEndIso: rangeEndIsoOverride,
 }: {
   readonly projectId: string
   readonly filters: FilterSet
+  readonly searchQuery?: string
   readonly rangeStartIso?: string
   readonly rangeEndIso?: string
 }) {
@@ -309,12 +314,13 @@ export function useSessionTimeHistogram({
         "sessions-histogram",
         projectId,
         effectiveFilters,
+        searchQuery,
         effectiveRangeStartIso,
         effectiveRangeEndIso,
         bs,
       ] as const,
     }
-  }, [scope, projectId, effectiveFilters, rangeStartIsoOverride, rangeEndIsoOverride])
+  }, [scope, projectId, effectiveFilters, searchQuery, rangeStartIsoOverride, rangeEndIsoOverride])
 
   const query = useQuery({
     queryKey,
@@ -327,6 +333,7 @@ export function useSessionTimeHistogram({
           rangeEndIso,
           bucketSeconds,
           ...(Object.keys(effectiveFilters).length > 0 ? { filters: effectiveFilters } : {}),
+          ...(searchQuery ? { searchQuery } : {}),
         },
       }),
     staleTime: 30_000,

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -245,6 +245,7 @@ const sessionHistogramInputSchema = z.object({
     .int()
     .positive()
     .max(90 * 24 * 60 * 60),
+  searchQuery: z.string().max(500).optional(),
 })
 
 export const getSessionTimeHistogramByProject = createServerFn({ method: "GET" })
@@ -269,14 +270,24 @@ export const getSessionTimeHistogramByProject = createServerFn({ method: "GET" }
           projectId: ProjectId(data.projectId),
           filters: mergedFilters,
           bucketSeconds: data.bucketSeconds,
+          ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(
+        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
     )
   })
 
 export const getSessionMetricsByProject = createServerFn({ method: "GET" })
   .inputValidator(
-    z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), filters: filterSetSchema.optional() }),
+    z.object({
+      sandboxOrgId: z.string().optional(),
+      projectId: z.string(),
+      filters: filterSetSchema.optional(),
+      searchQuery: z.string().max(500).optional(),
+    }),
   )
   .handler(async ({ data }): Promise<SessionMetrics | null> => {
     const orgId = await resolveOrgScope(data)
@@ -289,8 +300,13 @@ export const getSessionMetricsByProject = createServerFn({ method: "GET" })
           organizationId: orgId,
           projectId: ProjectId(data.projectId),
           ...(filters ? { filters } : {}),
+          ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(
+        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
     )
   })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -16,6 +16,8 @@ interface TraceAggregationsPanelProps {
   readonly filters: FilterSet
   /** Must match the table below the panel — drives which rollup the cards + histogram use. */
   readonly mode: "traces" | "sessions"
+  /** Free-text search query active on the page; narrows the cards + histogram to matches. */
+  readonly searchQuery?: string
   /** Called when user selects a time range via brush on the histogram. */
   readonly onTimeRangeSelect?: (range: { from: string; to: string } | null) => void
 }
@@ -25,6 +27,7 @@ export function TraceAggregationsPanel({
   projectSlug,
   filters,
   mode,
+  searchQuery,
   onTimeRangeSelect,
 }: TraceAggregationsPanelProps) {
   const [collapsed, setCollapsed] = useState(false)
@@ -62,6 +65,7 @@ export function TraceAggregationsPanel({
           selectedMetric={selectedMetric}
           onMetricSelect={onMetricSelect}
           onCollapse={() => setCollapsed(true)}
+          {...(searchQuery ? { searchQuery } : {})}
         />
         {incidentsFlagEnabled ? (
           <div className="flex items-center justify-end gap-2 px-4 -mb-1">
@@ -91,6 +95,7 @@ export function TraceAggregationsPanel({
           metric={selectedMetric}
           showIncidents={incidentsFlagEnabled && showIncidents}
           onRangeSelect={onTimeRangeSelect}
+          {...(searchQuery ? { searchQuery } : {})}
         />
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -61,6 +61,7 @@ export function GeneralAggregations({
   projectId,
   filters,
   mode,
+  searchQuery,
   selectedMetric,
   onMetricSelect,
   onCollapse,
@@ -68,6 +69,7 @@ export function GeneralAggregations({
   readonly projectId: string
   readonly filters: FilterSet
   readonly mode: "traces" | "sessions"
+  readonly searchQuery?: string
   readonly selectedMetric: TraceHistogramMetric
   readonly onMetricSelect: (metric: TraceHistogramMetric) => void
   readonly onCollapse: () => void
@@ -75,24 +77,29 @@ export function GeneralAggregations({
   const isSessionsMode = mode === "sessions"
   const hasActiveFilters = Object.keys(filters).length > 0
   const filterOpts = hasActiveFilters ? { filters } : {}
+  const searchOpts = searchQuery ? { searchQuery } : {}
   const traceModeProjectId = isSessionsMode ? "" : projectId
   const sessionModeProjectId = isSessionsMode ? projectId : ""
 
   const { data: traceMetrics, isLoading: traceMetricsLoading } = useTraceMetrics({
     projectId: traceModeProjectId,
     ...filterOpts,
+    ...searchOpts,
   })
   const { totalCount: traceTotalCount, isLoading: traceCountLoading } = useTracesCount({
     projectId: traceModeProjectId,
     ...filterOpts,
+    ...searchOpts,
   })
   const { totalCount: sessionTotalCount, isLoading: sessionCountLoading } = useSessionsCount({
     projectId,
     ...filterOpts,
+    ...searchOpts,
   })
   const { data: sessionMetrics, isLoading: sessionMetricsLoading } = useSessionMetrics({
     projectId: sessionModeProjectId,
     ...filterOpts,
+    ...searchOpts,
   })
 
   const activeMetrics: TraceMetrics | SessionMetrics | undefined = isSessionsMode

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -28,6 +28,7 @@ interface HistogramProps {
   readonly mode: "traces" | "sessions"
   readonly metric: TraceHistogramMetric
   readonly showIncidents: boolean
+  readonly searchQuery?: string
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }
 
@@ -38,16 +39,20 @@ export function Histogram({
   mode,
   metric,
   showIncidents,
+  searchQuery,
   onRangeSelect,
 }: HistogramProps) {
   const isSessionsMode = mode === "sessions"
+  const searchOpts = searchQuery ? { searchQuery } : {}
   const traceHistogram = useTraceTimeHistogram({
     projectId: isSessionsMode ? "" : projectId,
     filters,
+    ...searchOpts,
   })
   const sessionHistogram = useSessionTimeHistogram({
     projectId: isSessionsMode ? projectId : "",
     filters,
+    ...searchOpts,
   })
   const {
     data: sparseBuckets,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -215,6 +215,7 @@ export function SessionsView({
   const { data: sessionMetrics, isLoading: sessionMetricsLoading } = useSessionMetrics({
     projectId,
     ...(hasActiveFilters ? { filters } : {}),
+    ...(searchQuery ? { searchQuery } : {}),
   })
 
   // Fetch annotation counts for every trace that could show in the visible

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -549,6 +549,7 @@ function ProjectPage() {
           filters={filters}
           mode={activeTab}
           onTimeRangeSelect={onTimeRangeSelect}
+          {...(hasSearchQuery ? { searchQuery: query } : {})}
         />
       </div>
 

--- a/packages/domain/spans/src/ports/session-repository.ts
+++ b/packages/domain/spans/src/ports/session-repository.ts
@@ -49,6 +49,7 @@ export interface SessionRepositoryShape {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly filters?: FilterSet
+    readonly searchQuery?: string
   }): Effect.Effect<SessionMetrics, RepositoryError, ChSqlClient>
 
   histogramByProjectId(input: {
@@ -56,6 +57,7 @@ export interface SessionRepositoryShape {
     readonly projectId: ProjectId
     readonly filters?: FilterSet
     readonly bucketSeconds: number
+    readonly searchQuery?: string
   }): Effect.Effect<readonly TraceTimeHistogramBucket[], RepositoryError, ChSqlClient>
 
   findBySessionId(input: {

--- a/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
+++ b/packages/platform/db-clickhouse/src/repositories/search-by-project.ts
@@ -18,9 +18,11 @@ import type {
   SessionCountResult,
   SessionListCursor,
   SessionListPage,
+  SessionMetrics,
   SessionSearchMatch,
+  TraceTimeHistogramBucket,
 } from "@domain/spans"
-import { SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW } from "@domain/spans"
+import { emptySessionMetrics, SESSION_SEARCH_MAX_MATCHING_TRACES_PER_ROW } from "@domain/spans"
 import { normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect } from "effect"
 import { buildClickHouseWhere } from "../filter-builder.ts"
@@ -548,5 +550,281 @@ export const countSessionsBySearchQuery = ({
           matchingTraceCount: Number(rows[0]?.matching_trace_count_total ?? 0),
         })),
         Effect.mapError((error) => toRepositoryError(error, "countByProjectId")),
+      )
+  })
+
+/**
+ * Rolls the matched `trace_rollup` rows up to one row per session, summing the
+ * per-trace numerics the analytics panels report so the metrics/histogram agree
+ * with the searched list (`listSessionsBySearchQuery` projects the same shape).
+ * `session_start_time` (min over the session's matched traces) is the column the
+ * histogram buckets on, mirroring the non-search panels' `min(min_start_time)`.
+ *
+ * **Coupling**: like {@link TRACE_ROLLUP_BODY}, this embeds in a `WITH` that
+ * already declares the `trace_rollup` CTE; it is not standalone.
+ */
+const SESSION_ROLLUP_BODY = `
+  SELECT
+    session_id,
+    count()                       AS matching_trace_count,
+    min(start_time)               AS session_start_time,
+    sum(cost_total_microcents)    AS cost_total_microcents,
+    sum(span_count)               AS span_count,
+    sum(tokens_total)             AS tokens_total,
+    sum(duration_ns)              AS duration_ns,
+    sum(time_to_first_token_ns)   AS time_to_first_token_ns
+  FROM trace_rollup
+  GROUP BY session_id
+`
+
+const num = (raw: string | number): number => {
+  const n = typeof raw === "number" ? raw : Number(raw)
+  return Number.isFinite(n) ? n : 0
+}
+
+const toRollup = (min: string, max: string, avg: string, median: string, sum: string) => ({
+  min: num(min),
+  max: num(max),
+  avg: num(avg),
+  median: num(median),
+  sum: num(sum),
+})
+
+type SessionSearchMetricsRow = {
+  row_count: string
+  trace_count_sum: string
+  duration_min: string
+  duration_max: string
+  duration_avg: string
+  duration_median: string
+  duration_sum: string
+  cost_min: string
+  cost_max: string
+  cost_avg: string
+  cost_median: string
+  cost_sum: string
+  span_min: string
+  span_max: string
+  span_avg: string
+  span_median: string
+  span_sum: string
+  tokens_min: string
+  tokens_max: string
+  tokens_avg: string
+  tokens_median: string
+  tokens_sum: string
+  ttft_min: string
+  ttft_max: string
+  ttft_avg: string
+  ttft_median: string
+  ttft_sum: string
+}
+
+const toSessionSearchMetrics = (row: SessionSearchMetricsRow | undefined): SessionMetrics => {
+  if (!row || num(row.row_count) === 0) return emptySessionMetrics()
+  return {
+    durationNs: toRollup(row.duration_min, row.duration_max, row.duration_avg, row.duration_median, row.duration_sum),
+    costTotalMicrocents: toRollup(row.cost_min, row.cost_max, row.cost_avg, row.cost_median, row.cost_sum),
+    spanCount: toRollup(row.span_min, row.span_max, row.span_avg, row.span_median, row.span_sum),
+    tokensTotal: toRollup(row.tokens_min, row.tokens_max, row.tokens_avg, row.tokens_median, row.tokens_sum),
+    timeToFirstTokenNs: toRollup(row.ttft_min, row.ttft_max, row.ttft_avg, row.ttft_median, row.ttft_sum),
+    traceCount: num(row.trace_count_sum),
+  }
+}
+
+interface MetricsSearchInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly parsed: ParsedSearchQuery
+  readonly filters: FilterSet | undefined
+}
+
+/**
+ * Search-active metrics path. Aggregates min/max/avg/median/sum over the
+ * `session_rollup` (one row per session, numerics summed across that session's
+ * matched traces). The non-search aggregate in `session-repository.ts` runs the
+ * same SELECT against the `sessions` table; keeping the column aliases identical
+ * means the two share the `toSessionMetrics`-shaped contract and the cards read
+ * the same whether or not a search is active.
+ */
+export const aggregateMetricsBySearchQuery = ({
+  organizationId,
+  projectId,
+  parsed,
+  filters,
+}: MetricsSearchInput): Effect.Effect<SessionMetrics, RepositoryError, ChSqlClient> =>
+  Effect.gen(function* () {
+    const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+    const plan = yield* planSearch(parsed)
+    const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
+
+    const candidates = yield* fetchSearchCandidates({ organizationId, projectId, plan })
+    if (candidates.length === 0) return emptySessionMetrics()
+    const traceIds = candidates.map((c) => normalizeCHString(c.trace_id))
+    const relevanceScores = candidates.map((c) => Number(c.relevance_score))
+
+    return yield* chSqlClient
+      .query(async (client) => {
+        const result = await client.query({
+          query: `WITH
+                    mapFromArrays(
+                      {traceIds:Array(FixedString(32))},
+                      {relevanceScores:Array(Float64)}
+                    ) AS scoreByTrace,
+                    trace_rollup AS (${TRACE_ROLLUP_BODY}
+                    ${traceScoreWhere}
+                    GROUP BY
+                      t.organization_id, t.project_id, t.trace_id
+                    ${finalHaving}
+                  ),
+                  session_rollup AS (${SESSION_ROLLUP_BODY})
+                  SELECT
+                    count() AS row_count,
+                    sum(matching_trace_count) AS trace_count_sum,
+                    min(duration_ns) AS duration_min,
+                    max(duration_ns) AS duration_max,
+                    avg(duration_ns) AS duration_avg,
+                    quantileTDigest(0.5)(duration_ns) AS duration_median,
+                    sum(duration_ns) AS duration_sum,
+                    min(cost_total_microcents) AS cost_min,
+                    max(cost_total_microcents) AS cost_max,
+                    avg(cost_total_microcents) AS cost_avg,
+                    quantileTDigest(0.5)(cost_total_microcents) AS cost_median,
+                    sum(cost_total_microcents) AS cost_sum,
+                    min(span_count) AS span_min,
+                    max(span_count) AS span_max,
+                    avg(span_count) AS span_avg,
+                    quantileTDigest(0.5)(span_count) AS span_median,
+                    sum(span_count) AS span_sum,
+                    min(tokens_total) AS tokens_min,
+                    max(tokens_total) AS tokens_max,
+                    avg(tokens_total) AS tokens_avg,
+                    quantileTDigest(0.5)(tokens_total) AS tokens_median,
+                    sum(tokens_total) AS tokens_sum,
+                    minIf(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_min,
+                    maxIf(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_max,
+                    avgIf(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_avg,
+                    quantileTDigestIf(0.5)(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_median,
+                    sumIf(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_sum
+                  FROM session_rollup`,
+          query_params: {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            traceIds,
+            relevanceScores,
+            ...telemetryParams,
+            ...scoreParams,
+          },
+          format: "JSONEachRow",
+        })
+        return result.json<SessionSearchMetricsRow>()
+      })
+      .pipe(
+        Effect.map((rows) => toSessionSearchMetrics(rows[0])),
+        Effect.mapError((error) => toRepositoryError(error, "aggregateMetricsByProjectId")),
+      )
+  })
+
+type SessionSearchHistogramRow = {
+  bucket_start: string
+  session_count: string
+  trace_count: string
+  cost_sum: string
+  duration_median: string
+  tokens_sum: string
+  span_sum: string
+  ttft_median: string
+}
+
+const toSessionSearchHistogramBucket = (row: SessionSearchHistogramRow): TraceTimeHistogramBucket => ({
+  bucketStart: parseCHDate(row.bucket_start).toISOString(),
+  sessionCount: num(row.session_count),
+  traceCount: num(row.trace_count),
+  costTotalMicrocentsSum: num(row.cost_sum),
+  durationNsMedian: num(row.duration_median),
+  tokensTotalSum: num(row.tokens_sum),
+  spanCountSum: num(row.span_sum),
+  timeToFirstTokenNsMedian: num(row.ttft_median),
+})
+
+interface HistogramSearchInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly parsed: ParsedSearchQuery
+  readonly filters: FilterSet | undefined
+  readonly bucketSeconds: number
+}
+
+/**
+ * Search-active histogram path. Buckets the matched `session_rollup` by each
+ * session's earliest matched-trace `start_time`. Time-window filters arrive in
+ * `filters` (merged upstream by `mergeTraceHistogramTimeFilters`) and are
+ * applied per-trace inside `trace_rollup` via `buildSearchFilters`, exactly like
+ * the list/count search paths.
+ */
+export const histogramBySearchQuery = ({
+  organizationId,
+  projectId,
+  parsed,
+  filters,
+  bucketSeconds,
+}: HistogramSearchInput): Effect.Effect<readonly TraceTimeHistogramBucket[], RepositoryError, ChSqlClient> =>
+  Effect.gen(function* () {
+    const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+    const plan = yield* planSearch(parsed)
+    const { telemetryParams, traceScoreWhere, scoreParams, finalHaving } = buildSearchFilters(filters)
+
+    const candidates = yield* fetchSearchCandidates({ organizationId, projectId, plan })
+    if (candidates.length === 0) return []
+    const traceIds = candidates.map((c) => normalizeCHString(c.trace_id))
+    const relevanceScores = candidates.map((c) => Number(c.relevance_score))
+    const bs = Math.floor(bucketSeconds)
+
+    return yield* chSqlClient
+      .query(async (client) => {
+        const result = await client.query({
+          query: `WITH
+                    mapFromArrays(
+                      {traceIds:Array(FixedString(32))},
+                      {relevanceScores:Array(Float64)}
+                    ) AS scoreByTrace,
+                    trace_rollup AS (${TRACE_ROLLUP_BODY}
+                    ${traceScoreWhere}
+                    GROUP BY
+                      t.organization_id, t.project_id, t.trace_id
+                    ${finalHaving}
+                  ),
+                  session_rollup AS (${SESSION_ROLLUP_BODY})
+                  SELECT
+                    toDateTime(
+                      intDiv(toUnixTimestamp(session_start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
+                      'UTC'
+                    ) AS bucket_start,
+                    count() AS session_count,
+                    sum(matching_trace_count) AS trace_count,
+                    sum(cost_total_microcents) AS cost_sum,
+                    quantileTDigest(0.5)(duration_ns) AS duration_median,
+                    sum(tokens_total) AS tokens_sum,
+                    sum(span_count) AS span_sum,
+                    quantileTDigestIf(0.5)(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_median
+                  FROM session_rollup
+                  GROUP BY bucket_start
+                  ORDER BY bucket_start ASC`,
+          query_params: {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            traceIds,
+            relevanceScores,
+            bucketSeconds: bs,
+            ...telemetryParams,
+            ...scoreParams,
+          },
+          format: "JSONEachRow",
+        })
+        return result.json<SessionSearchHistogramRow>()
+      })
+      .pipe(
+        Effect.map((rows): readonly TraceTimeHistogramBucket[] => rows.map(toSessionSearchHistogramBucket)),
+        Effect.mapError((error) => toRepositoryError(error, "histogramByProjectId")),
       )
   })

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.test.ts
@@ -1,6 +1,7 @@
 import { AI, AIError, type AIShape } from "@domain/ai"
 import { type ChSqlClient, isNotFoundError, OrganizationId, ProjectId, SessionId } from "@domain/shared"
 import {
+  emptySessionMetrics,
   type SessionListPage,
   SessionRepository,
   type SessionRepositoryShape,
@@ -2160,6 +2161,162 @@ describe("SessionRepository", () => {
           }),
         )
         expect(page.items.map((s) => s.sessionId)).toEqual(["dur-long", "dur-medium", "dur-short"])
+      })
+    })
+
+    // The metrics + histogram panels must agree with the searched list/count:
+    // both aggregate over the same trace_rollup → session_rollup candidate set,
+    // so non-matching sessions drop out and per-session numerics reflect only
+    // the matched traces.
+    describe("metrics + histogram in search mode", () => {
+      it("aggregateMetricsByProjectId rolls up matched-trace numerics over matched sessions", async () => {
+        const start = new Date(Date.UTC(2026, 0, 12, 10, 0, 0))
+        const sessionM1 = "mh-match-1"
+        const sessionM2 = "mh-match-2"
+        const sessionN = "mh-nomatch"
+        const m1a = padTrace("mh1a")
+        const m1b = padTrace("mh1b")
+        const m2a = padTrace("mh2a")
+        const n1 = padTrace("mhn1")
+
+        await insertSpans([
+          makeSpanRow({
+            traceId: m1a,
+            spanId: padSpan("mh1a"),
+            sessionId: sessionM1,
+            startTime: start,
+            costTotalMicrocents: 100,
+          }),
+          makeSpanRow({
+            traceId: m1b,
+            spanId: padSpan("mh1b"),
+            sessionId: sessionM1,
+            startTime: new Date(start.getTime() + 1_000),
+            costTotalMicrocents: 200,
+          }),
+          makeSpanRow({
+            traceId: m2a,
+            spanId: padSpan("mh2a"),
+            sessionId: sessionM2,
+            startTime: new Date(start.getTime() + 2_000),
+            costTotalMicrocents: 400,
+          }),
+          makeSpanRow({
+            traceId: n1,
+            spanId: padSpan("mhn1"),
+            sessionId: sessionN,
+            startTime: new Date(start.getTime() + 3_000),
+            costTotalMicrocents: 9_999,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: m1a, text: "metricsneedle alpha", startTime: start, contentHashSuffix: "mh1a" },
+          { traceId: m1b, text: "metricsneedle beta", startTime: start, contentHashSuffix: "mh1b" },
+          { traceId: m2a, text: "metricsneedle gamma", startTime: start, contentHashSuffix: "mh2a" },
+          { traceId: n1, text: "unrelated chatter", startTime: start, contentHashSuffix: "mhn1" },
+        ])
+
+        const searchQuery = '"metricsneedle"'
+        const metrics = await runCh(
+          repo.aggregateMetricsByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, searchQuery }),
+        )
+        const count = await runCh(repo.countByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, searchQuery }))
+
+        expect(count.totalCount).toBe(2)
+        expect(count.matchingTraceCount).toBe(3)
+        // traceCount mirrors matchingTraceCount; the non-matching session is excluded.
+        expect(metrics.traceCount).toBe(3)
+        // Cost is rolled up per session first (M1 = 100 + 200 = 300, M2 = 400),
+        // then min/max/sum are taken across sessions.
+        expect(metrics.costTotalMicrocents.sum).toBe(700)
+        expect(metrics.costTotalMicrocents.min).toBe(300)
+        expect(metrics.costTotalMicrocents.max).toBe(400)
+      })
+
+      it("histogramByProjectId buckets matched sessions and excludes non-matching", async () => {
+        const start = new Date(Date.UTC(2026, 0, 13, 10, 0, 0))
+        const sessionA = "hh-a"
+        const sessionB = "hh-b"
+        const sessionN = "hh-n"
+        const a1 = padTrace("hha1")
+        const a2 = padTrace("hha2")
+        const b1 = padTrace("hhb1")
+        const n1 = padTrace("hhn1")
+
+        await insertSpans([
+          makeSpanRow({
+            traceId: a1,
+            spanId: padSpan("hha1"),
+            sessionId: sessionA,
+            startTime: start,
+            costTotalMicrocents: 50,
+          }),
+          makeSpanRow({
+            traceId: a2,
+            spanId: padSpan("hha2"),
+            sessionId: sessionA,
+            startTime: new Date(start.getTime() + 1_000),
+            costTotalMicrocents: 70,
+          }),
+          makeSpanRow({
+            traceId: b1,
+            spanId: padSpan("hhb1"),
+            sessionId: sessionB,
+            startTime: new Date(start.getTime() + 2_000),
+            costTotalMicrocents: 30,
+          }),
+          makeSpanRow({
+            traceId: n1,
+            spanId: padSpan("hhn1"),
+            sessionId: sessionN,
+            startTime: new Date(start.getTime() + 3_000),
+            costTotalMicrocents: 9_000,
+          }),
+        ])
+        await insertSearchDocs([
+          { traceId: a1, text: "histoneedle one", startTime: start, contentHashSuffix: "hha1" },
+          { traceId: a2, text: "histoneedle two", startTime: start, contentHashSuffix: "hha2" },
+          { traceId: b1, text: "histoneedle three", startTime: start, contentHashSuffix: "hhb1" },
+          { traceId: n1, text: "background noise", startTime: start, contentHashSuffix: "hhn1" },
+        ])
+
+        const searchQuery = '"histoneedle"'
+        const buckets = await runCh(
+          repo.histogramByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            bucketSeconds: 3600,
+            searchQuery,
+          }),
+        )
+        const count = await runCh(repo.countByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, searchQuery }))
+
+        const sessionTotal = buckets.reduce((acc, b) => acc + b.sessionCount, 0)
+        const traceTotal = buckets.reduce((acc, b) => acc + b.traceCount, 0)
+        const costTotal = buckets.reduce((acc, b) => acc + b.costTotalMicrocentsSum, 0)
+
+        // Buckets agree with the searched count: 2 sessions, 3 matched traces.
+        expect(sessionTotal).toBe(count.totalCount)
+        expect(traceTotal).toBe(count.matchingTraceCount)
+        // The non-matching session's 9_000 microcents never enters the rollup.
+        expect(costTotal).toBe(50 + 70 + 30)
+      })
+
+      it("returns empty metrics and no buckets when the search matches nothing", async () => {
+        const searchQuery = '"needle-that-matches-no-document-zzz"'
+        const metrics = await runCh(
+          repo.aggregateMetricsByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, searchQuery }),
+        )
+        const buckets = await runCh(
+          repo.histogramByProjectId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            bucketSeconds: 3600,
+            searchQuery,
+          }),
+        )
+        expect(metrics).toEqual(emptySessionMetrics())
+        expect(buckets).toEqual([])
       })
     })
 

--- a/packages/platform/db-clickhouse/src/repositories/session-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-repository.ts
@@ -43,7 +43,13 @@ import { buildClickHouseWhere } from "../filter-builder.ts"
 import { SESSION_FIELD_REGISTRY } from "../registries/session-fields.ts"
 import { buildScoreRollupSubquery, splitScoreFilters } from "../score-filter-subquery.ts"
 import { buildSessionIntelligenceFilters } from "../session-intelligence-filters.ts"
-import { countSessionsBySearchQuery, type FetchFullSessions, listSessionsBySearchQuery } from "./search-by-project.ts"
+import {
+  aggregateMetricsBySearchQuery,
+  countSessionsBySearchQuery,
+  type FetchFullSessions,
+  histogramBySearchQuery,
+  listSessionsBySearchQuery,
+} from "./search-by-project.ts"
 import { isActiveSearch } from "./search-plan.ts"
 
 const LIST_SELECT = `
@@ -797,10 +803,21 @@ export const SessionRepositoryLive = Layer.effect(
             )
         }),
 
-      aggregateMetricsByProjectId: ({ organizationId, projectId, filters }) =>
+      aggregateMetricsByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           const resolvedFilters = yield* resolvePercentileFilters(organizationId, projectId, filters)
+
+          const parsed = searchQuery && searchQuery.length > 0 ? parseSearchQuery(searchQuery) : undefined
+          if (parsed && isActiveSearch(parsed)) {
+            return yield* aggregateMetricsBySearchQuery({
+              organizationId,
+              projectId,
+              parsed,
+              filters: resolvedFilters,
+            })
+          }
+
           const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(resolvedFilters)
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
@@ -860,10 +877,22 @@ export const SessionRepositoryLive = Layer.effect(
             )
         }),
 
-      histogramByProjectId: ({ organizationId, projectId, filters, bucketSeconds }) =>
+      histogramByProjectId: ({ organizationId, projectId, filters, bucketSeconds, searchQuery }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           const resolvedFilters = yield* resolvePercentileFilters(organizationId, projectId, filters)
+
+          const parsed = searchQuery && searchQuery.length > 0 ? parseSearchQuery(searchQuery) : undefined
+          if (parsed && isActiveSearch(parsed)) {
+            return yield* histogramBySearchQuery({
+              organizationId,
+              projectId,
+              parsed,
+              filters: resolvedFilters,
+              bucketSeconds,
+            })
+          }
+
           const { havingClauses, whereClauses, params: filterParams } = buildSessionFilterClauses(resolvedFilters)
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""


### PR DESCRIPTION
On the traces/sessions dashboard, typing a search query filtered the table rows but left everything else showing project-wide numbers: the histogram, the analytics cards (sessions/cost/duration/tokens/ttft/traces/spans), and the table column rollups (avg/min/max/median on duration, ttft, cost, spans). This makes those surfaces reflect the matched set instead.

## Trace tab

UI wiring only — the trace repository already accepted `searchQuery` for metrics and histogram. The page never threaded the query into `TraceAggregationsPanel`, and `GeneralAggregations` / `Histogram` didn't accept it. They do now. The trace table's column rollups already worked (`TracesView` passed `searchQuery` to `useTraceMetrics`).

## Session tab

The session side had no search support below the table at all, so it gained it end to end:

- `SessionRepository` port: `searchQuery` added to `aggregateMetricsByProjectId` and `histogramByProjectId`.
- ClickHouse repo: when a search is active, both dispatch to new `aggregateMetricsBySearchQuery` / `histogramBySearchQuery` in `search-by-project.ts`. These reuse the existing `trace_rollup -> session_rollup` candidate machinery that `listSessionsBySearchQuery` / `countSessionsBySearchQuery` already use, so the panels aggregate over the same matched set the list shows — non-matching sessions drop out, per-session numerics reflect only the matched traces, and orphan-trace sessions are included.
- Server functions `getSessionMetricsByProject` / `getSessionTimeHistogramByProject`: accept `searchQuery`, and now run under the `withAi(AIEmbedLive, ...)` layer the semantic-search path needs (the list/count handlers already did; these two didn't).
- Hooks `useSessionMetrics` / `useSessionTimeHistogram`: `searchQuery` added to params and query keys.
- `SessionsView` now passes `searchQuery` to `useSessionMetrics`, which feeds the table column subheaders.

## Semantics

In search mode the session cards, histogram, and column rollups reflect **only the matched traces per session** (cost summed over matching traces, "traces" = matching-trace count), matching what the searched list already displays — not the sessions' full all-trace totals.

## Tests

Added three ClickHouse repo tests (search-mode metrics, histogram, empty-match) asserting the panels agree with `countByProjectId`'s `totalCount` / `matchingTraceCount`. `@platform/db-clickhouse` (228) and `@app/web` (413) suites pass; typecheck clean on the three affected packages.