### PR TITLE
fix(spans): render non-JSON tool input/output as a code block

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/tool-execution-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/tool-execution-section.tsx
@@ -1,4 +1,4 @@
-import { CopyButton, DetailSection, DetailSummary, Text } from "@repo/ui"
+import { CodeBlock, DetailSection, DetailSummary, Text } from "@repo/ui"
 import { ArrowDownRightIcon, ArrowUpRightIcon, WrenchIcon } from "lucide-react"
 import { useMemo } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
@@ -41,14 +41,7 @@ export function ToolExecutionSection({ span }: { readonly span: SpanDetailRecord
         {parsedInput !== null ? (
           <JsonBlock value={parsedInput} />
         ) : span.toolInput ? (
-          <div className="flex flex-col gap-1">
-            <div className="flex flex-row items-center gap-2">
-              <Text.H6 color="foreground" className="whitespace-pre-wrap break-all">
-                {span.toolInput}
-              </Text.H6>
-              <CopyButton value={span.toolInput} />
-            </div>
-          </div>
+          <CodeBlock value={span.toolInput} className="bg-secondary" />
         ) : (
           <Text.H6 color="foregroundMuted">No input</Text.H6>
         )}
@@ -58,14 +51,7 @@ export function ToolExecutionSection({ span }: { readonly span: SpanDetailRecord
         {parsedOutput !== null ? (
           <JsonBlock value={parsedOutput} />
         ) : span.toolOutput ? (
-          <div className="flex flex-col gap-1">
-            <div className="flex flex-row items-center gap-2">
-              <Text.H6 color="foreground" className="whitespace-pre-wrap break-all">
-                {span.toolOutput}
-              </Text.H6>
-              <CopyButton value={span.toolOutput} />
-            </div>
-          </div>
+          <CodeBlock value={span.toolOutput} className="bg-secondary" />
         ) : (
           <Text.H6 color="foregroundMuted">No output</Text.H6>
         )}


### PR DESCRIPTION
Fixes [LAT-639](https://linear.app/latitude/issue/LAT-639/tool-output-isnt-in-a-code-box).

In the span detail panel, tool input and output are parsed as JSON and rendered in a `CodeBlock`. When the value isn't valid JSON — typically a plain-text tool error like `EISDIR: illegal operation on a directory…` — it fell back to bare `Text.H6`, so the output blended into the page and was easy to miss.

The non-JSON fallback now renders the raw string in the same `CodeBlock` used for the JSON path. `CodeBlock` ships its own copy and expand controls, so the manual `CopyButton` wrapper is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)