### PR TITLE
fix(taxonomy): reduce gardening sample memory pressure

### DIFF
--- a/dev-docs/taxonomy.md
+++ b/dev-docs/taxonomy.md
@@ -54,7 +54,7 @@ ClickHouse:
 Two distinct bounded reads sit over the observations table:
 
 - **`latestProjectWindow`** — the newest `TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX` (10k) project rows, newest-first. Used by the read/aggregation paths (`listByCluster`, `listAllByCluster`, `listNoise`).
-- **`listForClustering`** — the gardening sample. It does **not** take newest-N; it **day-stratifies** across the lookback window so the rebuilt tree is representative of the whole window instead of biased to the last few hours. Each observation is ranked within its UTC day by `cityHash64(observation_id)` and days are interleaved round-robin (`ORDER BY rn`) up to the limit; the inner scan selects only `observation_id` so the embedding column is never materialized while ranking. The ordering is deterministic (no `rand()`) so a gardening pass replays identically under Temporal.
+- **`listForClusteringSample`** — the gardening sample. It does **not** take newest-N; it **day-stratifies** across the lookback window so the rebuilt tree is representative of the whole window instead of biased to the last few hours. Each observation is ranked within its UTC day by `cityHash64(observation_id)` and days are interleaved round-robin (`ORDER BY rn`) up to the limit; the inner scan selects only `observation_id` so the embedding column is never materialized while ranking. The outer read intentionally returns only `observation_id`, `start_time`, and `embedding` so clustering does not pull projection metadata or full observation rows into the workflow worker. The ordering is deterministic (no `rand()`) so a gardening pass replays identically under Temporal.
 
 ### ReplacingMergeTree version discipline
 
@@ -85,11 +85,11 @@ Each activity is idempotent under Temporal retries via the run-scoped determinis
 
 ### Build (`buildHierarchicalTaxonomyUseCase`)
 
-1. **Sample** up to `TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX` (10k) observations from the `TAXONOMY_NOISE_LOOKBACK_DAYS` (7-day) window via the day-stratified `listForClustering`, regardless of current assignment. Below `TAXONOMY_GARDENING_MIN_OBSERVATIONS` the build returns empty (cold-start gate).
+1. **Sample** up to `TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX` (1.5k) observations from the `TAXONOMY_NOISE_LOOKBACK_DAYS` (7-day) window via the day-stratified `listForClusteringSample`, regardless of current assignment. The cap bounds workflow-worker heap and CPU while the sample stays representative across active days. Below `TAXONOMY_GARDENING_MIN_OBSERVATIONS` the build returns empty (cold-start gate).
 2. **Build the tree top-down** with `buildHierarchicalClusters` (see "Clustering primitives"). All sampled members end up on leaves.
 3. **Persist top-down** (clusters sorted by depth ascending) so a child save never references a missing parent. Interior nodes are stored with `observation_count = 0` and a `split_link_threshold` derived from their children's tightest sibling separation.
 4. **Match new nodes against the previous tree** with the continuity matcher (see "Cross-run continuity"): a confident 1:1 centroid match reuses the old cluster's id, so trends that key on the id stay continuous across passes.
-5. **Reassign every member to its leaf** in bulk (`reassignMany`, `assignment_method = "gardening_birth"`), confidence = cosine to the leaf centroid clamped to `[0,1]`.
+5. **Reassign every member to its leaf** in bulk (`reassignManyById`, `assignment_method = "gardening_birth"`), confidence = cosine to the leaf centroid clamped to `[0,1]`. Reassignment copies unchanged observation columns with ClickHouse-side `INSERT … SELECT`, keyed by observation id, so large metadata and embedding payloads do not round-trip through Node after clustering.
 6. **Deprecate every previously-active cluster** that no new node continued.
 7. **Emit lineage**: a `continuation` row per reused id, a `birth` row per genuinely new node, a `death` row per deprecated cluster.
 

--- a/packages/domain/taxonomy/src/clustering.ts
+++ b/packages/domain/taxonomy/src/clustering.ts
@@ -20,7 +20,7 @@
  *
  * Why bisecting K-means with auto-K instead of HDBSCAN / single-linkage:
  *   - We rebuild the whole tree per gardening pass over a bounded sample
- *     (≤10k) and want a single algorithmic primitive that gives both a
+ *     (≤1.5k) and want a single algorithmic primitive that gives both a
  *     coarse-to-fine partition AND a stable per-node centroid suitable for
  *     online assignment. Spherical k-means satisfies both. HDBSCAN is not
  *     ergonomic in JS and produces clusters that don't carry well-defined

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -99,9 +99,9 @@ export const TAXONOMY_GARDENING_MIN_OBSERVATIONS = 15
 
 /** Gardening works over the live taxonomy window: newest observations first. */
 /** Maximum in-memory proposal sample passed to clustering helpers. */
