### PR TITLE
fix(auth): surface OAuth login errors and add connected accounts settings

### DIFF
--- a/apps/web/src/domains/sessions/user-accounts.functions.ts
+++ b/apps/web/src/domains/sessions/user-accounts.functions.ts
@@ -1,0 +1,83 @@
+import { UnauthorizedError } from "@domain/shared"
+import { createServerFn } from "@tanstack/react-start"
+import { getRequestHeaders } from "@tanstack/react-start/server"
+import { z } from "zod"
+import { getBetterAuth } from "../../server/clients.ts"
+
+export const SOCIAL_PROVIDER_IDS = ["google", "github"] as const
+export type SocialProviderId = (typeof SOCIAL_PROVIDER_IDS)[number]
+
+export interface UserAccountProfile {
+  readonly name: string | null
+  readonly email: string | null
+  readonly image: string | null
+}
+
+export interface UserAccountDto {
+  readonly id: string
+  readonly providerId: string
+  readonly accountId: string
+  readonly createdAt: string
+  readonly profile: UserAccountProfile | null
+}
+
+const asIso = (value: Date | string): string =>
+  value instanceof Date ? value.toISOString() : new Date(value).toISOString()
+
+export const listUserAccounts = createServerFn({ method: "GET" }).handler(
+  async (): Promise<readonly UserAccountDto[]> => {
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+
+    const session = await auth.api.getSession({ headers })
+    if (!session) throw new UnauthorizedError({ message: "Unauthorized" })
+
+    const rows = await auth.api.listUserAccounts({ headers })
+    return await Promise.all(
+      rows.map(async (row) => {
+        let profile: UserAccountProfile | null = null
+        try {
+          const info = await auth.api.accountInfo({
+            headers,
+            query: { accountId: row.accountId },
+          })
+          if (info?.user) {
+            profile = {
+              name: info.user.name ?? null,
+              email: info.user.email ?? null,
+              image: info.user.image ?? null,
+            }
+          }
+        } catch {}
+        return {
+          id: row.id,
+          providerId: row.providerId,
+          accountId: row.accountId,
+          createdAt: asIso(row.createdAt),
+          profile,
+        }
+      }),
+    )
+  },
+)
+
+export const unlinkUserAccount = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      providerId: z.enum(SOCIAL_PROVIDER_IDS),
+      accountId: z.string().min(1),
+    }),
+  )
+  .handler(async ({ data }): Promise<{ readonly success: true }> => {
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+
+    const session = await auth.api.getSession({ headers })
+    if (!session) throw new UnauthorizedError({ message: "Unauthorized" })
+
+    await auth.api.unlinkAccount({
+      headers,
+      body: { providerId: data.providerId, accountId: data.accountId },
+    })
+    return { success: true }
+  })

--- a/apps/web/src/lib/auth/oauth-errors.test.ts
+++ b/apps/web/src/lib/auth/oauth-errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { oauthCallbackErrorMessage } from "./oauth-errors.ts"
+
+describe("oauthCallbackErrorMessage", () => {
+  it("returns undefined when there is no error code", () => {
+    expect(oauthCallbackErrorMessage(undefined)).toBeUndefined()
+  })
+
+  it("maps account_not_linked to copy that steers the user to email sign-in", () => {
+    expect(oauthCallbackErrorMessage("account_not_linked")).toContain("Continue with email")
+  })
+
+  it("falls back to a generic message without echoing unknown codes", () => {
+    const crafted = "<script>alert(1)</script> visit evil.example to fix your account"
+    const message = oauthCallbackErrorMessage(crafted)
+    expect(message).toBe(oauthCallbackErrorMessage("some_future_code"))
+    expect(message).not.toContain(crafted)
+  })
+})

