### PR TITLE
feat: add recent session intelligence backfill workflow

### DIFF
--- a/apps/workflows/src/activities/index.ts
+++ b/apps/workflows/src/activities/index.ts
@@ -48,10 +48,17 @@ export {
   seedDemoProjectTraceSearchActivity,
 } from "./seed-demo-project-activities.ts"
 export {
+  type BackfillProjectDescriptor,
   type BackfillSessionDescriptor,
+  type ListBackfillProjectsActivityInput,
+  type ListRecentBackfillSessionsActivityInput,
   listBackfillSessionsActivity,
+  listRecentBackfillSessionsActivity,
+  listSessionIntelligenceBackfillProjectsActivity,
   resetSessionIntelligenceForProjectActivity,
+  resetSessionIntelligenceForSessionsActivity,
   resetTaxonomyForProjectActivity,
+  type SelectiveSessionIntelligenceResetActivityInput,
   type SessionIntelligenceBackfillActivityInput,
   waitForTaxonomyObservationStabilityActivity,
 } from "./session-intelligence-backfill-activities.ts"

--- a/apps/workflows/src/activities/session-intelligence-backfill-activities.ts
+++ b/apps/workflows/src/activities/session-intelligence-backfill-activities.ts
@@ -16,10 +16,61 @@ export interface ListBackfillSessionsActivityInput extends SessionIntelligenceBa
   readonly sessionLimit: number
 }
 
+export interface ListRecentBackfillSessionsActivityInput extends ListBackfillSessionsActivityInput {
+  readonly startedAfter: string
+}
+
+export interface ListBackfillProjectsActivityInput {
+  readonly organizationId?: string
+  readonly projectId?: string
+}
+
+export interface SelectiveSessionIntelligenceResetActivityInput extends SessionIntelligenceBackfillActivityInput {
+  readonly sessionIds: readonly string[]
+}
+
+export interface BackfillProjectDescriptor {
+  readonly organizationId: string
+  readonly projectId: string
+}
+
 export interface BackfillSessionDescriptor {
   readonly sessionId: string
   readonly triggeringTraceId: string
   readonly triggeringStartTime: string
+}
+
+export async function listSessionIntelligenceBackfillProjectsActivity(
+  input: ListBackfillProjectsActivityInput = {},
+): Promise<readonly BackfillProjectDescriptor[]> {
+  const adminPostgres = getAdminPostgresClient()
+  const clauses = ["deleted_at IS NULL"]
+  const values: string[] = []
+
+  if (input.organizationId) {
+    values.push(input.organizationId)
+    clauses.push(`organization_id = $${values.length}`)
+  }
+  if (input.projectId) {
+    values.push(input.projectId)
+    clauses.push(`id = $${values.length}`)
+  }
+
+  const result = await adminPostgres.pool.query<{
+    readonly organization_id: string
+    readonly project_id: string
+  }>(
+    `SELECT organization_id, id AS project_id
+     FROM latitude.projects
+     WHERE ${clauses.join(" AND ")}
+     ORDER BY organization_id, id`,
+    values,
+  )
+
+  return result.rows.map((row) => ({
+    organizationId: row.organization_id,
+    projectId: row.project_id,
+  }))
 }
 
 export async function resetSessionIntelligenceForProjectActivity(
@@ -36,6 +87,36 @@ export async function resetSessionIntelligenceForProjectActivity(
   ] as const) {
     await clickhouse.command({
       query: `ALTER TABLE ${table} DELETE WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}`,
+      query_params: queryParams,
+      clickhouse_settings: { mutations_sync: "2" },
+    })
+    await clickhouse.command({ query: `OPTIMIZE TABLE ${table} FINAL` })
+  }
+}
+
+export async function resetSessionIntelligenceForSessionsActivity(
+  input: SelectiveSessionIntelligenceResetActivityInput,
+): Promise<void> {
+  if (input.sessionIds.length === 0) return
+
+  const clickhouse = getClickhouseClient()
+  const queryParams = {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sessionIds: [...new Set(input.sessionIds)],
+  }
+
+  for (const table of [
+    "session_moment_labels",
+    "session_semantic_moments",
+    "taxonomy_observations",
+    "session_analyses",
+  ] as const) {
+    await clickhouse.command({
+      query: `ALTER TABLE ${table} DELETE
+              WHERE organization_id = {organizationId:String}
+                AND project_id = {projectId:String}
+                AND session_id IN {sessionIds:Array(String)}`,
       query_params: queryParams,
       clickhouse_settings: { mutations_sync: "2" },
     })
@@ -71,6 +152,33 @@ export async function listBackfillSessionsActivity(
         organizationId: OrganizationId(input.organizationId),
         projectId: ProjectId(input.projectId),
         options: { limit: input.sessionLimit, sortBy: "lastActivity", sortDirection: "desc" },
+      })
+      return page.items
+        .filter((session) => session.traceIds.length > 0)
+        .map((session) => ({
+          sessionId: session.sessionId,
+          triggeringTraceId: session.traceIds[0] ?? session.sessionId,
+          triggeringStartTime: session.startTime.toISOString(),
+        }))
+    }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId))),
+  )
+}
+
+export async function listRecentBackfillSessionsActivity(
+  input: ListRecentBackfillSessionsActivityInput,
+): Promise<readonly BackfillSessionDescriptor[]> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const repository = yield* SessionRepository
+      const page = yield* repository.listByProjectId({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        options: {
+          limit: input.sessionLimit,
+          sortBy: "lastActivity",
+          sortDirection: "desc",
+          filters: { startTime: [{ op: "gte", value: input.startedAfter }] },
+        },
       })
       return page.items
         .filter((session) => session.traceIds.length > 0)

