### PR TITLE
fix(utils): promote to next unit when rounding rolls over in formatCount/formatBytes

### DIFF
--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -26,6 +26,10 @@ describe("formatBytes", () => {
   it("handles negative values", () => {
     expect(formatBytes(-1536)).toBe("-1.5 KB")
   })
+
+  it("promotes to the next unit when rounding reaches 1024", () => {
+    expect(formatBytes(1024 * 1024 - 1)).toBe("1 MB")
+  })
 })
 
 describe("formatCount", () => {
@@ -55,6 +59,11 @@ describe("formatCount", () => {
 
   it("formats billions", () => {
     expect(formatCount(1000000000)).toBe("1B")
+  })
+
+  it("promotes to the next unit when rounding reaches 1000", () => {
+    expect(formatCount(999999)).toBe("1M")
+    expect(formatCount(999500)).toBe("1M")
   })
 
   it("handles negative numbers", () => {

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -26,7 +26,14 @@ export function formatCount(count: number): string {
     unitIndex++
   }
 
-  const decimal = value < 10 ? 1 : 0
+  let decimal = value < 10 ? 1 : 0
+  // Rounding can bump the value up to the next unit (e.g. 999_999 would render
+  // as "1000K"), so promote to the next unit when that happens.
+  if (Number(value.toFixed(decimal)) >= 1000 && unitIndex < COUNT_UNITS.length - 1) {
+    value /= 1000
+    unitIndex++
+    decimal = value < 10 ? 1 : 0
+  }
   return `${value.toFixed(decimal).replace(/\.0$/, "")}${COUNT_UNITS[unitIndex]}`
 }
 
@@ -65,6 +72,12 @@ export function formatBytes(bytes: number): string {
     unitIndex++
   }
 
+  // Rounding to one decimal can bump the value up to 1024 (e.g. 1048575 bytes
+  // would render as "1024 KB"), so promote to the next unit when that happens.
+  if (Number(value.toFixed(1)) >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    value /= 1024
+    unitIndex++
+  }
   return `${value.toFixed(1).replace(/\.0$/, "")} ${BYTE_UNITS[unitIndex]}`
 }
 


### PR DESCRIPTION
## What does this PR do?

`formatCount` and `formatBytes` (in `packages/utils`) choose a unit by dividing the value while it is `>= 1000` (or `1024`), then render it with `toFixed`. When the value sits just below the threshold, rounding pushes it back up to the threshold and produces nonsensical output:

- `formatCount(999999)` rendered `"1000K"` instead of `"1M"`
- `formatCount(999500)` rendered `"1000K"`
- `formatBytes(1024 * 1024 - 1)` rendered `"1024 KB"` instead of `"1 MB"`

After rounding, this promotes to the next unit when the rounded value reaches the threshold. All existing outputs are unchanged — only the rounding-boundary cases differ.

## Related issue (if applicable)

N/A — spotted while reading the formatting utilities.

## How was this tested?

Added regression tests in `packages/utils/src/format.test.ts` for both functions (the rollover cases plus the existing values). I also ran the edited `format.ts` directly and confirmed every existing case in the test file still produces the same output and that the boundary cases now render `"1M"` / `"1 MB"`.

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA
