### PR TITLE
feat(monitors): unified create path (target-on-monitor, sourceless alerts)

### DIFF
--- a/packages/domain/monitors/src/use-cases/create-monitor-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor-alert.test.ts
@@ -80,7 +80,11 @@ describe("buildMonitorAlert", () => {
       buildMonitorAlert(
         {
           kind: "metric.threshold",
-          condition: { kind: "metric.threshold", metric: { kind: "errorRate" }, threshold: { mode: "absolute", value: 0.1 } },
+          condition: {
+            kind: "metric.threshold",
+            metric: { kind: "errorRate" },
+            threshold: { mode: "absolute", value: 0.1 },
+          },
         },
         monitorId,
         at,

--- a/packages/domain/monitors/src/use-cases/create-monitor-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor-alert.test.ts
@@ -68,4 +68,44 @@ describe("buildMonitorAlert", () => {
     )
     expect(error._tag).toBe("AlertConditionMismatchError")
   })
+
+  it("builds a sourceless unified alert with no condition (event.matched)", async () => {
+    const alert = await Effect.runPromise(buildMonitorAlert({ kind: "event.matched" }, monitorId, at))
+    expect(alert).toMatchObject({ kind: "event.matched", severity: "low", condition: null })
+    expect(alert.source).toBeNull()
+  })
+
+  it("builds a sourceless unified metric alert with its condition", async () => {
+    const alert = await Effect.runPromise(
+      buildMonitorAlert(
+        {
+          kind: "metric.threshold",
+          condition: { kind: "metric.threshold", metric: { kind: "errorRate" }, threshold: { mode: "absolute", value: 0.1 } },
+        },
+        monitorId,
+        at,
+      ),
+    )
+    expect(alert.source).toBeNull()
+    expect(alert.condition?.kind).toBe("metric.threshold")
+  })
+
+  it("rejects a unified kind that carries a source", async () => {
+    const error = await Effect.runPromise(
+      buildMonitorAlert(
+        { kind: "metric.threshold", source: { type: "savedSearch", id: savedSearchId } },
+        monitorId,
+        at,
+      ).pipe(Effect.flip),
+    )
+    expect(error._tag).toBe("ValidationError")
+    expect((error as { field: string }).field).toBe("source")
+  })
+
+  it("rejects a unified metric kind with no condition", async () => {
+    const error = await Effect.runPromise(
+      buildMonitorAlert({ kind: "metric.threshold" }, monitorId, at).pipe(Effect.flip),
+    )
+    expect(error._tag).toBe("AlertConditionMismatchError")
+  })
 })

