### PR TITLE
feat(monitors): aggregate metrics (errorRate/avg/p95/sum) for the traces stream

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
@@ -79,6 +79,11 @@ const t0930 = new Date("2026-06-01T09:30:00.000Z")
 const t10 = new Date("2026-06-01T10:00:00.000Z")
 const t1030 = new Date("2026-06-01T10:30:00.000Z")
 const t11 = new Date("2026-06-01T11:00:00.000Z")
+// Aggregate-metric fixtures live in their own windows so they can't perturb the
+// count/bucket assertions above regardless of test ordering.
+const t12 = new Date("2026-06-01T12:00:00.000Z")
+const t13 = new Date("2026-06-01T13:00:00.000Z")
+const t14 = new Date("2026-06-01T14:00:00.000Z")
 
 /** A `traces` + `count` target — the saved-search/match shape this reader supersedes. */
 const countTarget = (filterSet: FilterSet = {}, query: string | null = null): MetricSeriesTarget => ({
@@ -86,6 +91,20 @@ const countTarget = (filterSet: FilterSet = {}, query: string | null = null): Me
   filterSet,
   query,
   metric: { kind: "count" },
+})
+
+/** A `traces` target carrying an arbitrary metric (no filter / no query). */
+const metricTarget = (metric: MetricSeriesTarget["metric"]): MetricSeriesTarget => ({
+  stream: "traces",
+  filterSet: {},
+  query: null,
+  metric,
+})
+
+// span() defaults to status_code 0 / 1s; override duration via its arg and status inline.
+const errorSpan = (n: number, startTime: Date, durationMs: number): SpanRow => ({
+  ...span(n, startTime, [TAG], durationMs),
+  status_code: 2,
 })
 
 const ch = setupTestClickHouse()
@@ -224,5 +243,68 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
     )
     // The 'other'-tagged trace at 10:30 is dropped by the tag filter → idx 1 falls to 1.
     expect(counts).toEqual([0, 1, 1])
+  })
+
+  it("computes errorRate / avg / sum over the matched traces", async () => {
+    // [12:00, 13:00): three traces of 2s / 4s / 6s, the 6s one errored.
+    // Ids 41/42/43: padEnd-collision-safe (no n↔10n overlap with the seeded 1–6).
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        span(41, t12, [TAG], 2_000),
+        span(42, t12, [TAG], 4_000),
+        errorSpan(43, t12, 6_000),
+      ]),
+    )
+    const window = { organizationId: ORG_ID, projectId: PROJECT_ID, from: t12, to: t13 }
+
+    const errorRate = await runCh(reader.valueInWindow({ ...window, target: metricTarget({ kind: "errorRate" }) }))
+    expect(errorRate).toBeCloseTo(1 / 3)
+
+    const avg = await runCh(
+      reader.valueInWindow({ ...window, target: metricTarget({ kind: "avg", field: "duration" }) }),
+    )
+    expect(avg).toBe(4_000_000_000) // (2+4+6)/3 s, in ns
+
+    const sum = await runCh(
+      reader.valueInWindow({ ...window, target: metricTarget({ kind: "sum", field: "duration" }) }),
+    )
+    expect(sum).toBe(12_000_000_000) // (2+4+6) s, in ns
+  })
+
+  it("computes p95 over the matched traces", async () => {
+    // Uniform durations ⇒ the quantile is exact regardless of the estimator.
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        span(51, t13, [TAG], 3_000),
+        span(52, t13, [TAG], 3_000),
+        span(53, t13, [TAG], 3_000),
+      ]),
+    )
+    const p95 = await runCh(
+      reader.valueInWindow({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        from: t13,
+        to: t14,
+        target: metricTarget({ kind: "p95", field: "duration" }),
+      }),
+    )
+    expect(p95).toBe(3_000_000_000)
+  })
+
+  it("reads 0 (not nan) for a ratio/aggregate over an empty window", async () => {
+    const empty = {
+      organizationId: ORG_ID,
+      projectId: PROJECT_ID,
+      from: new Date("2026-06-02T00:00:00.000Z"),
+      to: new Date("2026-06-02T01:00:00.000Z"),
+    }
+    expect(await runCh(reader.valueInWindow({ ...empty, target: metricTarget({ kind: "errorRate" }) }))).toBe(0)
+    expect(
+      await runCh(reader.valueInWindow({ ...empty, target: metricTarget({ kind: "avg", field: "duration" }) })),
+    ).toBe(0)
+    expect(
+      await runCh(reader.valueInWindow({ ...empty, target: metricTarget({ kind: "p95", field: "duration" }) })),
+    ).toBe(0)
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
@@ -56,7 +56,7 @@ const metricAggregate = (metric: MonitorMetric, columns: MetricColumns): string 
     case "avg":
       return `if(count() = 0, 0, avg(${columns[metric.field]}))`
     case "p95":
-      return `if(count() = 0, 0, quantile(0.95)(${columns[metric.field]}))`
+      return `if(count() = 0, 0, quantileTDigest(0.95)(${columns[metric.field]}))`
   }
 }
 

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
@@ -21,17 +21,42 @@ import { buildTraceFilterClauses, LIST_SELECT, resolvePercentileFilters } from "
 const toClickHouseDateTime64 = (value: Date): string => value.toISOString().replace("T", " ").replace("Z", "")
 
 /**
- * SQL aggregate applied over the per-entity grouped subquery. `count` (one row
- * per matched entity) is the only metric wired today — it makes this reader an
- * exact drop-in for the saved-search match reader it supersedes. `errorRate`/`avg`/`p95`/`sum`
- * land with the spans/scores streams (per-stream field columns differ).
+ * Per-stream column expressions a metric aggregates over. The inner subquery
+ * exposes these as output columns (for `traces`, the `LIST_SELECT` aliases);
+ * `isError` is a boolean expression, not a column. Spans/sessions add their own.
  */
-const metricAggregate = (metric: MonitorMetric): string => {
+interface MetricColumns {
+  readonly duration: string
+  readonly cost: string
+  readonly tokens: string
+  readonly isError: string
+}
+
+const TRACE_METRIC_COLUMNS: MetricColumns = {
+  duration: "duration_ns",
+  cost: "cost_total_microcents",
+  tokens: "tokens_total",
+  isError: "error_count > 0",
+}
+
+/**
+ * SQL aggregate applied over the per-entity grouped subquery. `count` makes this
+ * reader an exact drop-in for the saved-search match reader it supersedes.
+ * Ratios/averages guard the empty group (`count() = 0`) so a metric over an empty
+ * window/bucket reads `0`, not `nan` — densified empty buckets then stay numeric.
+ */
+const metricAggregate = (metric: MonitorMetric, columns: MetricColumns): string => {
   switch (metric.kind) {
     case "count":
       return "count()"
-    default:
-      throw new Error(`MetricSeriesReader: metric '${metric.kind}' not implemented yet`)
+    case "errorRate":
+      return `if(count() = 0, 0, countIf(${columns.isError}) / count())`
+    case "sum":
+      return `sum(${columns[metric.field]})`
+    case "avg":
+      return `if(count() = 0, 0, avg(${columns[metric.field]}))`
+    case "p95":
+      return `if(count() = 0, 0, quantile(0.95)(${columns[metric.field]}))`
   }
 }
 
@@ -103,7 +128,7 @@ const make = (): MetricSeriesReaderShape => ({
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const inner = yield* buildInnerQuery(input)
-      const aggregate = metricAggregate(input.target.metric)
+      const aggregate = metricAggregate(input.target.metric, TRACE_METRIC_COLUMNS)
       return yield* chSqlClient
         .query(async (client) => {
           const result = await client.query({
@@ -175,7 +200,7 @@ const make = (): MetricSeriesReaderShape => ({
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const inner = yield* buildInnerQuery(input)
-      const aggregate = metricAggregate(input.target.metric)
+      const aggregate = metricAggregate(input.target.metric, TRACE_METRIC_COLUMNS)
       const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
       // Bucket each matching trace by how far its `start_time` sits before `to`,
       // in `bucketNs` (= bucketMs) steps — index 0 is the bucket ending at `to`.


### PR DESCRIPTION
> **Stacked on #3555** (`feat/general-monitors-stream-model`). Review/merge that first; this PR's base will retarget to `development` once it lands.

## What

Extends `MetricSeriesReader` beyond `count` with the aggregate metrics from the unified monitor model (`specs/signals.md`): **errorRate**, **avg**, **p95**, **sum** over a numeric field — for the `traces` stream.

The traces inner query already exposes the per-trace columns (`duration_ns`, `cost_total_microcents`, `tokens_total`, `error_count`), so the metrics map straight onto it:
- `errorRate` → `countIf(error_count > 0) / count()`
- `avg|p95|sum` → `avg|quantile(0.95)|sum(<field column>)`

Ratios/averages guard the empty group (`if(count() = 0, 0, …)`) so a metric over an empty window/bucket reads `0`, not `nan` — densified empty buckets stay numeric.

## Why

This is purely **additive and behavior-preserving**: saved-search monitors still use `count`, and nothing yet constructs a non-count target. It unblocks **user-monitor metrics** (error rate / cost / p95 over a user's traces, all on the `traces` stream). The `spans` stream for per-call **tool** metrics follows as its own PR.

## Verification

- `@platform/db-clickhouse` typecheck clean; reader test green (13/13).
- New chdb tests cover `errorRate`/`avg`/`sum`/`p95` over isolated windows + the empty-window guard (incl. `p95`). p95 is asserted only on uniform data (exact regardless of the approximate estimator).
- `knip` + `format` clean.
- Adversarial review subagent: **APPROVE** — verified column mappings resolve to real `LIST_SELECT` aliases, `error_count > 0` matches the traces MV's `status_code = 2` error definition, empty-group guards prevent nan, no SQL injection (fixed column map indexed by a Zod enum), switch is exhaustive. Acted on its nit (added `p95` to the empty-window test).

## Follow-ups

- `spans` stream adapter (`SPAN_FIELD_REGISTRY` + `buildSpanFilterClauses`) → tool per-call metrics.
- Target-on-monitor model + create/update wiring.
- In-context tool & user monitor UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)