### PR TITLE
feat(web): navigation bar for conversations

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -9,6 +9,7 @@ import {
   listSpansBySession,
   listSpansByTrace,
   mapConversationToSpans,
+  mapSessionConversationToSpans,
   type SpanDetailRecord,
   type SpanRecord,
 } from "./spans.functions.ts"
@@ -159,6 +160,47 @@ export const useSpanDetail = ({
         },
       }),
     staleTime: Infinity, // Span data is immutable once ingested
+  })
+}
+
+export function useSessionConversationSpanMaps({
+  projectId,
+  sessionId,
+  latestTraceId,
+  sessionStartTime,
+  sessionEndTime,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly latestTraceId: string
+  readonly sessionStartTime: string
+  readonly sessionEndTime: string
+  readonly enabled?: boolean
+}) {
+  const scope = use(TraceScopeContext)
+  return useQuery({
+    queryKey: [
+      "sessionConversationSpanMaps",
+      scope?.sandboxOrgId,
+      projectId,
+      sessionId,
+      latestTraceId,
+      sessionStartTime,
+      sessionEndTime,
+    ],
+    queryFn: () =>
+      mapSessionConversationToSpans({
+        data: {
+          ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}),
+          projectId,
+          sessionId,
+          latestTraceId,
+          sessionStartTime,
+          sessionEndTime,
+        },
+      }),
+    enabled: enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0,
   })
 }
 

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -235,6 +235,51 @@ export const mapConversationToSpans = createServerFn({ method: "GET" })
     },
   )
 
+export const mapSessionConversationToSpans = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      sandboxOrgId: z.string().optional(),
+      projectId: z.string(),
+      sessionId: z.string(),
+      latestTraceId: z.string(),
+      sessionStartTime: dateTimeParamSchema,
+      sessionEndTime: dateTimeParamSchema,
+    }),
+  )
+  .handler(
+    async ({ data }): Promise<{ messageSpanMap: Record<number, string>; toolCallSpanMap: Record<string, string> }> => {
+      const orgId = await resolveOrgScope(data)
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const traceRepo = yield* TraceRepository
+          const spanRepo = yield* SpanRepository
+
+          const projectId = ProjectId(data.projectId)
+          const traceDetail = yield* traceRepo
+            .findByTraceId({ organizationId: orgId, projectId, traceId: TraceId(data.latestTraceId) })
+            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+
+          if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
+
+          const spans = yield* spanRepo.findMessagesForSession({
+            organizationId: orgId,
+            projectId,
+            sessionId: SessionId(data.sessionId),
+            startTimeFrom: new Date(data.sessionStartTime.getTime() - 60 * 1000),
+            startTimeTo: new Date(data.sessionEndTime.getTime() + 24 * 60 * 60 * 1000),
+          })
+
+          return buildConversationSpanMaps(traceDetail.allMessages, spans)
+        }).pipe(
+          withClickHouse(Layer.merge(TraceRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
+          withAi(AIEmbedLive, getRedisClient()),
+          withTracing,
+        ),
+      )
+    },
+  )
+
 export const getSpanDetail = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/lib/conversation-timeline/build-activity-track.test.ts
+++ b/apps/web/src/lib/conversation-timeline/build-activity-track.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { buildActivityTrack } from "./build-activity-track.ts"
+import { buildConversationTimeline } from "./build-conversation-timeline.ts"
+import { TIMELINE_FIXTURE as FIXTURE, FIXTURE_T0, fixtureSpan as span } from "./timeline-fixture.ts"
+import { buildTimelineScale, GAP_TIMELINE_MS } from "./timeline-scale.ts"
+
+const at = (ms: number) => FIXTURE_T0 + ms
+
+describe("buildActivityTrack", () => {
+  it("paints the fixture session as ordered activity phases in timeline coordinates", () => {
+    const timeline = buildConversationTimeline(FIXTURE)
+    expect(timeline.activity).toEqual([
+      { category: "idle", timelineStartMs: 0, timelineEndMs: 500, durationMs: 500 },
+      { category: "generation", timelineStartMs: 500, timelineEndMs: 10_000, durationMs: 9_500 },
+      { category: "tool", timelineStartMs: 10_000, timelineEndMs: 14_000, durationMs: 4_000 },
+      { category: "generation", timelineStartMs: 14_000, timelineEndMs: 20_000, durationMs: 6_000 },
+      {
+        category: "idle",
+        timelineStartMs: 20_000 + GAP_TIMELINE_MS,
+        timelineEndMs: 20_200 + GAP_TIMELINE_MS,
+        durationMs: 200,
+      },
+      {
+        category: "generation",
+        timelineStartMs: 20_200 + GAP_TIMELINE_MS,
+        timelineEndMs: 30_000 + GAP_TIMELINE_MS,
+        durationMs: 9_800,
+      },
+    ])
+  })
+
+  it("resolves overlapping work by priority (generation wins over tool)", () => {
+    const scale = buildTimelineScale([{ startMs: at(0), endMs: at(10_000) }])
+    const segments = buildActivityTrack(
+      [
+        span({ spanId: "llm", traceId: "t1", startMs: at(0), endMs: at(10_000), operation: "chat" }),
+        span({ spanId: "tool", traceId: "t1", startMs: at(2_000), endMs: at(4_000), operation: "execute_tool" }),
+      ],
+      scale,
+    )
+    expect(segments).toEqual([
+      { category: "generation", timelineStartMs: 0, timelineEndMs: 10_000, durationMs: 10_000 },
+    ])
+  })
+
+  it("excludes container spans so their children are not double-counted", () => {
+    const scale = buildTimelineScale([{ startMs: at(0), endMs: at(10_000) }])
+    const segments = buildActivityTrack(
+      [
+        span({ spanId: "agent", traceId: "t1", startMs: at(0), endMs: at(10_000), operation: "invoke_agent" }),
+        span({
+          spanId: "tool",
+          parentSpanId: "agent",
+          traceId: "t1",
+          startMs: at(2_000),
+          endMs: at(4_000),
+          operation: "execute_tool",
+        }),
+      ],
+      scale,
+    )
+    expect(segments).toEqual([
+      { category: "idle", timelineStartMs: 0, timelineEndMs: 2_000, durationMs: 2_000 },
+      { category: "tool", timelineStartMs: 2_000, timelineEndMs: 4_000, durationMs: 2_000 },
+      { category: "idle", timelineStartMs: 4_000, timelineEndMs: 10_000, durationMs: 6_000 },
+    ])
+  })
+
+  it("returns no segments when there are no spans", () => {
+    const scale = buildTimelineScale([{ startMs: at(0), endMs: at(10_000) }])
+    expect(buildActivityTrack([], scale)).toEqual([
+      { category: "idle", timelineStartMs: 0, timelineEndMs: 10_000, durationMs: 10_000 },
+    ])
+  })
+})

--- a/apps/web/src/lib/conversation-timeline/build-activity-track.ts
+++ b/apps/web/src/lib/conversation-timeline/build-activity-track.ts
@@ -1,0 +1,135 @@
+import type { TimelineScale } from "./timeline-scale.ts"
+import { wallToTimeline } from "./timeline-scale.ts"
+
+/**
+ * Same categories and overlap-resolution priority as the trace duration bar
+ * (duration-composition.ts), but producing time-ordered segments instead of
+ * per-category totals, so the scrubber can paint what the agent was doing at
+ * each moment.
+ */
+export type ActivityCategory = "generation" | "tool" | "retrieval" | "other" | "idle"
+type WorkCategory = Exclude<ActivityCategory, "idle">
+
+export interface ActivitySegment {
+  readonly category: ActivityCategory
+  readonly timelineStartMs: number
+  readonly timelineEndMs: number
+  readonly durationMs: number
+}
+
+interface ActivitySpanInput {
+  readonly spanId: string
+  readonly parentSpanId: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly operation: string
+}
+
+const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "tool", "retrieval", "other"]
+
+function categoryFor(operation: string): WorkCategory {
+  switch (operation) {
+    case "chat":
+    case "text_completion":
+      return "generation"
+    case "execute_tool":
+      return "tool"
+    case "retrieval":
+    case "reranker":
+      return "retrieval"
+    default:
+      return "other"
+  }
+}
+
+interface WallSlice {
+  readonly startMs: number
+  readonly endMs: number
+  readonly category: ActivityCategory
+}
+
+/** Partition wall-clock time into category slices via a sweep over leaf spans. */
+function sweepWallSlices(spans: readonly ActivitySpanInput[]): WallSlice[] {
+  const parentIds = new Set(spans.map((s) => s.parentSpanId).filter((id) => id !== ""))
+  const leaves = spans.filter((s) => !parentIds.has(s.spanId) && s.endMs > s.startMs)
+
+  const events = leaves
+    .flatMap((s) => {
+      const category = categoryFor(s.operation)
+      return [
+        { t: s.startMs, category, delta: 1 },
+        { t: s.endMs, category, delta: -1 },
+      ]
+    })
+    .sort((a, b) => a.t - b.t)
+
+  const active: Record<WorkCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0 }
+  const dominant = (): ActivityCategory => WORK_PRIORITY.find((c) => active[c] > 0) ?? "idle"
+
+  const slices: WallSlice[] = []
+  let cursor = Number.NEGATIVE_INFINITY
+  let i = 0
+  while (i < events.length) {
+    const event = events[i]
+    if (!event) break
+    const t = event.t
+    if (Number.isFinite(cursor) && t > cursor) {
+      slices.push({ startMs: cursor, endMs: t, category: dominant() })
+    }
+    cursor = Math.max(cursor, t)
+    while (i < events.length && events[i]?.t === t) {
+      const e = events[i]
+      if (e) active[e.category] += e.delta
+      i++
+    }
+  }
+  return slices
+}
+
+/**
+ * Activity segments covering the scale's active windows, in timeline
+ * coordinates. Moments inside a trace with no running leaf span are `idle`;
+ * the compressed between-trace gaps are not included (the scrubber renders
+ * those from the scale itself).
+ */
+export function buildActivityTrack(
+  spans: readonly ActivitySpanInput[],
+  scale: TimelineScale,
+): readonly ActivitySegment[] {
+  const slices = sweepWallSlices(spans)
+  const segments: ActivitySegment[] = []
+
+  for (const window of scale.segments) {
+    if (window.kind !== "active") continue
+
+    let cursor = window.wallStartMs
+    const emit = (startMs: number, endMs: number, category: ActivityCategory) => {
+      if (endMs <= startMs) return
+      const timelineStartMs = wallToTimeline(scale, startMs)
+      const timelineEndMs = wallToTimeline(scale, endMs)
+      const last = segments[segments.length - 1]
+      if (last && last.category === category && last.timelineEndMs === timelineStartMs) {
+        segments[segments.length - 1] = {
+          category,
+          timelineStartMs: last.timelineStartMs,
+          timelineEndMs,
+          durationMs: last.durationMs + (endMs - startMs),
+        }
+        return
+      }
+      segments.push({ category, timelineStartMs, timelineEndMs, durationMs: endMs - startMs })
+    }
+
+    for (const slice of slices) {
+      const startMs = Math.max(slice.startMs, window.wallStartMs)
+      const endMs = Math.min(slice.endMs, window.wallEndMs)
+      if (endMs <= startMs) continue
+      if (startMs > cursor) emit(cursor, startMs, "idle")
+      emit(startMs, endMs, slice.category)
+      cursor = Math.max(cursor, endMs)
+    }
+    if (cursor < window.wallEndMs) emit(cursor, window.wallEndMs, "idle")
+  }
+
+  return segments
+}

--- a/apps/web/src/lib/conversation-timeline/build-conversation-timeline.test.ts
+++ b/apps/web/src/lib/conversation-timeline/build-conversation-timeline.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest"
+import { buildConversationTimeline } from "./build-conversation-timeline.ts"
+import {
+  TIMELINE_FIXTURE as FIXTURE,
+  FIXTURE_T0,
+  fixtureMessage as message,
+  fixtureSpan as span,
+  fixtureText as text,
+  fixtureToolCall as toolCall,
+  fixtureToolResponse as toolResponse,
+} from "./timeline-fixture.ts"
+
+const at = (ms: number) => FIXTURE_T0 + ms
+
+describe("buildConversationTimeline", () => {
+  const timeline = buildConversationTimeline(FIXTURE)
+
+  it("schedules system and first user message at session start", () => {
+    expect(timeline.schedules[0]).toEqual({ kind: "instant", atMs: at(0) })
+    expect(timeline.schedules[1]).toEqual({ kind: "instant", atMs: at(0) })
+  })
+
+  it("streams mapped assistant messages from start+ttft to span end", () => {
+    expect(timeline.schedules[2]).toEqual({
+      kind: "streamed",
+      revealStartMs: at(1_500),
+      revealEndMs: at(10_000),
+      textChars: "Let me check.".length,
+    })
+    expect(timeline.schedules[4]).toEqual({
+      kind: "streamed",
+      revealStartMs: at(14_500),
+      revealEndMs: at(20_000),
+      textChars: "Result is 42.".length,
+    })
+  })
+
+  it("schedules tool results at the execute_tool span end", () => {
+    expect(timeline.schedules[3]).toEqual({
+      kind: "toolResult",
+      parts: [{ partIndex: 0, toolCallId: "call_1", atMs: at(14_000) }],
+    })
+  })
+
+  it("schedules a new-turn user message at its trace start", () => {
+    expect(timeline.schedules[5]).toEqual({ kind: "instant", atMs: at(140_000) })
+  })
+
+  it("collapses non-streaming spans to instant at span end", () => {
+    expect(timeline.schedules[6]).toEqual({ kind: "instant", atMs: at(150_000) })
+  })
+
+  it("places annotation markers at anchored message completion, not createdAt", () => {
+    const annotations = timeline.markers.filter((m) => m.kind === "annotation")
+    expect(annotations).toEqual([
+      {
+        kind: "annotation",
+        atMs: at(20_000),
+        annotationId: "ann1",
+        messageIndex: 4,
+        passed: false,
+        feedback: "wrong",
+        flaggerSlug: null,
+        annotatorName: "Carlos",
+      },
+      {
+        kind: "annotation",
+        atMs: at(150_000),
+        annotationId: "ann2",
+        messageIndex: null,
+        passed: true,
+        feedback: "overall fine",
+        flaggerSlug: null,
+        annotatorName: null,
+      },
+    ])
+  })
+
+  it("attaches the turn-starting user message excerpt to trace markers", () => {
+    const traceMarkers = timeline.markers.filter((m) => m.kind === "trace")
+    expect(traceMarkers.map((m) => m.userExcerpt)).toEqual(["question one", "question two"])
+  })
+
+  it("attaches the turn-starting user message index to trace markers", () => {
+    const traceMarkers = timeline.markers.filter((m) => m.kind === "trace")
+    expect(traceMarkers.map((m) => m.firstMessageIndex)).toEqual([1, 5])
+  })
+
+  it("emits markers sorted by time, skipping successful tools and non-tool errors", () => {
+    expect(timeline.markers.map((m) => m.kind)).toEqual(["trace", "annotation", "trace", "annotation", "moment"])
+  })
+
+  it("places moment markers at the anchored message completion", () => {
+    const moment = timeline.markers.find((m) => m.kind === "moment")
+    expect(moment).toEqual({
+      kind: "moment",
+      atMs: at(150_000),
+      momentId: "label1",
+      messageIndex: 6,
+      label: "frustration",
+      summary: "User repeated the request",
+      confidence: 0.87,
+    })
+  })
+
+  it("compresses the inter-trace gap in the scale", () => {
+    expect(timeline.scale.segments.map((s) => s.kind)).toEqual(["active", "gap", "active"])
+    expect(timeline.wallStartMs).toBe(at(0))
+    expect(timeline.wallEndMs).toBe(at(150_000))
+  })
+})
+
+describe("buildConversationTimeline edge cases", () => {
+  it("falls back to monotonic instants for unmapped assistant messages", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [
+        message("user", text("hi")),
+        message("assistant", text("mapped")),
+        message("assistant", text("unmapped")),
+      ],
+      messageSpanMap: { 1: "s1" },
+      annotations: [],
+    })
+    expect(timeline.schedules[2]).toEqual({ kind: "instant", atMs: at(10_001) })
+  })
+
+  it("degrades to an evenly spaced slideshow when nothing is mapped", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [message("system", text("s")), message("user", text("u")), message("assistant", text("a"))],
+      messageSpanMap: {},
+      toolCallSpanMap: {},
+      annotations: [],
+    })
+    expect(timeline.schedules[0]).toEqual({ kind: "instant", atMs: at(0) })
+    const atMsOf = (i: number) => {
+      const schedule = timeline.schedules[i]
+      return schedule?.kind === "instant" ? schedule.atMs : Number.NaN
+    }
+    expect(atMsOf(1)).toBeGreaterThan(at(0))
+    expect(atMsOf(2)).toBeGreaterThan(atMsOf(1))
+    expect(atMsOf(2)).toBeLessThan(at(150_000))
+  })
+
+  it("collapses streaming spans with ttft past span end to instant at span end", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [message("assistant", text("late"))],
+      spans: [
+        span({ spanId: "s1", traceId: "t1", startMs: at(0), endMs: at(1_000), ttftMs: 5_000, isStreaming: true }),
+      ],
+      messageSpanMap: { 0: "s1" },
+      annotations: [],
+    })
+    expect(timeline.schedules[0]).toEqual({ kind: "instant", atMs: at(1_000) })
+  })
+
+  it("splits one span's reveal window across consecutive assistant messages by char share", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [message("assistant", text("aaaaaa")), message("assistant", text("bb"))],
+      spans: [span({ spanId: "s1", traceId: "t1", startMs: at(0), endMs: at(8_000), ttftMs: 0, isStreaming: true })],
+      messageSpanMap: { 0: "s1", 1: "s1" },
+      annotations: [],
+    })
+    expect(timeline.schedules[0]).toEqual({
+      kind: "streamed",
+      revealStartMs: at(0),
+      revealEndMs: at(6_000),
+      textChars: 6,
+    })
+    expect(timeline.schedules[1]).toEqual({
+      kind: "streamed",
+      revealStartMs: at(6_000),
+      revealEndMs: at(8_000),
+      textChars: 2,
+    })
+  })
+
+  it("falls back tool results to the next mapped span start when no execute_tool span exists", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [
+        message("assistant", text("calling"), toolCall("call_x")),
+        message("tool", toolResponse("call_x")),
+        message("assistant", text("done")),
+      ],
+      messageSpanMap: { 0: "s1", 2: "s3" },
+      toolCallSpanMap: {},
+      annotations: [],
+    })
+    expect(timeline.schedules[1]).toEqual({
+      kind: "toolResult",
+      parts: [{ partIndex: 0, toolCallId: "call_x", atMs: at(14_000) }],
+    })
+  })
+
+  it("marks only failing tool calls — successful tools and errored non-tool spans get no marker", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      spans: [
+        span({ spanId: "fast", traceId: "t1", startMs: at(0), endMs: at(500), operation: "execute_tool" }),
+        span({
+          spanId: "failed",
+          traceId: "t1",
+          startMs: at(1_000),
+          endMs: at(1_200),
+          operation: "execute_tool",
+          isError: true,
+          name: "lookup",
+        }),
+        span({
+          spanId: "llm",
+          traceId: "t1",
+          startMs: at(2_000),
+          endMs: at(3_000),
+          operation: "chat",
+          isError: true,
+        }),
+      ],
+      annotations: [],
+      moments: [],
+    })
+    const eventMarkers = timeline.markers.filter((m) => m.kind !== "trace")
+    expect(eventMarkers).toEqual([
+      {
+        kind: "toolCall",
+        atMs: at(1_200),
+        spanId: "failed",
+        toolCallId: null,
+        label: "lookup",
+        durationMs: 200,
+        errorExcerpt: null,
+      },
+    ])
+  })
+
+  it("excerpts the mapped tool's returned output on failed-tool markers", () => {
+    const longError = `Error: The number of items\nto be exchanged should match. ${"details ".repeat(40)}`
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [
+        message("assistant", text("calling"), toolCall("call_1")),
+        message("tool", { type: "tool_call_response", id: "call_1", response: longError }),
+      ],
+      spans: [
+        span({ spanId: "s1", traceId: "t1", startMs: at(0), endMs: at(1_000), operation: "chat" }),
+        span({
+          spanId: "s2",
+          traceId: "t1",
+          startMs: at(1_000),
+          endMs: at(2_000),
+          operation: "execute_tool",
+          isError: true,
+        }),
+      ],
+      messageSpanMap: { 0: "s1" },
+      toolCallSpanMap: { call_1: "s2" },
+      annotations: [],
+      moments: [],
+    })
+    const marker = timeline.markers.find((m) => m.kind === "toolCall")
+    expect(marker?.errorExcerpt).toMatch(/^Error: The number of items to be exchanged should match\./)
+    expect(marker?.errorExcerpt?.endsWith("…")).toBe(true)
+    expect(marker?.errorExcerpt?.length).toBeLessThanOrEqual(181)
+    expect(timeline.failedToolCallIds).toEqual(new Set(["call_1"]))
+  })
+
+  it("leaves failedToolCallIds empty when no mapped tool errored", () => {
+    expect(buildConversationTimeline(FIXTURE).failedToolCallIds.size).toBe(0)
+  })
+
+  it("stringifies object tool outputs in the excerpt", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      messages: [
+        message("assistant", text("calling"), toolCall("call_1")),
+        message("tool", { type: "tool_call_response", id: "call_1", response: { error: "mismatch", code: 42 } }),
+      ],
+      spans: [
+        span({
+          spanId: "s2",
+          traceId: "t1",
+          startMs: at(1_000),
+          endMs: at(2_000),
+          operation: "execute_tool",
+          isError: true,
+        }),
+      ],
+      messageSpanMap: {},
+      toolCallSpanMap: { call_1: "s2" },
+      annotations: [],
+      moments: [],
+    })
+    const marker = timeline.markers.find((m) => m.kind === "toolCall")
+    expect(marker?.errorExcerpt).toBe('{"error":"mismatch","code":42}')
+  })
+
+  it("falls back to the span status message when the failed tool is unmapped", () => {
+    const timeline = buildConversationTimeline({
+      ...FIXTURE,
+      spans: [
+        span({
+          spanId: "s2",
+          traceId: "t1",
+          startMs: at(1_000),
+          endMs: at(2_000),
+          operation: "execute_tool",
+          isError: true,
+          statusMessage: "tool runner crashed",
+        }),
+      ],
+      toolCallSpanMap: {},
+      annotations: [],
+      moments: [],
+    })
+    const marker = timeline.markers.find((m) => m.kind === "toolCall")
+    expect(marker?.errorExcerpt).toBe("tool runner crashed")
+  })
+
+  it("handles empty conversations", () => {
+    const timeline = buildConversationTimeline({ ...FIXTURE, messages: [], annotations: [], moments: [] })
+    expect(timeline.schedules).toEqual([])
+    expect(timeline.scale.totalTimelineMs).toBeGreaterThan(0)
+  })
+})

