### PR TITLE
fix(web): show session traces newest-first

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -128,9 +128,11 @@ export function SessionSlot({
 
   const traceNumberById = useMemo(() => {
     const map = new Map<string, number>()
+    // `traces` arrives newest-first; "Trace N" stays chronological (1 = oldest)
+    // so labels don't shift as new traces land.
     for (let index = 0; index < traces.length; index++) {
       const trace = traces[index]
-      if (trace) map.set(trace.traceId, index + 1)
+      if (trace) map.set(trace.traceId, traces.length - index)
     }
     return map
   }, [traces])

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.test.ts
@@ -30,7 +30,7 @@ describe("sessionTracesQueryOptions queryFn", () => {
         projectId: "p1",
         limit: 1,
         sortBy: "startTime",
-        sortDirection: "asc",
+        sortDirection: "desc",
         filters: { traceId: [{ op: "in", value: ["t1"] }] },
       },
     })
@@ -57,10 +57,10 @@ describe("sessionTracesQueryOptions queryFn", () => {
     expect(result).toEqual([])
   })
 
-  it("merges chunks and sorts by startTime then traceId", async () => {
+  it("merges chunks and sorts by startTime descending then traceId", async () => {
     const ids = Array.from({ length: 101 }, (_, i) => `t${i}`)
-    listTracesByProject.mockResolvedValueOnce({ traces: [trace("t0", "2024-01-02T00:00:00Z")] }).mockResolvedValueOnce({
-      traces: [trace("t100", "2024-01-01T00:00:00Z")],
+    listTracesByProject.mockResolvedValueOnce({ traces: [trace("t0", "2024-01-01T00:00:00Z")] }).mockResolvedValueOnce({
+      traces: [trace("t100", "2024-01-02T00:00:00Z")],
     })
 
     const result = await sessionTracesQueryOptions(undefined, "p1", "s1", ids).queryFn()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/use-session-traces.ts
@@ -56,18 +56,18 @@ export const sessionTracesQueryOptions = (
           projectId,
           limit: chunk.length,
           sortBy: "startTime",
-          sortDirection: "asc",
+          sortDirection: "desc",
           filters: { traceId: [{ op: "in" as const, value: chunk }] },
         },
       })
       if (page?.traces.length) traces.push(...page.traces)
     }
 
-    // Child traces are shown in chronological order — they form a conversation,
-    // and reading order is what users want. Each chunk is fetched asc, but the
-    // chunks are independent queries, so re-sort the merged set (tiebreak on
-    // traceId for deterministic "Trace N" labels).
-    traces.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.traceId.localeCompare(b.traceId))
+    // Child traces are shown newest-first, matching the sessions table's
+    // last-activity ordering. Each chunk is fetched desc, but the chunks are
+    // independent queries, so re-sort the merged set (tiebreak on traceId for
+    // deterministic "Trace N" labels).
+    traces.sort((a, b) => b.startTime.localeCompare(a.startTime) || b.traceId.localeCompare(a.traceId))
     return traces
   },
   staleTime: 30_000,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-session-selection-adapter.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-session-selection-adapter.ts
@@ -17,7 +17,7 @@ import { type SelectionState, useSelectableRows } from "../../../../../lib/hooks
  *     anchor→target slice flips check state.
  *   - Trace sub-rows: range selection uses the inner hook's `rowIds`, which
  *     this adapter builds from `expandedTraces` so the order matches the DOM
- *     (chronological asc from `sessionTracesQueryOptions`), not the
+ *     (newest-first from `sessionTracesQueryOptions`), not the
  *     ClickHouse `groupArray` order of `SessionRecord.traceIds`.
  *
  * Cross-depth shift+click (e.g. session-row anchor → trace-row target, or
@@ -36,7 +36,7 @@ export function useSessionSelectionAdapter({
   sessions: readonly SessionRecord[]
   totalTraceCount: number
   /**
-   * Per-session trace lists in **rendered (chronological-asc) order**, fetched
+   * Per-session trace lists in **rendered (newest-first) order**, fetched
    * by `useExpandedSessionTraces`. Used to compute shift+click ranges for
    * expanded trace sub-rows — `SessionRecord.traceIds` is ClickHouse
    * `groupArray` order and doesn't match the DOM, which would slice the


### PR DESCRIPTION
## What

Reverses the order of a session's traces in the sessions table (expanded sub-rows) and the session detail panel: traces are now listed **newest-first** instead of oldest-first.

## Why

The sessions table itself sorts by last activity descending, but expanding a session showed its traces oldest-first — the most recent trace (usually the one you care about) was at the bottom.

## How

- `use-session-traces.ts`: the shared session-traces query now fetches and merges chunks sorted by `startTime` **descending** (tiebreak on `traceId` descending for determinism). Both the sessions table sub-rows and the session panel read from this single cache entry, so both surfaces flip together.
- `session-slot.tsx`: "Trace N" labels in the Annotations tab stay **chronological** (Trace 1 = oldest) by numbering from the end of the now-descending list — labels don't shift meaning as new traces land.
- `use-session-selection-adapter.ts`: updated comments that documented the old chronological-asc DOM order (shift+click range logic follows the rendered order, so no behavior change needed).
- Updated `use-session-traces.test.ts` expectations for the descending sort.

## Testing

- `pnpm --filter @app/web test` — 36 files / 420 tests pass.
- `pnpm --filter @app/web typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)