### PR TITLE
fix(ai-voyage): truncate oversized embed/rerank inputs instead of 400ing

### DIFF
--- a/packages/platform/ai-voyage/src/ai.ts
+++ b/packages/platform/ai-voyage/src/ai.ts
@@ -64,7 +64,11 @@ export const embedWithVoyage = (input: EmbedInput): Effect.Effect<EmbedResult, A
             input: input.text,
             model: input.model,
             inputType: input.inputType ?? "document",
-            truncation: false,
+            // Must stay true: the shared-embedding design embeds whole messages and
+            // relies on provider truncation for oversized ones. With `false`, Voyage
+            // 400s on any input past its 32k-token window, which both the trace-search
+            // indexer and CI session analysis feed it on long messages.
+            truncation: true,
             outputDimension: EMBEDDING_DIMENSIONS,
             outputDtype: "float",
           })
@@ -96,7 +100,9 @@ export const rerankWithVoyage = (input: RerankInput): Effect.Effect<readonly Rer
             documents: input.documents as string[],
             model: input.model,
             returnDocuments: false,
-            truncation: false,
+            // Truncate oversized documents to the model window rather than 400 the
+            // whole rerank request (same failure mode as embed above).
+            truncation: true,
           })
 
           if (!response.data) {


### PR DESCRIPTION
## Problem (Datadog: workers / trace-search.embed)

```
VoyageAIError: Status code: 400
"Request to model 'voyage-4-large' failed. The example at index 0 in your batch
 has too many tokens and does not fit into the model's context window of 32000
 tokens. Please lower the number of tokens ... or use truncation."
```

`embedWithVoyage` (and `rerankWithVoyage`) call Voyage with `truncation: false`, so any input past the model's **32k-token** window comes back as a 400 instead of being truncated.

**Why it started:** before #3496 the trace-search indexer embedded bounded ~2k-char chunks (`packChunks`). The shared-message-embeddings rewrite embeds **whole** user/assistant messages, so a single long message now exceeds the window. The spec deliberately chose this (`specs/shared-message-embeddings.md`, line 37):

> v1 embeds the whole canonical message … **Provider-side token-cap truncation applies to oversized messages.**

…so the flag should have been `true`. The implementation set it to `false` — that's the regression.

## Why the fix is in the shared call, not trace-search

CI session analysis embeds whole messages through the **same** `ai.embed` path (`analyze-session.ts`, `anchors.ts`), so it 400s on long messages too. More importantly, the shared store's load-bearing invariant is that **both writers produce the same embedding for a given content hash**. Pre-truncating text in the trace-search path would change its hash relative to CI's full-text hash → divergence, double-embedding, and CI still erroring. Truncating at the provider keeps the hash over the full canonical text and identical across both writers.

## Fix

Set `truncation: true` on both the embed and rerank calls in `@platform/ai-voyage`. Oversized inputs are now truncated to the model window (Voyage's own recommended remedy) instead of failing the request.

- Affects: trace-search indexing, CI session analysis, query-side embedding, reranking.
- Behavior change: long messages produce a (provider-truncated) embedding instead of being silently dropped on a 400. Sub-message chunking remains the spec's documented follow-up if recall on long messages regresses.
- Typecheck green; ai-voyage has no unit tests (Voyage client is mocked elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)