--- a/apps/web/src/lib/conversation-timeline/build-conversation-timeline.ts
+++ b/apps/web/src/lib/conversation-timeline/build-conversation-timeline.ts
@@ -1,0 +1,418 @@
+import type { GenAIMessage } from "rosetta-ai"
+import { type ActivitySegment, buildActivityTrack } from "./build-activity-track.ts"
+import { buildTimelineScale, type TimelineScale } from "./timeline-scale.ts"
+
+export interface TimelineSpanInput {
+  readonly spanId: string
+  readonly parentSpanId: string
+  readonly traceId: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly ttftMs: number
+  readonly isStreaming: boolean
+  readonly isError: boolean
+  readonly name: string
+  readonly operation: string
+  readonly statusMessage: string
+}
+
+export interface TimelineTraceInput {
+  readonly traceId: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly label: string
+}
+
+export interface TimelineAnnotationInput {
+  readonly id: string
+  readonly messageIndex: number | null
+  readonly spanId: string | null
+  readonly passed: boolean | null
+  readonly feedback: string
+  /** Set when a Latitude flagger created the annotation (e.g. "jailbreaking"). */
+  readonly flaggerSlug: string | null
+  readonly annotatorName: string | null
+}
+
+export interface TimelineMomentInput {
+  readonly id: string
+  readonly messageIndex: number
+  readonly kind: string
+  readonly summary: string
+  readonly confidence: number | null
+}
+
+export type TimelineMessageSchedule =
+  | { readonly kind: "instant"; readonly atMs: number }
+  | {
+      readonly kind: "streamed"
+      readonly revealStartMs: number
+      readonly revealEndMs: number
+      readonly textChars: number
+    }
+  | {
+      readonly kind: "toolResult"
+      readonly parts: readonly {
+        readonly partIndex: number
+        readonly toolCallId: string | null
+        readonly atMs: number
+      }[]
+    }
+
+export type TimelineMarker =
+  | {
+      readonly kind: "trace"
+      readonly atMs: number
+      readonly traceIndex: number
+      readonly traceId: string
+      readonly label: string
+      /** Excerpt of the user message that started the turn, when one is mapped. */
+      readonly userExcerpt: string | null
+      /** Index of the turn-starting user message; null when none is mapped. */
+      readonly firstMessageIndex: number | null
+    }
+  | {
+      readonly kind: "annotation"
+      readonly atMs: number
+      readonly annotationId: string
+      readonly messageIndex: number | null
+      readonly passed: boolean | null
+      readonly feedback: string
+      readonly flaggerSlug: string | null
+      readonly annotatorName: string | null
+    }
+  | {
+      readonly kind: "toolCall"
+      readonly atMs: number
+      readonly spanId: string
+      readonly toolCallId: string | null
+      readonly label: string
+      readonly durationMs: number
+      readonly errorExcerpt: string | null
+    }
+  | {
+      readonly kind: "moment"
+      readonly atMs: number
+      readonly momentId: string
+      readonly messageIndex: number
+      readonly label: string
+      readonly summary: string
+      readonly confidence: number | null
+    }
+
+export interface ConversationTimeline {
+  readonly messages: readonly GenAIMessage[]
+  readonly schedules: readonly TimelineMessageSchedule[]
+  readonly markers: readonly TimelineMarker[]
+  /** Tool calls whose execute_tool span errored — overrides the message part's own success flag in the UI. */
+  readonly failedToolCallIds: ReadonlySet<string>
+  readonly activity: readonly ActivitySegment[]
+  readonly scale: TimelineScale
+  readonly wallStartMs: number
+  readonly wallEndMs: number
+}
+
+export interface BuildConversationTimelineInput {
+  readonly messages: readonly GenAIMessage[]
+  readonly spans: readonly TimelineSpanInput[]
+  readonly messageSpanMap: Readonly<Record<number, string>>
+  readonly toolCallSpanMap: Readonly<Record<string, string>>
+  readonly traces: readonly TimelineTraceInput[]
+  readonly annotations: readonly TimelineAnnotationInput[]
+  readonly moments: readonly TimelineMomentInput[]
+}
+
+function countStreamableChars(message: GenAIMessage): number {
+  let chars = 0
+  for (const part of message.parts ?? []) {
+    if (part.type === "text" || part.type === "reasoning") {
+      chars += (part as { content: string }).content.length
+    }
+  }
+  return chars
+}
+
+const EXCERPT_MAX_CHARS = 180
+
+function excerptText(value: string): string | null {
+  const collapsed = value.replace(/\s+/g, " ").trim()
+  if (collapsed.length === 0) return null
+  return collapsed.length > EXCERPT_MAX_CHARS ? `${collapsed.slice(0, EXCERPT_MAX_CHARS)}…` : collapsed
+}
+
+function messageTextExcerpt(message: GenAIMessage): string | null {
+  let text = ""
+  for (const part of message.parts ?? []) {
+    if (part.type === "text") text += `${(part as { content: string }).content} `
+  }
+  return excerptText(text)
+}
+
+function toolResponseExcerpt(messages: readonly GenAIMessage[], toolCallId: string): string | null {
+  for (const message of messages) {
+    if (message.role !== "tool") continue
+    for (const part of message.parts ?? []) {
+      if (part.type !== "tool_call_response") continue
+      const p = part as { id?: string | null; response?: unknown; result?: unknown }
+      if (p.id !== toolCallId) continue
+      const raw = p.response ?? p.result
+      if (raw === undefined || raw === null) return null
+      return excerptText(typeof raw === "string" ? raw : JSON.stringify(raw))
+    }
+  }
+  return null
+}
+
+export function scheduleCompletionMs(schedule: TimelineMessageSchedule): number {
+  switch (schedule.kind) {
+    case "instant":
+      return schedule.atMs
+    case "streamed":
+      return schedule.revealEndMs
+    case "toolResult":
+      return schedule.parts.reduce((max, part) => Math.max(max, part.atMs), 0)
+  }
+}
+
+export function scheduleStartMs(schedule: TimelineMessageSchedule): number {
+  switch (schedule.kind) {
+    case "instant":
+      return schedule.atMs
+    case "streamed":
+      return schedule.revealStartMs
+    case "toolResult":
+      return schedule.parts.length === 0
+        ? scheduleCompletionMs(schedule)
+        : schedule.parts.reduce((min, part) => Math.min(min, part.atMs), Number.POSITIVE_INFINITY)
+  }
+}
+
+interface RevealWindow {
+  readonly revealStartMs: number
+  readonly revealEndMs: number
+}
+
+/**
+ * Reveal window per mapped assistant message. A run of consecutive assistant
+ * messages mapped to the same span splits that span's reveal window
+ * proportionally by char count, in index order.
+ */
+function buildRevealWindows(
+  messages: readonly GenAIMessage[],
+  spanAt: (index: number) => TimelineSpanInput | null,
+  clamp: (ms: number) => number,
+): Map<number, RevealWindow> {
+  const windows = new Map<number, RevealWindow>()
+  let run: { span: TimelineSpanInput; indices: number[] } | null = null
+
+  const flush = () => {
+    if (!run) return
+    const windowStart = clamp(Math.min(run.span.startMs + run.span.ttftMs, run.span.endMs))
+    const windowEnd = Math.max(windowStart, clamp(run.span.endMs))
+    const charCounts = run.indices.map((index) => {
+      const message = messages[index]
+      return message ? countStreamableChars(message) : 0
+    })
+    const totalChars = charCounts.reduce((sum, count) => sum + count, 0)
+    let consumed = 0
+    for (const [position, index] of run.indices.entries()) {
+      if (totalChars === 0) {
+        windows.set(index, { revealStartMs: windowEnd, revealEndMs: windowEnd })
+        continue
+      }
+      const span = windowEnd - windowStart
+      const revealStartMs = windowStart + (span * consumed) / totalChars
+      consumed += charCounts[position] ?? 0
+      const revealEndMs = windowStart + (span * consumed) / totalChars
+      windows.set(index, { revealStartMs, revealEndMs })
+    }
+    run = null
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const span = messages[i]?.role === "assistant" ? spanAt(i) : null
+    if (!span) {
+      flush()
+      continue
+    }
+    if (run && run.span === span && run.indices[run.indices.length - 1] === i - 1) {
+      run.indices.push(i)
+    } else {
+      flush()
+      run = { span, indices: [i] }
+    }
+  }
+  flush()
+  return windows
+}
+
+export function buildConversationTimeline(input: BuildConversationTimelineInput): ConversationTimeline {
+  const traces = [...input.traces].sort((a, b) => a.startMs - b.startMs)
+  const scale = buildTimelineScale(traces)
+  const wallStartMs = scale.wallStartMs
+  const wallEndMs = scale.wallEndMs
+  const clamp = (ms: number) => Math.min(wallEndMs, Math.max(wallStartMs, ms))
+
+  const spanById = new Map(input.spans.map((span) => [span.spanId, span]))
+  const traceById = new Map(traces.map((trace) => [trace.traceId, trace]))
+
+  const mappedSpanAt = (index: number): TimelineSpanInput | null => {
+    const spanId = input.messageSpanMap[index]
+    return spanId ? (spanById.get(spanId) ?? null) : null
+  }
+  const hasAnyMapping = input.messages.some((message, i) => message.role === "assistant" && mappedSpanAt(i) !== null)
+
+  // nextMappedSpan[i]: the span generating the first mapped assistant message at or after i.
+  const nextMappedSpan: (TimelineSpanInput | null)[] = new Array(input.messages.length).fill(null)
+  for (let i = input.messages.length - 1; i >= 0; i--) {
+    const message = input.messages[i]
+    const own = message?.role === "assistant" ? mappedSpanAt(i) : null
+    nextMappedSpan[i] = own ?? nextMappedSpan[i + 1] ?? null
+  }
+
+  const revealWindows = buildRevealWindows(input.messages, mappedSpanAt, clamp)
+
+  const schedules: TimelineMessageSchedule[] = []
+  const slideshowSlotMs = (index: number) =>
+    wallStartMs + ((wallEndMs - wallStartMs) * (index + 1)) / (input.messages.length + 1)
+
+  let prevEventMs = wallStartMs
+  let currentTraceId: string | null = null
+  const turnUserExcerpts = new Map<string, string>()
+  const turnFirstMessageIndex = new Map<string, number>()
+
+  for (let i = 0; i < input.messages.length; i++) {
+    const message = input.messages[i]
+    let schedule: TimelineMessageSchedule
+
+    if (!message) {
+      schedule = { kind: "instant", atMs: prevEventMs }
+    } else if (!hasAnyMapping) {
+      schedule = { kind: "instant", atMs: clamp(message.role === "system" ? wallStartMs : slideshowSlotMs(i)) }
+    } else if (message.role === "system") {
+      schedule = { kind: "instant", atMs: wallStartMs }
+    } else if (message.role === "assistant") {
+      const span = mappedSpanAt(i)
+      const window = revealWindows.get(i)
+      if (!span || !window) {
+        schedule = { kind: "instant", atMs: clamp(prevEventMs + 1) }
+      } else {
+        currentTraceId = span.traceId
+        const textChars = countStreamableChars(message)
+        schedule =
+          span.isStreaming && window.revealEndMs > window.revealStartMs && textChars > 0
+            ? { kind: "streamed", revealStartMs: window.revealStartMs, revealEndMs: window.revealEndMs, textChars }
+            : { kind: "instant", atMs: window.revealEndMs }
+      }
+    } else if (message.role === "tool") {
+      const parts = (message.parts ?? []).map((part, partIndex) => {
+        const toolCallId = part.type === "tool_call_response" ? ((part as { id?: string | null }).id ?? null) : null
+        const executeSpanId = toolCallId ? input.toolCallSpanMap[toolCallId] : undefined
+        const executeSpan = executeSpanId ? spanById.get(executeSpanId) : undefined
+        const atMs = executeSpan ? clamp(executeSpan.endMs) : clamp(nextMappedSpan[i + 1]?.startMs ?? prevEventMs + 1)
+        return { partIndex, toolCallId, atMs }
+      })
+      schedule = { kind: "toolResult", parts }
+    } else {
+      const nextSpan = nextMappedSpan[i]
+      if (!nextSpan) {
+        schedule = { kind: "instant", atMs: clamp(prevEventMs + 1) }
+      } else {
+        const trace = traceById.get(nextSpan.traceId)
+        const isNewTurn = nextSpan.traceId !== currentTraceId
+        if (message.role === "user" && isNewTurn) {
+          if (!turnFirstMessageIndex.has(nextSpan.traceId)) turnFirstMessageIndex.set(nextSpan.traceId, i)
+          if (!turnUserExcerpts.has(nextSpan.traceId)) {
+            const excerpt = messageTextExcerpt(message)
+            if (excerpt) turnUserExcerpts.set(nextSpan.traceId, excerpt)
+          }
+        }
+        const atMs = isNewTurn && trace ? trace.startMs : nextSpan.startMs
+        schedule = { kind: "instant", atMs: clamp(Math.max(atMs, prevEventMs)) }
+      }
+    }
+
+    schedules.push(schedule)
+    prevEventMs = Math.max(prevEventMs, scheduleCompletionMs(schedule))
+  }
+
+  const markers: TimelineMarker[] = []
+  for (const [index, trace] of traces.entries()) {
+    markers.push({
+      kind: "trace",
+      atMs: clamp(trace.startMs),
+      traceIndex: index,
+      traceId: trace.traceId,
+      label: trace.label,
+      userExcerpt: turnUserExcerpts.get(trace.traceId) ?? null,
+      firstMessageIndex: turnFirstMessageIndex.get(trace.traceId) ?? null,
+    })
+  }
+  for (const annotation of input.annotations) {
+    const anchoredSchedule = annotation.messageIndex !== null ? schedules[annotation.messageIndex] : undefined
+    const anchoredSpan = annotation.spanId ? spanById.get(annotation.spanId) : undefined
+    const atMs = anchoredSchedule
+      ? scheduleCompletionMs(anchoredSchedule)
+      : anchoredSpan
+        ? anchoredSpan.endMs
+        : wallEndMs
+    markers.push({
+      kind: "annotation",
+      atMs: clamp(atMs),
+      annotationId: annotation.id,
+      messageIndex: annotation.messageIndex,
+      passed: annotation.passed,
+      feedback: annotation.feedback,
+      flaggerSlug: annotation.flaggerSlug,
+      annotatorName: annotation.annotatorName,
+    })
+  }
+  const toolCallIdBySpanId = new Map(
+    Object.entries(input.toolCallSpanMap).map(([toolCallId, spanId]) => [spanId, toolCallId]),
+  )
+  const failedToolCallIds = new Set<string>()
+  for (const span of input.spans) {
+    if (span.operation !== "execute_tool" || !span.isError) continue
+    // The tool's returned output (what the conversation shows) beats the span status message.
+    const toolCallId = toolCallIdBySpanId.get(span.spanId)
+    if (toolCallId) failedToolCallIds.add(toolCallId)
+    const errorExcerpt =
+      (toolCallId ? toolResponseExcerpt(input.messages, toolCallId) : null) ?? excerptText(span.statusMessage)
+    markers.push({
+      kind: "toolCall",
+      atMs: clamp(span.endMs),
+      spanId: span.spanId,
+      toolCallId: toolCallId ?? null,
+      label: span.name,
+      durationMs: span.endMs - span.startMs,
+      errorExcerpt,
+    })
+  }
+  for (const moment of input.moments) {
+    const anchoredSchedule = schedules[moment.messageIndex]
+    const atMs = anchoredSchedule ? scheduleCompletionMs(anchoredSchedule) : wallEndMs
+    markers.push({
+      kind: "moment",
+      atMs: clamp(atMs),
+      momentId: moment.id,
+      messageIndex: moment.messageIndex,
+      label: moment.kind,
+      summary: moment.summary,
+      confidence: moment.confidence,
+    })
+  }
+  markers.sort((a, b) => a.atMs - b.atMs)
+
+  const activity = buildActivityTrack(input.spans, scale)
+
+  return {
+    messages: input.messages,
+    schedules,
+    markers,
+    failedToolCallIds,
+    activity,
+    scale,
+    wallStartMs,
+    wallEndMs,
+  }
+}

--- a/apps/web/src/lib/conversation-timeline/cluster-markers.test.ts
+++ b/apps/web/src/lib/conversation-timeline/cluster-markers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import type { TimelineMarker } from "./build-conversation-timeline.ts"
+import { clusterMarkers, type PositionedMarker } from "./cluster-markers.ts"
+
+const marker = (id: string): TimelineMarker => ({
+  kind: "toolCall",
+  atMs: 0,
+  spanId: id,
+  toolCallId: null,
+  label: id,
+  durationMs: 100,
+  errorExcerpt: null,
+})
+
+const positioned = (id: string, leftPct: number, timelineMs = leftPct * 100): PositionedMarker => ({
+  marker: marker(id),
+  timelineMs,
+  leftPct,
+})
+
+const spanIds = (markers: readonly TimelineMarker[]) => markers.map((m) => (m.kind === "toolCall" ? m.spanId : ""))
+
+describe("clusterMarkers", () => {
+  it("returns no clusters for no markers", () => {
+    expect(clusterMarkers([])).toEqual([])
+  })
+
+  it("keeps far-apart markers as singletons in position order", () => {
+    const clusters = clusterMarkers([positioned("b", 50), positioned("a", 10), positioned("c", 90)])
+    expect(clusters.map((c) => spanIds(c.markers))).toEqual([["a"], ["b"], ["c"]])
+    expect(clusters.map((c) => c.leftPct)).toEqual([10, 50, 90])
+  })
+
+  it("merges markers within the threshold", () => {
+    const clusters = clusterMarkers([positioned("a", 10), positioned("b", 11)])
+    expect(clusters).toHaveLength(1)
+    expect(spanIds(clusters[0]?.markers ?? [])).toEqual(["a", "b"])
+    expect(clusters[0]?.leftPct).toBe(10.5)
+  })
+
+  it("bounds clusters to one chip-width — chains do not merge transitively", () => {
+    const clusters = clusterMarkers([positioned("a", 10), positioned("b", 11.5), positioned("c", 13)])
+    expect(clusters.map((c) => spanIds(c.markers))).toEqual([["a", "b"], ["c"]])
+    expect(clusters.map((c) => c.leftPct)).toEqual([10.75, 13])
+  })
+
+  it("packs a dense lane into many chips instead of one mega-cluster", () => {
+    const items = Array.from({ length: 100 }, (_, i) => positioned(`m${i}`, i))
+    const clusters = clusterMarkers(items, 1.8)
+    expect(clusters).toHaveLength(50)
+    expect(clusters.every((c) => c.markers.length === 2)).toBe(true)
+  })
+
+  it("merges markers at identical positions", () => {
+    const clusters = clusterMarkers([positioned("a", 42), positioned("b", 42)])
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0]?.markers).toHaveLength(2)
+  })
+
+  it("uses the earliest member's time as the seek target", () => {
+    const clusters = clusterMarkers([positioned("late", 10.5, 9_999), positioned("early", 10, 5_000)])
+    expect(clusters[0]?.timelineMs).toBe(5_000)
+  })
+
+  it("respects a custom threshold", () => {
+    const items = [positioned("a", 10), positioned("b", 14)]
+    expect(clusterMarkers(items)).toHaveLength(2)
+    expect(clusterMarkers(items, 5)).toHaveLength(1)
+  })
+})

--- a/apps/web/src/lib/conversation-timeline/cluster-markers.ts
+++ b/apps/web/src/lib/conversation-timeline/cluster-markers.ts
@@ -1,0 +1,54 @@
+import type { TimelineMarker } from "./build-conversation-timeline.ts"
+
+export const MARKER_CLUSTER_THRESHOLD_PCT = 1.8
+
+export interface PositionedMarker {
+  readonly marker: TimelineMarker
+  readonly timelineMs: number
+  readonly leftPct: number
+}
+
+export interface MarkerCluster {
+  /** Midpoint of the first and last member positions. */
+  readonly leftPct: number
+  /** Earliest member's time — the seek target. */
+  readonly timelineMs: number
+  readonly markers: readonly TimelineMarker[]
+}
+
+/**
+ * Groups markers that would visually overlap on the lane: a greedy sweep over
+ * position-sorted markers where a marker joins the cluster only while it is
+ * within the threshold of the cluster's FIRST member. Anchoring to the first
+ * member bounds every cluster to one chip-width — a dense lane packs into as
+ * many chips as fit instead of chaining into a single mega-cluster. Clustering
+ * is purely visual — dwell stops and seek targets keep using the raw markers.
+ */
+export function clusterMarkers(
+  items: readonly PositionedMarker[],
+  thresholdPct: number = MARKER_CLUSTER_THRESHOLD_PCT,
+): readonly MarkerCluster[] {
+  const sorted = [...items].sort((a, b) => a.leftPct - b.leftPct)
+  const clusters: MarkerCluster[] = []
+  let run: PositionedMarker[] = []
+
+  const flush = () => {
+    const first = run[0]
+    const last = run[run.length - 1]
+    if (!first || !last) return
+    clusters.push({
+      leftPct: (first.leftPct + last.leftPct) / 2,
+      timelineMs: run.reduce((min, item) => Math.min(min, item.timelineMs), first.timelineMs),
+      markers: run.map((item) => item.marker),
+    })
+    run = []
+  }
+
+  for (const item of sorted) {
+    const first = run[0]
+    if (first && item.leftPct - first.leftPct > thresholdPct) flush()
+    run.push(item)
+  }
+  flush()
+  return clusters
+}

--- a/apps/web/src/lib/conversation-timeline/message-windows.test.ts
+++ b/apps/web/src/lib/conversation-timeline/message-windows.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { buildConversationTimeline } from "./build-conversation-timeline.ts"
+import { messageIndexAtTime, visibleRangeToBand } from "./message-windows.ts"
+import { TIMELINE_FIXTURE as FIXTURE, FIXTURE_T0 } from "./timeline-fixture.ts"
+import { timelineToPct, wallToTimeline } from "./timeline-scale.ts"
+
+const at = (ms: number) => FIXTURE_T0 + ms
+
+// Fixture geometry: trace 1 active [0s,20s], gap compressed to 1.5s, trace 2
+// active [140s,150s] → total timeline 31.5s.
+const timeline = buildConversationTimeline(FIXTURE)
+const pctAtWall = (wallMs: number) => timelineToPct(timeline.scale, wallToTimeline(timeline.scale, wallMs))
+
+describe("messageIndexAtTime", () => {
+  it("resolves a position inside a streamed window to that message", () => {
+    expect(messageIndexAtTime(timeline, 5_000)).toBe(2)
+  })
+
+  it("resolves a position between messages to the last started one", () => {
+    expect(messageIndexAtTime(timeline, 12_000)).toBe(2)
+  })
+
+  it("resolves a position inside a compressed gap to the next trace's first message", () => {
+    expect(messageIndexAtTime(timeline, 20_500)).toBe(5)
+  })
+
+  it("clamps positions before the start and past the end", () => {
+    expect(messageIndexAtTime(timeline, -100)).toBe(1)
+    expect(messageIndexAtTime(timeline, timeline.scale.totalTimelineMs + 100)).toBe(6)
+  })
+
+  it("returns null for empty conversations", () => {
+    expect(messageIndexAtTime({ ...timeline, schedules: [] }, 1_000)).toBeNull()
+  })
+})
+
+describe("visibleRangeToBand", () => {
+  it("maps a message range to its time band in track percent", () => {
+    expect(visibleRangeToBand(timeline, 2, 4)).toEqual({
+      startPct: pctAtWall(at(1_500)),
+      endPct: pctAtWall(at(20_000)),
+    })
+  })
+
+  it("covers the whole track for the full message range", () => {
+    expect(visibleRangeToBand(timeline, 0, 6)).toEqual({ startPct: 0, endPct: 100 })
+  })
+
+  it("clamps an inverted range to a zero-width band", () => {
+    const band = visibleRangeToBand(timeline, 6, 2)
+    expect(band).not.toBeNull()
+    expect(band?.startPct).toBe(band?.endPct)
+  })
+
+  it("returns null for out-of-range indices or an empty scale", () => {
+    expect(visibleRangeToBand(timeline, 0, 99)).toBeNull()
+    expect(visibleRangeToBand(buildConversationTimeline({ ...FIXTURE, traces: [] }), 0, 1)).toBeNull()
+  })
+})

--- a/apps/web/src/lib/conversation-timeline/message-windows.ts
+++ b/apps/web/src/lib/conversation-timeline/message-windows.ts
@@ -1,0 +1,53 @@
+import { type ConversationTimeline, scheduleCompletionMs, scheduleStartMs } from "./build-conversation-timeline.ts"
+import { segmentAt, timelineToPct, timelineToWall, wallToTimeline } from "./timeline-scale.ts"
+
+export interface TrackBand {
+  readonly startPct: number
+  readonly endPct: number
+}
+
+type MessageWindows = Pick<ConversationTimeline, "schedules" | "scale">
+
+/**
+ * Message a track position lands on: the last message whose window starts at
+ * or before the position's wall time. Inside a compressed gap, the first
+ * message of the next trace. Null when there is nothing to resolve.
+ */
+export function messageIndexAtTime(timeline: MessageWindows, timelineMs: number): number | null {
+  const { schedules, scale } = timeline
+  if (schedules.length === 0 || scale.totalTimelineMs <= 0) return null
+
+  const segment = segmentAt(scale, timelineMs)
+  if (segment?.kind === "gap") {
+    for (let i = 0; i < schedules.length; i++) {
+      const schedule = schedules[i]
+      if (schedule && scheduleStartMs(schedule) >= segment.wallEndMs) return i
+    }
+    return schedules.length - 1
+  }
+
+  const wallMs = timelineToWall(scale, timelineMs)
+  let index = 0
+  for (let i = 0; i < schedules.length; i++) {
+    const schedule = schedules[i]
+    if (schedule && scheduleStartMs(schedule) <= wallMs) index = i
+  }
+  return index
+}
+
+/** Track band (percent) covering the time windows of messages [first..last]. */
+export function visibleRangeToBand(
+  timeline: MessageWindows,
+  firstMessageIndex: number,
+  lastMessageIndex: number,
+): TrackBand | null {
+  const { schedules, scale } = timeline
+  if (scale.totalTimelineMs <= 0) return null
+  const first = schedules[firstMessageIndex]
+  const last = schedules[lastMessageIndex]
+  if (!first || !last) return null
+
+  const endPct = timelineToPct(scale, wallToTimeline(scale, scheduleCompletionMs(last)))
+  const startPct = Math.min(timelineToPct(scale, wallToTimeline(scale, scheduleStartMs(first))), endPct)
+  return { startPct, endPct }
+}

--- a/apps/web/src/lib/conversation-timeline/timeline-fixture.ts
+++ b/apps/web/src/lib/conversation-timeline/timeline-fixture.ts
@@ -1,0 +1,116 @@
+import type { GenAIMessage } from "rosetta-ai"
+import type {
+  BuildConversationTimelineInput,
+  TimelineSpanInput,
+  TimelineTraceInput,
+} from "./build-conversation-timeline.ts"
+
+export const FIXTURE_T0 = 1_700_000_000_000
+const at = (ms: number) => FIXTURE_T0 + ms
+
+export const fixtureMessage = (role: string, ...parts: object[]) => ({ role, parts }) as GenAIMessage
+export const fixtureText = (content: string) => ({ type: "text", content })
+export const fixtureToolCall = (id: string, name = "search") => ({ type: "tool_call", id, name, arguments: {} })
+export const fixtureToolResponse = (id: string) => ({ type: "tool_call_response", id, response: "ok" })
+
+export const fixtureSpan = (
+  overrides: Partial<TimelineSpanInput> & { spanId: string; traceId: string },
+): TimelineSpanInput => ({
+  parentSpanId: "",
+  startMs: at(0),
+  endMs: at(1_000),
+  ttftMs: 0,
+  isStreaming: false,
+  isError: false,
+  name: overrides.spanId,
+  operation: "",
+  statusMessage: "",
+  ...overrides,
+})
+
+const TRACE_1: TimelineTraceInput = { traceId: "t1", startMs: at(0), endMs: at(20_000), label: "Trace 1" }
+const TRACE_2: TimelineTraceInput = { traceId: "t2", startMs: at(140_000), endMs: at(150_000), label: "Trace 2" }
+
+// Two-turn session: turn 1 streams an answer with a tool loop, turn 2 is a
+// non-streaming answer after a 2m idle gap, plus an unrelated error span.
+export const TIMELINE_FIXTURE: BuildConversationTimelineInput = {
+  messages: [
+    fixtureMessage("system", fixtureText("be helpful")),
+    fixtureMessage("user", fixtureText("question one")),
+    fixtureMessage("assistant", fixtureText("Let me check."), fixtureToolCall("call_1")),
+    fixtureMessage("tool", fixtureToolResponse("call_1")),
+    fixtureMessage("assistant", fixtureText("Result is 42.")),
+    fixtureMessage("user", fixtureText("question two")),
+    fixtureMessage("assistant", fixtureText("Final.")),
+  ],
+  spans: [
+    fixtureSpan({
+      spanId: "s1",
+      traceId: "t1",
+      startMs: at(500),
+      endMs: at(10_000),
+      ttftMs: 1_000,
+      isStreaming: true,
+      operation: "chat",
+    }),
+    fixtureSpan({
+      spanId: "s2",
+      traceId: "t1",
+      startMs: at(10_000),
+      endMs: at(14_000),
+      operation: "execute_tool",
+      name: "search",
+    }),
+    fixtureSpan({
+      spanId: "s3",
+      traceId: "t1",
+      startMs: at(14_000),
+      endMs: at(20_000),
+      ttftMs: 500,
+      isStreaming: true,
+      operation: "chat",
+    }),
+    fixtureSpan({
+      spanId: "s4",
+      traceId: "t2",
+      startMs: at(140_200),
+      endMs: at(150_000),
+      ttftMs: 1_000,
+      operation: "chat",
+    }),
+    fixtureSpan({
+      spanId: "s5",
+      traceId: "t2",
+      startMs: at(141_000),
+      endMs: at(142_000),
+      isError: true,
+      name: "guardrail",
+    }),
+  ],
+  messageSpanMap: { 2: "s1", 4: "s3", 6: "s4" },
+  toolCallSpanMap: { call_1: "s2" },
+  traces: [TRACE_1, TRACE_2],
+  annotations: [
+    {
+      id: "ann1",
+      messageIndex: 4,
+      spanId: null,
+      passed: false,
+      feedback: "wrong",
+      flaggerSlug: null,
+      annotatorName: "Carlos",
+    },
+    {
+      id: "ann2",
+      messageIndex: null,
+      spanId: null,
+      passed: true,
+      feedback: "overall fine",
+      flaggerSlug: null,
+      annotatorName: null,
+    },
+  ],
+  moments: [
+    { id: "label1", messageIndex: 6, kind: "frustration", summary: "User repeated the request", confidence: 0.87 },
+  ],
+}

--- a/apps/web/src/lib/conversation-timeline/timeline-scale.test.ts
+++ b/apps/web/src/lib/conversation-timeline/timeline-scale.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildTimelineScale,
+  formatGapLabel,
+  GAP_TIMELINE_MS,
+  segmentAt,
+  timelineToPct,
+  timelineToWall,
+  wallToTimeline,
+} from "./timeline-scale.ts"
+
+const T0 = 1_700_000_000_000
+
+describe("buildTimelineScale", () => {
+  it("returns an empty scale for no windows", () => {
+    const scale = buildTimelineScale([])
+    expect(scale.segments).toEqual([])
+    expect(scale.totalTimelineMs).toBe(0)
+  })
+
+  it("keeps a single window linear with no gaps", () => {
+    const scale = buildTimelineScale([{ startMs: T0, endMs: T0 + 10_000 }])
+    expect(scale.segments).toHaveLength(1)
+    expect(scale.segments[0]).toMatchObject({ kind: "active", timelineStartMs: 0, timelineEndMs: 10_000 })
+    expect(scale.totalTimelineMs).toBe(10_000)
+  })
+
+  it("compresses gaps above the threshold to a constant timeline duration", () => {
+    const scale = buildTimelineScale([
+      { startMs: T0, endMs: T0 + 10_000 },
+      { startMs: T0 + 130_000, endMs: T0 + 140_000 },
+    ])
+    expect(scale.segments.map((s) => s.kind)).toEqual(["active", "gap", "active"])
+    expect(scale.segments[1]).toMatchObject({
+      timelineStartMs: 10_000,
+      timelineEndMs: 10_000 + GAP_TIMELINE_MS,
+      gapLabel: "+2m",
+    })
+    expect(scale.totalTimelineMs).toBe(20_000 + GAP_TIMELINE_MS)
+  })
+
+  it("merges windows separated by sub-threshold gaps into one active segment", () => {
+    const scale = buildTimelineScale([
+      { startMs: T0, endMs: T0 + 10_000 },
+      { startMs: T0 + 12_000, endMs: T0 + 20_000 },
+    ])
+    expect(scale.segments).toHaveLength(1)
+    expect(scale.totalTimelineMs).toBe(20_000)
+  })
+
+  it("merges overlapping windows (clock skew tolerance)", () => {
+    const scale = buildTimelineScale([
+      { startMs: T0, endMs: T0 + 10_000 },
+      { startMs: T0 + 5_000, endMs: T0 + 8_000 },
+    ])
+    expect(scale.segments).toHaveLength(1)
+    expect(scale.totalTimelineMs).toBe(10_000)
+  })
+
+  it("drops zero and negative duration windows", () => {
+    const scale = buildTimelineScale([{ startMs: T0, endMs: T0 }])
+    expect(scale.segments).toEqual([])
+  })
+})
+
+describe("coordinate mapping", () => {
+  const scale = buildTimelineScale([
+    { startMs: T0, endMs: T0 + 10_000 },
+    { startMs: T0 + 70_000, endMs: T0 + 80_000 },
+  ])
+
+  it("round-trips timeline → wall → timeline inside active segments", () => {
+    for (const t of [0, 4_000, 10_000, 10_000 + GAP_TIMELINE_MS / 2, 12_000, scale.totalTimelineMs]) {
+      expect(wallToTimeline(scale, timelineToWall(scale, t))).toBeCloseTo(t, 6)
+    }
+  })
+
+  it("maps gap wall time proportionally into the constant gap window", () => {
+    expect(wallToTimeline(scale, T0 + 40_000)).toBeCloseTo(10_000 + GAP_TIMELINE_MS / 2, 6)
+    expect(timelineToWall(scale, 10_000 + GAP_TIMELINE_MS / 2)).toBeCloseTo(T0 + 40_000, 6)
+  })
+
+  it("clamps out-of-range values", () => {
+    expect(wallToTimeline(scale, T0 - 5_000)).toBe(0)
+    expect(wallToTimeline(scale, T0 + 100_000)).toBe(scale.totalTimelineMs)
+    expect(timelineToWall(scale, -5)).toBe(T0)
+    expect(timelineToWall(scale, scale.totalTimelineMs + 5)).toBe(T0 + 80_000)
+  })
+
+  it("computes percentages from the timeline domain", () => {
+    expect(timelineToPct(scale, 0)).toBe(0)
+    expect(timelineToPct(scale, scale.totalTimelineMs)).toBe(100)
+    expect(timelineToPct(buildTimelineScale([]), 10)).toBe(0)
+  })
+
+  it("finds the segment at a timeline position", () => {
+    expect(segmentAt(scale, 5_000)?.kind).toBe("active")
+    expect(segmentAt(scale, 10_500)?.kind).toBe("gap")
+    expect(segmentAt(scale, scale.totalTimelineMs)?.kind).toBe("active")
+  })
+})
+
+describe("formatGapLabel", () => {
+  it("formats compact durations", () => {
+    expect(formatGapLabel(45_000)).toBe("+45s")
+    expect(formatGapLabel(120_000)).toBe("+2m")
+    expect(formatGapLabel(150_000)).toBe("+2m 30s")
+    expect(formatGapLabel(2 * 3_600_000 + 13 * 60_000)).toBe("+2h 13m")
+    expect(formatGapLabel(3_600_000)).toBe("+1h")
+  })
+})

