### PR TITLE
chore(telemetry): promote Python and TypeScript SDKs out of alpha to 3.0.1

### DIFF
--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-06-10
+
+### Changed
+
+- **First stable release of the 3.x line.** No code changes since `3.0.0a8` — this promotes the alpha channel to stable, so a plain `pip install latitude-telemetry` now resolves to the new `Latitude` API instead of the legacy `2.0.4` (`Telemetry` / `Instrumentors`). The `--pre` flag is no longer needed.
+- Version `3.0.0` is skipped on purpose: it was published in February for the deprecated pre-rewrite line and later yanked, and PyPI does not allow reusing yanked version numbers.
+
 ## [3.0.0a8] - 2026-05-16
 
 ### Changed

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a8"
+version = "3.0.1"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.0.0a8"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-06-10
+
+### Changed
+
+- **First stable release of the 3.x line.** No code changes since `3.0.0-alpha.13` — this promotes the alpha channel to stable. The npm `latest` dist-tag, previously pointing at `3.0.0-alpha.13`, now resolves to a stable version.
+- Version `3.0.0` is skipped on purpose: it was published in February for the deprecated pre-rewrite line, and npm versions are immutable.
+
 ## [3.0.0-alpha.13] - 2026-05-19
 
 ### Fixed

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.13",
+  "version": "3.0.1",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",


### PR DESCRIPTION
## Why

Users following the telemetry docs hit `ImportError: cannot import name 'Latitude' from 'latitude_telemetry'`. The 3.x rewrite has only ever shipped as pre-releases (`latitude-telemetry==3.0.0a8`, `@latitude-data/telemetry@3.0.0-alpha.13`), so a plain `pip install latitude-telemetry` resolves to the legacy **2.0.4** (`Telemetry` / `Instrumentors` API) — pip never selects pre-releases by default, and the stable `3.0.0` on PyPI is yanked.

## What

Promote both telemetry SDKs to stable **3.0.1**:

- **Python**: `pyproject.toml` + `uv.lock` `3.0.0a8` → `3.0.1`, changelog entry added (the publish workflow hard-fails without one).
- **TypeScript**: `package.json` `3.0.0-alpha.13` → `3.0.1`, changelog entry added.

No code changes — version + changelog only.

## Notes

- **`3.0.0` is skipped on purpose**: it's burned on both registries by the deprecated February release (yanked on PyPI, which forbids reusing yanked filenames; immutable on npm). `3.0.1` semver-resolves above both the alphas and the dead `3.0.0`.
- **Merging this PR publishes immediately**: `publish-packages.yml` runs on every push to `development` and publishes any package whose repo version differs from the registry.
- As a side effect, the npm `latest` dist-tag moves off `3.0.0-alpha.13` onto a stable version.
- The `uv.lock` change is minimal (own-version only); a full `uv lock` re-resolve was intentionally avoided to keep the diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)