### PR TITLE
feat(destinations): testDestinationConnection use case (LAT-674)

### DIFF
--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -20,3 +20,6 @@ export const DESTINATION_EVENT_UUID_NAMESPACE = "c7696d7f-b92d-518a-9525-9c635f6
 
 /** Default per-event ingestion size guard (1 MiB); the deliverer adapter owns the live vendor cap and passes it to the mapper. */
 export const DESTINATION_MAX_EVENT_BYTES_DEFAULT = 1_048_576
+
+/** Event name of the canary delivered by `testDestinationConnection`; named so customers can recognize it in their destination. */
+export const DESTINATION_CONNECTION_TEST_EVENT_NAME = "latitude_connection_test"

--- a/packages/domain/destinations/src/index.ts
+++ b/packages/domain/destinations/src/index.ts
@@ -1,5 +1,6 @@
 // Constants
 export {
+  DESTINATION_CONNECTION_TEST_EVENT_NAME,
   DESTINATION_EVENT_UUID_NAMESPACE,
   DESTINATION_IDLE_BACKOFF_MAX_MS,
   DESTINATION_INTERVAL_MS_DEFAULT,
@@ -92,3 +93,8 @@ export { DestinationSyncRunRepository } from "./ports/destination-sync-run-repos
 // Use cases
 export type { CreateDestinationError, CreateDestinationInput } from "./use-cases/create-destination.ts"
 export { createDestinationUseCase } from "./use-cases/create-destination.ts"
+export type {
+  TestDestinationConnectionInput,
+  TestDestinationConnectionResult,
+} from "./use-cases/test-destination-connection.ts"
+export { testDestinationConnectionUseCase } from "./use-cases/test-destination-connection.ts"

--- a/packages/domain/destinations/src/use-cases/test-destination-connection.test.ts
+++ b/packages/domain/destinations/src/use-cases/test-destination-connection.test.ts
@@ -1,0 +1,61 @@
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { DESTINATION_CONNECTION_TEST_EVENT_NAME, POSTHOG_US_INGESTION_HOST } from "../constants.ts"
+import type { DestinationConfig, DestinationCredentials } from "../entities/destination.ts"
+import { NonRetryableDeliveryError, RetryableDeliveryError } from "../errors.ts"
+import { DestinationDeliverers } from "../ports/destination-deliverer.ts"
+import { createFakeDestinationDeliverer } from "../testing/fake-destination-deliverer.ts"
+import { testDestinationConnectionUseCase } from "./test-destination-connection.ts"
+
+const config: DestinationConfig = {
+  kind: "posthog",
+  host: POSTHOG_US_INGESTION_HOST,
+  excludePayloads: false,
+  intervalMs: 300_000,
+  maxSpansPerRun: 50_000,
+}
+const credentials: DestinationCredentials = { kind: "posthog", apiKey: "phc_test" }
+
+function setup() {
+  const fake = createFakeDestinationDeliverer()
+  const layer = Layer.succeed(DestinationDeliverers, { posthog: fake.deliverer })
+  const run = () =>
+    Effect.runPromise(testDestinationConnectionUseCase({ config, credentials }).pipe(Effect.provide(layer)))
+  return { fake, run }
+}
+
+describe("testDestinationConnectionUseCase", () => {
+  it("returns ok and delivers a single canary event on success", async () => {
+    const { fake, run } = setup()
+
+    const result = await run()
+
+    expect(result).toEqual({ status: "ok" })
+    expect(fake.deliveries).toHaveLength(1)
+    expect(fake.deliveries[0]?.events).toHaveLength(1)
+    expect(fake.deliveries[0]?.events[0]?.name).toBe(DESTINATION_CONNECTION_TEST_EVENT_NAME)
+  })
+
+  it("reports a non-retryable failure for an invalid key (401)", async () => {
+    const { fake, run } = setup()
+    fake.failWith(new NonRetryableDeliveryError({ kind: "posthog", reason: "invalid_api_key", upstreamStatus: 401 }))
+
+    const result = await run()
+
+    expect(result).toEqual({
+      status: "failed",
+      retryable: false,
+      reason: "invalid_api_key",
+      upstreamStatus: 401,
+    })
+  })
+
+  it("reports a retryable failure for a transport error", async () => {
+    const { fake, run } = setup()
+    fake.failWith(new RetryableDeliveryError({ kind: "posthog", reason: "transport_error" }))
+
+    const result = await run()
+
+    expect(result).toEqual({ status: "failed", retryable: true, reason: "transport_error" })
+  })
+})

--- a/packages/domain/destinations/src/use-cases/test-destination-connection.ts
+++ b/packages/domain/destinations/src/use-cases/test-destination-connection.ts
@@ -1,0 +1,87 @@
+import { SpanId } from "@domain/shared"
+import { Effect } from "effect"
+import { DESTINATION_CONNECTION_TEST_EVENT_NAME, DESTINATION_EVENT_UUID_NAMESPACE } from "../constants.ts"
+import type { DestinationConfig, DestinationCredentials } from "../entities/destination.ts"
+import type { DestinationEvent } from "../entities/destination-event.ts"
+import { isRetryableDeliveryError } from "../errors.ts"
+import { uuidV5 } from "../helpers.ts"
+import { DestinationDeliverers } from "../ports/destination-deliverer.ts"
+
+const CANARY_DISTINCT_ID = "latitude-connection-test"
+const CANARY_SPAN_ID = SpanId("connection-test")
+
+export interface TestDestinationConnectionInput {
+  readonly config: DestinationConfig
+  readonly credentials: DestinationCredentials
+}
+
+/**
+ * Outcome of a pre-save connection test. Known limits the UI (P2-2) must surface
+ * to the user:
+ *
+ * - PostHog `phc_` keys are **write-only**: a valid key scoped to the WRONG
+ *   project still returns `ok` here and silently sends the canary to that other
+ *   project. The test proves reachability + key acceptance, NOT project identity.
+ * - The canary event (`latitude_connection_test`) is delivered for real and is
+ *   visible in the customer's PostHog project.
+ */
+export type TestDestinationConnectionResult =
+  | { readonly status: "ok" }
+  | {
+      readonly status: "failed"
+      /** Transient failure (transport, 5xx, 429): retrying may succeed. `false` means fix the config/key. */
+      readonly retryable: boolean
+      /** Sanitized adapter taxonomy (e.g. `invalid_api_key`), never an upstream response body. */
+      readonly reason: string
+      readonly upstreamStatus?: number
+    }
+
+const buildCanaryEvent = (config: DestinationConfig): Effect.Effect<DestinationEvent> =>
+  Effect.gen(function* () {
+    const uuid = yield* Effect.promise(() =>
+      uuidV5({ namespace: DESTINATION_EVENT_UUID_NAMESPACE, name: `connection-test:${config.host}` }),
+    )
+    return {
+      uuid,
+      name: DESTINATION_CONNECTION_TEST_EVENT_NAME,
+      distinctId: CANARY_DISTINCT_ID,
+      timestamp: new Date(),
+      spanId: CANARY_SPAN_ID,
+      properties: { latitude_connection_test: true },
+    }
+  })
+
+/**
+ * Tests a destination before saving by delivering a single canary event through
+ * the kind's deliverer and mapping the adapter's retryable/non-retryable errors
+ * to a {@link TestDestinationConnectionResult}. The window ends now, so the
+ * adapter never flags the canary as a historical migration.
+ */
+export const testDestinationConnectionUseCase = (input: TestDestinationConnectionInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("kind", input.config.kind)
+
+    const deliverers = yield* DestinationDeliverers
+    const deliverer = deliverers[input.config.kind]
+    const canary = yield* buildCanaryEvent(input.config)
+
+    return yield* deliverer
+      .deliver([canary], input.config, input.credentials, {
+        window: { start: canary.timestamp, end: canary.timestamp },
+      })
+      .pipe(
+        Effect.match({
+          onSuccess: (): TestDestinationConnectionResult => ({ status: "ok" }),
+          onFailure: (error): TestDestinationConnectionResult => ({
+            status: "failed",
+            retryable: isRetryableDeliveryError(error),
+            reason: error.reason,
+            ...(error.upstreamStatus === undefined ? {} : { upstreamStatus: error.upstreamStatus }),
+          }),
+        }),
+      )
+  }).pipe(Effect.withSpan("destinations.testDestinationConnection")) as Effect.Effect<
+    TestDestinationConnectionResult,
+    never,
+    DestinationDeliverers
+  >


