### PR TITLE
fix(sandbox): allow zod require in QuickJS runtime

### DIFF
--- a/packages/platform/sandbox-quickjs/src/adversarial.test.ts
+++ b/packages/platform/sandbox-quickjs/src/adversarial.test.ts
@@ -76,11 +76,11 @@ describe("hostile scripts die by budget", () => {
 })
 
 describe("isolation boundary", () => {
-  it("exposes no ambient I/O, timers, process, or module system", async () => {
+  it("exposes no ambient I/O, timers, process, or network globals", async () => {
     const script = await Effect.runPromise(
       runtime.compile({
         source: `
-          const leaks = ["fetch", "setTimeout", "setInterval", "process", "require", "XMLHttpRequest", "WebSocket"]
+          const leaks = ["fetch", "setTimeout", "setInterval", "process", "XMLHttpRequest", "WebSocket"]
             .filter((name) => typeof globalThis[name] !== "undefined")
           return Score(leaks.length === 0 ? 1 : 0, leaks.join(","))
         `,

--- a/packages/platform/sandbox-quickjs/src/prelude.ts
+++ b/packages/platform/sandbox-quickjs/src/prelude.ts
@@ -60,7 +60,7 @@ export const SANDBOX_PRELUDE = `;(() => {
     return Object.freeze({ ...node, ...api })
   }
 
-  globalThis.z = Object.freeze({
+  const z = Object.freeze({
     string: () => schemaNode({ kind: "string" }),
     number: () => schemaNode({ kind: "number" }),
     boolean: () => schemaNode({ kind: "boolean" }),
@@ -70,6 +70,12 @@ export const SANDBOX_PRELUDE = `;(() => {
     object: (shape) => schemaNode({ kind: "object", shape: strip(shape) }),
     union: (options) => schemaNode({ kind: "union", options: strip(options) }),
   })
+  globalThis.z = z
+  const zodModule = Object.freeze({ ...z, z })
+  globalThis.require = (moduleName) => {
+    if (moduleName === "zod" || moduleName === "zod/v4") return zodModule
+    throw new TypeError('require() is unavailable in the sandbox for module "' + String(moduleName) + '"')
+  }
 
   if (hostParse) {
     globalThis.parse = (value, schema) => hostParse(value, strip(schema))

--- a/packages/platform/sandbox-quickjs/src/runtime.test.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.test.ts
@@ -178,6 +178,27 @@ describe("run: host-controlled globals", () => {
     expect(result.value).toBe(1)
     expect(result.feedback).toContain("validation failed")
   })
+
+  it("supports zod-only CommonJS imports without exposing general require", async () => {
+    const zod = await compileAndRun(`
+      const { z } = require("zod")
+      const parsed = parse({ ok: true }, z.object({ ok: z.boolean() }))
+      return Score(parsed.ok ? 1 : 0)
+    `)
+    expect(zod.value).toBe(1)
+
+    const zodV4 = await compileAndRun(`
+      const zod = require("zod/v4")
+      const parsed = parse({ ok: true }, zod.object({ ok: zod.boolean() }))
+      return Score(parsed.ok ? 1 : 0)
+    `)
+    expect(zodV4.value).toBe(1)
+
+    const script = await compile('require("node:fs"); return Score(0)')
+    const error = await runError({ script, context: { conversation: [] } })
+    expect(error._tag).toBe("ScriptRuntimeError")
+    expect(error.message).toContain('require() is unavailable in the sandbox for module "node:fs"')
+  })
 })
 
 describe("run: llm host calls", () => {
@@ -221,6 +242,25 @@ if (result.passed) {
       { llm: async () => ({ object: { ok: true }, tokens: 10, duration: 500, cost: 3 }) },
     )
     expect(result).toMatchObject({ value: 1, tokens: 20, cost: 6 })
+  })
+
+  it("accepts zod schemas imported through the compatibility require shim", async () => {
+    const calls: HostLlmCall[] = []
+    const result = await compileAndRun(
+      `
+      const { z } = require("zod")
+      const result = await llm("one", { schema: z.object({ ok: z.boolean() }) })
+      return Score(result.ok ? 1 : 0)
+      `,
+      {
+        llm: async (call) => {
+          calls.push(call)
+          return { object: { ok: true }, tokens: 10, duration: 500, cost: 3 }
+        },
+      },
+    )
+    expect(result).toMatchObject({ value: 1, tokens: 10, cost: 3 })
+    expect(calls[0]?.schema).toEqual({ kind: "object", shape: { ok: { kind: "boolean" } } })
   })
 
   it("does not inject llm for pure-capability scripts", async () => {


### PR DESCRIPTION
## what changed

Adds a narrow CommonJS compatibility shim to the QuickJS sandbox prelude so stored evaluation scripts can call `require("zod")` or `require("zod/v4")`. Both imports return the same sandbox schema descriptor API already exposed as global `z`.

The shim rejects every other module with an explicit sandbox error, so scripts still cannot reach Node built-ins or ambient I/O through `require`.

## why

Datadog Error Tracking issue `d9b04804-66e8-11f1-bea1-da7ad0900005` showed production live evaluation executions failing with `LiveEvaluationExecutionError: require is not a function`. The sandbox runtime exposes `z` globally, but some stored scripts import Zod with CommonJS syntax. This keeps those scripts compatible without opening a general module system inside the sandbox.

## validation

- `pnpm --filter @platform/sandbox-quickjs test`
- `pnpm --filter @platform/sandbox-quickjs check`
- `pnpm --filter @platform/sandbox-quickjs typecheck`
- `pnpm --filter @app/workers build`
- Local sandbox smoke: `require("zod")` succeeds in sandboxed live evaluation execution; `require("node:fs")` remains blocked.
- Local app health after env/process restart: API, workers, ingest, workflows, and web login all responded successfully.