--- a/apps/web/src/lib/auth/oauth-errors.ts
+++ b/apps/web/src/lib/auth/oauth-errors.ts
@@ -1,0 +1,51 @@
+/**
+ * User-facing messages for OAuth callback failures.
+ *
+ * When a social sign-in fails at the Better Auth callback, BA redirects to
+ * our `errorCallbackURL` (`/login`, see `oauth-redirects.ts`) with the error
+ * code appended as `?error=<code>`. This maps the known codes to friendly
+ * copy. Unknown codes get a generic message — the raw query value is never
+ * echoed into the UI, so crafted links can't inject arbitrary text.
+ */
+
+const SIGN_IN_EXPIRED_MESSAGE = "That sign-in attempt expired or was interrupted. Please try again."
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  account_not_linked:
+    "This email already has an account that isn't connected to that provider. Continue with email below to sign in — you can then connect it under Settings → Account.",
+  access_denied: "Sign-in was cancelled before it completed. Please try again.",
+  please_restart_the_process: SIGN_IN_EXPIRED_MESSAGE,
+  state_mismatch: SIGN_IN_EXPIRED_MESSAGE,
+  state_not_found: SIGN_IN_EXPIRED_MESSAGE,
+  signup_disabled: "New sign-ups are currently disabled for this provider. Continue with email below instead.",
+  email_not_verified: "Your email address is not verified with that provider. Verify it there and try again.",
+}
+
+const GENERIC_OAUTH_ERROR_MESSAGE = "Could not complete the sign-in. Please try again or continue with email below."
+
+/**
+ * Resolve the `?error=` code from an OAuth callback redirect to a
+ * user-facing message, or `undefined` when there is no error.
+ */
+export function oauthCallbackErrorMessage(code: string | undefined): string | undefined {
+  if (!code) return undefined
+  return OAUTH_ERROR_MESSAGES[code] ?? GENERIC_OAUTH_ERROR_MESSAGE
+}
+
+/**
+ * Same idea for the account-LINKING flow (`linkSocial` from settings):
+ * the codes BA's `/callback/:id` emits when `state.link` is set.
+ */
+const LINK_ERROR_MESSAGES: Record<string, string> = {
+  "email_doesn't_match":
+    "That account uses a different email than your Latitude account. Pick the account that matches your Latitude email.",
+  account_already_linked_to_different_user: "That account is already connected to a different Latitude user.",
+  access_denied: "Connecting was cancelled before it completed.",
+}
+
+const GENERIC_LINK_ERROR_MESSAGE = "Could not connect the account. Please try again."
+
+/** Resolve a linking-callback `?error=` code to a user-facing message. */
+export function oauthLinkErrorMessage(code: string): string {
+  return LINK_ERROR_MESSAGES[code] ?? GENERIC_LINK_ERROR_MESSAGE
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -1,7 +1,10 @@
 import { NOTIFICATION_GROUP_META, NOTIFICATION_GROUPS, type NotificationPreferences } from "@domain/shared"
 import {
+  Avatar,
   Button,
   FormWrapper,
+  GitHubIcon,
+  GoogleIcon,
   Icon,
   Input,
   Label,
@@ -16,6 +19,7 @@ import {
   TableSkeleton,
   Text,
   Tooltip,
+  useMountEffect,
   useToast,
 } from "@repo/ui"
 import { relativeTime, toTitle } from "@repo/utils"
@@ -35,24 +39,42 @@ import {
   Watch,
 } from "lucide-react"
 import { useEffect, useState } from "react"
+import { z } from "zod"
 import {
   getNotificationPreferences,
   updateNotificationPreferences,
 } from "../../../../../domains/notifications/notifications.functions.ts"
 import { deleteCurrentUser, updateUserName } from "../../../../../domains/sessions/session.functions.ts"
 import {
+  listUserAccounts,
+  SOCIAL_PROVIDER_IDS,
+  type SocialProviderId,
+  type UserAccountDto,
+  unlinkUserAccount,
+} from "../../../../../domains/sessions/user-accounts.functions.ts"
+import {
   listUserSessions,
   revokeAllOtherUserSessions,
   revokeUserSession,
   type UserSessionDto,
 } from "../../../../../domains/sessions/user-sessions.functions.ts"
+import { oauthLinkErrorMessage } from "../../../../../lib/auth/oauth-errors.ts"
 import { authClient } from "../../../../../lib/auth-client.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../lib/form-server-action.ts"
 import { useAuthenticatedUser } from "../../../-route-data.ts"
 import { SettingsPage } from "./-components/settings-page.tsx"
 
+// Flash params from the `linkSocial` redirect round-trip: BA sends the user
+// back to `callbackURL` (`?linked=<provider>`) on success or appends
+// `?error=<code>` to `errorCallbackURL` on failure.
+const accountSearchParams = z.object({
+  linked: z.enum(SOCIAL_PROVIDER_IDS).optional(),
+  error: z.string().optional(),
+})
+
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/account")({
+  validateSearch: accountSearchParams,
   component: AccountSettingsPage,
 })
 