### PR DESCRIPTION
## What

Implements **P2-1 (LAT-674)** from `specs/data-destinations.md`: a `testDestinationConnectionUseCase` in `@domain/destinations` that validates a destination's reachability + key acceptance **before saving**.

## How

- Resolves the kind's deliverer from the `DestinationDeliverers` registry and delivers a **single canary event** through it.
- Canary UUID is a deterministic UUIDv5 namespaced on the host, so repeated tests dedupe to one event in the customer's PostHog rather than spamming it. The event name (`latitude_connection_test`) is deliberately **not** an `$ai_*` event, so it doesn't touch AI analytics/metrics.
- The delivery window ends now, so the adapter never flags the canary as a historical migration.
- Maps the adapter's `DeliveryError` to a structured `TestDestinationConnectionResult` via `Effect.match` — it **relies on the PostHog adapter's existing 401/invalid-key error mapping (P1-5) and does not re-implement it**. The Effect error channel is `never`; the outcome is always a result.
- Instrumented with `Effect.withSpan("destinations.testDestinationConnection")` + `kind` span annotation.

## Known limits (documented on the result type for the P2-2 UI)

- PostHog `phc_` keys are **write-only**: a valid key for the **wrong** project still returns `ok` and silently sends the canary there. The test proves reachability + key acceptance, **not** project identity.
- The canary event is delivered for real and is visible in the customer's PostHog project.

`failed` results expose `retryable` (transport/5xx/429 vs fix-your-key), the sanitized `reason`, and optional `upstreamStatus`.

## Tests

Uses the in-memory fake deliverer — happy path, non-retryable 401 (`invalid_api_key`), and transport failure.

- `pnpm --filter @domain/destinations exec vitest run` → 32 passed
- `pnpm --filter @domain/destinations typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)