### PR TITLE
feat(tools): error view breakdown and dashboard feedback fixes

### DIFF
--- a/apps/web/src/domains/tools/tools.collection.ts
+++ b/apps/web/src/domains/tools/tools.collection.ts
@@ -8,6 +8,7 @@ import {
   getToolCallHistogram,
   getToolContextBreakdown,
   getToolCoOccurrence,
+  getToolErrorBreakdown,
   getToolParameterStats,
   listProjectTools,
   listRecentToolCalls,
@@ -203,6 +204,34 @@ export function useToolCoOccurrence({
           toolName,
           ...range,
           ...(errorsOnly === undefined ? {} : { errorsOnly }),
+        },
+      }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0 && toolName.length > 0,
+  })
+}
+
+export function useToolErrorBreakdown({
+  projectId,
+  toolName,
+  range,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly toolName: string
+  readonly range: ToolsTimeRange
+  readonly enabled?: boolean
+}) {
+  const scope = use(TraceScopeContext)
+  return useQuery({
+    queryKey: [...traceScopeKey(scope), "tools-error-breakdown", projectId, toolName, range],
+    queryFn: () =>
+      getToolErrorBreakdown({
+        data: {
+          ...traceScopeData(scope),
+          projectId,
+          toolName,
+          ...range,
         },
       }),
     staleTime: 30_000,

--- a/apps/web/src/domains/tools/tools.functions.ts
+++ b/apps/web/src/domains/tools/tools.functions.ts
@@ -6,6 +6,7 @@ import type {
   ToolContextBreakdownRow,
   ToolCoOccurrenceRow,
   ToolDefinitionDetail,
+  ToolErrorBreakdownRow,
   ToolParameterStatsResult,
   ToolSummary,
   ToolsAnalyticsTotals,
@@ -310,6 +311,27 @@ export const getToolCoOccurrence = createServerFn({ method: "GET" })
           toolName: data.toolName,
           ...(data.limit === undefined ? {} : { limit: data.limit }),
           ...(data.errorsOnly === undefined ? {} : { errorsOnly: data.errorsOnly }),
+        })
+      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+export const getToolErrorBreakdown = createServerFn({ method: "GET" })
+  .inputValidator(
+    toolsScopeSchema.extend({
+      toolName: toolNameSchema,
+      limit: z.number().int().min(1).max(50).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly ToolErrorBreakdownRow[]> => {
+    const orgId = await resolveOrgScope(data)
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ToolAnalyticsRepository
+        return yield* repo.getToolErrorBreakdown({
+          ...toScope(orgId, data),
+          toolName: data.toolName,
+          ...(data.limit === undefined ? {} : { limit: data.limit }),
         })
       }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
@@ -3,6 +3,7 @@ import { formatDuration } from "@repo/utils"
 import { useMemo } from "react"
 import { type ToolsTimeRange, useToolCallHistogram } from "../../../../../../../domains/tools/tools.collection.ts"
 import { formatBucketLabel, TOOL_DETAIL_ROW_GRID } from "../../-components/tool-formatters.ts"
+import { ToolErrorBreakdown } from "./tool-error-breakdown.tsx"
 
 const OK_CALLS_COLOR = "hsl(217 91% 60%)"
 const FAILED_CALLS_COLOR = "hsl(0 70% 55%)"
@@ -44,12 +45,15 @@ export function ToolActivityRow({
   range,
   bucketSeconds,
   errorsOnly,
+  failedCalls,
 }: {
   readonly projectId: string
   readonly toolName: string
   readonly range: ToolsTimeRange
   readonly bucketSeconds: number
   readonly errorsOnly: boolean
+  /** Total failed calls in the window — the error breakdown's denominator. */
+  readonly failedCalls: number
 }) {
   const { data: histogram = [], isLoading } = useToolCallHistogram({
     projectId,
@@ -151,21 +155,22 @@ export function ToolActivityRow({
           ariaLabel={`Calls of ${toolName} over time`}
         />
       </ChartPanel>
-      <ChartPanel
-        title={errorsOnly ? "Latency of failed calls" : "Latency over time"}
-        isLoading={isLoading}
-        isEmpty={isEmpty}
-        emptyLabel={emptyLabel}
-      >
-        <Chart
-          categories={categories}
-          series={latencySeries}
-          height={200}
-          xAxisLabelFontSize={10}
-          tooltipTitle={latencyTooltipTitle}
-          ariaLabel={`p50 latency of ${toolName} over time`}
-        />
-      </ChartPanel>
+      {errorsOnly ? (
+        // Error view swaps the latency chart for the error breakdown — failed
+        // calls' latency is already in the Usage row's Duration tile.
+        <ToolErrorBreakdown projectId={projectId} toolName={toolName} range={range} failedCalls={failedCalls} />
+      ) : (
+        <ChartPanel title="Latency over time" isLoading={isLoading} isEmpty={isEmpty} emptyLabel={emptyLabel}>
+          <Chart
+            categories={categories}
+            series={latencySeries}
+            height={200}
+            xAxisLabelFontSize={10}
+            tooltipTitle={latencyTooltipTitle}
+            ariaLabel={`p50 latency of ${toolName} over time`}
+          />
+        </ChartPanel>
+      )}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
@@ -52,7 +52,6 @@ export function ToolActivityRow({
   readonly range: ToolsTimeRange
   readonly bucketSeconds: number
   readonly errorsOnly: boolean
-  /** Total failed calls in the window — the error breakdown's denominator. */
   readonly failedCalls: number
 }) {
   const { data: histogram = [], isLoading } = useToolCallHistogram({
@@ -156,8 +155,6 @@ export function ToolActivityRow({
         />
       </ChartPanel>
       {errorsOnly ? (
-        // Error view swaps the latency chart for the error breakdown — failed
-        // calls' latency is already in the Usage row's Duration tile.
         <ToolErrorBreakdown projectId={projectId} toolName={toolName} range={range} failedCalls={failedCalls} />
       ) : (
         <ChartPanel title="Latency over time" isLoading={isLoading} isEmpty={isEmpty} emptyLabel={emptyLabel}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-activity-row.tsx
@@ -2,7 +2,7 @@ import { Chart, type ChartSeries, HistogramSkeleton, Text } from "@repo/ui"
 import { formatDuration } from "@repo/utils"
 import { useMemo } from "react"
 import { type ToolsTimeRange, useToolCallHistogram } from "../../../../../../../domains/tools/tools.collection.ts"
-import { formatBucketLabel } from "../../-components/tool-formatters.ts"
+import { formatBucketLabel, TOOL_DETAIL_ROW_GRID } from "../../-components/tool-formatters.ts"
 
 const OK_CALLS_COLOR = "hsl(217 91% 60%)"
 const FAILED_CALLS_COLOR = "hsl(0 70% 55%)"
@@ -14,18 +14,16 @@ function ChartPanel({
   isLoading,
   isEmpty,
   emptyLabel,
-  className,
   children,
 }: {
   readonly title: string
   readonly isLoading: boolean
   readonly isEmpty: boolean
   readonly emptyLabel: string
-  readonly className?: string
   readonly children: React.ReactNode
 }) {
   return (
-    <div className={`flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4 ${className ?? ""}`}>
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4">
       <Text.H6 color="foregroundMuted">{title}</Text.H6>
       {isLoading ? (
         <HistogramSkeleton height={200} />
@@ -138,13 +136,12 @@ export function ToolActivityRow({
   )
 
   return (
-    <div className="flex flex-col gap-4 xl:flex-row xl:items-stretch">
+    <div className={TOOL_DETAIL_ROW_GRID}>
       <ChartPanel
         title={errorsOnly ? "Failed calls over time" : "Calls over time"}
         isLoading={isLoading}
         isEmpty={isEmpty}
         emptyLabel={emptyLabel}
-        className="xl:flex-1"
       >
         <Chart
           categories={categories}
@@ -159,7 +156,6 @@ export function ToolActivityRow({
         isLoading={isLoading}
         isEmpty={isEmpty}
         emptyLabel={emptyLabel}
-        className="xl:w-[420px]"
       >
         <Chart
           categories={categories}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-context-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-context-panel.tsx
@@ -8,7 +8,7 @@ import {
   useToolContextBreakdown,
   useToolCoOccurrence,
 } from "../../../../../../../domains/tools/tools.collection.ts"
-import { formatPercent } from "../../-components/tool-formatters.ts"
+import { formatPercent, TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
 
 const MAX_ROWS_PER_SECTION = 5
 
@@ -86,7 +86,9 @@ export function ToolContextPanel({
   const tracesNoun = errorsOnly ? "traces where it failed" : "traces calling it"
 
   return (
-    <div className="flex min-w-0 flex-col gap-4 overflow-y-auto rounded-lg bg-secondary p-4 xl:max-h-[420px] xl:w-[340px]">
+    <div
+      className={`flex min-w-0 flex-col gap-4 overflow-y-auto rounded-lg bg-secondary p-4 ${TOOL_DETAIL_PANEL_MAX_HEIGHT}`}
+    >
       <Text.H6 color="foregroundMuted">{errorsOnly ? "Where it fails" : "Where it's used"}</Text.H6>
       {coOccurrenceLoading ? (
         <div className="flex flex-col gap-2">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
@@ -1,11 +1,7 @@
 import { Button, Modal, Text, useMountEffect } from "@repo/ui"
 import { useRef, useState } from "react"
 
-// Tool descriptions are prompt content, so providers put no bound on their
-// length. Clamp the header to two lines and offer the full text in a modal —
-// the "Show more" trigger only appears when the text actually overflows the
-// clamp, measured on the rendered element (a character threshold would
-// misjudge depending on viewport width).
+// Tool descriptions are prompt content — providers put no bound on their length.
 export function ToolDescription({
   toolName,
   description,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
@@ -1,7 +1,6 @@
 import { Button, Modal, Text, useMountEffect } from "@repo/ui"
 import { useRef, useState } from "react"
 
-// Tool descriptions are prompt content — providers put no bound on their length.
 export function ToolDescription({
   toolName,
   description,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-description.tsx
@@ -1,0 +1,50 @@
+import { Button, Modal, Text, useMountEffect } from "@repo/ui"
+import { useRef, useState } from "react"
+
+// Tool descriptions are prompt content, so providers put no bound on their
+// length. Clamp the header to two lines and offer the full text in a modal —
+// the "Show more" trigger only appears when the text actually overflows the
+// clamp, measured on the rendered element (a character threshold would
+// misjudge depending on viewport width).
+export function ToolDescription({
+  toolName,
+  description,
+}: {
+  readonly toolName: string
+  readonly description: string
+}) {
+  const textRef = useRef<HTMLHeadingElement>(null)
+  const [overflowing, setOverflowing] = useState(false)
+  const [open, setOpen] = useState(false)
+
+  useMountEffect(() => {
+    const element = textRef.current
+    if (!element) return
+    // +1 tolerates subpixel rounding between scrollHeight and clientHeight.
+    const measure = () => setOverflowing(element.scrollHeight > element.clientHeight + 1)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  })
+
+  return (
+    <div className="flex min-w-0 flex-col items-start">
+      <Text.H5 ref={textRef} color="foregroundMuted" lineClamp={2}>
+        {description}
+      </Text.H5>
+      {overflowing ? (
+        <>
+          <Button variant="link" size="sm" className="px-0" onClick={() => setOpen(true)}>
+            Show more
+          </Button>
+          <Modal open={open} onOpenChange={setOpen} dismissible title={toolName} description="Tool description">
+            <Text.H5 color="foregroundMuted" whiteSpace="preWrap">
+              {description}
+            </Text.H5>
+          </Modal>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
@@ -1,0 +1,82 @@
+import { CopyableText, Skeleton, Status, Text } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { type ToolsTimeRange, useToolErrorBreakdown } from "../../../../../../../domains/tools/tools.collection.ts"
+import { TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
+import { ValueBar } from "./value-bar.tsx"
+
+// Takes the latency chart's slot in error view: failed-call latency already
+// lives in the Usage row's Duration tile, while "what is failing" has no
+// other home on the page. Rows are clusters of normalized error outputs with
+// a verbatim sample each; "Other" covers clusters past the server's top-N so
+// the bars always account for every failed call.
+export function ToolErrorBreakdown({
+  projectId,
+  toolName,
+  range,
+  failedCalls,
+}: {
+  readonly projectId: string
+  readonly toolName: string
+  readonly range: ToolsTimeRange
+  /** Total failed calls in the window (the bars' denominator). */
+  readonly failedCalls: number
+}) {
+  const { data: rows = [], isLoading } = useToolErrorBreakdown({ projectId, toolName, range })
+  const counted = rows.reduce((sum, row) => sum + row.calls, 0)
+  // The total comes from a separate query; never let "Other" go negative.
+  const total = Math.max(failedCalls, counted)
+  const other = total - counted
+
+  return (
+    <div className={`flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4 ${TOOL_DETAIL_PANEL_MAX_HEIGHT}`}>
+      <Text.H6 color="foregroundMuted">Common errors</Text.H6>
+      {isLoading ? (
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-5 w-1/2" />
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <Text.H6 color="foregroundMuted">No failed calls in this time window</Text.H6>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+          {rows.map((row) => (
+            <div key={row.key} className="flex flex-col gap-1">
+              <div className="flex min-w-0 flex-row items-center gap-2">
+                {row.sample ? (
+                  <div className="min-w-0 flex-1">
+                    <CopyableText value={row.sample} size="sm" ellipsis tooltip="Copy error output" />
+                  </div>
+                ) : (
+                  <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
+                    No error output
+                  </Text.H6>
+                )}
+                {row.errorType ? <Status variant="destructive" label={row.errorType} indicator={false} /> : null}
+                <Text.H6 color="foreground" className="shrink-0 tabular-nums">
+                  {formatCount(row.calls)}
+                </Text.H6>
+              </div>
+              <ValueBar fraction={total > 0 ? row.calls / total : 0} tone="destructive" />
+            </div>
+          ))}
+          {other > 0 ? (
+            <div className="flex flex-col gap-1">
+              <div className="flex min-w-0 flex-row items-center gap-2">
+                <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
+                  Other
+                </Text.H6>
+                <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
+                  {formatCount(other)}
+                </Text.H6>
+              </div>
+              <ValueBar fraction={total > 0 ? other / total : 0} muted />
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
@@ -4,8 +4,6 @@ import { type ToolsTimeRange, useToolErrorBreakdown } from "../../../../../../..
 import { TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
 import { ValueBar } from "./value-bar.tsx"
 
-// Takes the latency chart's slot in error view — failed-call latency already
-// lives in the Usage row's Duration tile.
 export function ToolErrorBreakdown({
   projectId,
   toolName,
@@ -15,12 +13,10 @@ export function ToolErrorBreakdown({
   readonly projectId: string
   readonly toolName: string
   readonly range: ToolsTimeRange
-  /** Total failed calls in the window — the bars' denominator. */
   readonly failedCalls: number
 }) {
   const { data: rows = [], isLoading } = useToolErrorBreakdown({ projectId, toolName, range })
   const counted = rows.reduce((sum, row) => sum + row.calls, 0)
-  // failedCalls comes from a separate query; never let "Other" go negative.
   const total = Math.max(failedCalls, counted)
   const other = total - counted
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-error-breakdown.tsx
@@ -4,11 +4,8 @@ import { type ToolsTimeRange, useToolErrorBreakdown } from "../../../../../../..
 import { TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
 import { ValueBar } from "./value-bar.tsx"
 
-// Takes the latency chart's slot in error view: failed-call latency already
-// lives in the Usage row's Duration tile, while "what is failing" has no
-// other home on the page. Rows are clusters of normalized error outputs with
-// a verbatim sample each; "Other" covers clusters past the server's top-N so
-// the bars always account for every failed call.
+// Takes the latency chart's slot in error view — failed-call latency already
+// lives in the Usage row's Duration tile.
 export function ToolErrorBreakdown({
   projectId,
   toolName,
@@ -18,12 +15,12 @@ export function ToolErrorBreakdown({
   readonly projectId: string
   readonly toolName: string
   readonly range: ToolsTimeRange
-  /** Total failed calls in the window (the bars' denominator). */
+  /** Total failed calls in the window — the bars' denominator. */
   readonly failedCalls: number
 }) {
   const { data: rows = [], isLoading } = useToolErrorBreakdown({ projectId, toolName, range })
   const counted = rows.reduce((sum, row) => sum + row.calls, 0)
-  // The total comes from a separate query; never let "Other" go negative.
+  // failedCalls comes from a separate query; never let "Other" go negative.
   const total = Math.max(failedCalls, counted)
   const other = total - counted
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-neighbor-nav.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-neighbor-nav.tsx
@@ -1,10 +1,57 @@
 import { Button, Tooltip } from "@repo/ui"
-import { useHotkeys } from "@tanstack/react-hotkeys"
-import { useNavigate } from "@tanstack/react-router"
+import { type RegisterableHotkey, useHotkeys } from "@tanstack/react-hotkeys"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { ArrowDownIcon, ArrowUpIcon } from "lucide-react"
-import { useMemo } from "react"
+import { type ReactNode, useMemo } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { type ToolsTimeRange, useProjectTools } from "../../../../../../../domains/tools/tools.collection.ts"
+
+/**
+ * Real link when a neighbor exists (href, cmd/middle-click), disabled button
+ * otherwise. The search params carry over so the error view and the selected
+ * time range survive paging between tools. The Tooltip wraps the Button
+ * directly — a wrapper component in between would swallow the trigger props
+ * Tooltip injects via asChild.
+ */
+function NeighborButton({
+  projectSlug,
+  target,
+  label,
+  hotkey,
+  children,
+}: {
+  readonly projectSlug: string
+  readonly target: string | undefined
+  readonly label: string
+  readonly hotkey: RegisterableHotkey
+  readonly children: ReactNode
+}) {
+  return (
+    <Tooltip
+      asChild
+      side="bottom"
+      trigger={
+        target ? (
+          <Button asChild variant="ghost" className="h-8 w-8 p-0" aria-label={label}>
+            <Link
+              to="/projects/$projectSlug/tools/$toolName"
+              params={{ projectSlug, toolName: target }}
+              search={(prev) => prev}
+            >
+              {children}
+            </Link>
+          </Button>
+        ) : (
+          <Button variant="ghost" className="h-8 w-8 p-0" disabled type="button" aria-label={label}>
+            {children}
+          </Button>
+        )
+      }
+    >
+      {label} <HotkeyBadge hotkey={hotkey} />
+    </Tooltip>
+  )
+}
 
 // J/K hotkeys are suppressed while a trace sheet is open so paging a trace
 // never swaps the tool.
@@ -41,9 +88,14 @@ export function ToolNeighborNav({
     }
   }, [analytics, toolName])
 
+  // Hotkeys are programmatic navigation — the buttons themselves are Links.
   const goToTool = (target: string | undefined) => {
     if (!target) return
-    void navigate({ to: "/projects/$projectSlug/tools/$toolName", params: { projectSlug, toolName: target } })
+    void navigate({
+      to: "/projects/$projectSlug/tools/$toolName",
+      params: { projectSlug, toolName: target },
+      search: (prev: Record<string, unknown>) => prev,
+    })
   }
 
   useHotkeys([
@@ -61,42 +113,12 @@ export function ToolNeighborNav({
 
   return (
     <>
-      <Tooltip
-        asChild
-        side="bottom"
-        trigger={
-          <Button
-            variant="ghost"
-            className="h-8 w-8 p-0"
-            disabled={!prevName}
-            onClick={() => goToTool(prevName)}
-            type="button"
-            aria-label="Previous tool"
-          >
-            <ArrowUpIcon className="h-4 w-4 text-muted-foreground" />
-          </Button>
-        }
-      >
-        Previous tool <HotkeyBadge hotkey="K" />
-      </Tooltip>
-      <Tooltip
-        asChild
-        side="bottom"
-        trigger={
-          <Button
-            variant="ghost"
-            className="h-8 w-8 p-0"
-            disabled={!nextName}
-            onClick={() => goToTool(nextName)}
-            type="button"
-            aria-label="Next tool"
-          >
-            <ArrowDownIcon className="h-4 w-4 text-muted-foreground" />
-          </Button>
-        }
-      >
-        Next tool <HotkeyBadge hotkey="J" />
-      </Tooltip>
+      <NeighborButton projectSlug={projectSlug} target={prevName} label="Previous tool" hotkey="K">
+        <ArrowUpIcon className="h-4 w-4 text-muted-foreground" />
+      </NeighborButton>
+      <NeighborButton projectSlug={projectSlug} target={nextName} label="Next tool" hotkey="J">
+        <ArrowDownIcon className="h-4 w-4 text-muted-foreground" />
+      </NeighborButton>
     </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-neighbor-nav.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-neighbor-nav.tsx
@@ -6,13 +6,8 @@ import { type ReactNode, useMemo } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { type ToolsTimeRange, useProjectTools } from "../../../../../../../domains/tools/tools.collection.ts"
 
-/**
- * Real link when a neighbor exists (href, cmd/middle-click), disabled button
- * otherwise. The search params carry over so the error view and the selected
- * time range survive paging between tools. The Tooltip wraps the Button
- * directly — a wrapper component in between would swallow the trigger props
- * Tooltip injects via asChild.
- */
+// The Tooltip must wrap the Button directly — a component in between would
+// swallow the trigger props Tooltip injects via asChild.
 function NeighborButton({
   projectSlug,
   target,
@@ -88,7 +83,6 @@ export function ToolNeighborNav({
     }
   }, [analytics, toolName])
 
-  // Hotkeys are programmatic navigation — the buttons themselves are Links.
   const goToTool = (target: string | undefined) => {
     if (!target) return
     void navigate({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
@@ -4,6 +4,7 @@ import { ChevronRightIcon, InfoIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { type ToolsTimeRange, useToolParameterStats } from "../../../../../../../domains/tools/tools.collection.ts"
 import { TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
+import { ValueBar } from "./value-bar.tsx"
 
 interface DefinedParameter {
   readonly type: string
@@ -66,17 +67,6 @@ interface MergedParameter {
   /** Sampled calls whose input contains this parameter. */
   readonly observed: number
   readonly topValues: readonly { readonly value: string; readonly count: number }[]
-}
-
-function ValueBar({ fraction, muted }: { readonly fraction: number; readonly muted?: boolean }) {
-  return (
-    <div className="relative h-2 w-full overflow-hidden rounded bg-muted">
-      <div
-        className={`absolute inset-y-0 left-0 rounded ${muted ? "bg-muted-foreground/40" : "bg-primary/70"}`}
-        style={{ width: `${Math.min(100, Math.max(2, fraction * 100))}%` }}
-      />
-    </div>
-  )
 }
 
 function ParameterBadges({ defined }: { readonly defined: DefinedParameter | undefined }) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
@@ -183,8 +183,7 @@ export function ToolParametersExplorer({
       ? selectedName
       : parameters[0]?.name
   const active = parameters.find((parameter) => parameter.name === activeName)
-  // With a single parameter there is nothing to select — skip the
-  // master-detail split so the lone entry doesn't render as a pressed button.
+  // A single parameter has nothing to select — skip the master-detail split.
   const single = parameters.length === 1 ? parameters[0] : undefined
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
@@ -183,7 +183,6 @@ export function ToolParametersExplorer({
       ? selectedName
       : parameters[0]?.name
   const active = parameters.find((parameter) => parameter.name === activeName)
-  // A single parameter has nothing to select — skip the master-detail split.
   const single = parameters.length === 1 ? parameters[0] : undefined
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
@@ -79,6 +79,78 @@ function ValueBar({ fraction, muted }: { readonly fraction: number; readonly mut
   )
 }
 
+function ParameterBadges({ defined }: { readonly defined: DefinedParameter | undefined }) {
+  if (!defined) return null
+  return (
+    <>
+      {defined.type ? (
+        defined.options.length > 0 ? (
+          <Tooltip asChild trigger={<Status variant="neutral" label={defined.type} indicator={false} />}>
+            <div className="flex flex-col gap-0.5">
+              <Text.H6 color="foregroundMuted">Allowed values</Text.H6>
+              {defined.options.map((option) => (
+                <Text.H6B key={option} className="font-mono">
+                  {option}
+                </Text.H6B>
+              ))}
+            </div>
+          </Tooltip>
+        ) : (
+          <Status variant="neutral" label={defined.type} indicator={false} />
+        )
+      ) : null}
+      {defined.description || defined.required ? (
+        <Tooltip asChild trigger={<InfoIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}>
+          <div className="flex max-w-72 flex-col gap-0.5">
+            {defined.description ? <Text.H6>{defined.description}</Text.H6> : null}
+            {defined.required ? <Text.H6 color="foregroundMuted">Required</Text.H6> : null}
+          </div>
+        </Tooltip>
+      ) : null}
+    </>
+  )
+}
+
+function ParameterValues({
+  parameter,
+  sampleSize,
+}: {
+  readonly parameter: MergedParameter
+  readonly sampleSize: number
+}) {
+  const notIncluded = Math.max(0, sampleSize - parameter.observed)
+  return (
+    <>
+      {parameter.topValues.map((value) => (
+        <div key={value.value} className="flex flex-col gap-1">
+          <div className="flex min-w-0 flex-row items-center gap-2">
+            <div className="min-w-0 flex-1">
+              <CopyableText value={value.value} size="sm" ellipsis tooltip="Copy value" />
+            </div>
+            <Text.H6 color="foreground" className="shrink-0 tabular-nums">
+              {formatCount(value.count)}
+            </Text.H6>
+          </div>
+          <ValueBar fraction={value.count / sampleSize} />
+        </div>
+      ))}
+      {notIncluded > 0 ? (
+        <div className="flex flex-col gap-1">
+          <div className="flex min-w-0 flex-row items-center gap-2">
+            <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
+              Not included
+            </Text.H6>
+            <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
+              {formatCount(notIncluded)}
+            </Text.H6>
+          </div>
+          <ValueBar fraction={notIncluded / sampleSize} muted />
+        </div>
+      ) : null}
+    </>
+  )
+}
+
 // "Not included" counts the sampled calls that omit a parameter, so
 // defined-but-never-sent parameters read as "Not included · 100%".
 export function ToolParametersExplorer({
@@ -121,7 +193,9 @@ export function ToolParametersExplorer({
       ? selectedName
       : parameters[0]?.name
   const active = parameters.find((parameter) => parameter.name === activeName)
-  const notIncluded = active ? Math.max(0, sampleSize - active.observed) : 0
+  // With a single parameter there is nothing to select — skip the
+  // master-detail split so the lone entry doesn't render as a pressed button.
+  const single = parameters.length === 1 ? parameters[0] : undefined
 
   return (
     <div className={`flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4 ${TOOL_DETAIL_PANEL_MAX_HEIGHT}`}>
@@ -145,6 +219,24 @@ export function ToolParametersExplorer({
             {errorsOnly ? "No parameters recorded on failed calls" : "No parameters defined or recorded"}
           </Text.H6>
         </div>
+      ) : single ? (
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <div className="flex flex-row items-center gap-1.5">
+            <Text.H6 color="foreground" className="min-w-0 truncate font-mono">
+              {single.name}
+            </Text.H6>
+            <ParameterBadges defined={single.defined} />
+          </div>
+          {sampleSize === 0 ? (
+            <Text.H6 color="foregroundMuted">
+              {errorsOnly ? "No failed calls in this window." : "No calls in this window."}
+            </Text.H6>
+          ) : (
+            <div className="flex min-h-0 min-w-0 flex-col gap-2 overflow-y-auto">
+              <ParameterValues parameter={single} sampleSize={sampleSize} />
+            </div>
+          )}
+        </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-4 sm:flex-row">
           <div className="flex min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[280px] sm:w-[240px] sm:shrink-0 xl:max-h-none">
@@ -157,42 +249,20 @@ export function ToolParametersExplorer({
                   type="button"
                   onClick={() => setSelectedName(parameter.name)}
                   aria-pressed={isActive}
-                  className={`group flex flex-row items-center gap-1.5 rounded-md border px-2 py-1.5 text-left transition-colors ${
-                    isActive
-                      ? "border-border bg-background shadow-sm"
-                      : "border-transparent hover:border-border/60 hover:bg-background/60"
+                  className={`group relative flex flex-row items-center gap-1.5 rounded-md py-1.5 pl-3 pr-2 text-left transition-colors ${
+                    isActive ? "bg-background" : "hover:bg-background/60"
                   } ${isUnobserved ? "opacity-60" : ""}`}
                 >
+                  <span
+                    aria-hidden
+                    className={`absolute inset-y-1.5 left-1 w-0.5 rounded-full bg-primary ${
+                      isActive ? "opacity-100" : "opacity-0"
+                    }`}
+                  />
                   <Text.H6 color="foreground" className="min-w-0 flex-1 truncate font-mono">
                     {parameter.name}
                   </Text.H6>
-                  {parameter.defined?.type ? (
-                    parameter.defined.options.length > 0 ? (
-                      <Tooltip
-                        asChild
-                        trigger={<Status variant="neutral" label={parameter.defined.type} indicator={false} />}
-                      >
-                        <div className="flex flex-col gap-0.5">
-                          <Text.H6 color="foregroundMuted">Allowed values</Text.H6>
-                          {parameter.defined.options.map((option) => (
-                            <Text.H6B key={option} className="font-mono">
-                              {option}
-                            </Text.H6B>
-                          ))}
-                        </div>
-                      </Tooltip>
-                    ) : (
-                      <Status variant="neutral" label={parameter.defined.type} indicator={false} />
-                    )
-                  ) : null}
-                  {parameter.defined && (parameter.defined.description || parameter.defined.required) ? (
-                    <Tooltip asChild trigger={<InfoIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}>
-                      <div className="flex max-w-72 flex-col gap-0.5">
-                        {parameter.defined.description ? <Text.H6>{parameter.defined.description}</Text.H6> : null}
-                        {parameter.defined.required ? <Text.H6 color="foregroundMuted">Required</Text.H6> : null}
-                      </div>
-                    </Tooltip>
-                  ) : null}
+                  <ParameterBadges defined={parameter.defined} />
                   <ChevronRightIcon
                     className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-opacity ${
                       isActive ? "opacity-100" : "opacity-0 group-hover:opacity-60"
@@ -213,32 +283,7 @@ export function ToolParametersExplorer({
                   <Text.H6 color="foregroundMuted">
                     Top values of <span className="font-mono">{active.name}</span>
                   </Text.H6>
-                  {active.topValues.map((value) => (
-                    <div key={value.value} className="flex flex-col gap-1">
-                      <div className="flex min-w-0 flex-row items-center gap-2">
-                        <div className="min-w-0 flex-1">
-                          <CopyableText value={value.value} size="sm" ellipsis tooltip="Copy value" />
-                        </div>
-                        <Text.H6 color="foreground" className="shrink-0 tabular-nums">
-                          {formatCount(value.count)}
-                        </Text.H6>
-                      </div>
-                      <ValueBar fraction={value.count / sampleSize} />
-                    </div>
-                  ))}
-                  {notIncluded > 0 ? (
-                    <div className="flex flex-col gap-1">
-                      <div className="flex min-w-0 flex-row items-center gap-2">
-                        <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
-                          Not included
-                        </Text.H6>
-                        <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
-                          {formatCount(notIncluded)}
-                        </Text.H6>
-                      </div>
-                      <ValueBar fraction={notIncluded / sampleSize} muted />
-                    </div>
-                  ) : null}
+                  <ParameterValues parameter={active} sampleSize={sampleSize} />
                 </>
               )
             ) : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/tool-parameters-explorer.tsx
@@ -3,6 +3,7 @@ import { formatCount } from "@repo/utils"
 import { ChevronRightIcon, InfoIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { type ToolsTimeRange, useToolParameterStats } from "../../../../../../../domains/tools/tools.collection.ts"
+import { TOOL_DETAIL_PANEL_MAX_HEIGHT } from "../../-components/tool-formatters.ts"
 
 interface DefinedParameter {
   readonly type: string
@@ -123,7 +124,7 @@ export function ToolParametersExplorer({
   const notIncluded = active ? Math.max(0, sampleSize - active.observed) : 0
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col gap-3 rounded-lg bg-secondary p-4">
+    <div className={`flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4 ${TOOL_DETAIL_PANEL_MAX_HEIGHT}`}>
       <div className="flex items-center justify-between">
         <Text.H6 color="foregroundMuted">Parameters</Text.H6>
         {sampleSize > 0 ? (
@@ -145,8 +146,8 @@ export function ToolParametersExplorer({
           </Text.H6>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-col gap-4 sm:flex-row">
-          <div className="flex min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[280px] sm:w-[240px] sm:shrink-0">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 sm:flex-row">
+          <div className="flex min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[280px] sm:w-[240px] sm:shrink-0 xl:max-h-none">
             {parameters.map((parameter) => {
               const isActive = parameter.name === activeName
               const isUnobserved = parameter.observed === 0 && sampleSize > 0
@@ -201,7 +202,7 @@ export function ToolParametersExplorer({
               )
             })}
           </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-2 overflow-y-auto border-t pt-3 sm:max-h-[280px] sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0">
+          <div className="flex min-w-0 flex-1 flex-col gap-2 overflow-y-auto border-t pt-3 sm:max-h-[280px] sm:border-l sm:border-t-0 sm:pl-4 sm:pt-0 xl:max-h-none">
             {active ? (
               sampleSize === 0 ? (
                 <Text.H6 color="foregroundMuted">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/value-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/-components/value-bar.tsx
@@ -1,0 +1,20 @@
+export function ValueBar({
+  fraction,
+  muted,
+  tone = "primary",
+}: {
+  readonly fraction: number
+  readonly muted?: boolean
+  readonly tone?: "primary" | "destructive"
+}) {
+  return (
+    <div className="relative h-2 w-full overflow-hidden rounded bg-muted">
+      <div
+        className={`absolute inset-y-0 left-0 rounded ${
+          muted ? "bg-muted-foreground/40" : tone === "destructive" ? "bg-destructive/60" : "bg-primary/70"
+        }`}
+        style={{ width: `${Math.min(100, Math.max(2, fraction * 100))}%` }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -168,7 +168,7 @@ function ToolDetailPageContent() {
               <div className="mx-1 h-5 w-px bg-border" />
               <Label htmlFor="tool-errors-only" className="cursor-pointer">
                 <Text.H6 color="foregroundMuted" noWrap>
-                  Errors only
+                  Error view
                 </Text.H6>
               </Label>
               <Switch
@@ -345,6 +345,7 @@ function ToolDetailPageContent() {
               range={range}
               bucketSeconds={trendBucketSeconds}
               errorsOnly={errorsOnly}
+              failedCalls={errorsUsage?.calls ?? 0}
             />
           ) : null}
           <div className={TOOL_DETAIL_ROW_GRID}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "../-components/tool-formatters.ts"
 import { ToolActivityRow } from "./-components/tool-activity-row.tsx"
 import { ToolContextPanel } from "./-components/tool-context-panel.tsx"
+import { ToolDescription } from "./-components/tool-description.tsx"
 import { ToolNeighborNav } from "./-components/tool-neighbor-nav.tsx"
 import { ToolParametersExplorer } from "./-components/tool-parameters-explorer.tsx"
 import { ToolRecentCalls } from "./-components/tool-recent-calls.tsx"
@@ -197,12 +198,13 @@ function ToolDetailPageContent() {
             </>
           }
           description={
-            isLoading ? undefined : (
+            isLoading ? undefined : definition?.definition?.description ? (
+              <ToolDescription key={toolName} toolName={toolName} description={definition.definition.description} />
+            ) : (
               <Text.H5 color="foregroundMuted">
-                {definition?.definition?.description ??
-                  (notFound
-                    ? "No definition or calls were found for this tool in the selected time window."
-                    : "Definition not found — this tool was called but no chat span in this window carried its definition.")}
+                {notFound
+                  ? "No definition or calls were found for this tool in the selected time window."
+                  : "Definition not found — this tool was called but no chat span in this window carried its definition."}
               </Text.H5>
             )
           }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_TOOLS_RANGE_SECONDS,
   formatPercent,
   pickToolTrendBucketSeconds,
+  TOOL_DETAIL_ROW_GRID,
 } from "../-components/tool-formatters.ts"
 import { ToolActivityRow } from "./-components/tool-activity-row.tsx"
 import { ToolContextPanel } from "./-components/tool-context-panel.tsx"
@@ -342,7 +343,7 @@ function ToolDetailPageContent() {
               errorsOnly={errorsOnly}
             />
           ) : null}
-          <div className="flex flex-col gap-4 xl:flex-row xl:items-stretch">
+          <div className={TOOL_DETAIL_ROW_GRID}>
             {/* Parameters render even for never-called tools — the definition
                 alone still lists what the tool accepts. */}
             <ToolParametersExplorer

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -201,7 +201,9 @@ function ToolDetailPageContent() {
             isLoading ? undefined : definition?.definition?.description ? (
               <ToolDescription key={toolName} toolName={toolName} description={definition.definition.description} />
             ) : (
-              <Text.H5 color="foregroundMuted">
+              // Italic separates these placeholder messages from real tool
+              // descriptions, which render in the same slot.
+              <Text.H5 color="foregroundMuted" italic>
                 {notFound
                   ? "No definition or calls were found for this tool in the selected time window."
                   : "Definition not found — this tool was called but no chat span in this window carried its definition."}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -177,8 +177,7 @@ function ToolDetailPageContent() {
                 onCheckedChange={(checked) => setErrorsParam(checked ? "1" : "")}
               />
               <div className="mx-1 h-5 w-px bg-border" />
-              {/* w-auto: the button face's w-full lands directly on the Link
-                  in asChild mode and would stretch it across the header. */}
+              {/* w-auto: asChild lands the face's w-full on the Link, stretching it. */}
               <Button asChild variant="outline" size="sm" className="w-auto">
                 <Link
                   to="/projects/$projectSlug"
@@ -191,8 +190,6 @@ function ToolDetailPageContent() {
                         { op: "lte", value: range.toIso },
                       ],
                     }),
-                    // Open the filter sidebar so the applied filters are
-                    // visible — otherwise the scoped view looks unexplained.
                     filtersOpen: true,
                   }}
                 >
@@ -206,8 +203,7 @@ function ToolDetailPageContent() {
             isLoading ? undefined : definition?.definition?.description ? (
               <ToolDescription key={toolName} toolName={toolName} description={definition.definition.description} />
             ) : (
-              // Italic separates these placeholder messages from real tool
-              // descriptions, which render in the same slot.
+              // Italics mark these as placeholders, not a literal description.
               <Text.H5 color="foregroundMuted" italic>
                 {notFound
                   ? "No definition or calls were found for this tool in the selected time window."

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -203,7 +203,6 @@ function ToolDetailPageContent() {
             isLoading ? undefined : definition?.definition?.description ? (
               <ToolDescription key={toolName} toolName={toolName} description={definition.definition.description} />
             ) : (
-              // Italics mark these as placeholders, not a literal description.
               <Text.H5 color="foregroundMuted" italic>
                 {notFound
                   ? "No definition or calls were found for this tool in the selected time window."

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -177,7 +177,9 @@ function ToolDetailPageContent() {
                 onCheckedChange={(checked) => setErrorsParam(checked ? "1" : "")}
               />
               <div className="mx-1 h-5 w-px bg-border" />
-              <Button asChild variant="outline" size="sm">
+              {/* w-auto: the button face's w-full lands directly on the Link
+                  in asChild mode and would stretch it across the header. */}
+              <Button asChild variant="outline" size="sm" className="w-auto">
                 <Link
                   to="/projects/$projectSlug"
                   params={{ projectSlug }}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/$toolName/index.tsx
@@ -191,6 +191,9 @@ function ToolDetailPageContent() {
                         { op: "lte", value: range.toIso },
                       ],
                     }),
+                    // Open the filter sidebar so the applied filters are
+                    // visible — otherwise the scoped view looks unexplained.
+                    filtersOpen: true,
                   }}
                 >
                   <Icon icon={TextAlignStartIcon} size="sm" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
@@ -5,6 +5,15 @@ export const TOOL_CRITICAL_ERROR_RATE = 0.25
 
 export const DEFAULT_TOOLS_RANGE_SECONDS = 30 * 24 * 60 * 60 // last 30 days
 
+// Every two-column row of the tool detail page shares this template so the
+// right rail (latency chart, context panel) keeps one width and the columns
+// of a row stretch to equal heights.
+export const TOOL_DETAIL_ROW_GRID = "grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_400px]"
+
+// Cap shared by the panels of the parameters/context row; equal caps keep the
+// stretched columns the same height even when one side overflows.
+export const TOOL_DETAIL_PANEL_MAX_HEIGHT = "xl:max-h-[420px]"
+
 const TARGET_TREND_BUCKETS = 30
 const HOUR_SECONDS = 60 * 60
 const DAY_SECONDS = 24 * HOUR_SECONDS

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
@@ -5,11 +5,7 @@ export const TOOL_CRITICAL_ERROR_RATE = 0.25
 
 export const DEFAULT_TOOLS_RANGE_SECONDS = 30 * 24 * 60 * 60 // last 30 days
 
-// Shared by every two-column row of the tool detail page so the right rail
-// keeps one width across rows.
 export const TOOL_DETAIL_ROW_GRID = "grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_400px]"
-
-// Equal caps keep a row's stretched columns the same height when one overflows.
 export const TOOL_DETAIL_PANEL_MAX_HEIGHT = "xl:max-h-[420px]"
 
 const TARGET_TREND_BUCKETS = 30

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tool-formatters.ts
@@ -5,13 +5,11 @@ export const TOOL_CRITICAL_ERROR_RATE = 0.25
 
 export const DEFAULT_TOOLS_RANGE_SECONDS = 30 * 24 * 60 * 60 // last 30 days
 
-// Every two-column row of the tool detail page shares this template so the
-// right rail (latency chart, context panel) keeps one width and the columns
-// of a row stretch to equal heights.
+// Shared by every two-column row of the tool detail page so the right rail
+// keeps one width across rows.
 export const TOOL_DETAIL_ROW_GRID = "grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_400px]"
 
-// Cap shared by the panels of the parameters/context row; equal caps keep the
-// stretched columns the same height even when one side overflows.
+// Equal caps keep a row's stretched columns the same height when one overflows.
 export const TOOL_DETAIL_PANEL_MAX_HEIGHT = "xl:max-h-[420px]"
 
 const TARGET_TREND_BUCKETS = 30

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-view.tsx
@@ -193,17 +193,24 @@ export function ToolsView({
     {
       key: "errorRate",
       header: "Error rate",
-      width: 90,
-      minWidth: 80,
+      width: 110,
+      minWidth: 96,
       align: "end",
       sortKey: "errorRate",
       render: (tool) =>
         tool.metrics ? (
-          <span
-            className={`tabular-nums ${tool.metrics.errorRate >= TOOL_FAILING_ERROR_RATE ? "text-rose-600 dark:text-rose-400" : ""}`}
+          <Tooltip
+            asChild
+            trigger={
+              <span
+                className={`tabular-nums ${tool.metrics.errorRate >= TOOL_FAILING_ERROR_RATE ? "text-rose-600 dark:text-rose-400" : ""}`}
+              >
+                {formatPercent(tool.metrics.errorRate)} · {formatCount(tool.metrics.errors)}
+              </span>
+            }
           >
-            {formatPercent(tool.metrics.errorRate)}
-          </span>
+            {formatCount(tool.metrics.errors)} of {formatCount(tool.metrics.calls)} calls of {tool.name} failed.
+          </Tooltip>
         ) : (
           "-"
         ),

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -74,6 +74,7 @@ export type {
   ToolContextDimension,
   ToolCoOccurrenceRow,
   ToolDefinitionDetail,
+  ToolErrorBreakdownRow,
   ToolParameterStat,
   ToolParameterStatsResult,
   ToolParameterValueStat,

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -107,6 +107,7 @@ export type {
   ToolContextDimension,
   ToolCoOccurrenceRow,
   ToolDefinitionDetail,
+  ToolErrorBreakdownRow,
   ToolParameterStat,
   ToolParameterStatsResult,
   ToolParameterValueStat,

--- a/packages/domain/spans/src/ports/tool-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/tool-analytics-repository.ts
@@ -85,9 +85,8 @@ export interface ToolAnalyticsRepositoryShape {
   /**
    * Most common error outputs of one tool's failed calls, clustered by a
    * normalized form of the output (numbers/UUIDs/hex runs collapsed) so
-   * variable fragments don't split one error into many buckets. Ordered by
-   * cluster size, capped at `limit` — callers derive an "other" remainder
-   * from the total failed-call count.
+   * variable fragments don't split one error into many buckets. Top `limit`
+   * clusters by size.
    */
   getToolErrorBreakdown(
     input: ToolAnalyticsScope & {
@@ -234,11 +233,11 @@ export interface ToolCoOccurrenceRow {
 }
 
 export interface ToolErrorBreakdownRow {
-  /** Normalized cluster key; empty when the failed calls carried no error output. */
+  /** Normalized cluster key; empty when the calls carried no error output. */
   readonly key: string
   /** Verbatim sample output from the cluster (truncated). */
   readonly sample: string
-  /** An `error_type` seen in the cluster, preferring non-empty values. */
+  /** An `error_type` seen in the cluster, preferring non-empty. */
   readonly errorType: string
   readonly calls: number
 }

--- a/packages/domain/spans/src/ports/tool-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/tool-analytics-repository.ts
@@ -83,10 +83,9 @@ export interface ToolAnalyticsRepositoryShape {
   ): Effect.Effect<readonly ToolContextBreakdownRow[], RepositoryError, ChSqlClient>
 
   /**
-   * Most common error outputs of one tool's failed calls, clustered by a
-   * normalized form of the output (numbers/UUIDs/hex runs collapsed) so
-   * variable fragments don't split one error into many buckets. Top `limit`
-   * clusters by size.
+   * Most common error outputs of one tool's failed calls, grouped by a
+   * normalized form (numbers/UUIDs/hex runs collapsed) so variable fragments
+   * don't split one error into many buckets.
    */
   getToolErrorBreakdown(
     input: ToolAnalyticsScope & {

--- a/packages/domain/spans/src/ports/tool-analytics-repository.ts
+++ b/packages/domain/spans/src/ports/tool-analytics-repository.ts
@@ -83,6 +83,20 @@ export interface ToolAnalyticsRepositoryShape {
   ): Effect.Effect<readonly ToolContextBreakdownRow[], RepositoryError, ChSqlClient>
 
   /**
+   * Most common error outputs of one tool's failed calls, clustered by a
+   * normalized form of the output (numbers/UUIDs/hex runs collapsed) so
+   * variable fragments don't split one error into many buckets. Ordered by
+   * cluster size, capped at `limit` — callers derive an "other" remainder
+   * from the total failed-call count.
+   */
+  getToolErrorBreakdown(
+    input: ToolAnalyticsScope & {
+      readonly toolName: string
+      readonly limit?: number
+    },
+  ): Effect.Effect<readonly ToolErrorBreakdownRow[], RepositoryError, ChSqlClient>
+
+  /**
    * Other tools called in the same traces as this one, by shared trace count.
    * With `errorsOnly`, anchors on traces where THIS tool failed — the other
    * tools' calls are not status-filtered.
@@ -217,6 +231,16 @@ export interface ToolContextBreakdownRow {
 export interface ToolCoOccurrenceRow {
   readonly otherTool: string
   readonly sharedTraces: number
+}
+
+export interface ToolErrorBreakdownRow {
+  /** Normalized cluster key; empty when the failed calls carried no error output. */
+  readonly key: string
+  /** Verbatim sample output from the cluster (truncated). */
+  readonly sample: string
+  /** An `error_type` seen in the cluster, preferring non-empty values. */
+  readonly errorType: string
+  readonly calls: number
 }
 
 export interface ToolCallCursor {

--- a/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.test.ts
@@ -670,3 +670,79 @@ describe("errorsOnly scoping", () => {
     expect(coOccurrence).toEqual([{ otherTool: "lookup", sharedTraces: 1 }])
   })
 })
+
+// ---------------------------------------------------------------------------
+// getToolErrorBreakdown
+// ---------------------------------------------------------------------------
+
+describe("getToolErrorBreakdown", () => {
+  const fixture = setupFixture()
+
+  beforeEach(async () => {
+    await fixture.insertSpans([
+      // Variable durations cluster into one "Timeout after <n>ms" bucket.
+      callSpan({
+        trace_id: tid("t1"),
+        span_id: sid("u1"),
+        tool_name: "search",
+        status_code: 2,
+        error_type: "TimeoutError",
+        status_message: "Timeout after 5023ms",
+      }),
+      callSpan({
+        trace_id: tid("t2"),
+        span_id: sid("u2"),
+        tool_name: "search",
+        status_code: 2,
+        error_type: "TimeoutError",
+        status_message: "Timeout after 4998ms",
+      }),
+      // Empty status_message → the tool's own output is the error signal;
+      // UUIDs collapse so per-call ids don't split the cluster.
+      callSpan({
+        trace_id: tid("t3"),
+        span_id: sid("u3"),
+        tool_name: "search",
+        status_code: 2,
+        tool_output: '{"error":"Rate limit for key 0f8fad5b-d9cb-469f-a165-70867728950e"}',
+      }),
+      callSpan({
+        trace_id: tid("t4"),
+        span_id: sid("u4"),
+        tool_name: "search",
+        status_code: 2,
+        tool_output: '{"error":"Rate limit for key 7c9e6679-7425-40de-944b-e07fc1f90ae7"}',
+      }),
+      // Failed with no error output at all.
+      callSpan({ trace_id: tid("t5"), span_id: sid("u5"), tool_name: "search", status_code: 2 }),
+      // Excluded: a successful call and another tool's failure.
+      callSpan({ trace_id: tid("t6"), span_id: sid("u6"), tool_name: "search", tool_output: "ok!" }),
+      callSpan({
+        trace_id: tid("t7"),
+        span_id: sid("u7"),
+        tool_name: "render",
+        status_code: 2,
+        status_message: "Timeout after 1ms",
+      }),
+    ])
+  })
+
+  it("clusters failed-call outputs by normalized message", async () => {
+    const rows = await fixture.runCh(fixture.repo.getToolErrorBreakdown({ ...SCOPE, toolName: "search" }))
+    expect(rows.map((row) => ({ key: row.key, calls: row.calls }))).toEqual([
+      { key: "Timeout after <n>ms", calls: 2 },
+      { key: '{"error":"Rate limit for key <id>"}', calls: 2 },
+      { key: "", calls: 1 },
+    ])
+    const timeout = must(rows[0])
+    expect(timeout.errorType).toBe("TimeoutError")
+    expect(timeout.sample).toMatch(/^Timeout after (5023|4998)ms$/)
+    expect(must(rows[1]).errorType).toBe("")
+  })
+
+  it("caps the cluster list at limit", async () => {
+    const rows = await fixture.runCh(fixture.repo.getToolErrorBreakdown({ ...SCOPE, toolName: "search", limit: 1 }))
+    expect(rows).toHaveLength(1)
+    expect(must(rows[0]).calls).toBe(2)
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
@@ -47,9 +47,7 @@ const TOOL_CO_OCCURRENCE_MAX_LIMIT = 50
 
 const TOOL_ERROR_BREAKDOWN_DEFAULT_LIMIT = 10
 const TOOL_ERROR_BREAKDOWN_MAX_LIMIT = 50
-// Error outputs are capped before normalization (errors differing only past
-// the cap share a cluster) and cluster keys are capped again after it, to
-// bound aggregation state.
+// Caps bound aggregation state; errors differing only past a cap share a cluster.
 const TOOL_ERROR_SAMPLE_CAP = 1_024
 const TOOL_ERROR_KEY_CAP = 256
 
@@ -693,12 +691,9 @@ export const ToolAnalyticsRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                // The error signal lives in status_message (OTel) or, when
-                // that's empty, in the tool's own output. UUIDs, long hex
-                // runs and numbers are collapsed (in that order — they nest)
-                // before grouping so variable fragments don't split one error
-                // into many clusters; `sample` keeps a verbatim
-                // representative for display.
+                // UUIDs, hex runs and numbers collapse (in that order — they
+                // nest) so variable fragments don't split one error into many
+                // clusters; `sample` keeps a verbatim representative.
                 query: `SELECT
                       substring(
                         replaceRegexpAll(

--- a/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
@@ -10,6 +10,7 @@ import type {
   ToolCoOccurrenceRow,
   ToolDefinition,
   ToolDefinitionDetail,
+  ToolErrorBreakdownRow,
   ToolParameterStat,
   ToolParameterStatsResult,
   ToolSummary,
@@ -43,6 +44,14 @@ const TOOL_PARAM_MAX_TOP_VALUES = 10
 const TOOL_CONTEXT_BREAKDOWN_LIMIT = 50
 const TOOL_CO_OCCURRENCE_DEFAULT_LIMIT = 10
 const TOOL_CO_OCCURRENCE_MAX_LIMIT = 50
+
+const TOOL_ERROR_BREAKDOWN_DEFAULT_LIMIT = 10
+const TOOL_ERROR_BREAKDOWN_MAX_LIMIT = 50
+// Error outputs are capped before normalization (errors differing only past
+// the cap share a cluster) and cluster keys are capped again after it, to
+// bound aggregation state.
+const TOOL_ERROR_SAMPLE_CAP = 1_024
+const TOOL_ERROR_KEY_CAP = 256
 
 const RECENT_CALLS_DEFAULT_LIMIT = 10
 const RECENT_CALLS_MAX_LIMIT = 50
@@ -184,6 +193,13 @@ type ContextBreakdownRow = {
 type CoOccurrenceRow = {
   other_tool: string
   shared_traces: string
+}
+
+type ErrorBreakdownRow = {
+  key: string
+  sample: string
+  error_type: string
+  calls: string
 }
 
 type RecentCallRow = {
@@ -662,6 +678,77 @@ export const ToolAnalyticsRepositoryLive = Layer.effect(
                   value: normalizeCHString(row.value),
                   traces: num(row.traces),
                   occurrences: num(row.occurrences),
+                })),
+              ),
+            )
+        }),
+
+      getToolErrorBreakdown: (input) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const limit = Math.min(
+            Math.max(input.limit ?? TOOL_ERROR_BREAKDOWN_DEFAULT_LIMIT, 1),
+            TOOL_ERROR_BREAKDOWN_MAX_LIMIT,
+          )
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                // The error signal lives in status_message (OTel) or, when
+                // that's empty, in the tool's own output. UUIDs, long hex
+                // runs and numbers are collapsed (in that order — they nest)
+                // before grouping so variable fragments don't split one error
+                // into many clusters; `sample` keeps a verbatim
+                // representative for display.
+                query: `SELECT
+                      substring(
+                        replaceRegexpAll(
+                          replaceRegexpAll(
+                            replaceRegexpAll(
+                              raw_output,
+                              '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+                              '<id>'
+                            ),
+                            '[0-9a-fA-F]{16,}',
+                            '<hex>'
+                          ),
+                          '[0-9]+',
+                          '<n>'
+                        ),
+                        1, {keyCap:UInt16}
+                      ) AS key,
+                      any(raw_output) AS sample,
+                      anyIf(error_type, error_type != '') AS error_type,
+                      count() AS calls
+                    FROM (
+                      SELECT
+                        substring(coalesce(nullif(status_message, ''), tool_output), 1, {rawCap:UInt32}) AS raw_output,
+                        error_type
+                      FROM spans
+                      WHERE ${CALLS_FILTER}
+                        AND tool_name = {toolName:String}
+                        AND status_code = 2
+                    )
+                    GROUP BY key
+                    ORDER BY calls DESC, key ASC
+                    LIMIT {breakdownLimit:UInt16}`,
+                query_params: {
+                  ...scopeParams(input),
+                  toolName: input.toolName,
+                  keyCap: TOOL_ERROR_KEY_CAP,
+                  rawCap: TOOL_ERROR_SAMPLE_CAP,
+                  breakdownLimit: limit,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<ErrorBreakdownRow>()
+            })
+            .pipe(
+              Effect.map((rows): readonly ToolErrorBreakdownRow[] =>
+                rows.map((row) => ({
+                  key: row.key,
+                  sample: row.sample,
+                  errorType: normalizeCHString(row.error_type),
+                  calls: num(row.calls),
                 })),
               ),
             )

--- a/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/tool-analytics-repository.ts
@@ -47,7 +47,6 @@ const TOOL_CO_OCCURRENCE_MAX_LIMIT = 50
 
 const TOOL_ERROR_BREAKDOWN_DEFAULT_LIMIT = 10
 const TOOL_ERROR_BREAKDOWN_MAX_LIMIT = 50
-// Caps bound aggregation state; errors differing only past a cap share a cluster.
 const TOOL_ERROR_SAMPLE_CAP = 1_024
 const TOOL_ERROR_KEY_CAP = 256
 
@@ -691,9 +690,7 @@ export const ToolAnalyticsRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                // UUIDs, hex runs and numbers collapse (in that order — they
-                // nest) so variable fragments don't split one error into many
-                // clusters; `sample` keeps a verbatim representative.
+                // Collapse order matters — the patterns nest.
                 query: `SELECT
                       substring(
                         replaceRegexpAll(

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -186,9 +186,7 @@ function Button({
         className={cn(
           buttonContainerVariants({ variant }),
           buttonVariantsConfig({ variant, size }),
-          // The non-asChild branch spaces icon and label through an inner
-          // wrapper div; Slot can't add wrappers, so the gap goes on the
-          // child element itself.
+          // Slot can't add the inner wrapper that normally spaces icon and label.
           "gap-x-1.5",
           className,
           isLoading && "animate-pulse",

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -180,13 +180,16 @@ function Button({
   const visibleChildren = isLoading ? stripLeadingIconChild(children) : children
 
   if (asChild) {
-    // Used in combobox.ts <ComboboxInput>
     return (
       <Slot
         ref={ref}
         className={cn(
           buttonContainerVariants({ variant }),
           buttonVariantsConfig({ variant, size }),
+          // The non-asChild branch spaces icon and label through an inner
+          // wrapper div; Slot can't add wrappers, so the gap goes on the
+          // child element itself.
+          "gap-x-1.5",
           className,
           isLoading && "animate-pulse",
         )}


### PR DESCRIPTION
Follow-up to the tools dashboard (#3508), addressing the first round of internal feedback.


https://github.com/user-attachments/assets/55016022-17d8-4f82-ad5a-4ed451f53453



## error view and common errors

The detail page's "Errors only" switch is renamed to "Error view", and it now answers the question it exists for — what is failing. In error view, the latency chart (whose failed-call latency already appears in the Usage row's Duration tile) is replaced by a **Common errors** panel: failed-call outputs clustered by a normalized form, each cluster showing a verbatim sample (click to copy), its `error_type` badge, count, and share of all failed calls. An "Other" remainder row keeps the bars accounting for every failure even past the server's top-10. Normal view is unchanged.

Clustering happens in ClickHouse in a new `getToolErrorBreakdown` repository method. The error text is `status_message`, falling back to `tool_output`; UUIDs, 16+-char hex runs, and numbers are collapsed to `<id>` / `<hex>` / `<n>` (in that order — they nest) before grouping, so "Timeout after 5023ms" and "Timeout after 4998ms" form one cluster instead of two. No migration — it reads existing columns. Covered by chdb tests: clustering, output fallback, the empty-output bucket, exclusion of ok calls and other tools, and the limit cap.

A known follow-up, deliberately out of scope: clicking a cluster to filter Recent calls down to it — that needs the normalized key to round-trip through the query layer.

## layout and visual fixes

- The detail page's two-column rows (charts, parameters/context) each hard-coded a different right-rail width (420px vs 340px). Both rows now share one grid template and the panels share a height cap, so the rail is straight and columns of a row end at the same height.
- The selected parameter in the Parameters explorer rendered with border + background + shadow — the raised-button recipe — so it read as clickable rather than selected. It now uses a selection treatment (fill + left accent bar), and a tool with a single parameter skips the master–detail split entirely.
- The tools list's error rate column shows `rate · count` (matching the "% of traces" idiom) with a "N of M calls failed" tooltip.
- Tool descriptions are prompt content with no length bound and could fill the screen. The header clamps them to two lines with a "Show more" modal; the trigger only appears when the text actually overflows, measured on the rendered element.
- The "Definition not found…" / "No definition or calls…" placeholders render in italics so they don't read as a tool whose description literally says that.

## navigation

- The Previous/Next tool buttons are real links (href, cmd/middle-click) and carry the current search params over, so error view and a custom time range survive paging between tools. The J/K hotkeys keep the same search-preserving behavior through `navigate`.
- "View traces" opens the traces page with the filter sidebar already open (`filtersOpen=true`), so the applied tool/time filters are visible on arrival instead of an unexplained scoped view.

## ui kit

`Button`'s `asChild` branch skipped the inner wrapper that gives normal buttons their icon–label gap, and landed the face's `w-full` directly on the child element — "View traces" rendered with its icon glued to the label, stretched across the header's free space. The Slot now carries `gap-x-1.5` itself (it can't add wrapper elements); the width fix stays at the call site (`w-auto`) since other `asChild` consumers may rely on the full-width base.