--- a/apps/workflows/src/workflows/index.ts
+++ b/apps/workflows/src/workflows/index.ts
@@ -13,6 +13,16 @@ export {
   optimizeEvaluationWorkflow,
 } from "./optimize-evaluation-workflow.ts"
 export {
+  type BackfillRecentSessionIntelligenceWorkflowInput,
+  type BackfillRecentSessionIntelligenceWorkflowResult,
+  backfillRecentSessionIntelligenceWorkflow,
+} from "./recent-session-intelligence-backfill-workflow.ts"
+export {
+  type BackfillRecentSessionIntelligenceForProjectsWorkflowInput,
+  type BackfillRecentSessionIntelligenceForProjectsWorkflowResult,
+  backfillRecentSessionIntelligenceForProjectsWorkflow,
+} from "./recent-session-intelligence-projects-backfill-workflow.ts"
+export {
   type RefreshEvaluationAlignmentWorkflowResult,
   refreshEvaluationAlignmentWorkflow,
 } from "./refresh-evaluation-alignment-workflow.ts"

--- a/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.test.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { callOrder, childExecutions, mockActivities } = vi.hoisted(() => {
+  const callOrder: string[] = []
+  const childExecutions: Array<{ readonly args: unknown[]; readonly workflowId: string }> = []
+  const mockActivities = {
+    listRecentBackfillSessionsActivity: vi.fn(async () => {
+      callOrder.push("list-sessions")
+      return [
+        {
+          sessionId: "session-1",
+          triggeringTraceId: "trace-1",
+          triggeringStartTime: "2026-06-07T00:00:00.000Z",
+        },
+        {
+          sessionId: "session-2",
+          triggeringTraceId: "trace-2",
+          triggeringStartTime: "2026-06-07T00:01:00.000Z",
+        },
+      ]
+    }),
+    resetSessionIntelligenceForSessionsActivity: vi.fn(async () => {
+      callOrder.push("reset-sessions")
+    }),
+    waitForTaxonomyObservationStabilityActivity: vi.fn(async () => {
+      callOrder.push("wait-observations")
+    }),
+  }
+  return { callOrder, childExecutions, mockActivities }
+})
+
+vi.mock("@temporalio/workflow", () => ({
+  proxyActivities: () => mockActivities,
+  executeChild: async (_workflow: unknown, options: { args: unknown[]; workflowId: string }) => {
+    callOrder.push(options.workflowId.includes(":taxonomy:garden:") ? "garden" : "analyze")
+    childExecutions.push({ args: options.args, workflowId: options.workflowId })
+    return { status: "completed" }
+  },
+}))
+
+vi.mock("./analyze-session-workflow.ts", () => ({
+  analyzeSessionWorkflow: async () => ({ action: "recorded", status: "analyzed", momentCount: 0 }),
+}))
+
+vi.mock("./taxonomy-gardening-workflow.ts", () => ({
+  gardenTaxonomyWorkflow: async () => ({ status: "completed" }),
+}))
+
+import { backfillRecentSessionIntelligenceWorkflow } from "./recent-session-intelligence-backfill-workflow.ts"
+
+const input = {
+  organizationId: "org-1",
+  projectId: "project-1",
+  sessionLimit: 500,
+  startedAfter: "2026-06-07T00:00:00.000Z",
+  sessionConcurrency: 1,
+}
+
+describe("backfillRecentSessionIntelligenceWorkflow", () => {
+  beforeEach(() => {
+    callOrder.length = 0
+    childExecutions.length = 0
+    vi.clearAllMocks()
+  })
+
+  it("resets only selected sessions before analyzing and gardening", async () => {
+    const result = await backfillRecentSessionIntelligenceWorkflow(input)
+
+    expect(result).toEqual({ action: "completed", sessionsFound: 2 })
+    expect(mockActivities.listRecentBackfillSessionsActivity).toHaveBeenCalledWith(input)
+    expect(mockActivities.resetSessionIntelligenceForSessionsActivity).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "project-1",
+      sessionIds: ["session-1", "session-2"],
+    })
+    expect(callOrder).toEqual(["list-sessions", "reset-sessions", "analyze", "analyze", "wait-observations", "garden"])
+    expect(childExecutions).toEqual([
+      {
+        args: [
+          {
+            organizationId: "org-1",
+            projectId: "project-1",
+            sessionId: "session-1",
+            triggeringTraceId: "trace-1",
+            triggeringStartTime: "2026-06-07T00:00:00.000Z",
+            reason: "backfill",
+          },
+        ],
+        workflowId: "org:org-1:conversation-intelligence:recentBackfillAnalyzeSession:project-1:session-1",
+      },
+      {
+        args: [
+          {
+            organizationId: "org-1",
+            projectId: "project-1",
+            sessionId: "session-2",
+            triggeringTraceId: "trace-2",
+            triggeringStartTime: "2026-06-07T00:01:00.000Z",
+            reason: "backfill",
+          },
+        ],
+        workflowId: "org:org-1:conversation-intelligence:recentBackfillAnalyzeSession:project-1:session-2",
+      },
+      {
+        args: [{ organizationId: "org-1", projectId: "project-1", dimension: "topic", trigger: "manual" }],
+        workflowId: "org:org-1:taxonomy:garden:project-1:recent-backfill",
+      },
+    ])
+  })
+})

