### PR TITLE
Monitor bulk actions, palette resolve command, and archived-tab bulk action fix

### DIFF
--- a/apps/web/src/domains/monitors/monitors.collection.ts
+++ b/apps/web/src/domains/monitors/monitors.collection.ts
@@ -201,6 +201,7 @@ export function useMonitorIncidents(input: {
 interface MonitorIncidentStats {
   readonly total: number
   readonly firstStartedAtIso: string | null
+  readonly lastIncidentId: string | null
   readonly lastStartedAtIso: string | null
   readonly lastEndedAtIso: string | null
 }
@@ -295,6 +296,14 @@ const invalidateMonitorQueries = (queryClient: ReturnType<typeof useQueryClient>
     // Saved-search ↔ monitor summaries back the traces-page chip and selector
     // rows; creating/deleting/muting monitors changes them.
     queryClient.invalidateQueries({ queryKey: ["monitors", "savedSearchSummaries", projectId] }),
+  ])
+
+/** Broad invalidation for bulk actions — the list/detail queries plus the drawer's incidents and stats. */
+export const invalidateAllMonitorQueries = (queryClient: ReturnType<typeof useQueryClient>, projectId: string) =>
+  Promise.all([
+    invalidateMonitorQueries(queryClient, projectId),
+    queryClient.invalidateQueries({ queryKey: ["monitors", "incidents", projectId] }),
+    queryClient.invalidateQueries({ queryKey: ["monitors", "incident-stats", projectId] }),
   ])
 
 /** Create a user monitor (with its alerts). Invalidates the list on success. */

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -1,4 +1,5 @@
 import { AlertIncidentRepository, resolveAlertIncidentUseCase } from "@domain/alerts"
+import { exportSelectionSchema } from "@domain/exports"
 import { IssueRepository } from "@domain/issues"
 import {
   createMonitorUseCase,
@@ -329,6 +330,135 @@ export const unmuteMonitor = createServerFn({ method: "POST" })
   .inputValidator(monitorMutationInputSchema)
   .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, false))
 
+const bulkMonitorsInputSchema = z.object({
+  projectId: z.string(),
+  selection: exportSelectionSchema,
+  // Filters mirroring the dashboard list query, so `all` / `allExcept`
+  // selections act on exactly the rows the table shows.
+  searchQuery: z.string().max(500).optional(),
+  system: z.boolean().optional(),
+})
+
+type BulkMonitorsInput = z.infer<typeof bulkMonitorsInputSchema>
+
+const BULK_MONITORS_BATCH_SIZE = 100
+
+const resolveBulkSelectionMonitorIds = async (
+  orgId: OrganizationId,
+  data: BulkMonitorsInput,
+): Promise<readonly string[]> => {
+  if (data.selection.mode === "selected") return data.selection.rowIds
+
+  const excluded = data.selection.mode === "allExcept" ? new Set(data.selection.rowIds) : null
+  const trimmedSearchQuery = data.searchQuery?.trim() || undefined
+  const ids: string[] = []
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      let offset = 0
+      while (true) {
+        const page = yield* listMonitorsUseCase({
+          projectId: ProjectId(data.projectId),
+          limit: BULK_MONITORS_BATCH_SIZE,
+          offset,
+          ...(trimmedSearchQuery ? { searchQuery: trimmedSearchQuery } : {}),
+          ...(data.system !== undefined ? { system: data.system } : {}),
+        })
+        if (page.items.length === 0) break
+        for (const monitor of page.items) {
+          if (excluded?.has(monitor.id)) continue
+          ids.push(monitor.id)
+        }
+        if (!page.hasMore) break
+        offset += page.limit
+      }
+    }).pipe(withPostgres(MonitorRepositoryLive, getPostgresClient(), orgId), withTracing),
+  )
+
+  return ids
+}
+
+export const bulkMuteMonitors = createServerFn({ method: "POST" })
+  .inputValidator(bulkMonitorsInputSchema)
+  .handler(async ({ data }): Promise<{ readonly mutedCount: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
+
+    const mutedCount = await Effect.runPromise(
+      Effect.gen(function* () {
+        let count = 0
+        for (const monitorId of monitorIds) {
+          yield* muteMonitorUseCase({ id: MonitorId(monitorId) }).pipe(
+            Effect.catchTag("NotFoundError", () => Effect.void),
+          )
+          count += 1
+        }
+        return count
+      }).pipe(withPostgres(MonitorRepositoryLive, getPostgresClient(), orgId), withTracing),
+    )
+
+    return { mutedCount }
+  })
+
+export const bulkDeleteMonitors = createServerFn({ method: "POST" })
+  .inputValidator(bulkMonitorsInputSchema)
+  .handler(async ({ data }): Promise<{ readonly deletedCount: number; readonly skippedSystemCount: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        let deletedCount = 0
+        let skippedSystemCount = 0
+        for (const monitorId of monitorIds) {
+          const outcome = yield* deleteMonitorUseCase({ id: MonitorId(monitorId) }).pipe(
+            Effect.as("deleted" as const),
+            Effect.catchTags({
+              SystemMonitorForbiddenError: () => Effect.succeed("skipped" as const),
+              NotFoundError: () => Effect.succeed("missing" as const),
+            }),
+          )
+          if (outcome === "deleted") deletedCount += 1
+          if (outcome === "skipped") skippedSystemCount += 1
+        }
+        return { deletedCount, skippedSystemCount }
+      }).pipe(withPostgres(MonitorRepositoryLive, getPostgresClient(), orgId), withTracing),
+    )
+
+    return counts
+  })
+
+export const bulkResolveMonitorLastIncidents = createServerFn({ method: "POST" })
+  .inputValidator(bulkMonitorsInputSchema)
+  .handler(async ({ data }): Promise<{ readonly resolvedCount: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
+
+    const resolvedCount = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* AlertIncidentRepository
+        let count = 0
+        for (const monitorId of monitorIds) {
+          // Same ongoing-first pick the dashboard's "Last incident" column shows.
+          const page = yield* repository.listByMonitorId({ monitorId: MonitorId(monitorId), limit: 1 })
+          const last = page.items[0]
+          if (!last || last.endedAt !== null) continue
+          yield* resolveAlertIncidentUseCase({ id: last.id, endedAt: new Date() })
+          count += 1
+        }
+        return count
+      }).pipe(
+        withPostgres(Layer.mergeAll(AlertIncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withTracing,
+      ),
+    )
+
+    return { resolvedCount }
+  })
+
 const resolveIncidentInputSchema = z.object({ incidentId: z.string() })
 
 export const resolveMonitorIncident = createServerFn({ method: "POST" })
