### PR TITLE
feat(monitors): unified alert-kind vocabulary (event.*/metric.*), legacy marked

### DIFF
--- a/apps/web/src/domains/alerts/incident-markers.ts
+++ b/apps/web/src/domains/alerts/incident-markers.ts
@@ -18,6 +18,10 @@ const KIND_TOP_SYMBOL: Record<AlertIncidentKind, TopSymbol> = {
   "savedSearch.match": { shape: "triangle", size: 9 },
   "savedSearch.threshold": { shape: "diamond", size: 10 },
   "savedSearch.escalating": { shape: "rect", size: 7 },
+  // Unified query-time kinds — same glyphs as the saved-search analogues they supersede.
+  "event.matched": { shape: "triangle", size: 9 },
+  "metric.threshold": { shape: "diamond", size: 10 },
+  "metric.escalating": { shape: "rect", size: 7 },
 }
 
 export const SEVERITY_LABELS: Record<AlertSeverity, string> = {

--- a/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/EmailTemplate.tsx
@@ -39,6 +39,11 @@ const ALERT_KIND_TO_SUBTITLE: Record<AlertIncidentKind, string> = {
     "We notified everyone watching this project — traces matching the search were detected above the configured threshold.",
   "savedSearch.escalating":
     "We notified everyone watching this project — traces matching the search stayed above the threshold for the configured window.",
+  "event.matched": "We notified everyone watching this project — a new matching event was detected.",
+  "metric.threshold":
+    "We notified everyone watching this project — a monitored metric crossed its configured threshold.",
+  "metric.escalating":
+    "We notified everyone watching this project — a monitored metric stayed over its threshold for the configured window.",
 }
 
 interface IncidentEventEmailProps {

--- a/packages/domain/monitors/src/use-cases/create-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor-alert.ts
@@ -16,7 +16,10 @@ import type { MonitorAlert } from "../entities/monitor.ts"
 import { AlertConditionMismatchError } from "../errors.ts"
 
 const USER_CREATABLE = new Set<AlertIncidentKind>(USER_CREATABLE_ALERT_KINDS)
-/** Kinds that carry no `condition`; their condition stays `null`. */
+/**
+ * Kinds that carry no `condition`; their condition stays `null`.
+ * TODO(target-on-monitor): add `event.matched` here when unified kinds become user-creatable.
+ */
 const KINDS_WITHOUT_CONDITION = new Set<AlertIncidentKind>(["issue.new", "issue.regressed", "savedSearch.match"])
 
 const conditionMatchesKind = (condition: AlertIncidentCondition | null, kind: AlertIncidentKind): boolean =>

--- a/packages/domain/monitors/src/use-cases/resolve-monitor-alerts-for-source-event.ts
+++ b/packages/domain/monitors/src/use-cases/resolve-monitor-alerts-for-source-event.ts
@@ -21,10 +21,14 @@ export const resolveMonitorAlertsForSourceEventUseCase = (
 ): Effect.Effect<readonly MonitorAlert[], RepositoryError, SqlClient | MonitorRepository> =>
   Effect.gen(function* () {
     const repository = yield* MonitorRepository
+    const sourceType = ALERT_INCIDENT_KIND_SOURCE_TYPE[input.kind]
+    // Unified `event.*`/`metric.*` kinds carry their target on the monitor, not a
+    // `(sourceType, sourceId)` — they're never resolved via the source-event path.
+    if (sourceType === undefined) return []
     return yield* repository.listActiveAlertsForSourceEvent({
       projectId: input.projectId,
       kind: input.kind,
-      sourceType: ALERT_INCIDENT_KIND_SOURCE_TYPE[input.kind],
+      sourceType,
       sourceId: input.sourceId,
     })
   })

--- a/packages/domain/shared/src/alert-incident-condition.ts
+++ b/packages/domain/shared/src/alert-incident-condition.ts
@@ -90,10 +90,44 @@ export const monitorMetricSchema = z.discriminatedUnion("kind", [
 ])
 export type MonitorMetric = z.infer<typeof monitorMetricSchema>
 
-/** Per-kind alert config; `null` for kinds with no parameters (`issue.new`, `issue.regressed`, `savedSearch.match`). */
+/**
+ * Threshold for the UNIFIED `metric.*` kinds. Same modes as the legacy
+ * {@link alertCountThresholdSchema}, but `absolute` takes a float `value` (not an
+ * int `count`) — error-rate (0.1), p95 latency, cost, etc. aren't whole numbers.
+ */
+export const alertMetricThresholdSchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("absolute"), value: z.number().positive() }),
+  z.object({ mode: z.literal("multiplier"), factor: z.number().positive(), baseline: alertBaselineSchema }),
+  z.object({ mode: z.literal("expected"), sensitivity: escalationSensitivitySchema.optional() }),
+])
+export type AlertMetricThreshold = z.infer<typeof alertMetricThresholdSchema>
+
+/** UNIFIED point alert: the monitor's metric crosses a threshold. (Target lives on the monitor.) */
+export const alertIncidentMetricThresholdConditionSchema = z.object({
+  kind: z.literal("metric.threshold"),
+  metric: monitorMetricSchema,
+  threshold: alertMetricThresholdSchema,
+})
+export type AlertIncidentMetricThresholdCondition = z.infer<typeof alertIncidentMetricThresholdConditionSchema>
+
+/** UNIFIED sustained alert: the metric stays over threshold across `window` (see saved-search escalating semantics). */
+export const alertIncidentMetricEscalatingConditionSchema = z.object({
+  kind: z.literal("metric.escalating"),
+  metric: monitorMetricSchema,
+  threshold: alertMetricThresholdSchema,
+  window: z.object({ minutes: z.number().int().min(5) }),
+})
+export type AlertIncidentMetricEscalatingCondition = z.infer<typeof alertIncidentMetricEscalatingConditionSchema>
+
+/**
+ * Per-kind alert config; `null` for kinds with no parameters (`issue.new`,
+ * `issue.regressed`, `savedSearch.match`, `event.matched`).
+ */
 export const alertIncidentConditionSchema = z.discriminatedUnion("kind", [
   alertIncidentSavedSearchThresholdConditionSchema,
   alertIncidentSavedSearchEscalatingConditionSchema,
   alertIncidentIssueEscalatingConditionSchema,
+  alertIncidentMetricThresholdConditionSchema,
+  alertIncidentMetricEscalatingConditionSchema,
 ])
 export type AlertIncidentCondition = z.infer<typeof alertIncidentConditionSchema>