--- a/packages/domain/monitors/src/use-cases/create-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor-alert.ts
@@ -5,6 +5,7 @@ import {
   type AlertIncidentSourceType,
   type AlertSeverity,
   generateId,
+  KINDS_WITHOUT_CONDITION,
   MonitorAlertId,
   type MonitorId,
   SEVERITY_FOR_KIND,
@@ -16,19 +17,16 @@ import type { MonitorAlert } from "../entities/monitor.ts"
 import { AlertConditionMismatchError } from "../errors.ts"
 
 const USER_CREATABLE = new Set<AlertIncidentKind>(USER_CREATABLE_ALERT_KINDS)
-/**
- * Kinds that carry no `condition`; their condition stays `null`.
- * TODO(target-on-monitor): add `event.matched` here when unified kinds become user-creatable.
- */
-const KINDS_WITHOUT_CONDITION = new Set<AlertIncidentKind>(["issue.new", "issue.regressed", "savedSearch.match"])
+const NO_CONDITION = new Set<AlertIncidentKind>(KINDS_WITHOUT_CONDITION)
 
 const conditionMatchesKind = (condition: AlertIncidentCondition | null, kind: AlertIncidentKind): boolean =>
-  condition === null ? KINDS_WITHOUT_CONDITION.has(kind) : condition.kind === kind
+  condition === null ? NO_CONDITION.has(kind) : condition.kind === kind
 
 /** Fields a caller supplies to add an alert; `id` / `monitorId` / `createdAt` are generated. */
 export interface MonitorAlertInput {
   readonly kind: AlertIncidentKind
-  readonly source: { readonly type: AlertIncidentSourceType; readonly id: string | null }
+  /** Required for legacy source-based kinds; omitted/`null` for unified `event.*`/`metric.*` kinds (target on the monitor). */
+  readonly source?: { readonly type: AlertIncidentSourceType; readonly id: string | null } | null
   readonly condition?: AlertIncidentCondition | null
   readonly severity?: AlertSeverity
 }
@@ -40,8 +38,8 @@ export type BuildMonitorAlertError = ValidationError | AlertConditionMismatchErr
  * materialises it as a `MonitorAlert` for `monitorId`. Used by
  * `createMonitorUseCase` — alerts only come into existence with their monitor.
  * Severity defaults to the kind's canonical severity; condition defaults to
- * `null`. Every user-creatable kind watches a saved search, so `source.id`
- * (the saved search) is required.
+ * `null`. Legacy kinds watch a saved search (`source.id` required); unified
+ * `event.*`/`metric.*` kinds carry no source — their target lives on the monitor.
  */
 export const buildMonitorAlert = (
   input: MonitorAlertInput,
@@ -53,14 +51,24 @@ export const buildMonitorAlert = (
       return yield* new ValidationError({ field: "kind", message: `Alerts of kind "${input.kind}" cannot be created` })
     }
     const expectedSourceType = ALERT_INCIDENT_KIND_SOURCE_TYPE[input.kind]
-    if (input.source.type !== expectedSourceType) {
-      return yield* new ValidationError({
-        field: "source",
-        message: `Source type must be "${expectedSourceType}" for ${input.kind}`,
-      })
-    }
-    if (input.source.id === null) {
-      return yield* new ValidationError({ field: "source", message: "A saved search must be selected" })
+    let source: { type: AlertIncidentSourceType; id: string | null } | null
+    if (expectedSourceType === undefined) {
+      // Unified kind: the target lives on the monitor, so the alert carries no source.
+      if (input.source != null) {
+        return yield* new ValidationError({ field: "source", message: `Alerts of kind "${input.kind}" take no source` })
+      }
+      source = null
+    } else {
+      if (input.source?.type !== expectedSourceType) {
+        return yield* new ValidationError({
+          field: "source",
+          message: `Source type must be "${expectedSourceType}" for ${input.kind}`,
+        })
+      }
+      if (input.source.id === null) {
+        return yield* new ValidationError({ field: "source", message: "A saved search must be selected" })
+      }
+      source = { type: input.source.type, id: input.source.id }
     }
     const condition = input.condition ?? null
     if (!conditionMatchesKind(condition, input.kind)) {
@@ -70,7 +78,7 @@ export const buildMonitorAlert = (
       id: MonitorAlertId(generateId()),
       monitorId,
       kind: input.kind,
-      source: { type: input.source.type, id: input.source.id },
+      source,
       condition,
       severity: input.severity ?? SEVERITY_FOR_KIND[input.kind],
       createdAt: now,

--- a/packages/domain/monitors/src/use-cases/create-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor.test.ts
@@ -228,7 +228,11 @@ describe("createMonitorUseCase", () => {
           matchAlert,
           {
             kind: "metric.threshold",
-            condition: { kind: "metric.threshold", metric: { kind: "errorRate" }, threshold: { mode: "absolute", value: 0.1 } },
+            condition: {
+              kind: "metric.threshold",
+              metric: { kind: "errorRate" },
+              threshold: { mode: "absolute", value: 0.1 },
+            },
           },
         ],
       }),

--- a/packages/domain/monitors/src/use-cases/create-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor.test.ts
@@ -164,4 +164,89 @@ describe("createMonitorUseCase", () => {
     expect(error._tag).toBe("SavedSearchNotFoundError")
     expect(monitors).toHaveLength(0)
   })
+
+  const toolTarget = {
+    stream: "spans" as const,
+    filterSet: { operation: [{ op: "eq" as const, value: "execute_tool" }] },
+    query: null,
+    savedSearchId: null,
+    metric: { kind: "errorRate" as const },
+  }
+
+  it("creates a unified target-on-monitor with a sourceless alert", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    const monitor = await run(
+      createMonitorUseCase({
+        organizationId,
+        projectId,
+        name: "Tool errors",
+        target: toolTarget,
+        alerts: [
+          {
+            kind: "metric.threshold",
+            condition: {
+              kind: "metric.threshold",
+              metric: { kind: "errorRate" },
+              threshold: { mode: "absolute", value: 0.1 },
+            },
+          },
+        ],
+      }),
+      repo,
+    )
+    expect(monitor.target).toEqual(toolTarget)
+    expect(monitor.alerts[0]?.source).toBeNull()
+    expect(monitor.alerts[0]?.kind).toBe("metric.threshold")
+    expect(monitors).toHaveLength(1)
+  })
+
+  it("rejects a unified alert without a target", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    const error = await runError(
+      createMonitorUseCase({
+        organizationId,
+        projectId,
+        name: "No target",
+        alerts: [{ kind: "event.matched" }],
+      }),
+      repo,
+    )
+    expect(error._tag).toBe("ValidationError")
+    expect((error as { field: string }).field).toBe("target")
+    expect(monitors).toHaveLength(0)
+  })
+
+  it("rejects mixing a saved-search alert and a unified alert on one monitor", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    const error = await runError(
+      createMonitorUseCase({
+        organizationId,
+        projectId,
+        name: "Mixed kinds",
+        target: toolTarget,
+        alerts: [
+          matchAlert,
+          {
+            kind: "metric.threshold",
+            condition: { kind: "metric.threshold", metric: { kind: "errorRate" }, threshold: { mode: "absolute", value: 0.1 } },
+          },
+        ],
+      }),
+      repo,
+    )
+    expect(error._tag).toBe("ValidationError")
+    expect((error as { field: string }).field).toBe("alerts")
+    expect(monitors).toHaveLength(0)
+  })
+
+  it("rejects a legacy saved-search alert paired with a target", async () => {
+    const { repo, monitors } = createFakeMonitorRepository()
+    const error = await runError(
+      createMonitorUseCase({ organizationId, projectId, name: "Mixed", target: toolTarget, alerts: [matchAlert] }),
+      repo,
+    )
+    expect(error._tag).toBe("ValidationError")
+    expect((error as { field: string }).field).toBe("target")
+    expect(monitors).toHaveLength(0)
+  })
 })