--- a/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.ts
@@ -1,0 +1,81 @@
+import { executeChild, proxyActivities } from "@temporalio/workflow"
+import type * as activities from "../activities/index.ts"
+import { analyzeSessionWorkflow } from "./analyze-session-workflow.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
+import { gardenTaxonomyWorkflow } from "./taxonomy-gardening-workflow.ts"
+
+const DEFAULT_SESSION_CHILD_CONCURRENCY = 10
+
+const {
+  listRecentBackfillSessionsActivity,
+  resetSessionIntelligenceForSessionsActivity,
+  waitForTaxonomyObservationStabilityActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
+  retry: {
+    ...defaultActivityRetryPolicy,
+    initialInterval: "30 seconds",
+    maximumInterval: "10 minutes",
+  },
+})
+
+export interface BackfillRecentSessionIntelligenceWorkflowInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly sessionLimit: number
+  readonly startedAfter: string
+  readonly sessionConcurrency?: number
+  readonly gardenAfter?: boolean
+}
+
+export interface BackfillRecentSessionIntelligenceWorkflowResult {
+  readonly action: "completed"
+  readonly sessionsFound: number
+}
+
+export const backfillRecentSessionIntelligenceWorkflow = async (
+  input: BackfillRecentSessionIntelligenceWorkflowInput,
+): Promise<BackfillRecentSessionIntelligenceWorkflowResult> => {
+  const sessions = await listRecentBackfillSessionsActivity(input)
+  await resetSessionIntelligenceForSessionsActivity({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    sessionIds: sessions.map((session) => session.sessionId),
+  })
+
+  const childConcurrency = Math.max(1, input.sessionConcurrency ?? DEFAULT_SESSION_CHILD_CONCURRENCY)
+  for (let index = 0; index < sessions.length; index += childConcurrency) {
+    const batch = sessions.slice(index, index + childConcurrency)
+    await Promise.all(
+      batch.map((session) =>
+        executeChild(analyzeSessionWorkflow, {
+          args: [
+            {
+              organizationId: input.organizationId,
+              projectId: input.projectId,
+              sessionId: session.sessionId,
+              triggeringTraceId: session.triggeringTraceId,
+              triggeringStartTime: session.triggeringStartTime,
+              reason: "backfill",
+            },
+          ],
+          workflowId: `org:${input.organizationId}:conversation-intelligence:recentBackfillAnalyzeSession:${input.projectId}:${session.sessionId}`,
+          workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        }),
+      ),
+    )
+  }
+
+  if (sessions.length > 0 && input.gardenAfter !== false) {
+    await waitForTaxonomyObservationStabilityActivity(input)
+    await executeChild(gardenTaxonomyWorkflow, {
+      args: [
+        { organizationId: input.organizationId, projectId: input.projectId, dimension: "topic", trigger: "manual" },
+      ],
+      workflowId: `org:${input.organizationId}:taxonomy:garden:${input.projectId}:recent-backfill`,
+      workflowIdReusePolicy: "ALLOW_DUPLICATE",
+    })
+  }
+
+  return { action: "completed", sessionsFound: sessions.length }
+}

