### PR TITLE
fix(monitors): keep muted monitors visible in saved-search summaries

### DIFF
--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -195,6 +195,7 @@ export interface SavedSearchMonitorSummaryRecord {
   readonly monitors: readonly {
     readonly slug: string
     readonly name: string
+    readonly muted: boolean
     readonly severities: readonly AlertSeverity[]
   }[]
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -13,6 +13,7 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Status,
   Text,
   Tooltip,
   TooltipContent,
@@ -24,6 +25,7 @@ import {
 import { useNavigate } from "@tanstack/react-router"
 import {
   BellIcon,
+  BellOffIcon,
   BellPlusIcon,
   BookmarkIcon,
   BookmarkPlusIcon,
@@ -118,6 +120,8 @@ export function SavedSearchSelector({
   }
 
   const selectedSummary = selected ? monitorSummaries[selected.id] : undefined
+  const selectedAllMuted = selectedSummary?.monitors.every((monitor) => monitor.muted) ?? false
+  const selectedMutedCount = selectedSummary?.monitors.filter((monitor) => monitor.muted).length ?? 0
 
   return (
     <>
@@ -162,7 +166,9 @@ export function SavedSearchSelector({
             ) : (
               filtered.map((record) => {
                 const isSelected = record.slug === selectedSlug
-                const hasMonitor = Boolean(monitorSummaries[record.id])
+                const summary = monitorSummaries[record.id]
+                const hasMonitor = Boolean(summary)
+                const allMuted = hasMonitor && (summary?.monitors.every((monitor) => monitor.muted) ?? false)
                 const filtersCount = Object.keys(record.filterSet).length
                 return (
                   <div
@@ -230,11 +236,15 @@ export function SavedSearchSelector({
                               }
                               onClick={() => goToMonitor(record)}
                             >
-                              <Icon icon={hasMonitor ? BellIcon : BellPlusIcon} size="sm" color="foregroundMuted" />
+                              <Icon
+                                icon={hasMonitor ? (allMuted ? BellOffIcon : BellIcon) : BellPlusIcon}
+                                size="sm"
+                                color="foregroundMuted"
+                              />
                             </Button>
                           }
                         >
-                          {hasMonitor ? "View monitor" : "Create monitor"}
+                          {hasMonitor ? (allMuted ? "View monitor (muted)" : "View monitor") : "Create monitor"}
                         </Tooltip>
                       )
                     ) : null}
@@ -304,7 +314,7 @@ export function SavedSearchSelector({
                       aria-label={`View monitors for ${selected.name}`}
                       className="flex h-full shrink-0 cursor-pointer items-center gap-1.5 self-stretch border-input border-r px-2 transition-colors hover:bg-secondary/60"
                     >
-                      <Icon icon={BellIcon} size="sm" color="foregroundMuted" />
+                      <Icon icon={selectedAllMuted ? BellOffIcon : BellIcon} size="sm" color="foregroundMuted" />
                       <SeverityDots severities={selectedSummary.severities} />
                     </button>
                   </DropdownMenuTrigger>
@@ -312,6 +322,11 @@ export function SavedSearchSelector({
                 <TooltipContent>
                   {selectedSummary.monitors.length} monitor
                   {selectedSummary.monitors.length === 1 ? "" : "s"}
+                  {selectedMutedCount > 0
+                    ? selectedMutedCount === selectedSummary.monitors.length
+                      ? " · muted"
+                      : ` · ${selectedMutedCount} muted`
+                    : ""}
                 </TooltipContent>
               </TooltipRoot>
             </TooltipProvider>
@@ -335,6 +350,7 @@ export function SavedSearchSelector({
                         {monitor.name}
                       </Text.H5>
                     </div>
+                    {monitor.muted ? <Status variant="neutral" label="Muted" /> : null}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -69,10 +69,12 @@ export interface MonitorSearchResult {
 
 /**
  * Per-saved-search monitoring summary. `monitorSlug` is the earliest-created
- * live, unmuted monitor watching the search (the primary deep-link target);
+ * live monitor watching the search (the primary deep-link target);
  * `severities` covers every live alert on such monitors (one UI dot per
  * alert); `monitors` lists each distinct watching monitor (earliest first)
- * so the UI can offer a picker when several watch the same search.
+ * so the UI can offer a picker when several watch the same search. Muted
+ * monitors are included (flagged via `muted`) — muting silences
+ * notifications, it does not sever the saved-search linkage.
  */
 export interface SavedSearchMonitorSummary {
   readonly savedSearchId: string
@@ -82,6 +84,7 @@ export interface SavedSearchMonitorSummary {
   readonly monitors: readonly {
     readonly slug: string
     readonly name: string
+    readonly muted: boolean
     /** Severities of this monitor's live alerts watching the search. */
     readonly severities: readonly AlertSeverity[]
   }[]
@@ -167,9 +170,9 @@ export interface MonitorRepositoryShape {
   /** Active saved-search alerts in a project (live alert + monitor). Org-scoped — the firing orchestrator resolves + evaluates each. */
   listActiveSavedSearchAlerts(projectId: ProjectId): Effect.Effect<readonly MonitorAlert[], RepositoryError, SqlClient>
   /**
-   * For every saved search watched by a live, unmuted monitor in the project: the slug of the
-   * earliest-created such monitor, the distinct monitor count, and the severities of every live
-   * alert watching it. Batched — one call covers all the project's saved searches.
+   * For every saved search watched by a live monitor (muted included) in the project: the slug of
+   * the earliest-created such monitor, the distinct monitor count, and the severities of every
+   * live alert watching it. Batched — one call covers all the project's saved searches.
    */
   listSavedSearchMonitorSummaries(
     projectId: ProjectId,

--- a/packages/domain/monitors/src/testing/fake-monitor-repository.ts
+++ b/packages/domain/monitors/src/testing/fake-monitor-repository.ts
@@ -186,7 +186,7 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
       Effect.sync(() => {
         const summaries = new Map<string, { byMonitor: Map<string, Monitor>; severities: MonitorAlert["severity"][] }>()
         for (const monitor of monitors) {
-          if (monitor.projectId !== projectId || !isLive(monitor) || monitor.mutedAt !== null) continue
+          if (monitor.projectId !== projectId || !isLive(monitor)) continue
           for (const alert of monitor.alerts) {
             if (alert.source.type !== "savedSearch" || !alert.source.id) continue
             const entry = summaries.get(alert.source.id) ?? {
@@ -214,6 +214,7 @@ export const createFakeMonitorRepository = (seed: readonly Monitor[] = []) => {
               monitors: ordered.map((m) => ({
                 slug: m.slug,
                 name: m.name,
+                muted: m.mutedAt !== null,
                 severities: m.alerts
                   .filter((alert) => alert.source.type === "savedSearch" && alert.source.id === savedSearchId)
                   .map((alert) => alert.severity),

--- a/packages/domain/monitors/src/use-cases/list-saved-search-monitor-summaries.ts
+++ b/packages/domain/monitors/src/use-cases/list-saved-search-monitor-summaries.ts
@@ -4,8 +4,9 @@ import { MonitorRepository } from "../ports/monitor-repository.ts"
 
 /**
  * Batched lookup backing the saved-search ↔ monitor linkage in the UI: for every saved search
- * watched by a live, unmuted monitor in the project, the earliest-created such monitor's slug
- * (the deep-link target) plus the distinct monitor count and the watching alerts' severities.
+ * watched by a live monitor in the project (muted included — muting silences notifications, not
+ * the linkage), the earliest-created such monitor's slug (the deep-link target) plus the distinct
+ * monitor count and the watching alerts' severities.
  */
 export const listSavedSearchMonitorSummariesUseCase = Effect.fn("monitors.listSavedSearchMonitorSummaries")(
   function* (input: { readonly projectId: ProjectId }) {

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -1158,7 +1158,7 @@ describe("MonitorRepositoryLive", () => {
         makeAlertRow({ id: "1".repeat(24), monitorId: older, sourceId: searchX, severity: "low" }),
         makeAlertRow({ id: "2".repeat(24), monitorId: newer, sourceId: searchX, severity: "high" }),
         makeAlertRow({ id: "3".repeat(24), monitorId: deleted, sourceId: searchX }),
-        // searchY is only watched by a muted monitor → excluded.
+        // searchY is only watched by a muted monitor → still listed, flagged muted.
         makeAlertRow({ id: "4".repeat(24), monitorId: muted, sourceId: searchY }),
         // soft-deleted alert on a live monitor → its source (searchZ) excluded.
         makeAlertRow({ id: "5".repeat(24), monitorId: older, sourceId: searchZ, deletedAt: new Date() }),
@@ -1177,9 +1177,16 @@ describe("MonitorRepositoryLive", () => {
           monitorCount: 2,
           severities: ["low", "high"],
           monitors: [
-            { slug: "older", name: "Older", severities: ["low"] },
-            { slug: "newer", name: "Newer", severities: ["high"] },
+            { slug: "older", name: "Older", muted: false, severities: ["low"] },
+            { slug: "newer", name: "Newer", muted: false, severities: ["high"] },
           ],
+        },
+        {
+          savedSearchId: searchY,
+          monitorSlug: "muted",
+          monitorCount: 1,
+          severities: ["medium"],
+          monitors: [{ slug: "muted", name: "Muted", muted: true, severities: ["medium"] }],
         },
       ])
     })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -580,9 +580,9 @@ export const MonitorRepositoryLive = Layer.effect(
       listSavedSearchMonitorSummaries: (projectId) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
-          // One row per live alert on a live, unmuted monitor; ordering puts the
-          // earliest-created monitor first per saved search so the first row seen
-          // carries the primary deep-link slug.
+          // One row per live alert on a live monitor (muted included — muting only
+          // silences notifications); ordering puts the earliest-created monitor first
+          // per saved search so the first row seen carries the primary deep-link slug.
           const rows = yield* sqlClient.query((db) =>
             db
               .select({
@@ -590,6 +590,7 @@ export const MonitorRepositoryLive = Layer.effect(
                 monitorId: monitors.id,
                 monitorSlug: monitors.slug,
                 monitorName: monitors.name,
+                monitorMutedAt: monitors.mutedAt,
                 severity: monitorAlerts.severity,
               })
               .from(monitorAlerts)
@@ -602,7 +603,6 @@ export const MonitorRepositoryLive = Layer.effect(
                   isNotNull(monitorAlerts.sourceId),
                   isNull(monitorAlerts.deletedAt),
                   isNull(monitors.deletedAt),
-                  isNull(monitors.mutedAt),
                 ),
               )
               .orderBy(
@@ -613,7 +613,12 @@ export const MonitorRepositoryLive = Layer.effect(
               ),
           )
 
-          type MonitorEntry = { slug: string; name: string; severities: (typeof rows)[number]["severity"][] }
+          type MonitorEntry = {
+            slug: string
+            name: string
+            muted: boolean
+            severities: (typeof rows)[number]["severity"][]
+          }
           const summaries = new Map<
             string,
             {
@@ -632,7 +637,12 @@ export const MonitorRepositoryLive = Layer.effect(
             let monitor = entry.byMonitorId.get(row.monitorId)
             if (!monitor) {
               // Row order is earliest monitor first, so `monitors[0]` is the primary.
-              monitor = { slug: row.monitorSlug, name: row.monitorName, severities: [] }
+              monitor = {
+                slug: row.monitorSlug,
+                name: row.monitorName,
+                muted: row.monitorMutedAt !== null,
+                severities: [],
+              }
               entry.byMonitorId.set(row.monitorId, monitor)
               entry.monitors.push(monitor)
             }


### PR DESCRIPTION
## What

Muting a monitor made it disappear from the traces-page saved-search selector: the bell badge and monitored-state chip vanished and the row reverted to "Create monitor", as if the linkage had been deleted. The monitor and its alerts still existed — `listSavedSearchMonitorSummaries` filtered them out with `isNull(monitors.mutedAt)`.

This drops that filter and carries a `muted` flag on each monitor entry in the summary (port, live repository, fake repository, web record type). The selector now keeps the linkage visible and renders the muted state instead:

- row bell and monitored-state chip switch to a bell-off icon when every watching monitor is muted
- the chip tooltip appends `· muted` (or `· N muted` when only some are)
- muted monitors get a neutral `Muted` chip in the chip's monitor picker, matching the monitor detail drawer

## Why notifications are unaffected

Muting was never enforced through this query — it's display-only (its single consumer is the web server function behind the selector). The notification mute gate lives in `requestIncidentNotificationsUseCase`, which resolves the owning monitor per incident and skips with `monitor-muted`; the alert-evaluation sweep already includes muted monitors by design. Both paths are untouched.

## Testing

Updated the repository test: a saved search watched only by a muted monitor is now summarized with `muted: true`, and unmuted entries assert `muted: false`. `@platform/db-postgres` and `@domain/monitors` suites pass; typecheck clean on the three touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)