### PR TITLE
fix(web): narrow-width usability across nav, headers, toolbars, popovers, settings and side panels

### DIFF
--- a/apps/web/src/components/member-selector.tsx
+++ b/apps/web/src/components/member-selector.tsx
@@ -129,7 +129,12 @@ export function MemberSelector({
           <SelectedTrigger selected={selectedOption} />
         </ComboboxTrigger>
       </Button>
-      <ComboboxContent anchor={triggerRef} container={portalContainer?.current} chips={false} className="min-w-56">
+      <ComboboxContent
+        anchor={triggerRef}
+        container={portalContainer?.current}
+        chips={false}
+        className="min-w-56 max-w-[calc(100vw-2rem)]"
+      >
         <ComboboxInput
           placeholder="Search members..."
           value={inputValue}

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -89,9 +89,9 @@ interface HeaderProps {
 
 function Header({ title, badge, description, actions, className }: HeaderProps) {
   return (
-    <div className={cn("flex flex-col gap-1 p-6 pb-0", className)}>
-      <div className="flex min-w-0 flex-row flex-wrap items-start gap-x-4 gap-y-2">
-        <div className="flex min-w-64 flex-1 flex-col gap-1">
+    <div className={cn("@container flex flex-col gap-1 p-6 pb-0", className)}>
+      <div className="flex min-w-0 flex-row flex-wrap items-start gap-x-4 gap-y-2 @max-[45rem]:flex-col">
+        <div className="flex min-w-64 flex-1 flex-col gap-1 @max-[45rem]:min-w-0 @max-[45rem]:flex-none">
           <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-2 gap-y-1">
             {typeof title === "string" ? <Text.H4 className="min-w-0 shrink">{title}</Text.H4> : title}
             {badge ? <span className="shrink-0 flex">{badge}</span> : null}
@@ -104,7 +104,11 @@ function Header({ title, badge, description, actions, className }: HeaderProps) 
             )
           ) : null}
         </div>
-        {actions ? <div className="ml-auto flex shrink-0 flex-row items-center gap-2 self-start">{actions}</div> : null}
+        {actions ? (
+          <div className="ml-auto flex max-w-full shrink-0 flex-row flex-wrap items-center gap-2 self-start @max-[45rem]:w-full @max-[45rem]:justify-between">
+            {actions}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -78,7 +78,7 @@ interface HeaderProps {
   /** Shown inline after the title (e.g. queue type badge). */
   readonly badge?: ReactNode
   readonly description?: ReactNode
-  /** Right-aligned controls on the same row as the title (e.g. primary actions). */
+  /** Right-aligned controls beside the title; wrap below it when the header is too narrow to fit both. */
   readonly actions?: ReactNode
   readonly className?: string
 }
@@ -86,8 +86,8 @@ interface HeaderProps {
 function Header({ title, badge, description, actions, className }: HeaderProps) {
   return (
     <div className={cn("flex flex-col gap-1 p-6 pb-0", className)}>
-      <div className="flex min-w-0 flex-row items-start justify-between gap-4">
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex min-w-0 flex-row flex-wrap items-start gap-x-4 gap-y-2">
+        <div className="flex min-w-64 flex-1 flex-col gap-1">
           <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-2 gap-y-1">
             {typeof title === "string" ? <Text.H4 className="min-w-0 shrink">{title}</Text.H4> : title}
             {badge ? <span className="shrink-0 flex">{badge}</span> : null}
@@ -100,7 +100,7 @@ function Header({ title, badge, description, actions, className }: HeaderProps) 
             )
           ) : null}
         </div>
-        {actions ? <div className="flex shrink-0 flex-row items-center gap-2 self-start">{actions}</div> : null}
+        {actions ? <div className="ml-auto flex shrink-0 flex-row items-center gap-2 self-start">{actions}</div> : null}
       </div>
     </div>
   )

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -36,9 +36,13 @@ function ListingLayout({ children, className }: ListingLayoutProps) {
 
   const main = <div className={cn("flex flex-col h-full gap-3", className)}>{content}</div>
   return (
-    <div className="relative flex flex-row h-full">
+    <div className="@container relative flex flex-row h-full">
       <div className="flex-1 min-w-0 flex flex-col">{main}</div>
-      {aside ? <div className="relative z-10">{aside}</div> : null}
+      {aside ? (
+        <div className="relative z-10 @max-[48rem]:absolute @max-[48rem]:inset-y-0 @max-[48rem]:right-0 @max-[48rem]:z-20 @max-[48rem]:shadow-xl">
+          {aside}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -61,7 +61,11 @@ interface ActionsRowProps {
 }
 
 function ActionsRow({ children, className }: ActionsRowProps) {
-  return <div className={cn("flex flex-row gap-2 items-center justify-between min-w-0", className)}>{children}</div>
+  return (
+    <div className={cn("flex flex-row flex-wrap gap-2 items-center justify-between min-w-0", className)}>
+      {children}
+    </div>
+  )
 }
 
 interface ActionRowItemProps {
@@ -70,7 +74,7 @@ interface ActionRowItemProps {
 }
 
 function ActionRowItem({ children, className }: ActionRowItemProps) {
-  return <div className={cn("flex flex-row gap-2 items-center min-w-0 shrink-0", className)}>{children}</div>
+  return <div className={cn("flex flex-row flex-wrap gap-2 items-center min-w-0", className)}>{children}</div>
 }
 
 interface HeaderProps {

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -124,12 +124,22 @@ function List({ children, className }: ListProps) {
 }
 
 function Body({ children, className }: { readonly children: ReactNode; readonly className?: string }) {
-  return <div className={cn("flex flex-row flex-1 min-h-0 min-w-0 overflow-hidden", className)}>{children}</div>
+  return (
+    <div className={cn("@container relative flex flex-row flex-1 min-h-0 min-w-0 overflow-hidden", className)}>
+      {children}
+    </div>
+  )
 }
 
 function Sidebar({ children, className }: { readonly children: ReactNode; readonly className?: string }) {
   return (
-    <div className={cn("flex flex-col h-full w-[280px] min-w-[280px] shrink-0 border-r bg-background", className)}>
+    <div
+      className={cn(
+        "flex flex-col h-full w-[280px] min-w-[280px] shrink-0 border-r bg-background",
+        "@max-[48rem]:absolute @max-[48rem]:inset-y-0 @max-[48rem]:left-0 @max-[48rem]:z-20 @max-[48rem]:shadow-xl",
+        className,
+      )}
+    >
       {children}
     </div>
   )

--- a/apps/web/src/lib/hooks/useMediaQuery.ts
+++ b/apps/web/src/lib/hooks/useMediaQuery.ts
@@ -1,0 +1,18 @@
+import { useCallback, useSyncExternalStore } from "react"
+
+/** Reactive `window.matchMedia` result; returns `false` on the server. */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener("change", onStoreChange)
+      return () => mql.removeEventListener("change", onStoreChange)
+    },
+    [query],
+  )
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false,
+  )
+}

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -176,7 +176,7 @@ function BillingCreditCounter({ organizationId }: { readonly organizationId: str
                 />
               </svg>
             </span>
-            <div className="flex items-baseline gap-1">
+            <div className="hidden items-baseline gap-1 md:flex">
               <Text.H6 weight="medium" color={isOverage ? "destructive" : "foreground"}>
                 {usageLabel}
               </Text.H6>
@@ -234,10 +234,10 @@ function NavHeader() {
   const [activeOrgEmoji, activeOrgName] = extractLeadingEmoji(org.name)
 
   return (
-    <header className="w-full bg-background border-b border-border h-12 flex items-center px-4 shrink-0">
-      <div className="flex items-center gap-2 flex-1">
-        <LatitudeLogo className="h-5 w-5" />
-        <span className="text-muted-foreground text-sm select-none">/</span>
+    <header className="w-full bg-background border-b border-border h-12 flex items-center gap-4 px-4 shrink-0">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <LatitudeLogo className="h-5 w-5 shrink-0" />
+        <span className="text-muted-foreground text-sm select-none shrink-0">/</span>
         <DropdownMenu
           side="bottom"
           align="start"
@@ -253,26 +253,29 @@ function NavHeader() {
           trigger={() => (
             <button
               type="button"
-              className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted transition-colors cursor-pointer"
+              className="flex min-w-0 max-w-48 items-center gap-1.5 px-2 py-1 rounded hover:bg-muted transition-colors cursor-pointer"
             >
-              {activeOrgEmoji ? <span className="text-base leading-none">{activeOrgEmoji}</span> : null}
-              <span className="text-sm font-medium text-foreground">{activeOrgName || org.name}</span>
-              <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+              {activeOrgEmoji ? <span className="text-base leading-none shrink-0">{activeOrgEmoji}</span> : null}
+              <span className="text-sm font-medium text-foreground truncate">{activeOrgName || org.name}</span>
+              <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
             </button>
           )}
         />
         <CreateOrganizationModal open={createOrgModalOpen} onOpenChange={setCreateOrgModalOpen} />
         <BreadcrumbTrail />
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex shrink-0 items-center gap-4">
         <button
           type="button"
           onClick={() => commandPalette.setOpen(true)}
+          aria-label="Search"
           className="flex items-center gap-2 rounded-md border border-border px-2 py-1 transition-colors hover:bg-muted"
         >
           <Icon icon={SearchIcon} size="sm" color="foregroundMuted" />
-          <Text.H6 color="foregroundMuted">Search</Text.H6>
-          <kbd className="rounded bg-muted px-1 font-mono text-xs text-muted-foreground">⌘K</kbd>
+          <span className="hidden items-center gap-2 md:flex">
+            <Text.H6 color="foregroundMuted">Search</Text.H6>
+            <kbd className="rounded bg-muted px-1 font-mono text-xs text-muted-foreground">⌘K</kbd>
+          </span>
         </button>
         <BillingCreditCounter organizationId={organizationId} />
         <NotificationBell />
@@ -280,17 +283,20 @@ function NavHeader() {
           <button
             type="button"
             onClick={() => showIntercom()}
+            aria-label="Help"
             className="flex items-center gap-1.5 hover:text-muted-foreground transition-colors cursor-pointer"
           >
             <Icon icon={LifeBuoy} size="sm" />
-            <Text.H5>Help</Text.H5>
+            <span className="hidden md:block">
+              <Text.H5>Help</Text.H5>
+            </span>
           </button>
         )}
         <a
           href="https://docs.latitude.so"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-sm text-foreground hover:text-muted-foreground transition-colors"
+          className="hidden text-sm text-foreground hover:text-muted-foreground transition-colors md:block"
         >
           Docs
         </a>

--- a/apps/web/src/routes/_authenticated/-components/breadcrumb-ui.tsx
+++ b/apps/web/src/routes/_authenticated/-components/breadcrumb-ui.tsx
@@ -16,7 +16,7 @@ export type BreadcrumbLinkProps = Omit<CreateLinkProps, "children"> & {
 export function BreadcrumbLink({ className, children, ...props }: BreadcrumbLinkProps) {
   return (
     <Link {...props} className={cn(linkClass, className)}>
-      <Text.H5M color="foregroundMuted" className="truncate">
+      <Text.H5M color="foregroundMuted" ellipsis>
         {children}
       </Text.H5M>
     </Link>
@@ -37,6 +37,7 @@ export function BreadcrumbText({ children, className, variant = "muted" }: Bread
   return (
     <Text.H5M
       color={variant === "current" ? "foreground" : "foregroundMuted"}
+      ellipsis
       className={cn("px-2 py-1 min-w-0", className)}
     >
       {children}

--- a/apps/web/src/routes/_authenticated/-components/notifications/notification-bell.tsx
+++ b/apps/web/src/routes/_authenticated/-components/notifications/notification-bell.tsx
@@ -72,7 +72,7 @@ export function NotificationBell() {
           ) : null}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={8} className="w-[360px] p-0">
+      <PopoverContent align="end" sideOffset={8} className="w-[360px] max-w-[calc(100vw-2rem)] p-0">
         {open ? (
           <>
             <NotificationHeader unread={unread} onMarkAll={() => markSeen.mutate()} pending={markSeen.isPending} />

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -105,10 +105,12 @@ export function ProjectBreadcrumbSegment() {
       >
         <ComboboxTrigger
           ref={triggerRef}
-          className="flex items-center gap-1 rounded px-2 py-1 transition-colors hover:bg-muted [&>svg]:text-muted-foreground"
+          className="flex min-w-0 max-w-48 items-center gap-1 rounded px-2 py-1 transition-colors hover:bg-muted [&>svg]:text-muted-foreground [&>svg]:shrink-0"
         >
-          {emoji && <span className="text-sm">{emoji}</span>}
-          <Text.H5M color="foregroundMuted">{title}</Text.H5M>
+          {emoji && <span className="text-sm shrink-0">{emoji}</span>}
+          <Text.H5M color="foregroundMuted" ellipsis>
+            {title}
+          </Text.H5M>
         </ComboboxTrigger>
         <ComboboxContent anchor={triggerRef} className="w-80 min-w-80">
           <ComboboxInput

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-approval-popover.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-approval-popover.tsx
@@ -118,7 +118,7 @@ export function AnnotationApprovalPopover({ annotationId, onAction }: Annotation
           </Button>
         </div>
       </PopoverAnchor>
-      <PopoverContent side="bottom" align="end" className="w-96">
+      <PopoverContent side="bottom" align="end" className="w-96 max-w-[calc(100vw-2rem)]">
         {decision !== null && (
           <div className="flex flex-col gap-2">
             <Text.H5 weight="semibold">Tell us why</Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover-content.tsx
@@ -60,7 +60,7 @@ export function AnnotationPopoverContent({
 }
 
 const ANNOTATION_POPOVER_CONTENT_CLASS =
-  "w-[400px] max-h-[70vh] overflow-y-auto p-1 rounded-2xl bg-secondary border-0 shadow"
+  "w-[400px] max-w-[calc(100vw-2rem)] max-h-[70vh] overflow-y-auto p-1 rounded-2xl bg-secondary border-0 shadow"
 
 function handleInteractOutside(e: Event) {
   const target = e.target as HTMLElement

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/enrichment-popover.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/enrichment-popover.tsx
@@ -79,7 +79,7 @@ export function EnrichmentPopover({ annotationId, rawFeedback }: EnrichmentPopov
             <Icon icon={SparklesIcon} size="xs" color="foregroundMuted" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent side="bottom" align="end" className="w-96">
+        <PopoverContent side="bottom" align="end" className="w-96 max-w-[calc(100vw-2rem)]">
           <div className="flex flex-col gap-2">
             <Text.H5 className="whitespace-pre-wrap">{rawFeedback}</Text.H5>
             <span className="flex items-center gap-1">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -126,17 +126,17 @@ export function SavedSearchSelector({
           <button
             type="button"
             aria-label="Saved searches"
-            className="flex h-full shrink-0 cursor-pointer items-center gap-1 self-stretch border-r border-input bg-secondary px-2 text-secondary-foreground transition-colors hover:bg-secondary/80"
+            className="flex h-full min-w-0 cursor-pointer items-center gap-1 self-stretch border-r border-input bg-secondary px-2 text-secondary-foreground transition-colors hover:bg-secondary/80"
           >
             {selected ? (
-              <span className="max-w-40 truncate text-sm">{selected.name}</span>
+              <span className="min-w-0 max-w-40 truncate text-sm">{selected.name}</span>
             ) : (
               <>
-                <Icon icon={BookmarkIcon} size="sm" color="foregroundMuted" />
+                <Icon icon={BookmarkIcon} size="sm" color="foregroundMuted" className="shrink-0" />
                 <span className="text-muted-foreground text-sm">Searches</span>
               </>
             )}
-            <Icon icon={ChevronDownIcon} size="sm" color="foregroundMuted" />
+            <Icon icon={ChevronDownIcon} size="sm" color="foregroundMuted" className="shrink-0" />
           </button>
         </PopoverTrigger>
         <PopoverContent align="start" sideOffset={6} className="w-80 p-0">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -89,7 +89,7 @@ function MomentLabelBadge({ label, store }: { readonly label: MomentLabelRecord;
           {label.kind.replaceAll("_", " ")}
         </button>
       </PopoverTrigger>
-      <PopoverContent side="bottom" align="start" className="w-96">
+      <PopoverContent side="bottom" align="start" className="w-96 max-w-[calc(100vw-2rem)]">
         <div className="flex items-start gap-3">
           <div className="min-w-0 flex-1">
             <MomentLabelEvidence label={label} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -51,8 +51,8 @@ const findNodeById = (
 
 function BehavioursBreadcrumb() {
   return (
-    <span className="flex items-center gap-2">
-      <TagsIcon className="h-4 w-4 text-muted-foreground" />
+    <span className="flex min-w-0 items-center gap-2">
+      <TagsIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
       <BreadcrumbText variant="current">Behaviours</BreadcrumbText>
     </span>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -30,14 +30,14 @@ function IssuesBreadcrumb() {
   const hasActiveFlaggers = flaggers.some((f) => f.enabled)
 
   return (
-    <span className="flex items-center gap-0">
+    <span className="flex min-w-0 items-center gap-0">
       <BreadcrumbText variant="current">Issues</BreadcrumbText>
       {hasActiveFlaggers && (
         <Tooltip
           side="bottom"
           align="center"
           trigger={
-            <span className="flex h-5 w-5 items-center justify-center cursor-default">
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center cursor-default">
               <DotIndicator variant="primary" size="md" ping />
             </span>
           }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/integration-card.tsx
@@ -26,7 +26,7 @@ export function IntegrationCard({
   readonly actions?: ReactNode
 }) {
   return (
-    <div className="flex flex-row items-center justify-between gap-4 rounded-lg border border-border p-4">
+    <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg border border-border p-4">
       <div className="flex min-w-0 flex-row items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
           <Icon icon={icon} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-page.tsx
@@ -24,7 +24,7 @@ interface SettingsPageProps {
 
 export function SettingsPage({ title, description, actions, children, headerSticky = false }: SettingsPageProps) {
   const header = (
-    <div className="flex flex-col gap-1">
+    <div className="flex min-w-48 flex-1 flex-col gap-1">
       {typeof title === "string" ? <SettingsPageTitle>{title}</SettingsPageTitle> : title}
       {description ? <Text.H6M color="foregroundMuted">{description}</Text.H6M> : null}
     </div>
@@ -33,7 +33,7 @@ export function SettingsPage({ title, description, actions, children, headerStic
   return (
     <>
       <div
-        className={cn("flex flex-row items-center justify-between gap-4", {
+        className={cn("flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2", {
           "sticky top-0 z-10 -mx-6 border-b border-border bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80":
             headerSticky,
         })}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-sub-nav.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/settings-sub-nav.tsx
@@ -1,22 +1,25 @@
-import { cn, Icon, Text } from "@repo/ui"
+import { cn, Icon, Text, Tooltip } from "@repo/ui"
 import { Link, useRouterState } from "@tanstack/react-router"
 import { useVisibleProjectSettingsGroups } from "../../../../../../domains/projects/project-sections.ts"
+import { useMediaQuery } from "../../../../../../lib/hooks/useMediaQuery.ts"
 
 export function SettingsSubNav({ projectSlug }: { projectSlug: string }) {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
   const groups = useVisibleProjectSettingsGroups()
+  // Mirrors the `md:` breakpoint that switches the nav to its icons-only rail.
+  const collapsed = !useMediaQuery("(min-width: 48rem)")
 
   return (
-    <nav className="flex w-72 shrink-0 flex-col gap-6 overflow-y-auto bg-secondary p-4">
+    <nav className="flex w-fit shrink-0 flex-col gap-6 overflow-y-auto bg-secondary p-4 md:w-72">
       {groups.map((group) => (
         <div key={group.title} className="flex flex-col gap-1">
-          <Text.H6 color="foregroundMuted" className="px-2 pb-1">
-            {group.title}
-          </Text.H6>
+          <span className="hidden px-2 pb-1 md:block">
+            <Text.H6 color="foregroundMuted">{group.title}</Text.H6>
+          </span>
           {group.items.map((item) => {
             const to = item.path(projectSlug)
             const active = pathname === to || pathname.startsWith(`${to}/`)
-            return (
+            const link = (
               <Link
                 key={item.key}
                 to={to}
@@ -25,8 +28,16 @@ export function SettingsSubNav({ projectSlug }: { projectSlug: string }) {
                 })}
               >
                 <Icon icon={item.icon} size="sm" color={active ? "foreground" : "foregroundMuted"} />
-                <Text.H5M color={active ? "foreground" : "foregroundMuted"}>{item.label}</Text.H5M>
+                <span className="hidden md:block">
+                  <Text.H5M color={active ? "foreground" : "foregroundMuted"}>{item.label}</Text.H5M>
+                </span>
               </Link>
+            )
+            if (!collapsed) return link
+            return (
+              <Tooltip key={item.key} asChild side="right" trigger={link}>
+                {item.label}
+              </Tooltip>
             )
           })}
         </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/slack-route-row.tsx
@@ -102,12 +102,12 @@ export function SlackRouteRow({
     // Mirrors the email-notification group cards in account settings; the only
     // difference is the channel picker where email has a switch.
     <div className="flex w-full flex-col gap-3 rounded-lg bg-muted/30 p-4">
-      <div className="flex w-full flex-row items-center justify-between gap-4">
+      <div className="flex w-full flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <div className="flex flex-col gap-1">
           <Text.H5M>{meta.label}</Text.H5M>
           <Text.H6 color="foregroundMuted">{meta.description}</Text.H6>
         </div>
-        <div className="w-52 shrink-0">
+        <div className="w-52 max-w-full shrink-0">
           <Combobox
             modal
             value={selected}
@@ -162,7 +162,7 @@ export function SlackRouteRow({
         </div>
       </div>
       {group === "incidents" && currentRoute ? (
-        <div className="flex flex-row items-center justify-between gap-4 rounded-lg bg-muted/80 px-3 py-2">
+        <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg bg-muted/80 px-3 py-2">
           <Text.H6 color="foregroundMuted">Severity · {minSeverityHint(currentRoute.minSeverity ?? "low")}</Text.H6>
           <SeveritySelector
             variant="bordered"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/account.tsx
@@ -354,7 +354,7 @@ function ConnectedAccountsSection() {
           return (
             <div
               key={provider.id}
-              className="flex w-full flex-row items-center justify-between gap-4 rounded-lg bg-muted/30 p-4"
+              className="flex w-full flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg bg-muted/30 p-4"
             >
               <div className="flex flex-row items-center gap-3">
                 {profile ? (
@@ -421,7 +421,7 @@ function SessionsSection() {
 
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex flex-row items-center justify-between">
+      <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <div className="flex flex-col gap-1">
           <Text.H5 weight="semibold">Sessions</Text.H5>
           <Text.H5 color="foregroundMuted">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/general.tsx
@@ -225,7 +225,7 @@ function TraceSamplingSection({
         </div>
         {enabled ? (
           <div className="flex w-full flex-col gap-2 border-border border-t p-4">
-            <div className="flex w-full flex-row items-center justify-between gap-4">
+            <div className="flex w-full flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2">
               <Label htmlFor="trace-sampling-rate" className="shrink-0">
                 Sampling rate
               </Label>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
@@ -127,7 +127,7 @@ function ConnectedSlackCard({
       )}
 
       {/* Identity row */}
-      <div className="flex flex-row items-center justify-between gap-4 p-4">
+      <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 p-4">
         <div className="flex min-w-0 flex-row items-center gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
             <Icon icon={SlackIcon} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/sso.tsx
@@ -328,7 +328,7 @@ function ProviderCard({
   return (
     <>
       <div className="flex flex-col gap-4 rounded-lg border border-border p-6">
-        <div className="flex flex-row items-center justify-between gap-4">
+        <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2">
           <div className="flex min-w-0 flex-col gap-1">
             <div className="flex flex-row items-center gap-2">
               <Text.H4 weight="bold">{provider.domain}</Text.H4>
@@ -492,7 +492,7 @@ function DangerZoneCard({ provider }: { provider: SsoProviderDto }) {
   }
 
   return (
-    <div className="flex flex-row items-center justify-between gap-4 rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+    <div className="flex flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg border border-destructive/30 bg-destructive/5 p-6">
       <div className="flex flex-col gap-1">
         <Text.H5 weight="semibold" color="destructive">
           Remove SSO provider


### PR DESCRIPTION
Narrow windows (~400–900px) broke layouts across the web app: nav header text wrapped and overflowed vertically, page headers crushed their titles to zero width behind `shrink-0` action clusters, toolbars clipped off-screen, fixed-width popovers rendered wider than the viewport, and the settings sub-nav left ~300px for forms. This PR fixes the app shell, the listing pages, settings, and the traces side panels. All changes are inert at wide widths — layouts only respond once space actually runs out.

## app nav header

Org name, project name, and breadcrumbs now ellipse on one 48px line instead of wrapping (completed `min-w-0` chain + the `Text` `ellipsis` prop). The logo, separators, and icons are pinned with `shrink-0`. Below `md` the right side collapses: search becomes icon-only, the billing counter keeps only its ring, Help loses its label, and the Docs link hides.

A note on `Text`: passing `className="truncate"` is unreliable because the component's default `whiteSpace="normal"` emits a class whose conflict with `truncate`'s `whitespace-nowrap` is resolved by stylesheet order. The `ellipsis` prop suppresses the whitespace class entirely — `BreadcrumbLink` carried that latent bug and was switched over too.

## listing page headers (`Layout.Header`)

Below 45rem of header width (container query — pane width depends on sidebars, not the viewport) the header stacks into two full-width rows: title block first, actions second, justified across the row. Above the threshold the single title-left/actions-right row is unchanged. The actions cluster also wraps internally when it alone exceeds the pane (the issue detail page packs ~440px of controls), so nothing clips off-screen even at very narrow widths.

## listing toolbars (`Layout.ActionsRow` / `ActionRowItem`)

Both now `flex-wrap`, and `ActionRowItem` lost its `shrink-0`, so filter/search/tab clusters flow onto extra lines instead of overflowing. Covers Issues, Tools, Monitors, Datasets, Behaviours, Traces, and the sandbox page. On Traces, the saved-search selector now shrinks with a truncated name instead of starving the search input (which already handles narrowness with internal scrolling).

## popovers

Six popovers had fixed widths up to 400px with no viewport clamp and clipped off-screen on small windows: annotation, enrichment, annotation approval, session moment label, notification bell, and the member selector. All now cap at `calc(100vw - 2rem)`.

## settings

The sub-nav collapses to an icons-only rail below `md`, with right-side tooltips matching the collapsed `AppSidebar` pattern (backed by a new `useMediaQuery` hook). The page header wraps so the sticky Apply/Discard bar stops crushing the title. Form rows with sliders, channel dropdowns, or buttons on the right wrap onto a second line; switch-only rows were left alone since they degrade fine.

## traces side panels

`Layout.Body` and the layout root are containers now: below 48rem of pane width, the filters panel (left) and the trace/session detail drawer (right) float over the table — absolute, full height, `z-20` above the sticky table header, with a shadow — instead of squeezing the table into an unusable sliver. They stay non-modal: no backdrop, content behind remains interactive, and the drawer keeps its resize handle.

## out of scope

Wide data tables (recent tool calls, traces) already scroll horizontally inside their own containers and were left as-is. Span-detail metadata tiles and conversation blocks flagged during the audit turned out fine on inspection.

Each change was hand-verified in the running app at narrow widths. `pnpm --filter web typecheck` and Biome pass.
