### PR TITLE
feat(monitors): unified metric-alert evaluator (metric.threshold/escalating)

### DIFF
--- a/packages/domain/monitors/src/index.ts
+++ b/packages/domain/monitors/src/index.ts
@@ -66,6 +66,14 @@ export { buildMonitorAlert } from "./use-cases/create-monitor-alert.ts"
 export type { DeleteMonitorError, DeleteMonitorInput } from "./use-cases/delete-monitor.ts"
 export { deleteMonitorUseCase } from "./use-cases/delete-monitor.ts"
 export type {
+  EvaluateMetricAlertError,
+  EvaluateMetricAlertInput,
+  EvaluateMetricEscalatingAlertInput,
+  MetricAlertEvaluation,
+  MetricEscalatingEvaluation,
+} from "./use-cases/evaluate-metric-alert.ts"
+export { evaluateMetricAlert, evaluateMetricEscalatingAlert } from "./use-cases/evaluate-metric-alert.ts"
+export type {
   EvaluateSavedSearchAlertError,
   EvaluateSavedSearchAlertInput,
   SavedSearchEscalatingEvaluation,

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
@@ -1,0 +1,116 @@
+import { ChSqlClient, OrganizationId, ProjectId } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MetricSeriesTarget } from "../ports/metric-series-reader.ts"
+import { createFakeMetricSeriesReader } from "../testing/fake-metric-series-reader.ts"
+import { evaluateMetricAlert, evaluateMetricEscalatingAlert } from "./evaluate-metric-alert.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const now = new Date("2026-06-01T12:00:00.000Z")
+const minutesAgo = (m: number) => new Date(now.getTime() - m * 60 * 1000)
+
+// The fake reader counts seeded event times per window/bucket regardless of metric
+// kind — so it exercises the threshold/window math; per-metric aggregation is the
+// reader's job (covered by the platform chdb test). The metric kind here still
+// drives the accumulating-vs-intensive normalization branch under test.
+const target = (metric: MetricSeriesTarget["metric"]): MetricSeriesTarget => ({
+  stream: "spans",
+  filterSet: {},
+  query: null,
+  metric,
+})
+
+const runThreshold = (
+  events: readonly Date[],
+  t: MetricSeriesTarget,
+  threshold: Parameters<typeof evaluateMetricAlert>[0]["condition"]["threshold"],
+) =>
+  Effect.runPromise(
+    evaluateMetricAlert({
+      organizationId,
+      projectId,
+      target: t,
+      condition: { kind: "metric.threshold", metric: t.metric, threshold },
+      now,
+    }).pipe(
+      Effect.provide(createFakeMetricSeriesReader(events).layer),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    ),
+  )
+
+describe("evaluateMetricAlert (metric.threshold)", () => {
+  it("absolute mode fires when the value meets the float threshold", async () => {
+    const events = [minutesAgo(1), minutesAgo(2), minutesAgo(3)] // 3 in the 5-min window
+    const met = await runThreshold(events, target({ kind: "count" }), { mode: "absolute", value: 2 })
+    expect(met.value).toBe(3)
+    expect(met.threshold).toBe(2)
+    expect(met.isMet).toBe(true)
+  })
+
+  it("absolute mode does not fire below the threshold", async () => {
+    const events = [minutesAgo(1), minutesAgo(2), minutesAgo(3)]
+    const notMet = await runThreshold(events, target({ kind: "count" }), { mode: "absolute", value: 5 })
+    expect(notMet.isMet).toBe(false)
+  })
+
+  it("multiplier normalizes the baseline for accumulating metrics but not intensive ones", async () => {
+    // 2 events in the last 5 min; 12 in the last hour (baseline window). The 10 older
+    // events sit strictly before the 5-min boundary (6 min ago onward).
+    const events = [minutesAgo(1), minutesAgo(2), ...[6, 10, 15, 20, 25, 30, 35, 40, 45, 50].map((m) => minutesAgo(m))]
+    const baseline = { kind: "average" as const, lookback: { unit: "hours" as const, hours: 1 } }
+
+    // count (accumulating): threshold = 1 × 12 × (5min / 60min) = 1 → value 2 ≥ 1 → fires.
+    const countEval = await runThreshold(events, target({ kind: "count" }), { mode: "multiplier", factor: 1, baseline })
+    expect(countEval.baselineValue).toBe(12)
+    expect(countEval.threshold).toBeCloseTo(1)
+    expect(countEval.isMet).toBe(true)
+
+    // avg (intensive): threshold = 1 × 12 (no window scaling) → value 2 < 12 → does not fire.
+    const avgEval = await runThreshold(events, target({ kind: "avg", field: "duration" }), {
+      mode: "multiplier",
+      factor: 1,
+      baseline,
+    })
+    expect(avgEval.threshold).toBe(12)
+    expect(avgEval.isMet).toBe(false)
+  })
+})
+
+describe("evaluateMetricEscalatingAlert (metric.escalating)", () => {
+  const run = (
+    events: readonly Date[],
+    t: MetricSeriesTarget,
+    threshold: Parameters<typeof evaluateMetricEscalatingAlert>[0]["condition"]["threshold"],
+  ) =>
+    Effect.runPromise(
+      evaluateMetricEscalatingAlert({
+        organizationId,
+        projectId,
+        target: t,
+        condition: { kind: "metric.escalating", metric: t.metric, threshold, window: { minutes: 10 } },
+        now,
+      }).pipe(
+        Effect.provide(createFakeMetricSeriesReader(events).layer),
+        Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+      ),
+    )
+
+  it("tiles a 10-min window into 1-min buckets and scales an accumulating absolute threshold per bucket", async () => {
+    const events = [minutesAgo(1), minutesAgo(4), minutesAgo(7)]
+    const evalResult = await run(events, target({ kind: "count" }), { mode: "absolute", value: 10 })
+    expect(evalResult.bucketMs).toBe(60 * 1000)
+    expect(evalResult.bucketValues).toHaveLength(10)
+    // count is accumulating: per-bucket = 10 × (1min / 10min) = 1.
+    expect(evalResult.perBucketThreshold).toBeCloseTo(1)
+  })
+
+  it("uses an intensive absolute threshold per bucket as-is", async () => {
+    const evalResult = await run([minutesAgo(1)], target({ kind: "p95", field: "duration" }), {
+      mode: "absolute",
+      value: 3,
+    })
+    expect(evalResult.perBucketThreshold).toBe(3)
+  })
+})

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
@@ -1,0 +1,191 @@
+import {
+  DEFAULT_ESCALATION_SENSITIVITY_K,
+  MIN_SEASONAL_SAMPLES,
+  SEASONAL_HISTORY_WEEKS,
+  seasonalAnomalyThreshold,
+} from "@domain/issues"
+import type {
+  AlertIncidentMetricEscalatingCondition,
+  AlertIncidentMetricThresholdCondition,
+  AlertMetricThreshold,
+  ChSqlClient,
+  MonitorMetric,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { pickEscalatingBucketMs, SAVED_SEARCH_CURRENT_WINDOW_MS } from "../constants.ts"
+import { MetricSeriesReader, type MetricSeriesTarget } from "../ports/metric-series-reader.ts"
+import { baselineWindow, mean, sampleStddev, WEEK_MS } from "./evaluate-saved-search-alert.ts"
+
+/**
+ * `count`/`sum` accumulate over a window, so a `multiplier` baseline (and a
+ * windowed absolute) must be normalised to the measurement window; `avg`/`p95`/
+ * `errorRate` are already intensive (a rate/level), so they compare directly.
+ */
+const isAccumulating = (metric: MonitorMetric): boolean => metric.kind === "count" || metric.kind === "sum"
+
+export interface EvaluateMetricAlertInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  /** The monitor's resolved target — its `metric` is what gets measured. */
+  readonly target: MetricSeriesTarget
+  readonly condition: AlertIncidentMetricThresholdCondition
+  readonly now: Date
+}
+
+export type EvaluateMetricAlertError = RepositoryError
+
+/** Verdict + the numbers the state machine snapshots onto the incident. */
+export interface MetricAlertEvaluation {
+  readonly isMet: boolean
+  readonly value: number
+  readonly threshold: number
+  /** Earliest matching-event time in the window; backs `startedAt` backtracking. `null` when empty. */
+  readonly firstEventInWindow: Date | null
+  /** Present only for multiplier mode. */
+  readonly baselineValue?: number
+}
+
+const seasonalThreshold = (
+  historical: readonly number[],
+  threshold: Extract<AlertMetricThreshold, { mode: "expected" }>,
+): number => {
+  const sensitivity = threshold.sensitivity ?? DEFAULT_ESCALATION_SENSITIVITY_K
+  const expected = mean(historical)
+  // Widen the band when the sample is thin (mirrors the seasonal detector).
+  const kAdj = historical.length < MIN_SEASONAL_SAMPLES ? sensitivity + 1 : sensitivity
+  return seasonalAnomalyThreshold(expected, sampleStddev(historical, expected), kAdj)
+}
+
+/**
+ * Evaluate one `metric.threshold` alert at `now` over the monitor's target
+ * metric. Pure modulo the `MetricSeriesReader` IO. Mirrors the saved-search
+ * threshold evaluator, but the metric is the target's (not a hardcoded count)
+ * and the absolute threshold is a float `value` (not an int `count`).
+ */
+export const evaluateMetricAlert = (
+  input: EvaluateMetricAlertInput,
+): Effect.Effect<MetricAlertEvaluation, EvaluateMetricAlertError, MetricSeriesReader | ChSqlClient> =>
+  Effect.gen(function* () {
+    const reader = yield* MetricSeriesReader
+    const { organizationId, projectId, target, condition, now } = input
+    const valueIn = (from: Date, to: Date) => reader.valueInWindow({ organizationId, projectId, target, from, to })
+
+    const accumulating = isAccumulating(target.metric)
+    const windowMs = SAVED_SEARCH_CURRENT_WINDOW_MS
+    const from = new Date(now.getTime() - windowMs)
+    const value = yield* valueIn(from, now)
+
+    const threshold = condition.threshold
+    let thresholdValue: number
+    let baselineValue: number | undefined
+    let isMet: boolean
+    if (threshold.mode === "absolute") {
+      thresholdValue = threshold.value
+      isMet = value >= thresholdValue
+    } else if (threshold.mode === "multiplier") {
+      const window = baselineWindow(threshold.baseline, now)
+      baselineValue = yield* valueIn(window.from, window.to)
+      // Accumulating metrics need the baseline rescaled to the current window; intensive metrics don't.
+      const scale = accumulating ? windowMs / window.lengthMs : 1
+      thresholdValue = threshold.factor * baselineValue * scale
+      isMet = value > 0 && value >= thresholdValue
+    } else {
+      const historical = yield* Effect.all(
+        Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
+          const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
+          return valueIn(new Date(historyTo.getTime() - windowMs), historyTo)
+        }),
+        { concurrency: "unbounded" },
+      )
+      thresholdValue = seasonalThreshold(historical, threshold)
+      isMet = value > 0 && value > thresholdValue
+    }
+
+    // Only the firing branch backtracks `startedAt`; gate on `isMet`, not the metric
+    // value (an intensive metric like avg/errorRate can be 0 with real activity).
+    const firstEventInWindow = isMet
+      ? yield* reader.firstEventAt({ organizationId, projectId, target, from, to: now })
+      : null
+
+    return {
+      isMet,
+      value,
+      threshold: thresholdValue,
+      firstEventInWindow,
+      ...(baselineValue !== undefined ? { baselineValue } : {}),
+    } satisfies MetricAlertEvaluation
+  }).pipe(Effect.withSpan("monitors.evaluateMetricAlert"))
+
+/** The numbers the `metric.escalating` sustained-gate state machine reads. */
+export interface MetricEscalatingEvaluation {
+  /** Per-bucket metric values over `[now - window, now]`, newest-first, zero-filled. */
+  readonly bucketValues: readonly number[]
+  readonly bucketMs: number
+  /** Threshold a single bucket must clear to "pass" (frozen onto `entrySignals` at open). */
+  readonly perBucketThreshold: number
+  readonly firstEventInWindow: Date | null
+  readonly baselineValue?: number
+}
+
+export interface EvaluateMetricEscalatingAlertInput extends Omit<EvaluateMetricAlertInput, "condition"> {
+  readonly condition: AlertIncidentMetricEscalatingCondition
+}
+
+/**
+ * Evaluate one `metric.escalating` alert at `now` over fixed-size buckets tiling
+ * `[now - window, now]`. The threshold is computed for a single bucket, so
+ * "sustained for the whole window" reduces to "(almost) every bucket clears the
+ * per-bucket threshold" (same state machine as saved-search escalating).
+ */
+export const evaluateMetricEscalatingAlert = (
+  input: EvaluateMetricEscalatingAlertInput,
+): Effect.Effect<MetricEscalatingEvaluation, EvaluateMetricAlertError, MetricSeriesReader | ChSqlClient> =>
+  Effect.gen(function* () {
+    const reader = yield* MetricSeriesReader
+    const { organizationId, projectId, target, condition, now } = input
+    const valueIn = (from: Date, to: Date) => reader.valueInWindow({ organizationId, projectId, target, from, to })
+
+    const accumulating = isAccumulating(target.metric)
+    const windowMs = condition.window.minutes * 60 * 1000
+    const bucketMs = pickEscalatingBucketMs(windowMs)
+    const from = new Date(now.getTime() - windowMs)
+    const bucketValues = yield* reader.seriesPerBucket({ organizationId, projectId, target, from, to: now, bucketMs })
+
+    const threshold = condition.threshold
+    let perBucketThreshold: number
+    let baselineValue: number | undefined
+    if (threshold.mode === "absolute") {
+      // Accumulating absolute thresholds are per-window totals → scale down to one bucket; intensive ones are per-bucket as-is.
+      perBucketThreshold = accumulating ? threshold.value * (bucketMs / windowMs) : threshold.value
+    } else if (threshold.mode === "multiplier") {
+      const baseline = baselineWindow(threshold.baseline, now)
+      baselineValue = yield* valueIn(baseline.from, baseline.to)
+      const scale = accumulating ? bucketMs / baseline.lengthMs : 1
+      perBucketThreshold = threshold.factor * baselineValue * scale
+    } else {
+      const historical = yield* Effect.all(
+        Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
+          const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
+          return valueIn(new Date(historyTo.getTime() - bucketMs), historyTo)
+        }),
+        { concurrency: "unbounded" },
+      )
+      perBucketThreshold = seasonalThreshold(historical, threshold)
+    }
+
+    // The open decision is downstream (state machine); always resolve the backtrace
+    // anchor. `firstEventAt` self-guards (returns null on no rows), so this is safe for
+    // intensive metrics where a zero bucket value doesn't imply zero activity.
+    const firstEventInWindow = yield* reader.firstEventAt({ organizationId, projectId, target, from, to: now })
+
+    return {
+      bucketValues,
+      bucketMs,
+      perBucketThreshold,
+      firstEventInWindow,
+      ...(baselineValue !== undefined ? { baselineValue } : {}),
+    } satisfies MetricEscalatingEvaluation
+  }).pipe(Effect.withSpan("monitors.evaluateMetricEscalatingAlert"))