@@ -481,6 +611,7 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
     }): Promise<{
       readonly total: number
       readonly firstStartedAtIso: string | null
+      readonly lastIncidentId: string | null
       readonly lastStartedAtIso: string | null
       readonly lastEndedAtIso: string | null
     }> => {
@@ -497,6 +628,7 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
       return {
         total: stats.total,
         firstStartedAtIso: stats.firstStartedAt?.toISOString() ?? null,
+        lastIncidentId: stats.lastIncidentId,
         lastStartedAtIso: stats.lastStartedAt?.toISOString() ?? null,
         lastEndedAtIso: stats.lastEndedAt?.toISOString() ?? null,
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -56,7 +56,9 @@ import {
   CircleUserRoundIcon,
   DownloadIcon,
   PauseIcon,
+  PlayIcon,
   SearchIcon,
+  XIcon,
 } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { invalidateIssueQueries, useIssues } from "../../../../../domains/issues/issues.collection.ts"
@@ -168,6 +170,9 @@ function IssuesPage() {
   })
   const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
   const setSorting = useCallback((next: IssuesTableSorting) => setRawSorting(serializeSorting(next)), [setRawSorting])
+  // The archived tab lists resolved/ignored issues, so its bulk actions undo
+  // the lifecycle commands instead of re-applying them.
+  const archived = lifecycleGroup === "archived"
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
@@ -291,8 +296,8 @@ function IssuesPage() {
         data: {
           projectId: project.id,
           selection: bulkSelection,
-          command: "resolve",
-          keepMonitoring,
+          command: archived ? "unresolve" : "resolve",
+          ...(archived ? {} : { keepMonitoring }),
           lifecycleGroup,
           sort: {
             field: sorting.column,
@@ -304,14 +309,15 @@ function IssuesPage() {
         },
       })
       const changedCount = result.items.filter((item) => item.changed).length
+      const verb = archived ? "unresolved" : "resolved"
       await invalidateIssueQueries(project.id)
       toast({
         description:
           changedCount === 0
-            ? "No issues were resolved."
+            ? `No issues were ${verb}.`
             : changedCount === 1
-              ? "1 issue resolved."
-              : `${changedCount} issues resolved.`,
+              ? `1 issue ${verb}.`
+              : `${changedCount} issues ${verb}.`,
       })
       selection.clearSelections()
       setBulkResolveModalOpen(false)
@@ -323,7 +329,17 @@ function IssuesPage() {
     } finally {
       setBulkActionLoading(false)
     }
-  }, [keepMonitoring, lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
+  }, [
+    archived,
+    keepMonitoring,
+    lifecycleGroup,
+    project.id,
+    searchQuery,
+    selection,
+    sorting.column,
+    sorting.direction,
+    timeRange,
+  ])
 
   const handleBulkIgnore = useCallback(async () => {
     const bulkSelection = selection.bulkSelection
@@ -335,7 +351,7 @@ function IssuesPage() {
         data: {
           projectId: project.id,
           selection: bulkSelection,
-          command: "ignore",
+          command: archived ? "unignore" : "ignore",
           lifecycleGroup,
           sort: {
             field: sorting.column,
@@ -347,14 +363,15 @@ function IssuesPage() {
         },
       })
       const changedCount = result.items.filter((item) => item.changed).length
+      const verb = archived ? "unignored" : "ignored"
       await invalidateIssueQueries(project.id)
       toast({
         description:
           changedCount === 0
-            ? "No issues were ignored."
+            ? `No issues were ${verb}.`
             : changedCount === 1
-              ? "1 issue ignored."
-              : `${changedCount} issues ignored.`,
+              ? `1 issue ${verb}.`
+              : `${changedCount} issues ${verb}.`,
       })
       selection.clearSelections()
       setBulkIgnoreModalOpen(false)
@@ -366,7 +383,7 @@ function IssuesPage() {
     } finally {
       setBulkActionLoading(false)
     }
-  }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
+  }, [archived, lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
 
   const hasActiveFilters =
     lifecycleGroup !== "active" || searchQuery !== "" || Boolean(timeRange) || assigneeIds.length > 0
@@ -469,8 +486,8 @@ function IssuesPage() {
               onClick={() => setBulkIgnoreModalOpen(true)}
               disabled={bulkActionLoading}
             >
-              <Icon icon={PauseIcon} size="sm" />
-              Ignore ({selection.selectedCount.toLocaleString()})
+              <Icon icon={archived ? PlayIcon : PauseIcon} size="sm" />
+              {archived ? "Unignore" : "Ignore"} ({selection.selectedCount.toLocaleString()})
             </Button>
             <Button
               variant="outline"
@@ -481,8 +498,8 @@ function IssuesPage() {
               }}
               disabled={bulkActionLoading}
             >
-              <Icon icon={CheckIcon} size="sm" />
-              Resolve ({selection.selectedCount.toLocaleString()})
+              <Icon icon={archived ? XIcon : CheckIcon} size="sm" />
+              {archived ? "Unresolve" : "Resolve"} ({selection.selectedCount.toLocaleString()})
             </Button>
             <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
               <Icon icon={DownloadIcon} size="sm" />
@@ -529,51 +546,71 @@ function IssuesPage() {
           open={bulkResolveModalOpen}
           onOpenChange={setBulkResolveModalOpen}
           dismissible
-          title="Resolve issues"
-          description={`Mark ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`} as resolved. If any of these issues start occurring again we will alert you and promote them as regressed.`}
+          title={archived ? "Unresolve issues" : "Resolve issues"}
+          description={
+            archived
+              ? `Reopen ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`}. New occurrences won't mark ${selection.selectedCount === 1 ? "it" : "them"} as regressed.`
+              : `Mark ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`} as resolved. If any of these issues start occurring again we will alert you and promote them as regressed.`
+          }
           footer={
             <>
               <Button variant="outline" onClick={() => setBulkResolveModalOpen(false)} disabled={bulkActionLoading}>
                 Cancel
               </Button>
-              <Button onClick={() => void handleBulkResolve()} disabled={bulkActionLoading}>
-                <Icon icon={CheckIcon} size="sm" />
-                Resolve {selection.selectedCount === 1 ? "Issue" : `${selection.selectedCount} Issues`}
+              <Button
+                {...(archived ? { variant: "destructive" as const } : {})}
+                onClick={() => void handleBulkResolve()}
+                disabled={bulkActionLoading}
+              >
+                <Icon icon={archived ? XIcon : CheckIcon} size="sm" />
+                {archived ? "Unresolve" : "Resolve"}{" "}
+                {selection.selectedCount === 1 ? "Issue" : `${selection.selectedCount} Issues`}
               </Button>
             </>
           }
         >
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-row items-center justify-between gap-4">
-              <div className="flex flex-col gap-1">
-                <Label htmlFor="bulk-keep-monitoring">Keep evaluating these issues</Label>
-                <Text.H6 color="foregroundMuted">
-                  Evaluations for these issues will stay active to detect further regressions
-                </Text.H6>
+          {!archived && (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-row items-center justify-between gap-4">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="bulk-keep-monitoring">Keep evaluating these issues</Label>
+                  <Text.H6 color="foregroundMuted">
+                    Evaluations for these issues will stay active to detect further regressions
+                  </Text.H6>
+                </div>
+                <Switch
+                  id="bulk-keep-monitoring"
+                  checked={keepMonitoring}
+                  onCheckedChange={setKeepMonitoring}
+                  disabled={bulkActionLoading}
+                  aria-label="Keep evaluating these issues"
+                />
               </div>
-              <Switch
-                id="bulk-keep-monitoring"
-                checked={keepMonitoring}
-                onCheckedChange={setKeepMonitoring}
-                disabled={bulkActionLoading}
-                aria-label="Keep evaluating these issues"
-              />
             </div>
-          </div>
+          )}
         </Modal>
 
         <Modal
           open={bulkIgnoreModalOpen}
           onOpenChange={setBulkIgnoreModalOpen}
           dismissible
-          title="Ignore issues"
-          description={`Mark ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`} as ignored. You won't be alerted about new occurrences of these issues anymore.`}
+          title={archived ? "Unignore issues" : "Ignore issues"}
+          description={
+            archived
+              ? `Stop ignoring ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`}. New occurrences will surface ${selection.selectedCount === 1 ? "it" : "them"} again.`
+              : `Mark ${selection.selectedCount === 1 ? "this issue" : `${selection.selectedCount} issues`} as ignored. You won't be alerted about new occurrences of these issues anymore.`
+          }
           footer={
             <>
               <CloseTrigger />
-              <Button variant="destructive" onClick={() => void handleBulkIgnore()} disabled={bulkActionLoading}>
-                <Icon icon={PauseIcon} size="sm" />
-                Ignore {selection.selectedCount === 1 ? "Issue" : `${selection.selectedCount} Issues`}
+              <Button
+                {...(archived ? {} : { variant: "destructive" as const })}
+                onClick={() => void handleBulkIgnore()}
+                disabled={bulkActionLoading}
+              >
+                <Icon icon={archived ? PlayIcon : PauseIcon} size="sm" />
+                {archived ? "Unignore" : "Ignore"}{" "}
+                {selection.selectedCount === 1 ? "Issue" : `${selection.selectedCount} Issues`}
               </Button>
             </>
           }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-detail-drawer.tsx