-export const TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX = 10_000
+export const TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX = 1_500
 
-/** Gardening reads are capped to the same bounded sample size as clustering. */
+/** Read-path live window for project/cluster observation pages. */
 export const TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX = 10_000
 
 /** Hard cap on per-cluster batch reads inside the live gardening window. */

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -123,7 +123,9 @@ export {
 export {
   type ListTaxonomyNoiseInput,
   type ListTaxonomyObservationClusterInput,
+  type ReassignTaxonomyObservationByIdInput,
   type ReassignTaxonomyObservationInput,
+  type TaxonomyClusteringObservation,
   type TaxonomyObservationClusterAssignmentCount,
   type TaxonomyObservationClusterOccurrence,
   type TaxonomyObservationClusterTrendCounts,

--- a/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
@@ -35,6 +35,21 @@ export interface ReassignTaxonomyObservationInput {
   readonly indexedAt: Date
 }
 
+export interface ReassignTaxonomyObservationByIdInput {
+  readonly observationId: string
+  readonly assignedClusterId: TaxonomyClusterId
+  readonly assignmentMethod: TaxonomyMomentObservation["assignmentMethod"]
+  readonly assignmentConfidence: number
+  readonly reassignmentRunId: TaxonomyRunId
+  readonly indexedAt: Date
+}
+
+export interface TaxonomyClusteringObservation {
+  readonly observationId: string
+  readonly embedding: readonly number[]
+  readonly startTime: Date
+}
+
 export interface TaxonomyObservationCounts {
   readonly total: number
   readonly assigned: number
@@ -68,6 +83,11 @@ export interface TaxonomyObservationRepositoryShape {
   readonly reassignMany: (
     inputs: readonly ReassignTaxonomyObservationInput[],
   ) => Effect.Effect<void, RepositoryError, ChSqlClient>
+  readonly reassignManyById: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly assignments: readonly ReassignTaxonomyObservationByIdInput[]
+  }) => Effect.Effect<void, RepositoryError, ChSqlClient>
   /**
    * Which of the given observation ids already exist (any version). Lets the
    * analyzer make centroid increments idempotent across activity retries:
@@ -82,9 +102,9 @@ export interface TaxonomyObservationRepositoryShape {
     input: ListTaxonomyNoiseInput,
   ) => Effect.Effect<readonly TaxonomyMomentObservation[], RepositoryError, ChSqlClient>
   /**
-   * Newest observations in the live gardening window, regardless of current
-   * assignment. The divisive tree builder rebuilds the project's taxonomy
-   * from scratch each pass and needs to see all members, not just noise.
+   * Full observation rows in the live gardening window, regardless of current
+   * assignment. Prefer `listForClusteringSample` for taxonomy builds so large
+   * metadata columns do not round-trip through workflow activities.
    */
   readonly listForClustering: (input: {
     readonly organizationId: OrganizationId
@@ -92,6 +112,12 @@ export interface TaxonomyObservationRepositoryShape {
     readonly since: Date
     readonly limit: number
   }) => Effect.Effect<readonly TaxonomyMomentObservation[], RepositoryError, ChSqlClient>
+  readonly listForClusteringSample: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly since: Date
+    readonly limit: number
+  }) => Effect.Effect<readonly TaxonomyClusteringObservation[], RepositoryError, ChSqlClient>
   readonly listByCluster: (
     input: ListTaxonomyObservationClusterInput,
   ) => Effect.Effect<readonly TaxonomyMomentObservation[], RepositoryError, ChSqlClient>

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
@@ -86,6 +86,30 @@ export const createFakeTaxonomyObservationRepository = (
         }
       }),
 
