### PR TITLE
feat(monitors): spans stream for MetricSeriesReader (per tool-call metrics)

### DIFF
--- a/packages/platform/db-clickhouse/src/registries/span-fields.ts
+++ b/packages/platform/db-clickhouse/src/registries/span-fields.ts
@@ -1,0 +1,34 @@
+import type { FilterSet } from "@domain/shared"
+import { buildClickHouseWhere, type ChFieldRegistry } from "../filter-builder.ts"
+
+/**
+ * Span-level filter fields for the `spans` stream (one row per span). Mirrors the
+ * trace/session registries but maps to raw `spans` columns — `operation` +
+ * `tool_name` let a tool monitor scope to `execute_tool` spans of one tool.
+ * `duration_ns` is an alias column (read-time `end − start`). `gtePercentile` is
+ * intentionally unsupported here (no per-span distribution resolution); it fails
+ * loud (the builder throws) rather than silently mis-filtering.
+ */
+const SPAN_FIELD_REGISTRY: ChFieldRegistry = {
+  operation: { column: "operation", chType: "String" },
+  toolName: { column: "tool_name", chType: "String" },
+  name: { column: "name", chType: "String" },
+  model: { column: "model", chType: "String" },
+  provider: { column: "provider", chType: "String" },
+  userId: { column: "user_id", chType: "String" },
+  sessionId: { column: "session_id", chType: "String" },
+  traceId: { column: "trace_id", chType: "String" },
+  tags: { column: "tags", chType: "String", isArray: true, arrayContains: true },
+  duration: { column: "duration_ns", chType: "Int64" },
+  cost: { column: "cost_total_microcents", chType: "UInt64" },
+  tokensInput: { column: "tokens_input", chType: "UInt64" },
+  tokensOutput: { column: "tokens_output", chType: "UInt64" },
+}
+
+/** Span filters are row-local — all WHERE clauses, no HAVING (the spans stream doesn't aggregate). */
+export const buildSpanFilterClauses = (
+  filterSet: FilterSet,
+): { whereClauses: string[]; params: Record<string, unknown> } => {
+  const { clauses, params } = buildClickHouseWhere(filterSet, SPAN_FIELD_REGISTRY)
+  return { whereClauses: clauses, params }
+}

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.test.ts
@@ -84,6 +84,9 @@ const t11 = new Date("2026-06-01T11:00:00.000Z")
 const t12 = new Date("2026-06-01T12:00:00.000Z")
 const t13 = new Date("2026-06-01T13:00:00.000Z")
 const t14 = new Date("2026-06-01T14:00:00.000Z")
+const t15 = new Date("2026-06-01T15:00:00.000Z")
+const t16 = new Date("2026-06-01T16:00:00.000Z")
+const t17 = new Date("2026-06-01T17:00:00.000Z")
 
 /** A `traces` + `count` target — the saved-search/match shape this reader supersedes. */
 const countTarget = (filterSet: FilterSet = {}, query: string | null = null): MetricSeriesTarget => ({
@@ -101,10 +104,31 @@ const metricTarget = (metric: MetricSeriesTarget["metric"]): MetricSeriesTarget 
   metric,
 })
 
+/** A `spans` target carrying a metric + row-local filter (the tool-monitor shape). */
+const spanTarget = (metric: MetricSeriesTarget["metric"], filterSet: FilterSet): MetricSeriesTarget => ({
+  stream: "spans",
+  filterSet,
+  query: null,
+  metric,
+})
+
 // span() defaults to status_code 0 / 1s; override duration via its arg and status inline.
 const errorSpan = (n: number, startTime: Date, durationMs: number): SpanRow => ({
   ...span(n, startTime, [TAG], durationMs),
   status_code: 2,
+})
+
+// An `execute_tool` span for one named tool (the spans-stream fixture shape).
+const toolSpan = (
+  n: number,
+  startTime: Date,
+  toolName: string,
+  opts: { durationMs?: number; statusCode?: number } = {},
+): SpanRow => ({
+  ...span(n, startTime, [TAG], opts.durationMs ?? 1_000),
+  operation: "execute_tool",
+  tool_name: toolName,
+  status_code: opts.statusCode ?? 0,
 })
 
 const ch = setupTestClickHouse()