@@ -14,7 +14,16 @@ import {
 } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { ArrowDownIcon, ArrowUpIcon, BellIcon, BellOffIcon, LinkIcon, PencilIcon, ShieldAlertIcon } from "lucide-react"
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  BellIcon,
+  BellOffIcon,
+  CheckIcon,
+  LinkIcon,
+  PencilIcon,
+  ShieldAlertIcon,
+} from "lucide-react"
 import { type ReactNode, useMemo, useState } from "react"
 import { useRegisterCommands } from "../../../../../../components/command-palette/command-palette-provider.tsx"
 import type { PaletteCommand } from "../../../../../../components/command-palette/types.ts"
@@ -22,6 +31,7 @@ import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { SeverityStatus } from "../../../../../../domains/alerts/severity-selector.tsx"
 import { useMonitorIncidentStats } from "../../../../../../domains/monitors/monitors.collection.ts"
 import type { MonitorAlertRecord, MonitorRecord } from "../../../../../../domains/monitors/monitors.functions.ts"
+import { IncidentResolveConfirmModal } from "./incident-resolve-confirm-modal.tsx"
 import { MonitorAlertEditModal } from "./monitor-alert-edit-modal.tsx"
 import { MonitorIncidentsTable, MonitorIncidentsTableSkeleton } from "./monitor-incidents-table.tsx"
 import { MonitorMuteConfirmModal } from "./monitor-mute-confirm-modal.tsx"
