### PR TITLE
feat(spans): parse LiveKit Agents telemetry content

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,7 +105,8 @@
               "telemetry/frameworks/langchain",
               "telemetry/frameworks/llamaindex",
               "telemetry/frameworks/mastra",
-              "telemetry/frameworks/strands"
+              "telemetry/frameworks/strands",
+              "telemetry/frameworks/livekit"
             ]
           },
           {

--- a/docs/telemetry/frameworks/livekit.mdx
+++ b/docs/telemetry/frameworks/livekit.mdx
@@ -7,7 +7,7 @@ description: Connect your LiveKit voice AI agents to Latitude for observability.
 
 This guide shows you how to send traces from a [**LiveKit Agents**](https://docs.livekit.io/agents/) application to Latitude.
 
-LiveKit Agents ships with built-in OpenTelemetry support and owns its own `TracerProvider`. Instead of bootstrapping telemetry with the `Latitude` class, you attach a **`LatitudeSpanProcessor`** to LiveKit's provider — Latitude then receives the same spans LiveKit emits for LLM, agent, and tool activity.
+LiveKit Agents ships with built-in OpenTelemetry support and owns its own tracer provider. Instead of bootstrapping telemetry with the `Latitude` class, you attach a **`LatitudeSpanProcessor`** to LiveKit's provider — Latitude then receives the same spans LiveKit emits for LLM, agent, and tool activity. This works the same way for the **Python** (`livekit-agents`) and **Node.js** (`@livekit/agents`) SDKs.
 
 <Check>
   You'll keep building your LiveKit agent exactly as you do today. Latitude
@@ -20,7 +20,7 @@ LiveKit Agents ships with built-in OpenTelemetry support and owns its own `Trace
 
 - A **Latitude account** and **API key**
 - A **Latitude project slug**
-- A project that uses **LiveKit Agents** (`livekit-agents`)
+- A project that uses **LiveKit Agents** (`livekit-agents` or `@livekit/agents`)
 
 ---
 
@@ -29,43 +29,91 @@ LiveKit Agents ships with built-in OpenTelemetry support and owns its own `Trace
 <Steps>
 
   <Step title="Install">
-    ```bash pip
-    pip install latitude-telemetry "livekit-agents[openai]"
-    ```
+    <Tabs>
+      <Tab title="Python">
+        ```bash pip
+        pip install latitude-telemetry "livekit-agents[openai]"
+        ```
+      </Tab>
+      <Tab title="TypeScript">
+        <CodeGroup>
+          ```bash npm
+          npm install @latitude-data/telemetry @opentelemetry/sdk-trace-node
+          ```
+
+          ```bash pnpm
+          pnpm add @latitude-data/telemetry @opentelemetry/sdk-trace-node
+          ```
+
+          ```bash yarn
+          yarn add @latitude-data/telemetry @opentelemetry/sdk-trace-node
+          ```
+        </CodeGroup>
+      </Tab>
+    </Tabs>
   </Step>
 
   <Step title="Register the span processor">
-    Build a `TracerProvider`, add the `LatitudeSpanProcessor`, and hand the provider to LiveKit with `set_tracer_provider` inside your entrypoint.
+    Build a tracer provider, add the `LatitudeSpanProcessor`, and hand the provider to LiveKit inside your entrypoint.
 
-    ```python
-    import os
+    <Tabs>
+      <Tab title="Python">
+        ```python
+        import os
 
-    from livekit.agents import AgentSession, JobContext
-    from livekit.agents.telemetry import set_tracer_provider
-    from opentelemetry.sdk.trace import TracerProvider
+        from livekit.agents import AgentSession, JobContext
+        from livekit.agents.telemetry import set_tracer_provider
+        from opentelemetry.sdk.trace import TracerProvider
 
-    from latitude_telemetry import LatitudeSpanProcessor
+        from latitude_telemetry import LatitudeSpanProcessor
 
 
-    def setup_latitude_telemetry():
-        provider = TracerProvider()
-        provider.add_span_processor(
-            LatitudeSpanProcessor(
-                os.environ["LATITUDE_API_KEY"],
-                os.environ["LATITUDE_PROJECT_SLUG"],
+        def setup_latitude_telemetry():
+            provider = TracerProvider()
+            provider.add_span_processor(
+                LatitudeSpanProcessor(
+                    os.environ["LATITUDE_API_KEY"],
+                    os.environ["LATITUDE_PROJECT_SLUG"],
+                )
             )
-        )
-        set_tracer_provider(provider)
+            set_tracer_provider(provider)
 
 
-    async def entrypoint(ctx: JobContext):
-        setup_latitude_telemetry()
+        async def entrypoint(ctx: JobContext):
+            setup_latitude_telemetry()
 
-        session = AgentSession(
-            # ... your STT / LLM / TTS configuration
-        )
-        # ... start your agent as usual
-    ```
+            session = AgentSession(
+                # ... your STT / LLM / TTS configuration
+            )
+            # ... start your agent as usual
+        ```
+      </Tab>
+      <Tab title="TypeScript">
+        ```ts
+        import { telemetry, type JobContext } from "@livekit/agents"
+        import { LatitudeSpanProcessor } from "@latitude-data/telemetry"
+        import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
+
+        function setupLatitudeTelemetry() {
+          const provider = new NodeTracerProvider({
+            spanProcessors: [
+              new LatitudeSpanProcessor(
+                process.env.LATITUDE_API_KEY!,
+                process.env.LATITUDE_PROJECT_SLUG!,
+              ),
+            ],
+          })
+          telemetry.setTracerProvider(provider)
+        }
+
+        export default async function entrypoint(ctx: JobContext) {
+          setupLatitudeTelemetry()
+
+          // ... build and start your AgentSession as usual
+        }
+        ```
+      </Tab>
+    </Tabs>
   </Step>
 
 </Steps>
@@ -87,15 +135,21 @@ LiveKit's LLM spans carry both `gen_ai.*` metadata and the conversation content 
   processor's smart filter forwards only LLM-relevant spans to keep your traces
   focused. To export every LiveKit span, pass options:
 
-  ```python
-  from latitude_telemetry import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
+  <CodeGroup>
+    ```python Python
+    from latitude_telemetry import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
 
-  LatitudeSpanProcessor(
-      api_key,
-      project,
-      LatitudeSpanProcessorOptions(disable_smart_filter=True),
-  )
-  ```
+    LatitudeSpanProcessor(
+        api_key,
+        project,
+        LatitudeSpanProcessorOptions(disable_smart_filter=True),
+    )
+    ```
+
+    ```ts TypeScript
+    new LatitudeSpanProcessor(apiKey, project, { disableSmartFilter: true })
+    ```
+  </CodeGroup>
 </Note>
 
 ---

--- a/docs/telemetry/frameworks/livekit.mdx
+++ b/docs/telemetry/frameworks/livekit.mdx
@@ -1,0 +1,109 @@
+---
+title: LiveKit Agents
+description: Connect your LiveKit voice AI agents to Latitude for observability.
+---
+
+## Overview
+
+This guide shows you how to send traces from a [**LiveKit Agents**](https://docs.livekit.io/agents/) application to Latitude.
+
+LiveKit Agents ships with built-in OpenTelemetry support and owns its own `TracerProvider`. Instead of bootstrapping telemetry with the `Latitude` class, you attach a **`LatitudeSpanProcessor`** to LiveKit's provider — Latitude then receives the same spans LiveKit emits for LLM, agent, and tool activity.
+
+<Check>
+  You'll keep building your LiveKit agent exactly as you do today. Latitude
+  observes the LLM spans the framework already produces.
+</Check>
+
+---
+
+## Requirements
+
+- A **Latitude account** and **API key**
+- A **Latitude project slug**
+- A project that uses **LiveKit Agents** (`livekit-agents`)
+
+---
+
+## Steps
+
+<Steps>
+
+  <Step title="Install">
+    ```bash pip
+    pip install latitude-telemetry "livekit-agents[openai]"
+    ```
+  </Step>
+
+  <Step title="Register the span processor">
+    Build a `TracerProvider`, add the `LatitudeSpanProcessor`, and hand the provider to LiveKit with `set_tracer_provider` inside your entrypoint.
+
+    ```python
+    import os
+
+    from livekit.agents import AgentSession, JobContext
+    from livekit.agents.telemetry import set_tracer_provider
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from latitude_telemetry import LatitudeSpanProcessor
+
+
+    def setup_latitude_telemetry():
+        provider = TracerProvider()
+        provider.add_span_processor(
+            LatitudeSpanProcessor(
+                os.environ["LATITUDE_API_KEY"],
+                os.environ["LATITUDE_PROJECT_SLUG"],
+            )
+        )
+        set_tracer_provider(provider)
+
+
+    async def entrypoint(ctx: JobContext):
+        setup_latitude_telemetry()
+
+        session = AgentSession(
+            # ... your STT / LLM / TTS configuration
+        )
+        # ... start your agent as usual
+    ```
+  </Step>
+
+</Steps>
+
+---
+
+## What you get
+
+LiveKit's LLM spans carry both `gen_ai.*` metadata and the conversation content in custom `lk.*` attributes. Latitude parses both, so each LLM turn shows up with:
+
+- **Model and provider** — from `gen_ai.request.model` / `gen_ai.provider.name`
+- **Token usage and latency** — input/output tokens, time-to-first-token
+- **Input messages** — the chat context (system prompt, user turns, prior tool calls and results)
+- **Output messages** — the assistant response text and any tool calls the model emitted
+- **Tool definitions** — the function tools available to the agent
+
+<Note>
+  LiveKit produces many non-LLM spans (STT, TTS, VAD). By default the span
+  processor's smart filter forwards only LLM-relevant spans to keep your traces
+  focused. To export every LiveKit span, pass options:
+
+  ```python
+  from latitude_telemetry import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
+
+  LatitudeSpanProcessor(
+      api_key,
+      project,
+      LatitudeSpanProcessorOptions(disable_smart_filter=True),
+  )
+  ```
+</Note>
+
+---
+
+## Seeing Your Traces
+
+Once connected, traces appear automatically in Latitude:
+
+1. Open your **project** in the Latitude dashboard
+2. Each agent turn shows the LLM call with its input/output conversation
+3. Token usage and latency are aggregated at every level

--- a/docs/telemetry/frameworks/livekit.mdx
+++ b/docs/telemetry/frameworks/livekit.mdx
@@ -31,9 +31,19 @@ LiveKit Agents ships with built-in OpenTelemetry support and owns its own tracer
   <Step title="Install">
     <Tabs>
       <Tab title="Python">
-        ```bash pip
-        pip install latitude-telemetry "livekit-agents[openai]"
-        ```
+        <CodeGroup>
+          ```bash pip
+          pip install latitude-telemetry "livekit-agents[openai]"
+          ```
+
+          ```bash uv
+          uv add latitude-telemetry "livekit-agents[openai]"
+          ```
+
+          ```bash poetry
+          poetry add latitude-telemetry "livekit-agents[openai]"
+          ```
+        </CodeGroup>
       </Tab>
       <Tab title="TypeScript">
         <CodeGroup>

--- a/packages/domain/spans/src/otlp/content/index.ts
+++ b/packages/domain/spans/src/otlp/content/index.ts
@@ -5,6 +5,7 @@ import type { OtlpKeyValue } from "../types.ts"
 import { parseClaudeCode } from "./claude-code.ts"
 import { parseGenAICurrent } from "./genai.ts"
 import { parseGenAIDeprecated } from "./genai_deprecated.ts"
+import { parseLiveKit } from "./livekit.ts"
 import { parseOpenInference } from "./openinference.ts"
 import { parseVercel } from "./vercel.ts"
 
@@ -60,6 +61,11 @@ const PARSERS: readonly ContentParser[] = [
       hasKeyPrefix(attrs, "gen_ai.prompt.") ||
       hasKeyPrefix(attrs, "gen_ai.completion."),
     parse: parseGenAIDeprecated,
+  },
+  {
+    canHandle: (attrs) =>
+      hasKey(attrs, "lk.chat_ctx") || hasKey(attrs, "lk.response.text") || hasKey(attrs, "lk.response.function_calls"),
+    parse: parseLiveKit,
   },
   {
     canHandle: (attrs) => hasKey(attrs, "user_prompt"), // Claude Code

--- a/packages/domain/spans/src/otlp/content/index.ts
+++ b/packages/domain/spans/src/otlp/content/index.ts
@@ -64,7 +64,10 @@ const PARSERS: readonly ContentParser[] = [
   },
   {
     canHandle: (attrs) =>
-      hasKey(attrs, "lk.chat_ctx") || hasKey(attrs, "lk.response.text") || hasKey(attrs, "lk.response.function_calls"),
+      hasKey(attrs, "lk.chat_ctx") ||
+      hasKey(attrs, "lk.response.text") ||
+      hasKey(attrs, "lk.response.function_calls") ||
+      hasKey(attrs, "lk.function_tools"),
     parse: parseLiveKit,
   },
   {

--- a/packages/domain/spans/src/otlp/content/livekit.ts
+++ b/packages/domain/spans/src/otlp/content/livekit.ts
@@ -1,0 +1,164 @@
+/**
+ * Content parser for LiveKit Agents telemetry.
+ *
+ * LiveKit carries model/usage metadata on gen_ai.* attributes but serializes the
+ * actual conversation content into custom `lk.*` attributes. OTel attributes are
+ * primitives, so every structured value below is a JSON string.
+ *
+ *   lk.chat_ctx                — ChatContext.to_dict(): { items: ChatItem[] } (LLM input)
+ *   lk.response.text           — assistant completion text
+ *   lk.response.function_calls — FunctionCall[] the model emitted this turn
+ *   lk.function_tools          — available tool schemas
+ *
+ * ChatItem is discriminated by `type`:
+ *   message              — { role, content: (string | { type: "image_content" | "audio_content", ... })[] }
+ *   function_call        — { call_id, name, arguments } (assistant tool call)
+ *   function_call_output — { call_id, output } (tool result)
+ */
+import type { GenAIMessage, GenAISystem } from "rosetta-ai"
+import type { ToolDefinition } from "../../entities/span.ts"
+import type { OtlpKeyValue } from "../types.ts"
+import type { ParsedContent } from "./index.ts"
+import { toToolDefinition } from "./utils.ts"
+
+function rawString(attrs: readonly OtlpKeyValue[], key: string): string | undefined {
+  return attrs.find((a) => a.key === key)?.value?.stringValue
+}
+
+function rawJson(attrs: readonly OtlpKeyValue[], key: string): unknown {
+  const raw = rawString(attrs, key)
+  if (raw === undefined) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+function parseArguments(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+type Part = Record<string, unknown>
+
+function contentToParts(content: unknown): Part[] {
+  if (typeof content === "string") return content ? [{ type: "text", content }] : []
+  if (!Array.isArray(content)) return []
+
+  const parts: Part[] = []
+  for (const item of content) {
+    if (typeof item === "string") {
+      if (item) parts.push({ type: "text", content: item })
+      continue
+    }
+    if (!item || typeof item !== "object") continue
+
+    const obj = item as Record<string, unknown>
+    if (obj.type === "image_content") {
+      if (typeof obj.image === "string" && obj.image) {
+        parts.push({ type: "uri", modality: "image", uri: obj.image })
+      }
+    } else if (obj.type === "audio_content") {
+      if (typeof obj.transcript === "string" && obj.transcript) {
+        parts.push({ type: "text", content: obj.transcript })
+      }
+    } else if (typeof obj.text === "string" && obj.text) {
+      parts.push({ type: "text", content: obj.text })
+    }
+  }
+  return parts
+}
+
+function isSystemRole(role: unknown): boolean {
+  return role === "system" || role === "developer"
+}
+
+function parseChatContext(attrs: readonly OtlpKeyValue[]): {
+  inputMessages: GenAIMessage[]
+  systemInstructions: GenAISystem
+} {
+  const ctx = rawJson(attrs, "lk.chat_ctx")
+  const items = (ctx as { items?: unknown })?.items
+  if (!Array.isArray(items)) return { inputMessages: [], systemInstructions: [] }
+
+  const inputMessages: Part[] = []
+  const systemInstructions: Part[] = []
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue
+    const obj = item as Record<string, unknown>
+
+    switch (obj.type) {
+      case "message": {
+        const parts = contentToParts(obj.content)
+        if (parts.length === 0) break
+        if (isSystemRole(obj.role)) {
+          for (const part of parts) {
+            if (part.type === "text") systemInstructions.push(part)
+          }
+        } else {
+          inputMessages.push({ role: obj.role, parts })
+        }
+        break
+      }
+      case "function_call":
+        inputMessages.push({
+          role: "assistant",
+          parts: [{ type: "tool_call", id: obj.call_id, name: obj.name, arguments: parseArguments(obj.arguments) }],
+        })
+        break
+      case "function_call_output":
+        inputMessages.push({
+          role: "tool",
+          parts: [{ type: "tool_call_response", id: obj.call_id, response: obj.output }],
+        })
+        break
+    }
+  }
+
+  return {
+    inputMessages: inputMessages as unknown as GenAIMessage[],
+    systemInstructions: systemInstructions as unknown as GenAISystem,
+  }
+}
+
+function parseOutput(attrs: readonly OtlpKeyValue[]): GenAIMessage[] {
+  const parts: Part[] = []
+
+  const text = rawString(attrs, "lk.response.text")
+  if (text) parts.push({ type: "text", content: text })
+
+  const calls = rawJson(attrs, "lk.response.function_calls")
+  if (Array.isArray(calls)) {
+    for (const call of calls) {
+      if (!call || typeof call !== "object") continue
+      const obj = call as Record<string, unknown>
+      parts.push({ type: "tool_call", id: obj.call_id, name: obj.name, arguments: parseArguments(obj.arguments) })
+    }
+  }
+
+  if (parts.length === 0) return []
+  return [{ role: "assistant", parts }] as unknown as GenAIMessage[]
+}
+
+function parseToolDefinitions(attrs: readonly OtlpKeyValue[]): ToolDefinition[] {
+  const tools = rawJson(attrs, "lk.function_tools")
+  if (!Array.isArray(tools)) return []
+  return tools.map(toToolDefinition).filter(Boolean) as ToolDefinition[]
+}
+
+export function parseLiveKit(attrs: readonly OtlpKeyValue[]): ParsedContent {
+  const { inputMessages, systemInstructions } = parseChatContext(attrs)
+
+  return {
+    inputMessages,
+    outputMessages: parseOutput(attrs),
+    systemInstructions,
+    toolDefinitions: parseToolDefinitions(attrs),
+  }
+}

--- a/packages/domain/spans/src/otlp/tests/livekit.test.ts
+++ b/packages/domain/spans/src/otlp/tests/livekit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+import { parseContent } from "../content/index.ts"
+import type { OtlpKeyValue } from "../types.ts"
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+
+const SYSTEM_PROMPT = "You are a helpful voice assistant."
+const USER_TEXT = "What's the weather in Barcelona?"
+const IMAGE_URL = "https://example.com/photo.jpg"
+const FINAL_RESPONSE = "It's 22°C and sunny in Barcelona."
+
+const TOOL_DEFS = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a city",
+      parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+    },
+  },
+]
+
+describe("parseContent (LiveKit)", () => {
+  it("parses chat_ctx messages, system instructions, images, response text and tool definitions", () => {
+    const chatCtx = {
+      items: [
+        { type: "message", role: "system", content: [SYSTEM_PROMPT] },
+        {
+          type: "message",
+          role: "user",
+          content: [USER_TEXT, { type: "image_content", image: IMAGE_URL }],
+        },
+      ],
+    }
+
+    const result = parseContent([
+      str("gen_ai.operation.name", "chat"),
+      str("gen_ai.request.model", "gpt-4o"),
+      str("lk.chat_ctx", JSON.stringify(chatCtx)),
+      str("lk.response.text", FINAL_RESPONSE),
+      str("lk.function_tools", JSON.stringify(TOOL_DEFS)),
+    ])
+
+    expect(result.systemInstructions).toEqual([{ type: "text", content: SYSTEM_PROMPT }])
+    expect(result.inputMessages).toEqual([
+      {
+        role: "user",
+        parts: [
+          { type: "text", content: USER_TEXT },
+          { type: "uri", modality: "image", uri: IMAGE_URL },
+        ],
+      },
+    ])
+    expect(result.outputMessages).toEqual([{ role: "assistant", parts: [{ type: "text", content: FINAL_RESPONSE }] }])
+    expect(result.toolDefinitions).toEqual([
+      {
+        name: "get_weather",
+        description: "Get current weather for a city",
+        parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+      },
+    ])
+  })
+
+  it("maps function calls and function call outputs from chat_ctx to tool messages", () => {
+    const chatCtx = {
+      items: [
+        { type: "message", role: "user", content: ["Book a hotel"] },
+        { type: "function_call", call_id: "call_1", name: "book_hotel", arguments: '{"city":"Barcelona"}' },
+        { type: "function_call_output", call_id: "call_1", name: "book_hotel", output: "No rooms available" },
+      ],
+    }
+
+    const result = parseContent([str("lk.chat_ctx", JSON.stringify(chatCtx))])
+
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "text", content: "Book a hotel" }] },
+      {
+        role: "assistant",
+        parts: [{ type: "tool_call", id: "call_1", name: "book_hotel", arguments: { city: "Barcelona" } }],
+      },
+      { role: "tool", parts: [{ type: "tool_call_response", id: "call_1", response: "No rooms available" }] },
+    ])
+  })
+
+  it("parses response function_calls into an assistant tool-call message", () => {
+    const functionCalls = [{ call_id: "call_2", name: "get_weather", arguments: '{"city":"Barcelona"}' }]
+
+    const result = parseContent([
+      str("lk.response.text", "Let me check that for you."),
+      str("lk.response.function_calls", JSON.stringify(functionCalls)),
+    ])
+
+    expect(result.outputMessages).toEqual([
+      {
+        role: "assistant",
+        parts: [
+          { type: "text", content: "Let me check that for you." },
+          { type: "tool_call", id: "call_2", name: "get_weather", arguments: { city: "Barcelona" } },
+        ],
+      },
+    ])
+  })
+
+  it("returns empty content when no LiveKit attributes are present", () => {
+    const result = parseContent([str("gen_ai.operation.name", "chat")])
+
+    expect(result.inputMessages).toEqual([])
+    expect(result.outputMessages).toEqual([])
+    expect(result.systemInstructions).toEqual([])
+    expect(result.toolDefinitions).toEqual([])
+  })
+})

