### PR TITLE
feat(observability): re-enable Latitude self-telemetry

### DIFF
--- a/packages/observability/src/otel.ts
+++ b/packages/observability/src/otel.ts
@@ -48,7 +48,7 @@ export const startTracing = async ({
     ),
   ]
 
-  const isLatitudeTelemetryEnabled = false
+  const isLatitudeTelemetryEnabled = true
 
   if (isLatitudeTelemetryEnabled && apiKey !== "") {
     const latitudeIngestTracesUrl = `${latitudeIngestBase.replace(/\/$/, "")}/v1/traces`


### PR DESCRIPTION
## what

Flips `isLatitudeTelemetryEnabled` to `true` in `packages/observability/src/otel.ts`. With the flag on (and `LAT_LATITUDE_TELEMETRY_API_KEY` set), the `LatitudeSpanProcessor` is added to the OTEL span processors, so our own internal AI features export their generation spans to Latitude — we observe our own product with our own product.

Wiring already exists: each AI feature routes its spans to its per-feature project via the `latitude.project` attribute, and the ingest URL / API key are read from env and provisioned in `infra/lib/ecs.ts`. The `apiKey !== ""` guard keeps this a no-op anywhere the key is unset (e.g. local dev), so this only activates ingest in environments where the secret is configured.

## why now

Self-telemetry was originally disabled because it was too expensive. The cost drivers have since been addressed:

- **Embeddings disabled** for our own telemetry — semantic search over our self-telemetry will not work, which is an accepted trade-off for the cost savings.
- **Per-feature projects** — each feature now has its own project, with **trace sampling manually set to 10%** on each, cutting ingest volume.

With those in place, re-enabling is affordable.