--- a/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-saved-search-alert.ts
@@ -51,23 +51,25 @@ export interface EvaluateSavedSearchAlertInput {
 
 export type EvaluateSavedSearchAlertError = RepositoryError
 
-const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+// Exported for the unified `evaluate-metric-alert` evaluator, which shares the same
+// seasonal/baseline math (legacy logic here is unchanged — these were already private).
+export const WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 const durationToMs = (duration: AlertDuration): number =>
   duration.unit === "hours" ? duration.hours * 60 * 60 * 1000 : duration.days * 24 * 60 * 60 * 1000
 
-const mean = (values: readonly number[]): number =>
+export const mean = (values: readonly number[]): number =>
   values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
 
 /** Sample (n−1) standard deviation; `0` for fewer than two points. */
-const sampleStddev = (values: readonly number[], avg: number): number => {
+export const sampleStddev = (values: readonly number[], avg: number): number => {
   if (values.length < 2) return 0
   const variance = values.reduce((sum, value) => sum + (value - avg) ** 2, 0) / (values.length - 1)
   return Math.sqrt(variance)
 }
 
 /** `average` = trailing window of length `L`; `period` = the equal-length window just before it (yesterday / last week). */
-const baselineWindow = (baseline: AlertBaseline, now: Date): { from: Date; to: Date; lengthMs: number } => {
+export const baselineWindow = (baseline: AlertBaseline, now: Date): { from: Date; to: Date; lengthMs: number } => {
   const lengthMs = durationToMs(baseline.lookback)
   if (baseline.kind === "average") return { from: new Date(now.getTime() - lengthMs), to: now, lengthMs }
   return { from: new Date(now.getTime() - 2 * lengthMs), to: new Date(now.getTime() - lengthMs), lengthMs }


### PR DESCRIPTION
> **Stacked on #3560 → #3559 → #3558 → #3557 → #3556 → #3555.** Merge those first; base retargets as they land.

## What

A pure evaluator for the unified alert kinds:
- `evaluateMetricAlert` (`metric.threshold`, point)
- `evaluateMetricEscalatingAlert` (`metric.escalating`, sustained)

Both compute the verdict over a monitor's resolved target (`{stream, filterSet, query, metric}`) via the `MetricSeriesReader`. The computational core of unified-monitor firing.

## How

Mirrors the saved-search evaluator's window / baseline / seasonal math (helpers now exported and shared — **legacy logic unchanged**), with the unified generalizations:
- the measured metric is the target's (not a hardcoded count);
- the absolute threshold is a **float `value`** (not an int count);
- a `multiplier` baseline is normalized to the window **only for accumulating metrics** (`count`/`sum`); intensive metrics (`avg`/`p95`/`errorRate`) compare directly;
- `metric.threshold` uses a fixed 5-min current window for all modes (a current-window rate is the right semantics for a float metric — the evaluator is pure, taking target+condition+now).

## Why it's safe

Pure and isolated — **not yet wired** to a state machine/orchestrator (firing + incidents are the next PR). The only change to the legacy evaluator is adding `export` to four math helpers (`WEEK_MS`/`mean`/`sampleStddev`/`baselineWindow`); no behavior change.

## Verification

- `@domain/monitors` typecheck clean; 120 tests pass (115 + 5 new).
- New unit tests (fake reader): absolute fire/no-fire, multiplier normalization split (same data → count fires at threshold ≈1, avg doesn't at threshold 12), per-bucket escalating scaling (10×1-min buckets, accumulating scaled vs intensive as-is).
- `knip` + `format` clean.
- Adversarial review: **Approve with nits** — verified legacy untouched, the accumulating-vs-intensive split is the correct generalization, escalating per-bucket math matches legacy, window choice deliberate. Acted on its Minor (gate `firstEventInWindow` on firing/activity, not the metric value — an intensive metric can be 0 with activity) and the test-comment nit.

## Follow-ups

- Wire the evaluator into state machines + orchestrator + **incident model** (sourceless incidents + notifications) → tool/user monitors fire end-to-end.
- Unified-kind create path; in-context tool/user UI + dashboard Target column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)