--- a/packages/domain/monitors/src/use-cases/create-monitor.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor.ts
@@ -10,7 +10,7 @@ import {
   ValidationError,
 } from "@domain/shared"
 import { Effect } from "effect"
-import type { Monitor } from "../entities/monitor.ts"
+import type { Monitor, MonitorTarget } from "../entities/monitor.ts"
 import type { AlertConditionMismatchError } from "../errors.ts"
 import { MonitorRepository } from "../ports/monitor-repository.ts"
 import { assertMonitorableSavedSearch } from "./assert-monitorable-saved-search.ts"
@@ -25,6 +25,12 @@ export interface CreateMonitorInput {
   readonly description?: string
   /** At least one; each must be a user-creatable kind (see `buildMonitorAlert`). */
   readonly alerts: readonly MonitorAlertInput[]
+  /**
+   * The unified query-time target for `event.*`/`metric.*` alerts (tool/user/raw-stream
+   * monitors). Required when the alerts are unified kinds; omitted for legacy saved-search
+   * monitors (which carry their target on the alert source).
+   */
+  readonly target?: MonitorTarget
 }
 
 export type CreateMonitorError =
@@ -63,6 +69,24 @@ export const createMonitorUseCase = (
           buildMonitorAlert(alertInput, monitorId, now),
         )
 