--- a/packages/domain/shared/src/alert-incident-kinds.test.ts
+++ b/packages/domain/shared/src/alert-incident-kinds.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import { alertIncidentConditionSchema } from "./alert-incident-condition.ts"
+import {
+  ALERT_INCIDENT_KIND_LABEL,
+  ALERT_INCIDENT_KIND_LIFECYCLE,
+  ALERT_INCIDENT_KIND_SOURCE_TYPE,
+  ALERT_INCIDENT_KINDS,
+  SEVERITY_FOR_KIND,
+} from "./alert-incident-kinds.ts"
+
+const UNIFIED_KINDS = ["event.matched", "metric.threshold", "metric.escalating"] as const
+
+describe("alert incident kinds", () => {
+  it("includes the unified query-time kinds", () => {
+    for (const kind of UNIFIED_KINDS) expect(ALERT_INCIDENT_KINDS).toContain(kind)
+  })
+
+  it("covers every kind in the total maps", () => {
+    for (const kind of ALERT_INCIDENT_KINDS) {
+      expect(ALERT_INCIDENT_KIND_LIFECYCLE[kind]).toBeDefined()
+      expect(ALERT_INCIDENT_KIND_LABEL[kind]).toBeTruthy()
+      expect(SEVERITY_FOR_KIND[kind]).toBeDefined()
+    }
+  })
+
+  it("omits a source type for unified kinds (target lives on the monitor) but keeps it for legacy kinds", () => {
+    expect(ALERT_INCIDENT_KIND_SOURCE_TYPE["metric.threshold"]).toBeUndefined()
+    expect(ALERT_INCIDENT_KIND_SOURCE_TYPE["metric.escalating"]).toBeUndefined()
+    expect(ALERT_INCIDENT_KIND_SOURCE_TYPE["event.matched"]).toBeUndefined()
+    expect(ALERT_INCIDENT_KIND_SOURCE_TYPE["savedSearch.threshold"]).toBe("savedSearch")
+    expect(ALERT_INCIDENT_KIND_SOURCE_TYPE["issue.escalating"]).toBe("issue")
+  })
+
+  it("classifies unified escalating as sustained, threshold/match as point", () => {
+    expect(ALERT_INCIDENT_KIND_LIFECYCLE["metric.escalating"]).toBe("sustained")
+    expect(ALERT_INCIDENT_KIND_LIFECYCLE["metric.threshold"]).toBe("point")
+    expect(ALERT_INCIDENT_KIND_LIFECYCLE["event.matched"]).toBe("point")
+  })
+})
+
+describe("unified metric conditions", () => {
+  it("accepts a float absolute threshold (error rate) for metric.threshold", () => {
+    const parsed = alertIncidentConditionSchema.parse({
+      kind: "metric.threshold",
+      metric: { kind: "errorRate" },
+      threshold: { mode: "absolute", value: 0.1 },
+    })
+    expect(parsed.kind).toBe("metric.threshold")
+  })
+
+  it("accepts an aggregate metric + expected mode + window for metric.escalating", () => {
+    const parsed = alertIncidentConditionSchema.parse({
+      kind: "metric.escalating",
+      metric: { kind: "p95", field: "duration" },
+      threshold: { mode: "expected" },
+      window: { minutes: 30 },
+    })
+    expect(parsed.kind).toBe("metric.escalating")
+  })
+
+  it("rejects a metric.escalating with a sub-5-minute window", () => {
+    const result = alertIncidentConditionSchema.safeParse({
+      kind: "metric.escalating",
+      metric: { kind: "count" },
+      threshold: { mode: "absolute", value: 3 },
+      window: { minutes: 1 },
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/domain/shared/src/alert-incident-kinds.ts
+++ b/packages/domain/shared/src/alert-incident-kinds.ts
@@ -11,18 +11,33 @@ export type AlertIncidentSourceType = z.infer<typeof alertIncidentSourceTypeSche
  * on the alerts package.
  */
 export const ALERT_INCIDENT_KINDS = [
+  // ── LEGACY · issue.* — system, event-driven (fired from @domain/issues). Folded into
+  //    the unified model with the signals migration; not user-creatable.
   "issue.new",
   "issue.regressed",
   "issue.escalating",
+  // ── LEGACY · savedSearch.* — saved-search-only, target carried on the alert's
+  //    (sourceType, sourceId). SUPERSEDED by the unified kinds below; kept only until
+  //    existing saved-search monitors are migrated off them (then removed — breaking SDK).
   "savedSearch.match",
   "savedSearch.threshold",
   "savedSearch.escalating",
+  // ── UNIFIED · query-time kinds. Target lives on the MONITOR ({stream, filterSet, metric}),
+  //    not on the alert source. Used by tool / user / raw-stream monitors.
+  "event.matched", // ← supersedes savedSearch.match
+  "metric.threshold", // ← supersedes savedSearch.threshold
+  "metric.escalating", // ← supersedes savedSearch.escalating
 ] as const
 export const alertIncidentKindSchema = z.enum(ALERT_INCIDENT_KINDS)
 export type AlertIncidentKind = z.infer<typeof alertIncidentKindSchema>
 
-/** Each kind has exactly one legal source type; create/update reject mismatches. */
-export const ALERT_INCIDENT_KIND_SOURCE_TYPE: Record<AlertIncidentKind, AlertIncidentSourceType> = {
+/**
+ * Legal source type for the LEGACY source-based kinds; create/update reject mismatches.
+ * UNIFIED kinds (`event.matched` / `metric.*`) carry their target on the monitor — not a
+ * `(sourceType, sourceId)` on the alert — so they are intentionally absent (lookups return
+ * `undefined`, and callers treat that as "target lives on the monitor").
+ */
+export const ALERT_INCIDENT_KIND_SOURCE_TYPE: Partial<Record<AlertIncidentKind, AlertIncidentSourceType>> = {
   "issue.new": "issue",
   "issue.regressed": "issue",
   "issue.escalating": "issue",
@@ -39,6 +54,9 @@ export const ALERT_INCIDENT_KIND_LIFECYCLE: Record<AlertIncidentKind, "point" | 
   "savedSearch.match": "point",
   "savedSearch.threshold": "point",
   "savedSearch.escalating": "sustained",
+  "event.matched": "point",
+  "metric.threshold": "point",
+  "metric.escalating": "sustained",
 }
 
 /**
@@ -53,9 +71,16 @@ export const ALERT_INCIDENT_KIND_LABEL: Record<AlertIncidentKind, string> = {
   "savedSearch.match": "Search match",
   "savedSearch.threshold": "Search threshold",
   "savedSearch.escalating": "Search escalating",
+  "event.matched": "New match",
+  "metric.threshold": "Metric threshold",
+  "metric.escalating": "Metric escalating",
 }
 
-/** Kinds users may put on their own monitors; `issue.*` are system-only. Create/update enforce this. */
+/**
+ * Kinds users may put on their own monitors; `issue.*` are system-only. Create/update enforce this.
+ * Still the LEGACY saved-search kinds — the unified `event.matched` / `metric.*` kinds become
+ * user-creatable once target-on-monitor creation lands (they take a monitor target, not a source).
+ */
 export const USER_CREATABLE_ALERT_KINDS = [
   "savedSearch.match",
   "savedSearch.threshold",
@@ -105,4 +130,7 @@ export const SEVERITY_FOR_KIND: Record<AlertIncidentKind, AlertSeverity> = {
   "savedSearch.match": "low",
   "savedSearch.threshold": "medium",
   "savedSearch.escalating": "high",
+  "event.matched": "low",
+  "metric.threshold": "medium",
+  "metric.escalating": "high",
 }


### PR DESCRIPTION
> **Stacked on #3557 → #3556 → #3555.** Merge those first; base retargets as they land.

## What

Introduces the **target-agnostic alert kinds** for the unified monitor model — `event.matched`, `metric.threshold`, `metric.escalating` — alongside the existing kinds, which are now **clearly marked legacy** in code (per request):

- `savedSearch.*` (target on the alert's `source`) → superseded by the named unified kind; kept until existing saved-search monitors are migrated off them (removal is a later, **breaking-SDK** change).
- `issue.*` (system, event-driven) → folds in with the signals migration.

Unified kinds carry their target on the **monitor** (`{stream, filterSet, metric}`), so they have no `(sourceType, sourceId)`:
- `ALERT_INCIDENT_KIND_SOURCE_TYPE` is now `Partial` (absent for unified kinds); the source-event resolver returns `[]` for them.
- New `metric.*` conditions get a **float-capable** absolute threshold (error-rate `0.1`, p95 latency, cost — not integers), separate from the legacy count-only saved-search threshold.

## Why

This is the alert vocabulary the in-context tool/user monitors will use. It's the approved **additive** step toward the unified model: the only breaking part (removing `savedSearch.*` + SDK regen) is deferred to a later, deliberately-scheduled migration. Following the repo's existing pattern of clearly-marked "wired in a later milestone" scaffolding.

## Why it's safe

Strictly additive and behavior-preserving — **no existing kind/condition/severity/label value changed**, and nothing constructs a unified-kind monitor yet. The `Partial` relaxation is provably safe: the `undefined` branch is reachable only by unified kinds (never by legacy `issue.*`/`savedSearch.*`), so no legacy source-type check is disabled. All downstream formatters (human-readable alert, Slack/email templates, web incident markers) degrade to safe fallbacks for the new kinds.

## Verification

- Typecheck clean across `@domain/shared`, `@domain/monitors`, `@domain/alerts`, `@domain/notifications`, `@domain/integrations`, `@app/api`, `@app/web`.
- New shared tests (93 pass): kind-map completeness/consistency, source-type omission for unified kinds, float-absolute threshold accepted, aggregate-metric + expected + window accepted, sub-5-min window rejected.
- `knip` + `format` clean.
- Adversarial review: **Approve** — verified additivity (no legacy value altered), all 11 `SOURCE_TYPE` consumers handle the `Partial` correctly, discriminated union stays valid, formatters safe-fallback. Acted on its note: added a `TODO(target-on-monitor)` so `event.matched` gets added to `KINDS_WITHOUT_CONDITION` when creation lands.

## Follow-ups

- Target-on-monitor schema/entity/repository + evaluator-reads-target (uses these kinds) + saved-search fold-in equivalence.
- In-context tool & user monitor UI + dashboard Target column.
- (Later, breaking) migrate saved-search monitors off `savedSearch.*` + regen SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)