@@ -306,5 +330,105 @@ describe("MetricSeriesReaderLive (traces / count)", () => {
     expect(
       await runCh(reader.valueInWindow({ ...empty, target: metricTarget({ kind: "p95", field: "duration" }) })),
     ).toBe(0)
+  })
+
+  // ── spans stream (per tool-call) ────────────────────────────────────────────
+  const EXECUTE_TOOL = { operation: [{ op: "eq" as const, value: "execute_tool" }] }
+
+  it("counts execute_tool spans, scoped by tool name", async () => {
+    // [15:00, 16:00): three `search` calls + one `fetch` call.
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        toolSpan(61, t15, "search", { durationMs: 2_000 }),
+        toolSpan(62, t15, "search", { durationMs: 4_000 }),
+        toolSpan(63, t15, "search", { durationMs: 6_000, statusCode: 2 }),
+        toolSpan(64, t15, "fetch", { durationMs: 1_000 }),
+      ]),
+    )
+    const window = { organizationId: ORG_ID, projectId: PROJECT_ID, from: t15, to: t16 }
+
+    const allTools = await runCh(
+      reader.valueInWindow({ ...window, target: spanTarget({ kind: "count" }, EXECUTE_TOOL) }),
+    )
+    expect(allTools).toBe(4)
+
+    const searchOnly = await runCh(
+      reader.valueInWindow({
+        ...window,
+        target: spanTarget({ kind: "count" }, { ...EXECUTE_TOOL, toolName: [{ op: "eq", value: "search" }] }),
+      }),
+    )
+    expect(searchOnly).toBe(3)
+  })
+
+  it("computes errorRate / avg / sum per tool call", async () => {
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        toolSpan(61, t15, "search", { durationMs: 2_000 }),
+        toolSpan(62, t15, "search", { durationMs: 4_000 }),
+        toolSpan(63, t15, "search", { durationMs: 6_000, statusCode: 2 }),
+      ]),
+    )
+    const window = { organizationId: ORG_ID, projectId: PROJECT_ID, from: t15, to: t16 }
+    const filter = { ...EXECUTE_TOOL, toolName: [{ op: "eq" as const, value: "search" }] }
+
+    expect(
+      await runCh(reader.valueInWindow({ ...window, target: spanTarget({ kind: "errorRate" }, filter) })),
+    ).toBeCloseTo(1 / 3)
+    expect(
+      await runCh(reader.valueInWindow({ ...window, target: spanTarget({ kind: "avg", field: "duration" }, filter) })),
+    ).toBe(4_000_000_000)
+    expect(
+      await runCh(reader.valueInWindow({ ...window, target: spanTarget({ kind: "sum", field: "duration" }, filter) })),
+    ).toBe(12_000_000_000)
+  })
+
+  it("computes p95 per tool call (uniform ⇒ exact)", async () => {
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        toolSpan(71, t16, "search", { durationMs: 3_000 }),
+        toolSpan(72, t16, "search", { durationMs: 3_000 }),
+        toolSpan(73, t16, "search", { durationMs: 3_000 }),
+      ]),
+    )
+    const p95 = await runCh(
+      reader.valueInWindow({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        from: t16,
+        to: t17,
+        target: spanTarget(
+          { kind: "p95", field: "duration" },
+          {
+            ...EXECUTE_TOOL,
+            toolName: [{ op: "eq", value: "search" }],
+          },
+        ),
+      }),
+    )
+    expect(p95).toBe(3_000_000_000)
+  })
+
+  it("buckets tool calls newest-first over the spans stream", async () => {
+    await Effect.runPromise(
+      insertJsonEachRow(ch.client, "spans", [
+        toolSpan(61, new Date(t15.getTime() + 15 * 60 * 1000), "search"),
+        toolSpan(62, new Date(t15.getTime() + 45 * 60 * 1000), "search"),
+      ]),
+    )
+    // [15:00, 16:00) into 2×30-min buckets aligned to 16:00 (newest-first):
+    //   idx 0 = (15:30, 16:00) → the 15:45 call → 1
+    //   idx 1 = (15:00, 15:30] → the 15:15 call → 1
+    const counts = await runCh(
+      reader.seriesPerBucket({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        from: t15,
+        to: t16,
+        bucketMs: 30 * 60 * 1000,
+        target: spanTarget({ kind: "count" }, { ...EXECUTE_TOOL, toolName: [{ op: "eq", value: "search" }] }),
+      }),
+    )
+    expect(counts).toEqual([1, 1])
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/metric-series-reader.ts
@@ -14,6 +14,7 @@ import {
 } from "@domain/shared"
 import { parseSearchQuery } from "@domain/spans"
 import { Effect, Layer } from "effect"
+import { buildSpanFilterClauses } from "../registries/span-fields.ts"
 import { isActiveSearch, planSearch } from "./search-plan.ts"
 import { buildTraceFilterClauses, LIST_SELECT, resolvePercentileFilters } from "./trace-repository.ts"
 
@@ -39,6 +40,20 @@ const TRACE_METRIC_COLUMNS: MetricColumns = {
   isError: "error_count > 0",
 }
 
+// Spans are individual rows (one per span): error is the span's own OTEL status,
+// tokens come off the raw input/output columns (no per-trace `tokens_total` rollup).
+// Note: cost/tokens are ~0 on `execute_tool` spans — meaningful only when the
+// filter scopes to LLM spans; tool monitors use count/errorRate/duration.
+const SPAN_METRIC_COLUMNS: MetricColumns = {
+  duration: "duration_ns",
+  cost: "cost_total_microcents",
+  tokens: "tokens_input + tokens_output",
+  isError: "status_code = 2",
+}
+
+const metricColumnsFor = (stream: MetricSeriesWindowInput["target"]["stream"]): MetricColumns =>
+  stream === "spans" ? SPAN_METRIC_COLUMNS : TRACE_METRIC_COLUMNS
+
 /**
  * SQL aggregate applied over the per-entity grouped subquery. `count` makes this
  * reader an exact drop-in for the saved-search match reader it supersedes.
@@ -60,24 +75,48 @@ const metricAggregate = (metric: MonitorMetric, columns: MetricColumns): string 
   }
 }
 
+type InnerQuery = {
+  readonly sql: string
+  readonly params: Record<string, unknown>
+  readonly clickhouseSettings?: Record<string, string | number | boolean>
+}
+
+/**
+ * Per-span subquery for the `spans` stream: one row per span, windowed on the
+ * span's own `start_time` (plain WHERE — no aggregation), filtered by the row-local
+ * span predicate. The outer metric then aggregates these rows. Mirrors how
+ * tool-analytics aggregates `execute_tool` spans (no dedup — same convention).
+ */
+const buildSpanInnerQuery = (input: MetricSeriesWindowInput): InnerQuery => {
+  const { whereClauses, params: filterParams } = buildSpanFilterClauses(input.target.filterSet)
+  const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+  return {
+    sql: `SELECT span_id, start_time, status_code, duration_ns, cost_total_microcents, tokens_input, tokens_output
+          FROM spans
+          WHERE organization_id = {organizationId:String}
+            AND project_id = {projectId:String}
+            AND start_time >= toDateTime64({windowFrom:String}, 9, 'UTC')
+            AND start_time < toDateTime64({windowTo:String}, 9, 'UTC')
+            ${extraWhere}`,
+    params: {
+      organizationId: input.organizationId as string,
+      projectId: input.projectId as string,
+      windowFrom: toClickHouseDateTime64(input.from),
+      windowTo: toClickHouseDateTime64(input.to),
+      ...filterParams,
+    },
+  }
+}
+
 /**
  * The grouped per-trace subquery the metric queries wrap, for the `traces`
  * stream. The window is a `HAVING` on the aggregated `start_time` (same as the
  * trace list/count), combined with the target's filters + semantic query.
- * Lifted from the saved-search match reader; spans/sessions add sibling branches.
+ * Lifted from the saved-search match reader; `spans` is a sibling branch, sessions later.
  */
-const buildInnerQuery = (
-  input: MetricSeriesWindowInput,
-): Effect.Effect<
-  {
-    readonly sql: string
-    readonly params: Record<string, unknown>
-    readonly clickhouseSettings?: Record<string, string | number | boolean>
-  },
-  RepositoryError,
-  ChSqlClient
-> =>
+const buildInnerQuery = (input: MetricSeriesWindowInput): Effect.Effect<InnerQuery, RepositoryError, ChSqlClient> =>
   Effect.gen(function* () {
+    if (input.target.stream === "spans") return buildSpanInnerQuery(input)
     if (input.target.stream !== "traces") {
       return yield* Effect.die(`MetricSeriesReader: stream '${input.target.stream}' not implemented yet`)
     }
@@ -128,7 +167,7 @@ const make = (): MetricSeriesReaderShape => ({
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const inner = yield* buildInnerQuery(input)
-      const aggregate = metricAggregate(input.target.metric, TRACE_METRIC_COLUMNS)
+      const aggregate = metricAggregate(input.target.metric, metricColumnsFor(input.target.stream))
       return yield* chSqlClient
         .query(async (client) => {
           const result = await client.query({
@@ -200,7 +239,7 @@ const make = (): MetricSeriesReaderShape => ({
     Effect.gen(function* () {
       const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
       const inner = yield* buildInnerQuery(input)
-      const aggregate = metricAggregate(input.target.metric, TRACE_METRIC_COLUMNS)
+      const aggregate = metricAggregate(input.target.metric, metricColumnsFor(input.target.stream))
       const bucketCount = Math.max(0, Math.floor((input.to.getTime() - input.from.getTime()) / input.bucketMs))
       // Bucket each matching trace by how far its `start_time` sits before `to`,
       // in `bucketNs` (= bucketMs) steps — index 0 is the bucket ending at `to`.


### PR DESCRIPTION
> **Stacked on #3556 → #3555.** Merge those first; base retargets to `development` as they land.

## What

Adds the `spans` target stream to `MetricSeriesReader`, so a monitor can measure **individual tool calls** rather than the traces that contain them — the per-call metric source for **tool monitors**.

- New span filter registry (`operation`, `tool_name`, `model`/`provider`, `user`/`session`/`trace`, `tags`, `duration`, `cost`, `tokens`) drives a row-local `WHERE` via the shared `buildClickHouseWhere`.
- The reader's spans branch windows on each span's own `start_time` (plain `WHERE`, no GROUP BY) and aggregates `count` / `errorRate` (`status_code = 2`) / `avg`|`p95`|`sum` of `duration`|`cost`|`tokens`.
- Matches how `tool-analytics-repository` aggregates `execute_tool` spans (no `span_id` dedup — same convention).

## Why

Tool monitors need per-call metrics (error rate / p95 latency of `search`'s calls), which are span-level — the trace `tools` filter only selects *traces containing* a tool. This is **additive and behavior-preserving**: the traces path is byte-for-byte unchanged, and nothing constructs a `spans` target yet.

## Verification

- `@platform/db-clickhouse` typecheck clean; reader test green (17/17).
- New chdb tests: tool-name scoping, `errorRate`/`avg`/`sum`, `p95` (uniform → exact), newest-first bucketing over the spans stream.
- `knip` + `format` clean (`SPAN_FIELD_REGISTRY` kept module-private until the UI PR needs it).
- Adversarial review: **Approve with minor changes** — confirmed all spans columns exist, `status_code = 2` matches tool-analytics' error predicate, no-dedup matches convention, `gtePercentile` on spans fails as an isolated defect (never mis-filters), traces path untouched, switch exhaustive, test ids collision-safe. Acted on its notes: corrected the `duration_ns` ALIAS comment, documented that `cost`/`tokens` are inert on `execute_tool` spans, and noted the intentional `gtePercentile` gap.

## Follow-ups

- Target-on-monitor model (`{stream, filterSet, metric}` on the monitor) + create/update wiring.
- In-context tool & user monitor UI + dashboard Target column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)