### PR TITLE
fix(web): move saved-search save button to the search bar's right edge

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/save-search-segment.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/save-search-segment.tsx
@@ -18,9 +18,8 @@ import { toUserMessage } from "../../../../../lib/errors.ts"
 import { serializeFilters } from "./trace-page-state.ts"
 
 /**
- * Save affordance inset in the search bar's left cluster (a button at the bar's
- * right edge sits ~viewport-width away from the content on big screens). The
- * bar context makes the short labels unambiguous:
+ * Save affordance inset at the search bar's right edge. The bar context makes
+ * the short labels unambiguous:
  *  - hidden when there's nothing to save, and when the selected saved search is unchanged;
  *  - a primary "Save" button when content is present but no saved search is selected;
  *  - a primary "Update ⌄" group once a selected saved search has drifted — Update fires
@@ -80,13 +79,12 @@ export function SaveSearchSegment({
       // its visible rounding on an inner face, so the joining classes ride on
       // `className` rather than relying on ButtonGroup's child selectors alone.
       return (
-        <div className="flex h-full shrink-0 items-center pl-2 pr-1">
+        <div className="flex h-full shrink-0 items-center pl-1 pr-2">
           <ButtonGroup>
-            {/* Outline variant: no per-button hover halo, so the joined halves read as one control. */}
+            {/* before:hidden drops the per-button hover halo, so the joined halves read as one control. */}
             <Button
-              variant="outline"
               size="sm"
-              className="rounded-r-none"
+              className="rounded-r-none before:hidden"
               onClick={updateSearch}
               {...(updateMutation.isPending ? { isLoading: true } : {})}
             >
@@ -95,9 +93,8 @@ export function SaveSearchSegment({
             <DropdownMenuRoot modal={false}>
               <DropdownMenuTrigger asChild>
                 <Button
-                  variant="outline"
                   size="sm"
-                  className="rounded-l-none border-l-0 px-1.5"
+                  className="rounded-l-none border-l border-primary-foreground/25 px-1.5 before:hidden"
                   aria-label="More save options"
                 >
                   <Icon icon={ChevronDownIcon} size="sm" />
@@ -124,9 +121,9 @@ export function SaveSearchSegment({
   if (!hasContent) return null
 
   return (
-    <div className="flex h-full shrink-0 items-center pl-2 pr-1">
+    <div className="flex h-full shrink-0 items-center pl-1 pr-2">
       <Button size="sm" onClick={onRequestSave}>
-        Save
+        Save search
       </Button>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -130,7 +130,8 @@ export function SavedSearchSelector({
           <button
             type="button"
             aria-label="Saved searches"
-            className="flex h-full min-w-0 cursor-pointer items-center gap-1 self-stretch border-r border-input bg-secondary px-2 text-secondary-foreground transition-colors hover:bg-secondary/80"
+            // pl-3 ≈ pr-2 + the chevron glyph's ~4px empty right inset, so both sides read even.
+            className="flex h-full min-w-0 cursor-pointer items-center gap-1 self-stretch border-r border-input bg-secondary pl-3 pr-2 text-secondary-foreground transition-colors hover:bg-secondary/80"
           >
             {selected ? (
               <span className="min-w-0 max-w-40 truncate text-sm">{selected.name}</span>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/search-input.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/search-input.tsx
@@ -35,7 +35,7 @@ export function SearchInput({
   return (
     <div
       data-active={active ? "" : undefined}
-      className="group/search flex h-full min-w-0 flex-1 items-center bg-transparent pl-1"
+      className="group/search flex h-full min-w-0 flex-1 items-center bg-transparent pl-1.5"
     >
       <Popover open={legendOpen} onOpenChange={setLegendOpen}>
         <PopoverTrigger asChild>
@@ -63,7 +63,7 @@ export function SearchInput({
           }}
         />
       </Popover>
-      <div className="no-scrollbar flex h-full min-w-0 flex-1 items-center gap-1 overflow-x-auto pr-3 pl-1 text-sm">
+      <div className="no-scrollbar flex h-full min-w-0 flex-1 items-center gap-1 overflow-x-auto pr-2 pl-1.5 text-sm">
         {segments.map((segment, index) => {
           const isSemantic = segment.kind === "semantic"
           const label = segment.kind === "literal" ? "Literal" : "Phrase"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -518,6 +518,7 @@ function ProjectPage() {
                 onSaveCurrent={() => setSaveModalOpen(true)}
                 canSaveCurrent={hasSearchQuery || hasActiveFilters}
               />
+              <SearchInput key={query} initialValue={query} onSubmit={handleSubmitQuery} />
               <SaveSearchSegment
                 projectId={currentProject.id}
                 query={query}
@@ -526,7 +527,6 @@ function ProjectPage() {
                 loadedSavedSearch={loadedSavedSearch}
                 onRequestSave={() => setSaveModalOpen(true)}
               />
-              <SearchInput key={query} initialValue={query} onSubmit={handleSubmitQuery} />
             </div>
           </div>
         </Layout.ActionsRow>


### PR DESCRIPTION
## What

Moves the saved-search Save/Update affordance from the left cluster of the traces/sessions search bar (between the saved-searches selector and the input) to inside the bar at its right edge, and polishes the bar's spacing.

- `SaveSearchSegment` now renders after the flex-1 `SearchInput`, so it sits flush at the bar's right edge; its padding flips accordingly (`pl-2 pr-1` → `pl-1 pr-2`).
- The unsaved-content button reads **Save search** instead of **Save**.
- The drifted-search **Update ⌄** split button switches from outline to primary. Primary buttons carry a per-button hover halo (`before:` pseudo) that would break the joined look, so both halves get `before:hidden`; and since primary faces are borderless solid fills, the chevron half adds a `border-l border-primary-foreground/25` divider so the halves don't blend into one blob.
- Horizontal spacing across the bar is aligned to an even ~8px optical rhythm: the search cluster's wrappers go from `pl-1`/`pr-3` to `pl-1.5`/`pr-2` (the magnifier icon is inset ~2px in its ghost button, so 6px + 2px reads as the same 8px as the selector chips' `px-2`), and the selector trigger goes from `px-2` to `pl-3 pr-2` to compensate for the chevron glyph's ~4px of built-in whitespace before the divider.

## Why

The save button sat between the selector and the input, pushing the search field right and reading as part of the selector cluster. At the right edge it reads as an action on the assembled search, and the bar's left side stays a clean selector + input.

Behavior is unchanged: drift detection, the Update action, the "Save as a new search" dropdown, and the save-modal delegation all work as before — this is purely a layout/visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)