--- a/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.test.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { childExecutions, mockActivities } = vi.hoisted(() => {
+  const childExecutions: Array<{ readonly args: unknown[]; readonly workflowId: string }> = []
+  const mockActivities = {
+    listSessionIntelligenceBackfillProjectsActivity: vi.fn(async () => [
+      { organizationId: "org-1", projectId: "project-1" },
+      { organizationId: "org-2", projectId: "project-2" },
+    ]),
+  }
+  return { childExecutions, mockActivities }
+})
+
+vi.mock("@temporalio/workflow", () => ({
+  proxyActivities: () => mockActivities,
+  executeChild: async (_workflow: unknown, options: { args: unknown[]; workflowId: string }) => {
+    childExecutions.push({ args: options.args, workflowId: options.workflowId })
+    return {
+      action: "completed",
+      sessionsFound: options.workflowId.includes("project-1") ? 2 : 3,
+    }
+  },
+}))
+
+vi.mock("./recent-session-intelligence-backfill-workflow.ts", () => ({
+  backfillRecentSessionIntelligenceWorkflow: async () => ({ action: "completed", sessionsFound: 0 }),
+}))
+
+import { backfillRecentSessionIntelligenceForProjectsWorkflow } from "./recent-session-intelligence-projects-backfill-workflow.ts"
+
+describe("backfillRecentSessionIntelligenceForProjectsWorkflow", () => {
+  beforeEach(() => {
+    childExecutions.length = 0
+    vi.clearAllMocks()
+  })
+
+  it("starts one recent backfill child per project with bounded project inputs", async () => {
+    const result = await backfillRecentSessionIntelligenceForProjectsWorkflow({
+      sessionLimitPerProject: 500,
+      startedAfter: "2026-06-07T00:00:00.000Z",
+      projectConcurrency: 1,
+      sessionConcurrencyPerProject: 4,
+      gardenAfter: true,
+    })
+
+    expect(result).toEqual({ action: "completed", projectsFound: 2, sessionsFound: 5 })
+    expect(mockActivities.listSessionIntelligenceBackfillProjectsActivity).toHaveBeenCalledWith({})
+    expect(childExecutions).toEqual([
+      {
+        args: [
+          {
+            organizationId: "org-1",
+            projectId: "project-1",
+            sessionLimit: 500,
+            startedAfter: "2026-06-07T00:00:00.000Z",
+            sessionConcurrency: 4,
+            gardenAfter: true,
+          },
+        ],
+        workflowId: "org:org-1:conversation-intelligence:recentBackfill:project-1:2026-06-07T00:00:00.000Z",
+      },
+      {
+        args: [
+          {
+            organizationId: "org-2",
+            projectId: "project-2",
+            sessionLimit: 500,
+            startedAfter: "2026-06-07T00:00:00.000Z",
+            sessionConcurrency: 4,
+            gardenAfter: true,
+          },
+        ],
+        workflowId: "org:org-2:conversation-intelligence:recentBackfill:project-2:2026-06-07T00:00:00.000Z",
+      },
+    ])
+  })
+})

