### PR TITLE
feat(taxonomy): fail fast on lost gardening plan artifacts

### DIFF
--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -30,7 +30,7 @@ import {
   withPostgres,
 } from "@platform/db-postgres"
 import { createLogger, withTracing } from "@repo/observability"
-import { Effect, Layer } from "effect"
+import { Data, Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 import { buildHierarchicalClustersInWorker } from "./taxonomy-clustering-worker.ts"
 
@@ -186,14 +186,22 @@ const storeGardenTaxonomyPlan = (input: GardenTaxonomyStepInput, plan: StoredGar
     catch: (error) => (error instanceof Error ? error : new Error(String(error))),
   })
 
+class TaxonomyGardeningPlanMissingError extends Data.TaggedError("TaxonomyGardeningPlanMissingError")<{
+  readonly message: string
+}> {}
+
 const loadGardenTaxonomyPlan = (input: GardenTaxonomyPlanReferenceInput) =>
-  Effect.tryPromise({
-    try: async () => {
-      const value = await getRedisClient().get(input.planKey)
-      if (value === null) throw new Error(`Missing taxonomy gardening plan artifact: ${input.planKey}`)
-      return JSON.parse(value) as StoredGardenTaxonomyPlan
-    },
-    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+  Effect.gen(function* () {
+    const value = yield* Effect.tryPromise({
+      try: () => getRedisClient().get(input.planKey),
+      catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+    })
+    if (value === null) {
+      return yield* new TaxonomyGardeningPlanMissingError({
+        message: `Missing taxonomy gardening plan artifact: ${input.planKey}`,
+      })
+    }
+    return JSON.parse(value) as StoredGardenTaxonomyPlan
   })
 
 const reviveDate = (value: Date | string): Date => (value instanceof Date ? value : new Date(value))

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -30,6 +30,8 @@ const {
     ...defaultActivityRetryPolicy,
     initialInterval: "1 minute",
     maximumInterval: "30 minutes",
+    // A staged plan lost from Redis (eviction, flush) cannot reappear; fail fast and let the next sweep rebuild.
+    nonRetryableErrorTypes: ["TaxonomyGardeningPlanMissingError"],
   },
 })
 

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -102,9 +102,6 @@ export const TAXONOMY_GARDENING_MIN_OBSERVATIONS = 15
 export const TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX = 1_500
 export const TAXONOMY_CLUSTERING_SAMPLE_STRATEGY = "day_stratified_hash_round_robin"
 
-export const taxonomyClusteringSampleLimit = (observationsAvailable: number): number =>
-  Math.min(Math.max(0, Math.floor(observationsAvailable)), TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX)
-
 /** Read-path live window for project/cluster observation pages. */
 export const TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX = 10_000
 

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -49,7 +49,6 @@ export {
   TAXONOMY_TREE_DEPTH_SCHEDULE,
   type TaxonomyObservationWeightScheme,
   type TaxonomyTreeDepthSchedule,
-  taxonomyClusteringSampleLimit,
 } from "./constants.ts"
 export {
   type TaxonomyCentroid,

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -72,7 +72,6 @@ import {
   TAXONOMY_NOISE_LOOKBACK_DAYS,
   TAXONOMY_PENDING_DISPLAY_NAME,
   TAXONOMY_TREE_DEPTH_SCHEDULE,
-  taxonomyClusteringSampleLimit,
 } from "../constants.ts"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
@@ -293,13 +292,11 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       projectId: input.projectId,
       since,
     })
-    const sampleLimit = taxonomyClusteringSampleLimit(counts.total)
-
     const observations = yield* observationsRepo.listForClusteringSample({
       organizationId: input.organizationId,
       projectId: input.projectId,
       since,
-      limit: sampleLimit,
+      limit: TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
     })
 
     const baseResult = {


### PR DESCRIPTION
## What does this PR do?

Follow-up to #3519, picking up the two non-blocking review notes:

- The gardening write activities (`save` / `reassign` / `deprecate`) now raise a tagged `TaxonomyGardeningPlanMissingError` when the staged plan artifact is gone from Redis, and the gardening proxy lists it in `nonRetryableErrorTypes`. Redis is not durable storage — an evicted or flushed plan cannot reappear, so retrying only burned the ~2-day retry budget before the run failed anyway. The run now fails immediately and the next cron sweep rebuilds from scratch. Verified the tagged error's `name` survives `Effect.runPromise` rejection, which is what Temporal matches `nonRetryableErrorTypes` against (same mechanism the seed-demo-project workflow relies on for `SeedError`).
- Drops `taxonomyClusteringSampleLimit`. After #3519 removed the fractional sampling it reduced to `min(available, cap)`, which is exactly what `listForClusteringSample` returns for `limit: cap` — the plan use-case now passes `TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX` directly. No behavior change; `observations_available` still comes from `getCounts`.

## Validation

- `pnpm --filter @domain/taxonomy typecheck`
- `pnpm --filter @domain/taxonomy check` / `pnpm --filter @domain/taxonomy test -- build-hierarchical-taxonomy`
- `pnpm --filter @app/workflows check`
- `pnpm --filter @app/workflows exec vitest run src/workflows/taxonomy-gardening-workflow.test.ts src/activities/taxonomy-clustering-worker.test.ts`
- `pnpm format` / `pnpm knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)