### PR TITLE
feat(issues): Related issues section — semantic similarity + session co-occurrence

### DIFF
--- a/apps/web/src/domains/issues/issues.collection.ts
+++ b/apps/web/src/domains/issues/issues.collection.ts
@@ -14,6 +14,7 @@ import type {
   IssueTracePageRecord,
   IssueTraceRecord,
   OrgIssueSearchRecord,
+  RelatedIssueRecord,
   UpdateIssueTriageRecord,
 } from "./issues.functions.ts"
 import {
@@ -23,6 +24,7 @@ import {
   getIssueDimensions,
   getIssueImpact,
   getIssueOccurrences,
+  getRelatedIssues,
   listIssues,
   listIssueTraces,
   searchOrgIssues,
@@ -97,6 +99,8 @@ const getIssueDimensionsQueryKey = (projectId: string, issueId: string, dimensio
 
 const getIssueOccurrencesQueryKey = (projectId: string, issueId: string) =>
   ["issue-occurrences", projectId, issueId] as const
+
+const getRelatedIssuesQueryKey = (projectId: string, issueId: string) => ["related-issues", projectId, issueId] as const
 
 const getIssueTracesQueryKey = (projectId: string, issueId: string) => ["issue-traces", projectId, issueId] as const
 
@@ -324,6 +328,23 @@ export function useIssueDimensions({
   return useQuery({
     queryKey: getIssueDimensionsQueryKey(projectId, issueId, dimension),
     queryFn: (): Promise<IssueDimensionsRecord> => getIssueDimensions({ data: { projectId, issueId, dimension } }),
+    enabled: enabled && projectId.length > 0 && issueId.length > 0,
+    staleTime: ISSUES_QUERY_STALE_TIME_MS,
+  })
+}
+
+export function useRelatedIssues({
+  projectId,
+  issueId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly issueId: string
+  readonly enabled?: boolean
+}) {
+  return useQuery({
+    queryKey: getRelatedIssuesQueryKey(projectId, issueId),
+    queryFn: (): Promise<readonly RelatedIssueRecord[]> => getRelatedIssues({ data: { projectId, issueId } }),
     enabled: enabled && projectId.length > 0 && issueId.length > 0,
     staleTime: ISSUES_QUERY_STALE_TIME_MS,
   })

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -10,6 +10,7 @@ import {
   embedIssueSearchQueryUseCase,
   fillBuckets,
   getEscalationOccurrenceThreshold,
+  getRelatedIssuesUseCase,
   type Issue,
   type IssueListItem,
   IssueRepository,
@@ -194,6 +195,11 @@ const issueDimensionsInputSchema = z.object({
 })
 
 const issueOccurrencesInputSchema = z.object({
+  projectId: z.string(),
+  issueId: z.string(),
+})
+
+const relatedIssuesInputSchema = z.object({
   projectId: z.string(),
   issueId: z.string(),
 })
@@ -775,6 +781,60 @@ export const getIssueDimensions = createServerFn({ method: "GET" })
       issueAffectedTraces: comparison.issueAffectedTraces,
       patterns: rankDimensionValues(comparison),
     }
+  })
+
+/** One Related-list row: why another issue relates to this one, plus identity to render/link it. */
+export interface RelatedIssueRecord {
+  readonly issueId: string
+  readonly slug: string
+  readonly name: string
+  readonly states: readonly string[]
+  /** Combined ranking score — sort-order only, never displayed. */
+  readonly relatedness: number
+  /** Present when the semantic (centroid cosine) signal contributed. */
+  readonly semantic: {
+    readonly similarity: number
+    readonly score: number
+  } | null
+  /** Present when the session co-occurrence signal contributed. */
+  readonly coOccurrence: {
+    readonly sharedSessions: number
+    readonly sharedSessionsPercent: number
+    readonly score: number
+  } | null
+}
+
+export const getRelatedIssues = createServerFn({ method: "GET" })
+  .inputValidator(relatedIssuesInputSchema)
+  .handler(async ({ data }): Promise<readonly RelatedIssueRecord[]> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const pgClient = getPostgresClient()
+    const chClient = getClickhouseClient()
+
+    const related = await Effect.runPromise(
+      getRelatedIssuesUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        issueId: IssueId(data.issueId),
+      }).pipe(
+        withPostgres(IssueRepositoryLive, pgClient, orgId),
+        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withTracing,
+      ),
+    )
+
+    return related.map(
+      (row): RelatedIssueRecord => ({
+        issueId: row.issueId,
+        slug: row.slug,
+        name: row.name,
+        states: row.states,
+        relatedness: row.relatedness,
+        semantic: row.semantic,
+        coOccurrence: row.coOccurrence,
+      }),
+    )
   })
 
 /** An occurrence (annotation score) that pinpoints where the issue manifests in a conversation. */

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -788,7 +788,10 @@ export interface RelatedIssueRecord {
   readonly issueId: string
   readonly slug: string
   readonly name: string
+  readonly description: string
   readonly states: readonly string[]
+  readonly occurrences: number
+  readonly lastSeenAt: string | null
   /** Combined ranking score — sort-order only, never displayed. */
   readonly relatedness: number
   /** Present when the semantic (centroid cosine) signal contributed. */
@@ -829,7 +832,10 @@ export const getRelatedIssues = createServerFn({ method: "GET" })
         issueId: row.issueId,
         slug: row.slug,
         name: row.name,
+        description: row.description,
         states: row.states,
+        occurrences: row.occurrences,
+        lastSeenAt: row.lastSeenAt?.toISOString() ?? null,
         relatedness: row.relatedness,
         semantic: row.semantic,
         coOccurrence: row.coOccurrence,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/-components/issue-related.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/-components/issue-related.tsx
@@ -1,10 +1,16 @@
 import { DetailSection, Icon, Skeleton, Status, Text, Tooltip } from "@repo/ui"
-import { formatCount } from "@repo/utils"
+import { formatCount, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { NetworkIcon } from "lucide-react"
 import { useRelatedIssues } from "../../../../../../../domains/issues/issues.collection.ts"
 import type { RelatedIssueRecord } from "../../../../../../../domains/issues/issues.functions.ts"
 import { IssueLifecycleStatuses } from "../../-components/issue-lifecycle-statuses.tsx"
+
+/**
+ * Semantic score above which the chip reads "Very similar topic" instead of
+ * "Similar topic". Purely presentational — the score itself is never shown.
+ */
+const VERY_SIMILAR_TOPIC_SCORE = 0.66
 
 /** Integer percentage, with `<1%` for a tiny-but-present share so it never reads as 0%. */
 const formatPercent = (fraction: number) => {
@@ -14,24 +20,30 @@ const formatPercent = (fraction: number) => {
 }
 
 /**
- * Reason chips explain *why* a row is in the list — the raw similarity /
- * relatedness numbers are deliberately never shown (they rank, the chips
- * explain). A row carrying both chips is the "possibly the same issue" case
- * and ranks above either signal alone.
+ * Reason chips state *why* the issue is related — a similar **topic**
+ * (semantic centroid similarity) and/or shared **conversations** (session
+ * co-occurrence). The raw similarity / relatedness numbers are deliberately
+ * never shown (they rank, the chips explain). A card carrying both chips is
+ * the "possibly the same issue" case and ranks above either signal alone.
  */
 function ReasonChips({ row }: { readonly row: RelatedIssueRecord }) {
   return (
-    <div className="flex shrink-0 flex-row items-center gap-1.5">
+    <div className="flex min-w-0 flex-row flex-wrap items-center gap-1.5">
       {row.semantic ? (
         <Tooltip
           asChild
           trigger={
             <span className="inline-flex">
-              <Status variant="info" label="Similar pattern" indicator={false} />
+              <Status
+                variant="info"
+                label={row.semantic.score >= VERY_SIMILAR_TOPIC_SCORE ? "Very similar topic" : "Similar topic"}
+                indicator={false}
+              />
             </span>
           }
         >
-          The two issues' failure patterns are semantically similar.
+          The two issues describe semantically similar failures — their occurrences' feedback points at the same kind of
+          problem.
         </Tooltip>
       ) : null}
       {row.coOccurrence ? (
@@ -40,38 +52,49 @@ function ReasonChips({ row }: { readonly row: RelatedIssueRecord }) {
           trigger={
             <span className="inline-flex">
               <Status
-                variant="neutral"
-                label={`In ${formatPercent(row.coOccurrence.sharedSessionsPercent)} of sessions`}
+                variant="warning"
+                label={`Same conversations · ${formatPercent(row.coOccurrence.sharedSessionsPercent)}`}
                 indicator={false}
               />
             </span>
           }
         >
-          Both issues occur together in {formatCount(row.coOccurrence.sharedSessions)} of this issue's sessions over the
-          last 30 days — more than chance would predict.
+          Both issues occur in {formatCount(row.coOccurrence.sharedSessions)} of the same conversations over the last 30
+          days ({formatPercent(row.coOccurrence.sharedSessionsPercent)} of this issue's sessions) — more overlap than
+          chance would predict.
         </Tooltip>
       ) : null}
     </div>
   )
 }
 
-function RelatedIssueRow({ projectSlug, row }: { readonly projectSlug: string; readonly row: RelatedIssueRecord }) {
+function RelatedIssueCard({ projectSlug, row }: { readonly projectSlug: string; readonly row: RelatedIssueRecord }) {
   return (
     <Link
       to="/projects/$projectSlug/issues/$issueId"
       params={{ projectSlug, issueId: row.issueId }}
       aria-label={`Open the ${row.name} issue`}
-      className="group flex flex-row items-center gap-3 rounded-lg bg-secondary p-3 hover:bg-accent"
+      className="group flex flex-col gap-2 rounded-lg bg-secondary p-4 hover:bg-accent"
     >
-      <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
-        <Text.H5 className="min-w-0 truncate group-hover:underline">{row.name}</Text.H5>
-        {/* Resolved/ignored rows are included on purpose — "a similar issue was
+      <div className="flex min-w-0 flex-row items-center gap-2">
+        <Text.H5 className="min-w-0 flex-1 truncate group-hover:underline">{row.name}</Text.H5>
+        {/* Resolved/ignored cards are included on purpose — "a similar issue was
             already resolved" is the most actionable neighbor to surface. */}
         <div className="shrink-0">
           <IssueLifecycleStatuses states={row.states} wrap={false} />
         </div>
       </div>
-      <ReasonChips row={row} />
+      {/* The description lets users judge the similarity themselves. */}
+      <Text.H6 color="foregroundMuted" className="line-clamp-2 flex-1">
+        {row.description}
+      </Text.H6>
+      <div className="flex flex-row items-end justify-between gap-2">
+        <ReasonChips row={row} />
+        <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap">
+          {formatCount(row.occurrences)} occurrences
+          {row.lastSeenAt ? ` · last seen ${relativeTime(new Date(row.lastSeenAt))}` : ""}
+        </Text.H6>
+      </div>
     </Link>
   )
 }
@@ -79,8 +102,9 @@ function RelatedIssueRow({ projectSlug, row }: { readonly projectSlug: string; r
 /**
  * Related-issues section: one merged list combining two signals — semantic
  * similarity (centroid cosine) and session co-occurrence (NPMI) — ranked by a
- * fused relatedness score computed server-side. Rows link to the related
- * issue's page. See `specs/issue-details-page.md` (Data model #3).
+ * fused relatedness score computed server-side. Rendered as a responsive card
+ * grid at the bottom of the page; cards link to the related issue's page.
+ * See `specs/issue-details-page.md` (Data model #3).
  */
 export function IssueRelated({
   projectId,
@@ -101,19 +125,19 @@ export function IssueRelated({
       contentClassName="pl-0 max-h-none overflow-visible"
     >
       {isLoading ? (
-        <div className="flex flex-col gap-2">
-          {[0, 1].map((rowIndex) => (
-            <Skeleton key={rowIndex} className="h-12 w-full" />
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
+          {[0, 1, 2].map((cardIndex) => (
+            <Skeleton key={cardIndex} className="h-28 w-full" />
           ))}
         </div>
       ) : !related || related.length === 0 ? (
         <Text.H6 color="foregroundMuted">
-          No related issues found — nothing semantically similar and nothing co-occurring in the same sessions.
+          No related issues found — nothing with a similar topic and nothing occurring in the same conversations.
         </Text.H6>
       ) : (
-        <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
           {related.map((row) => (
-            <RelatedIssueRow key={row.issueId} projectSlug={projectSlug} row={row} />
+            <RelatedIssueCard key={row.issueId} projectSlug={projectSlug} row={row} />
           ))}
         </div>
       )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/-components/issue-related.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/-components/issue-related.tsx
@@ -1,0 +1,122 @@
+import { DetailSection, Icon, Skeleton, Status, Text, Tooltip } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { NetworkIcon } from "lucide-react"
+import { useRelatedIssues } from "../../../../../../../domains/issues/issues.collection.ts"
+import type { RelatedIssueRecord } from "../../../../../../../domains/issues/issues.functions.ts"
+import { IssueLifecycleStatuses } from "../../-components/issue-lifecycle-statuses.tsx"
+
+/** Integer percentage, with `<1%` for a tiny-but-present share so it never reads as 0%. */
+const formatPercent = (fraction: number) => {
+  if (fraction <= 0) return "0%"
+  if (fraction < 0.01) return "<1%"
+  return `${Math.round(fraction * 100)}%`
+}
+
+/**
+ * Reason chips explain *why* a row is in the list — the raw similarity /
+ * relatedness numbers are deliberately never shown (they rank, the chips
+ * explain). A row carrying both chips is the "possibly the same issue" case
+ * and ranks above either signal alone.
+ */
+function ReasonChips({ row }: { readonly row: RelatedIssueRecord }) {
+  return (
+    <div className="flex shrink-0 flex-row items-center gap-1.5">
+      {row.semantic ? (
+        <Tooltip
+          asChild
+          trigger={
+            <span className="inline-flex">
+              <Status variant="info" label="Similar pattern" indicator={false} />
+            </span>
+          }
+        >
+          The two issues' failure patterns are semantically similar.
+        </Tooltip>
+      ) : null}
+      {row.coOccurrence ? (
+        <Tooltip
+          asChild
+          trigger={
+            <span className="inline-flex">
+              <Status
+                variant="neutral"
+                label={`In ${formatPercent(row.coOccurrence.sharedSessionsPercent)} of sessions`}
+                indicator={false}
+              />
+            </span>
+          }
+        >
+          Both issues occur together in {formatCount(row.coOccurrence.sharedSessions)} of this issue's sessions over the
+          last 30 days — more than chance would predict.
+        </Tooltip>
+      ) : null}
+    </div>
+  )
+}
+
+function RelatedIssueRow({ projectSlug, row }: { readonly projectSlug: string; readonly row: RelatedIssueRecord }) {
+  return (
+    <Link
+      to="/projects/$projectSlug/issues/$issueId"
+      params={{ projectSlug, issueId: row.issueId }}
+      aria-label={`Open the ${row.name} issue`}
+      className="group flex flex-row items-center gap-3 rounded-lg bg-secondary p-3 hover:bg-accent"
+    >
+      <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
+        <Text.H5 className="min-w-0 truncate group-hover:underline">{row.name}</Text.H5>
+        {/* Resolved/ignored rows are included on purpose — "a similar issue was
+            already resolved" is the most actionable neighbor to surface. */}
+        <div className="shrink-0">
+          <IssueLifecycleStatuses states={row.states} wrap={false} />
+        </div>
+      </div>
+      <ReasonChips row={row} />
+    </Link>
+  )
+}
+
+/**
+ * Related-issues section: one merged list combining two signals — semantic
+ * similarity (centroid cosine) and session co-occurrence (NPMI) — ranked by a
+ * fused relatedness score computed server-side. Rows link to the related
+ * issue's page. See `specs/issue-details-page.md` (Data model #3).
+ */
+export function IssueRelated({
+  projectId,
+  projectSlug,
+  issueId,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly issueId: string
+}) {
+  const { data: related, isLoading } = useRelatedIssues({ projectId, issueId })
+
+  return (
+    <DetailSection
+      icon={<Icon icon={NetworkIcon} size="sm" />}
+      label="Related issues"
+      defaultOpen
+      contentClassName="pl-0 max-h-none overflow-visible"
+    >
+      {isLoading ? (
+        <div className="flex flex-col gap-2">
+          {[0, 1].map((rowIndex) => (
+            <Skeleton key={rowIndex} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : !related || related.length === 0 ? (
+        <Text.H6 color="foregroundMuted">
+          No related issues found — nothing semantically similar and nothing co-occurring in the same sessions.
+        </Text.H6>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {related.map((row) => (
+            <RelatedIssueRow key={row.issueId} projectSlug={projectSlug} row={row} />
+          ))}
+        </div>
+      )}
+    </DetailSection>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/index.tsx
@@ -132,11 +132,9 @@ function IssueDetailPage() {
           }
           trendAside={<IssuePatterns projectId={project.id} issueId={issueId} />}
           beforeTraces={
-            <>
-              <IssueRelated projectId={project.id} projectSlug={projectSlug} issueId={issueId} />
-              <IssueExamples projectId={project.id} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
-            </>
+            <IssueExamples projectId={project.id} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
           }
+          append={<IssueRelated projectId={project.id} projectSlug={projectSlug} issueId={issueId} />}
         />
       </Layout.Content>
     </Layout>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/$issueId/index.tsx
@@ -14,6 +14,7 @@ import { IssueLifecycleStatuses } from "../-components/issue-lifecycle-statuses.
 import { IssueExamples } from "./-components/issue-examples.tsx"
 import { IssueNeighborNav } from "./-components/issue-neighbor-nav.tsx"
 import { IssuePatterns } from "./-components/issue-patterns.tsx"
+import { IssueRelated } from "./-components/issue-related.tsx"
 import { IssueSummary } from "./-components/issue-summary.tsx"
 import { IssueTriageControls } from "./-components/issue-triage-controls.tsx"
 
@@ -131,7 +132,10 @@ function IssueDetailPage() {
           }
           trendAside={<IssuePatterns projectId={project.id} issueId={issueId} />}
           beforeTraces={
-            <IssueExamples projectId={project.id} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
+            <>
+              <IssueRelated projectId={project.id} projectSlug={projectSlug} issueId={issueId} />
+              <IssueExamples projectId={project.id} issueId={issueId} onOverlayActiveChange={setOverlayActive} />
+            </>
           }
         />
       </Layout.Content>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -113,6 +113,7 @@ export function IssueDetailBody({
   prepend,
   trendAside,
   beforeTraces,
+  append,
 }: {
   readonly projectId: string
   readonly issueId: string
@@ -132,6 +133,8 @@ export function IssueDetailBody({
   readonly trendAside?: ReactNode
   /** Rendered in the scroll area just before the Traces section (e.g. Examples). */
   readonly beforeTraces?: ReactNode
+  /** Rendered at the end of the scroll area, after the Traces section (e.g. Related issues). */
+  readonly append?: ReactNode
 }) {
   const { data: issue, isLoading } = useIssueDetail({ projectId, issueId })
   const {
@@ -407,6 +410,8 @@ export function IssueDetailBody({
               scrollContainerClassName="max-h-[min(28rem,50vh)]"
             />
           </DetailSection>
+
+          {append}
         </div>
 
         {bulkSelection && (

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -39,6 +39,54 @@ export const ISSUE_DIMENSION_MIN_SUPPORT = 10
  */
 export const ISSUE_DIMENSION_MIN_RATE_ELEVATION = 0.01
 
+// ---------------------------------------------------------------------------
+// Related issues (Related panel)
+// ---------------------------------------------------------------------------
+
+/**
+ * Useful band of centroid cosine similarity for the Related list's semantic
+ * signal, rescaled linearly to a `[0, 1]` score. Below the floor two issues
+ * are simply unrelated; at/above the ceiling they are effectively duplicate
+ * clusters (discovery would merge a new score into either). Surviving issue
+ * pairs sit *below* the discovery merge thresholds by construction
+ * (`ISSUE_DISCOVERY_MIN_*`), so this band is where all the signal lives.
+ * Provisional values — calibrate against real data before widening use.
+ */
+export const ISSUE_RELATED_SEMANTIC_FLOOR = 0.55
+export const ISSUE_RELATED_SEMANTIC_CEILING = 0.85
+
+/**
+ * Minimum sessions shared with the source issue before a candidate's
+ * co-occurrence is scored at all. Below this, NPMI is meaningless — one or
+ * two coincidental sessions would otherwise post a high score for tiny pairs.
+ */
+export const ISSUE_RELATED_MIN_SHARED_SESSIONS = 3
+
+/**
+ * Minimum combined relatedness (noisy-OR of the semantic and co-occurrence
+ * scores, in `[0, 1]`) for a row to appear in the Related list. Drops
+ * candidates that only barely cleared either signal's own gate.
+ */
+export const ISSUE_RELATED_MIN_RELATEDNESS = 0.05
+
+/** Maximum rows in the Related list. */
+export const ISSUE_RELATED_LIMIT = 8
+
+/**
+ * Candidate pool fetched per signal (pgvector neighbors / co-occurrence
+ * candidates) before scoring, gating, and merging down to
+ * `ISSUE_RELATED_LIMIT`.
+ */
+export const ISSUE_RELATED_CANDIDATE_LIMIT = 25
+
+/**
+ * Window for the co-occurrence signal. Fixed (not wired to a page range
+ * selector): co-occurrence is a behavioral "currently travels together"
+ * signal, while the semantic signal is lifetime by nature (the centroid is a
+ * decayed running sum).
+ */
+export const ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS = 30
+
 export const NEW_ISSUE_AGE_DAYS = 7
 
 /**

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -29,6 +29,13 @@ export {
   ISSUE_DISCOVERY_SEARCH_RATIO,
   ISSUE_PRIORITIES,
   ISSUE_REFRESH_THROTTLE_MS,
+  ISSUE_RELATED_CANDIDATE_LIMIT,
+  ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS,
+  ISSUE_RELATED_LIMIT,
+  ISSUE_RELATED_MIN_RELATEDNESS,
+  ISSUE_RELATED_MIN_SHARED_SESSIONS,
+  ISSUE_RELATED_SEMANTIC_CEILING,
+  ISSUE_RELATED_SEMANTIC_FLOOR,
   ISSUE_SOURCES,
   ISSUE_STATES,
   ISSUE_UPDATE_LOCK_KEY,
@@ -98,6 +105,15 @@ export {
   type ListIssuesRepositoryInput,
   type OrgIssueSearchHit,
 } from "./ports/issue-repository.ts"
+export {
+  type CoOccurrenceScoreInput,
+  combinedRelatedness,
+  coOccurrenceRelatednessScore,
+  type RankRelatedIssuesInput,
+  type RelatedIssueSignals,
+  rankRelatedIssues,
+  semanticRelatednessScore,
+} from "./related-issues.ts"
 export {
   type ApplyIssueLifecycleCommandError,
   type ApplyIssueLifecycleCommandInput,
@@ -183,6 +199,12 @@ export {
   type GetIssueTrendResult,
   getIssueTrendUseCase,
 } from "./use-cases/get-issue-trend.ts"
+export {
+  type GetRelatedIssuesError,
+  type GetRelatedIssuesInput,
+  getRelatedIssuesUseCase,
+  type RelatedIssue,
+} from "./use-cases/get-related-issues.ts"
 export {
   type ListIssueTracesError,
   type ListIssueTracesInput,

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -88,6 +88,7 @@ export {
 export { buildHistogramBucketScaffold, fillBuckets } from "./histogram-buckets.ts"
 export { type IssueDiscoveryLockInput, issueDiscoveryLockKey, withIssueDiscoveryLock } from "./locks.ts"
 export {
+  type IssueCentroidNeighbor,
   type IssueLifecycleFlags,
   type IssueListPage,
   IssueRepository,

--- a/packages/domain/issues/src/ports/issue-repository.ts
+++ b/packages/domain/issues/src/ports/issue-repository.ts
@@ -35,6 +35,16 @@ export interface IssueSearchCandidate {
 }
 
 /**
+ * One semantic neighbor of an issue: another issue in the same project ranked
+ * by cosine similarity between the two `centroid_embedding` vectors.
+ */
+export interface IssueCentroidNeighbor {
+  readonly issueId: IssueId
+  /** Cosine similarity in `[-1, 1]` (in practice `[0, 1]` for feedback embeddings). */
+  readonly similarity: number
+}
+
+/**
  * One org-wide search hit for the Command Palette: the matched issue (with lifecycle flags so the
  * caller can derive its states without a second read) plus its owning project's slug/name and the
  * relevance score of whichever tier produced it.
@@ -69,6 +79,22 @@ export interface IssueRepositoryShape {
     readonly query: string
     readonly normalizedEmbedding: readonly number[]
   }): Effect.Effect<readonly IssueSearchCandidate[], RepositoryError, SqlClient>
+  /**
+   * Semantic neighbors for the Related-issues list: the project's other issues
+   * ranked by cosine similarity against this issue's `centroid_embedding`
+   * (exact scan, no ANN index — same trade-off as `hybridSearch`).
+   *
+   * Returns an empty list when the source issue is missing or has no embedding
+   * (zero-mass centroid) — the semantic signal degrades to nothing rather than
+   * failing the whole Related read. Resolved/ignored issues are **included**:
+   * "a similar issue was already resolved" is the most actionable neighbor.
+   * No similarity floor here; gating lives in the domain scorer.
+   */
+  findSimilarByCentroid(input: {
+    readonly projectId: ProjectId
+    readonly issueId: IssueId
+    readonly limit: number
+  }): Effect.Effect<readonly IssueCentroidNeighbor[], RepositoryError, SqlClient>
   /**
    * Org-wide issue search across every project in the organization (RLS-scoped to the caller's
    * org), powering the Command Palette. Two tiers selected by `normalizedEmbedding`:

--- a/packages/domain/issues/src/related-issues.test.ts
+++ b/packages/domain/issues/src/related-issues.test.ts
@@ -1,0 +1,171 @@
+import type { IssueCoOccurrenceAggregate } from "@domain/scores"
+import { IssueId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { ISSUE_RELATED_SEMANTIC_CEILING, ISSUE_RELATED_SEMANTIC_FLOOR } from "./constants.ts"
+import {
+  combinedRelatedness,
+  coOccurrenceRelatednessScore,
+  rankRelatedIssues,
+  semanticRelatednessScore,
+} from "./related-issues.ts"
+
+const issueA = IssueId("a".repeat(24))
+const issueB = IssueId("b".repeat(24))
+const issueC = IssueId("c".repeat(24))
+const issueD = IssueId("d".repeat(24))
+
+const emptyCoOccurrence: IssueCoOccurrenceAggregate = {
+  mySessions: 0,
+  totalSessions: 0,
+  candidates: [],
+}
+
+describe("semanticRelatednessScore", () => {
+  it("clamps below the floor to 0 and above the ceiling to 1", () => {
+    expect(semanticRelatednessScore(ISSUE_RELATED_SEMANTIC_FLOOR)).toBe(0)
+    expect(semanticRelatednessScore(0.2)).toBe(0)
+    expect(semanticRelatednessScore(-1)).toBe(0)
+    expect(semanticRelatednessScore(ISSUE_RELATED_SEMANTIC_CEILING)).toBe(1)
+    expect(semanticRelatednessScore(0.99)).toBe(1)
+  })
+
+  it("rescales linearly inside the band", () => {
+    const mid = (ISSUE_RELATED_SEMANTIC_FLOOR + ISSUE_RELATED_SEMANTIC_CEILING) / 2
+    expect(semanticRelatednessScore(mid)).toBeCloseTo(0.5, 10)
+    expect(semanticRelatednessScore(0.7)).toBeCloseTo(
+      (0.7 - ISSUE_RELATED_SEMANTIC_FLOOR) / (ISSUE_RELATED_SEMANTIC_CEILING - ISSUE_RELATED_SEMANTIC_FLOOR),
+      10,
+    )
+  })
+})
+
+describe("coOccurrenceRelatednessScore", () => {
+  it("returns 0 under the shared-session floor", () => {
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 2, mySessions: 10, theirSessions: 10, totalSessions: 1000 }),
+    ).toBe(0)
+  })
+
+  it("returns 0 at chance-level overlap (lift = 1), even when the overlap percent is high", () => {
+    // Two big issues overlapping exactly as much as independence predicts.
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 250, mySessions: 500, theirSessions: 500, totalSessions: 1000 }),
+    ).toBe(0)
+    // The big-neighbor trap: 90% of my sessions shared, but the neighbor covers
+    // 90% of the universe — pure chance, no association.
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 54, mySessions: 60, theirSessions: 900, totalSessions: 1000 }),
+    ).toBe(0)
+  })
+
+  it("scores a perfectly co-occurring rare pair at 1", () => {
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 10, mySessions: 10, theirSessions: 10, totalSessions: 1000 }),
+    ).toBeCloseTo(1, 10)
+  })
+
+  it("scores partial above-chance association between 0 and 1", () => {
+    // pBoth = 0.01, pMine = 0.03, pTheirs = 0.02 → lift ≈ 16.7,
+    // NPMI = ln(16.7) / −ln(0.01) ≈ 0.61.
+    const score = coOccurrenceRelatednessScore({
+      sharedSessions: 20,
+      mySessions: 60,
+      theirSessions: 40,
+      totalSessions: 2000,
+    })
+    expect(score).toBeCloseTo(Math.log(50 / 3) / -Math.log(0.01), 10)
+    expect(score).toBeGreaterThan(0.5)
+    expect(score).toBeLessThan(0.7)
+  })
+
+  it("guards degenerate inputs", () => {
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 5, mySessions: 0, theirSessions: 5, totalSessions: 100 }),
+    ).toBe(0)
+    expect(coOccurrenceRelatednessScore({ sharedSessions: 5, mySessions: 5, theirSessions: 5, totalSessions: 0 })).toBe(
+      0,
+    )
+    // Both issues in every session: necessity, not association.
+    expect(
+      coOccurrenceRelatednessScore({ sharedSessions: 10, mySessions: 10, theirSessions: 10, totalSessions: 10 }),
+    ).toBe(0)
+  })
+})
+
+describe("combinedRelatedness", () => {
+  it("passes a lone signal through and boosts dual signals above either", () => {
+    expect(combinedRelatedness(0.7, 0)).toBeCloseTo(0.7, 10)
+    expect(combinedRelatedness(0, 0.4)).toBeCloseTo(0.4, 10)
+    const dual = combinedRelatedness(0.5, 0.5)
+    expect(dual).toBeCloseTo(0.75, 10)
+    expect(dual).toBeGreaterThan(0.5)
+    expect(combinedRelatedness(1, 0.3)).toBe(1)
+  })
+})
+
+describe("rankRelatedIssues", () => {
+  it("merges both candidate sets, ranks by fused relatedness, and nulls non-contributing signals", () => {
+    const ranked = rankRelatedIssues({
+      neighbors: [
+        { issueId: issueA, similarity: 0.7 }, // dual signal: semScore 0.5
+        { issueId: issueB, similarity: 0.79 }, // semantic only: semScore 0.8
+      ],
+      coOccurrence: {
+        mySessions: 20,
+        totalSessions: 1000,
+        candidates: [
+          { issueId: issueA, sharedSessions: 10, theirSessions: 20 }, // coocScore ≈ 0.70
+          { issueId: issueC, sharedSessions: 12, theirSessions: 15 }, // cooc only ≈ 0.83
+          { issueId: issueB, sharedSessions: 2, theirSessions: 5 }, // under the floor → cooc null
+        ],
+      },
+    })
+
+    // A: 1 − (1−0.5)(1−0.70) ≈ 0.85 > C ≈ 0.83 > B = 0.8.
+    expect(ranked.map((row) => row.issueId)).toEqual([issueA, issueC, issueB])
+
+    const [a, c, b] = ranked
+    expect(a?.semantic?.similarity).toBe(0.7)
+    expect(a?.semantic?.score).toBeCloseTo(0.5, 10)
+    expect(a?.coOccurrence?.sharedSessions).toBe(10)
+    expect(a?.coOccurrence?.sharedSessionsPercent).toBeCloseTo(0.5, 10)
+    expect(a?.relatedness).toBeGreaterThan(c?.relatedness ?? Number.NaN)
+
+    expect(c?.semantic).toBeNull()
+    expect(c?.coOccurrence?.sharedSessionsPercent).toBeCloseTo(0.6, 10)
+
+    expect(b?.semantic?.score).toBeCloseTo(0.8, 10)
+    expect(b?.coOccurrence).toBeNull()
+  })
+
+  it("drops candidates below the minimum relatedness", () => {
+    const ranked = rankRelatedIssues({
+      neighbors: [
+        // Barely above the semantic floor: semScore ≈ 0.033 < min relatedness.
+        { issueId: issueA, similarity: ISSUE_RELATED_SEMANTIC_FLOOR + 0.01 },
+        // Under-floor co-occurrence contributes nothing either.
+      ],
+      coOccurrence: {
+        mySessions: 20,
+        totalSessions: 1000,
+        candidates: [{ issueId: issueD, sharedSessions: 2, theirSessions: 10 }],
+      },
+    })
+
+    expect(ranked).toEqual([])
+  })
+
+  it("respects the row limit", () => {
+    const ranked = rankRelatedIssues({
+      neighbors: [
+        { issueId: issueA, similarity: 0.8 },
+        { issueId: issueB, similarity: 0.75 },
+        { issueId: issueC, similarity: 0.7 },
+      ],
+      coOccurrence: emptyCoOccurrence,
+      limit: 2,
+    })
+
+    expect(ranked.map((row) => row.issueId)).toEqual([issueA, issueB])
+  })
+})

--- a/packages/domain/issues/src/related-issues.ts
+++ b/packages/domain/issues/src/related-issues.ts
@@ -1,0 +1,159 @@
+import type { IssueCoOccurrenceAggregate } from "@domain/scores"
+import {
+  ISSUE_RELATED_LIMIT,
+  ISSUE_RELATED_MIN_RELATEDNESS,
+  ISSUE_RELATED_MIN_SHARED_SESSIONS,
+  ISSUE_RELATED_SEMANTIC_CEILING,
+  ISSUE_RELATED_SEMANTIC_FLOOR,
+} from "./constants.ts"
+import type { IssueCentroidNeighbor } from "./ports/issue-repository.ts"
+
+/**
+ * Pure scoring for the Related-issues list. Two independent signals are
+ * normalized to `[0, 1]` and fused:
+ *
+ * - **Semantic** — centroid cosine similarity, rescaled linearly over its
+ *   useful band (`ISSUE_RELATED_SEMANTIC_FLOOR`..`CEILING`). Raw cosine is
+ *   bounded but its meaning is concentrated in that band: pairs at/above the
+ *   ceiling would have been merged by discovery, pairs below the floor are
+ *   noise.
+ * - **Co-occurrence** — NPMI (normalized pointwise mutual information) over
+ *   session sets, clamped at 0, gated on a minimum shared-session count.
+ *   NPMI is preferred over raw lift (unbounded, inflated for rare pairs) and
+ *   over Jaccard/overlap percent (inflated by big neighbors that overlap
+ *   everything by chance): its numerator *is* log-lift and its denominator
+ *   normalizes by joint-event rarity, killing both failure modes at the
+ *   source.
+ * - **Fusion** — noisy-OR (`1 − (1−a)(1−b)`): either signal alone carries a
+ *   row; a row scoring on both (the "possibly the same issue" case) ranks
+ *   above either alone.
+ *
+ * The combined score is sort-order only — the UI shows reason chips (shared
+ * session percent, "similar failure pattern"), never the raw numbers. Design
+ * rationale: `specs/issue-details-page.md` (Data model #3).
+ */
+
+/** Per-candidate scored signals; `null` means the signal contributed nothing. */
+export interface RelatedIssueSignals {
+  readonly issueId: string
+  /** Noisy-OR of the two signal scores, in `[0, 1]`. Sort key, never displayed. */
+  readonly relatedness: number
+  readonly semantic: {
+    /** Raw centroid cosine similarity. */
+    readonly similarity: number
+    /** Band-rescaled score in `[0, 1]`. */
+    readonly score: number
+  } | null
+  readonly coOccurrence: {
+    readonly sharedSessions: number
+    /** `sharedSessions / mySessions` — share of the source issue's sessions where this issue also appears. */
+    readonly sharedSessionsPercent: number
+    /** Clamped NPMI in `[0, 1]`. */
+    readonly score: number
+  } | null
+}
+
+/** Linear rescale of centroid cosine similarity over its useful band, clamped to `[0, 1]`. */
+export const semanticRelatednessScore = (similarity: number): number => {
+  const band = ISSUE_RELATED_SEMANTIC_CEILING - ISSUE_RELATED_SEMANTIC_FLOOR
+  return Math.min(1, Math.max(0, (similarity - ISSUE_RELATED_SEMANTIC_FLOOR) / band))
+}
+
+export interface CoOccurrenceScoreInput {
+  /** Sessions where both issues have an occurrence. */
+  readonly sharedSessions: number
+  /** Sessions where the source issue has an occurrence. */
+  readonly mySessions: number
+  /** Sessions where the candidate issue has an occurrence. */
+  readonly theirSessions: number
+  /** Sessions with any issue occurrence — the probability universe. */
+  readonly totalSessions: number
+}
+
+/**
+ * Clamped NPMI over session sets: `ln(P(A,B) / (P(A)·P(B))) / −ln(P(A,B))`,
+ * 0 when at/below chance (lift ≤ 1) or under the shared-session floor.
+ * Approaches 1 as two issues occur in exactly the same sessions and those
+ * sessions are rare in the universe.
+ */
+export const coOccurrenceRelatednessScore = (input: CoOccurrenceScoreInput): number => {
+  const { sharedSessions, mySessions, theirSessions, totalSessions } = input
+  if (sharedSessions < ISSUE_RELATED_MIN_SHARED_SESSIONS) return 0
+  if (totalSessions === 0 || mySessions === 0 || theirSessions === 0) return 0
+
+  const pBoth = sharedSessions / totalSessions
+  const pMine = mySessions / totalSessions
+  const pTheirs = theirSessions / totalSessions
+  const pmi = Math.log(pBoth / (pMine * pTheirs))
+  // At/below chance (lift ≤ 1) there is no association to report. This also
+  // covers the degenerate pBoth === 1 case (then pMine = pTheirs = 1, pmi = 0),
+  // so the −ln(pBoth) denominator below is always strictly positive.
+  if (pmi <= 0) return 0
+
+  return Math.min(1, pmi / -Math.log(pBoth))
+}
+
+/** Noisy-OR fusion: either signal alone carries a row, both together rank higher than either. */
+export const combinedRelatedness = (semanticScore: number, coOccurrenceScore: number): number =>
+  1 - (1 - semanticScore) * (1 - coOccurrenceScore)
+
+export interface RankRelatedIssuesInput {
+  /** Semantic neighbors from `IssueRepository.findSimilarByCentroid`. */
+  readonly neighbors: readonly IssueCentroidNeighbor[]
+  /** Session co-occurrence counts from `ScoreAnalyticsRepository.coOccurrenceByIssue`. */
+  readonly coOccurrence: IssueCoOccurrenceAggregate
+  readonly limit?: number
+}
+
+/**
+ * Merge the two candidate sets, score each signal, fuse with noisy-OR, gate on
+ * `ISSUE_RELATED_MIN_RELATEDNESS`, and return the top rows by relatedness.
+ * A signal that scored 0 is reported as `null` so the UI renders only the
+ * reason chips that actually apply.
+ */
+export const rankRelatedIssues = (input: RankRelatedIssuesInput): readonly RelatedIssueSignals[] => {
+  const limit = input.limit ?? ISSUE_RELATED_LIMIT
+  const similarityById = new Map(input.neighbors.map((neighbor) => [neighbor.issueId as string, neighbor.similarity]))
+  const coOccurrenceById = new Map(
+    input.coOccurrence.candidates.map((candidate) => [candidate.issueId as string, candidate]),
+  )
+  const candidateIds = new Set([...similarityById.keys(), ...coOccurrenceById.keys()])
+
+  return [...candidateIds]
+    .flatMap((issueId): RelatedIssueSignals[] => {
+      const similarity = similarityById.get(issueId)
+      const candidate = coOccurrenceById.get(issueId)
+      const semanticScore = similarity === undefined ? 0 : semanticRelatednessScore(similarity)
+      const coOccurrenceScore =
+        candidate === undefined
+          ? 0
+          : coOccurrenceRelatednessScore({
+              sharedSessions: candidate.sharedSessions,
+              theirSessions: candidate.theirSessions,
+              mySessions: input.coOccurrence.mySessions,
+              totalSessions: input.coOccurrence.totalSessions,
+            })
+
+      const relatedness = combinedRelatedness(semanticScore, coOccurrenceScore)
+      if (relatedness < ISSUE_RELATED_MIN_RELATEDNESS) return []
+
+      return [
+        {
+          issueId,
+          relatedness,
+          semantic: similarity !== undefined && semanticScore > 0 ? { similarity, score: semanticScore } : null,
+          coOccurrence:
+            candidate !== undefined && coOccurrenceScore > 0
+              ? {
+                  sharedSessions: candidate.sharedSessions,
+                  sharedSessionsPercent:
+                    input.coOccurrence.mySessions === 0 ? 0 : candidate.sharedSessions / input.coOccurrence.mySessions,
+                  score: coOccurrenceScore,
+                }
+              : null,
+        },
+      ]
+    })
+    .sort((a, b) => b.relatedness - a.relatedness || a.issueId.localeCompare(b.issueId))
+    .slice(0, limit)
+}

--- a/packages/domain/issues/src/testing/fake-issue-repository.ts
+++ b/packages/domain/issues/src/testing/fake-issue-repository.ts
@@ -8,6 +8,15 @@ const DEFAULT_LIFECYCLE: IssueLifecycleFlags = {
   isRegressed: false,
 }
 
+const dot = (a: readonly number[], b: readonly number[]): number =>
+  a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0)
+
+const normalize = (vector: readonly number[]): readonly number[] | null => {
+  const magnitude = Math.sqrt(dot(vector, vector))
+  if (magnitude === 0) return null
+  return vector.map((value) => value / magnitude)
+}
+
 interface FakeIssueRepositoryOptions {
   /**
    * Per-issue lifecycle overlay. Tests that exercise escalation / regression
@@ -64,6 +73,26 @@ export const createFakeIssueRepository = (
             score: 1,
           })),
       ),
+
+    findSimilarByCentroid: ({ projectId, issueId, limit }) =>
+      Effect.sync(() => {
+        // Mirrors the real adapter: cosine over normalized centroid bases,
+        // empty when the source is missing or has a zero-mass centroid,
+        // zero-mass neighbors skipped, self excluded, project-scoped.
+        const source = issues.get(issueId)
+        if (!source || source.projectId !== projectId || source.centroid.mass <= 0) return []
+        const sourceVector = normalize(source.centroid.base)
+        if (sourceVector === null) return []
+        return [...issues.values()]
+          .filter((issue) => issue.projectId === projectId && issue.id !== issueId && issue.centroid.mass > 0)
+          .flatMap((issue) => {
+            const vector = normalize(issue.centroid.base)
+            if (vector === null) return []
+            return [{ issueId: issue.id, similarity: dot(sourceVector, vector) }]
+          })
+          .sort((a, b) => b.similarity - a.similarity)
+          .slice(0, limit)
+      }),
 
     searchOrgWide: ({ query, preferProjectId, limit }) =>
       Effect.sync(() => {

--- a/packages/domain/issues/src/use-cases/get-related-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/get-related-issues.test.ts
@@ -1,0 +1,159 @@
+import { type IssueCoOccurrenceAggregate, ScoreAnalyticsRepository, type ScoreAnalyticsTimeRange } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository } from "@domain/scores/testing"
+import { ChSqlClient, IssueId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS } from "../constants.ts"
+import type { Issue } from "../entities/issue.ts"
+import { createIssueCentroid } from "../helpers.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+import { createFakeIssueRepository } from "../testing/fake-issue-repository.ts"
+import { getRelatedIssuesUseCase } from "./get-related-issues.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+
+const sourceIssueId = IssueId("s".repeat(24))
+const twinIssueId = IssueId("a".repeat(24))
+const resolvedTwinIssueId = IssueId("b".repeat(24))
+const coOccurringIssueId = IssueId("c".repeat(24))
+const vanishedIssueId = IssueId("v".repeat(24))
+
+const now = new Date("2026-06-01T12:00:00.000Z")
+
+/** Unit-ish embedding with the given leading components (rest zero). */
+const embedding = (...components: number[]): { base: number[]; mass: number } => {
+  const base = createIssueCentroid().base
+  components.forEach((value, index) => {
+    base[index] = value
+  })
+  return { base, mass: 1 }
+}
+
+const makeIssue = (overrides: Partial<Issue> & { id: Issue["id"] }): Issue => ({
+  organizationId: organizationId as string,
+  projectId: projectId as string,
+  slug: `issue-${(overrides.id as string).slice(0, 4)}`,
+  name: `Issue ${(overrides.id as string).slice(0, 4)}`,
+  description: "An issue",
+  source: "annotation",
+  assigneeId: null,
+  priority: null,
+  centroid: createIssueCentroid(),
+  clusteredAt: new Date("2026-01-01T00:00:00.000Z"),
+  escalatedAt: null,
+  resolvedAt: null,
+  ignoredAt: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  ...overrides,
+})
+
+const buildLayer = (input: {
+  readonly issues: readonly Issue[]
+  readonly coOccurrence?: IssueCoOccurrenceAggregate
+  readonly captureTimeRange?: (timeRange: ScoreAnalyticsTimeRange) => void
+}) => {
+  const issueRepo = createFakeIssueRepository(input.issues)
+  const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
+    coOccurrenceByIssue: ({ timeRange }) =>
+      Effect.sync(() => {
+        input.captureTimeRange?.(timeRange)
+        return input.coOccurrence ?? { mySessions: 0, totalSessions: 0, candidates: [] }
+      }),
+  })
+  return Layer.mergeAll(
+    Layer.succeed(IssueRepository, issueRepo.repository),
+    Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+    Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+  )
+}
+
+describe("getRelatedIssuesUseCase", () => {
+  it("merges semantic and co-occurrence signals, hydrates rows, and sorts by relatedness", async () => {
+    const layer = buildLayer({
+      issues: [
+        // Source: unit vector on dim 0.
+        makeIssue({ id: sourceIssueId, centroid: { ...createIssueCentroid(), ...embedding(1) } }),
+        // Cosine 0.7 → semScore 0.5.
+        makeIssue({
+          id: twinIssueId,
+          centroid: { ...createIssueCentroid(), ...embedding(0.7, Math.sqrt(1 - 0.7 ** 2)) },
+        }),
+        // Cosine 0.8 → semScore ≈ 0.83; resolved — must still rank, with the state surfaced.
+        makeIssue({
+          id: resolvedTwinIssueId,
+          resolvedAt: new Date("2026-05-01T00:00:00.000Z"),
+          centroid: { ...createIssueCentroid(), ...embedding(0.8, 0.6) },
+        }),
+        // Orthogonal (cosine 0) — reachable only through co-occurrence.
+        makeIssue({ id: coOccurringIssueId, centroid: { ...createIssueCentroid(), ...embedding(0, 0, 1) } }),
+      ],
+      coOccurrence: {
+        mySessions: 20,
+        totalSessions: 1000,
+        candidates: [{ issueId: coOccurringIssueId, sharedSessions: 10, theirSessions: 20 }], // NPMI ≈ 0.70
+      },
+    })
+
+    const related = await Effect.runPromise(
+      getRelatedIssuesUseCase({ organizationId, projectId, issueId: sourceIssueId, now }).pipe(Effect.provide(layer)),
+    )
+
+    // resolvedTwin (0.83) > coOccurring (0.70) > twin (0.5).
+    expect(related.map((row) => row.issueId)).toEqual([resolvedTwinIssueId, coOccurringIssueId, twinIssueId])
+
+    const [resolvedTwin, coOccurring, twin] = related
+    expect(resolvedTwin?.states).toContain("resolved")
+    expect(resolvedTwin?.name).toBe(`Issue ${"b".repeat(4)}`)
+    expect(resolvedTwin?.slug).toBe(`issue-${"b".repeat(4)}`)
+    expect(resolvedTwin?.semantic?.similarity).toBeCloseTo(0.8, 5)
+    expect(resolvedTwin?.coOccurrence).toBeNull()
+
+    expect(coOccurring?.states).toEqual(["ongoing"])
+    expect(coOccurring?.semantic).toBeNull()
+    expect(coOccurring?.coOccurrence?.sharedSessions).toBe(10)
+    expect(coOccurring?.coOccurrence?.sharedSessionsPercent).toBeCloseTo(0.5, 10)
+
+    expect(twin?.semantic?.score).toBeCloseTo(0.5, 5)
+  })
+
+  it("windows the co-occurrence read to the trailing configured days", async () => {
+    let captured: ScoreAnalyticsTimeRange | undefined
+    const layer = buildLayer({
+      issues: [makeIssue({ id: sourceIssueId, centroid: { ...createIssueCentroid(), ...embedding(1) } })],
+      captureTimeRange: (timeRange) => {
+        captured = timeRange
+      },
+    })
+
+    await Effect.runPromise(
+      getRelatedIssuesUseCase({ organizationId, projectId, issueId: sourceIssueId, now }).pipe(Effect.provide(layer)),
+    )
+
+    expect(captured?.to).toEqual(now)
+    expect(captured?.from).toEqual(
+      new Date(now.getTime() - ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS * 24 * 60 * 60 * 1000),
+    )
+  })
+
+  it("drops candidates that cannot be hydrated and returns empty when nothing relates", async () => {
+    const layer = buildLayer({
+      issues: [makeIssue({ id: sourceIssueId, centroid: { ...createIssueCentroid(), ...embedding(1) } })],
+      coOccurrence: {
+        mySessions: 20,
+        totalSessions: 1000,
+        // Strong co-occurrence, but the issue row no longer exists in Postgres.
+        candidates: [{ issueId: vanishedIssueId, sharedSessions: 10, theirSessions: 20 }],
+      },
+    })
+
+    const related = await Effect.runPromise(
+      getRelatedIssuesUseCase({ organizationId, projectId, issueId: sourceIssueId, now }).pipe(Effect.provide(layer)),
+    )
+
+    expect(related).toEqual([])
+  })
+})

--- a/packages/domain/issues/src/use-cases/get-related-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/get-related-issues.test.ts
@@ -1,4 +1,9 @@
-import { type IssueCoOccurrenceAggregate, ScoreAnalyticsRepository, type ScoreAnalyticsTimeRange } from "@domain/scores"
+import {
+  type IssueCoOccurrenceAggregate,
+  type IssueOccurrenceAggregate,
+  ScoreAnalyticsRepository,
+  type ScoreAnalyticsTimeRange,
+} from "@domain/scores"
 import { createFakeScoreAnalyticsRepository } from "@domain/scores/testing"
 import { ChSqlClient, IssueId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
@@ -53,6 +58,7 @@ const makeIssue = (overrides: Partial<Issue> & { id: Issue["id"] }): Issue => ({
 const buildLayer = (input: {
   readonly issues: readonly Issue[]
   readonly coOccurrence?: IssueCoOccurrenceAggregate
+  readonly occurrenceAggregates?: readonly IssueOccurrenceAggregate[]
   readonly captureTimeRange?: (timeRange: ScoreAnalyticsTimeRange) => void
 }) => {
   const issueRepo = createFakeIssueRepository(input.issues)
@@ -62,6 +68,7 @@ const buildLayer = (input: {
         input.captureTimeRange?.(timeRange)
         return input.coOccurrence ?? { mySessions: 0, totalSessions: 0, candidates: [] }
       }),
+    aggregateByIssues: () => Effect.succeed(input.occurrenceAggregates ?? []),
   })
   return Layer.mergeAll(
     Layer.succeed(IssueRepository, issueRepo.repository),
@@ -96,6 +103,16 @@ describe("getRelatedIssuesUseCase", () => {
         totalSessions: 1000,
         candidates: [{ issueId: coOccurringIssueId, sharedSessions: 10, theirSessions: 20 }], // NPMI ≈ 0.70
       },
+      occurrenceAggregates: [
+        {
+          issueId: resolvedTwinIssueId,
+          totalOccurrences: 42,
+          recentOccurrences: 0,
+          baselineAvgOccurrences: 0,
+          firstSeenAt: new Date("2026-04-01T00:00:00.000Z"),
+          lastSeenAt: new Date("2026-05-20T00:00:00.000Z"),
+        },
+      ],
     })
 
     const related = await Effect.runPromise(
@@ -109,10 +126,16 @@ describe("getRelatedIssuesUseCase", () => {
     expect(resolvedTwin?.states).toContain("resolved")
     expect(resolvedTwin?.name).toBe(`Issue ${"b".repeat(4)}`)
     expect(resolvedTwin?.slug).toBe(`issue-${"b".repeat(4)}`)
+    expect(resolvedTwin?.description).toBe("An issue")
     expect(resolvedTwin?.semantic?.similarity).toBeCloseTo(0.8, 5)
     expect(resolvedTwin?.coOccurrence).toBeNull()
+    expect(resolvedTwin?.occurrences).toBe(42)
+    expect(resolvedTwin?.lastSeenAt).toEqual(new Date("2026-05-20T00:00:00.000Z"))
 
     expect(coOccurring?.states).toEqual(["ongoing"])
+    // No analytics row for this candidate — stats degrade to zero/null.
+    expect(coOccurring?.occurrences).toBe(0)
+    expect(coOccurring?.lastSeenAt).toBeNull()
     expect(coOccurring?.semantic).toBeNull()
     expect(coOccurring?.coOccurrence?.sharedSessions).toBe(10)
     expect(coOccurring?.coOccurrence?.sharedSessionsPercent).toBeCloseTo(0.5, 10)

--- a/packages/domain/issues/src/use-cases/get-related-issues.ts
+++ b/packages/domain/issues/src/use-cases/get-related-issues.ts
@@ -1,0 +1,107 @@
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import {
+  type ChSqlClient,
+  IssueId,
+  type OrganizationId,
+  type ProjectId,
+  type RepositoryError,
+  type SqlClient,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { ISSUE_RELATED_CANDIDATE_LIMIT, ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS } from "../constants.ts"
+import type { IssueState } from "../entities/issue.ts"
+import { deriveIssueLifecycleStates } from "../helpers.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+import { type RelatedIssueSignals, rankRelatedIssues } from "../related-issues.ts"
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface GetRelatedIssuesInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly issueId: IssueId
+  readonly now?: Date
+}
+
+/** One Related-list row: scored signals hydrated with the canonical issue. */
+export interface RelatedIssue extends RelatedIssueSignals {
+  readonly slug: string
+  readonly name: string
+  readonly states: readonly IssueState[]
+}
+
+export type GetRelatedIssuesError = RepositoryError
+
+/**
+ * The Related-issues read: runs the two candidate reads in parallel —
+ * semantic neighbors (pgvector centroid cosine, lifetime) and session
+ * co-occurrence counts (ClickHouse, trailing
+ * `ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS`) — fuses them with the pure
+ * scorer (`rankRelatedIssues`), and hydrates the surviving rows from
+ * Postgres with lifecycle states derived here. Resolved/ignored issues are
+ * included by design: "a similar issue was already resolved" is the most
+ * actionable row. Project-scoped only.
+ */
+export const getRelatedIssuesUseCase = (
+  input: GetRelatedIssuesInput,
+): Effect.Effect<
+  readonly RelatedIssue[],
+  GetRelatedIssuesError,
+  ChSqlClient | IssueRepository | ScoreAnalyticsRepository | SqlClient
+> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", String(input.projectId))
+    yield* Effect.annotateCurrentSpan("issueId", String(input.issueId))
+
+    const issueRepository = yield* IssueRepository
+    const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+    const now = input.now ?? new Date()
+    const from = new Date(now.getTime() - ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS * MILLISECONDS_PER_DAY)
+
+    const [neighbors, coOccurrence] = yield* Effect.all(
+      [
+        issueRepository.findSimilarByCentroid({
+          projectId: input.projectId,
+          issueId: input.issueId,
+          limit: ISSUE_RELATED_CANDIDATE_LIMIT,
+        }),
+        scoreAnalyticsRepository.coOccurrenceByIssue({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          issueId: input.issueId,
+          timeRange: { from, to: now },
+          limit: ISSUE_RELATED_CANDIDATE_LIMIT,
+        }),
+      ],
+      { concurrency: 2 },
+    )
+
+    const ranked = rankRelatedIssues({ neighbors, coOccurrence })
+    if (ranked.length === 0) return []
+
+    const issues = yield* issueRepository.findByIds({
+      projectId: input.projectId,
+      issueIds: ranked.map((signals) => IssueId(signals.issueId)),
+    })
+    const issuesById = new Map(issues.map((issue) => [issue.id as string, issue]))
+
+    return ranked.flatMap((signals): RelatedIssue[] => {
+      // A candidate can vanish between the analytics read and hydration (or
+      // exist only in ClickHouse after a Postgres delete) — drop it silently.
+      const issue = issuesById.get(signals.issueId)
+      if (issue === undefined) return []
+      return [
+        {
+          ...signals,
+          slug: issue.slug,
+          name: issue.name,
+          states: deriveIssueLifecycleStates({
+            issue,
+            isEscalating: issue.lifecycle.isEscalating,
+            isRegressed: issue.lifecycle.isRegressed,
+            now,
+          }),
+        },
+      ]
+    })
+  }).pipe(Effect.withSpan("issues.getRelatedIssues"))

--- a/packages/domain/issues/src/use-cases/get-related-issues.ts
+++ b/packages/domain/issues/src/use-cases/get-related-issues.ts
@@ -27,7 +27,13 @@ export interface GetRelatedIssuesInput {
 export interface RelatedIssue extends RelatedIssueSignals {
   readonly slug: string
   readonly name: string
+  /** Shown on the card so users can judge the similarity themselves. */
+  readonly description: string
   readonly states: readonly IssueState[]
+  /** Lifetime occurrence count; 0 when the issue has no analytics rows. */
+  readonly occurrences: number
+  /** Last occurrence timestamp; null when the issue has no analytics rows. */
+  readonly lastSeenAt: Date | null
 }
 
 export type GetRelatedIssuesError = RepositoryError
@@ -79,28 +85,43 @@ export const getRelatedIssuesUseCase = (
     const ranked = rankRelatedIssues({ neighbors, coOccurrence })
     if (ranked.length === 0) return []
 
-    const issues = yield* issueRepository.findByIds({
-      projectId: input.projectId,
-      issueIds: ranked.map((signals) => IssueId(signals.issueId)),
-    })
+    const rankedIssueIds = ranked.map((signals) => IssueId(signals.issueId))
+    const [issues, occurrenceAggregates] = yield* Effect.all(
+      [
+        issueRepository.findByIds({ projectId: input.projectId, issueIds: rankedIssueIds }),
+        // Lifetime occurrences + last-seen per row, so the card can show how
+        // active each neighbor is. Batched — one read for the whole list.
+        scoreAnalyticsRepository.aggregateByIssues({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          issueIds: rankedIssueIds,
+        }),
+      ],
+      { concurrency: 2 },
+    )
     const issuesById = new Map(issues.map((issue) => [issue.id as string, issue]))
+    const aggregatesById = new Map(occurrenceAggregates.map((aggregate) => [aggregate.issueId as string, aggregate]))
 
     return ranked.flatMap((signals): RelatedIssue[] => {
       // A candidate can vanish between the analytics read and hydration (or
       // exist only in ClickHouse after a Postgres delete) — drop it silently.
       const issue = issuesById.get(signals.issueId)
       if (issue === undefined) return []
+      const aggregate = aggregatesById.get(signals.issueId)
       return [
         {
           ...signals,
           slug: issue.slug,
           name: issue.name,
+          description: issue.description,
           states: deriveIssueLifecycleStates({
             issue,
             isEscalating: issue.lifecycle.isEscalating,
             isRegressed: issue.lifecycle.isRegressed,
             now,
           }),
+          occurrences: aggregate?.totalOccurrences ?? 0,
+          lastSeenAt: aggregate?.lastSeenAt ?? null,
         },
       ]
     })

--- a/packages/domain/scores/src/index.ts
+++ b/packages/domain/scores/src/index.ts
@@ -42,6 +42,8 @@ export { ScoreDraftClosedError, ScoreDraftUpdateConflictError } from "./errors.t
 export { isImmutableScore } from "./helpers.ts"
 export {
   type DimensionConditionalRate,
+  type IssueCoOccurrence,
+  type IssueCoOccurrenceAggregate,
   type IssueDimension,
   type IssueDimensionComparison,
   type IssueEscalationSignals,

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -165,6 +165,36 @@ export interface IssueDimensionComparison {
   readonly values: readonly DimensionConditionalRate[]
 }
 
+/**
+ * One co-occurrence candidate for the Related-issues list: another issue that
+ * has occurrences in at least one of the source issue's sessions (in range).
+ * Raw session counts only — NPMI scoring, the shared-session floor, and
+ * ranking live in `@domain/issues` so the math is unit-testable without
+ * ClickHouse.
+ */
+export interface IssueCoOccurrence {
+  readonly issueId: IssueId
+  /** Sessions where both the source issue and this issue have an occurrence. */
+  readonly sharedSessions: number
+  /** Sessions where this issue has an occurrence. */
+  readonly theirSessions: number
+}
+
+/**
+ * Session co-occurrence counts for one issue. The probability universe
+ * (`totalSessions`) is **sessions carrying at least one issue occurrence** —
+ * not all project sessions: unscored sessions carry no information about
+ * issue association and would only dilute every probability uniformly.
+ */
+export interface IssueCoOccurrenceAggregate {
+  /** Sessions where the source issue has an occurrence (in range). */
+  readonly mySessions: number
+  /** Sessions with any issue occurrence (in range) — the probability universe. */
+  readonly totalSessions: number
+  /** Top candidates by shared sessions, self-excluded, `sharedSessions ≥ 1`. */
+  readonly candidates: readonly IssueCoOccurrence[]
+}
+
 /** A single time-bucket for issue occurrence time-series. */
 export interface IssueOccurrenceBucket {
   readonly bucket: string // ISO date string
@@ -353,6 +383,20 @@ export interface ScoreAnalyticsRepositoryShape {
     readonly timeRange?: ScoreAnalyticsTimeRange
     readonly options?: ScoreAnalyticsOptions
   }): Effect.Effect<IssueDimensionComparison, RepositoryError, ChSqlClient>
+
+  // -- Per-issue session co-occurrence (Related-issues signal) ---------------
+  // One scan over issue-carrying `scores` in `timeRange`: the source issue's
+  // distinct session set, then GROUP BY issue_id counting shared vs. total
+  // sessions per candidate, self-excluded. Scoreless sessions are outside the
+  // universe by construction (see `IssueCoOccurrenceAggregate`).
+  coOccurrenceByIssue(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly issueId: IssueId
+    readonly timeRange: ScoreAnalyticsTimeRange
+    readonly limit?: number // default 25 candidates
+    readonly options?: ScoreAnalyticsOptions
+  }): Effect.Effect<IssueCoOccurrenceAggregate, RepositoryError, ChSqlClient>
 
   // -- Per-issue signals for the seasonal-anomaly escalation detector --------
   // Reads:

--- a/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
+++ b/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
@@ -43,6 +43,7 @@ export const createFakeScoreAnalyticsRepository = (overrides?: Partial<ScoreAnal
         costMicrocents: 0,
         tokens: 0,
       }),
+    coOccurrenceByIssue: () => Effect.succeed({ mySessions: 0, totalSessions: 0, candidates: [] }),
     escalationSignalsByIssues: () => Effect.succeed([]),
     aggregateTagsByIssues: () => Effect.succeed([]),
     trendByIssue: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -658,6 +658,106 @@ describe("ScoreAnalyticsRepository", () => {
   })
 
   // ------------------------------------------------------------------
+  // coOccurrenceByIssue
+  // ------------------------------------------------------------------
+
+  describe("coOccurrenceByIssue", () => {
+    const fixture = setupFixture()
+    const issueSource = "issue_cooccurrencesrc"
+    const issueHeavy = "issue_cooccurrencehvy" // shares 3 sessions
+    const issueLight = "issue_cooccurrencelgt" // shares 1 session
+    const issueDisjoint = "issue_cooccurrencedsj" // shares nothing
+    const issueStale = "issue_cooccurrenceold" // shares only outside the range
+
+    const inRange = "2026-03-15 12:00:00.000"
+    const outOfRange = "2026-01-01 12:00:00.000"
+    const timeRange = {
+      from: new Date("2026-03-01T00:00:00.000Z"),
+      to: new Date("2026-03-31T23:59:59.999Z"),
+    }
+
+    const session = (n: number) => `session-cooc-${n}`
+
+    beforeEach(async () => {
+      await fixture.insertScores([
+        // Source issue: sessions 1-4. Session 1 carries TWO source occurrences
+        // so distinct session counting is exercised.
+        makeScoreRow({ issue_id: issueSource, session_id: session(1), created_at: inRange }),
+        makeScoreRow({ issue_id: issueSource, session_id: session(1), created_at: inRange }),
+        makeScoreRow({ issue_id: issueSource, session_id: session(2), created_at: inRange }),
+        makeScoreRow({ issue_id: issueSource, session_id: session(3), created_at: inRange }),
+        makeScoreRow({ issue_id: issueSource, session_id: session(4), created_at: inRange }),
+        // Sessionless source occurrence: ignored by session co-occurrence.
+        makeScoreRow({ issue_id: issueSource, session_id: "", created_at: inRange }),
+        // Heavy co-occurrer: shares sessions 1-3, plus its own sessions 5-6.
+        makeScoreRow({ issue_id: issueHeavy, session_id: session(1), created_at: inRange }),
+        makeScoreRow({ issue_id: issueHeavy, session_id: session(2), created_at: inRange }),
+        makeScoreRow({ issue_id: issueHeavy, session_id: session(3), created_at: inRange }),
+        makeScoreRow({ issue_id: issueHeavy, session_id: session(5), created_at: inRange }),
+        makeScoreRow({ issue_id: issueHeavy, session_id: session(6), created_at: inRange }),
+        // Light co-occurrer: shares session 1 only, plus its own session 7.
+        makeScoreRow({ issue_id: issueLight, session_id: session(1), created_at: inRange }),
+        makeScoreRow({ issue_id: issueLight, session_id: session(7), created_at: inRange }),
+        // Disjoint issue: session 8 only — must not appear as a candidate.
+        makeScoreRow({ issue_id: issueDisjoint, session_id: session(8), created_at: inRange }),
+        // Stale co-occurrer: shares session 1 but outside the window.
+        makeScoreRow({ issue_id: issueStale, session_id: session(1), created_at: outOfRange }),
+      ])
+    })
+
+    it("counts shared and total sessions per candidate, self-excluded, windowed", async () => {
+      const aggregate = await fixture.runCh(
+        fixture.repo.coOccurrenceByIssue({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueId: IssueId(issueSource),
+          timeRange,
+        }),
+      )
+
+      // Sessions 1-4 (the sessionless occurrence doesn't count).
+      expect(aggregate.mySessions).toBe(4)
+      // Universe: sessions 1-8 carry at least one in-range issue occurrence.
+      expect(aggregate.totalSessions).toBe(8)
+      expect(aggregate.candidates).toEqual([
+        { issueId: issueHeavy, sharedSessions: 3, theirSessions: 5 },
+        { issueId: issueLight, sharedSessions: 1, theirSessions: 2 },
+      ])
+    })
+
+    it("respects the candidate limit (trimmed by shared sessions)", async () => {
+      const aggregate = await fixture.runCh(
+        fixture.repo.coOccurrenceByIssue({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueId: IssueId(issueSource),
+          timeRange,
+          limit: 1,
+        }),
+      )
+
+      expect(aggregate.candidates.map((candidate) => candidate.issueId)).toEqual([issueHeavy])
+      // Totals are unaffected by the candidate cap.
+      expect(aggregate.mySessions).toBe(4)
+      expect(aggregate.totalSessions).toBe(8)
+    })
+
+    it("returns empty counts for an issue with no in-range sessions", async () => {
+      const aggregate = await fixture.runCh(
+        fixture.repo.coOccurrenceByIssue({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueId: IssueId(issueStale),
+          timeRange,
+        }),
+      )
+
+      expect(aggregate.mySessions).toBe(0)
+      expect(aggregate.candidates).toEqual([])
+    })
+  })
+
+  // ------------------------------------------------------------------
   // aggregateDimensionByIssue
   // ------------------------------------------------------------------
 

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -1,6 +1,7 @@
 import type { ClickHouseClient } from "@clickhouse/client"
 import type {
   DimensionConditionalRate,
+  IssueCoOccurrenceAggregate,
   IssueDimension,
   IssueDimensionComparison,
   IssueEscalationSignals,
@@ -49,6 +50,11 @@ import { SCORE_FIELD_REGISTRY } from "../registries/score-fields.ts"
 // tags. Tag distributions converge fast, so a sample of this size captures
 // effectively all tag variants while bounding the join cost for noisy issues.
 const ISSUE_TAG_TRACE_SAMPLE_LIMIT = 200
+
+// Default candidate pool returned by `coOccurrenceByIssue` when the caller
+// doesn't pass a limit. Sized well above the Related list's display cap so the
+// domain scorer has room to gate and re-rank.
+const ISSUE_CO_OCCURRENCE_CANDIDATE_LIMIT = 25
 
 // SQL value expression per dimension. `tag` flattens the span tags array so
 // each tag is counted once per span; the others read a single span column.
@@ -202,6 +208,17 @@ type DimensionRateRow = {
 type DimensionTotalsRow = {
   total_traces: string
   affected_traces: string
+}
+
+type CoOccurrenceCandidateRow = {
+  issue_id: string
+  shared_sessions: string
+  their_sessions: string
+}
+
+type CoOccurrenceTotalsRow = {
+  my_sessions: string
+  total_sessions: string
 }
 
 type IssueOccurrenceBucketRow = {
@@ -1121,6 +1138,84 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
           })
 
           return { dimension, baseRate, issueAffectedTraces, values } satisfies IssueDimensionComparison
+        }),
+
+      // -- coOccurrenceByIssue -------------------------------------------------
+      // Session co-occurrence counts for the Related-issues list. Two reads run
+      // concurrently over issue-carrying scores in range:
+      //   1. per-candidate shared/their session counts (GROUP BY issue_id with
+      //      the source issue's session set as an IN subquery),
+      //   2. the source issue's session count + the probability universe
+      //      (sessions with any issue occurrence).
+      // Raw counts only — NPMI scoring/gating lives in `@domain/issues`. The
+      // candidate cap keeps the read bounded; it trims by shared sessions, so a
+      // very small but perfectly-overlapping issue can in principle fall out of
+      // an over-full pool — an accepted trade-off at the default size.
+      coOccurrenceByIssue: ({ organizationId, projectId, issueId, timeRange, limit, options }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const range = buildScoreCreatedAtTimeRange(timeRange, "cooc")
+          const rangeWhere = range.clauses.length > 0 ? ` AND ${range.clauses.join(" AND ")}` : ""
+          const params = {
+            ...scopeParams(organizationId, projectId),
+            issueId: issueId as string,
+            candidateLimit: limit ?? ISSUE_CO_OCCURRENCE_CANDIDATE_LIMIT,
+            ...range.params,
+          }
+
+          const mySessionsSql = `SELECT DISTINCT session_id
+                      FROM scores
+                      WHERE ${scopeClause(options)}
+                        AND issue_id = {issueId:String}
+                        AND session_id != ''${rangeWhere}`
+
+          const candidates = chSqlClient.query<CoOccurrenceCandidateRow[]>(async (client) => {
+            const result = await client.query({
+              query: `SELECT
+                      issue_id,
+                      uniqExactIf(session_id, session_id IN (${mySessionsSql})) AS shared_sessions,
+                      uniqExact(session_id) AS their_sessions
+                    FROM scores
+                    WHERE ${scopeClause(options)}
+                      AND issue_id != ''
+                      AND issue_id != {issueId:String}
+                      AND session_id != ''${rangeWhere}
+                    GROUP BY issue_id
+                    HAVING shared_sessions > 0
+                    ORDER BY shared_sessions DESC, their_sessions ASC, issue_id ASC
+                    LIMIT {candidateLimit:UInt32}`,
+              query_params: params,
+              format: "JSONEachRow",
+            })
+            return result.json<CoOccurrenceCandidateRow>()
+          })
+
+          const totals = chSqlClient.query<CoOccurrenceTotalsRow[]>(async (client) => {
+            const result = await client.query({
+              query: `SELECT
+                      uniqExactIf(session_id, issue_id = {issueId:String}) AS my_sessions,
+                      uniqExact(session_id) AS total_sessions
+                    FROM scores
+                    WHERE ${scopeClause(options)}
+                      AND issue_id != ''
+                      AND session_id != ''${rangeWhere}`,
+              query_params: params,
+              format: "JSONEachRow",
+            })
+            return result.json<CoOccurrenceTotalsRow>()
+          })
+
+          const [candidateRows, totalsRows] = yield* Effect.all([candidates, totals], { concurrency: 2 })
+
+          return {
+            mySessions: Number(totalsRows[0]?.my_sessions ?? 0),
+            totalSessions: Number(totalsRows[0]?.total_sessions ?? 0),
+            candidates: candidateRows.map((row) => ({
+              issueId: toIssueId(normalizeCHString(row.issue_id)),
+              sharedSessions: Number(row.shared_sessions),
+              theirSessions: Number(row.their_sessions),
+            })),
+          } satisfies IssueCoOccurrenceAggregate
         }),
 
       // -- escalationSignalsByIssues -----------------------------------------

--- a/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
@@ -300,6 +300,113 @@ describe("IssueRepositoryLive", () => {
     expect(items.map((item) => item.issueId)).toEqual([issueId])
   })
 
+  describe("findSimilarByCentroid", () => {
+    const sourceEmbedding = makeEmbedding({ 0: 1 })
+
+    const saveWithEmbedding = (issue: Issue, embedding: number[]) =>
+      Effect.gen(function* () {
+        const repository = yield* IssueRepository
+        yield* repository.save({
+          ...issue,
+          centroid: { ...createIssueCentroid(), base: embedding, mass: 1 },
+        })
+      })
+
+    it("ranks project neighbors by cosine similarity, excluding self and other projects", async () => {
+      const closeNeighborId = IssueId("a".repeat(24))
+      const farNeighborId = IssueId("b".repeat(24))
+      const orthogonalId = IssueId("c".repeat(24))
+      const otherProjectNeighborId = IssueId("d".repeat(24))
+
+      const neighbors = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* saveWithEmbedding(makeIssue(), sourceEmbedding)
+          yield* saveWithEmbedding(
+            makeIssue({ id: closeNeighborId, name: "Close neighbor" }),
+            makeEmbedding({ 0: 0.9, 1: Math.sqrt(1 - 0.9 ** 2) }),
+          )
+          yield* saveWithEmbedding(
+            makeIssue({ id: farNeighborId, name: "Far neighbor" }),
+            makeEmbedding({ 0: 0.6, 1: 0.8 }),
+          )
+          yield* saveWithEmbedding(makeIssue({ id: orthogonalId, name: "Orthogonal" }), makeEmbedding({ 1: 1 }))
+          yield* saveWithEmbedding(
+            makeIssue({ id: otherProjectNeighborId, name: "Other project", projectId: otherProjectId as string }),
+            makeEmbedding({ 0: 0.95, 1: Math.sqrt(1 - 0.95 ** 2) }),
+          )
+
+          return yield* repository.findSimilarByCentroid({ projectId, issueId, limit: 10 })
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(neighbors.map((neighbor) => neighbor.issueId)).toEqual([closeNeighborId, farNeighborId, orthogonalId])
+      expect(neighbors[0]?.similarity).toBeCloseTo(0.9, 5)
+      expect(neighbors[1]?.similarity).toBeCloseTo(0.6, 5)
+      expect(neighbors[2]?.similarity).toBeCloseTo(0, 5)
+    })
+
+    it("includes resolved and ignored neighbors and respects the limit", async () => {
+      const resolvedId = IssueId("a".repeat(24))
+      const ignoredId = IssueId("b".repeat(24))
+
+      const neighbors = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* saveWithEmbedding(makeIssue(), sourceEmbedding)
+          yield* saveWithEmbedding(
+            makeIssue({ id: resolvedId, name: "Resolved twin", resolvedAt: new Date("2026-04-02T00:00:00.000Z") }),
+            makeEmbedding({ 0: 0.9, 1: Math.sqrt(1 - 0.9 ** 2) }),
+          )
+          yield* saveWithEmbedding(
+            makeIssue({ id: ignoredId, name: "Ignored twin", ignoredAt: new Date("2026-04-02T00:00:00.000Z") }),
+            makeEmbedding({ 0: 0.8, 1: 0.6 }),
+          )
+
+          return yield* repository.findSimilarByCentroid({ projectId, issueId, limit: 1 })
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(neighbors.map((neighbor) => neighbor.issueId)).toEqual([resolvedId])
+    })
+
+    it("skips neighbors without an embedding and returns empty when the source has none", async () => {
+      const embeddedNeighborId = IssueId("a".repeat(24))
+      const embeddinglessId = IssueId("b".repeat(24))
+
+      const { fromSource, fromEmbeddingless, fromMissing } = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* saveWithEmbedding(makeIssue(), sourceEmbedding)
+          yield* saveWithEmbedding(
+            makeIssue({ id: embeddedNeighborId, name: "Embedded neighbor" }),
+            makeEmbedding({ 0: 0.7, 1: Math.sqrt(1 - 0.7 ** 2) }),
+          )
+          // Zero-mass centroid → `save` persists a NULL `centroid_embedding`.
+          yield* repository.save(makeIssue({ id: embeddinglessId, name: "No embedding yet" }))
+
+          return {
+            fromSource: yield* repository.findSimilarByCentroid({ projectId, issueId, limit: 10 }),
+            fromEmbeddingless: yield* repository.findSimilarByCentroid({
+              projectId,
+              issueId: embeddinglessId,
+              limit: 10,
+            }),
+            fromMissing: yield* repository.findSimilarByCentroid({
+              projectId,
+              issueId: IssueId("z".repeat(24)),
+              limit: 10,
+            }),
+          }
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(fromSource.map((neighbor) => neighbor.issueId)).toEqual([embeddedNeighborId])
+      expect(fromEmbeddingless).toEqual([])
+      expect(fromMissing).toEqual([])
+    })
+  })
+
   it("lists only visible issues scoped to project, newest-first, and paginates with hasMore", async () => {
     const older = makeIssue({
       id: IssueId("aaaaaaaaaaaaaaaaaaaaaaaa"),

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -343,6 +343,59 @@ const issueRepositoryCoreLive = Layer.effect(
           }))
         }),
 
+      findSimilarByCentroid: ({ projectId, issueId, limit }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+
+          // Two round-trips instead of a self-join: the source embedding is read
+          // first so the second query can inline it as a pgvector literal (the
+          // same wire-format constraint `hybridSearch` documents — a JS number[]
+          // binds as a Postgres array, which cannot be cast to `vector`).
+          const [source] = yield* sqlClient.query((db, organizationId) =>
+            db
+              .select({ centroidEmbedding: issues.centroidEmbedding })
+              .from(issues)
+              .where(
+                and(eq(issues.organizationId, organizationId), eq(issues.projectId, projectId), eq(issues.id, issueId)),
+              )
+              .limit(1),
+          )
+
+          // Missing issue or zero-mass centroid (no embedding persisted): the
+          // semantic signal degrades to nothing rather than failing the read.
+          const embedding = source?.centroidEmbedding ?? null
+          if (embedding === null) return []
+          const vector = yield* validateVector(embedding, "IssueRepository.findSimilarByCentroid")
+          const queryVector = sql.raw(`'[${vector.join(",")}]'::vector`)
+
+          // Exact cosine scan over the project's other issues — no ANN index by
+          // design (see the schema comment on `centroidEmbedding`). Resolved and
+          // ignored issues are deliberately included. `save()` only persists
+          // embeddings for CENTROID_EMBEDDING_MODEL, so every non-null row is in
+          // the same embedding space by construction.
+          const similarity = sql<number>`(1::double precision - (${issues.centroidEmbedding} <=> ${queryVector}))`
+          const rows = yield* sqlClient.query((db, organizationId) =>
+            db
+              .select({ issueId: issues.id, similarity })
+              .from(issues)
+              .where(
+                and(
+                  eq(issues.organizationId, organizationId),
+                  eq(issues.projectId, projectId),
+                  ne(issues.id, issueId),
+                  isNotNull(issues.centroidEmbedding),
+                ),
+              )
+              .orderBy(desc(similarity), desc(issues.updatedAt), asc(issues.id))
+              .limit(limit),
+          )
+
+          return rows.map((row) => ({
+            issueId: IssueId(row.issueId),
+            similarity: Number(row.similarity),
+          }))
+        }),
+
       searchOrgWide: ({ query, normalizedEmbedding, preferProjectId, limit }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/specs/issue-details-page.md
+++ b/specs/issue-details-page.md
@@ -473,10 +473,10 @@ The page becomes the single issue surface; the drawer and flag are removed. Abso
 
 Related issues redesigned before build (no v1 shipped): one merged list combining **semantic similarity** (centroid cosine, pgvector) and **co-occurrence** (shared sessions, NPMI), ranked by noisy-OR relatedness. Displayed lift is dropped for the same instability reason Patterns dropped it (see Data model #3).
 
-- [ ] **P4-1**: `IssueRepository.findSimilarByCentroid` (pgvector exact cosine scan, project-scoped, resolved/ignored included, empty when no embedding) + PGlite test.
-- [ ] **P4-2**: `coOccurrenceByIssue` ClickHouse method (session co-occurrence counts + probability universe, self-exclusion, 30d window) + chdb tests.
-- [ ] **P4-3**: Pure related-issues scorer in `@domain/issues` (semScore band rescale, NPMI with shared-session floor, noisy-OR merge, min-relatedness gate, top N) + unit tests; named constants (`ISSUE_RELATED_*`).
-- [ ] **P4-4**: `getRelatedIssues` web function (parallel reads → scorer → Postgres hydration) + hook + Related-issues section (merged list, lifecycle badges, reason chips, empty state), linking to other issue pages.
+- [x] **P4-1**: `IssueRepository.findSimilarByCentroid` (pgvector exact cosine scan, project-scoped, resolved/ignored included, empty when no embedding) + PGlite test.
+- [x] **P4-2**: `coOccurrenceByIssue` ClickHouse method (session co-occurrence counts + probability universe, self-exclusion, 30d window) + chdb tests.
+- [x] **P4-3**: Pure related-issues scorer in `@domain/issues` (semScore band rescale, NPMI with shared-session floor, noisy-OR merge, min-relatedness gate, top N) + unit tests; named constants (`ISSUE_RELATED_*`). *(As built: the scorer is fronted by `getRelatedIssuesUseCase` in `@domain/issues`, which runs the two reads in parallel and hydrates rows — the web fn stays thin.)*
+- [x] **P4-4**: `getRelatedIssues` web function (parallel reads → scorer → Postgres hydration) + hook + Related-issues section (merged list, lifecycle badges, reason chips, empty state), linking to other issue pages.
 - [ ] **P4-5**: `issueBenchmark` method (occurrence + user-reach percentile) + tests; benchmark chips (rail + section). *(Unchanged from the original design; not part of the related-issues build.)*
 
 **Exit gate**: the page shows one ranked list of related issues — semantically similar and/or co-occurring — with reason chips, plus (separately) a project benchmark rank.

--- a/specs/issue-details-page.md
+++ b/specs/issue-details-page.md
@@ -309,9 +309,6 @@ A sticky header, a scrollable main column, and a sticky right metadata/triage ra
 │  interaction-position bar chart of the        │  Monitoring                │
 │  session  (median: interaction 3)             │   1 evaluation · 92%       │
 │                                               │   [open ↓]                 │
-│ ── Related issues ────────────────────────────│                            │
-│  co-occurring issues list (shared %, lift)    │                            │
-│                                               │                            │
 │ ── Examples ──────────────────────────────────│                            │
 │  ◀  conversation with highlighted part   ▶    │                            │
 │      feedback card inline on the message      │                            │
@@ -321,6 +318,11 @@ A sticky header, a scrollable main column, and a sticky right metadata/triage ra
 │                                               │                            │
 │ ── Monitoring (full) ─────────────────────────│                            │
 │  linked evaluations + alignment + advanced    │                            │
+│                                               │                            │
+│ ── Related issues (card grid, page footer) ───│                            │
+│  [name + badges]  [name + badges]             │                            │
+│  [description…ㅤ]  [description…ㅤ]            │                            │
+│  [chips · stats ]  [chips · stats ]            │                            │
 └──────────────────────────────────────────────┴───────────────────────────┘
 ```
 
@@ -351,16 +353,14 @@ A sticky header, a scrollable main column, and a sticky right metadata/triage ra
 
 6. **Where it happens.** A compact bar chart of the **session-interaction position** distribution (`getIssueFailurePositions`): x-axis = interaction index within the conversation (`1, 2, 3, … , 10+`), y-axis = share of occurrences, with a callout for the **median interaction** (e.g. *"usually on interaction 3 of the conversation"*) and a separate note for the single-interaction share. This is the headline "where" insight; it directly tells users whether failures are an opening-turn problem or a long-conversation-degradation problem.
 
-7. **Related issues.** A **single merged list** from `getRelatedIssues`, ranked by the combined relatedness score (semantic ⊕ co-occurrence, noisy-OR). Each row shows the related issue name (hydrated from Postgres), its lifecycle badge (resolved/ignored included — *"a similar issue was resolved"* is the actionable case), and **reason chips explaining why the row is here** rather than any raw score:
+7. **Related issues.** A **single merged set** from `getRelatedIssues`, ranked by the combined relatedness score (semantic ⊕ co-occurrence, noisy-OR), rendered as a **responsive card grid at the bottom of the page** (it is a *"where to go next"* section — navigational, not evidence about this issue — so it reads as a footer, after Occurrences and Monitoring). Each **card** shows:
 
-   > *Tool call timeout on search* `Ongoing` — appears in **64%** of this issue's sessions
-   > *Hallucinated citations* `Resolved` — **similar failure pattern**
-   > *Wrong refund amounts* `Ongoing` — **similar pattern** · shares **20%** of sessions
+   - the related issue **name** + lifecycle badges (resolved/ignored included — *"a similar issue was resolved"* is the actionable case),
+   - the issue **description** (2-line clamp) — so users can judge the similarity themselves,
+   - **reason chips that state which signal made it related**: `Similar topic` / `Very similar topic` (semantic — strength bucketed by score, threshold presentational) and `Same conversations · 64%` (co-occurrence, percent = `sharedSessions / mySessions`). Dual-chip cards are implicitly the "possibly the same issue" case — no explicit duplicate claim in v1,
+   - an activity footer: lifetime **occurrence count** + **last seen** (batched `aggregateByIssues` read).
 
-   - Co-occurrence rows lead with the **shared-session percent** sentence (`sharedSessions / mySessions`); semantic rows lead with the **similar-pattern** chip; dual-signal rows show both (implicitly the "possibly the same issue" case — no explicit duplicate claim in v1).
-   - Cosine values and the combined score are **never displayed** — they rank, the chips explain.
-   - Rows link to that issue's page. Project-scoped only.
-   - Below the list, the **benchmark** summary may also appear here as well as in the rail (*"Top 3% by user reach, top 8% by volume among 214 issues"*). Empty state when neither signal produces a row.
+   Cosine values and the combined score are **never displayed** — they rank, the chips explain (each chip carries an explanatory tooltip). Cards link to that issue's page. Project-scoped only. The **benchmark** summary may also appear here as well as in the rail (*"Top 3% by user reach, top 8% by volume among 214 issues"*). Empty state when neither signal produces a row.
 
 8. **Examples.** An inline **occurrence carousel** built on the reusable `Conversation` component (`packages/ui/src/components/genai-conversation/conversation.tsx`) and the annotation-navigation system (`use-annotation-navigation.ts`):
    - Prev/next (and **H/L** keys) cycle through occurrences (scores) of the issue. (Issue-level prev/next on the page uses J/K; examples use H/L to avoid the collision.)

--- a/specs/issue-details-page.md
+++ b/specs/issue-details-page.md
@@ -44,6 +44,10 @@ The drawer is intentionally **not** the design baseline. We build the page first
 - **Rate-elevation**: `conditionalRate − baseRate`, in percentage points — how much more a value's traces fall into the issue than traces overall. Patterns' sort key.
 - **Coverage**: `affectedTracesWithValue / issueAffectedTraces` — what share of the *issue* a value explains. Distinguishes a strong-and-broad culprit from a strong-but-niche one.
 - **Lift**: `conditionalRate / baseRate` (equivalently `P(v | issue) / P(v)` — the two are algebraically identical). Lift > 1 means over-represented. Kept as a concept; the UI shows the rate pair + rate-elevation rather than the raw multiplier, which is unstable for rare values.
+- **Semantic similarity**: cosine similarity between two issues' centroid embeddings (`issues.centroid_embedding`) — "these two issues *mean* the same failure". Lives in Postgres/pgvector, maintained by the clustering pipeline.
+- **Co-occurrence**: two issues having occurrences in the same **sessions** — "these two issues *travel together*". Measured over the session sets in ClickHouse `scores`.
+- **NPMI** (normalized pointwise mutual information): bounded `[-1, 1]` measure of co-occurrence above chance — `ln(P(A,B) / (P(A)·P(B))) / −ln(P(A,B))`. The numerator is log-lift; the denominator normalizes by the rarity of the joint event, which kills both the rare-pair lift inflation and the big-neighbor chance overlap. Clamped at 0 for the related-issues score.
+- **Relatedness**: the merged ranking score for the Related-issues list — noisy-OR of the normalized semantic and co-occurrence scores: `1 − (1 − semScore)(1 − coocScore)`. Sort-order only; never displayed raw.
 
 ## Conceptual model
 
@@ -54,7 +58,7 @@ The page is organized as a top-to-bottom **report** with a persistent metadata/t
 3. **Trend** — wide, zoomable occurrence histogram with existing escalation/incident overlays.
 4. **Patterns** — a single ranked list of the dimension values (model, provider, tool, tag, finish reason) whose traces most disproportionately fall into this issue vs. the project base rate (rate-elevation), support-gated.
 5. **Where it happens** — distribution of the session-interaction position at which the issue occurs.
-6. **Related** — co-occurring issues (shared traces/sessions, with lift) and a project benchmark rank.
+6. **Related** — a single merged list of the project's most related issues, combining two independent signals: **semantically similar** issues (centroid cosine, pgvector) and **co-occurring** issues (shared sessions, NPMI), ranked by a combined relatedness score; plus a project benchmark rank.
 7. **Examples** — inline carousel cycling through occurrences with the exact message/part highlighted.
 8. **Occurrences** — paginated traces table (the existing list, kept).
 9. **Monitoring** — linked evaluations (the existing section, kept).
@@ -96,6 +100,15 @@ The `Issue` entity, `IssueWithLifecycle`, `IssueDetails`, and `IssueListItem` sh
 
 - `updateIssueTriageUseCase({ issueId, assigneeId?, priority? })` — single use-case that patches assignee and/or priority. Validates the assignee is a member of the issue's organization. Emits no domain event beyond the standard issue update.
 - Read paths (`get-issue-details`, `list-issues`) include the two new fields.
+
+### Postgres — semantic neighbors (`IssueRepository.findSimilarByCentroid`)
+
+New read on the issue repository powering the Related list's semantic signal:
+
+- `findSimilarByCentroid({ projectId, issueId, limit }) → { issueId, similarity }[]` — exact cosine scan of the project's other issues against this issue's `centroid_embedding` (`1 − (centroid_embedding <=> me)`), ordered by similarity, capped at `limit`. Returns an **empty list** when the source issue has no embedding (zero-mass centroid) — the semantic signal simply degrades to nothing.
+- Same-embedding-space comparison is guaranteed by construction: `save()` only persists `centroid_embedding` for `CENTROID_EMBEDDING_MODEL`, so no per-row model guard is needed.
+- **Resolved/ignored issues are included** — "a similar issue was already resolved" is the most actionable row in the list. No similarity floor at the repository layer; gating lives in the domain scorer.
+- No ANN index, same as `hybridSearch`/`searchOrgWide` (exact scan is faster below ~10k issues/project).
 
 ### ClickHouse — new read-only analytics (no migrations)
 
@@ -187,20 +200,34 @@ All methods live on `ScoreAnalyticsRepository` (port: `packages/domain/scores/sr
 
    **Significance gate.** Values are filtered to a minimum trace support (`totalTraces ≥ ISSUE_DIMENSION_MIN_SUPPORT`, a named constant) so a value used by a handful of traces cannot post a "93% rate". When no value clears the gate, `values` is empty and the UI shows "not enough data to compare against the project baseline yet". `baseRate` and `issueAffectedTraces` may be reused from `aggregateImpactByIssue` rather than recomputed.
 
-3. **`coOccurringIssues(issueId, range?) → CoOccurringIssue[]`**
+3. **`coOccurrenceByIssue(issueId, range) → IssueCoOccurrenceAggregate`**
 
    ```typescript
-   type CoOccurringIssue = {
-     issueId: string;
-     sharedTraces: number;        // traces where both issues have an occurrence
-     sharedSessions: number;      // sessions where both have an occurrence
-     coOccurrencePercent: number; // sharedSessions / this-issue affectedSessions
-     lift: number;                // P(other | this session) / P(other across project sessions)
+   type IssueCoOccurrence = {
+     issueId: string;          // the other issue
+     sharedSessions: number;   // sessions where both issues have an occurrence (in range)
+     theirSessions: number;    // sessions where the other issue has an occurrence (in range)
+   };
+
+   type IssueCoOccurrenceAggregate = {
+     mySessions: number;       // sessions where this issue has an occurrence (in range)
+     totalSessions: number;    // sessions with ANY issue occurrence (the probability universe)
+     candidates: IssueCoOccurrence[]; // top N by sharedSessions, self-excluded, sharedSessions ≥ 1
    };
    ```
 
-   - Implemented by selecting the issue's affected `trace_id`/`session_id` set, then `GROUP BY issue_id` over scores on those traces/sessions, excluding `issueId` itself.
-   - Returns top N by lift, with a minimum shared-count floor. Issue name/lifecycle is hydrated from Postgres by the caller (`IN (...)`).
+   - One scan over `scores` in `range`: select the issue's distinct non-empty `session_id` set, then `GROUP BY issue_id` over issue-carrying scores counting `uniqExactIf(session_id, session_id IN mySessions)` vs `uniqExact(session_id)`, excluding `issueId` itself. A second cheap read returns `mySessions` + `totalSessions`.
+   - The probability universe is **sessions carrying at least one issue occurrence** (not all project sessions): unscored sessions carry no information about issue association and would only dilute every probability uniformly.
+   - The repository returns **raw counts only** — NPMI scoring, the shared-session floor, and ranking live in `@domain/issues` (see *Related-issues scoring* below) so the math is unit-testable without ClickHouse.
+   - The window is fixed at the last `ISSUE_RELATED_COOCCURRENCE_WINDOW_DAYS` (30) days — not wired to a page range selector.
+
+   **Related-issues scoring (`@domain/issues`, pure).** The Related list merges two independent signals into one ranking:
+
+   - `semScore = clamp((cosine − ISSUE_RELATED_SEMANTIC_FLOOR) / (ISSUE_RELATED_SEMANTIC_CEILING − ISSUE_RELATED_SEMANTIC_FLOOR), 0, 1)` — a linear rescale of centroid cosine similarity over its *useful* band. Above the ceiling (≈0.85) two clusters are effectively duplicates (discovery would merge new scores into either); below the floor (≈0.55) they are unrelated. Surviving issue pairs sit below the discovery merge threshold *by construction*, so the band is where all the signal lives.
+   - `coocScore = max(0, NPMI)` over the session counts above, gated to `sharedSessions ≥ ISSUE_RELATED_MIN_SHARED_SESSIONS` (3) so one coincidental session cannot post a high score. NPMI is preferred over raw lift (unbounded, inflated for rare pairs) and over Jaccard/overlap percent (inflated by big neighbors that co-occur with everything by chance): its numerator *is* log-lift and its denominator normalizes by joint-event rarity, so both failure modes die at the source.
+   - `relatedness = 1 − (1 − semScore)(1 − coocScore)` (noisy-OR): either signal alone carries a row; a row scoring on both — the "possibly the same issue" case — ranks above either alone. Rows below `ISSUE_RELATED_MIN_RELATEDNESS` are dropped; top `ISSUE_RELATED_LIMIT` survive. The combined score is sort-order only and never displayed.
+
+   The forward design (`lift` displayed, sessions/traces both counted) is superseded: lift's instability for rare values is the same problem Patterns hit (see method #2's reverse-conditioning rationale), and a merged single list needs one bounded, comparable score per signal.
 
 4. **`failurePositionBySession(issueId, range?) → FailurePositionDistribution`**
 
@@ -234,7 +261,7 @@ All methods live on `ScoreAnalyticsRepository` (port: `packages/domain/scores/sr
 
 Extend `issues.functions.ts` with serializable wrappers, fetched by dedicated React Query hooks in `issues.collection.ts` (one hook per analysis block so blocks load and revalidate independently):
 
-- `getIssueImpact`, `getIssueDimensions(dimension)`, `getCoOccurringIssues`, `getIssueFailurePositions`, `getIssueBenchmark`, plus `updateIssueTriage`.
+- `getIssueImpact`, `getIssueDimensions(dimension)`, `getRelatedIssues`, `getIssueFailurePositions`, `getIssueBenchmark`, plus `updateIssueTriage`. `getRelatedIssues` orchestrates the two reads (pgvector neighbors + ClickHouse co-occurrence counts, in parallel), runs the pure domain scorer, and hydrates the surviving rows from Postgres (`findByIds`) with lifecycle states derived server-side.
 - `getIssueDetail` (existing) gains `assigneeId` + `priority`.
 - The **examples** block reuses existing data: `listIssueTraces` + per-trace conversation (`useTraceDetail`) + annotations (`useAnnotationsByTrace`); no new occurrence-fetch endpoint is required beyond surfacing the per-occurrence score anchor (`metadata.messageIndex` / `partIndex` / offsets) for the focused score.
 
@@ -324,7 +351,16 @@ A sticky header, a scrollable main column, and a sticky right metadata/triage ra
 
 6. **Where it happens.** A compact bar chart of the **session-interaction position** distribution (`getIssueFailurePositions`): x-axis = interaction index within the conversation (`1, 2, 3, … , 10+`), y-axis = share of occurrences, with a callout for the **median interaction** (e.g. *"usually on interaction 3 of the conversation"*) and a separate note for the single-interaction share. This is the headline "where" insight; it directly tells users whether failures are an opening-turn problem or a long-conversation-degradation problem.
 
-7. **Related issues.** A list from `getCoOccurringIssues`: each row shows the related issue name (hydrated from Postgres), its lifecycle badge, the **shared-session percent**, and a **lift** chip (*"appears in 64% of this issue's sessions — ×8 vs baseline"*). Rows link to that issue's page. Below the list, the **benchmark** summary may also appear here as well as in the rail (*"Top 3% by user reach, top 8% by volume among 214 issues"*). Empty state when no meaningful co-occurrence exists.
+7. **Related issues.** A **single merged list** from `getRelatedIssues`, ranked by the combined relatedness score (semantic ⊕ co-occurrence, noisy-OR). Each row shows the related issue name (hydrated from Postgres), its lifecycle badge (resolved/ignored included — *"a similar issue was resolved"* is the actionable case), and **reason chips explaining why the row is here** rather than any raw score:
+
+   > *Tool call timeout on search* `Ongoing` — appears in **64%** of this issue's sessions
+   > *Hallucinated citations* `Resolved` — **similar failure pattern**
+   > *Wrong refund amounts* `Ongoing` — **similar pattern** · shares **20%** of sessions
+
+   - Co-occurrence rows lead with the **shared-session percent** sentence (`sharedSessions / mySessions`); semantic rows lead with the **similar-pattern** chip; dual-signal rows show both (implicitly the "possibly the same issue" case — no explicit duplicate claim in v1).
+   - Cosine values and the combined score are **never displayed** — they rank, the chips explain.
+   - Rows link to that issue's page. Project-scoped only.
+   - Below the list, the **benchmark** summary may also appear here as well as in the rail (*"Top 3% by user reach, top 8% by volume among 214 issues"*). Empty state when neither signal produces a row.
 
 8. **Examples.** An inline **occurrence carousel** built on the reusable `Conversation` component (`packages/ui/src/components/genai-conversation/conversation.tsx`) and the annotation-navigation system (`use-annotation-navigation.ts`):
    - Prev/next (and **H/L** keys) cycle through occurrences (scores) of the issue. (Issue-level prev/next on the page uses J/K; examples use H/L to avoid the collision.)
@@ -435,11 +471,15 @@ The page becomes the single issue surface; the drawer and flag are removed. Abso
 
 ### Phase 4 — Related issues + benchmark
 
-- [ ] **P4-1**: `coOccurringIssues` ClickHouse method (shared traces/sessions, lift, self-exclusion, floor) + tests; Postgres hydration of related issue rows.
-- [ ] **P4-2**: `issueBenchmark` method (occurrence + user-reach percentile) + tests.
-- [ ] **P4-3**: Related-issues list + benchmark chips (rail + section), linking to other issue pages.
+Related issues redesigned before build (no v1 shipped): one merged list combining **semantic similarity** (centroid cosine, pgvector) and **co-occurrence** (shared sessions, NPMI), ranked by noisy-OR relatedness. Displayed lift is dropped for the same instability reason Patterns dropped it (see Data model #3).
 
-**Exit gate**: the page shows co-occurring issues with lift and a project benchmark rank.
+- [ ] **P4-1**: `IssueRepository.findSimilarByCentroid` (pgvector exact cosine scan, project-scoped, resolved/ignored included, empty when no embedding) + PGlite test.
+- [ ] **P4-2**: `coOccurrenceByIssue` ClickHouse method (session co-occurrence counts + probability universe, self-exclusion, 30d window) + chdb tests.
+- [ ] **P4-3**: Pure related-issues scorer in `@domain/issues` (semScore band rescale, NPMI with shared-session floor, noisy-OR merge, min-relatedness gate, top N) + unit tests; named constants (`ISSUE_RELATED_*`).
+- [ ] **P4-4**: `getRelatedIssues` web function (parallel reads → scorer → Postgres hydration) + hook + Related-issues section (merged list, lifecycle badges, reason chips, empty state), linking to other issue pages.
+- [ ] **P4-5**: `issueBenchmark` method (occurrence + user-reach percentile) + tests; benchmark chips (rail + section). *(Unchanged from the original design; not part of the related-issues build.)*
+
+**Exit gate**: the page shows one ranked list of related issues — semantically similar and/or co-occurring — with reason chips, plus (separately) a project benchmark rank.
 
 ### Phase 5 — Where it happens (session-interaction position)
 


### PR DESCRIPTION
## what this does

Adds a **Related issues** section to the issue page (Phase 4 of the issue-details-page spec, minus the benchmark): a card grid at the bottom of the page listing the project's most related issues, each linking to its own page.

"Related" merges two independent signals into one ranking:

- **Semantic similarity** — this issue's failure pattern *means* the same thing as another's. Computed as cosine similarity between the issues' `centroid_embedding` vectors (already maintained by the clustering pipeline; no new storage). Surfaces near-duplicate clusters and "a similar issue was already resolved — see how".
- **Session co-occurrence** — the two issues *travel together*: they have occurrences in the same conversations (trailing 30 days). Surfaces correlated/cascading failures that share a root cause.

Either signal alone carries a card; a card scoring on both is the "possibly the same issue" case and ranks highest.

## scoring

Each signal is normalized to `[0, 1]` and fused; the math lives in a pure `@domain/issues` module (`related-issues.ts`) so it's unit-tested without infra:

- **Semantic**: linear rescale of cosine over its useful band (`0.55–0.85`, named constants). Above the ceiling, discovery would have merged the clusters; below the floor it's noise. Surviving issue pairs sit below the discovery merge threshold by construction, so the band is where the signal lives. The band is provisional — calibrate against real data.
- **Co-occurrence**: clamped **NPMI** over session sets, gated on ≥ 3 shared sessions. NPMI instead of raw lift (unbounded, explodes for rare pairs) or overlap percent (inflated by big issues that overlap everything by chance): its numerator is log-lift and its denominator normalizes by joint-event rarity, killing both failure modes. The probability universe is sessions carrying at least one issue occurrence — unscored sessions carry no information about issue association.
- **Fusion**: noisy-OR (`1 − (1−a)(1−b)`), min-relatedness gate, top 8.

The combined score and raw cosine are never displayed — they rank, the reason chips explain (`Similar topic` / `Very similar topic` vs `Same conversations · 64%`, each with a tooltip).

## pieces

- `IssueRepository.findSimilarByCentroid` (Postgres): exact pgvector cosine scan over the project's other issues, same no-ANN-index trade-off as `hybridSearch`. Empty when the source has no embedding. Resolved/ignored neighbors included on purpose.
- `ScoreAnalyticsRepository.coOccurrenceByIssue` (ClickHouse): per-candidate shared/total session counts + the probability universe, one windowed scan over issue-carrying scores, self-excluded, capped candidate pool.
- `getRelatedIssuesUseCase` (`@domain/issues`): runs both reads in parallel, ranks with the pure scorer, hydrates rows from Postgres (`findByIds`) with lifecycle states, plus a batched `aggregateByIssues` read for each card's occurrences / last-seen footer. Candidates that vanished between reads are dropped.
- Web: `getRelatedIssues` server fn, `useRelatedIssues` hook, `IssueRelated` card grid (name + lifecycle badges, 2-line description so the reader can judge the similarity, reason chips, activity footer). Rendered through a new `append` slot on `IssueDetailBody` so it sits after Traces as a page footer — it's a "where to go next" section, not evidence about the issue itself.

## scope cuts / follow-ups

- The project **benchmark** (occurrence/user-reach percentile, original P4-2) is not in this PR — tracked as P4-5 in the spec.
- Semantic band constants (`ISSUE_RELATED_SEMANTIC_FLOOR/CEILING`) need calibration against production data once real clusters exist.
- Co-occurrence cards require occurrences with session ids, ≥ 3 shared sessions in 30 days, and above-chance overlap — sparse projects will mostly see semantic cards, by design.

## testing

- PGlite: `findSimilarByCentroid` ranking, self/project exclusion, resolved/ignored inclusion, missing-embedding degradation.
- chdb: `coOccurrenceByIssue` shared/total counts, windowing, self-exclusion, candidate cap.
- Unit: scorer math, including the chance-overlap (lift = 1 → 0) and big-neighbor traps, perfect-rare-pair = 1, gates, ordering, top-N.
- Use case: signal merge, hydration, lifecycle states, 30-day window, vanished-candidate drop, missing-analytics degradation.

Spec updated in `specs/issue-details-page.md` (Data model #3, glossary, layout, task status).