--- a/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.ts
@@ -1,0 +1,77 @@
+import { executeChild, proxyActivities } from "@temporalio/workflow"
+import type * as activities from "../activities/index.ts"
+import { backfillRecentSessionIntelligenceWorkflow } from "./recent-session-intelligence-backfill-workflow.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
+
+const DEFAULT_LOOKBACK_DAYS = 3
+const DEFAULT_PROJECT_CONCURRENCY = 2
+const DEFAULT_SESSION_CONCURRENCY_PER_PROJECT = 10
+
+const { listSessionIntelligenceBackfillProjectsActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+  retry: {
+    ...defaultActivityRetryPolicy,
+    initialInterval: "30 seconds",
+    maximumInterval: "10 minutes",
+  },
+})
+
+export interface BackfillRecentSessionIntelligenceForProjectsWorkflowInput {
+  readonly sessionLimitPerProject: number
+  readonly lookbackDays?: number
+  readonly startedAfter?: string
+  readonly projectConcurrency?: number
+  readonly sessionConcurrencyPerProject?: number
+  readonly gardenAfter?: boolean
+  readonly organizationId?: string
+  readonly projectId?: string
+}
+
+export interface BackfillRecentSessionIntelligenceForProjectsWorkflowResult {
+  readonly action: "completed"
+  readonly projectsFound: number
+  readonly sessionsFound: number
+}
+
+const startedAfterForInput = (input: BackfillRecentSessionIntelligenceForProjectsWorkflowInput): string => {
+  if (input.startedAfter) return input.startedAfter
+  const lookbackDays = Math.max(1, input.lookbackDays ?? DEFAULT_LOOKBACK_DAYS)
+  return new Date(Date.now() - lookbackDays * 24 * 60 * 60_000).toISOString()
+}
+
+export const backfillRecentSessionIntelligenceForProjectsWorkflow = async (
+  input: BackfillRecentSessionIntelligenceForProjectsWorkflowInput,
+): Promise<BackfillRecentSessionIntelligenceForProjectsWorkflowResult> => {
+  const startedAfter = startedAfterForInput(input)
+  const projects = await listSessionIntelligenceBackfillProjectsActivity({
+    ...(input.organizationId ? { organizationId: input.organizationId } : {}),
+    ...(input.projectId ? { projectId: input.projectId } : {}),
+  })
+
+  const projectConcurrency = Math.max(1, input.projectConcurrency ?? DEFAULT_PROJECT_CONCURRENCY)
+  let sessionsFound = 0
+  for (let index = 0; index < projects.length; index += projectConcurrency) {
+    const batch = projects.slice(index, index + projectConcurrency)
+    const results = await Promise.all(
+      batch.map((project) =>
+        executeChild(backfillRecentSessionIntelligenceWorkflow, {
+          args: [
+            {
+              organizationId: project.organizationId,
+              projectId: project.projectId,
+              sessionLimit: input.sessionLimitPerProject,
+              startedAfter,
+              sessionConcurrency: input.sessionConcurrencyPerProject ?? DEFAULT_SESSION_CONCURRENCY_PER_PROJECT,
+              ...(input.gardenAfter === undefined ? {} : { gardenAfter: input.gardenAfter }),
+            },
+          ],
+          workflowId: `org:${project.organizationId}:conversation-intelligence:recentBackfill:${project.projectId}:${startedAfter}`,
+          workflowIdReusePolicy: "ALLOW_DUPLICATE",
+        }),
+      ),
+    )
+    sessionsFound += results.reduce((sum, result) => sum + result.sessionsFound, 0)
+  }
+
+  return { action: "completed", projectsFound: projects.length, sessionsFound }
+}

--- a/packages/domain/queue/src/workflow-registry.ts
+++ b/packages/domain/queue/src/workflow-registry.ts
@@ -18,6 +18,24 @@ const _registry = {
     readonly sessionLimit: number
     readonly reason: "backoffice"
   }>(),
+  backfillRecentSessionIntelligenceWorkflow: input<{
+    readonly organizationId: string
+    readonly projectId: string
+    readonly sessionLimit: number
+    readonly startedAfter: string
+    readonly sessionConcurrency?: number
+    readonly gardenAfter?: boolean
+  }>(),
+  backfillRecentSessionIntelligenceForProjectsWorkflow: input<{
+    readonly sessionLimitPerProject: number
+    readonly lookbackDays?: number
+    readonly startedAfter?: string
+    readonly projectConcurrency?: number
+    readonly sessionConcurrencyPerProject?: number
+    readonly gardenAfter?: boolean
+    readonly organizationId?: string
+    readonly projectId?: string
+  }>(),
   refreshEvaluationAlignmentWorkflow: input<{
     readonly organizationId: string
     readonly projectId: string


### PR DESCRIPTION
## What does this PR do?

Adds a recent-session conversation-intelligence backfill path that finds active projects, selects sessions from a bounded start-time window, resets only those sessions' intelligence rows, reruns `AnalyzeSessionWorkflow`, and gardens taxonomy once per project. It keeps the existing destructive project reset workflow separate while adding project-level and session-level concurrency controls for the production taxonomy-observation backfill.

## Related issue (if applicable)

N/A

## How was this tested?

Ran `pnpm --filter @app/workflows test -- recent-session-intelligence`, `pnpm --filter @app/workflows typecheck`, `pnpm --filter @app/workflows check`, and `pnpm --filter @domain/queue typecheck`; the commit hook also ran workspace formatting and `knip`.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA
