### PR TITLE
fix(trace-search): co-locate embed-budget keys on one Redis Cluster slot

### DIFF
--- a/packages/platform/cache-redis/src/trace-search-budget.test.ts
+++ b/packages/platform/cache-redis/src/trace-search-budget.test.ts
@@ -195,8 +195,10 @@ describe("TraceSearchBudgetLive.tryConsume", () => {
     const orgBKeys = Array.from(redis.store.keys()).filter((k) => k.includes(OTHER_ORG))
     expect(orgAKeys).toHaveLength(3)
     expect(orgBKeys).toHaveLength(3)
-    for (const k of orgAKeys) expect(k.startsWith(`org:${ORG_ID}:`)).toBe(true)
-    for (const k of orgBKeys) expect(k.startsWith(`org:${OTHER_ORG}:`)).toBe(true)
+    // Keys carry a Redis Cluster hash tag around the org id so all three window
+    // keys land on one slot (cross-window mget/pipeline would otherwise CROSSSLOT).
+    for (const k of orgAKeys) expect(k.startsWith(`org:{${ORG_ID}}:`)).toBe(true)
+    for (const k of orgBKeys) expect(k.startsWith(`org:{${OTHER_ORG}}:`)).toBe(true)
     for (const k of [...orgAKeys, ...orgBKeys]) expect(redis.store.get(k)).toBe(900)
   })
 

--- a/packages/platform/cache-redis/src/trace-search-budget.ts
+++ b/packages/platform/cache-redis/src/trace-search-budget.ts
@@ -11,8 +11,12 @@ const MONTHLY_TTL_SECONDS = 60 * 60 * 24 * 62 // ~2 months
 
 const pad2 = (n: number): string => n.toString().padStart(2, "0")
 
+// The `{orgId}` hash tag is load-bearing on Redis Cluster: it forces all three
+// window keys for an org onto the same slot so the cross-window `mget` and
+// `pipeline` below don't fail with CROSSSLOT. Without it the budget check
+// errors on every call against a clustered Redis (prod) and fails open.
 const buildBudgetKey = (orgId: OrganizationId, window: "daily" | "weekly" | "monthly", suffix: string): string =>
-  `org:${orgId}:trace-search:embed-budget:${window}:${suffix}`
+  `org:{${orgId}}:trace-search:embed-budget:${window}:${suffix}`
 
 const dailyKey = (orgId: OrganizationId, now: Date): string => {
   const yyyy = now.getUTCFullYear()


### PR DESCRIPTION
## Problem

The per-org trace-search embed budget reads its three window counters in one `mget(daily, weekly, monthly)` and increments them in one `pipeline`. On a Redis **Cluster** (production), the three keys hash to different slots, so both the read and the pipeline fail with:

```
ReplyError: CROSSSLOT Keys in request don't hash to the same slot
  at packages/platform/cache-redis/src/trace-search-budget.ts (mget)
```

The worker catches this and fails open (`tryConsume(...).pipe(Effect.orElseSucceed(() => true))`), so embedding still proceeds — but two real consequences:

1. **The org embed-cost budget is never enforced in production** (every check errors → fail-open).
2. **Heavy error-log / Datadog noise** — one `CacheError` per trace-search embed. Observed at ~220/min during the production backfill, ~**160k** errors over its ~12h run.

(Staging didn't catch it — single-node Redis tolerates cross-slot multi-key ops; only Cluster enforces the constraint.)

## Fix

Wrap the org id in a Redis Cluster **hash tag** so all three window keys for an org route to the same slot, making the cross-window `mget`/`pipeline` legal:

```
org:${orgId}:trace-search:embed-budget:...   →   org:{${orgId}}:trace-search:embed-budget:...
```

One change in the single key-builder (`buildBudgetKey`). Keys still start with the `org:` tenant prefix.

## Notes

- Counters under the old key shape are abandoned and age out via their existing TTLs (2d / 2w / ~2mo). Acceptable: the budget was unenforced on Cluster anyway, so there's nothing meaningful to preserve.
- Test updated to assert the hash-tagged prefix and guard the co-location property. Full `@platform/cache-redis` suite (30 tests) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)