### PR TITLE
Resolve ongoing incidents from the monitors dashboard and API

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -7582,6 +7582,479 @@
       }
     },
     {
+      "name": "resolveIncident",
+      "title": "Resolve incident",
+      "description": "Resolves (closes) an ongoing incident. An already-closed incident is returned unchanged. If the incident's condition triggers again, a new incident will be opened.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          },
+          "incidentId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Incident identifier."
+          }
+        },
+        "required": [
+          "projectSlug",
+          "incidentId"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Stable incident identifier."
+          },
+          "organizationId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Organization that owns this incident."
+          },
+          "projectId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Project this incident belongs to."
+          },
+          "sourceType": {
+            "type": "string",
+            "enum": [
+              "issue",
+              "savedSearch"
+            ],
+            "description": "Kind of entity that triggered the incident. `issue` for issue-lifecycle incidents; `savedSearch` for incidents raised by a monitor watching a search."
+          },
+          "sourceId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Id of the entity that triggered the incident (matches `sourceType`)."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "issue.new",
+              "issue.regressed",
+              "issue.escalating",
+              "savedSearch.match",
+              "savedSearch.threshold",
+              "savedSearch.escalating"
+            ],
+            "description": "Reason the incident opened. `issue.new` fires when a new issue is discovered; `issue.regressed` when a resolved issue is detected again; `issue.escalating` when an ongoing issue is being detected more than expected. The `savedSearch.*` kinds are raised by monitors watching a search: `savedSearch.match` on each new matching trace, `savedSearch.threshold` when matching traces are detected above a configured threshold, and `savedSearch.escalating` when they stay above the threshold for a sustained window."
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Severity bucket assigned to the incident: `low`, `medium`, or `high`."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the incident opened."
+          },
+          "endedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the incident closed, or `null` if still open."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the incident row was created."
+          },
+          "monitorAlertId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Id of the monitor alert that opened this incident, or `null` when not attributed to a monitor."
+          },
+          "condition": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "savedSearch.threshold",
+                        "description": "Threshold alert: opens once the count threshold is crossed."
+                      },
+                      "threshold": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "absolute",
+                                "description": "Compare the match count against a fixed number; read `count`."
+                              },
+                              "count": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0,
+                                "maximum": 9007199254740991,
+                                "description": "Number of matching traces that opens the incident."
+                              }
+                            },
+                            "required": [
+                              "mode",
+                              "count"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "multiplier",
+                                "description": "Compare the match rate against `factor × baseline`; read `factor` and `baseline`."
+                              },
+                              "factor": {
+                                "type": "number",
+                                "exclusiveMinimum": 0,
+                                "description": "Multiple of the baseline rate that opens the incident (e.g. `3` = 3×)."
+                              },
+                              "baseline": {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                      "average",
+                                      "period"
+                                    ],
+                                    "description": "How the comparison rate is computed. `average` is the rolling rate over the last `lookback`; `period` is the equal-length window immediately before it (e.g. `lookback` of 1 day compares against yesterday) for daily/weekly seasonality."
+                                  },
+                                  "lookback": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "unit": {
+                                            "type": "string",
+                                            "const": "hours",
+                                            "description": "The duration is expressed in whole hours; read `hours`."
+                                          },
+                                          "hours": {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0,
+                                            "description": "Number of hours."
+                                          }
+                                        },
+                                        "required": [
+                                          "unit",
+                                          "hours"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "unit": {
+                                            "type": "string",
+                                            "const": "days",
+                                            "description": "The duration is expressed in whole days; read `days`."
+                                          },
+                                          "days": {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0,
+                                            "description": "Number of days."
+                                          }
+                                        },
+                                        "required": [
+                                          "unit",
+                                          "days"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ],
+                                    "description": "Length of the window used to compute the baseline rate."
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "lookback"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Fixed-window baseline the current rate is compared against."
+                              }
+                            },
+                            "required": [
+                              "mode",
+                              "factor",
+                              "baseline"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "expected",
+                                "description": "Compare against the seasonally-learned expected rate for this time of day/week (the same detector as automatic issue escalation); the only knob is `sensitivity`."
+                              },
+                              "sensitivity": {
+                                "description": "Detector sensitivity from 1 (noisiest) to 6 (strictest). Defaults to 3 when omitted.",
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 6
+                              }
+                            },
+                            "required": [
+                              "mode"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "How the match count/rate is compared."
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "threshold"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "savedSearch.escalating",
+                        "description": "Sustained alert: opens only when the threshold stays crossed for the whole `window`."
+                      },
+                      "threshold": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "absolute",
+                                "description": "Compare the match count against a fixed number; read `count`."
+                              },
+                              "count": {
+                                "type": "integer",
+                                "exclusiveMinimum": 0,
+                                "maximum": 9007199254740991,
+                                "description": "Number of matching traces that opens the incident."
+                              }
+                            },
+                            "required": [
+                              "mode",
+                              "count"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "multiplier",
+                                "description": "Compare the match rate against `factor × baseline`; read `factor` and `baseline`."
+                              },
+                              "factor": {
+                                "type": "number",
+                                "exclusiveMinimum": 0,
+                                "description": "Multiple of the baseline rate that opens the incident (e.g. `3` = 3×)."
+                              },
+                              "baseline": {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                      "average",
+                                      "period"
+                                    ],
+                                    "description": "How the comparison rate is computed. `average` is the rolling rate over the last `lookback`; `period` is the equal-length window immediately before it (e.g. `lookback` of 1 day compares against yesterday) for daily/weekly seasonality."
+                                  },
+                                  "lookback": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "unit": {
+                                            "type": "string",
+                                            "const": "hours",
+                                            "description": "The duration is expressed in whole hours; read `hours`."
+                                          },
+                                          "hours": {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0,
+                                            "description": "Number of hours."
+                                          }
+                                        },
+                                        "required": [
+                                          "unit",
+                                          "hours"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "unit": {
+                                            "type": "string",
+                                            "const": "days",
+                                            "description": "The duration is expressed in whole days; read `days`."
+                                          },
+                                          "days": {
+                                            "type": "number",
+                                            "exclusiveMinimum": 0,
+                                            "description": "Number of days."
+                                          }
+                                        },
+                                        "required": [
+                                          "unit",
+                                          "days"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ],
+                                    "description": "Length of the window used to compute the baseline rate."
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "lookback"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Fixed-window baseline the current rate is compared against."
+                              }
+                            },
+                            "required": [
+                              "mode",
+                              "factor",
+                              "baseline"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "const": "expected",
+                                "description": "Compare against the seasonally-learned expected rate for this time of day/week (the same detector as automatic issue escalation); the only knob is `sensitivity`."
+                              },
+                              "sensitivity": {
+                                "description": "Detector sensitivity from 1 (noisiest) to 6 (strictest). Defaults to 3 when omitted.",
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 6
+                              }
+                            },
+                            "required": [
+                              "mode"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "How the match count/rate is compared."
+                      },
+                      "window": {
+                        "type": "object",
+                        "properties": {
+                          "minutes": {
+                            "type": "integer",
+                            "minimum": 5,
+                            "maximum": 9007199254740991,
+                            "description": "How long the threshold must stay crossed before the incident opens. The incident stays open while the threshold keeps holding over this window and closes once it no longer does. Minimum 5."
+                          }
+                        },
+                        "required": [
+                          "minutes"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Sustained-condition window."
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "threshold",
+                      "window"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "issue.escalating",
+                        "description": "System issue-escalation alert; only `sensitivity` is tunable."
+                      },
+                      "sensitivity": {
+                        "description": "Detector sensitivity from 1 (noisiest) to 6 (strictest). Defaults to 3 when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The alert's configuration when the incident opened, or `null` for kinds with no parameters."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "projectId",
+          "sourceType",
+          "sourceId",
+          "kind",
+          "severity",
+          "startedAt",
+          "endedAt",
+          "createdAt",
+          "monitorAlertId",
+          "condition"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "listDatasets",
       "title": "List project datasets",
       "description": "Returns a cursor-paginated page of datasets in the project.",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8996,6 +8996,89 @@
         }
       }
     },
+    "/v1/projects/{projectSlug}/incidents/{incidentId}": {
+      "post": {
+        "tags": [
+          "Incidents"
+        ],
+        "x-fern-sdk-group-name": "incidents",
+        "x-fern-sdk-method-name": "resolve",
+        "summary": "Resolve incident",
+        "description": "Resolves (closes) an ongoing incident. An already-closed incident is returned unchanged. If the incident's condition triggers again, a new incident will be opened.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "resolveIncident",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Project slug (human-readable identifier)"
+            },
+            "required": true,
+            "description": "Project slug (human-readable identifier)",
+            "name": "projectSlug",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 24,
+              "maxLength": 24,
+              "description": "Incident identifier."
+            },
+            "required": true,
+            "description": "Incident identifier.",
+            "name": "incidentId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolved incident",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Incident"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/projects/{projectSlug}/datasets": {
       "get": {
         "tags": [

--- a/apps/api/src/routes/incidents.test.ts
+++ b/apps/api/src/routes/incidents.test.ts
@@ -428,4 +428,99 @@ describe("Incidents Routes Integration", () => {
 
     expect(res.status).toBe(400)
   })
+
+  it<ApiTestContext>("POST /:incidentId rejects unauthenticated requests with 401", async ({ app }) => {
+    const res = await app.fetch(
+      new Request("http://localhost/v1/projects/foo/incidents/incidresolveunauth000aaa", { method: "POST" }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("POST /:incidentId resolves an ongoing incident and is idempotent", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const projectId = "5555555555555555ffffffff"
+    const slug = await createProjectRecord(database, tenant.organizationId, projectId)
+    const incidentId = "incidresolveongoing00aaa"
+
+    await seedIncident(database, {
+      id: incidentId,
+      organizationId: tenant.organizationId,
+      projectId,
+      sourceType: "issue",
+      sourceId: "issuerrrrrrrrrrrrrrrrrrr",
+      kind: "issue.escalating",
+      severity: "high",
+      startedAt: new Date("2026-06-01T00:00:00.000Z"),
+    })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/projects/${slug}/incidents/${incidentId}`, {
+        method: "POST",
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { id: string; endedAt: string | null }
+    expect(body.id).toBe(incidentId)
+    expect(body.endedAt).not.toBeNull()
+
+    // A second resolve returns the incident unchanged.
+    const again = await app.fetch(
+      new Request(`http://localhost/v1/projects/${slug}/incidents/${incidentId}`, {
+        method: "POST",
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+    expect(again.status).toBe(200)
+    const againBody = (await again.json()) as { id: string; endedAt: string | null }
+    expect(againBody.endedAt).toBe(body.endedAt)
+  })
+
+  it<ApiTestContext>("POST /:incidentId returns 404 for an unknown incident", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const projectId = "6666666666666666ffffffff"
+    const slug = await createProjectRecord(database, tenant.organizationId, projectId)
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/projects/${slug}/incidents/incidresolvemissing00aaa`, {
+        method: "POST",
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it<ApiTestContext>("POST /:incidentId returns 404 when the incident belongs to another project", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    const projectId = "7777777777777777ffffffff"
+    const otherProjectId = "8888888888888888ffffffff"
+    const slug = await createProjectRecord(database, tenant.organizationId, projectId)
+    await createProjectRecord(database, tenant.organizationId, otherProjectId)
+    const incidentId = "incidresolveotherprj0aaa"
+
+    await seedIncident(database, {
+      id: incidentId,
+      organizationId: tenant.organizationId,
+      projectId: otherProjectId,
+      sourceType: "issue",
+      sourceId: "issuesssssssssssssssssss",
+      kind: "issue.escalating",
+      severity: "high",
+      startedAt: new Date("2026-06-01T00:00:00.000Z"),
+    })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/projects/${slug}/incidents/${incidentId}`, {
+        method: "POST",
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
 })

--- a/apps/api/src/routes/incidents.ts
+++ b/apps/api/src/routes/incidents.ts
@@ -1,8 +1,13 @@
-import { AlertIncidentRepository } from "@domain/alerts"
+import { AlertIncidentRepository, resolveAlertIncidentUseCase } from "@domain/alerts"
 import { ProjectRepository } from "@domain/projects"
-import { cuidSchema, OrganizationId, ProjectId } from "@domain/shared"
+import { AlertIncidentId, cuidSchema, NotFoundError, OrganizationId, ProjectId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { AlertIncidentRepositoryLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import {
+  AlertIncidentRepositoryLive,
+  OutboxEventWriterLive,
+  ProjectRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { defineApiEndpoint } from "../mcp/index.ts"
@@ -134,8 +139,65 @@ const listIncidents = incidentEndpoint({
   },
 })
 
+const IncidentParamsSchema = ProjectParamsSchema.extend({
+  incidentId: cuidSchema.describe("Incident identifier."),
+})
+
+const resolveIncident = incidentEndpoint({
+  route: createRoute({
+    method: "post",
+    path: "/{incidentId}",
+    name: "resolveIncident",
+    tags: ["Incidents"],
+    ...incidentsFernGroup("resolve"),
+    summary: "Resolve incident",
+    description:
+      "Resolves (closes) an ongoing incident. An already-closed incident is returned unchanged. If the incident's condition triggers again, a new incident will be opened.",
+    security: PROTECTED_SECURITY,
+    request: { params: IncidentParamsSchema },
+    responses: openApiResponses({ status: 200, schema: IncidentSchema, description: "Resolved incident" }),
+  }),
+  handler: async (c) => {
+    const { projectSlug, incidentId } = c.req.valid("param")
+    const organizationId = c.var.organization.id
+
+    const incident = await Effect.runPromise(
+      Effect.gen(function* () {
+        const projectRepo = yield* ProjectRepository
+        const project = yield* projectRepo.findBySlug(projectSlug)
+
+        // Re-tag lookup misses as `Incident` and 404 incidents outside the
+        // project in the path, so callers can't probe other projects' ids.
+        const incidentRepo = yield* AlertIncidentRepository
+        const current = yield* incidentRepo
+          .findById(AlertIncidentId(incidentId))
+          .pipe(
+            Effect.catchTag("NotFoundError", () =>
+              Effect.fail(new NotFoundError({ entity: "Incident", id: incidentId })),
+            ),
+          )
+        if ((current.projectId as string) !== (project.id as string)) {
+          return yield* new NotFoundError({ entity: "Incident", id: incidentId })
+        }
+
+        return yield* resolveAlertIncidentUseCase({ id: current.id, endedAt: new Date() })
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(ProjectRepositoryLive, AlertIncidentRepositoryLive, OutboxEventWriterLive),
+          c.var.postgresClient,
+          organizationId,
+        ),
+        withTracing,
+      ),
+    )
+
+    return c.json(toIncidentResponse(incident), 200)
+  },
+})
+
 export const createIncidentsRoutes = () => {
   const app = new OpenAPIHono<OrganizationScopedEnv>()
   listIncidents.mountHttp(app, createTierRateLimiter("low"))
+  resolveIncident.mountHttp(app, createTierRateLimiter("medium"))
   return app
 }

--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -17,6 +17,7 @@ import {
   type MonitorRecord,
   type MonitorSearchRecord,
   muteMonitor,
+  resolveMonitorIncident,
   type SavedSearchMonitorSummaryRecord,
   searchMonitorsOrgWide,
   unmuteMonitor,
@@ -250,6 +251,41 @@ export function useMonitorMuteAction(projectId: string) {
   )
 
   return { setMuted, isPending }
+}
+
+/**
+ * Resolve an ongoing incident, shared by the dashboard "Last incident" pill
+ * and the details-panel incidents table. Calls the server fn, invalidates the
+ * monitor list + incident queries, and toasts. Re-throws so the caller can
+ * keep its confirmation modal open on failure.
+ */
+export function useIncidentResolveAction(projectId: string) {
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+  const [isPending, setIsPending] = useState(false)
+
+  const resolve = useCallback(
+    async (incidentId: string) => {
+      setIsPending(true)
+      try {
+        await resolveMonitorIncident({ data: { incidentId } })
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["monitors", "list", projectId] }),
+          queryClient.invalidateQueries({ queryKey: ["monitors", "incidents", projectId] }),
+          queryClient.invalidateQueries({ queryKey: ["monitors", "incident-stats", projectId] }),
+        ])
+        toast({ description: "Incident resolved." })
+      } catch (error) {
+        toast({ variant: "destructive", description: toUserMessage(error) })
+        throw error
+      } finally {
+        setIsPending(false)
+      }
+    },
+    [projectId, queryClient, toast],
+  )
+
+  return { resolve, isPending }
 }
 
 const invalidateMonitorQueries = (queryClient: ReturnType<typeof useQueryClient>, projectId: string) =>

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -1,4 +1,4 @@
-import { AlertIncidentRepository } from "@domain/alerts"
+import { AlertIncidentRepository, resolveAlertIncidentUseCase } from "@domain/alerts"
 import { IssueRepository } from "@domain/issues"
 import {
   createMonitorUseCase,
@@ -39,6 +39,7 @@ import {
   IssueRepositoryLive,
   MonitorRepositoryLive,
   NotificationRepositoryLive,
+  OutboxEventWriterLive,
   SavedSearchRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
@@ -123,6 +124,7 @@ const toMonitorRecordResolved = async (orgId: OrganizationId, monitor: Monitor):
 }
 
 export interface MonitorLastIncidentRecord {
+  readonly id: string
   readonly startedAtIso: string
   readonly endedAtIso: string | null
 }
@@ -139,7 +141,7 @@ const toMonitorListRowRecord = (
 ): MonitorListRowRecord => ({
   monitor: toMonitorRecord(monitor, savedSearchRefs),
   lastIncident: last
-    ? { startedAtIso: last.startedAt.toISOString(), endedAtIso: last.endedAt?.toISOString() ?? null }
+    ? { id: last.id, startedAtIso: last.startedAt.toISOString(), endedAtIso: last.endedAt?.toISOString() ?? null }
     : null,
 })
 
@@ -326,6 +328,23 @@ export const muteMonitor = createServerFn({ method: "POST" })
 export const unmuteMonitor = createServerFn({ method: "POST" })
   .inputValidator(monitorMutationInputSchema)
   .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, false))
+
+const resolveIncidentInputSchema = z.object({ incidentId: z.string() })
+
+export const resolveMonitorIncident = createServerFn({ method: "POST" })
+  .inputValidator(resolveIncidentInputSchema)
+  .handler(async ({ data }): Promise<{ readonly id: string; readonly endedAtIso: string | null }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    const incident = await Effect.runPromise(
+      resolveAlertIncidentUseCase({ id: AlertIncidentId(data.incidentId), endedAt: new Date() }).pipe(
+        withPostgres(Layer.mergeAll(AlertIncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withTracing,
+      ),
+    )
+    return { id: incident.id, endedAtIso: incident.endedAt?.toISOString() ?? null }
+  })
 
 // --- Create / update / delete (M5) -----------------------------------------
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-resolve-confirm-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-resolve-confirm-modal.tsx
@@ -1,0 +1,51 @@
+import { Button, Modal } from "@repo/ui"
+import { useIncidentResolveAction } from "../../../../../../domains/monitors/monitors.collection.ts"
+
+/**
+ * Confirmation modal for resolving an ongoing incident, shared by the
+ * dashboard "Last incident" pill and the details-panel incidents table. Open
+ * when `incidentId` is non-null; `onOpenChange(null)` closes it.
+ */
+export function IncidentResolveConfirmModal({
+  projectId,
+  incidentId,
+  onOpenChange,
+}: {
+  readonly projectId: string
+  readonly incidentId: string | null
+  readonly onOpenChange: (incidentId: string | null) => void
+}) {
+  const { resolve, isPending } = useIncidentResolveAction(projectId)
+
+  const onConfirm = async () => {
+    if (!incidentId) return
+    try {
+      await resolve(incidentId)
+      onOpenChange(null)
+    } catch {
+      // Error toast is handled in the hook; keep the modal open to retry.
+    }
+  }
+
+  return (
+    <Modal
+      open={incidentId !== null}
+      onOpenChange={(open) => {
+        if (!open) onOpenChange(null)
+      }}
+      title="Resolve incident"
+      description="The incident will be closed and marked as resolved. If its condition triggers again, a new incident will be created."
+      dismissible
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" disabled={isPending} onClick={() => onOpenChange(null)}>
+            Cancel
+          </Button>
+          <Button disabled={isPending} isLoading={isPending} onClick={() => void onConfirm()}>
+            Resolve
+          </Button>
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-status.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/incident-status.tsx
@@ -1,17 +1,52 @@
-import { Status } from "@repo/ui"
+import { Button, Icon, Status } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
+import { CheckIcon } from "lucide-react"
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export function IncidentStatus({
   startedAtIso,
   endedAtIso,
+  onResolve,
 }: {
   readonly startedAtIso: string
   readonly endedAtIso: string | null
+  /** When set on an ongoing incident, hovering the pill fades in a Resolve button over it. */
+  readonly onResolve?: () => void
 }) {
   if (!endedAtIso) {
-    return <Status variant="destructive" label={`Ongoing since ${relativeTime(new Date(startedAtIso))}`} />
+    const pill = (
+      <Status
+        variant="destructive"
+        label={`Ongoing since ${relativeTime(new Date(startedAtIso))}`}
+        className="min-w-0"
+      />
+    )
+    if (!onResolve) return pill
+    return (
+      // `relative z-1` keeps the overlay clickable above InfiniteTable's stretched row link.
+      <div className="group/incident relative z-1 inline-flex max-w-full min-w-0 items-center">
+        {pill}
+        <Button
+          asChild
+          variant="destructive"
+          size="sm"
+          className="absolute inset-0 h-full rounded-full opacity-0 transition-opacity focus-visible:opacity-100 group-hover/incident:opacity-100"
+        >
+          <button
+            type="button"
+            aria-label="Resolve incident"
+            onClick={(event) => {
+              event.stopPropagation()
+              onResolve()
+            }}
+          >
+            <Icon icon={CheckIcon} size="xs" className="shrink-0 stroke-3" />
+            Resolve
+          </button>
+        </Button>
+      </div>
+    )
   }
   const stale = Date.now() - Date.parse(endedAtIso) > ONE_WEEK_MS
   return <Status variant={stale ? "neutral" : "warning"} label={`Closed ${relativeTime(new Date(endedAtIso))}`} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -1,11 +1,12 @@
 import { InfiniteTable, type InfiniteTableColumn, Status, Text } from "@repo/ui"
 import { formatDuration } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
-import { type ReactNode, useCallback } from "react"
+import { type ReactNode, useCallback, useState } from "react"
 import {
   type MonitorIncidentRecord,
   useMonitorIncidents,
 } from "../../../../../../domains/monitors/monitors.collection.ts"
+import { IncidentResolveConfirmModal } from "./incident-resolve-confirm-modal.tsx"
 import { IncidentStatus } from "./incident-status.tsx"
 
 /** Human-readable, lowercased source-type labels for the deleted-source fallback. */
@@ -44,7 +45,7 @@ function DurationCell({ incident }: { readonly incident: MonitorIncidentRecord }
   return <Text.H6 noWrap>{formatDuration(elapsedMs * 1_000_000)}</Text.H6>
 }
 
-const INCIDENT_COLUMNS: InfiniteTableColumn<MonitorIncidentRecord>[] = [
+const incidentColumns = (onResolve?: (incidentId: string) => void): InfiniteTableColumn<MonitorIncidentRecord>[] => [
   {
     key: "status",
     header: "Status",
@@ -52,7 +53,13 @@ const INCIDENT_COLUMNS: InfiniteTableColumn<MonitorIncidentRecord>[] = [
     sortKey: "status",
     width: 200,
     minWidth: 150,
-    render: (incident) => <IncidentStatus startedAtIso={incident.startedAt} endedAtIso={incident.endedAt} />,
+    render: (incident) => (
+      <IncidentStatus
+        startedAtIso={incident.startedAt}
+        endedAtIso={incident.endedAt}
+        {...(onResolve && incident.endedAt === null ? { onResolve: () => onResolve(incident.id) } : {})}
+      />
+    ),
   },
   {
     key: "source",
@@ -87,7 +94,7 @@ export function MonitorIncidentsTableSkeleton() {
     <InfiniteTable<MonitorIncidentRecord>
       data={[]}
       isLoading
-      columns={INCIDENT_COLUMNS}
+      columns={incidentColumns()}
       getRowKey={(incident) => incident.id}
       defaultSorting={INCIDENT_DEFAULT_SORTING}
       scrollAreaLayout="intrinsic"
@@ -106,6 +113,7 @@ export function MonitorIncidentsTable({
   readonly monitorId: string
 }) {
   const { incidents, isLoading, infiniteScroll } = useMonitorIncidents({ projectId, monitorId })
+  const [resolveTarget, setResolveTarget] = useState<string | null>(null)
 
   // Rows whose source was deleted (or can't be deep-linked) return null and aren't navigable.
   const renderRowLink = useCallback(
@@ -137,17 +145,20 @@ export function MonitorIncidentsTable({
   )
 
   return (
-    <InfiniteTable
-      data={incidents}
-      isLoading={isLoading}
-      columns={INCIDENT_COLUMNS}
-      getRowKey={(incident) => incident.id}
-      infiniteScroll={infiniteScroll}
-      renderRowLink={renderRowLink}
-      defaultSorting={INCIDENT_DEFAULT_SORTING}
-      blankSlate="No incidents yet."
-      scrollAreaLayout="intrinsic"
-      className={INCIDENT_TABLE_CLASS}
-    />
+    <>
+      <InfiniteTable
+        data={incidents}
+        isLoading={isLoading}
+        columns={incidentColumns(setResolveTarget)}
+        getRowKey={(incident) => incident.id}
+        infiniteScroll={infiniteScroll}
+        renderRowLink={renderRowLink}
+        defaultSorting={INCIDENT_DEFAULT_SORTING}
+        blankSlate="No incidents yet."
+        scrollAreaLayout="intrinsic"
+        className={INCIDENT_TABLE_CLASS}
+      />
+      <IncidentResolveConfirmModal projectId={projectId} incidentId={resolveTarget} onOpenChange={setResolveTarget} />
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
@@ -19,6 +19,7 @@ import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { IncidentResolveConfirmModal } from "./incident-resolve-confirm-modal.tsx"
 import { IncidentStatus } from "./incident-status.tsx"
 import { MonitorDeleteConfirmModal } from "./monitor-delete-confirm-modal.tsx"
 import { MonitorMuteConfirmModal } from "./monitor-mute-confirm-modal.tsx"
@@ -69,7 +70,13 @@ export function sortMonitorRows(
   })
 }
 
-function LastIncidentCell({ summary }: { readonly summary: MonitorsTableRow["lastIncident"] }) {
+function LastIncidentCell({
+  summary,
+  onResolve,
+}: {
+  readonly summary: MonitorsTableRow["lastIncident"]
+  readonly onResolve: (incidentId: string) => void
+}) {
   if (!summary) {
     return (
       <Text.H6 color="foregroundMuted" noWrap>
@@ -77,7 +84,13 @@ function LastIncidentCell({ summary }: { readonly summary: MonitorsTableRow["las
       </Text.H6>
     )
   }
-  return <IncidentStatus startedAtIso={summary.startedAtIso} endedAtIso={summary.endedAtIso} />
+  return (
+    <IncidentStatus
+      startedAtIso={summary.startedAtIso}
+      endedAtIso={summary.endedAtIso}
+      {...(summary.endedAtIso === null ? { onResolve: () => onResolve(summary.id) } : {})}
+    />
+  )
 }
 
 /**
@@ -189,6 +202,7 @@ export function MonitorsView({
   const [pendingMute, setPendingMute] = useState<MonitorRecord | null>(null)
   const [renameTarget, setRenameTarget] = useState<MonitorRecord | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<MonitorRecord | null>(null)
+  const [resolveTarget, setResolveTarget] = useState<string | null>(null)
   const activeRowKey = activeMonitorSlug
     ? rows.find((r) => r.monitor.slug === activeMonitorSlug)?.monitor.id
     : undefined
@@ -240,7 +254,7 @@ export function MonitorsView({
       sortKey: "lastIncident",
       width: 187,
       minWidth: 153,
-      render: (row) => <LastIncidentCell summary={row.lastIncident} />,
+      render: (row) => <LastIncidentCell summary={row.lastIncident} onResolve={setResolveTarget} />,
     },
     ...(showWatching
       ? [
@@ -327,6 +341,7 @@ export function MonitorsView({
         </Layout.List>
       </Layout.Body>
       <MonitorMuteConfirmModal projectId={projectId} monitor={pendingMute} onOpenChange={setPendingMute} />
+      <IncidentResolveConfirmModal projectId={projectId} incidentId={resolveTarget} onOpenChange={setResolveTarget} />
       {renameTarget ? (
         <MonitorRenameModal
           key={renameTarget.id}

--- a/packages/domain/alerts/src/index.ts
+++ b/packages/domain/alerts/src/index.ts
@@ -46,3 +46,5 @@ export type {
   CreateAlertIncidentFromIssueEventInput,
 } from "./use-cases/create-alert-incident-from-issue-event.ts"
 export { createAlertIncidentFromIssueEventUseCase } from "./use-cases/create-alert-incident-from-issue-event.ts"
+export type { ResolveAlertIncidentError, ResolveAlertIncidentInput } from "./use-cases/resolve-alert-incident.ts"
+export { resolveAlertIncidentUseCase } from "./use-cases/resolve-alert-incident.ts"

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -133,6 +133,13 @@ export interface AlertIncidentRepositoryShape {
   /** Set `ended_at` on one incident by id (org scope) — the saved-search machines already hold the row; close events (if any) are emitted by the caller. */
   setEndedAt(input: SetAlertIncidentEndedAtInput): Effect.Effect<void, RepositoryError, SqlClient>
   /**
+   * Set `ended_at` on one incident by id (org scope) only while it is still
+   * open, returning the closed row or `null` when the row is missing or
+   * already closed. The atomic guard lets the manual-resolve use case emit
+   * `IncidentClosed` exactly once under concurrent resolves.
+   */
+  closeById(input: SetAlertIncidentEndedAtInput): Effect.Effect<AlertIncident | null, RepositoryError, SqlClient>
+  /**
    * Returns every incident in the project whose lifetime overlaps the optional `[from, to]`
    * window, ordered ascending by `started_at`. Uses the
    * `(organization_id, project_id, started_at)` index. An incident overlaps the window when

--- a/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
@@ -33,6 +33,7 @@ function createTestLayers(opts: { closedId: string | null }) {
       findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used in this test"),
       existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used in this test"),
       setEndedAt: () => Effect.die("setEndedAt not used in this test"),
+      closeById: () => Effect.die("closeById not used in this test"),
     }),
   )
 

--- a/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
@@ -32,6 +32,7 @@ function createTestLayers() {
       findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used in this test"),
       existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used in this test"),
       setEndedAt: () => Effect.die("setEndedAt not used in this test"),
+      closeById: () => Effect.die("closeById not used in this test"),
     }),
   )
 

--- a/packages/domain/alerts/src/use-cases/resolve-alert-incident.test.ts
+++ b/packages/domain/alerts/src/use-cases/resolve-alert-incident.test.ts
@@ -1,0 +1,135 @@
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { AlertIncidentId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Exit, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AlertIncident } from "../entities/alert-incident.ts"
+import type { SetAlertIncidentEndedAtInput } from "../ports/alert-incident-repository.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+import { resolveAlertIncidentUseCase } from "./resolve-alert-incident.ts"
+
+const cuid = (seed: string) => seed.padEnd(24, "0")
+
+const incident = (overrides?: Partial<AlertIncident>): AlertIncident => ({
+  id: AlertIncidentId(cuid("a")),
+  organizationId: OrganizationId(cuid("o")),
+  projectId: ProjectId(cuid("p")),
+  sourceType: "issue",
+  sourceId: cuid("i"),
+  kind: "issue.escalating",
+  severity: "high",
+  startedAt: new Date("2026-06-01T00:00:00Z"),
+  endedAt: null,
+  createdAt: new Date("2026-06-01T00:00:00Z"),
+  entrySignals: null,
+  exitEligibleSince: null,
+  monitorAlertId: null,
+  condition: null,
+  ...overrides,
+})
+
+function createTestLayers(opts: { closeResult: AlertIncident | null; stored?: AlertIncident }) {
+  const closeCalls: SetAlertIncidentEndedAtInput[] = []
+  const events: OutboxWriteEvent[] = []
+
+  const AlertIncidentRepositoryTest = Layer.succeed(
+    AlertIncidentRepository,
+    AlertIncidentRepository.of({
+      insert: () => Effect.die("insert not used in this test"),
+      findById: (id) =>
+        opts.stored ? Effect.succeed(opts.stored) : Effect.fail(new NotFoundError({ entity: "AlertIncident", id })),
+      findOpen: () => Effect.die("findOpen not used in this test"),
+      closeOpen: () => Effect.die("closeOpen not used in this test"),
+      updateExitDwell: () => Effect.die("updateExitDwell not used in this test"),
+      listByProjectId: () => Effect.die("listByProjectId not used in this test"),
+      listOpenByKind: () => Effect.die("listOpenByKind not used in this test"),
+      listByMonitorId: () => Effect.die("listByMonitorId not used in this test"),
+      statsByMonitorId: () => Effect.die("statsByMonitorId not used in this test"),
+      listByMonitorAlertId: () => Effect.die("listByMonitorAlertId not used in this test"),
+      findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used in this test"),
+      existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used in this test"),
+      setEndedAt: () => Effect.die("setEndedAt not used in this test"),
+      closeById: (input) =>
+        Effect.sync(() => {
+          closeCalls.push(input)
+          return opts.closeResult
+        }),
+    }),
+  )
+
+  const OutboxEventWriterTest = Layer.succeed(
+    OutboxEventWriter,
+    OutboxEventWriter.of({
+      write: (event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+    }),
+  )
+
+  const SqlClientTest = Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(cuid("o")) }))
+
+  return {
+    closeCalls,
+    events,
+    layer: Layer.mergeAll(AlertIncidentRepositoryTest, OutboxEventWriterTest, SqlClientTest),
+  }
+}
+
+describe("resolveAlertIncidentUseCase", () => {
+  it("closes the open incident and emits IncidentClosed with reason resolved", async () => {
+    const endedAt = new Date("2026-06-12T10:00:00Z")
+    const closed = incident({ endedAt })
+    const { closeCalls, events, layer } = createTestLayers({ closeResult: closed })
+
+    const result = await Effect.runPromise(
+      resolveAlertIncidentUseCase({ id: closed.id, endedAt }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result).toEqual(closed)
+    expect(closeCalls).toEqual([{ id: closed.id, endedAt }])
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IncidentClosed",
+      aggregateType: "alert_incident",
+      aggregateId: closed.id,
+      organizationId: closed.organizationId,
+      payload: {
+        organizationId: closed.organizationId,
+        projectId: closed.projectId,
+        alertIncidentId: closed.id,
+        kind: "issue.escalating",
+        sourceType: "issue",
+        sourceId: closed.sourceId,
+        reason: "resolved",
+      },
+    })
+  })
+
+  it("returns the stored incident without emitting when it is already closed", async () => {
+    const stored = incident({ endedAt: new Date("2026-06-10T00:00:00Z") })
+    const { events, layer } = createTestLayers({ closeResult: null, stored })
+
+    const result = await Effect.runPromise(
+      resolveAlertIncidentUseCase({ id: stored.id, endedAt: new Date("2026-06-12T10:00:00Z") }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(result).toEqual(stored)
+    expect(events).toHaveLength(0)
+  })
+
+  it("fails with NotFoundError when the incident does not exist", async () => {
+    const { events, layer } = createTestLayers({ closeResult: null })
+
+    const exit = await Effect.runPromiseExit(
+      resolveAlertIncidentUseCase({ id: AlertIncidentId(cuid("x")), endedAt: new Date("2026-06-12T10:00:00Z") }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(events).toHaveLength(0)
+  })
+})

--- a/packages/domain/alerts/src/use-cases/resolve-alert-incident.ts
+++ b/packages/domain/alerts/src/use-cases/resolve-alert-incident.ts
@@ -1,0 +1,60 @@
+import { OutboxEventWriter } from "@domain/events"
+import type { AlertIncidentId, NotFoundError, RepositoryError } from "@domain/shared"
+import { SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { AlertIncident } from "../entities/alert-incident.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+
+export interface ResolveAlertIncidentInput {
+  readonly id: AlertIncidentId
+  readonly endedAt: Date
+}
+
+export type ResolveAlertIncidentError = NotFoundError | RepositoryError
+
+/**
+ * User-initiated close of an ongoing incident. Emits `IncidentClosed` with
+ * reason `"resolved"`, which suppresses the recovery notification — a
+ * deliberate user action shouldn't read as an organic recovery. Idempotent:
+ * an already-closed incident is returned as-is without emitting again.
+ */
+export const resolveAlertIncidentUseCase = (input: ResolveAlertIncidentInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("alertIncident.id", input.id)
+
+    const sqlClient = yield* SqlClient
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const alertIncidentRepository = yield* AlertIncidentRepository
+        const outboxEventWriter = yield* OutboxEventWriter
+
+        const closed = yield* alertIncidentRepository.closeById({ id: input.id, endedAt: input.endedAt })
+        // Missing or resolved concurrently — fall back to the stored row so a
+        // double-click stays a no-op and a bad id still surfaces NotFoundError.
+        if (closed === null) return yield* alertIncidentRepository.findById(input.id)
+
+        yield* outboxEventWriter.write({
+          eventName: "IncidentClosed",
+          aggregateType: "alert_incident",
+          aggregateId: closed.id,
+          organizationId: closed.organizationId,
+          payload: {
+            organizationId: closed.organizationId,
+            projectId: closed.projectId,
+            alertIncidentId: closed.id,
+            kind: closed.kind,
+            sourceType: closed.sourceType,
+            sourceId: closed.sourceId,
+            reason: "resolved",
+          },
+        })
+
+        return closed
+      }),
+    )
+  }).pipe(Effect.withSpan("alerts.resolveAlertIncident")) as Effect.Effect<
+    AlertIncident,
+    ResolveAlertIncidentError,
+    SqlClient | AlertIncidentRepository | OutboxEventWriter
+  >

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -134,6 +134,7 @@ const provideTestLayers = (params: {
     findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
     existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
     setEndedAt: () => Effect.die("setEndedAt not used"),
+    closeById: () => Effect.die("closeById not used"),
   }
 
   return {

--- a/packages/domain/issues/src/use-cases/sweep-escalating-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/sweep-escalating-issues.test.ts
@@ -59,6 +59,7 @@ const provideRepository = (incidents: readonly AlertIncident[]): AlertIncidentRe
   findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
   existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
   setEndedAt: () => Effect.die("setEndedAt not used"),
+  closeById: () => Effect.die("closeById not used"),
 })
 
 const runSweep = (

--- a/packages/domain/monitors/src/ports/monitor-repository.ts
+++ b/packages/domain/monitors/src/ports/monitor-repository.ts
@@ -36,6 +36,7 @@ export interface ListMonitorsRepositoryInput {
 }
 
 export interface MonitorLastIncident {
+  readonly id: string
   readonly startedAt: Date
   readonly endedAt: Date | null
 }

--- a/packages/domain/monitors/src/testing/fake-alert-incident-store.ts
+++ b/packages/domain/monitors/src/testing/fake-alert-incident-store.ts
@@ -32,6 +32,7 @@ export const createFakeAlertIncidentStore = (seed: readonly AlertIncident[] = []
     findById: () => Effect.die("findById not used by saved-search firing"),
     findOpen: () => Effect.die("findOpen not used by saved-search firing"),
     closeOpen: () => Effect.die("closeOpen not used by saved-search firing"),
+    closeById: () => Effect.die("closeById not used by saved-search firing"),
     listByProjectId: () => Effect.die("listByProjectId not used by saved-search firing"),
     listOpenByKind: () => Effect.die("listOpenByKind not used by saved-search firing"),
     listByMonitorId: () => Effect.die("listByMonitorId not used by saved-search firing"),

--- a/packages/domain/monitors/src/use-cases/get-monitor-incidents.test.ts
+++ b/packages/domain/monitors/src/use-cases/get-monitor-incidents.test.ts
@@ -74,6 +74,7 @@ const buildIncidentRepo = (page: {
   findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
   existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
   setEndedAt: () => Effect.die("setEndedAt not used"),
+  closeById: () => Effect.die("closeById not used"),
 })
 
 const provideLayer = (incidentRepo: AlertIncidentRepositoryShape, notificationRepo: NotificationRepositoryShape) =>

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
@@ -102,6 +102,7 @@ function setup(opts: SetupOpts = {}) {
     findOpenByMonitorAlertId: () => Effect.die("findOpenByMonitorAlertId not used"),
     existsByMonitorAlertId: () => Effect.die("existsByMonitorAlertId not used"),
     setEndedAt: () => Effect.die("setEndedAt not used"),
+    closeById: () => Effect.die("closeById not used"),
   }
 
   const members: MemberWithUser[] = (opts.memberUserIds ?? [cuid("u1"), cuid("u2")]).map((uid, i) => ({

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
@@ -604,4 +604,37 @@ describe("AlertIncidentRepositoryLive monitor-alert lookups (saved-search firing
     )
     expect(stillOpen).toBeNull()
   })
+
+  it("closeById closes an open incident once and returns null for closed or other-org rows", async () => {
+    const endedAt = new Date("2026-05-07T13:00:00.000Z")
+    const open = makeRow({
+      id: AlertIncidentId("1".repeat(24)),
+      sourceId: "1".repeat(24),
+      monitorAlertId: alertA,
+      endedAt: null,
+    })
+    const otherOrgOpen = makeRow({
+      id: AlertIncidentId("2".repeat(24)),
+      sourceId: "2".repeat(24),
+      organizationId: otherOrganizationId,
+      endedAt: null,
+    })
+    await database.db.insert(alertIncidentsTable).values([open, otherOrgOpen])
+
+    const [closed, again, foreign] = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        return [
+          yield* repository.closeById({ id: open.id as AlertIncidentId, endedAt }),
+          yield* repository.closeById({ id: open.id as AlertIncidentId, endedAt }),
+          yield* repository.closeById({ id: otherOrgOpen.id as AlertIncidentId, endedAt }),
+        ] as const
+      }).pipe(makeRlsProvider(database, organizationId)),
+    )
+
+    expect(closed?.id).toEqual(open.id)
+    expect(closed?.endedAt).toEqual(endedAt)
+    expect(again).toBeNull()
+    expect(foreign).toBeNull()
+  })
 })

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -192,6 +192,25 @@ export const AlertIncidentRepositoryLive = Layer.effect(
               .where(and(eq(alertIncidents.id, id), eq(alertIncidents.organizationId, sqlClient.organizationId))),
           )
         }),
+      closeById: ({ id, endedAt }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .update(alertIncidents)
+              .set({ endedAt })
+              .where(
+                and(
+                  eq(alertIncidents.id, id),
+                  eq(alertIncidents.organizationId, sqlClient.organizationId),
+                  isNull(alertIncidents.endedAt),
+                ),
+              )
+              .returning(),
+          )
+          const row = rows[0]
+          return row ? toDomain(row) : null
+        }),
       listByProjectId: ({ organizationId, projectId, from, to, sourceTypes, sourceId, kinds, severities }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.test.ts
@@ -180,6 +180,8 @@ describe("MonitorRepositoryLive", () => {
       const recentStartedAt = new Date("2026-06-01T09:00:00.000Z")
       const olderStartedAt = new Date("2026-05-20T09:00:00.000Z")
       const olderEndedAt = new Date("2026-05-20T11:00:00.000Z")
+      const recentOngoingIncidentId = AlertIncidentId(generateId())
+      const olderIncidentId = AlertIncidentId(generateId())
       await database.db.insert(alertIncidentsTable).values([
         {
           id: AlertIncidentId(generateId()),
@@ -194,7 +196,7 @@ describe("MonitorRepositoryLive", () => {
           monitorAlertId: recentAlertId,
         },
         {
-          id: AlertIncidentId(generateId()),
+          id: recentOngoingIncidentId,
           organizationId: organizationId as string,
           projectId: projectId as string,
           sourceType: "savedSearch",
@@ -206,7 +208,7 @@ describe("MonitorRepositoryLive", () => {
           monitorAlertId: recentAlertId,
         },
         {
-          id: AlertIncidentId(generateId()),
+          id: olderIncidentId,
           organizationId: organizationId as string,
           projectId: projectId as string,
           sourceType: "savedSearch",
@@ -241,8 +243,13 @@ describe("MonitorRepositoryLive", () => {
       )
 
       expect(result.items.map((m) => m.slug)).toEqual(["recent", "older", "no-incident", "issue-discovered"])
-      expect(result.lastIncidentByMonitorId.get(recentId)).toEqual({ startedAt: recentStartedAt, endedAt: null })
+      expect(result.lastIncidentByMonitorId.get(recentId)).toEqual({
+        id: recentOngoingIncidentId,
+        startedAt: recentStartedAt,
+        endedAt: null,
+      })
       expect(result.lastIncidentByMonitorId.get(olderId)).toEqual({
+        id: olderIncidentId,
         startedAt: olderStartedAt,
         endedAt: olderEndedAt,
       })

--- a/packages/platform/db-postgres/src/repositories/monitor-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/monitor-repository.ts
@@ -241,6 +241,7 @@ export const MonitorRepositoryLive = Layer.effect(
             db
               .select({
                 monitorId: monitorAlerts.monitorId,
+                incidentId: alertIncidents.id,
                 startedAt: alertIncidents.startedAt,
                 endedAt: alertIncidents.endedAt,
               })
@@ -252,7 +253,11 @@ export const MonitorRepositoryLive = Layer.effect(
           const lastIncidentByMonitorId = new Map<string, MonitorLastIncident>()
           for (const row of incidentRows) {
             if (!lastIncidentByMonitorId.has(row.monitorId)) {
-              lastIncidentByMonitorId.set(row.monitorId, { startedAt: row.startedAt, endedAt: row.endedAt })
+              lastIncidentByMonitorId.set(row.monitorId, {
+                id: row.incidentId,
+                startedAt: row.startedAt,
+                endedAt: row.endedAt,
+              })
             }
           }
 

--- a/packages/sdk/typescript/CHANGELOG.md
+++ b/packages/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-alpha.8] - 2026-06-12
+
+### Added
+
+- **`client.incidents.resolve(projectSlug, incidentId)`** and the `POST /v1/projects/{projectSlug}/incidents/{incidentId}` endpoint — resolves (closes) an ongoing incident and returns it. Resolving an already-closed incident is a no-op that returns it unchanged; an incident id that doesn't exist in the project returns 404. If the incident's condition triggers again, a new incident opens.
+
 ## [6.0.0-alpha.7] - 2026-06-11
 
 ### Changed

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "6.0.0-alpha.7",
+  "version": "6.0.0-alpha.8",
   "description": "Official TypeScript SDK for the Latitude API",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/sdk/typescript/src/api/resources/incidents/client/Client.ts
+++ b/packages/sdk/typescript/src/api/resources/incidents/client/Client.ts
@@ -134,4 +134,91 @@ export class IncidentsClient {
             "/v1/projects/{projectSlug}/incidents",
         );
     }
+
+    /**
+     * Resolves (closes) an ongoing incident. An already-closed incident is returned unchanged. If the incident's condition triggers again, a new incident will be opened.
+     *
+     * @param {string} projectSlug - Project slug (human-readable identifier)
+     * @param {string} incidentId - Incident identifier.
+     * @param {IncidentsClient.RequestOptions} requestOptions - Request-specific configuration.
+     *
+     * @throws {@link LatitudeApi.BadRequestError}
+     * @throws {@link LatitudeApi.UnauthorizedError}
+     * @throws {@link LatitudeApi.NotFoundError}
+     *
+     * @example
+     *     await client.incidents.resolve("projectSlug", "incidentId")
+     */
+    public resolve(
+        projectSlug: string,
+        incidentId: string,
+        requestOptions?: IncidentsClient.RequestOptions,
+    ): core.HttpResponsePromise<LatitudeApi.Incident> {
+        return core.HttpResponsePromise.fromPromise(this.__resolve(projectSlug, incidentId, requestOptions));
+    }
+
+    private async __resolve(
+        projectSlug: string,
+        incidentId: string,
+        requestOptions?: IncidentsClient.RequestOptions,
+    ): Promise<core.WithRawResponse<LatitudeApi.Incident>> {
+        const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
+        const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
+            _authRequest.headers,
+            this._options?.headers,
+            requestOptions?.headers,
+        );
+        const _response = await core.fetcher({
+            url: core.url.join(
+                (await core.Supplier.get(this._options.baseUrl)) ??
+                    (await core.Supplier.get(this._options.environment)) ??
+                    environments.LatitudeApiEnvironment.Production,
+                `v1/projects/${core.url.encodePathParam(projectSlug)}/incidents/${core.url.encodePathParam(incidentId)}`,
+            ),
+            method: "POST",
+            headers: _headers,
+            queryParameters: requestOptions?.queryParams,
+            timeoutMs: (requestOptions?.timeoutInSeconds ?? this._options?.timeoutInSeconds ?? 60) * 1000,
+            maxRetries: requestOptions?.maxRetries ?? this._options?.maxRetries,
+            abortSignal: requestOptions?.abortSignal,
+            fetchFn: this._options?.fetch,
+            logging: this._options.logging,
+        });
+        if (_response.ok) {
+            return { data: _response.body as LatitudeApi.Incident, rawResponse: _response.rawResponse };
+        }
+
+        if (_response.error.reason === "status-code") {
+            switch (_response.error.statusCode) {
+                case 400:
+                    throw new LatitudeApi.BadRequestError(
+                        _response.error.body as LatitudeApi.Error_,
+                        _response.rawResponse,
+                    );
+                case 401:
+                    throw new LatitudeApi.UnauthorizedError(
+                        _response.error.body as LatitudeApi.Error_,
+                        _response.rawResponse,
+                    );
+                case 404:
+                    throw new LatitudeApi.NotFoundError(
+                        _response.error.body as LatitudeApi.Error_,
+                        _response.rawResponse,
+                    );
+                default:
+                    throw new errors.LatitudeApiError({
+                        statusCode: _response.error.statusCode,
+                        body: _response.error.body,
+                        rawResponse: _response.rawResponse,
+                    });
+            }
+        }
+
+        return handleNonStatusCodeError(
+            _response.error,
+            _response.rawResponse,
+            "POST",
+            "/v1/projects/{projectSlug}/incidents/{incidentId}",
+        );
+    }
 }


### PR DESCRIPTION
## what

Lets users close an ongoing alert incident by hand, from three surfaces:

- **Monitors dashboard** — hovering the "Ongoing since …" pill in the "Last incident" column fades in a `✓ Resolve` button overlaid on the pill.
- **Monitor details panel** — same hover affordance on every ongoing row of the incidents table.
- **Public API / MCP / SDK** — `POST /v1/projects/{projectSlug}/incidents/{incidentId}` (`resolveIncident`, SDK: `client.incidents.resolve`).

Both UI entry points confirm through a shared modal, then toast and refresh the monitor list, incidents table, and incident stats.

## how it resolves

The shared seam is a new `resolveAlertIncidentUseCase` in `@domain/alerts`, used by both the web server fn and the API route. It closes the incident and emits `IncidentClosed` with reason `"resolved"` — the existing reason for deliberate user closes, so the recovery notification fan-out stays suppressed (same as resolving/ignoring the issue). Since "currently escalating" is derived from open `alert_incidents` rows, resolving the incident also clears the issue's escalating state everywhere.

Closing goes through a new `AlertIncidentRepository.closeById` (`UPDATE … WHERE id … AND ended_at IS NULL RETURNING *`): the conditional update makes the close atomic, so two concurrent resolves can't double-emit `IncidentClosed`. An already-closed incident is an idempotent no-op that returns the stored row; a missing id still surfaces `NotFoundError` (404 on the API).

## notable details

- The dashboard's "Last incident" summary only carried `startedAt`/`endedAt`; it now also carries the incident id (threaded through `MonitorLastIncident` in the port, the Postgres repository, and the web record) so the pill can be actionable.
- The API route 404s when the incident exists but belongs to a different project than the one in the path, and re-tags lookup misses as `Incident` so internal entity names don't leak.
- In the details-panel table the overlay sits above `InfiniteTable`'s stretched row link (`relative z-1`, the same convention as the selection cells), so clicking Resolve doesn't navigate to the incident source.
- `openapi.json`, `mcp.json`, and the Fern TypeScript SDK are regenerated and committed.

## tests

- Use-case unit tests: resolve + event payload, idempotent re-resolve, not-found.
- Postgres adapter test for `closeById` (closes once, null for already-closed and cross-org rows under RLS).
- API integration tests: 401, resolve + idempotency, unknown incident 404, cross-project 404.
- Existing fakes of `AlertIncidentRepositoryShape` across `@domain/{alerts,monitors,issues,notifications}` updated for the new port method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)