### PR TITLE
fix(telemetry): stop silently dropping long Claude Code traces

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-06-11
+
 ### Fixed
 
+- **Long agentic turns are no longer silently lost.** A single long turn (hundreds of LLM calls) produced one OTLP POST of 130–340 MB — too big to upload inside the client timeout and over the ingest rate limit — and the hook recorded it as sent anyway. Three changes fix this:
+  - The transcript offset only advances after the export is confirmed delivered (2xx on every chunk). Failed exports are retried on the next Stop; deterministic span IDs make re-sends idempotent server-side.
+  - Exports are split into POSTs of at most 3 MB each. One trace may arrive across several POSTs; the server already assembles spans by `trace_id`.
+  - Spans over 128 KB get their bulkiest attributes truncated (repeated tool definitions, then system prompt, oldest input messages, tool results — in that order), always keeping valid JSON and the most recent context. A `latitude.truncation` attribute records what was cut. Spans under the budget are byte-identical to before. This also removes a `JSON.stringify` RangeError crash on very large sessions.
+- **State lock handling.** A hook run that failed to acquire the state lock no longer deletes the lock file owned by a concurrent run; locks abandoned by killed hooks are broken after 10 minutes.
 - Installer links now point to the current Latitude docs and API key settings URLs.
+
+### Changed
+
+- Per-POST client timeout raised from 10 s to 30 s (each POST is now bounded at 3 MB).
 
 ## [0.0.7] - 2026-04-24
 

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/client.ts
+++ b/packages/telemetry/claude-code/src/client.ts
@@ -1,13 +1,17 @@
 import type { Logger } from "./logger.ts"
 import type { OtlpExportRequest } from "./types.ts"
 