--- a/apps/web/src/lib/conversation-timeline/timeline-scale.ts
+++ b/apps/web/src/lib/conversation-timeline/timeline-scale.ts
@@ -1,0 +1,151 @@
+interface TimelineWindow {
+  readonly startMs: number
+  readonly endMs: number
+}
+
+export interface TimelineSegment {
+  readonly kind: "active" | "gap"
+  readonly wallStartMs: number
+  readonly wallEndMs: number
+  readonly timelineStartMs: number
+  readonly timelineEndMs: number
+  readonly gapLabel: string | null
+}
+
+export interface TimelineScale {
+  readonly segments: readonly TimelineSegment[]
+  readonly totalTimelineMs: number
+  readonly wallStartMs: number
+  readonly wallEndMs: number
+}
+
+export const GAP_TIMELINE_MS = 1_500
+const MIN_COMPRESSIBLE_GAP_MS = 5_000
+
+export function formatGapLabel(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000)
+  if (totalSeconds < 60) return `+${totalSeconds}s`
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes < 60) {
+    const seconds = totalSeconds % 60
+    return seconds > 0 ? `+${totalMinutes}m ${seconds}s` : `+${totalMinutes}m`
+  }
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes > 0 ? `+${hours}h ${minutes}m` : `+${hours}h`
+}
+
+function mergeWindows(windows: readonly TimelineWindow[]): TimelineWindow[] {
+  const sorted = windows
+    .filter((w) => w.endMs > w.startMs)
+    .map((w) => ({ startMs: w.startMs, endMs: w.endMs }))
+    .sort((a, b) => a.startMs - b.startMs)
+
+  const merged: { startMs: number; endMs: number }[] = []
+  for (const window of sorted) {
+    const last = merged[merged.length - 1]
+    if (last && window.startMs - last.endMs < MIN_COMPRESSIBLE_GAP_MS) {
+      last.endMs = Math.max(last.endMs, window.endMs)
+    } else {
+      merged.push(window)
+    }
+  }
+  return merged
+}
+
+/**
+ * Maps wall-clock time onto a compressed timeline domain: active windows keep
+ * their real duration, while idle gaps between them collapse to a constant
+ * GAP_TIMELINE_MS so the track gives idle stretches a small constant width.
+ */
+export function buildTimelineScale(windows: readonly TimelineWindow[]): TimelineScale {
+  const merged = mergeWindows(windows)
+  const first = merged[0]
+  if (!first) {
+    return { segments: [], totalTimelineMs: 0, wallStartMs: 0, wallEndMs: 0 }
+  }
+
+  const segments: TimelineSegment[] = []
+  let timelineCursor = 0
+  let previousEnd = first.startMs
+
+  for (const window of merged) {
+    if (window.startMs > previousEnd) {
+      segments.push({
+        kind: "gap",
+        wallStartMs: previousEnd,
+        wallEndMs: window.startMs,
+        timelineStartMs: timelineCursor,
+        timelineEndMs: timelineCursor + GAP_TIMELINE_MS,
+        gapLabel: formatGapLabel(window.startMs - previousEnd),
+      })
+      timelineCursor += GAP_TIMELINE_MS
+    }
+    const duration = window.endMs - window.startMs
+    segments.push({
+      kind: "active",
+      wallStartMs: window.startMs,
+      wallEndMs: window.endMs,
+      timelineStartMs: timelineCursor,
+      timelineEndMs: timelineCursor + duration,
+      gapLabel: null,
+    })
+    timelineCursor += duration
+    previousEnd = window.endMs
+  }
+
+  return {
+    segments,
+    totalTimelineMs: timelineCursor,
+    wallStartMs: first.startMs,
+    wallEndMs: previousEnd,
+  }
+}
+
+export function wallToTimeline(scale: TimelineScale, wallMs: number): number {
+  const segments = scale.segments
+  const first = segments[0]
+  const last = segments[segments.length - 1]
+  if (!first || !last) return 0
+  if (wallMs <= first.wallStartMs) return 0
+  if (wallMs >= last.wallEndMs) return scale.totalTimelineMs
+
+  for (const segment of segments) {
+    if (wallMs > segment.wallEndMs) continue
+    const wallSpan = segment.wallEndMs - segment.wallStartMs
+    const timelineSpan = segment.timelineEndMs - segment.timelineStartMs
+    if (wallSpan === 0) return segment.timelineStartMs
+    return segment.timelineStartMs + ((wallMs - segment.wallStartMs) / wallSpan) * timelineSpan
+  }
+  return scale.totalTimelineMs
+}
+
+export function timelineToWall(scale: TimelineScale, timelineMs: number): number {
+  const segments = scale.segments
+  const first = segments[0]
+  const last = segments[segments.length - 1]
+  if (!first || !last) return 0
+  if (timelineMs <= 0) return first.wallStartMs
+  if (timelineMs >= scale.totalTimelineMs) return last.wallEndMs
+
+  for (const segment of segments) {
+    if (timelineMs > segment.timelineEndMs) continue
+    const wallSpan = segment.wallEndMs - segment.wallStartMs
+    const timelineSpan = segment.timelineEndMs - segment.timelineStartMs
+    if (timelineSpan === 0) return segment.wallStartMs
+    return segment.wallStartMs + ((timelineMs - segment.timelineStartMs) / timelineSpan) * wallSpan
+  }
+  return last.wallEndMs
+}
+
+export function timelineToPct(scale: TimelineScale, timelineMs: number): number {
+  if (scale.totalTimelineMs === 0) return 0
+  return Math.min(100, Math.max(0, (timelineMs / scale.totalTimelineMs) * 100))
+}
+
+export function segmentAt(scale: TimelineScale, timelineMs: number): TimelineSegment | null {
+  for (const segment of scale.segments) {
+    if (timelineMs >= segment.timelineStartMs && timelineMs < segment.timelineEndMs) return segment
+  }
+  return scale.segments[scale.segments.length - 1] ?? null
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/flash-highlight.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/flash-highlight.ts
@@ -1,0 +1,35 @@
+const FLASH_BOX_SHADOW = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
+const FLASH_DURATION_MS = 4_000
+
+let activeFlash: { element: HTMLElement; timeout: number } | null = null
+
+/** Transient scroll-target emphasis: a ring that clears after a few seconds. */
+export function flashElement(element: HTMLElement): void {
+  if (activeFlash) {
+    window.clearTimeout(activeFlash.timeout)
+    activeFlash.element.style.boxShadow = ""
+  }
+  element.style.boxShadow = FLASH_BOX_SHADOW
+  const timeout = window.setTimeout(() => {
+    element.style.boxShadow = ""
+    activeFlash = null
+  }, FLASH_DURATION_MS)
+  activeFlash = { element, timeout }
+}
+
+/** Finds the rendered message element closest to `messageIndex` (tool-result
+ * messages can be absorbed into their caller, so exact anchors may not render). */
+export function findNearestMessageAnchor(container: HTMLElement, messageIndex: number): HTMLElement | null {
+  const exact = container.querySelector<HTMLElement>(`[data-message-index="${messageIndex}"]`)
+  if (exact) return exact
+  let best: { node: HTMLElement; distance: number } | null = null
+  for (const node of container.querySelectorAll<HTMLElement>("[data-message-index]")) {
+    const raw = node.getAttribute("data-message-index")
+    if (raw == null) continue
+    const index = Number.parseInt(raw, 10)
+    if (Number.isNaN(index)) continue
+    const distance = Math.abs(index - messageIndex)
+    if (!best || distance < best.distance) best = { node, distance }
+  }
+  return best?.node ?? null
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-adapters.ts
@@ -1,0 +1,59 @@
+import { getAnnotationProvenance } from "@domain/annotations"
+import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
+import type { MemberRecord } from "../../../../../../domains/members/members.functions.ts"
+import { pickUserFromMembersMap } from "../../../../../../domains/members/pick-users-from-members.ts"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import type {
+  TimelineAnnotationInput,
+  TimelineSpanInput,
+  TimelineTraceInput,
+} from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+
+export function toTimelineSpan(span: SpanRecord): TimelineSpanInput {
+  return {
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId,
+    traceId: span.traceId,
+    startMs: Date.parse(span.startTime),
+    endMs: Date.parse(span.endTime),
+    ttftMs: span.timeToFirstTokenNs / 1e6,
+    isStreaming: span.isStreaming,
+    isError: span.statusCode === "error",
+    name: span.name,
+    operation: span.operation,
+    statusMessage: span.statusMessage,
+  }
+}
+
+export function toTimelineTrace(trace: TraceRecord): TimelineTraceInput {
+  return {
+    traceId: trace.traceId,
+    startMs: Date.parse(trace.startTime),
+    endMs: Date.parse(trace.endTime),
+    label: trace.rootSpanName || "Unnamed trace",
+  }
+}
+
+export function annotatorNameFor(
+  annotation: AnnotationRecord,
+  memberByUserId: ReadonlyMap<string, MemberRecord>,
+): string | null {
+  if (annotation.annotatorId) return pickUserFromMembersMap(memberByUserId, annotation.annotatorId)?.name ?? null
+  return getAnnotationProvenance(annotation) === "agent" ? "Latitude Agent" : null
+}
+
+export function toTimelineAnnotation(
+  annotation: AnnotationRecord,
+  annotatorName: string | null,
+): TimelineAnnotationInput {
+  return {
+    id: annotation.id,
+    messageIndex: annotation.metadata?.messageIndex ?? null,
+    spanId: annotation.spanId,
+    passed: annotation.passed,
+    feedback: annotation.feedback,
+    flaggerSlug: annotation.metadata?.flaggerSlug ?? null,
+    annotatorName,
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-bar.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react"
+import type {
+  ConversationTimeline,
+  TimelineMarker,
+} from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import type { TrackBand } from "../../../../../../lib/conversation-timeline/message-windows.ts"
+import { TimelineEventHoverCard } from "./timeline-event-card.tsx"
+import { type MarkerHover, TimelineTrack } from "./timeline-track.tsx"
+
+export function TimelineBar({
+  timeline,
+  band,
+  onTrackClick,
+  onMarkerClick,
+}: {
+  readonly timeline: ConversationTimeline
+  /** Time band of the messages currently on screen (the viewport indicator). */
+  readonly band: TrackBand | null
+  readonly onTrackClick: (timelineMs: number) => void
+  readonly onMarkerClick: (marker: TimelineMarker) => void
+}) {
+  const [markerHover, setMarkerHover] = useState<MarkerHover | null>(null)
+
+  return (
+    <div className="relative flex flex-col gap-1 border-t border-border bg-background px-4 py-3">
+      {markerHover && <TimelineEventHoverCard markers={markerHover.markers} leftPct={markerHover.leftPct} />}
+      <TimelineTrack
+        timeline={timeline}
+        band={band}
+        onTrackClick={onTrackClick}
+        onMarkerClick={onMarkerClick}
+        onMarkerHover={setMarkerHover}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-bar.tsx
@@ -10,12 +10,15 @@ import { type MarkerHover, TimelineTrack } from "./timeline-track.tsx"
 export function TimelineBar({
   timeline,
   band,
+  hoverSlice,
   onTrackClick,
   onMarkerClick,
 }: {
   readonly timeline: ConversationTimeline
   /** Time band of the messages currently on screen (the viewport indicator). */
   readonly band: TrackBand | null
+  /** Time slice of the message hovered in the conversation, highlighted on the track. */
+  readonly hoverSlice?: TrackBand | null | undefined
   readonly onTrackClick: (timelineMs: number) => void
   readonly onMarkerClick: (marker: TimelineMarker) => void
 }) {
@@ -27,6 +30,7 @@ export function TimelineBar({
       <TimelineTrack
         timeline={timeline}
         band={band}
+        hoverSlice={hoverSlice ?? null}
         onTrackClick={onTrackClick}
         onMarkerClick={onMarkerClick}
         onMarkerHover={setMarkerHover}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-event-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-event-card.tsx
@@ -1,0 +1,236 @@
+import { cn, LatitudeLogo, Text } from "@repo/ui"
+import { MessageSquareIcon, TagsIcon, ThumbsDownIcon, ThumbsUpIcon, UserIcon, WrenchIcon } from "lucide-react"
+import type { ReactNode } from "react"
+import type { TimelineMarker } from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import { formatDuration } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+
+const CARD_MAX_EVENTS = 2
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1)
+
+export function markerAriaLabel(marker: TimelineMarker): string {
+  switch (marker.kind) {
+    case "trace":
+      return `Turn ${marker.traceIndex + 1}: ${marker.userExcerpt ?? marker.label}`
+    case "annotation": {
+      const status = marker.flaggerSlug
+        ? `Flagged: ${capitalize(marker.flaggerSlug.replaceAll("-", " "))}`
+        : marker.passed === null
+          ? "Annotation"
+          : marker.passed
+            ? "Passed annotation"
+            : "Failed annotation"
+      return marker.feedback ? `${status}: ${marker.feedback}` : status
+    }
+    case "toolCall":
+      return `${marker.label} failed · ${formatDuration(marker.durationMs)}`
+    case "moment":
+      return marker.summary ? `${marker.label} — ${marker.summary}` : marker.label
+  }
+}
+
+export function markerIcon(marker: TimelineMarker): ReactNode {
+  switch (marker.kind) {
+    case "trace":
+      return (
+        <span className="flex h-4 w-4 items-center justify-center rounded-full border border-border bg-background">
+          <UserIcon className="h-2.5 w-2.5 text-foreground" />
+        </span>
+      )
+    case "annotation":
+      if (marker.flaggerSlug) return <LatitudeLogo className="h-3.5 w-3.5" />
+      return (
+        <MessageSquareIcon
+          className={cn("h-3.5 w-3.5", marker.passed === false ? "text-destructive" : "text-primary")}
+        />
+      )
+    case "toolCall":
+      return <WrenchIcon className="h-3.5 w-3.5 text-destructive" />
+    case "moment":
+      return <TagsIcon className="h-3.5 w-3.5 text-violet-500" />
+  }
+}
+
+/** Compact icon for cluster chips — same kind colors, no circled-trace chrome. */
+export function markerChipIcon(marker: TimelineMarker): ReactNode {
+  switch (marker.kind) {
+    case "trace":
+      return <UserIcon className="h-3 w-3 text-foreground" />
+    case "annotation":
+      if (marker.flaggerSlug) return <LatitudeLogo className="h-3 w-3" />
+      return (
+        <MessageSquareIcon className={cn("h-3 w-3", marker.passed === false ? "text-destructive" : "text-primary")} />
+      )
+    case "toolCall":
+      return <WrenchIcon className="h-3 w-3 text-destructive" />
+    case "moment":
+      return <TagsIcon className="h-3 w-3 text-violet-500" />
+  }
+}
+
+function eventHeader(marker: TimelineMarker): {
+  readonly label: string
+  readonly colorClass: string
+  readonly icon: ReactNode
+} {
+  switch (marker.kind) {
+    case "trace":
+      return { label: "User turn", colorClass: "text-muted-foreground", icon: <UserIcon className="h-3.5 w-3.5" /> }
+    case "toolCall":
+      return { label: "Tool failed", colorClass: "text-destructive", icon: <WrenchIcon className="h-3.5 w-3.5" /> }
+    case "moment":
+      return { label: "Moment", colorClass: "text-violet-500", icon: <TagsIcon className="h-3.5 w-3.5" /> }
+    case "annotation":
+      if (marker.flaggerSlug)
+        return {
+          label: "Flagged",
+          colorClass: "text-accent-foreground",
+          icon: <LatitudeLogo className="h-3.5 w-3.5" />,
+        }
+      return marker.passed === null
+        ? {
+            label: "Annotation",
+            colorClass: "text-muted-foreground",
+            icon: <MessageSquareIcon className="h-3.5 w-3.5" />,
+          }
+        : marker.passed
+          ? {
+              label: "Annotation",
+              colorClass: "text-success-muted-foreground",
+              icon: <ThumbsUpIcon className="h-3.5 w-3.5" />,
+            }
+          : {
+              label: "Annotation",
+              colorClass: "text-destructive",
+              icon: <ThumbsDownIcon className="h-3.5 w-3.5" />,
+            }
+  }
+}
+
+function eventFooterMeta(marker: TimelineMarker): readonly string[] {
+  switch (marker.kind) {
+    case "trace":
+      return [`Turn ${marker.traceIndex + 1}`, ...(marker.userExcerpt ? [marker.label] : [])]
+    case "toolCall":
+      return [`took ${formatDuration(marker.durationMs)}`]
+    case "annotation":
+      return !marker.flaggerSlug && marker.annotatorName ? [`by ${marker.annotatorName}`] : []
+    case "moment":
+      return marker.confidence !== null ? [`${Math.round(marker.confidence * 100)}% confidence`] : []
+  }
+}
+
+function EventDetails({ marker }: { readonly marker: TimelineMarker }) {
+  switch (marker.kind) {
+    case "trace":
+      return marker.userExcerpt ? (
+        <Text.H6 lineClamp={2}>{marker.userExcerpt}</Text.H6>
+      ) : (
+        <Text.H6 lineClamp={2}>{marker.label}</Text.H6>
+      )
+    case "toolCall":
+      return (
+        <>
+          <Text.Mono size="h6" ellipsis>
+            {marker.label}
+          </Text.Mono>
+          {marker.errorExcerpt && (
+            <div className="line-clamp-3 rounded-md bg-muted px-2 py-1.5">
+              <Text.Mono size="h7" color="foregroundMuted" whiteSpace="normal">
+                {marker.errorExcerpt}
+              </Text.Mono>
+            </div>
+          )}
+        </>
+      )
+    case "annotation":
+      return (
+        <>
+          {marker.flaggerSlug ? (
+            <Text.H6>{capitalize(marker.flaggerSlug.replaceAll("-", " "))}</Text.H6>
+          ) : marker.passed !== null ? (
+            <Text.H6>{marker.passed ? "Passed" : "Failed"}</Text.H6>
+          ) : null}
+          {marker.feedback && (
+            <Text.H6 color="foregroundMuted" lineClamp={4}>
+              {marker.feedback}
+            </Text.H6>
+          )}
+        </>
+      )
+    case "moment":
+      return (
+        <>
+          <Text.H6>{marker.label}</Text.H6>
+          {marker.summary && (
+            <Text.H6 color="foregroundMuted" lineClamp={4}>
+              {marker.summary}
+            </Text.H6>
+          )}
+        </>
+      )
+  }
+}
+
+/**
+ * Structured event rendering for the marker hover card. Header = colored icon
+ * + event type; footer = wall-clock time plus kind-specific meta, closest to
+ * the timeline.
+ */
+export function TimelineEventCardContent({ marker }: { readonly marker: TimelineMarker }) {
+  const header = eventHeader(marker)
+  const meta = [new Date(marker.atMs).toLocaleTimeString(), ...eventFooterMeta(marker)]
+  return (
+    <div className="flex w-60 flex-col gap-1.5">
+      <div className={cn("flex items-center gap-1.5 uppercase tracking-wide", header.colorClass)}>
+        <span className="shrink-0">{header.icon}</span>
+        <Text.H7 color="inherit">{header.label}</Text.H7>
+      </div>
+      <EventDetails marker={marker} />
+      <Text.H7 color="foregroundMuted" noWrap ellipsis>
+        {meta.join(" · ")}
+      </Text.H7>
+    </div>
+  )
+}
+
+/** Positions a card above the whole timeline bar at the marker's position. */
+function TimelineBarCard({ leftPct, children }: { readonly leftPct: number; readonly children: ReactNode }) {
+  return (
+    <div
+      className="pointer-events-none absolute bottom-[calc(100%+0.5rem)] z-10 -translate-x-1/2"
+      style={{ left: `${Math.min(80, Math.max(20, leftPct))}%` }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function TimelineEventHoverCard({
+  markers,
+  leftPct,
+}: {
+  readonly markers: readonly TimelineMarker[]
+  readonly leftPct: number
+}) {
+  const visibleMarkers = markers.slice(0, CARD_MAX_EVENTS)
+  const hiddenCount = markers.length - visibleMarkers.length
+  return (
+    <TimelineBarCard leftPct={leftPct}>
+      <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-md">
+        <div className="flex flex-col divide-y divide-border">
+          {visibleMarkers.map((marker, index) => (
+            <div key={index} className="p-3">
+              <TimelineEventCardContent marker={marker} />
+            </div>
+          ))}
+        </div>
+        {hiddenCount > 0 && (
+          <div className="px-3 pb-2">
+            <Text.H6 color="foregroundMuted">+{hiddenCount} more events</Text.H6>
+          </div>
+        )}
+      </div>
+    </TimelineBarCard>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
@@ -25,6 +25,8 @@ const CLUSTER_CHIP_PX = 26
 // Quantizing the measured lane width makes a drag-resize re-cluster only every
 // step instead of every pixel (same-value setState bails out of the render).
 const LANE_WIDTH_QUANTUM_PX = 24
+// Widens zero-width slices (instant messages) so their containing bar matches.
+const ZERO_WIDTH_SLICE_PCT = 0.0001
 
 export interface MarkerHover {
   readonly markers: readonly TimelineMarker[]
@@ -99,6 +101,7 @@ function MarkerClusterChip({
 export function TimelineTrack({
   timeline,
   band,
+  hoverSlice,
   onTrackClick,
   onMarkerClick,
   onMarkerHover,
@@ -106,6 +109,8 @@ export function TimelineTrack({
   readonly timeline: ConversationTimeline
   /** Time band covered by the messages currently on screen; null dims nothing. */
   readonly band: TrackBand | null
+  /** Time slice of the message hovered in the conversation; null highlights nothing. */
+  readonly hoverSlice: TrackBand | null
   readonly onTrackClick: (timelineMs: number) => void
   readonly onMarkerClick: (marker: TimelineMarker) => void
   readonly onMarkerHover: (hover: MarkerHover | null) => void
@@ -194,24 +199,32 @@ export function TimelineTrack({
         onPointerLeave={() => setHoverRatio(null)}
       >
         <div className="relative h-4 w-full overflow-hidden rounded-sm">
-          {timeline.activity.map((segment) => (
-            <div
-              key={segment.timelineStartMs}
-              className={cn(
-                "absolute top-1/2 -translate-y-1/2 transition-[height] duration-100",
-                hoverActivity?.timelineStartMs === segment.timelineStartMs ? "h-full" : "h-3",
-              )}
-              style={{
-                left: `${timelineToPct(scale, segment.timelineStartMs)}%`,
-                width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,
-                ...(segment.category === "idle"
-                  ? {
-                      backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 2px, ${DURATION_COLORS.idle} 2px, ${DURATION_COLORS.idle} 3px)`,
-                    }
-                  : { backgroundColor: DURATION_COLORS[segment.category] }),
-              }}
-            />
-          ))}
+          {timeline.activity.map((segment) => {
+            const startPct = timelineToPct(scale, segment.timelineStartMs)
+            const endPct = timelineToPct(scale, segment.timelineEndMs)
+            const inHoverSlice =
+              hoverSlice !== null &&
+              endPct > hoverSlice.startPct &&
+              startPct < Math.max(hoverSlice.endPct, hoverSlice.startPct + ZERO_WIDTH_SLICE_PCT)
+            return (
+              <div
+                key={segment.timelineStartMs}
+                className={cn(
+                  "absolute top-1/2 -translate-y-1/2 transition-[height] duration-100",
+                  hoverActivity?.timelineStartMs === segment.timelineStartMs || inHoverSlice ? "h-full" : "h-3",
+                )}
+                style={{
+                  left: `${startPct}%`,
+                  width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,
+                  ...(segment.category === "idle"
+                    ? {
+                        backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 2px, ${DURATION_COLORS.idle} 2px, ${DURATION_COLORS.idle} 3px)`,
+                      }
+                    : { backgroundColor: DURATION_COLORS[segment.category] }),
+                }}
+              />
+            )
+          })}
 
           {scale.segments.map((segment) => {
             if (segment.kind !== "gap") return null

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@repo/ui"
+import { cn, Text } from "@repo/ui"
 import { type MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from "react"
 import type { ActivityCategory } from "../../../../../../lib/conversation-timeline/build-activity-track.ts"
 import type {
@@ -193,11 +193,14 @@ export function TimelineTrack({
         onPointerMove={(e) => setHoverRatio(pointerRatio(e))}
         onPointerLeave={() => setHoverRatio(null)}
       >
-        <div className="relative h-3 w-full overflow-hidden rounded-sm transition-[height] group-hover:h-3.5">
+        <div className="relative h-4 w-full overflow-hidden rounded-sm">
           {timeline.activity.map((segment) => (
             <div
               key={segment.timelineStartMs}
-              className="absolute top-0 h-full"
+              className={cn(
+                "absolute top-1/2 -translate-y-1/2 transition-[height] duration-100",
+                hoverActivity?.timelineStartMs === segment.timelineStartMs ? "h-full" : "h-3",
+              )}
               style={{
                 left: `${timelineToPct(scale, segment.timelineStartMs)}%`,
                 width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,
@@ -215,7 +218,10 @@ export function TimelineTrack({
             return (
               <div
                 key={segment.timelineStartMs}
-                className="absolute top-0 h-full border-x border-background bg-background"
+                className={cn(
+                  "absolute top-1/2 -translate-y-1/2 border-x border-background bg-background transition-[height] duration-100",
+                  hoverInGap && hoverSegment.timelineStartMs === segment.timelineStartMs ? "h-full" : "h-3",
+                )}
                 style={{
                   left: `${timelineToPct(scale, segment.timelineStartMs)}%`,
                   width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
@@ -1,0 +1,309 @@
+import { Text } from "@repo/ui"
+import { type MouseEvent as ReactMouseEvent, useEffect, useMemo, useRef, useState } from "react"
+import type { ActivityCategory } from "../../../../../../lib/conversation-timeline/build-activity-track.ts"
+import type {
+  ConversationTimeline,
+  TimelineMarker,
+} from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import {
+  clusterMarkers,
+  MARKER_CLUSTER_THRESHOLD_PCT,
+  type MarkerCluster,
+} from "../../../../../../lib/conversation-timeline/cluster-markers.ts"
+import type { TrackBand } from "../../../../../../lib/conversation-timeline/message-windows.ts"
+import {
+  segmentAt,
+  timelineToPct,
+  timelineToWall,
+  wallToTimeline,
+} from "../../../../../../lib/conversation-timeline/timeline-scale.ts"
+import { DURATION_COLORS } from "../trace-detail-drawer/duration-composition.ts"
+import { formatDuration } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+import { markerAriaLabel, markerChipIcon, markerIcon } from "./timeline-event-card.tsx"
+
+const CLUSTER_CHIP_PX = 26
+// Quantizing the measured lane width makes a drag-resize re-cluster only every
+// step instead of every pixel (same-value setState bails out of the render).
+const LANE_WIDTH_QUANTUM_PX = 24
+
+export interface MarkerHover {
+  readonly markers: readonly TimelineMarker[]
+  readonly leftPct: number
+}
+
+const ACTIVITY_LABELS: Readonly<Record<ActivityCategory, string>> = {
+  generation: "Generating",
+  tool: "Running tools",
+  retrieval: "Retrieving",
+  other: "Working",
+  idle: "Waiting",
+}
+
+function EventMarker({
+  marker,
+  leftPct,
+  onClick,
+  onHover,
+}: {
+  readonly marker: TimelineMarker
+  readonly leftPct: number
+  readonly onClick: () => void
+  readonly onHover: (hover: MarkerHover | null) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onPointerEnter={() => onHover({ markers: [marker], leftPct })}
+      onPointerLeave={() => onHover(null)}
+      onFocus={() => onHover({ markers: [marker], leftPct })}
+      onBlur={() => onHover(null)}
+      aria-label={markerAriaLabel(marker)}
+      className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded p-0.5 transition-transform hover:scale-125"
+      style={{ left: `${leftPct}%` }}
+    >
+      {markerIcon(marker)}
+    </button>
+  )
+}
+
+function MarkerClusterChip({
+  cluster,
+  onClick,
+  onHover,
+}: {
+  readonly cluster: MarkerCluster
+  readonly onClick: () => void
+  readonly onHover: (hover: MarkerHover | null) => void
+}) {
+  const hover: MarkerHover = { markers: cluster.markers, leftPct: cluster.leftPct }
+  const first = cluster.markers[0]
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onPointerEnter={() => onHover(hover)}
+      onPointerLeave={() => onHover(null)}
+      onFocus={() => onHover(hover)}
+      onBlur={() => onHover(null)}
+      aria-label={`${cluster.markers.length} events`}
+      className="absolute top-1/2 flex h-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center gap-0.5 rounded-full border border-border bg-background px-1 font-medium text-[10px] text-foreground transition-transform hover:scale-110"
+      style={{ left: `${cluster.leftPct}%` }}
+    >
+      {first && markerChipIcon(first)}
+      {cluster.markers.length}
+    </button>
+  )
+}
+
+export function TimelineTrack({
+  timeline,
+  band,
+  onTrackClick,
+  onMarkerClick,
+  onMarkerHover,
+}: {
+  readonly timeline: ConversationTimeline
+  /** Time band covered by the messages currently on screen; null dims nothing. */
+  readonly band: TrackBand | null
+  readonly onTrackClick: (timelineMs: number) => void
+  readonly onMarkerClick: (marker: TimelineMarker) => void
+  readonly onMarkerHover: (hover: MarkerHover | null) => void
+}) {
+  const { scale } = timeline
+  const total = scale.totalTimelineMs
+  const wallPct = (wallMs: number) => timelineToPct(scale, wallToTimeline(scale, wallMs))
+
+  const laneRef = useRef<HTMLDivElement>(null)
+  const [laneWidthPx, setLaneWidthPx] = useState<number | null>(null)
+
+  // TODO(frontend-use-effect-policy): cluster density depends on the rendered
+  // lane width, an external layout value only observable via ResizeObserver.
+  useEffect(() => {
+    const lane = laneRef.current
+    if (!lane) return
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width
+      if (width !== undefined) setLaneWidthPx(Math.round(width / LANE_WIDTH_QUANTUM_PX) * LANE_WIDTH_QUANTUM_PX)
+    })
+    observer.observe(lane)
+    return () => observer.disconnect()
+  }, [])
+
+  // Merge only what would actually overlap at the current width: one chip-width
+  // of pixels, expressed as a track percentage.
+  const clusterThresholdPct =
+    laneWidthPx && laneWidthPx > 0 ? (CLUSTER_CHIP_PX / laneWidthPx) * 100 : MARKER_CLUSTER_THRESHOLD_PCT
+
+  // Positions clamped to 1.5–98.5% keep edge markers fully inside the lane
+  // instead of half-clipped at 0%/100%.
+  const clusters = useMemo(
+    () =>
+      clusterMarkers(
+        timeline.markers.map((marker) => ({
+          marker,
+          timelineMs: wallToTimeline(scale, marker.atMs),
+          leftPct: Math.min(98.5, Math.max(1.5, timelineToPct(scale, wallToTimeline(scale, marker.atMs)))),
+        })),
+        clusterThresholdPct,
+      ),
+    [timeline.markers, scale, clusterThresholdPct],
+  )
+
+  const [hoverRatio, setHoverRatio] = useState<number | null>(null)
+  const hoverTimelineMs = hoverRatio === null ? null : hoverRatio * total
+  const hoverSegment = hoverTimelineMs === null ? null : segmentAt(scale, hoverTimelineMs)
+  const hoverInGap = hoverSegment?.kind === "gap"
+  // Wall time inside a compressed gap is interpolated and misleading — omit it there.
+  const hoverTimeLabel =
+    hoverTimelineMs === null || hoverInGap
+      ? null
+      : new Date(timelineToWall(scale, hoverTimelineMs)).toLocaleTimeString()
+  const hoverActivity =
+    hoverTimelineMs === null || hoverInGap
+      ? null
+      : (timeline.activity.find((s) => hoverTimelineMs >= s.timelineStartMs && hoverTimelineMs < s.timelineEndMs) ??
+        null)
+  const hoverActionLabel = hoverInGap
+    ? hoverSegment.gapLabel
+      ? `Idle · ${hoverSegment.gapLabel}`
+      : "Idle"
+    : hoverActivity
+      ? `${ACTIVITY_LABELS[hoverActivity.category]} · ${formatDuration(hoverActivity.durationMs)}`
+      : null
+
+  const pointerRatio = (e: ReactMouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    if (rect.width === 0) return null
+    return Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width))
+  }
+
+  if (total <= 0) return null
+
+  return (
+    <div className="flex flex-col">
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: pointer-only hit target; keyboard users reach events via the marker buttons and messages via N/P */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: same — clicking the track is a pointer shortcut to the message at that time */}
+      <div
+        className="group relative cursor-pointer rounded-sm py-1"
+        onClick={(e) => {
+          const ratio = pointerRatio(e)
+          if (ratio !== null) onTrackClick(ratio * total)
+        }}
+        onPointerMove={(e) => setHoverRatio(pointerRatio(e))}
+        onPointerLeave={() => setHoverRatio(null)}
+      >
+        <div className="relative h-3 w-full overflow-hidden rounded-sm transition-[height] group-hover:h-3.5">
+          {timeline.activity.map((segment) => (
+            <div
+              key={segment.timelineStartMs}
+              className="absolute top-0 h-full"
+              style={{
+                left: `${timelineToPct(scale, segment.timelineStartMs)}%`,
+                width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,
+                ...(segment.category === "idle"
+                  ? {
+                      backgroundImage: `repeating-linear-gradient(45deg, transparent, transparent 2px, ${DURATION_COLORS.idle} 2px, ${DURATION_COLORS.idle} 3px)`,
+                    }
+                  : { backgroundColor: DURATION_COLORS[segment.category] }),
+              }}
+            />
+          ))}
+
+          {scale.segments.map((segment) => {
+            if (segment.kind !== "gap") return null
+            return (
+              <div
+                key={segment.timelineStartMs}
+                className="absolute top-0 h-full border-x border-background bg-background"
+                style={{
+                  left: `${timelineToPct(scale, segment.timelineStartMs)}%`,
+                  width: `${((segment.timelineEndMs - segment.timelineStartMs) / total) * 100}%`,
+                  backgroundImage:
+                    "repeating-linear-gradient(45deg, transparent, transparent 2px, var(--border) 2px, var(--border) 3px)",
+                }}
+              />
+            )
+          })}
+
+          {band && (
+            <>
+              <div
+                className="pointer-events-none absolute top-0 left-0 h-full bg-background/70"
+                style={{ width: `${band.startPct}%` }}
+              />
+              <div
+                className="pointer-events-none absolute top-0 right-0 h-full bg-background/70"
+                style={{ width: `${100 - band.endPct}%` }}
+              />
+            </>
+          )}
+        </div>
+
+        {timeline.markers.map((marker) => {
+          if (marker.kind !== "trace" || marker.traceIndex === 0) return null
+          return (
+            <div
+              key={marker.traceId}
+              className="pointer-events-none absolute top-1 h-[calc(100%-0.5rem)] w-0.5 -translate-x-1/2 bg-foreground/50"
+              style={{ left: `${wallPct(marker.atMs)}%` }}
+            />
+          )
+        })}
+
+        {hoverTimelineMs !== null && (hoverTimeLabel !== null || hoverActionLabel !== null) && (
+          <>
+            <div
+              className="pointer-events-none absolute top-0 h-full -translate-x-1/2"
+              style={{ left: `${timelineToPct(scale, hoverTimelineMs)}%` }}
+            >
+              <div className="h-full w-px bg-foreground/40" />
+            </div>
+            <div
+              className="pointer-events-none absolute bottom-[calc(100%+0.25rem)] z-10 flex -translate-x-1/2 flex-col items-center rounded bg-foreground/80 px-1.5 py-0.5"
+              style={{ left: `${Math.min(96, Math.max(4, timelineToPct(scale, hoverTimelineMs)))}%` }}
+            >
+              {hoverTimeLabel && (
+                <Text.H6 color="background" noWrap>
+                  {hoverTimeLabel}
+                </Text.H6>
+              )}
+              {hoverActionLabel && (
+                <div className="opacity-80">
+                  <Text.H6 color="background" noWrap>
+                    {hoverActionLabel}
+                  </Text.H6>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      <div ref={laneRef} className="relative h-6">
+        {clusters.map((cluster, index) => {
+          const single = cluster.markers.length === 1 ? cluster.markers[0] : undefined
+          return single ? (
+            <EventMarker
+              key={`marker-${index}`}
+              marker={single}
+              leftPct={cluster.leftPct}
+              onClick={() => onMarkerClick(single)}
+              onHover={onMarkerHover}
+            />
+          ) : (
+            <MarkerClusterChip
+              key={`cluster-${index}`}
+              cluster={cluster}
+              onClick={() => {
+                const first = cluster.markers[0]
+                if (first) onMarkerClick(first)
+              }}
+              onHover={onMarkerHover}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -1,0 +1,69 @@
+import { useMemo } from "react"
+import { useAnnotationsBySession } from "../../../../../../domains/annotations/annotations.collection.ts"
+import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
+import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
+import {
+  useSessionConversationSpanMaps,
+  useSpansBySessionCollection,
+} from "../../../../../../domains/spans/spans.collection.ts"
+import { useTraceDetail } from "../../../../../../domains/traces/traces.collection.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import {
+  buildConversationTimeline,
+  type ConversationTimeline,
+  type TimelineMomentInput,
+} from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import { annotatorNameFor, toTimelineAnnotation, toTimelineSpan, toTimelineTrace } from "./timeline-adapters.ts"
+
+export function useSessionTimeline({
+  projectId,
+  session,
+  traces,
+  latestTraceId,
+  annotationsEnabled,
+  moments,
+}: {
+  readonly projectId: string
+  readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
+  readonly latestTraceId: string
+  readonly annotationsEnabled: boolean
+  /** Behaviour-moment labels (already fetched by the conversation tab for its pills). */
+  readonly moments: readonly TimelineMomentInput[]
+}): ConversationTimeline | null {
+  const { data: traceDetail } = useTraceDetail({ projectId, traceId: latestTraceId })
+  const { data: spans } = useSpansBySessionCollection({
+    projectId,
+    sessionId: session.sessionId,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const { data: spanMaps } = useSessionConversationSpanMaps({
+    projectId,
+    sessionId: session.sessionId,
+    latestTraceId,
+    sessionStartTime: session.startTime,
+    sessionEndTime: session.endTime,
+  })
+  const { data: annotationsData } = useAnnotationsBySession({
+    projectId,
+    traceIds: session.traceIds,
+    enabled: annotationsEnabled,
+  })
+  const memberByUserId = useMemberByUserIdMap()
+
+  return useMemo(() => {
+    if (!traceDetail || !spanMaps) return null
+    return buildConversationTimeline({
+      messages: traceDetail.allMessages,
+      spans: (spans ?? []).map(toTimelineSpan),
+      messageSpanMap: spanMaps.messageSpanMap,
+      toolCallSpanMap: spanMaps.toolCallSpanMap,
+      traces: traces.map(toTimelineTrace),
+      annotations: (annotationsData?.items ?? []).map((a) =>
+        toTimelineAnnotation(a, annotatorNameFor(a, memberByUserId)),
+      ),
+      moments,
+    })
+  }, [traceDetail, spans, spanMaps, traces, annotationsData, moments, memberByUserId])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react"
+import { useAnnotationsByTrace } from "../../../../../../domains/annotations/annotations.collection.ts"
+import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
+import { useConversationSpanMaps } from "../../../../../../domains/spans/spans.collection.ts"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import type { TraceDetailRecord, TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import {
+  buildConversationTimeline,
+  type ConversationTimeline,
+} from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import { annotatorNameFor, toTimelineAnnotation, toTimelineSpan, toTimelineTrace } from "./timeline-adapters.ts"
+
+export function useTraceTimeline({
+  projectId,
+  traceId,
+  traceRecord,
+  traceDetail,
+  spans,
+  annotationsEnabled,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly traceRecord: TraceRecord | undefined
+  readonly traceDetail: TraceDetailRecord | null | undefined
+  readonly spans: readonly SpanRecord[] | undefined
+  readonly annotationsEnabled: boolean
+}): ConversationTimeline | null {
+  const { data: spanMaps } = useConversationSpanMaps({ projectId, traceId })
+  const { data: annotationsData } = useAnnotationsByTrace({
+    projectId,
+    traceId,
+    draftMode: "include",
+    enabled: annotationsEnabled,
+  })
+  const memberByUserId = useMemberByUserIdMap()
+
+  return useMemo(() => {
+    if (!traceDetail || !spanMaps) return null
+    return buildConversationTimeline({
+      messages: traceDetail.allMessages,
+      spans: (spans ?? []).map(toTimelineSpan),
+      messageSpanMap: spanMaps.messageSpanMap,
+      toolCallSpanMap: spanMaps.toolCallSpanMap,
+      traces: [toTimelineTrace(traceRecord ?? traceDetail)],
+      annotations: (annotationsData?.items ?? []).map((a) =>
+        toTimelineAnnotation(a, annotatorNameFor(a, memberByUserId)),
+      ),
+      moments: [],
+    })
+  }, [traceDetail, traceRecord, spans, spanMaps, annotationsData, memberByUserId])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-viewport-band.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-viewport-band.ts
@@ -1,0 +1,81 @@
+import { type RefObject, useEffect, useState } from "react"
+import type { ConversationTimeline } from "../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import { type TrackBand, visibleRangeToBand } from "../../../../../../lib/conversation-timeline/message-windows.ts"
+
+/**
+ * Time band covered by the messages currently visible in the scroll container,
+ * for the track's viewport indicator. Null when nothing is measurable (no
+ * timeline yet, hidden tab, empty viewport).
+ */
+export function useViewportBand({
+  scrollRef,
+  timeline,
+  isActive,
+}: {
+  readonly scrollRef: RefObject<HTMLDivElement | null>
+  readonly timeline: ConversationTimeline | null
+  readonly isActive: boolean
+}): TrackBand | null {
+  const [band, setBand] = useState<TrackBand | null>(null)
+
+  // TODO(frontend-use-effect-policy): the band tracks scroll position and
+  // layout, external systems only observable via listeners/observers.
+  useEffect(() => {
+    const container = scrollRef.current
+    if (!container || !timeline || !isActive) {
+      setBand(null)
+      return
+    }
+
+    const measure = () => {
+      const containerRect = container.getBoundingClientRect()
+      if (containerRect.height === 0) {
+        setBand(null)
+        return
+      }
+      let first = -1
+      let last = -1
+      for (const node of container.querySelectorAll<HTMLElement>("[data-message-index]")) {
+        const raw = node.getAttribute("data-message-index")
+        if (raw == null) continue
+        const index = Number.parseInt(raw, 10)
+        if (Number.isNaN(index)) continue
+        const rect = node.getBoundingClientRect()
+        if (rect.bottom <= containerRect.top || rect.top >= containerRect.bottom) continue
+        if (first === -1 || index < first) first = index
+        if (index > last) last = index
+      }
+      if (first === -1) {
+        setBand(null)
+        return
+      }
+      const exact = visibleRangeToBand(timeline, first, last)
+      const next = exact
+        ? { startPct: Math.round(exact.startPct * 10) / 10, endPct: Math.round(exact.endPct * 10) / 10 }
+        : null
+      setBand((prev) => (prev && next && prev.startPct === next.startPct && prev.endPct === next.endPct ? prev : next))
+    }
+
+    let raf = 0
+    const scheduleMeasure = () => {
+      if (raf) return
+      raf = requestAnimationFrame(() => {
+        raf = 0
+        measure()
+      })
+    }
+
+    measure()
+    container.addEventListener("scroll", scheduleMeasure, { passive: true })
+    const observer = new ResizeObserver(scheduleMeasure)
+    observer.observe(container)
+    if (container.firstElementChild) observer.observe(container.firstElementChild)
+    return () => {
+      container.removeEventListener("scroll", scheduleMeasure)
+      observer.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [scrollRef, timeline, isActive])
+
+  return band
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -2,11 +2,14 @@ import type { MomentKind } from "@domain/conversation-intelligence"
 import { Button, Icon, Popover, PopoverClose, PopoverContent, PopoverTrigger, Text } from "@repo/ui"
 import { XIcon } from "lucide-react"
 import { type RefObject, use, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
+import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { TraceScopeContext } from "../../../../../../domains/traces/trace-scope.tsx"
 import { useSessionMomentIntelligence } from "../../../../../../domains/traces/traces.collection.ts"
-import type { SessionMomentIntelligenceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import type { SessionMomentIntelligenceRecord, TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { useConversationAnnotationFocus } from "../annotations/hooks/use-conversation-annotation-focus.ts"
+import { findNearestMessageAnchor } from "../conversation-timeline/flash-highlight.ts"
+import { useSessionTimeline } from "../conversation-timeline/use-session-timeline.ts"
 import { ConversationTab as TraceConversationTab } from "../trace-detail-drawer/tabs/conversation-tab.tsx"
 
 const MOMENT_FOCUS_OBSERVER_TIMEOUT_MS = 2000
@@ -105,23 +108,6 @@ function MomentLabelBadge({ label, store }: { readonly label: MomentLabelRecord;
   )
 }
 
-/** Finds the rendered message element closest to `messageIndex` (tool-result
- * messages can be absorbed into their caller, so exact anchors may not render). */
-function findMomentAnchor(container: HTMLElement, messageIndex: number): HTMLElement | null {
-  const exact = container.querySelector<HTMLElement>(`[data-message-index="${messageIndex}"]`)
-  if (exact) return exact
-  let best: { node: HTMLElement; distance: number } | null = null
-  for (const node of container.querySelectorAll<HTMLElement>("[data-message-index]")) {
-    const raw = node.getAttribute("data-message-index")
-    if (raw == null) continue
-    const index = Number.parseInt(raw, 10)
-    if (Number.isNaN(index)) continue
-    const distance = Math.abs(index - messageIndex)
-    if (!best || distance < best.distance) best = { node, distance }
-  }
-  return best?.node ?? null
-}
-
 function findMomentRangeAnchors(
   container: HTMLElement,
   firstMessageIndex: number,
@@ -137,7 +123,7 @@ function findMomentRangeAnchors(
   }
 
   if (anchors.length > 0) return anchors
-  const fallback = findMomentAnchor(container, firstMessageIndex)
+  const fallback = findNearestMessageAnchor(container, firstMessageIndex)
   return fallback ? [fallback] : []
 }
 
@@ -234,7 +220,7 @@ function useScrollToFocusedMoment({
       if (done || !container || anchorIndex === undefined) return true
       const anchors = momentTarget
         ? findMomentRangeAnchors(container, momentTarget.moment.firstMessageIndex, momentTarget.moment.lastMessageIndex)
-        : [findMomentAnchor(container, anchorIndex)].filter((anchor): anchor is HTMLElement => anchor !== null)
+        : [findNearestMessageAnchor(container, anchorIndex)].filter((anchor): anchor is HTMLElement => anchor !== null)
       const anchor = anchors[0]
       if (!anchor) return false
       lastScrolledKey.current = key
@@ -282,7 +268,8 @@ function useScrollToFocusedMoment({
  */
 export function ConversationTab({
   projectId,
-  sessionId,
+  session,
+  traces,
   latestTraceId,
   isActive,
   searchQuery,
@@ -290,7 +277,8 @@ export function ConversationTab({
   focusMomentId,
 }: {
   readonly projectId: string
-  readonly sessionId: string
+  readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
   readonly latestTraceId: string
   readonly isActive: boolean
   readonly searchQuery?: string
@@ -298,8 +286,33 @@ export function ConversationTab({
   /** Scrolls to this semantic moment when no label kind is focused. */
   readonly focusMomentId?: string | undefined
 }) {
+  const sessionId = session.sessionId
   // Annotations are an LLM-feedback feature — off under a sandbox scope.
   const annotationsEnabled = !use(TraceScopeContext)
+  const { data: moments } = useSessionMomentIntelligence({ projectId, sessionId })
+
+  const timelineMoments = useMemo(
+    () =>
+      (moments ?? []).flatMap((row) =>
+        row.labels.map((label) => ({
+          id: label.labelId,
+          messageIndex: label.lastMessageIndex,
+          kind: capitalizeMomentKind(label.kind),
+          summary: displayLabelSummary(label.summary),
+          confidence: label.confidence,
+        })),
+      ),
+    [moments],
+  )
+
+  const timeline = useSessionTimeline({
+    projectId,
+    session,
+    traces,
+    latestTraceId,
+    annotationsEnabled,
+    moments: timelineMoments,
+  })
   const [focusAnnotationId, setFocusAnnotationId] = useParamState("annotationId", "")
   const selectedLabelStore = useSelectedLabelStore()
   const { scrollContainerRef, textSelectionPopoverControlsRef, traceDetail, isDetailLoading } =
@@ -311,7 +324,6 @@ export function ConversationTab({
       onFocusConsumed: () => setFocusAnnotationId(""),
       annotationsEnabled,
     })
-  const { data: moments } = useSessionMomentIntelligence({ projectId, sessionId })
 
   // Labels are scored per turn, so each badge anchors to the exact message
   // that triggered the detection (label.lastMessageIndex), not the end of the
@@ -372,6 +384,7 @@ export function ConversationTab({
       annotationsEnabled={annotationsEnabled}
       scrollContainerRef={scrollContainerRef}
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
+      timeline={timeline}
       {...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {})}
       {...(searchQuery ? { searchQuery } : {})}
     />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -254,7 +254,8 @@ export function SessionSlot({
           <div className={effectiveActiveTab === "conversation" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
             <ConversationTab
               projectId={projectId}
-              sessionId={session.sessionId}
+              session={session}
+              traces={traces}
               latestTraceId={latestTraceId}
               isActive={effectiveActiveTab === "conversation"}
               focusMomentKind={focusMomentKind}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -35,6 +35,7 @@ import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { isGlobalAnnotation } from "./annotations/hooks/use-annotation-navigation.ts"
 import { useConversationAnnotationFocus } from "./annotations/hooks/use-conversation-annotation-focus.ts"
 import { TraceAnnotationsList } from "./annotations/trace-annotations-list.tsx"
+import { useTraceTimeline } from "./conversation-timeline/use-trace-timeline.ts"
 import { ConversationTab } from "./trace-detail-drawer/tabs/conversation-tab.tsx"
 import { useSpanFilters } from "./trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import { SpansTab } from "./trace-detail-drawer/tabs/spans-tab.tsx"
@@ -290,6 +291,15 @@ export function TraceDetailBody({
     [onActiveTabChange],
   )
 
+  const timeline = useTraceTimeline({
+    projectId,
+    traceId,
+    traceRecord,
+    traceDetail,
+    spans,
+    annotationsEnabled,
+  })
+
   const { scrollContainerRef, textSelectionPopoverControlsRef, scrollToAnnotation } = useConversationAnnotationFocus({
     projectId,
     traceId,
@@ -417,6 +427,7 @@ export function TraceDetailBody({
             annotationsEnabled={annotationsEnabled}
             scrollContainerRef={scrollContainerRef}
             textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
+            timeline={timeline}
             {...(searchQuery ? { searchQuery } : {})}
           />
         )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
@@ -33,7 +33,7 @@ export interface DurationSegment {
 // work categories use warm tones (orange/amber) deliberately distinct from the
 // blue/purple of the token & cost bars, so the two never get confused. Other is
 // neutral slate; idle stays a hatched gray.
-const DURATION_COLORS: Readonly<Record<DurationCategory, string>> = {
+export const DURATION_COLORS: Readonly<Record<DurationCategory, string>> = {
   generation: "#4ade80",
   tool: "#f97316",
   retrieval: "#f59e0b",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -18,6 +18,12 @@ import { useAuthSession } from "../../../../../../../domains/sessions/session.co
 import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
 import { useTraceSearchHighlights } from "../../../../../../../domains/traces/traces.collection.ts"
 import type { TraceDetailRecord } from "../../../../../../../domains/traces/traces.functions.ts"
+import type {
+  ConversationTimeline,
+  TimelineMarker,
+} from "../../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
+import { messageIndexAtTime } from "../../../../../../../lib/conversation-timeline/message-windows.ts"
+import { wallToTimeline } from "../../../../../../../lib/conversation-timeline/timeline-scale.ts"
 import { AnnotationPopover } from "../../annotations/annotation-popover.tsx"
 import {
   type TextSelectionPopoverControls,
@@ -25,6 +31,9 @@ import {
 } from "../../annotations/hooks/use-annotation-popover.ts"
 import { useTraceAnnotationsData } from "../../annotations/hooks/use-trace-annotations-data.ts"
 import { MessageAnnotationTrigger } from "../../annotations/message-annotation-trigger.tsx"
+import { findNearestMessageAnchor, flashElement } from "../../conversation-timeline/flash-highlight.ts"
+import { TimelineBar } from "../../conversation-timeline/timeline-bar.tsx"
+import { useViewportBand } from "../../conversation-timeline/use-viewport-band.ts"
 import { useScrollToFirstHighlight } from "./use-scroll-to-first-highlight.ts"
 
 function toSearchHighlightRanges(result: TraceSearchHighlightsResult | undefined): readonly HighlightRange[] {
@@ -81,6 +90,7 @@ function ConversationContent({
   onPopoverClose,
   searchQuery,
   messageTrailingSlot,
+  timeline,
 }: {
   readonly traceDetail: TraceDetailRecord
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
@@ -94,6 +104,8 @@ function ConversationContent({
   readonly searchQuery?: string | undefined
   /** Renders a slot below each message (e.g. semantic moment labels). Receives the original messageIndex and role. */
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
+  /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
+  readonly timeline?: ConversationTimeline | null | undefined
 }) {
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = scrollContainerRef ?? internalScrollRef
@@ -105,6 +117,8 @@ function ConversationContent({
     projectId,
     traceId: traceDetail.traceId,
   })
+
+  const band = useViewportBand({ scrollRef, timeline: timeline ?? null, isActive })
 
   useHotkeys([
     {
@@ -146,6 +160,88 @@ function ConversationContent({
     getSpanIdForMessage,
     annotationsEnabled,
   })
+
+  const dismissSelectionUi = useCallback(() => {
+    closeAnnotationPopover()
+    clearSelectionRef.current?.()
+  }, [closeAnnotationPopover])
+
+  const scrollToMessageAnchor = useCallback(
+    (messageIndex: number) => {
+      const container = scrollRef.current
+      if (!container) return
+      const el = findNearestMessageAnchor(container, messageIndex)
+      if (!el) return
+      el.scrollIntoView({ block: "center", behavior: "smooth" })
+      flashElement(el)
+    },
+    [scrollRef],
+  )
+
+  const handleTrackClick = useCallback(
+    (timelineMs: number) => {
+      if (!timeline) return
+      dismissSelectionUi()
+      const index = messageIndexAtTime(timeline, timelineMs)
+      if (index !== null) scrollToMessageAnchor(index)
+    },
+    [timeline, dismissSelectionUi, scrollToMessageAnchor],
+  )
+
+  const handleMarkerClick = useCallback(
+    (marker: TimelineMarker) => {
+      const container = scrollRef.current
+      if (!container || !timeline) return
+      dismissSelectionUi()
+      switch (marker.kind) {
+        case "annotation": {
+          // Text-anchored annotations open in context; the instant scroll keeps
+          // the popover position measured against the settled layout.
+          const el = annotationsEnabled
+            ? container.querySelector<HTMLElement>(`[data-annotation-id="${marker.annotationId}"]`)
+            : null
+          if (el) {
+            el.scrollIntoView({ block: "center" })
+            const rect = el.getBoundingClientRect()
+            onAnnotationClick(marker.annotationId, { x: rect.left + rect.width / 2, y: rect.bottom })
+            return
+          }
+          scrollToMessageAnchor(marker.messageIndex ?? timeline.messages.length - 1)
+          return
+        }
+        case "moment":
+          scrollToMessageAnchor(marker.messageIndex)
+          return
+        case "toolCall": {
+          const el = marker.toolCallId
+            ? container.querySelector<HTMLElement>(`[data-tool-call-id="${marker.toolCallId}"]`)
+            : null
+          if (el) {
+            el.scrollIntoView({ block: "center", behavior: "smooth" })
+            flashElement(el)
+            return
+          }
+          handleTrackClick(wallToTimeline(timeline.scale, marker.atMs))
+          return
+        }
+        case "trace": {
+          const index =
+            marker.firstMessageIndex ?? messageIndexAtTime(timeline, wallToTimeline(timeline.scale, marker.atMs))
+          scrollToMessageAnchor(index ?? 0)
+          return
+        }
+      }
+    },
+    [
+      scrollRef,
+      timeline,
+      dismissSelectionUi,
+      annotationsEnabled,
+      onAnnotationClick,
+      scrollToMessageAnchor,
+      handleTrackClick,
+    ],
+  )
 
   const effectiveSearchQuery = searchQuery ?? ""
   const { data: searchHighlightsData } = useTraceSearchHighlights({
@@ -199,6 +295,12 @@ function ConversationContent({
         )
       : undefined
 
+  // A "successful" result part from a failed execution span should always
+  // render as failed.
+  const failedToolCallIds = timeline && timeline.failedToolCallIds.size > 0 ? timeline.failedToolCallIds : undefined
+
+  const showBar = timeline != null && timeline.scale.totalTimelineMs > 0 && timeline.messages.length > 0
+
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
       <div ref={scrollRef} className="flex min-w-0 flex-col py-8 px-4 overflow-y-auto overflow-x-hidden flex-1">
@@ -211,11 +313,9 @@ function ConversationContent({
           clearSelectionRef={clearSelectionRef}
           highlightRanges={mergedHighlightRanges}
           firstMatchHint={firstMatchHint}
+          {...(failedToolCallIds ? { failedToolCallIds } : {})}
           {...(annotationsEnabled
             ? {
-                onTextSelect: handleTextSelect,
-                onSelectionDismiss: closeAnnotationPopover,
-                onAnnotationClick,
                 messageAnnotationSlot: (messageIndex: number, role: string) => {
                   const data = messageLevelAnnotations.get(messageIndex)
                   return (
@@ -232,6 +332,9 @@ function ConversationContent({
                     />
                   )
                 },
+                onTextSelect: handleTextSelect,
+                onSelectionDismiss: closeAnnotationPopover,
+                onAnnotationClick,
               }
             : {})}
           {...(messageActions ? { messageActions } : {})}
@@ -277,6 +380,19 @@ function ConversationContent({
           }
         />
       </div>
+      {timeline === null && (
+        <div className="border-t border-border bg-background px-4 py-3">
+          <Skeleton className="h-10 w-full" />
+        </div>
+      )}
+      {showBar && timeline && (
+        <TimelineBar
+          timeline={timeline}
+          band={band}
+          onTrackClick={handleTrackClick}
+          onMarkerClick={handleMarkerClick}
+        />
+      )}
     </div>
   )
 }
@@ -293,6 +409,7 @@ export function ConversationTab({
   onPopoverClose,
   searchQuery,
   messageTrailingSlot,
+  timeline,
 }: {
   readonly traceDetail: TraceDetailRecord | null | undefined
   readonly isDetailLoading: boolean
@@ -310,6 +427,8 @@ export function ConversationTab({
   readonly searchQuery?: string | undefined
   /** Renders a slot below each message (e.g. semantic moment labels). Receives the original messageIndex and role. */
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
+  /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
+  readonly timeline?: ConversationTimeline | null | undefined
 }) {
   if (isDetailLoading) {
     return (
@@ -341,6 +460,7 @@ export function ConversationTab({
       onPopoverClose={onPopoverClose}
       searchQuery={searchQuery}
       messageTrailingSlot={messageTrailingSlot}
+      timeline={timeline}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -12,7 +12,7 @@ import {
 } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { DownloadIcon } from "lucide-react"
-import { type ReactNode, type RefObject, useCallback, useMemo, useRef } from "react"
+import { type ReactNode, type RefObject, useCallback, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { useAuthSession } from "../../../../../../../domains/sessions/session.collection.ts"
 import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
@@ -22,7 +22,10 @@ import type {
   ConversationTimeline,
   TimelineMarker,
 } from "../../../../../../../lib/conversation-timeline/build-conversation-timeline.ts"
-import { messageIndexAtTime } from "../../../../../../../lib/conversation-timeline/message-windows.ts"
+import {
+  messageIndexAtTime,
+  visibleRangeToBand,
+} from "../../../../../../../lib/conversation-timeline/message-windows.ts"
 import { wallToTimeline } from "../../../../../../../lib/conversation-timeline/timeline-scale.ts"
 import { AnnotationPopover } from "../../annotations/annotation-popover.tsx"
 import {
@@ -119,6 +122,15 @@ function ConversationContent({
   })
 
   const band = useViewportBand({ scrollRef, timeline: timeline ?? null, isActive })
+
+  const [hoveredMessageIndex, setHoveredMessageIndex] = useState<number | null>(null)
+  const hoverSlice = useMemo(
+    () =>
+      timeline && hoveredMessageIndex !== null
+        ? visibleRangeToBand(timeline, hoveredMessageIndex, hoveredMessageIndex)
+        : null,
+    [timeline, hoveredMessageIndex],
+  )
 
   useHotkeys([
     {
@@ -303,7 +315,17 @@ function ConversationContent({
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
-      <div ref={scrollRef} className="flex min-w-0 flex-col py-8 px-4 overflow-y-auto overflow-x-hidden flex-1">
+      <div
+        ref={scrollRef}
+        className="flex min-w-0 flex-col py-8 px-4 overflow-y-auto overflow-x-hidden flex-1"
+        onPointerMove={(e) => {
+          const anchor = e.target instanceof HTMLElement ? e.target.closest("[data-message-index]") : null
+          const raw = anchor?.getAttribute("data-message-index")
+          const index = raw == null ? Number.NaN : Number.parseInt(raw, 10)
+          setHoveredMessageIndex(Number.isNaN(index) ? null : index)
+        }}
+        onPointerLeave={() => setHoveredMessageIndex(null)}
+      >
         <Conversation
           messages={traceDetail.allMessages}
           enableNavigator
@@ -389,6 +411,7 @@ function ConversationContent({
         <TimelineBar
           timeline={timeline}
           band={band}
+          hoverSlice={hoverSlice}
           onTrackClick={handleTrackClick}
           onMarkerClick={handleMarkerClick}
         />

--- a/dev-docs/annotations.md
+++ b/dev-docs/annotations.md
@@ -10,6 +10,8 @@ They are used for:
 - evaluation alignment
 - reliability feedback loops in Latitude UI or in user-owned apps
 
+In the Conversation tab they also surface as timeline event markers (anchored at the annotated message’s generation moment) that scroll to and open the annotation on click; see [`./conversation-timeline.md`](./conversation-timeline.md).
+
 ## Core Rule
 
 Annotations are not a standalone canonical fact table.

--- a/dev-docs/conversation-intelligence.md
+++ b/dev-docs/conversation-intelligence.md
@@ -118,7 +118,7 @@ The analyzer is a retried Temporal activity, so every write is either idempotent
 
 ## Read paths
 
-- **Session drawer** (`listSessionMomentIntelligenceUseCase`): moments + labels + observations for one session, defaulting to the latest analysis generation; the conversation tab anchors moment pills to message ranges.
+- **Session drawer** (`listSessionMomentIntelligenceUseCase`): moments + labels + observations for one session, defaulting to the latest analysis generation; the conversation tab anchors moment pills to message ranges, and the conversation timeline places the same labels as event markers (see [`./conversation-timeline.md`](./conversation-timeline.md)).
 - **Sessions table filters** (`session-repository.ts`): `moments` (any-of label kinds) and `topics` (any-of subtree cluster ids) compile to `session_id IN (subquery)` with the argMax pin. When the view has a time window, its **lower bound** propagates into the subqueries for partition pruning — the always-safe direction, since analyses index after sessions start; an upper bound is not safe.
 - **Cluster intelligence rollups** (`taxonomy-cluster-intelligence-repository.ts`): per-cluster signal distributions and rates over source sessions, observation side pinned to current generations.
 

--- a/dev-docs/conversation-timeline.md
+++ b/dev-docs/conversation-timeline.md
@@ -1,0 +1,96 @@
+# Conversation Timeline
+
+The conversation timeline is a scroll-linked minimap of a trace or session conversation: a bar at the bottom of the **Conversation tab** (trace detail drawer, session detail drawer, and the nested trace slot, which reuses the trace drawer body) showing what the agent was doing at every moment, with an event-marker lane underneath. The conversation itself is always the full, static, interactive one — the bar and the scroll container are two synchronized views of the same conversation, one indexed by time, one by scroll position. Nothing replays or animates on its own.
+
+## Product behavior
+
+- The bar renders below the conversation: an activity-colored track (with hatched compressed idle gaps and trace notches) and a marker lane. While the timeline loads, a slim skeleton holds its place; a conversation with no timing data renders no bar.
+- **Viewport band:** the track dims everything *outside* the time range covered by the messages currently visible in the scroll viewport (`bg-background/70` overlays on both sides; the visible range stays full-color). The band is derived purely from scroll position, so it follows scrolling with no state of its own. Because time-width and scroll-height don't correlate (a 30s generation can be a two-line message), the band stretches non-linearly while scrolling — that is the point: it shows where the on-screen messages sit in time.
+- **Click-to-navigate:** clicking anywhere on the track scrolls the conversation to the message whose time window contains that position and flashes it (a transient ring, ~4s). Clicking inside a compressed gap goes to the first message of the next trace. Marker clicks dispatch by kind:
+  - *annotation* → scrolls to the highlighted text (`[data-annotation-id]`) and opens the annotation popover; annotations without a text anchor scroll to + flash the anchored message (conversation-level ones, the last message).
+  - *failed tool* → scrolls to + flashes the tool call block (`[data-tool-call-id]`, attribute on `ToolCallBlock`'s wrapper).
+  - *moment* → scrolls to + flashes the message carrying the behaviour-moment label.
+  - *trace* → scrolls to the turn-starting user message.
+  - Cluster chips navigate to their earliest member.
+- Hovering the track shows a ghost line with a chip: wall-clock time plus the activity at that position ("Generating · 4.2s"); over a compressed gap, just "Idle · +2m" (wall time inside a compressed gap is interpolated and misleading, so it is omitted). Hovering a marker or chip shows a rich event card instantly in the slot above the bar.
+- Idle gaps between traces (user think-time ≥5s) occupy a small constant width on the track (hatched, labeled "+2m" etc.).
+- `N`/`P` remain the message navigator keys; markers are real buttons (keyboard reachable). The track itself is a pointer-only shortcut.
+
+## Timing data and fidelity
+
+The timeline is reconstructed entirely from recorded span timing — nothing extra is ingested:
+
+- Spans carry `startTime`/`endTime` (ns precision in ClickHouse, ms after ISO serialization), `timeToFirstTokenNs`, `isStreaming`, `operation`, and `statusCode`.
+- Message↔span attribution uses `buildConversationSpanMaps` (`packages/domain/spans/src/use-cases/map-conversation-to-spans.ts`), which fingerprints assistant message content against span `output_messages` and disambiguates duplicates by preceding-context score. It only maps **assistant** messages; user/system/tool messages get derived times (see scheduling rules).
+- Per-trace maps come from the `mapConversationToSpans` server function. Session-wide maps come from `mapSessionConversationToSpans` (`apps/web/src/domains/spans/spans.functions.ts`), backed by `SpanRepository.findMessagesForSession` — the same projection as `findMessagesForTrace` but with the `sessions_mv` membership predicate `coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId}`, so orphan single-trace sessions work. Keys index into the **latest output trace's `allMessages`** (the canonical session conversation, same source as the session Conversation tab); values are span ids from any trace in the session.
+
+## Core model
+
+The pure logic lives in `apps/web/src/lib/conversation-timeline/` (no React, fully unit-tested):
+
+### `timeline-scale.ts` — coordinate system
+
+Two time domains: **wall-clock ms** (real timestamps) and **timeline ms** (the track domain, 0-based). `buildTimelineScale(traceWindows)` merges overlapping/abutting windows (clock-skew tolerance; gaps < `MIN_COMPRESSIBLE_GAP_MS` = 5s stay linear) and emits alternating active/gap segments, where each compressed gap maps to a constant `GAP_TIMELINE_MS` = 1.5s of track width. `wallToTimeline`/`timelineToWall`/`timelineToPct` are piecewise-linear over the segments.
+
+### `build-conversation-timeline.ts` — the model
+
+`buildConversationTimeline({ messages, spans, messageSpanMap, toolCallSpanMap, traces, annotations, moments })` produces index-aligned per-message `schedules`, sorted `markers`, `failedToolCallIds`, the `activity` track, and the scale.
+
+Schedules are each message's time window on the timeline (single forward walk, monotonic fallback chain):
+
+- **System** message → instant at session start.
+- **User** message → instant at the start of the trace it initiated (new-turn detection: the next mapped assistant span belongs to a different trace than the previous one); intra-trace user messages land at the consuming span's start. Clamped monotonic.
+- **Assistant** message with a mapped streaming span → `streamed` window from `start + TTFT` to span end. A run of consecutive assistant messages mapped to the *same* span splits the window proportionally by character count. Non-streaming, zero-window, or `TTFT ≥ duration` collapse to instant at span end.
+- **Tool** message → per-part `toolResult` times at the matching `execute_tool` span's end; fallbacks: next mapped assistant span's start, then emit+1ms.
+- **Unmapped assistant** messages (fingerprint miss) → instant at previous event +1ms. If *nothing* is mapped, the whole conversation degrades to evenly spaced instants — band and clicks still work, just approximately.
+
+Markers (the event lane) are exactly four kinds, each carrying the anchor its click needs:
+
+- `trace` — one per trace at its start (= the user interaction). `label` is the raw root span name; "Turn N" strings are composed in the UI from `traceIndex`. Carries a `userExcerpt` and `firstMessageIndex` of the turn-starting user message.
+- `annotation` — placed at the **completion time of the anchored message** (via `metadata.messageIndex` → schedule), never at `createdAt`; conversation-level annotations land at the timeline end. Carries `messageIndex`, `flaggerSlug` when created by a Latitude flagger, and `annotatorName` resolved in the data-assembly hooks (members map; agent-provenance annotations resolve to "Latitude Agent").
+- `toolCall` — **failed** tool executions only (`execute_tool` + error status). Successful tools never mark the lane, regardless of duration. Carries the `toolCallId` (for the DOM anchor) and an `errorExcerpt` (≤180 chars): the mapped tool's returned output (via `toolCallSpanMap` reverse lookup into the tool message parts), falling back to the span's `statusMessage`.
+- `moment` — behaviour-moment labels from conversation intelligence (session timeline only), anchored at the completion of the label's `lastMessageIndex` message. Carries `messageIndex` and the label's `confidence`.
+
+Errored non-tool spans deliberately produce no marker: container spans inherit error status from failing children, which previously produced confusing duplicate markers at trace end.
+
+### `build-activity-track.ts` — what the agent was doing
+
+The track background is painted by activity phases computed with the same category model as the trace duration bar (`duration-composition.ts`): leaf spans only (containers excluded), categories generation/tool/retrieval/other, overlap resolved by that priority order, uncovered in-trace time is `idle`. Output is time-ordered segments in timeline coordinates, clipped to active windows; the scale's compressed gaps render separately as hatched separators. Colors come from the exported `DURATION_COLORS` so the timeline track and the duration bar always match.
+
+### `message-windows.ts` — time↔message mapping
+
+- `messageIndexAtTime(timeline, timelineMs)` — the message a track position lands on: the last message whose window starts at or before that wall time; inside a compressed gap, the first message of the next trace. Drives bare track clicks.
+- `visibleRangeToBand(timeline, firstIndex, lastIndex)` — track band (percent) covering the time windows of a message index range. Drives the viewport band.
+- Both build on `scheduleStartMs`/`scheduleCompletionMs` exported from `build-conversation-timeline.ts`.
+
+### `cluster-markers.ts` — lane density
+
+Markers that would visually overlap collapse into a chip showing the first member's icon plus a count. Clusters are anchored to their first member — a marker joins only while within one chip-width of the cluster's anchor, so dense lanes pack into as many chips as fit instead of chaining into one mega-cluster. The threshold is pixel-aware: the track measures the lane via `ResizeObserver` and converts a chip's pixel width into a track percentage, so density adapts to the drawer width.
+
+## UI architecture
+
+Page-local components in `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/`:
+
+- `timeline-bar.tsx` — the bar: hover-card slot + the track. No controls row.
+- `timeline-track.tsx` — the track: activity segments, hatched gap separators, trace notches, the two band-dimming overlays, the hover ghost line + chip, and the marker lane (user-icon circles for interactions, message-square for annotations, the `LatitudeLogo` brand mark for flagger annotations, red wrench for failed tools, violet `TagsIcon` for moments). Pointer-only click target; markers are buttons.
+- `timeline-event-card.tsx` — `markerIcon`/`markerAriaLabel` plus `TimelineEventCardContent` and `TimelineEventHoverCard`. Card anatomy: colored icon + uppercase event-type header, main line (user excerpt / tool name / verdict / moment kind), muted body excerpt, and a footer meta row (wall-clock time · kind-specific meta like duration, author, or confidence).
+- `use-viewport-band.ts` — measures which `[data-message-index]` nodes intersect the scroll viewport (rAF-throttled scroll listener + `ResizeObserver` on the container and its content) and maps the first/last visible index through `visibleRangeToBand`. Returns null when nothing is measurable (hidden tab, no timeline), which renders no dimming.
+- `flash-highlight.ts` — `flashElement` (the transient boxShadow ring, same style as annotation navigation) and `findNearestMessageAnchor` (exact `[data-message-index]` hit, else nearest by index distance — tool messages can be absorbed into their caller's block, so exact anchors may not render). Shared with the session tab's moment-focus scrolling.
+- `use-trace-timeline.ts` / `use-session-timeline.ts` — data assembly per surface, called by the trace drawer body and the session conversation tab respectively; both feed `buildConversationTimeline` through `timeline-adapters.ts`. Queries are shared with what the drawers already fetch (React Query key reuse), so the always-on bar mostly adds only the conversation↔span mapping call.
+- The session hook receives behaviour moments from the session conversation tab, which already fetches them for its per-message pills (`useSessionMomentIntelligence`); the trace timeline passes an empty moments list since moment analysis is session-scoped.
+
+Integration point is `trace-detail-drawer/tabs/conversation-tab.tsx` (`ConversationContent`): it renders the bar (or its loading skeleton) below the scroll container and owns the click dispatch (`handleTrackClick`/`handleMarkerClick`, which also dismiss any open annotation popover before navigating). The `timeline` prop distinguishes `null` (loading → skeleton) from `undefined` (feature off → nothing).
+
+The shared `@repo/ui` `genai-conversation` component carries two timeline-generic extensions: `failedToolCallIds` threading `Conversation → Message → Part → ToolCallBlock` (forces failed rendering — border, X status, destructive result block — when the execution span errored, even if the response part claims success; sourced from `ConversationTimeline.failedToolCallIds`), and a `data-tool-call-id` attribute on `ToolCallBlock`'s wrapper used as the failed-tool markers' scroll anchor.
+
+## Invariants
+
+- The timeline never mutates or refetches conversation content — it only reads recorded span timing and maps it to scroll anchors.
+- All times in the model are clamped to `[wallStart, wallEnd]` and schedules are monotonic; marker placement for annotations is the anchored message's completion time, never `createdAt`.
+- The timeline rebuilds whenever its inputs change (e.g. an annotation is created); the band is recomputed from scroll on every rebuild.
+
+## Testing
+
+- The pure model is unit-tested with colocated vitest files in `apps/web/src/lib/conversation-timeline/` (`timeline-scale`, `build-conversation-timeline`, `build-activity-track`, `message-windows`, `cluster-markers`) against a shared fixture session (`timeline-fixture.ts`: two turns, streaming + non-streaming spans, a tool loop, an idle gap, annotations, a moment). Key covered properties: coordinate round-trips, gap compression, scheduling rules and fallbacks, marker placement and anchors, time→message resolution (including gap clicks), and band math.
+- `findMessagesForSession` has a chdb integration test in `packages/platform/db-clickhouse/src/repositories/span-repository.test.ts` (orphan-session membership, ReplacingMergeTree dedupe).
+- Bar/track components are verified manually; they intentionally have no unit tests.

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -95,6 +95,19 @@ export interface SpanRepositoryShape {
   }): Effect.Effect<readonly SpanMessagesData[], RepositoryError, ChSqlClient>
 
   /**
+   * Same projection as findMessagesForTrace but across every trace in a
+   * session (membership mirrors `sessions_mv`, see listBySessionId) — used to
+   * attribute a session-wide conversation to spans from any of its traces.
+   */
+  findMessagesForSession(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly sessionId: SessionId
+    readonly startTimeFrom: Date
+    readonly startTimeTo: Date
+  }): Effect.Effect<readonly SpanMessagesData[], RepositoryError, ChSqlClient>
+
+  /**
    * The trace of the latest output-producing span across a set of traces —
    * `argMaxIf(trace_id, end_time, output_messages != '')`. Matches the session
    * materialization's "current state" output (same span-level argMax by

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -18,6 +18,7 @@ export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape
     listByProjectId: () => Effect.succeed([]),
     findBySpanId: () => Effect.fail(new NotFoundError({ entity: "Span", id: "" })),
     findMessagesForTrace: () => Effect.succeed([]),
+    findMessagesForSession: () => Effect.succeed([]),
     findLatestOutputTraceId: () => Effect.succeed(null),
     listByIngestedAtWindow: () => Effect.succeed({ spans: [], nextCursor: null }),
     ...overrides,

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -1,4 +1,4 @@
-import { type ChSqlClient, OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
+import { type ChSqlClient, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
 import { SpanRepository, type SpanRepositoryShape } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
@@ -286,6 +286,108 @@ describe("SpanRepository", () => {
       )
       expect(exhausted.spans).toHaveLength(0)
       expect(exhausted.nextCursor).toBeNull()
+    })
+  })
+
+  describe("findMessagesForSession", () => {
+    const SESSION_ID = SessionId("session-replay")
+    const TRACE_A = TraceId("cccccccccccccccccccccccccccccccc")
+    const TRACE_B = TraceId("dddddddddddddddddddddddddddddddd")
+    const ORPHAN_TRACE = TraceId("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+
+    const insertSessionFixture = () =>
+      runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa111111111111",
+            operation: "chat",
+            output_messages: '[{"role":"assistant","parts":[{"type":"text","content":"older"}]}]',
+            start_time: "2026-03-01 00:00:00.000000000",
+            end_time: "2026-03-01 00:00:01.000000000",
+            ingested_at: "2026-03-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa111111111111",
+            operation: "chat",
+            output_messages: '[{"role":"assistant","parts":[{"type":"text","content":"newer"}]}]',
+            start_time: "2026-03-01 00:00:00.000000000",
+            end_time: "2026-03-01 00:00:01.000000000",
+            ingested_at: "2026-03-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa222222222222",
+            operation: "",
+            start_time: "2026-03-01 00:00:01.000000000",
+            end_time: "2026-03-01 00:00:02.000000000",
+            ingested_at: "2026-03-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_B,
+            span_id: "bbbb111111111111",
+            operation: "execute_tool",
+            tool_call_id: "call_1",
+            start_time: "2026-03-01 00:01:00.000000000",
+            end_time: "2026-03-01 00:01:01.000000000",
+            ingested_at: "2026-03-01 00:01:00.000",
+          }),
+          makeSpanRow({
+            session_id: "session-other",
+            trace_id: TraceId("ffffffffffffffffffffffffffffffff"),
+            span_id: "ffff111111111111",
+            operation: "chat",
+            start_time: "2026-03-01 00:02:00.000000000",
+            end_time: "2026-03-01 00:02:01.000000000",
+            ingested_at: "2026-03-01 00:02:00.000",
+          }),
+          makeSpanRow({
+            session_id: "",
+            trace_id: ORPHAN_TRACE,
+            span_id: "ee11111111111111",
+            operation: "chat",
+            start_time: "2026-03-01 00:03:00.000000000",
+            end_time: "2026-03-01 00:03:01.000000000",
+            ingested_at: "2026-03-01 00:03:00.000",
+          }),
+        ]),
+      )
+
+    it("returns deduped LLM/tool spans across all traces in the session, ordered by start time", async () => {
+      await insertSessionFixture()
+      const spans = await runCh(
+        repo.findMessagesForSession({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          sessionId: SESSION_ID,
+          startTimeFrom: new Date("2026-03-01T00:00:00.000Z"),
+          startTimeTo: new Date("2026-03-01T00:10:00.000Z"),
+        }),
+      )
+
+      expect(spans.map((span) => span.spanId)).toEqual(["aaaa111111111111", "bbbb111111111111"])
+      expect(spans[0]?.outputMessages[0]?.parts?.[0]).toMatchObject({ content: "newer" })
+      expect(spans[1]?.toolCallId).toBe("call_1")
+    })
+
+    it("matches orphan single-trace sessions keyed by trace id", async () => {
+      await insertSessionFixture()
+      const spans = await runCh(
+        repo.findMessagesForSession({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          sessionId: SessionId(ORPHAN_TRACE as string),
+          startTimeFrom: new Date("2026-03-01T00:00:00.000Z"),
+          startTimeTo: new Date("2026-03-01T00:10:00.000Z"),
+        }),
+      )
+
+      expect(spans.map((span) => span.spanId)).toEqual(["ee11111111111111"])
     })
   })
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -634,6 +634,43 @@ export const SpanRepositoryLive = Layer.effect(
             )
         }),
 
+      findMessagesForSession: ({ organizationId, projectId, sessionId, startTimeFrom, startTimeTo }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT span_id, operation, tool_call_id, input_messages, output_messages
+                      FROM (
+                        SELECT span_id, operation, tool_call_id, input_messages, output_messages, start_time
+                        FROM spans
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
+                          AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
+                          AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
+                          AND operation IN ('chat', 'text_completion', 'execute_tool')
+                        ORDER BY span_id, ingested_at DESC
+                        LIMIT 1 BY span_id
+                      )
+                      ORDER BY start_time ASC`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  startTimeFrom: toClickhouseDateTime(startTimeFrom),
+                  startTimeTo: toClickhouseDateTime(startTimeTo),
+                  sessionId: sessionId as string,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<SpanMessagesRow>()
+            })
+            .pipe(
+              Effect.map((rows) => rows.map(toDomainSpanMessages)),
+              Effect.mapError((error) => toRepositoryError(error, "findMessagesForSession")),
+            )
+        }),
+
       findLatestOutputTraceId: ({ organizationId, projectId, traceIds }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>

--- a/packages/ui/src/components/genai-conversation/conversation.tsx
+++ b/packages/ui/src/components/genai-conversation/conversation.tsx
@@ -118,6 +118,7 @@ export function Conversation({
   nextLabel,
   messageActions,
   toolCallActions,
+  failedToolCallIds,
   onTextSelect,
   onSelectionDismiss,
   clearSelectionRef,
@@ -147,6 +148,8 @@ export function Conversation({
   readonly messageActions?: ReadonlyMap<number, () => void>
   /** Map of toolCallId → action, renders a navigate button inside each ToolCallBlock. */
   readonly toolCallActions?: ToolCallActions
+  /** Tool calls whose execution span errored — renders them as failed even if the part claims success. */
+  readonly failedToolCallIds?: ReadonlySet<string> | undefined
   /** Called when the user selects text within a message part. Emits the canonical anchor and popover position. */
   readonly onTextSelect?:
     | ((anchor: TextSelectionAnchor, position: { x: number; y: number }, passed: boolean | null) => void)
@@ -312,6 +315,7 @@ export function Conversation({
                     toolResults={message.role === "assistant" ? resultMap : undefined}
                     {...(onNavigate ? { onNavigate } : {})}
                     {...(toolCallActions ? { toolCallActions } : {})}
+                    {...(failedToolCallIds ? { failedToolCallIds } : {})}
                   />
                   {annotationSlot && <div className="mt-3">{annotationSlot}</div>}
                 </div>

--- a/packages/ui/src/components/genai-conversation/message.tsx
+++ b/packages/ui/src/components/genai-conversation/message.tsx
@@ -117,11 +117,13 @@ function PartsRenderer({
   parts,
   toolResults,
   toolCallActions,
+  failedToolCallIds,
   messageIndex,
 }: {
   readonly parts: readonly PartType[]
   readonly toolResults?: ReadonlyMap<string, ToolCallResult> | undefined
   readonly toolCallActions?: ToolCallActions
+  readonly failedToolCallIds?: ReadonlySet<string> | undefined
   readonly messageIndex?: number | undefined
 }) {
   return (
@@ -132,6 +134,7 @@ function PartsRenderer({
         const partId = part.type === "tool_call" ? ((part as { id?: string }).id ?? "") : ""
         const result = toolResults?.get(partId)
         const onNavigateToSpan = toolCallActions?.get(partId)
+        const toolCallFailed = partId.length > 0 && failedToolCallIds?.has(partId) === true
         const isSelectableTextPart = part.type === "text" || part.type === "reasoning"
         return (
           <div
@@ -144,6 +147,7 @@ function PartsRenderer({
               part={part}
               messageIndex={messageIndex}
               partIndex={partIndex}
+              toolCallFailed={toolCallFailed}
               {...(result ? { toolResult: result } : {})}
               {...(onNavigateToSpan ? { onNavigateToSpan } : {})}
             />
@@ -187,12 +191,14 @@ function AssistantMessage({
   messageIndex,
   toolResults,
   toolCallActions,
+  failedToolCallIds,
   onNavigate,
 }: {
   readonly message: GenAIMessage
   readonly messageIndex?: number | undefined
   readonly toolResults?: ReadonlyMap<string, ToolCallResult> | undefined
   readonly toolCallActions?: ToolCallActions
+  readonly failedToolCallIds?: ReadonlySet<string> | undefined
   readonly onNavigate?: () => void
 }) {
   const [collapsed, setCollapsed] = useState(false)
@@ -212,6 +218,7 @@ function AssistantMessage({
           messageIndex={messageIndex}
           {...(toolResults ? { toolResults } : {})}
           {...(toolCallActions ? { toolCallActions } : {})}
+          {...(failedToolCallIds ? { failedToolCallIds } : {})}
         />
       )}
     </div>
@@ -276,6 +283,7 @@ export function Message({
   alignment = "right",
   toolResults,
   toolCallActions,
+  failedToolCallIds,
   onNavigate,
 }: {
   readonly message: GenAIMessage
@@ -283,6 +291,7 @@ export function Message({
   readonly alignment?: "left" | "right"
   readonly toolResults?: ReadonlyMap<string, ToolCallResult> | undefined
   readonly toolCallActions?: ToolCallActions
+  readonly failedToolCallIds?: ReadonlySet<string> | undefined
   readonly onNavigate?: () => void
 }) {
   switch (message.role) {
@@ -295,6 +304,7 @@ export function Message({
           messageIndex={messageIndex}
           {...(toolResults ? { toolResults } : {})}
           {...(toolCallActions ? { toolCallActions } : {})}
+          {...(failedToolCallIds ? { failedToolCallIds } : {})}
           {...(onNavigate ? { onNavigate } : {})}
         />
       )

--- a/packages/ui/src/components/genai-conversation/part.tsx
+++ b/packages/ui/src/components/genai-conversation/part.tsx
@@ -62,12 +62,14 @@ function SearchHitDecoration({ hasHit, children }: { readonly hasHit: boolean; r
 export function Part({
   part,
   toolResult,
+  toolCallFailed = false,
   onNavigateToSpan,
   messageIndex,
   partIndex,
 }: {
   readonly part: GenAIPart
   readonly toolResult?: ToolCallResult | undefined
+  readonly toolCallFailed?: boolean
   readonly onNavigateToSpan?: () => void
   readonly messageIndex?: number | undefined
   readonly partIndex?: number | undefined
@@ -172,6 +174,7 @@ export function Part({
             key={isFirstMatchPart ? "first-match" : "default"}
             call={p}
             defaultOpen={isFirstMatchPart}
+            failed={toolCallFailed}
             {...(toolResult ? { result: toolResult } : {})}
             {...(onNavigateToSpan ? { onNavigateToSpan } : {})}
           />

--- a/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
@@ -9,11 +9,18 @@ import { Tooltip } from "../../tooltip/tooltip.tsx"
 import { formatJson } from "./helpers.tsx"
 import type { ToolCallPart, ToolCallResult } from "./types.ts"
 
-function ToolCallStatusIcon({ result }: { readonly result: ToolCallResult | undefined }) {
-  if (!result) return null
+function ToolCallStatusIcon({
+  result,
+  failed = false,
+}: {
+  readonly result: ToolCallResult | undefined
+  readonly failed?: boolean
+}) {
+  if (!result && !failed) return null
 
-  const label = result.isError ? "Error" : "Success"
-  const icon = result.isError ? (
+  const isError = failed || result?.isError === true
+  const label = isError ? "Error" : "Success"
+  const icon = isError ? (
     <XIcon className="w-3.5 h-3.5 text-destructive" />
   ) : (
     <CheckIcon className="w-3.5 h-3.5 text-success" />
@@ -29,17 +36,20 @@ function ToolCallStatusIcon({ result }: { readonly result: ToolCallResult | unde
 export function ToolCallBlock({
   call,
   result,
+  failed = false,
   onNavigateToSpan,
   defaultOpen = false,
 }: {
   readonly call: ToolCallPart
   readonly result?: ToolCallResult | undefined
+  /** The execution span errored — render as failed even if the result part claims success. */
+  readonly failed?: boolean
   readonly onNavigateToSpan?: () => void
   readonly defaultOpen?: boolean
 }) {
   const [open, setOpen] = useState(defaultOpen)
   const panelId = useId()
-  const isError = result?.isError === true
+  const isError = failed || result?.isError === true
 
   const toggleOpen = () => setOpen((prev) => !prev)
 
@@ -48,6 +58,7 @@ export function ToolCallBlock({
 
   return (
     <div
+      data-tool-call-id={call.id || undefined}
       className={cn("flex min-w-0 max-w-full flex-col overflow-hidden rounded-lg border sm:max-w-150", {
         "border-border": !isError,
         "border-destructive": isError,
@@ -63,7 +74,7 @@ export function ToolCallBlock({
         <span className="min-w-0 flex-1 text-left">
           <Text.Mono size="h6">{call.name}</Text.Mono>
         </span>
-        <ToolCallStatusIcon result={result} />
+        <ToolCallStatusIcon result={result} failed={failed} />
         {call.id && <CopyButton value={call.id} tooltip={call.id} />}
         {onNavigateToSpan && (
           <Tooltip


### PR DESCRIPTION
## Summary

Adds a navigation bar to the Conversation tab of the trace and session detail drawers (and the nested trace slot): a time-axis minimap of the conversation. The track is colored by what the agent was doing at every moment — generating, running tools, retrieving, idle — and an event lane underneath carries every notable event (user turns, annotations, failed tools, behaviour moments). The bar and the conversation are two synchronized views of the same thing, one indexed by time and one by scroll position: scrolling moves an indicator on the track, and clicking the track or an event scrolls the conversation to the right message.

The goal is orientation and triage in long conversations: see at a glance where time went, where things failed or got flagged, and jump straight to any of it without scrolling blind.


https://github.com/user-attachments/assets/2c6962f0-9938-41ed-a70d-6da15e1630ad

(ignore the lag from the video, my mac is dying rn)

## the bar

- **Activity track**: contiguous segments colored with the same category model and `DURATION_COLORS` as the trace duration bar (leaf spans only, generation > tool > retrieval > other priority, uncovered in-trace time is idle). Idle gaps between traces (user think-time ≥5s) compress to a small constant-width hatched separator labeled "+2m" etc., so an hour-long session with two minutes of activity still has a usable track. Trace boundaries get notch lines.
- **Event lane**: markers for user turns, annotations (thumbs colors; Latitude logo for flagger-created ones), failed tool executions (only failures — successful tools never mark the lane), and behaviour moments (sessions only). Hovering shows a rich event card instantly: event type, excerpt (the turn's user message, the tool's error output, the annotation feedback…), wall-clock time and kind-specific meta. Overlapping markers collapse into count chips; the clustering threshold is pixel-aware via `ResizeObserver`, so density adapts to drawer width.
- **Hover readout**: a ghost line over the track with wall-clock time and the activity at that position ("Generating · 4.2s"; "Idle · +2m" over gaps). The bar under the cursor enlarges slightly.

## navigation

- **Viewport indicator**: the track dims everything outside the time range covered by the messages currently on screen. Derived purely from scroll position (which `[data-message-index]` nodes intersect the viewport), so it has no state of its own and stays correct through refetches and live-session growth.
- **Click to jump**: clicking the track scrolls to the message whose time window contains that position and flashes it (same ring style as annotation navigation); clicks inside a gap land on the next turn's first message. Marker clicks dispatch by kind — annotations scroll to the highlighted text and open the annotation popover, failed tools scroll to the exact tool call block (new `data-tool-call-id` anchor on `ToolCallBlock`), moments and turns scroll to their message.
- **Bidirectional hover**: hovering a message in the conversation enlarges the activity bars covering its time slice on the track, so while reading you can see "this short reply is that 40-second generation block."

## how it's built

Everything is reconstructed from recorded span timing — nothing new is ingested. The pure model lives in `apps/web/src/lib/conversation-timeline/` (no React, unit-tested): `timeline-scale` (wall-clock ↔ track coordinates, gap compression), `build-conversation-timeline` (per-message time windows, markers, activity), `build-activity-track`, `message-windows` (time → message resolution and the viewport band math), `cluster-markers`.

Message ↔ span attribution uses the existing `buildConversationSpanMaps` fingerprinting. Per-trace maps come from the existing `mapConversationToSpans` server function; session-wide maps come from a new `mapSessionConversationToSpans` server function backed by a new `SpanRepository.findMessagesForSession` port method — the same projection as `findMessagesForTrace` but with the `sessions_mv` membership predicate (`coalesce(nullIf(session_id,''), toString(trace_id)) = {sessionId}`), so orphan single-trace sessions work. Assistant messages get streamed windows (`start + TTFT` → span end, runs on the same span split by char count); user/system/tool messages get derived times. When fingerprinting matches nothing, windows degrade to even spacing — the bar still works, clicks just land approximately.

Data assembly reuses queries the drawers already fetch (React Query key reuse), so the always-on bar mostly adds only the conversation↔span mapping call.

## also in this PR

- Tool calls whose `execute_tool` span errored now render as failed (border, X status, destructive result block) even when the response part claims success — `failedToolCallIds` threading through the shared `genai-conversation` component, applied to the conversation independently of the bar.
- `dev-docs/conversation-timeline.md` documents the model and the UI architecture; `annotations.md` and `conversation-intelligence.md` link to it.

## testing

- Colocated vitest suites for the pure model against a shared fixture session (two turns, streaming + non-streaming spans, a tool loop, an idle gap, annotations, a moment): coordinate round-trips, gap compression, scheduling rules and fallbacks, marker placement and anchors, time→message resolution including gap clicks, band math, marker clustering.
- chdb integration test for `findMessagesForSession` (orphan-session membership, ReplacingMergeTree dedupe).
- Bar components verified manually; they intentionally have no unit tests.