+    reassignManyById: ({ organizationId, projectId, assignments }) =>
+      Effect.sync(() => {
+        for (const {
+          observationId,
+          assignedClusterId,
+          assignmentMethod,
+          assignmentConfidence,
+          reassignmentRunId,
+          indexedAt,
+        } of assignments) {
+          const key = observationKey(organizationId, projectId, observationId)
+          const existing = rows.get(key)
+          if (!existing) continue
+          setVersioned(key, {
+            ...existing,
+            assignedClusterId,
+            assignmentMethod,
+            assignmentConfidence,
+            reassignmentRunId,
+            indexedAt,
+          })
+        }
+      }),
+
     filterExistingIds: ({ organizationId, projectId, observationIds }) =>
       Effect.sync(() => {
         const requested = new Set(observationIds)
@@ -145,6 +169,41 @@ export const createFakeTaxonomyObservationRepository = (
           .sort(
             (a, b) => b.startTime.getTime() - a.startTime.getTime() || a.observationId.localeCompare(b.observationId),
           )
+      }),
+
+    listForClusteringSample: ({ organizationId, projectId, since, limit }) =>
+      Effect.sync(() => {
+        const eligible = [...rows.values()].filter(
+          (observation) =>
+            observation.organizationId === organizationId &&
+            observation.projectId === projectId &&
+            observation.embedding.length > 0 &&
+            observation.startTime >= since,
+        )
+        const dayBuckets = new Map<string, TaxonomyMomentObservation[]>()
+        for (const observation of eligible) {
+          const day = observation.startTime.toISOString().slice(0, 10)
+          const bucket = dayBuckets.get(day) ?? []
+          bucket.push(observation)
+          dayBuckets.set(day, bucket)
+        }
+        const ranked = [...dayBuckets.values()].flatMap((bucket) =>
+          [...bucket]
+            .sort((a, b) => deterministicHash(a.observationId) - deterministicHash(b.observationId))
+            .map((observation, rank) => ({ observation, rank })),
+        )
+        return ranked
+          .sort((a, b) => a.rank - b.rank || a.observation.observationId.localeCompare(b.observation.observationId))
+          .slice(0, limit)
+          .map((entry) => entry.observation)
+          .sort(
+            (a, b) => b.startTime.getTime() - a.startTime.getTime() || a.observationId.localeCompare(b.observationId),
+          )
+          .map((observation) => ({
+            observationId: observation.observationId,
+            embedding: observation.embedding,
+            startTime: observation.startTime,
+          }))
       }),
 
     listByCluster: ({ organizationId, projectId, clusterId, limit, beforeStartTime, beforeObservationId }) =>

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -10,8 +10,10 @@
  *      representative of the whole window rather than biased toward the last
  *      few hours. On large tenants (5M sessions/month) this spreads the budget
  *      across days; small tenants whose corpus fits under the cap see their
- *      whole live window. The sample is deterministic (hash-ordered, no
- *      rand()) so a gardening pass replays identically under Temporal.
+ *      whole live window. The sample is slim (id, start time, embedding) so
+ *      projection metadata does not round-trip through the workflow worker.
+ *      The sample is deterministic (hash-ordered, no rand()) so a gardening
+ *      pass replays identically under Temporal.
  *   2. Build the tree top-down with `buildHierarchicalClusters` using the
  *      per-depth schedule. The schedule encodes broad-at-the-root,
  *      narrow-at-the-leaves without per-corpus tuning.
@@ -26,8 +28,9 @@
  *   5. Materialize and persist the rows. `save` upserts on id, so a
  *      continuation updates its predecessor's row in place (new centroid,
  *      preserved age, carried-over name when the topic barely moved).
- *   6. Re-assign every member observation directly to its leaf cluster
- *      (interior nodes carry derived counts only).
+ *   6. Re-assign every member observation directly to its leaf cluster with a
+ *      ClickHouse-side INSERT SELECT keyed by observation id (interior nodes
+ *      carry derived counts only).
  *   7. Deprecate every previously-active cluster that no new node continued.
  *   8. Emit `continuation` rows for reused ids, `birth` rows for new nodes,
  *      and `death` rows for the deprecated clusters.