+// Resolves true only on a 2xx response. Callers must not record the payload as
+// delivered on false — the transcript offset only advances after every chunk of a
+// batch lands, so failed exports are retried on the next Stop (span IDs are
+// deterministic, so re-sends dedupe server-side).
 export async function postTraces({
   baseUrl,
   apiKey,
   project,
   payload,
   logger,
-  timeoutMs = 10_000,
+  timeoutMs = 30_000,
 }: {
   baseUrl: string
   apiKey: string
@@ -15,14 +19,14 @@ export async function postTraces({
   payload: OtlpExportRequest
   logger: Logger
   timeoutMs?: number
-}): Promise<void> {
+}): Promise<boolean> {
   const url = `${baseUrl.replace(/\/+$/, "")}/v1/traces`
-  const bodyText = JSON.stringify(payload)
-  logger.debug(`POST ${url} (project=${project}, ${bodyText.length} bytes)`)
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
+    const bodyText = JSON.stringify(payload)
+    logger.debug(`POST ${url} (project=${project}, ${bodyText.length} bytes)`)
     const res = await fetch(url, {
       method: "POST",
       headers: {
@@ -36,11 +40,13 @@ export async function postTraces({
     if (!res.ok) {
       const text = await res.text().catch(() => "")
       logger.warn(`ingest HTTP ${res.status}: ${text.slice(0, 500)}`)
-    } else {
-      logger.debug(`ingest HTTP ${res.status}`)
+      return false
     }
+    logger.debug(`ingest HTTP ${res.status}`)
+    return true
   } catch (err) {
     logger.warn(`ingest failed: ${String(err)}`)
+    return false
   } finally {
     clearTimeout(timer)
   }

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "./config.ts"
 import { collectTraceContext } from "./context.ts"
 import type { Logger } from "./logger.ts"
 import { createLogger } from "./logger.ts"
-import { buildOtlpRequest } from "./otlp.ts"
+import { buildOtlpRequest, chunkOtlpRequest } from "./otlp.ts"
 import { deleteRequest, loadRequestsByMessageId, pruneStaleRequests } from "./request-store.ts"
 import { normalizeInstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
 import { load, save, stateKey, withLock } from "./state.ts"
@@ -141,13 +141,30 @@ async function main(): Promise<void> {
       requestsByMessageId,
     })
 
-    return postTraces({
-      baseUrl: config.baseUrl,
-      apiKey: config.apiKey,
-      project: config.project,
-      payload: otlpRequest,
-      logger,
-    }).then(() => {
+    // Long agentic turns produce payloads far beyond what a single POST can deliver,
+    // so the batch ships as size-bounded chunks. The offset only advances after every
+    // chunk lands — on any failure the whole batch is retried on the next Stop, and
+    // deterministic span IDs make the re-send idempotent server-side.
+    const chunks = chunkOtlpRequest(otlpRequest)
+    if (chunks.length > 1) logger.debug(`payload split into ${chunks.length} chunks`)
+
+    return (async () => {
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i]
+        if (!chunk) continue
+        const ok = await postTraces({
+          baseUrl: config.baseUrl,
+          apiKey: config.apiKey,
+          project: config.project,
+          payload: chunk,
+          logger,
+        })
+        if (!ok) {
+          logger.warn(`chunk ${i + 1}/${chunks.length} failed; keeping offset so the next Stop retries this batch`)
+          return
+        }
+      }
+
       save(key, {
         offset: newOffset,
         buffer: newBuffer,
@@ -160,7 +177,7 @@ async function main(): Promise<void> {
       for (const id of requestsByMessageId.keys()) deleteRequest(id)
       const stalePruned = pruneStaleRequests()
       if (stalePruned > 0) logger.debug(`pruned ${stalePruned} stale request file(s)`)
-    })
+    })()
   })
 }
 

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildOtlpRequest } from "./otlp.ts"
+import { buildOtlpRequest, chunkOtlpRequest } from "./otlp.ts"
 import type { StoredRequest } from "./request-store.ts"
 import type { AssistantCall, OtlpKeyValue, ToolCall, Turn, Usage } from "./types.ts"
 
@@ -697,5 +697,124 @@ describe("buildOtlpRequest", () => {
     // Subagent tool is a sibling of the subagent llm_request, parented to the
     // subagent interaction span (same sibling rule applied recursively).
     expect(subTool.parentSpanId).toBe(subInteraction.spanId)
+  })
+})
+
+describe("span size capping", () => {
+  it("leaves spans under the budget untouched", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 1,
+      turns: [baseTurn({ assistantText: "normal sized response" })],
+    })
+    for (const span of otlpSpans(req)) {
+      expect(getAttr(span.attributes, "latitude.truncation")).toBeUndefined()
+    }
+  })
+
+  it("clamps giant tool results and keeps the span bounded", () => {
+    const giant = "x".repeat(500_000)
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          toolCalls: [{ id: "tool_1", name: "Bash", input: { command: "cat big.log" }, output: giant }],
+        }),
+      ],
+    })
+    const toolSpan = unwrap(otlpSpans(req).find((s) => s.name === "tool:Bash"))
+    const result = unwrap(getAttr(toolSpan.attributes, "gen_ai.tool.call.result"))
+    expect(result.length).toBeLessThan(150_000)
+    expect(result).toContain("[latitude: truncated")
+    expect(getAttr(toolSpan.attributes, "latitude.truncation")).toContain("tool result clamped")
+    expect(JSON.stringify(toolSpan).length).toBeLessThan(200_000)
+  })
+
+  it("drops oldest input messages on oversized llm_request spans, keeping valid JSON", () => {
+    const history: Turn[] = Array.from({ length: 50 }, (_, i) =>
+      baseTurn({
+        userText: `prompt ${i} ${"h".repeat(10_000)}`,
+        assistantText: `answer ${i} ${"a".repeat(10_000)}`,
+        messageId: `msg_h${i}`,
+      }),
+    )
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 51,
+      turns: [baseTurn({ userText: "latest question", assistantText: "latest answer", messageId: "msg_new" })],
+      conversationHistory: history,
+    })
+    const llm = unwrap(otlpSpans(req).find((s) => s.name === "llm_request"))
+    const inputJson = unwrap(getAttr(llm.attributes, "gen_ai.input.messages"))
+    expect(inputJson.length).toBeLessThanOrEqual(64 * 1024)
+    const messages = JSON.parse(inputJson) as Array<{ role: string; parts: Array<{ content?: string }> }>
+    // The tail (current prompt) survives; the oldest history is what gets dropped.
+    const last = unwrap(messages[messages.length - 1])
+    expect(JSON.stringify(last)).toContain("latest question")
+    expect(getAttr(llm.attributes, "latitude.truncation")).toContain("dropped")
+    expect(JSON.stringify(llm).length).toBeLessThan(256 * 1024)
+  })
+
+  it("clamps oversized user prompts on the interaction span", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 1,
+      turns: [baseTurn({ userText: "p".repeat(200_000) })],
+    })
+    const interaction = unwrap(otlpSpans(req).find((s) => s.name === "interaction"))
+    const prompt = unwrap(getAttr(interaction.attributes, "user_prompt"))
+    expect(prompt.length).toBeLessThan(70_000)
+    // The original length is preserved for analytics even when the text is clamped.
+    expect(getAttr(interaction.attributes, "user_prompt_length")).toBe("200000")
+    expect(getAttr(interaction.attributes, "latitude.truncation")).toBe("user prompt clamped")
+  })
+})
+
+describe("chunkOtlpRequest", () => {
+  it("returns the original request when it fits the budget", () => {
+    const req = buildOtlpRequest({ sessionId: "sess-chunk", turnStartNumber: 1, turns: [baseTurn()] })
+    const chunks = chunkOtlpRequest(req)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toBe(req)
+  })
+
+  it("splits oversized batches preserving every span, order, and the envelope", () => {
+    const turns = Array.from({ length: 10 }, (_, i) =>
+      baseTurn({
+        userText: `turn ${i}`,
+        assistantText: "b".repeat(30_000),
+        messageId: `msg_c${i}`,
+      }),
+    )
+    const req = buildOtlpRequest({ sessionId: "sess-chunk", turnStartNumber: 1, turns })
+    const all = otlpSpans(req)
+    const chunks = chunkOtlpRequest(req, 100_000)
+    expect(chunks.length).toBeGreaterThan(1)
+
+    const reassembled = chunks.flatMap((c) => otlpSpans(c))
+    expect(reassembled.map((s) => s.spanId)).toEqual(all.map((s) => s.spanId))
+    for (const chunk of chunks) {
+      // Multi-span chunks respect the budget; a lone span bigger than the budget
+      // still ships (in its own chunk) rather than being dropped.
+      if (otlpSpans(chunk).length > 1) {
+        expect(JSON.stringify(chunk).length).toBeLessThanOrEqual(100_000)
+      }
+      const rs = unwrap(chunk.resourceSpans[0])
+      expect(rs.resource).toEqual(unwrap(req.resourceSpans[0]).resource)
+      expect(unwrap(rs.scopeSpans[0]).scope).toEqual(unwrap(unwrap(req.resourceSpans[0]).scopeSpans[0]).scope)
+    }
+  })
+
+  it("gives a span larger than the budget its own chunk instead of dropping it", () => {
+    const turns = [
+      baseTurn({ userText: "small", messageId: "msg_s" }),
+      baseTurn({ userText: "big", assistantText: "z".repeat(50_000), messageId: "msg_b" }),
+    ]
+    const req = buildOtlpRequest({ sessionId: "sess-chunk", turnStartNumber: 1, turns })
+    const all = otlpSpans(req)
+    const chunks = chunkOtlpRequest(req, 10_000)
+    const reassembled = chunks.flatMap((c) => otlpSpans(c))
+    expect(reassembled.map((s) => s.spanId)).toEqual(all.map((s) => s.spanId))
   })
 })

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -16,6 +16,26 @@ import type {
 const SCOPE_NAME = "@latitude-data/claude-code-telemetry"
 const SCOPE_VERSION = "0.0.1"
 
+// Byte budgets (JSON string length as a proxy for bytes — the payload is almost
+// entirely ASCII). A long agentic turn can contain hundreds of LLM calls, each
+// embedding the full conversation context; on real sessions that produced single
+// POSTs of 130-340 MB, which can neither finish uploading inside the client
+// timeout nor pass the ingest rate limit (64 MB/min), so the whole turn was lost.
+// Spans under SPAN_BYTE_BUDGET are emitted untouched; oversized spans get their
+// bulkiest attributes truncated, lowest-value content first. The per-attribute
+// caps below sum to roughly SPAN_BYTE_BUDGET.
+const SPAN_BYTE_BUDGET = 128 * 1024
+const INPUT_MESSAGES_CAP = 64 * 1024
+const OUTPUT_MESSAGES_CAP = 32 * 1024
+const SYSTEM_CAP = 16 * 1024
+const TOOL_DEFS_CAP = 16 * 1024
+const TOOL_ARGS_CAP = 16 * 1024
+const USER_PROMPT_CAP = 64 * 1024
+// Each POST is kept under this size so it completes well inside the client
+// timeout even on modest uplinks; one logical trace may span several POSTs
+// (the server groups spans by trace_id, so splitting is transparent).
+const POST_BYTE_BUDGET = 3 * 1024 * 1024
+
 export function buildOtlpRequest(opts: {
   sessionId: string
   userId?: string | undefined
@@ -105,6 +125,7 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
   const durationMs = Math.max(0, turn.endMs - turn.startMs)
   const callCount = turn.calls.length
   const totalToolCalls = turn.calls.reduce((sum, c) => sum + c.toolUses.length, 0)
+  const promptText = clamp(turn.userText, USER_PROMPT_CAP)
 
   const interactionSpan: OtlpSpan = {
     traceId,
@@ -119,14 +140,15 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
       str("interaction.kind", isSubagent ? "subagent" : "user"),
       str("session.id", sessionId),
       userId ? str("user.id", userId) : undefined,
-      str("user_prompt", turn.userText),
+      str("user_prompt", promptText),
       int("user_prompt_length", turn.userText.length),
       int("interaction.duration_ms", durationMs),
       int("interaction.call_count", callCount),
       int("interaction.tool_call_count", totalToolCalls),
       turnNum !== undefined ? int("turn.number", turnNum) : undefined,
       isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
-      str("gen_ai.input.messages", JSON.stringify([messagePart("user", turn.userText)])),
+      str("gen_ai.input.messages", JSON.stringify([messagePart("user", promptText)])),
+      promptText.length < turn.userText.length ? str("latitude.truncation", "user prompt clamped") : undefined,
       // Diagnostic: per-interaction snapshot of what the hook saw from the intercept.
       // Shows up in the Latitude UI so users can see exactly why llm_request.captured
       // did or didn't land on a given trace.
@@ -168,8 +190,12 @@ function emitCallAndTools(out: OtlpSpan[], ctx: TreeCtx, call: AssistantCall, ca
     : buildCallInputMessages({ callIdx, priorTurns: ctx.priorTurns, turn })
   const outputMessages = [assistantMessageFromCall(call)]
 
-  const systemAttr = captured?.system ? buildSystemInstructions(captured.system) : undefined
-  const toolDefsAttr = captured?.tools && captured.tools.length > 0 ? JSON.stringify(captured.tools) : undefined
+  const payloads = capLlmRequestPayload({
+    inputMessages,
+    outputMessages,
+    systemParts: captured?.system ? buildSystemParts(captured.system) : undefined,
+    toolDefs: captured?.tools && captured.tools.length > 0 ? captured.tools : undefined,
+  })
 
   const callSpan: OtlpSpan = {
     traceId,
@@ -212,10 +238,11 @@ function emitCallAndTools(out: OtlpSpan[], ctx: TreeCtx, call: AssistantCall, ca
         : undefined,
       str("success", "true"),
       isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
-      systemAttr ? str("gen_ai.system_instructions", systemAttr) : undefined,
-      toolDefsAttr ? str("gen_ai.tool.definitions", toolDefsAttr) : undefined,
-      str("gen_ai.input.messages", JSON.stringify(inputMessages)),
-      str("gen_ai.output.messages", JSON.stringify(outputMessages)),
+      payloads.systemJson ? str("gen_ai.system_instructions", payloads.systemJson) : undefined,
+      payloads.toolDefsJson ? str("gen_ai.tool.definitions", payloads.toolDefsJson) : undefined,
+      str("gen_ai.input.messages", payloads.inputJson),
+      str("gen_ai.output.messages", payloads.outputJson),
+      payloads.truncationNote ? str("latitude.truncation", payloads.truncationNote) : undefined,
       // Diagnostic: show the lookup outcome per span so it's visible in the UI.
       str("latitude.debug.lookup_message_id", call.messageId),
       str("latitude.debug.request_file_found", captured ? "true" : "false"),
@@ -269,6 +296,22 @@ function buildToolSpan(
   call: ToolCall,
   contextAttrs: OtlpKeyValue[],
 ): OtlpSpan {
+  let argsJson = safeJson(call.input)
+  let resultJson = call.output !== undefined ? safeJson(call.output) : undefined
+  let truncationNote: string | undefined
+  if (argsJson.length + (resultJson?.length ?? 0) > SPAN_BYTE_BUDGET) {
+    const notes: string[] = []
+    if (argsJson.length > TOOL_ARGS_CAP) {
+      argsJson = clamp(argsJson, TOOL_ARGS_CAP)
+      notes.push("tool arguments clamped")
+    }
+    const resultCap = SPAN_BYTE_BUDGET - TOOL_ARGS_CAP
+    if (resultJson !== undefined && resultJson.length > resultCap) {
+      resultJson = clamp(resultJson, resultCap)
+      notes.push("tool result clamped")
+    }
+    truncationNote = notes.join("; ") || undefined
+  }
   return {
     traceId,
     spanId,
@@ -284,8 +327,9 @@ function buildToolSpan(
       userId ? str("user.id", userId) : undefined,
       str("gen_ai.tool.name", call.name),
       str("gen_ai.tool.call.id", call.id),
-      str("gen_ai.tool.call.arguments", safeJson(call.input)),
-      call.output !== undefined ? str("gen_ai.tool.call.result", safeJson(call.output)) : undefined,
+      str("gen_ai.tool.call.arguments", argsJson),
+      resultJson !== undefined ? str("gen_ai.tool.call.result", resultJson) : undefined,
+      truncationNote ? str("latitude.truncation", truncationNote) : undefined,
       call.isError ? str("error.type", "tool_error") : undefined,
       bool("tool.is_error", call.isError === true),
       str("success", call.isError ? "false" : "true"),
@@ -355,16 +399,169 @@ function countCapturedCalls(turn: Turn, requestsByMessageId: Map<string, StoredR
   return turn.calls.reduce((sum, call) => sum + (requestsByMessageId.has(call.messageId) ? 1 : 0), 0)
 }
 
-function buildSystemInstructions(system: AnthropicSystem): string {
-  if (!system) return JSON.stringify([])
+function buildSystemParts(system: AnthropicSystem): MessagePart[] {
+  if (!system) return []
   if (typeof system === "string") {
-    return JSON.stringify([{ type: "text", content: system }])
+    return [{ type: "text", content: system }]
   }
-  const parts = system.map((block) => ({
+  return system.map((block) => ({
     type: "text",
     content: typeof block.text === "string" ? block.text : typeof block.content === "string" ? block.content : "",
   }))
-  return JSON.stringify(parts)
+}
+
+interface LlmRequestPayloads {
+  inputJson: string
+  outputJson: string
+  systemJson: string | undefined
+  toolDefsJson: string | undefined
+  truncationNote: string | undefined
+}
+
+function capLlmRequestPayload(args: {
+  inputMessages: Message[]
+  outputMessages: Message[]
+  systemParts: MessagePart[] | undefined
+  toolDefs: unknown[] | undefined
+}): LlmRequestPayloads {
+  let inputJson = JSON.stringify(args.inputMessages)
+  let outputJson = JSON.stringify(args.outputMessages)
+  let systemJson = args.systemParts ? JSON.stringify(args.systemParts) : undefined
+  let toolDefsJson = args.toolDefs ? JSON.stringify(args.toolDefs) : undefined
+
+  const total = inputJson.length + outputJson.length + (systemJson?.length ?? 0) + (toolDefsJson?.length ?? 0)
+  if (total <= SPAN_BYTE_BUDGET) {
+    return { inputJson, outputJson, systemJson, toolDefsJson, truncationNote: undefined }
+  }
+
+  const notes: string[] = []
+  if (args.toolDefs && toolDefsJson && toolDefsJson.length > TOOL_DEFS_CAP) {
+    const r = capArrayJson(args.toolDefs, TOOL_DEFS_CAP)
+    toolDefsJson = r.json
+    if (r.note) notes.push(`tool definitions: ${r.note}`)
+  }
+  if (args.systemParts && systemJson && systemJson.length > SYSTEM_CAP) {
+    const r = capPartsJson(args.systemParts, SYSTEM_CAP)
+    systemJson = r.json
+    if (r.note) notes.push(`system instructions: ${r.note}`)
+  }
+  if (outputJson.length > OUTPUT_MESSAGES_CAP) {
+    const r = capMessagesJson(args.outputMessages, OUTPUT_MESSAGES_CAP)
+    outputJson = r.json
+    if (r.note) notes.push(`output messages: ${r.note}`)
+  }
+  if (inputJson.length > INPUT_MESSAGES_CAP) {
+    const r = capMessagesJson(args.inputMessages, INPUT_MESSAGES_CAP)
+    inputJson = r.json
+    if (r.note) notes.push(`input messages: ${r.note}`)
+  }
+  return { inputJson, outputJson, systemJson, toolDefsJson, truncationNote: notes.join(" | ") || undefined }
+}
+
+interface CapResult {
+  json: string
+  note?: string
+}
+
+// Keeps the most recent messages that fit the budget — the tail (current prompt and
+// latest tool context) is what the UI shows first; older context is recoverable from
+// earlier llm_request spans of the same session. Always emits valid JSON.
+function capMessagesJson(messages: Message[], maxBytes: number): CapResult {
+  const full = JSON.stringify(messages)
+  if (full.length <= maxBytes) return { json: full }
+
+  let budget = maxBytes - 2 // surrounding brackets
+  let start = messages.length
+  while (start > 0) {
+    const last = messages[start - 1]
+    const cost = JSON.stringify(last).length + 1
+    if (cost > budget) break
+    budget -= cost
+    start--
+  }
+
+  const kept = messages.slice(start)
+  const notes: string[] = []
+  if (kept.length === 0) {
+    // Even the newest message alone exceeds the budget: shrink its parts instead.
+    const last = messages[messages.length - 1]
+    if (last) {
+      const perPart = Math.max(1024, Math.floor(maxBytes / Math.max(1, last.parts.length)) - 64)
+      kept.push({ ...last, parts: last.parts.map((p) => shrinkPart(p, perPart)) })
+      notes.push("shrunk oversized message parts")
+    }
+    start = messages.length - 1
+  }
+  if (start > 0) notes.push(`dropped ${start} oldest of ${messages.length} messages`)
+  return { json: JSON.stringify(kept), note: notes.join("; ") }
+}
+
+function capPartsJson(parts: MessagePart[], maxBytes: number): CapResult {
+  const full = JSON.stringify(parts)
+  if (full.length <= maxBytes) return { json: full }
+  const perPart = Math.max(512, Math.floor(maxBytes / Math.max(1, parts.length)) - 32)
+  return { json: JSON.stringify(parts.map((p) => shrinkPart(p, perPart))), note: `shrunk ${parts.length} part(s)` }
+}
+
+// Keeps whole leading entries that fit the budget. Used for tool definitions, where
+// each entry is self-contained and order carries no recency meaning.
+function capArrayJson(items: unknown[], maxBytes: number): CapResult {
+  const full = JSON.stringify(items)
+  if (full.length <= maxBytes) return { json: full }
+  let budget = maxBytes - 2
+  let end = 0
+  while (end < items.length) {
+    const cost = JSON.stringify(items[end]).length + 1
+    if (cost > budget) break
+    budget -= cost
+    end++
+  }
+  return { json: JSON.stringify(items.slice(0, end)), note: `kept ${end} of ${items.length} entries` }
+}
+
+function shrinkPart(part: MessagePart, maxBytes: number): MessagePart {
+  if (JSON.stringify(part).length <= maxBytes) return part
+  if (typeof part.content === "string") return { ...part, content: clamp(part.content, maxBytes) }
+  if ("response" in part) return { ...part, response: clamp(safeJson(part.response), maxBytes) }
+  if ("arguments" in part) return { ...part, arguments: { truncated: clamp(safeJson(part.arguments), maxBytes) } }
+  return part
+}
+
+function clamp(s: string, maxLength: number): string {
+  if (s.length <= maxLength) return s
+  return `${s.slice(0, maxLength)}… [latitude: truncated ${s.length - maxLength} chars]`
+}
+
+// Splits one export request into several, each under maxBytes when serialized, by
+// distributing spans across copies of the same resource/scope envelope. The server
+// groups spans by trace_id, so a trace arriving across multiple POSTs is assembled
+// identically to one arriving whole.
+export function chunkOtlpRequest(req: OtlpExportRequest, maxBytes = POST_BYTE_BUDGET): OtlpExportRequest[] {
+  const rs = req.resourceSpans[0]
+  const ss = rs?.scopeSpans[0]
+  if (!rs || !ss || req.resourceSpans.length !== 1 || rs.scopeSpans.length !== 1) return [req]
+
+  const wrap = (spans: OtlpSpan[]): OtlpExportRequest => ({
+    resourceSpans: [{ resource: rs.resource, scopeSpans: [{ scope: ss.scope, spans }] }],
+  })
+  const overhead = JSON.stringify(wrap([])).length
+
+  const batches: OtlpSpan[][] = []
+  let current: OtlpSpan[] = []
+  let size = overhead
+  for (const span of ss.spans) {
+    const cost = JSON.stringify(span).length + 1
+    if (current.length > 0 && size + cost > maxBytes) {
+      batches.push(current)
+      current = []
+      size = overhead
+    }
+    current.push(span)
+    size += cost
+  }
+  if (current.length > 0) batches.push(current)
+  if (batches.length <= 1) return [req]
+  return batches.map(wrap)
 }
 
 function convertAnthropicMessages(messages: AnthropicMessage[]): Message[] {

--- a/packages/telemetry/claude-code/src/state.ts
+++ b/packages/telemetry/claude-code/src/state.ts
@@ -6,6 +6,7 @@ import {
   openSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs"
@@ -16,6 +17,9 @@ const STATE_DIR = join(homedir(), ".claude", "state", "latitude")
 const STATE_FILE = join(STATE_DIR, "state.json")
 const LOCK_FILE = join(STATE_DIR, "state.lock")
 const LOCK_TIMEOUT_MS = 2_000
+// A hook killed mid-run (e.g. by Claude Code's hook timeout) leaves its lock file
+// behind; anything older than this is treated as abandoned and broken.
+const LOCK_STALE_MS = 10 * 60_000
 
 interface SessionState {
   offset: number
@@ -71,24 +75,36 @@ export async function withLock<T>(fn: () => Promise<T> | T): Promise<T | undefin
       fd = openSync(LOCK_FILE, "wx")
       break
     } catch {
+      breakStaleLock()
       await sleep(50)
     }
   }
   try {
     return await fn()
   } finally {
+    // Only release the lock we actually acquired — when the wait timed out and we
+    // proceeded anyway, the file belongs to another hook run still in flight.
     if (fd !== undefined) {
       try {
         closeSync(fd)
       } catch {
         // ignore
       }
+      try {
+        unlinkSync(LOCK_FILE)
+      } catch {
+        // already gone
+      }
     }
-    try {
-      unlinkSync(LOCK_FILE)
-    } catch {
-      // lock was never acquired or already gone
-    }
+  }
+}
+
+function breakStaleLock(): void {
+  try {
+    const age = Date.now() - statSync(LOCK_FILE).mtimeMs
+    if (age > LOCK_STALE_MS) unlinkSync(LOCK_FILE)
+  } catch {
+    // lock vanished between the failed acquire and now — fine
   }
 }
 


### PR DESCRIPTION
## what

The Claude Code Stop hook silently lost every long agentic turn. A 67-minute turn (223 LLM calls) from a real session produced a single OTLP POST of **132 MB** — too big to finish uploading inside the 10 s client timeout and over the ingest rate limit (64 MB/min) — and `postTraces` swallowed the failure while the hook advanced the transcript offset anyway, so the turn was never retried. Short turns always worked, which is why only long traces went missing from dashboards. Bumps `@latitude-data/claude-code-telemetry` to 0.0.8.

Measured on real transcripts (replaying them through the span builder): long sessions produced per-turn POSTs of 80–340 MB, and past a certain size `JSON.stringify` throws `RangeError: Invalid string length`, crashing the hook. Production Datadog shows 221 × 429 on `POST /v1/traces` in the last 14 days — every one silently discarded by clients.

## the fix

Three mechanisms, all client-side (no server changes):

**Offset advances only on confirmed delivery.** `postTraces` now returns success/failure and the transcript offset is saved only after every chunk of the batch lands with a 2xx. Failed exports retry on the next Stop. Retries are idempotent: span IDs are deterministic hashes and the `spans` table is a ReplacingMergeTree, so re-sent spans dedupe.

**Chunked exports.** `chunkOtlpRequest` splits a batch into POSTs of ≤3 MB by distributing spans across copies of the same resource/scope envelope. The server already groups spans by `trace_id`, so one trace arriving across several POSTs assembles identically. A lone span bigger than the budget ships in its own chunk rather than being dropped. Per-POST timeout goes from 10 s to 30 s — bounded body size makes the timeout meaningful again.

**Span size caps, applied only when exceeded.** The payload blowup is quadratic: every `llm_request` span embeds the full conversation that hit the API for that call. Spans under 128 KB — the overwhelming majority — are byte-identical to before. Oversized spans get their bulkiest attributes truncated, lowest-value first: repeated tool definitions, then system prompt, then oldest input messages (the tail with the current prompt and latest tool context always survives), then tool results. Truncation always yields valid JSON and stamps a `latitude.truncation` attribute on the span saying exactly what was cut. This also makes the stringify RangeError unreachable.

Also fixes state-lock handling: a hook run that failed to acquire the lock no longer deletes the lock file owned by a concurrent run, and locks abandoned by killed hooks are broken after 10 minutes.

## validation

- 12 new unit tests covering capping (untouched under budget, valid JSON after truncation, tail preservation) and chunking (span order/envelope preservation, oversized-span isolation).
- Replayed the real 67-minute turn through the fixed pipeline: 132 MB / 1 impossible POST → 15.5 MB / 6 POSTs of ≤3 MB, each delivering in 0.3–2.2 s against prod ingest. All 517 spans (including 6 stitched subagents) verified present in prod ClickHouse with the full 67.5-minute duration.

## follow-ups

- gzip on the export path would shrink these payloads ~10× more, but needs `Content-Encoding` support in `apps/ingest` deployed before clients can send it.
- The fix reaches `npx` users only after the package is published to npm.