@@ -230,8 +252,176 @@ function RevokeAllOtherSessionsConfirmModal({ otherCount, onClose }: { otherCoun
   )
 }
 
+interface SocialProviderMeta {
+  readonly id: SocialProviderId
+  readonly label: string
+  readonly icon: React.ComponentType<{ className?: string }>
+}
+
+const SOCIAL_PROVIDERS: readonly SocialProviderMeta[] = [
+  { id: "google", label: "Google", icon: GoogleIcon },
+  { id: "github", label: "GitHub", icon: GitHubIcon },
+]
+
+const providerLabel = (id: SocialProviderId): string => SOCIAL_PROVIDERS.find((p) => p.id === id)?.label ?? id
+
+function DisconnectAccountConfirmModal({
+  provider,
+  account,
+  onClose,
+}: {
+  provider: SocialProviderMeta
+  account: UserAccountDto
+  onClose: () => void
+}) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const [disconnecting, setDisconnecting] = useState(false)
+
+  const handleConfirm = async () => {
+    setDisconnecting(true)
+    try {
+      await unlinkUserAccount({
+        data: { providerId: provider.id, accountId: account.accountId },
+      })
+      toast({ description: `${provider.label} disconnected` })
+      await queryClient.invalidateQueries({ queryKey: ["userAccounts"] })
+      onClose()
+    } catch (error) {
+      setDisconnecting(false)
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  return (
+    <Modal
+      open
+      onOpenChange={(open) => {
+        if (!open && !disconnecting) onClose()
+      }}
+      title={`Disconnect ${provider.label}`}
+      description={`You'll no longer be able to sign in with ${provider.label}. Email sign-in keeps working, and you can reconnect ${provider.label} at any time.`}
+      dismissible
+      footer={
+        <div className="flex flex-row items-center gap-2">
+          <Button variant="outline" onClick={onClose} disabled={disconnecting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => void handleConfirm()} disabled={disconnecting}>
+            {disconnecting ? "Disconnecting..." : "Disconnect"}
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+
+function ConnectedAccountsSection() {
+  const { toast } = useToast()
+  const { data, isLoading } = useQuery({
+    queryKey: ["userAccounts"],
+    queryFn: () => listUserAccounts(),
+  })
+  const [connecting, setConnecting] = useState<SocialProviderId | null>(null)
+  const [toDisconnect, setToDisconnect] = useState<{
+    provider: SocialProviderMeta
+    account: UserAccountDto
+  } | null>(null)
+
+  const handleConnect = async (provider: SocialProviderMeta) => {
+    if (connecting) return
+    setConnecting(provider.id)
+
+    // Full-page redirect to the provider; we come back to this page with a
+    // `?linked=` / `?error=` flash param (handled in AccountSettingsPage).
+    const { data: linkData, error } = await authClient.linkSocial({
+      provider: provider.id,
+      callbackURL: `${window.location.pathname}?linked=${provider.id}`,
+      errorCallbackURL: window.location.pathname,
+    })
+    if (error) {
+      toast({
+        variant: "destructive",
+        description: error.message ?? `Could not start connecting ${provider.label}`,
+      })
+      setConnecting(null)
+      return
+    }
+    // The BA client normally redirects on its own; this is a fallback. Keep
+    // the "Redirecting…" state — the page is about to unload either way.
+    if (linkData?.url) window.location.assign(linkData.url)
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Text.H5 weight="semibold">Connected accounts</Text.H5>
+        <Text.H5 color="foregroundMuted">
+          Connect Google or GitHub to sign in with one click. Signing in with your email always keeps working
+        </Text.H5>
+      </div>
+      <div className="flex w-full flex-col gap-1">
+        {SOCIAL_PROVIDERS.map((provider) => {
+          const account = data?.find((a) => a.providerId === provider.id)
+          const profile = account?.profile ?? null
+          const ProviderIcon = provider.icon
+          return (
+            <div
+              key={provider.id}
+              className="flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4"
+            >
+              <div className="flex flex-row items-center gap-3">
+                {profile ? (
+                  <Avatar name={profile.name ?? provider.label} imageSrc={profile.image} size="lg" />
+                ) : (
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background border border-border">
+                    <ProviderIcon />
+                  </div>
+                )}
+                <div className="flex flex-col">
+                  <div className="flex flex-row items-baseline gap-1.5">
+                    <Text.H5 weight="medium">{profile?.name ?? provider.label}</Text.H5>
+                    {profile?.name ? <Text.H6 color="foregroundMuted">· {provider.label}</Text.H6> : null}
+                  </div>
+                  <Text.H6 color="foregroundMuted">
+                    {isLoading
+                      ? "…"
+                      : account
+                        ? (profile?.email ?? `Connected ${relativeTime(account.createdAt)}`)
+                        : "Not connected"}
+                  </Text.H6>
+                </div>
+              </div>
+              {isLoading ? null : account ? (
+                <Button variant="destructive" onClick={() => setToDisconnect({ provider, account })}>
+                  Disconnect
+                </Button>
+              ) : (
+                <Button variant="outline" disabled={connecting !== null} onClick={() => void handleConnect(provider)}>
+                  {connecting === provider.id ? "Redirecting…" : "Connect"}
+                </Button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {toDisconnect ? (
+        <DisconnectAccountConfirmModal
+          provider={toDisconnect.provider}
+          account={toDisconnect.account}
+          onClose={() => setToDisconnect(null)}
+        />
+      ) : null}
+    </section>
+  )
+}
+
 function SessionsSection() {
-  const { data, isLoading } = useQuery({ queryKey: ["userSessions"], queryFn: () => listUserSessions() })
+  const { data, isLoading } = useQuery({
+    queryKey: ["userSessions"],
+    queryFn: () => listUserSessions(),
+  })
   const [sessionToRevoke, setSessionToRevoke] = useState<UserSessionDto | null>(null)
   const [revokeAllOpen, setRevokeAllOpen] = useState(false)
 
@@ -367,12 +557,16 @@ function NotificationsSection() {
       [group]: { ...(prefs[group] ?? {}), email: enabled },
     }
     // Optimistic update so the toggle never lags behind the user's intent.
-    queryClient.setQueryData(["notificationPreferences"], { preferences: next })
+    queryClient.setQueryData(["notificationPreferences"], {
+      preferences: next,
+    })
     try {
       await updateNotificationPreferences({ data: { preferences: next } })
     } catch (error) {
       // Roll back on failure.
-      queryClient.setQueryData(["notificationPreferences"], { preferences: prefs })
+      queryClient.setQueryData(["notificationPreferences"], {
+        preferences: prefs,
+      })
       toast({ variant: "destructive", description: toUserMessage(error) })
     }
   }
@@ -420,7 +614,24 @@ function AccountSettingsPage() {
   const user = useAuthenticatedUser()
   const { toast } = useToast()
   const router = useRouter()
+  const search = Route.useSearch()
   const [deleteOpen, setDeleteOpen] = useState(false)
+
+  // Toast the result of a `linkSocial` round-trip, then strip the flash
+  // params so a refresh doesn't repeat the toast.
+  useMountEffect(() => {
+    if (search.linked) {
+      toast({ description: `${providerLabel(search.linked)} connected` })
+    } else if (search.error) {
+      toast({
+        variant: "destructive",
+        description: oauthLinkErrorMessage(search.error),
+      })
+    }
+    if (search.linked || search.error) {
+      void router.navigate({ to: Route.fullPath, search: {}, replace: true })
+    }
+  })
 
   const form = useForm({
     defaultValues: { name: user.name ?? "" },
@@ -479,6 +690,7 @@ function AccountSettingsPage() {
         </div>
       </form>
       <NotificationsSection />
+      <ConnectedAccountsSection />
       <SessionsSection />
       <div className="flex flex-col gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-6">
         <Text.H4 weight="bold" color="destructive">

--- a/apps/web/src/routes/auth/invite.tsx
+++ b/apps/web/src/routes/auth/invite.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, LatitudeLogo, Text } from "@repo/ui"
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router"
 import { AlertCircle, Users } from "lucide-react"
-import { useState } from "react"
+import { type SubmitEvent, useState } from "react"
 import z from "zod"
 import { getInvitationPreview } from "../../domains/auth/auth.functions.ts"
 import { getSession, updateUserName } from "../../domains/sessions/session.functions.ts"
@@ -47,7 +47,7 @@ function InvitePage() {
 
   const userHasName = session.user.name && session.user.name.trim().length > 0
 
-  const handleAcceptInvitation = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleAcceptInvitation = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (isSubmitting) return
 
@@ -59,7 +59,9 @@ function InvitePage() {
         await updateUserName({ data: { name: name.trim() } })
       }
 
-      const { error } = await authClient.organization.acceptInvitation({ invitationId })
+      const { error } = await authClient.organization.acceptInvitation({
+        invitationId,
+      })
       if (error) {
         setError(error.message)
         setIsSubmitting(false)
@@ -79,7 +81,9 @@ function InvitePage() {
     setError(undefined)
 
     try {
-      const { error } = await authClient.organization.rejectInvitation({ invitationId })
+      const { error } = await authClient.organization.rejectInvitation({
+        invitationId,
+      })
       if (error) {
         setError(error.message)
         setIsSubmitting(false)

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,7 +1,7 @@
 import { Button, GitHubIcon, GoogleIcon, Icon, LatitudeLogo, Text } from "@repo/ui"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { AlertCircle, ArrowRight, Mail } from "lucide-react"
-import { useCallback, useRef, useState } from "react"
+import { type SubmitEvent, useCallback, useRef, useState } from "react"
 import z from "zod"
 import { Turnstile } from "../components/turnstile.tsx"
 import { sendMagicLink } from "../domains/auth/auth.functions.ts"
@@ -9,6 +9,7 @@ import { getSession } from "../domains/sessions/session.functions.ts"
 import { lookupSsoForEmail } from "../domains/sso/sso.functions.ts"
 import { appendTrackingParams, gtmHeadScripts, pickTrackingParams } from "../lib/analytics/gtm.ts"
 import { GtmNoScript, SignupCompleteWatcher } from "../lib/analytics/signup-complete-watcher.tsx"
+import { oauthCallbackErrorMessage } from "../lib/auth/oauth-errors.ts"
 import { authClient } from "../lib/auth-client.ts"
 import { TURNSTILE_SITE_KEY, WEB_BASE_URL } from "../lib/auth-config.ts"
 import { toUserMessage } from "../lib/errors.ts"
@@ -17,6 +18,9 @@ import { getPostHogSessionId } from "../lib/posthog/posthog-client.ts"
 const loginSearchParams = z.object({
   redirect: z.string().optional(),
   email: z.string().optional(),
+  // Better Auth appends `?error=<code>` to `errorCallbackURL` when a social
+  // sign-in fails at the OAuth callback (e.g. `account_not_linked`).
+  error: z.string().optional(),
 })
 
 export const Route = createFileRoute("/login")({
@@ -32,9 +36,9 @@ export const Route = createFileRoute("/login")({
 })
 
 function LoginPage() {
-  const { redirect: redirectPath, email: prefilledEmail } = Route.useSearch()
+  const { redirect: redirectPath, email: prefilledEmail, error: oauthErrorCode } = Route.useSearch()
   const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string>()
+  const [error, setError] = useState<string | undefined>(() => oauthCallbackErrorMessage(oauthErrorCode))
   const [isSent, setIsSent] = useState(false)
   const [isRedirectingToSso, setIsRedirectingToSso] = useState(false)
   const [email, setEmail] = useState(prefilledEmail ?? "")
@@ -46,7 +50,7 @@ function LoginPage() {
     captchaTokenRef.current = undefined
   }, [])
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (isLoading) return
 
@@ -59,7 +63,10 @@ function LoginPage() {
 
     const callbackURL = redirectPath ?? "/"
     const tracking = pickTrackingParams(window.location.search)
-    const newUserCallbackURL = appendTrackingParams(redirectPath ?? "/welcome", { ...tracking, signup: "email" })
+    const newUserCallbackURL = appendTrackingParams(redirectPath ?? "/welcome", {
+      ...tracking,
+      signup: "email",
+    })
 
     // Capture session + referrer/UTM now; the magic link is verified later
     // (maybe cross-device) without this context. Server stashes it by email and
@@ -216,8 +223,10 @@ function LoginPage() {
             )}
 
             {error && (
-              <div className="flex items-center gap-2 text-sm text-destructive">
-                <Icon icon={AlertCircle} className="h-4 w-4" />
+              <div className="flex items-start gap-2">
+                <div className="shrink-0 mt-0.5">
+                  <Icon icon={AlertCircle} size="sm" color="destructive" />
+                </div>
                 <Text.H6 color="destructive">{error}</Text.H6>
               </div>
             )}

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -256,6 +256,7 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
         disableImplicitLinking: true,
         allowDifferentEmails: false,
         updateUserInfoOnLink: false,
+        allowUnlinkingAll: true,
       },
     },
     socialProviders: {


### PR DESCRIPTION
## what & why

A user couldn't sign in with Google ([#3455](https://github.com/latitude-dev/latitude-llm/issues/3455)). Root cause: their account was created via magic link, and `disableImplicitLinking: true` makes Better Auth refuse to attach a Google identity to an existing user by email match — the callback bounces back to `/login?error=account_not_linked`. The login page never read the `error` param, so the failure was completely silent.

This PR makes OAuth failures visible and gives users a sanctioned way to link providers, keeping the no-implicit-linking security posture intact.

<img width="585" height="737" alt="image" src="https://github.com/user-attachments/assets/24a9a927-4824-4dfd-8cdb-dbd89c3fae83" />

## login error display

`/login` now accepts an `error` search param and maps Better Auth's callback error codes to messages in the existing inline error slot (`account_not_linked` points at email sign-in and Settings → Account; state/expiry codes say "try again"). Unknown codes get a generic message — the raw query value is never echoed into the UI, so a crafted link can't display attacker-controlled copy.

## connected accounts in settings

New section in Settings → Account with one row per provider (Google, GitHub):

- **Connect** runs `authClient.linkSocial` (full-page redirect; flash params on return drive success/error toasts, same pattern as the Slack integration callback). Linking only succeeds when the provider email matches the user's email (`allowDifferentEmails: false`).
- **Disconnect** sits behind a confirm modal and calls a server fn wrapping `auth.api.unlinkAccount`. BA requires a fresh session for unlinking; a stale session surfaces BA's error as a toast.
- Connected rows show the provider-side avatar, name, and email via `auth.api.accountInfo` — Google resolves from the stored `idToken` (local JWT decode, no network), GitHub from its API (those tokens don't expire). If the profile fetch fails, the row falls back to "Connected <relative time>" instead of breaking.

`accountLinking.allowUnlinkingAll` is now set: without it BA refuses to remove a user's only `accounts` row, which would have made Google un-disconnectable for magic-link-born users. Magic link always remains a sign-in path, so this can't lock anyone out.

<img width="1400" height="368" alt="image" src="https://github.com/user-attachments/assets/46253ada-3073-4b62-97c1-44d9cdde03f7" />


## also in here

- `React.FormEvent` → `React.SubmitEvent` in the two form handlers touched (`@types/react` 19.2 deprecated `FormEvent`).
- Fixed the login error icon being crushed by flex when the message wraps (`shrink-0` + top alignment).

## validation

Unit tests for the error-code mapping (including the no-echo fallback); typecheck, Biome, and the sessions-domain tests pass. Manual QA: reproduced `account_not_linked` locally, verified the message renders, connected and disconnected Google from settings, and confirmed Google sign-in works after linking.

Closes #3455

🤖 Generated with [Claude Code](https://claude.com/claude-code)