@@ -248,7 +251,7 @@ export const buildHierarchicalTaxonomyUseCase = (input: BuildHierarchicalTaxonom
     const observationsRepo = yield* TaxonomyObservationRepository
     const clustersRepo = yield* TaxonomyClusterRepository
 
-    const observations = yield* observationsRepo.listForClustering({
+    const observations = yield* observationsRepo.listForClusteringSample({
       organizationId: input.organizationId,
       projectId: input.projectId,
       since: lookbackStart(now),
@@ -411,7 +414,7 @@ export const buildHierarchicalTaxonomyUseCase = (input: BuildHierarchicalTaxonom
           const confidence = Math.max(0, Math.min(1, cosineSimilarityNormalized(embedding, leaf.centroid)))
           return [
             {
-              observation,
+              observationId: observation.observationId,
               assignedClusterId: leaf.clusterId,
               assignmentMethod: "gardening_birth" as const,
               assignmentConfidence: confidence,
@@ -421,7 +424,11 @@ export const buildHierarchicalTaxonomyUseCase = (input: BuildHierarchicalTaxonom
           ]
         }),
       )
-      yield* observationsRepo.reassignMany(reassignments)
+      yield* observationsRepo.reassignManyById({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        assignments: reassignments,
+      })
     }
 
     // Deprecate every previously-active cluster that no new node continued.

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -141,6 +141,46 @@ describe("TaxonomyObservationRepositoryLive", () => {
     expect(rows[0]?.reassignmentRunId).toBe(runId)
   })
 
+  it("rewrites observations by id without loading full rows into the caller", async () => {
+    const observation = makeObservation({
+      observationId: "i".repeat(24),
+      sessionId: SessionId("reassigned-by-id-session"),
+      projectionMetadata: { summary: "metadata stays server-side" },
+    })
+
+    const rows = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        yield* repo.upsert(observation)
+        yield* repo.reassignManyById({
+          organizationId,
+          projectId,
+          assignments: [
+            {
+              observationId: observation.observationId,
+              assignedClusterId: clusterId,
+              assignmentMethod: "gardening_birth",
+              assignmentConfidence: 0.73,
+              reassignmentRunId: runId,
+              indexedAt: new Date("2026-05-24T12:02:00.000Z"),
+            },
+          ],
+        })
+        return yield* repo.listBySession({ organizationId, projectId, sessionId: observation.sessionId })
+      }),
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      observationId: observation.observationId,
+      assignedClusterId: clusterId,
+      assignmentMethod: "gardening_birth",
+      assignmentConfidence: 0.73,
+      reassignmentRunId: runId,
+      projectionMetadata: { summary: "metadata stays server-side" },
+    })
+  })
+
   it("treats reassignment as one current observation", async () => {
     const observation = makeObservation({ observationId: "u".repeat(24), sessionId: SessionId("current-session") })
 
@@ -209,7 +249,7 @@ describe("TaxonomyObservationRepositoryLive", () => {
             }),
           )
         }