--- a/packages/domain/spans/src/otlp/tests/livekit.test.ts
+++ b/packages/domain/spans/src/otlp/tests/livekit.test.ts
@@ -103,6 +103,65 @@ describe("parseContent (LiveKit)", () => {
     ])
   })
 
+  it("treats the developer role as system instructions and preserves assistant history", () => {
+    const chatCtx = {
+      items: [
+        { type: "message", role: "developer", content: ["Stay concise."] },
+        { type: "message", role: "user", content: ["Hi"] },
+        { type: "message", role: "assistant", content: ["Hello, how can I help?"] },
+      ],
+    }
+
+    const result = parseContent([str("lk.chat_ctx", JSON.stringify(chatCtx))])
+
+    expect(result.systemInstructions).toEqual([{ type: "text", content: "Stay concise." }])
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "text", content: "Hi" }] },
+      { role: "assistant", parts: [{ type: "text", content: "Hello, how can I help?" }] },
+    ])
+  })
+
+  it("maps audio transcripts and plain-string content to text parts", () => {
+    const chatCtx = {
+      items: [
+        { type: "message", role: "user", content: "Just a string" },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "audio_content", transcript: "spoken question" }],
+        },
+      ],
+    }
+
+    const result = parseContent([str("lk.chat_ctx", JSON.stringify(chatCtx))])
+
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "text", content: "Just a string" }] },
+      { role: "user", parts: [{ type: "text", content: "spoken question" }] },
+    ])
+  })
+
+  it("extracts tool definitions from a span carrying only lk.function_tools", () => {
+    const result = parseContent([str("lk.function_tools", JSON.stringify(TOOL_DEFS))])
+
+    expect(result.toolDefinitions).toEqual([
+      {
+        name: "get_weather",
+        description: "Get current weather for a city",
+        parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+      },
+    ])
+    expect(result.inputMessages).toEqual([])
+    expect(result.outputMessages).toEqual([])
+  })
+
+  it("degrades gracefully on malformed lk.chat_ctx JSON", () => {
+    const result = parseContent([str("lk.chat_ctx", "{ not valid json"), str("lk.response.text", "ok")])
+
+    expect(result.inputMessages).toEqual([])
+    expect(result.outputMessages).toEqual([{ role: "assistant", parts: [{ type: "text", content: "ok" }] }])
+  })
+
   it("returns empty content when no LiveKit attributes are present", () => {
     const result = parseContent([str("gen_ai.operation.name", "chat")])
 


### PR DESCRIPTION
## Summary

Makes LiveKit Agents integrate seamlessly with Latitude.

LiveKit Agents already ship built-in OpenTelemetry and emit LLM **metadata** on standard `gen_ai.*` attributes — so model, provider, token usage, and latency already flowed into Latitude when you attach a `LatitudeSpanProcessor` to LiveKit's `TracerProvider` (the same pattern Langfuse/Opik use). But LiveKit carries the actual **conversation content** in custom `lk.*` attributes that no existing content resolver understood, so LiveKit LLM spans landed with correct metadata but **blank prompts and responses**.

This PR adds a LiveKit content resolver that closes that gap.

## What changed

- **`packages/domain/spans/src/otlp/content/livekit.ts`** — new resolver that maps:
  - `lk.chat_ctx` (`ChatContext.to_dict()`) → input messages, including system/user/assistant turns, image content, and embedded `function_call` / `function_call_output` items → tool calls and tool results
  - `lk.response.text` + `lk.response.function_calls` → assistant output message (text + tool calls)
  - `lk.function_tools` → tool definitions
- **`content/index.ts`** — registers the resolver, gated on the `lk.*` attributes
- **`otlp/tests/livekit.test.ts`** — unit tests for messages/images/system/tools, function-call history, response tool calls, and the empty case
- **`docs/telemetry/frameworks/livekit.mdx`** (+ nav entry) — integration guide using `set_tracer_provider` + `LatitudeSpanProcessor`

## Notes

- The Python SDK smart filter is intentionally left untouched: LiveKit's LLM spans already pass it (they carry `gen_ai.*`), and adding `livekit` to the default scope list would wrongly admit noisy STT/TTS/VAD spans. Users who want everything can opt in via `LatitudeSpanProcessorOptions(disable_smart_filter=True)` (documented).

## Testing

- `vitest run otlp/tests/livekit.test.ts` — 4/4 pass
- Biome clean on all new/changed files

https://claude.ai/code/session_015hNRZZbYcWYKoTQyU3kkYF

---
_Generated by [Claude Code](https://claude.ai/code/session_015hNRZZbYcWYKoTQyU3kkYF)_