@@ -207,6 +217,7 @@ export function MonitorDetailDrawer({
 }) {
   const { toast } = useToast()
   const [muteConfirmOpen, setMuteConfirmOpen] = useState(false)
+  const [resolveIncidentId, setResolveIncidentId] = useState<string | null>(null)
   // `null` = closed; an alert = edit that alert (alerts are never added or deleted from the app).
   const [alertModal, setAlertModal] = useState<MonitorAlertRecord | null>(null)
   const [sensitivityAlert, setSensitivityAlert] = useState<MonitorAlertRecord | null>(null)
@@ -215,6 +226,10 @@ export function MonitorDetailDrawer({
     projectId,
     monitorId: monitor.id,
   })
+  const ongoingIncidentId =
+    incidentStats && incidentStats.lastIncidentId !== null && incidentStats.lastEndedAtIso === null
+      ? incidentStats.lastIncidentId
+      : null
 
   // Registered only while this monitor is open, scoping these palette commands to it.
   const paletteCommands = useMemo<readonly PaletteCommand[]>(
@@ -228,6 +243,19 @@ export function MonitorDetailDrawer({
         keywords: muted ? "unmute monitor resume notifications bell" : "mute monitor silence notifications bell",
         perform: () => setMuteConfirmOpen(true),
       },
+      ...(ongoingIncidentId
+        ? [
+            {
+              id: `monitor:${monitor.id}:resolve-last-incident`,
+              title: "Resolve last incident",
+              icon: CheckIcon,
+              section: "context",
+              group: "Monitor",
+              keywords: "resolve incident close ongoing",
+              perform: () => setResolveIncidentId(ongoingIncidentId),
+            } satisfies PaletteCommand,
+          ]
+        : []),
       {
         id: `monitor:${monitor.id}:copy-link`,
         title: "Copy monitor link",
@@ -243,7 +271,7 @@ export function MonitorDetailDrawer({
         },
       },
     ],
-    [monitor.id, monitor.slug, muted, projectSlug, toast],
+    [monitor.id, monitor.slug, muted, ongoingIncidentId, projectSlug, toast],
   )
   useRegisterCommands(paletteCommands)
 
@@ -416,6 +444,12 @@ export function MonitorDetailDrawer({
         projectId={projectId}
         monitor={muteConfirmOpen ? monitor : null}
         onOpenChange={(next) => setMuteConfirmOpen(next !== null)}
+      />
+
+      <IncidentResolveConfirmModal
+        projectId={projectId}
+        incidentId={resolveIncidentId}
+        onOpenChange={setResolveIncidentId}
       />
 
       {alertModal ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-list-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-list-page.tsx
@@ -1,14 +1,39 @@
-import { Button, Icon, Input, type TabOption, Tabs, Text, useValueWithDefault } from "@repo/ui"
+import { Button, Icon, Input, Modal, type TabOption, Tabs, Text, toast, useValueWithDefault } from "@repo/ui"
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { BellPlusIcon, LockIcon, SearchIcon, ShieldAlertIcon, TextSearchIcon } from "lucide-react"
+import {
+  BellOffIcon,
+  BellPlusIcon,
+  CheckIcon,
+  LockIcon,
+  SearchIcon,
+  ShieldAlertIcon,
+  TextSearchIcon,
+  Trash2Icon,
+} from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { useRegisterCommands } from "../../../../../../components/command-palette/command-palette-provider.tsx"
 import type { PaletteCommand } from "../../../../../../components/command-palette/types.ts"
 import { useHasFeatureFlag } from "../../../../../../domains/feature-flags/feature-flags.collection.ts"
-import { useMonitor, useMonitors } from "../../../../../../domains/monitors/monitors.collection.ts"
+import {
+  invalidateAllMonitorQueries,
+  useMonitor,
+  useMonitors,
+} from "../../../../../../domains/monitors/monitors.collection.ts"
+import {
+  bulkDeleteMonitors,
+  bulkMuteMonitors,
+  bulkResolveMonitorLastIncidents,
+} from "../../../../../../domains/monitors/monitors.functions.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { useDebounce } from "../../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
+import {
+  EMPTY_SELECTION,
+  type SelectionState,
+  useSelectableRows,
+} from "../../../../../../lib/hooks/useSelectableRows.ts"
 import { BreadcrumbText } from "../../../../-components/breadcrumb-ui.tsx"
 import { useRouteProject } from "../../-route-data.ts"
 import { MonitorCreateModal } from "./monitor-create-modal.tsx"
@@ -95,6 +120,7 @@ function MonitorsTabs({ system, projectSlug }: { readonly system: boolean; reado
 
 function MonitorsPageContent({ system }: { readonly system: boolean }) {
   const project = useRouteProject()
+  const queryClient = useQueryClient()
   const [monitorSlug, setMonitorSlug] = useParamState("monitorSlug", "")
   const [searchQuery, setSearchQuery] = useParamState("monitorsSearch", "")
   const [searchInput, setSearchInput] = useValueWithDefault(searchQuery)
@@ -104,6 +130,11 @@ function MonitorsPageContent({ system }: { readonly system: boolean }) {
   })
   const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
   const setSorting = useCallback((next: MonitorsTableSorting) => setRawSorting(serializeSorting(next)), [setRawSorting])
+  const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
+  const [bulkResolveModalOpen, setBulkResolveModalOpen] = useState(false)
+  const [bulkMuteModalOpen, setBulkMuteModalOpen] = useState(false)
+  const [bulkDeleteModalOpen, setBulkDeleteModalOpen] = useState(false)
+  const [bulkActionLoading, setBulkActionLoading] = useState(false)
 
   // Registered only while this page is mounted, so it's implicitly gated to the
   // monitors flag. Creation is search-tab only (issue monitors are system-provisioned).
@@ -146,6 +177,18 @@ function MonitorsPageContent({ system }: { readonly system: boolean }) {
   const sortedRows = useMemo(() => sortMonitorRows(rows, sorting), [rows, sorting])
   const monitors = useMemo(() => sortedRows.map((row) => row.monitor), [sortedRows])
 
+  const monitorIds = useMemo(() => sortedRows.map((row) => row.monitor.id), [sortedRows])
+  const selection = useSelectableRows({
+    rowIds: monitorIds,
+    totalRowCount: totalCount,
+    controlledState: selectionState,
+    onStateChange: setSelectionState,
+  })
+  // Known from the loaded rows; an `all` selection may resolve more on the server.
+  const selectionHasOngoingIncident = sortedRows.some(
+    (row) => row.lastIncident?.endedAtIso === null && selection.isSelected(row.monitor.id),
+  )
+
   const listedMonitor = monitorSlug ? monitors.find((monitor) => monitor.slug === monitorSlug) : undefined
   // Each tab lists only its own kind; deep links to the other kind (command
   // palette, notifications) still open the drawer through a point lookup by slug.
@@ -158,6 +201,84 @@ function MonitorsPageContent({ system }: { readonly system: boolean }) {
   const activeIndex = activeMonitor ? monitors.findIndex((monitor) => monitor.slug === activeMonitor.slug) : -1
   const prevMonitor = activeIndex > 0 ? monitors[activeIndex - 1] : undefined
   const nextMonitor = activeIndex >= 0 ? monitors[activeIndex + 1] : undefined
+
+  const bulkActionData = useCallback(() => {
+    const bulkSelection = selection.bulkSelection
+    if (!bulkSelection) return null
+    return {
+      projectId: project.id,
+      selection: bulkSelection,
+      system,
+      ...(searchQuery ? { searchQuery } : {}),
+    }
+  }, [project.id, searchQuery, selection, system])
+
+  const handleBulkResolveIncidents = useCallback(async () => {
+    const data = bulkActionData()
+    if (!data) return
+    setBulkActionLoading(true)
+    try {
+      const { resolvedCount } = await bulkResolveMonitorLastIncidents({ data })
+      await invalidateAllMonitorQueries(queryClient, project.id)
+      toast({
+        description:
+          resolvedCount === 0
+            ? "No ongoing incidents to resolve."
+            : resolvedCount === 1
+              ? "1 incident resolved."
+              : `${resolvedCount} incidents resolved.`,
+      })
+      selection.clearSelections()
+      setBulkResolveModalOpen(false)
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setBulkActionLoading(false)
+    }
+  }, [bulkActionData, project.id, queryClient, selection])
+
+  const handleBulkMute = useCallback(async () => {
+    const data = bulkActionData()
+    if (!data) return
+    setBulkActionLoading(true)
+    try {
+      const { mutedCount } = await bulkMuteMonitors({ data })
+      await invalidateAllMonitorQueries(queryClient, project.id)
+      toast({ description: mutedCount === 1 ? "1 monitor muted." : `${mutedCount} monitors muted.` })
+      selection.clearSelections()
+      setBulkMuteModalOpen(false)
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setBulkActionLoading(false)
+    }
+  }, [bulkActionData, project.id, queryClient, selection])
+
+  const handleBulkDelete = useCallback(async () => {
+    const data = bulkActionData()
+    if (!data) return
+    const activeWasSelected = activeMonitor ? selection.isSelected(activeMonitor.id) : false
+    setBulkActionLoading(true)
+    try {
+      const { deletedCount, skippedSystemCount } = await bulkDeleteMonitors({ data })
+      await invalidateAllMonitorQueries(queryClient, project.id)
+      toast({
+        description: [
+          deletedCount === 1 ? "1 monitor removed." : `${deletedCount} monitors removed.`,
+          ...(skippedSystemCount > 0
+            ? [`${skippedSystemCount} system ${skippedSystemCount === 1 ? "monitor" : "monitors"} skipped.`]
+            : []),
+        ].join(" "),
+      })
+      if (activeWasSelected) setMonitorSlug("")
+      selection.clearSelections()
+      setBulkDeleteModalOpen(false)
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setBulkActionLoading(false)
+    }
+  }, [activeMonitor, bulkActionData, project.id, queryClient, selection, setMonitorSlug])
 
   const hasMonitors = totalCount > 0
   const hasActiveFilters = Boolean(searchQuery)
@@ -219,6 +340,36 @@ function MonitorsPageContent({ system }: { readonly system: boolean }) {
             </Layout.ActionRowItem>
           </Layout.ActionsRow>
         </Layout.Actions>
+        {selection.selectedCount > 0 && (
+          <div className="flex items-center gap-2 px-6">
+            {selectionHasOngoingIncident && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setBulkResolveModalOpen(true)}
+                disabled={bulkActionLoading}
+              >
+                <Icon icon={CheckIcon} size="sm" />
+                Resolve last incident
+              </Button>
+            )}
+            <Button variant="outline" size="sm" onClick={() => setBulkMuteModalOpen(true)} disabled={bulkActionLoading}>
+              <Icon icon={BellOffIcon} size="sm" />
+              Mute ({selection.selectedCount.toLocaleString()})
+            </Button>
+            {!system && (
+              <Button
+                variant="destructive-outline"
+                size="sm"
+                onClick={() => setBulkDeleteModalOpen(true)}
+                disabled={bulkActionLoading}
+              >
+                <Icon icon={Trash2Icon} size="sm" />
+                Remove ({selection.selectedCount.toLocaleString()})
+              </Button>
+            )}
+          </div>
+        )}
         <MonitorsView
           rows={sortedRows}
           isLoading={isLoading || isReloading}
@@ -230,8 +381,74 @@ function MonitorsPageContent({ system }: { readonly system: boolean }) {
           showWatching={!system}
           sorting={sorting}
           onSortChange={setSorting}
+          selection={selection}
         />
         {createModal}
+
+        <Modal
+          open={bulkResolveModalOpen}
+          onOpenChange={setBulkResolveModalOpen}
+          dismissible
+          title="Resolve ongoing incidents"
+          description="Each selected monitor's ongoing incident will be closed and marked as resolved. If a monitor's condition triggers again, a new incident will be created."
+          footer={
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setBulkResolveModalOpen(false)} disabled={bulkActionLoading}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => void handleBulkResolveIncidents()}
+                disabled={bulkActionLoading}
+                isLoading={bulkActionLoading}
+              >
+                <Icon icon={CheckIcon} size="sm" />
+                Resolve
+              </Button>
+            </div>
+          }
+        />
+
+        <Modal
+          open={bulkMuteModalOpen}
+          onOpenChange={setBulkMuteModalOpen}
+          dismissible
+          title={selection.selectedCount === 1 ? "Mute monitor" : "Mute monitors"}
+          description={`${selection.selectedCount === 1 ? "The selected monitor" : `The ${selection.selectedCount} selected monitors`} will keep creating incidents, but ${selection.selectedCount === 1 ? "it" : "they"} will stop sending notifications`}
+          footer={
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setBulkMuteModalOpen(false)} disabled={bulkActionLoading}>
+                Cancel
+              </Button>
+              <Button onClick={() => void handleBulkMute()} disabled={bulkActionLoading} isLoading={bulkActionLoading}>
+                <Icon icon={BellOffIcon} size="sm" />
+                Mute
+              </Button>
+            </div>
+          }
+        />
+
+        <Modal
+          open={bulkDeleteModalOpen}
+          onOpenChange={setBulkDeleteModalOpen}
+          dismissible
+          title={selection.selectedCount === 1 ? "Remove monitor" : "Remove monitors"}
+          description={`Removing ${selection.selectedCount === 1 ? "this monitor" : `these ${selection.selectedCount} monitors`} cannot be undone. Existing incidents will stay in your history`}
+          footer={
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setBulkDeleteModalOpen(false)} disabled={bulkActionLoading}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => void handleBulkDelete()}
+                disabled={bulkActionLoading}
+                isLoading={bulkActionLoading}
+              >
+                Remove
+              </Button>
+            </div>
+          }
+        />
       </Layout.Content>
       {activeMonitor ? (
         <Layout.Aside>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitors-view.tsx
@@ -3,6 +3,7 @@ import {
   InfiniteTable,
   type InfiniteTableColumn,
   type InfiniteTableInfiniteScroll,
+  type InfiniteTableSelection,
   LatitudeLogo,
   type MenuOption,
   optionsColumn,
@@ -134,8 +135,8 @@ function WatchingCell({
               onOpenSearch(slug)
             }}
           >
-            <Badge variant="muted" className="max-w-full">
-              <span className="truncate">{name}</span>
+            <Badge variant="muted" ellipsis className="max-w-full">
+              {name}
             </Badge>
           </button>
         }
@@ -185,6 +186,7 @@ export function MonitorsView({
   showWatching = false,
   sorting,
   onSortChange,
+  selection,
 }: {
   readonly rows: readonly MonitorsTableRow[]
   readonly isLoading: boolean
@@ -197,6 +199,7 @@ export function MonitorsView({
   readonly showWatching?: boolean
   readonly sorting: MonitorsTableSorting
   readonly onSortChange: (sorting: MonitorsTableSorting) => void
+  readonly selection: InfiniteTableSelection
 }) {
   const navigate = useNavigate()
   const [pendingMute, setPendingMute] = useState<MonitorRecord | null>(null)
@@ -261,9 +264,9 @@ export function MonitorsView({
           {
             key: "watching",
             header: "Watching",
-            width: 200,
-            minWidth: 140,
-            maxWidth: 240,
+            width: 180,
+            minWidth: 120,
+            maxWidth: 220,
             render: (row) => (
               <WatchingCell
                 alerts={row.monitor.alerts}
@@ -325,6 +328,7 @@ export function MonitorsView({
             columns={columns}
             getRowKey={(row) => row.monitor.id}
             infiniteScroll={infiniteScroll}
+            selection={selection}
             sorting={sorting}
             defaultSorting={DEFAULT_MONITORS_SORTING}
             onSortChange={(next) =>

--- a/apps/web/src/routes/design-system/button.tsx
+++ b/apps/web/src/routes/design-system/button.tsx
@@ -23,6 +23,7 @@ const VARIANTS = [
   { value: "outline", label: "Outline" },
   { value: "ghost", label: "Ghost" },
   { value: "destructive", label: "Destructive" },
+  { value: "destructive-outline", label: "Destructive outline" },
   { value: "destructive-soft", label: "Destructive soft" },
   { value: "link", label: "Link" },
 ] as const

--- a/apps/web/src/routes/design-system/index.tsx
+++ b/apps/web/src/routes/design-system/index.tsx
@@ -173,6 +173,7 @@ function DesignSystemShowcase({ theme }: { theme: "light" | "dark" }) {
               <Button variant="outline">Outline</Button>
               <Button variant="ghost">Ghost</Button>
               <Button variant="destructive">Destructive</Button>
+              <Button variant="destructive-outline">Destructive outline</Button>
               <Button variant="link">Link</Button>
             </div>
           </div>

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -95,6 +95,8 @@ export interface MonitorIncidentStats {
   readonly total: number
   /** `started_at` of the first (oldest) incident — "first detected at". */
   readonly firstStartedAt: Date | null
+  /** Last incident's id (ongoing-first pick) — the manual-resolve target while it's open; `null` when the monitor has no incidents. */
+  readonly lastIncidentId: AlertIncidentId | null
   /** Last incident's `started_at` (ongoing-first pick); the fallback for "last detected at" when it's still open. */
   readonly lastStartedAt: Date | null
   /** Last incident's `ended_at` — "last detected at"; `null` while that incident is ongoing. */

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.test.ts
@@ -398,6 +398,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
     expect(result.total).toBe(3)
     expect(result.firstStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
     // Last incident is ongoing, so "last detected at" has no close time and falls back to its start.
+    expect(result.lastIncidentId).toBe(AlertIncidentId("1".repeat(24)))
     expect(result.lastStartedAt?.toISOString()).toBe("2026-05-07T10:00:00.000Z")
     expect(result.lastEndedAt).toBeNull()
   })
@@ -431,6 +432,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
 
     expect(result.total).toBe(2)
     expect(result.firstStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
+    expect(result.lastIncidentId).toBe(AlertIncidentId("2".repeat(24)))
     expect(result.lastStartedAt?.toISOString()).toBe("2026-05-07T09:00:00.000Z")
     expect(result.lastEndedAt?.toISOString()).toBe("2026-05-07T11:00:00.000Z")
   })
@@ -447,6 +449,7 @@ describe("AlertIncidentRepositoryLive.statsByMonitorId", () => {
 
     expect(result.total).toBe(0)
     expect(result.firstStartedAt).toBeNull()
+    expect(result.lastIncidentId).toBeNull()
     expect(result.lastStartedAt).toBeNull()
     expect(result.lastEndedAt).toBeNull()
   })

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -286,7 +286,7 @@ export const AlertIncidentRepositoryLive = Layer.effect(
             // the latest-started one. We surface both ends: `ended_at` is "last detected at"
             // (the close time), `started_at` is the fallback while it's still ongoing.
             const lastPromise = db
-              .select({ startedAt: alertIncidents.startedAt, endedAt: alertIncidents.endedAt })
+              .select({ id: alertIncidents.id, startedAt: alertIncidents.startedAt, endedAt: alertIncidents.endedAt })
               .from(alertIncidents)
               .innerJoin(monitorAlerts, eq(monitorAlerts.id, alertIncidents.monitorAlertId))
               .where(where)
@@ -299,6 +299,7 @@ export const AlertIncidentRepositoryLive = Layer.effect(
           return {
             total: agg?.total ?? 0,
             firstStartedAt: agg?.firstStartedAt ? new Date(agg.firstStartedAt) : null,
+            lastIncidentId: last ? (last.id as AlertIncidentId) : null,
             lastStartedAt: last?.startedAt ? new Date(last.startedAt) : null,
             lastEndedAt: last?.endedAt ? new Date(last.endedAt) : null,
           }

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -18,6 +18,7 @@ const buttonContainerVariants = cva(
         default: "bg-transparent",
         destructive: "bg-destructive-muted-foreground hover:bg-destructive-muted-foreground/90",
         outline: "bg-secondary shadow-none hover:bg-secondary/60 hover:shadow-none",
+        "destructive-outline": "bg-secondary shadow-none hover:bg-secondary/60 hover:shadow-none",
         secondary: "bg-secondary hover:bg-secondary/80",
         ghost: "bg-transparent shadow-none hover:shadow-none",
         link: "bg-transparent shadow-none underline-offset-4 hover:underline hover:shadow-none",
@@ -44,6 +45,8 @@ const buttonVariantsConfig = cva(
         destructive: "border-0 bg-transparent text-destructive-foreground",
         outline:
           "border border-input bg-background shadow-none group-hover:bg-secondary group-hover:text-secondary-foreground/80 group-hover:shadow-none",
+        "destructive-outline":
+          "border border-destructive bg-background text-destructive shadow-none group-hover:bg-destructive-muted/40 group-hover:border-destructive-muted-foreground/40 group-hover:shadow-none [&_svg]:text-destructive-muted-foreground/85",
         secondary: "border-0 bg-transparent text-secondary-foreground [&_svg]:text-muted-foreground",
         ghost:
           "border-0 border-transparent bg-transparent text-muted-foreground shadow-none group-hover:bg-muted group-hover:shadow-none",


### PR DESCRIPTION
## monitors: row selection + bulk actions

The monitors dashboard table gets the same checkbox selection as the issues table (`useSelectableRows` + `InfiniteTable`'s `selection` prop): header select-all, shift-click ranges, and `all`/`allExcept` selection beyond the loaded pages. Selecting rows shows a bulk bar with:

- **Resolve last incident** — shown only while the selection contains a monitor whose last incident is ongoing (judged from loaded rows). Resolves each selected monitor's ongoing incident; the toast reports how many actually closed.
- **Mute (N)** — mutes every selected monitor.
- **Remove (N)** — destructive; hidden on the Issue-monitors tab since system monitors are locked. Closes the detail drawer if the open monitor was in the selection.

Each action confirms in its own modal (copy mirrors the existing single-monitor modals). The three new server fns (`bulkResolveMonitorLastIncidents`, `bulkMuteMonitors`, `bulkDeleteMonitors`) resolve `all`/`allExcept` selections server-side by paging the same filtered list the table shows (searchQuery + system), the same pattern as `applyBulkIssueLifecycleAction`. Bulk delete skips system monitors defensively (`SystemMonitorForbiddenError` caught per id and reported as skipped). "Resolve last incident" picks each monitor's incident with the same ongoing-first ordering the "Last incident" column displays.

## monitor details: palette command

With a monitor's detail panel open and its last incident ongoing, the command palette offers **Resolve last incident** next to Mute/Unmute, opening the existing resolve confirmation modal. To know the target, `statsByMonitorId` now returns `lastIncidentId` (port + Postgres adapter + web stats record), pinned in the adapter tests.

## issues: archived-tab bulk actions fix

The bulk bar on the issues page always offered Ignore/Resolve/Export, even on the Archived tab where those commands are no-ops. On Archived it now offers **Unignore** / **Unresolve** / Export, reusing the `unignore`/`unresolve` lifecycle commands that already existed in the domain. Modal copy, confirm variants, and toasts flip with the tab (adapted from the single-issue lifecycle actions), and the "keep evaluating" switch only renders for the active-tab resolve. Since an archived issue is either resolved or ignored, each command only flips its own kind — the changed-count in the toast reflects that.

## ui

- New `destructive-outline` Button variant in `@repo/ui` — outline shape with destructive border/text and a destructive-muted hover wash. Used by the bulk Remove button; registered in the design-system button playground and the index variants row.
- The monitors "Watching" cell now truncates long saved-search names with an ellipsis. The nested `span.truncate` never constrained because `Badge` wraps children in its own span; switched to Badge's first-class `ellipsis` prop.

## tests

Full suites pass for `@app/web` (420), `@platform/db-postgres` (323, incl. new `lastIncidentId` assertions), and `@domain/{alerts,monitors,issues}`; workspace typecheck and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)