-        return yield* repo.listForClustering({
+        return yield* repo.listForClusteringSample({
           organizationId,
           projectId: stratifiedProjectId,
           since: new Date("2026-05-19T00:00:00.000Z"),

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -11,6 +11,7 @@ import {
 } from "@domain/shared"
 import {
   TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+  type TaxonomyClusteringObservation,
   type TaxonomyMomentObservation,
   TaxonomyObservationRepository,
   taxonomyMomentObservationSchema,
@@ -45,6 +46,12 @@ type TaxonomyObservationRow = {
   readonly end_time: string
   readonly retention_days: number
   readonly indexed_at: string
+}
+
+type TaxonomyClusteringObservationRow = {
+  readonly observation_id: string
+  readonly start_time: string
+  readonly embedding: readonly number[]
 }
 
 const selectColumns = `
@@ -100,6 +107,12 @@ const toInsertRow = (observation: TaxonomyMomentObservation) => ({
   end_time: toClickhouseDateTime(observation.endTime),
   retention_days: observation.retentionDays,
   indexed_at: toClickhouseDateTime(observation.indexedAt),
+})
+
+const toDomainClusteringObservation = (row: TaxonomyClusteringObservationRow): TaxonomyClusteringObservation => ({
+  observationId: row.observation_id,
+  embedding: row.embedding,
+  startTime: parseClickhouseDate(row.start_time),
 })
 
 const toDomainObservation = (row: TaxonomyObservationRow): TaxonomyMomentObservation =>
@@ -176,6 +189,70 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
               await client.insert({ table: "taxonomy_observations", values, format: "JSONEachRow" })
             })
             .pipe(Effect.mapError((error) => toRepositoryError(error, "TaxonomyObservationRepository.reassignMany")))
+        }),
+
+      reassignManyById: ({ organizationId, projectId, assignments }) =>
+        Effect.gen(function* () {
+          if (assignments.length === 0) return
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const groups = new Map<string, Array<(typeof assignments)[number]>>()
+          for (const assignment of assignments) {
+            const key = `${assignment.assignmentMethod}\0${assignment.reassignmentRunId}\0${assignment.indexedAt.toISOString()}`
+            const group = groups.get(key) ?? []
+            group.push(assignment)
+            groups.set(key, group)
+          }
+
+          yield* chSqlClient
+            .query(async (client) => {
+              for (const group of groups.values()) {
+                const first = group[0]
+                if (!first) continue
+                await client.command({
+                  query: `INSERT INTO taxonomy_observations (${selectColumns})
+                          WITH
+                            {observationIds:Array(String)} AS observationIds,
+                            {assignedClusterIds:Array(String)} AS assignedClusterIds,
+                            {assignmentConfidences:Array(Float32)} AS assignmentConfidences
+                          SELECT
+                            organization_id,
+                            project_id,
+                            observation_id,
+                            session_id,
+                            analysis_hash,
+                            moment_id,
+                            projection_method,
+                            projection_hash,
+                            projection_metadata,
+                            embedding,
+                            assignedClusterIds[indexOf(observationIds, observation_id)],
+                            assignmentConfidences[indexOf(observationIds, observation_id)],
+                            {assignmentMethod:String},
+                            {reassignmentRunId:String},
+                            start_time,
+                            end_time,
+                            retention_days,
+                            {indexedAt:DateTime64(3, 'UTC')}
+                          FROM taxonomy_observations FINAL
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            AND observation_id IN {observationIds:Array(String)}`,
+                  query_params: {
+                    organizationId: organizationId as string,
+                    projectId: projectId as string,
+                    observationIds: group.map((assignment) => assignment.observationId),
+                    assignedClusterIds: group.map((assignment) => assignment.assignedClusterId as string),
+                    assignmentConfidences: group.map((assignment) => assignment.assignmentConfidence),
+                    assignmentMethod: first.assignmentMethod,
+                    reassignmentRunId: first.reassignmentRunId as string,
+                    indexedAt: toClickhouseDateTime(first.indexedAt),
+                  },
+                })
+              }
+            })
+            .pipe(
+              Effect.mapError((error) => toRepositoryError(error, "TaxonomyObservationRepository.reassignManyById")),
+            )
         }),
 
       filterExistingIds: ({ organizationId, projectId, observationIds }) =>
@@ -290,6 +367,58 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             })
             .pipe(
               Effect.mapError((error) => toRepositoryError(error, "TaxonomyObservationRepository.listForClustering")),
+            )
+        }),
+
+      listForClusteringSample: ({ organizationId, projectId, since, limit }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                          observation_id,
+                          start_time,
+                          embedding
+                        FROM taxonomy_observations FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND length(embedding) > 0
+                          AND start_time >= {since:DateTime64(9, 'UTC')}
+                          AND observation_id IN (
+                            SELECT observation_id
+                            FROM (
+                              SELECT
+                                observation_id,
+                                row_number() OVER (
+                                  PARTITION BY toDate(start_time)
+                                  ORDER BY cityHash64(observation_id)
+                                ) AS rn
+                              FROM taxonomy_observations FINAL
+                              WHERE organization_id = {organizationId:String}
+                                AND project_id = {projectId:String}
+                                AND length(embedding) > 0
+                                AND start_time >= {since:DateTime64(9, 'UTC')}
+                            )
+                            ORDER BY rn ASC, observation_id ASC
+                            LIMIT {limit:UInt32}
+                          )
+                        ORDER BY start_time DESC, observation_id ASC`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  since: toClickhouseDateTime(since),
+                  limit,
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<TaxonomyClusteringObservationRow>()
+              return rows.map(toDomainClusteringObservation)
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyObservationRepository.listForClusteringSample"),
+              ),
             )
         }),
 


### PR DESCRIPTION
## What does this PR do?

Reduces taxonomy gardening memory pressure in the workflow worker by shrinking the clustering sample and avoiding full observation round-trips during the build step.

The gardening build now samples up to 1,500 observations per project instead of 10,000. The sample remains day-stratified across the 7-day lookback window, but the ClickHouse read used by clustering now returns only the observation id, start time, and embedding. Projection metadata and other full observation columns stay out of the workflow activity heap.

After clustering, leaf reassignments now use a ClickHouse-side `INSERT ... SELECT` keyed by observation id. The worker sends only the assignment map (observation id → cluster id/confidence), and ClickHouse copies unchanged columns from the latest observation rows while overwriting the assignment fields.

## Why

A production taxonomy gardening workflow was repeatedly timing out on the largest project. Its build activity scanned ~4k 2048-dimensional taxonomy observations, materialized ~130MB of ClickHouse JSON before JS object overhead, and blocked the workflows worker. This PR bounds the immediate sample size and removes the largest unnecessary data movement from the clustering path.

## Validation

- `pnpm --filter @domain/taxonomy typecheck`
- `pnpm --filter @domain/taxonomy test -- build-hierarchical-taxonomy`
- `pnpm --filter @domain/taxonomy check`
- `pnpm --filter @platform/db-clickhouse check`
- `pnpm --filter @app/workflows check`
- Verified the new ClickHouse assignment-array expression against production with a read-only SELECT.

`pnpm --filter @app/workflows typecheck` still fails on pre-existing workspace dependency/type errors in integrations/sandboxes/db-postgres imports, unrelated to this change.
