### PR TITLE
fix(readme): self-host GitHub stars badge

### DIFF
--- a/.github/badges/stars.json
+++ b/.github/badges/stars.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "GitHub stars",
+  "message": "4.1k",
+  "color": "blue"
+}

--- a/.github/workflows/stars-badge.yml
+++ b/.github/workflows/stars-badge.yml
@@ -1,0 +1,65 @@
+name: Update GitHub stars badge
+
+# Reads the repo's star count via the authenticated GitHub API and writes it
+# into .github/badges/stars.json, which the README's shields "endpoint" badge
+# reads. We self-host this instead of using shields' live github/stars badge
+# because that endpoint is shared-rate-limited and frequently renders as
+# "Unable to select next GitHub token from pool".
+
+on:
+  schedule:
+    - cron: "23 6 * * *" # daily at 06:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stars-badge
+  cancel-in-progress: false
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'latitude-dev/latitude-llm' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute star count
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          stars=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.stargazers_count')
+          echo "Star count: ${stars}"
+
+          # Format as a human-readable message.
+          if [ "$stars" -ge 1000000 ]; then
+            msg=$(awk "BEGIN { printf \"%.1fM\", ${stars}/1000000 }")
+          elif [ "$stars" -ge 1000 ]; then
+            msg=$(awk "BEGIN { printf \"%.1fk\", ${stars}/1000 }")
+          else
+            msg="${stars}"
+          fi
+
+          mkdir -p .github/badges
+          jq -n --arg msg "$msg" \
+            '{schemaVersion: 1, label: "GitHub stars", message: $msg, color: "blue"}' \
+            > .github/badges/stars.json
+
+          echo "Wrote badge:"
+          cat .github/badges/stars.json
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/badges/stars.json; then
+            echo "Badge unchanged; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/stars.json
+          git commit -m "chore: update GitHub stars badge [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://github.com/latitude-dev/latitude-llm/graphs/commit-activity" target="_blank"><img alt="Commits last month" src="https://img.shields.io/github/commit-activity/m/latitude-dev/latitude-llm?labelColor=%20%2332b583&color=%20%2312b76a"></a>
   <a href="https://www.npmjs.com/org/latitude-data"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/latitude-dev/latitude-llm/development/.github/badges/npm-downloads.json&logo=npm&logoColor=white" alt="npm downloads"></a>
   <a href="https://pypi.org/project/latitude-telemetry/"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/latitude-dev/latitude-llm/development/.github/badges/pypi-downloads.json&logo=python&logoColor=white" alt="PyPI downloads"></a>
-  <a href="https://github.com/latitude-dev/latitude-llm"><img src="https://img.shields.io/github/stars/latitude-dev/latitude-llm?style=social" alt="GitHub stars"></a>
+  <a href="https://github.com/latitude-dev/latitude-llm"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/latitude-dev/latitude-llm/development/.github/badges/stars.json&logo=github&logoColor=white" alt="GitHub stars"></a>
   <a href="https://twitter.com/intent/follow?screen_name=trylatitude" target="_blank"><img src="https://img.shields.io/twitter/follow/trylatitude?logo=X&color=%20%23f5f5f5" alt="Follow on X"></a>
 </p>
 


### PR DESCRIPTION
## Problem

The README's **GitHub stars** badge renders as `Unable to select next GitHub token from pool` instead of a star count:

The badge used shields.io's *live* `github/stars` endpoint, which is served from a shared, rate-limited pool of GitHub tokens. When the pool is exhausted, shields returns that error string as the badge message. It's intermittent and outside our control.

## Fix

Self-host the value, exactly like the existing license / npm / pypi badges:

- **`.github/workflows/stars-badge.yml`** — daily workflow (06:23 UTC) that reads the star count via the repo's own authenticated `GITHUB_TOKEN` (no shared rate limit) and commits the result. Mirrors `npm-downloads-badge.yml`, including the `[skip ci]` commit, `concurrency` guard, and the `github.repository == 'latitude-dev/latitude-llm'` fork guard. `workflow_dispatch` allows manual refresh.
- **`.github/badges/stars.json`** — shields `endpoint` JSON, seeded with the current count (4.1k).
- **`README.md`** — stars badge now reads from that JSON, with `&logo=github` to keep the GitHub icon.

## Notes

- The badge will only render the new value once this is merged to `development`, since shields reads the raw JSON from that branch (same as when the other self-hosted badges were added).
- Trade-off: the badge loses the old `style=social` pill look in favor of the flat style matching the rest of the badge row.