+        // Source-vs-target split. A monitor is homogeneous: all unified (sourceless,
+        // target on the monitor) or all legacy (saved-search source, no target). Reject
+        // a mix outright, then require/forbid the target accordingly.
+        const sourcelessCount = alerts.filter((alert) => alert.source === null).length
+        if (sourcelessCount > 0 && sourcelessCount !== alerts.length) {
+          return yield* new ValidationError({
+            field: "alerts",
+            message: "A monitor cannot mix unified and saved-search alerts",
+          })
+        }
+        const unified = sourcelessCount > 0
+        if (unified && input.target == null) {
+          return yield* new ValidationError({ field: "target", message: "Unified alerts require a monitor target" })
+        }
+        if (!unified && input.target != null) {
+          return yield* new ValidationError({ field: "target", message: "A target is only valid for unified alerts" })
+        }
+
         // A search with a semantic part has no exact match rule to count against.
         const watchedSearchIds = [
           ...new Set(
@@ -92,9 +116,7 @@ export const createMonitorUseCase = (
           description: input.description?.trim() ?? "",
           system: false,
           alerts,
-          // Saved-search monitors carry the target on the alert source; unified
-          // target-on-monitor creation lands with the in-context tool/user UI.
-          target: null,
+          target: input.target ?? null,
           mutedAt: null,
           deletedAt: null,
           createdAt: now,

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
@@ -72,8 +72,12 @@ export const updateMonitorAlertUseCase = (
         const sourceIdChanged = input.source !== undefined && input.source.id !== (alert.source?.id ?? null)
 
         // Legacy kinds require their fixed source type; unified kinds carry no source (target on the monitor).
-        const expectedSourceType = ALERT_INCIDENT_KIND_SOURCE_TYPE[nextKind] ?? null
-        if ((nextSource?.type ?? null) !== expectedSourceType) {
+        const expectedSourceType = ALERT_INCIDENT_KIND_SOURCE_TYPE[nextKind]
+        if (expectedSourceType === undefined) {
+          if (nextSource !== null) {
+            return yield* new ValidationError({ field: "source", message: `Alerts of kind "${nextKind}" take no source` })
+          }
+        } else if ((nextSource?.type ?? null) !== expectedSourceType) {
           return yield* new ValidationError({
             field: "source",
             message: `Source type must be "${expectedSourceType}" for ${nextKind}`,
@@ -95,7 +99,6 @@ export const updateMonitorAlertUseCase = (
             return yield* new SystemMonitorForbiddenError({ monitorId: input.monitorId, operation: "restructured" })
           }
         } else if (kindChanged && !USER_CREATABLE.has(nextKind)) {
-          // Only saved-search kinds are user-owned; `issue.*` are system-only.
           return yield* new ValidationError({ field: "kind", message: `Alerts of kind "${nextKind}" cannot be set` })
         }
 

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
@@ -75,7 +75,10 @@ export const updateMonitorAlertUseCase = (
         const expectedSourceType = ALERT_INCIDENT_KIND_SOURCE_TYPE[nextKind]
         if (expectedSourceType === undefined) {
           if (nextSource !== null) {
-            return yield* new ValidationError({ field: "source", message: `Alerts of kind "${nextKind}" take no source` })
+            return yield* new ValidationError({
+              field: "source",
+              message: `Alerts of kind "${nextKind}" take no source`,
+            })
           }
         } else if ((nextSource?.type ?? null) !== expectedSourceType) {
           return yield* new ValidationError({

--- a/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor-alert.ts
@@ -5,6 +5,7 @@ import {
   type AlertIncidentKind,
   type AlertIncidentSourceType,
   type AlertSeverity,
+  KINDS_WITHOUT_CONDITION,
   type MonitorAlertId,
   type MonitorId,
   type NotFoundError,
@@ -20,11 +21,10 @@ import { MonitorRepository } from "../ports/monitor-repository.ts"
 import { assertMonitorableSavedSearch } from "./assert-monitorable-saved-search.ts"
 
 const USER_CREATABLE = new Set<AlertIncidentKind>(USER_CREATABLE_ALERT_KINDS)
-/** Kinds that carry no `condition` (nothing to configure). Their condition stays `null`. */
-const KINDS_WITHOUT_CONDITION = new Set<AlertIncidentKind>(["issue.new", "issue.regressed", "savedSearch.match"])
+const NO_CONDITION = new Set<AlertIncidentKind>(KINDS_WITHOUT_CONDITION)
 
 const conditionMatchesKind = (condition: AlertIncidentCondition | null, kind: AlertIncidentKind): boolean =>
-  condition === null ? KINDS_WITHOUT_CONDITION.has(kind) : condition.kind === kind
+  condition === null ? NO_CONDITION.has(kind) : condition.kind === kind
 
 export interface UpdateMonitorAlertInput {
   readonly monitorId: MonitorId

--- a/packages/domain/shared/src/alert-incident-kinds.ts
+++ b/packages/domain/shared/src/alert-incident-kinds.ts
@@ -78,13 +78,28 @@ export const ALERT_INCIDENT_KIND_LABEL: Record<AlertIncidentKind, string> = {
 
 /**
  * Kinds users may put on their own monitors; `issue.*` are system-only. Create/update enforce this.
- * Still the LEGACY saved-search kinds — the unified `event.matched` / `metric.*` kinds become
- * user-creatable once target-on-monitor creation lands (they take a monitor target, not a source).
+ * Legacy `savedSearch.*` take a saved-search source; unified `event.*`/`metric.*` take a monitor
+ * target instead (no source) — `buildMonitorAlert`/`createMonitor` enforce the source-vs-target split.
  */
 export const USER_CREATABLE_ALERT_KINDS = [
   "savedSearch.match",
   "savedSearch.threshold",
   "savedSearch.escalating",
+  "event.matched",
+  "metric.threshold",
+  "metric.escalating",
+] as const satisfies readonly AlertIncidentKind[]
+
+/**
+ * Kinds whose alert carries no `condition` (it stays `null`): the discrete-event
+ * kinds. Single source of truth — create/update alert validation both key off this
+ * (previously duplicated and drifted). Every other kind requires its matching condition.
+ */
+export const KINDS_WITHOUT_CONDITION = [
+  "issue.new",
+  "issue.regressed",
+  "savedSearch.match",
+  "event.matched",
 ] as const satisfies readonly AlertIncidentKind[]
 
 export const ALERT_SEVERITIES = ["low", "medium", "high"] as const


### PR DESCRIPTION
> **Stacked on #3561 → … → #3555.** Merge those first; base retargets as they land.

## What

`createMonitorUseCase` can now create **target-on-monitor** monitors whose alerts are unified `event.*`/`metric.*` kinds (no source) — the domain capability behind tool/user monitors.

- `buildMonitorAlert` splits on kind: legacy `savedSearch.*` still require a saved-search source; unified kinds take **none** (and `event.matched` joins the no-condition set).
- `createMonitorUseCase` gains an optional `target` and enforces the **source-vs-target invariant**: a monitor is homogeneous (all-unified-with-target or all-legacy-with-source); mixing or missing/extra target is rejected.
- `USER_CREATABLE_ALERT_KINDS` gains the unified kinds; `KINDS_WITHOUT_CONDITION` is **hoisted to `@domain/shared`** (was duplicated + had drifted across the create/update alert use-cases).

## Why it's safe

Additive and behavior-preserving: legacy saved-search creation is unchanged, and the **public API/web create surface is untouched** (no `target` field, kinds still restricted there) — a unified-kind create via those entry points fails cleanly with a `ValidationError`, no broken monitor persists.

## Verification

- Typecheck clean: `@domain/shared`, `@domain/monitors`, `@app/api`, `@app/web`, `@app/workers`.
- `@domain/monitors`: 128 tests (incl. unified create round-trip, sourceless `buildMonitorAlert` paths, and the rejection cases).
- `knip` + `format` clean.
- Adversarial review: **Request changes → fixed.** It caught two MAJOR defects, both fixed + covered by tests:
  1. the source-vs-target check used `some()`, letting a **mixed legacy+unified alert array** persist an incoherent monitor → now rejects any mix (`field: "alerts"`);
  2. `update-monitor-alert`'s **stale local `KINDS_WITHOUT_CONDITION`** made a freshly-created `event.matched` alert un-updatable → fixed by hoisting the constant to `@domain/shared`.
  Also added the suggested direct `buildMonitorAlert` unit tests.

## Follow-ups

- The firing vertical: state machines + orchestrator + **sourceless incidents** (nullable `alert_incidents` + notification handling) → unified monitors fire end-to-end.
- In-context tool/user monitor UI + dashboard Target column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)