### PR TITLE
feat(destinations): runDestinationSync engine (LAT-671)

### DIFF
--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -12,6 +12,14 @@ export const DESTINATION_QUARANTINE_FAILURE_THRESHOLD = 5
 /** Idle-backoff ceiling: a destination with only empty runs converges to one probe per hour. */
 export const DESTINATION_IDLE_BACKOFF_MAX_MS = 3_600_000
 
+/**
+ * Window-end safety lag (5 min): the window ends at `now − SAFETY_LAG` so reads
+ * see settled rows. Must cover both ReplacingMergeTree merge settling and
+ * ingest-queue lag — a span that becomes visible behind the watermark is lost
+ * to every destination, silently.
+ */
+export const DESTINATION_SAFETY_LAG_MS = 300_000
+
 export const POSTHOG_US_INGESTION_HOST = "https://us.i.posthog.com"
 export const POSTHOG_EU_INGESTION_HOST = "https://eu.i.posthog.com"
 

--- a/packages/domain/destinations/src/index.ts
+++ b/packages/domain/destinations/src/index.ts
@@ -11,6 +11,7 @@ export {
   DESTINATION_MAX_SPANS_PER_RUN_MAX,
   DESTINATION_MAX_SPANS_PER_RUN_MIN,
   DESTINATION_QUARANTINE_FAILURE_THRESHOLD,
+  DESTINATION_SAFETY_LAG_MS,
   POSTHOG_EU_INGESTION_HOST,
   POSTHOG_US_INGESTION_HOST,
 } from "./constants.ts"
@@ -38,7 +39,10 @@ export {
   posthogDestinationCredentialsSchema,
 } from "./entities/destination.ts"
 export type { DestinationEvent } from "./entities/destination-event.ts"
-export type { DestinationSyncRun, DestinationSyncRunStatus } from "./entities/destination-sync-run.ts"
+export type {
+  DestinationSyncRun,
+  DestinationSyncRunStatus,
+} from "./entities/destination-sync-run.ts"
 export {
   createDestinationSyncRun,
   DESTINATION_SYNC_RUN_STATUSES,
@@ -63,6 +67,7 @@ export type {
   PosthogEventName,
 } from "./mappers/posthog.ts"
 export {
+  createPosthogMapper,
   mapSpansToPosthogEvents,
   POSTHOG_CONTENT_PROPERTIES,
   POSTHOG_EVENT_NAMES,
@@ -79,9 +84,16 @@ export type {
 } from "./ports/destination-deliverer.ts"
 export { DestinationDeliverers } from "./ports/destination-deliverer.ts"
 export type {
+  DestinationMapper,
+  DestinationMapperRegistry,
+  MappedEvents,
+} from "./ports/destination-mapper.ts"
+export { DestinationMappers } from "./ports/destination-mapper.ts"
+export type {
   AdvanceDestinationCursorInput,
   DestinationCursor,
   DestinationRepositoryShape,
+  UpdateDestinationRunStateInput,
 } from "./ports/destination-repository.ts"
 export { DestinationRepository } from "./ports/destination-repository.ts"
 export type {
@@ -91,8 +103,18 @@ export type {
 export { DestinationSyncRunRepository } from "./ports/destination-sync-run-repository.ts"
 
 // Use cases
-export type { CreateDestinationError, CreateDestinationInput } from "./use-cases/create-destination.ts"
+export type {
+  CreateDestinationError,
+  CreateDestinationInput,
+} from "./use-cases/create-destination.ts"
 export { createDestinationUseCase } from "./use-cases/create-destination.ts"
+export type {
+  RunDestinationSyncError,
+  RunDestinationSyncInput,
+  RunDestinationSyncOutcome,
+  RunDestinationSyncResult,
+} from "./use-cases/run-destination-sync.ts"
+export { runDestinationSyncUseCase } from "./use-cases/run-destination-sync.ts"
 export type {
   TestDestinationConnectionInput,
   TestDestinationConnectionResult,

--- a/packages/domain/destinations/src/mappers/posthog.ts
+++ b/packages/domain/destinations/src/mappers/posthog.ts
@@ -1,9 +1,11 @@
 import type { DestinationId } from "@domain/shared"
 import type { SpanDetail } from "@domain/spans"
+import { Effect } from "effect"
 import { DESTINATION_EVENT_UUID_NAMESPACE, DESTINATION_MAX_EVENT_BYTES_DEFAULT } from "../constants.ts"
-import type { PosthogDestinationConfig } from "../entities/destination.ts"
+import type { Destination, PosthogDestinationConfig } from "../entities/destination.ts"
 import type { DestinationEvent } from "../entities/destination-event.ts"
 import { uuidV5 } from "../helpers.ts"
+import type { DestinationMapper } from "../ports/destination-mapper.ts"
 
 const MICROCENTS_PER_USD = 100_000_000
 const MS_PER_SECOND = 1_000
@@ -209,3 +211,24 @@ export const mapSpansToPosthogEvents = async (
 
   return { events, dropped }
 }
+
+/**
+ * Binds {@link mapSpansToPosthogEvents} to the {@link DestinationMapper} port.
+ * `buildSpanUrl` (app host + routing) and `maxEventBytes` (the adapter's live
+ * vendor cap) are injected at the wiring boundary, keeping the mapper pure.
+ */
+export const createPosthogMapper = (params: {
+  readonly buildSpanUrl: (span: SpanDetail) => string
+  readonly maxEventBytes?: number
+}): DestinationMapper => ({
+  toEvents: (spans, destination: Destination) =>
+    Effect.promise(() =>
+      mapSpansToPosthogEvents({
+        spans,
+        destinationId: destination.id,
+        config: destination.config as PosthogDestinationConfig,
+        buildSpanUrl: params.buildSpanUrl,
+        ...(params.maxEventBytes === undefined ? {} : { maxEventBytes: params.maxEventBytes }),
+      }),
+    ),
+})

--- a/packages/domain/destinations/src/ports/destination-mapper.ts
+++ b/packages/domain/destinations/src/ports/destination-mapper.ts
@@ -1,0 +1,22 @@
+import type { SpanDetail } from "@domain/spans"
+import { Context, type Effect } from "effect"
+import type { Destination, DestinationKind } from "../entities/destination.ts"
+import type { DestinationEvent } from "../entities/destination-event.ts"
+
+export interface MappedEvents {
+  readonly events: readonly DestinationEvent[]
+  /** Events dropped by the mapper's oversized-event policy, counted into `events_dropped`. */
+  readonly dropped: number
+}
+
+/** Per-kind pure span→event mapper. The engine maps a window's spans without knowing any vendor schema. */
+export interface DestinationMapper {
+  toEvents(spans: readonly SpanDetail[], destination: Destination): Effect.Effect<MappedEvents>
+}
+
+/** Exhaustive per-kind mapper registry, TS-enforced like {@link DestinationDelivererRegistry}. */
+export type DestinationMapperRegistry = Record<DestinationKind, DestinationMapper>
+
+export class DestinationMappers extends Context.Service<DestinationMappers, DestinationMapperRegistry>()(
+  "@domain/destinations/DestinationMappers",
+) {}

--- a/packages/domain/destinations/src/ports/destination-repository.ts
+++ b/packages/domain/destinations/src/ports/destination-repository.ts
@@ -1,6 +1,6 @@
 import type { ConflictError, DestinationId, ProjectId, RepositoryError, SqlClient } from "@domain/shared"
 import { Context, type Effect } from "effect"
-import type { Destination } from "../entities/destination.ts"
+import type { Destination, DestinationStatus } from "../entities/destination.ts"
 
 /** Position in the `(ingested_at, span_id)` compound cursor. `spanId` is `""` before the first advance. */
 export interface DestinationCursor {
@@ -13,6 +13,17 @@ export interface AdvanceDestinationCursorInput {
   /** The cursor the run started from; the write only applies while the row still holds it. */
   readonly expected: DestinationCursor
   readonly next: DestinationCursor
+}
+
+/** Post-run bookkeeping (status, counters, `last_run_at`) — never the cursor. */
+export interface UpdateDestinationRunStateInput {
+  readonly id: DestinationId
+  readonly status: DestinationStatus
+  readonly consecutiveFailures: number
+  readonly consecutiveEmptyRuns: number
+  /** Sanitized: HTTP status + our error taxonomy, never upstream response bodies. */
+  readonly lastFailureMessage: string | null
+  readonly lastRunAt: Date
 }
 
 export interface DestinationRepositoryShape {
@@ -32,6 +43,13 @@ export interface DestinationRepositoryShape {
    * never move the cursor backwards or double-advance it.
    */
   advanceCursor(input: AdvanceDestinationCursorInput): Effect.Effect<boolean, RepositoryError, SqlClient>
+  /**
+   * Persists post-run bookkeeping without touching the cursor columns — the
+   * cursor moves only through the optimistic {@link advanceCursor}. Keeping the
+   * two writes separate is what stops a stale run from dragging the cursor
+   * backwards while it records its failure or idle counters.
+   */
+  updateRunState(input: UpdateDestinationRunStateInput): Effect.Effect<void, RepositoryError, SqlClient>
   deleteByProjectId(projectId: ProjectId): Effect.Effect<readonly DestinationId[], RepositoryError, SqlClient>
 }
 

--- a/packages/domain/destinations/src/testing/fake-destination-mapper.ts
+++ b/packages/domain/destinations/src/testing/fake-destination-mapper.ts
@@ -1,0 +1,31 @@
+import type { SpanDetail } from "@domain/spans"
+import { Effect } from "effect"
+import type { DestinationEvent } from "../entities/destination-event.ts"
+import type { DestinationMapper } from "../ports/destination-mapper.ts"
+
+/**
+ * Minimal in-memory mapper: one event per span (engine tests assert on counts
+ * and cursor movement, not vendor schema). `dropped` is configurable so the
+ * `events_dropped` accounting can be exercised.
+ */
+export const createFakeDestinationMapper = (opts: { dropped?: number } = {}) => {
+  const mapped: SpanDetail[][] = []
+
+  const mapper: DestinationMapper = {
+    toEvents: (spans) =>
+      Effect.sync(() => {
+        mapped.push([...spans])
+        const events: DestinationEvent[] = spans.map((span) => ({
+          uuid: `${span.spanId}:event`,
+          name: "$ai_span",
+          distinctId: span.traceId,
+          timestamp: span.endTime,
+          spanId: span.spanId,
+          properties: {},
+        }))
+        return { events, dropped: opts.dropped ?? 0 }
+      }),
+  }
+
+  return { mapper, mapped }
+}

--- a/packages/domain/destinations/src/testing/fake-destination-repository.ts
+++ b/packages/domain/destinations/src/testing/fake-destination-repository.ts
@@ -48,6 +48,22 @@ export const createFakeDestinationRepository = (seed: readonly Destination[] = [
         ;(row as { cursorSpanId: string }).cursorSpanId = next.spanId
         return true
       }),
+    updateRunState: ({ id, status, consecutiveFailures, consecutiveEmptyRuns, lastFailureMessage, lastRunAt }) =>
+      Effect.sync(() => {
+        const index = rows.findIndex((r) => r.id === id)
+        if (index < 0) return
+        const row = rows[index]
+        if (!row) return
+        rows[index] = {
+          ...row,
+          status,
+          consecutiveFailures,
+          consecutiveEmptyRuns,
+          lastFailureMessage,
+          lastRunAt,
+          updatedAt: new Date(),
+        }
+      }),
     deleteByProjectId: (projectId: ProjectId) =>
       Effect.sync(() => {
         const deleted = rows.filter((r) => r.projectId === projectId).map((r) => r.id)

--- a/packages/domain/destinations/src/testing/index.ts
+++ b/packages/domain/destinations/src/testing/index.ts
@@ -1,3 +1,4 @@
 export { createFakeDestinationDeliverer, type RecordedDelivery } from "./fake-destination-deliverer.ts"
+export { createFakeDestinationMapper } from "./fake-destination-mapper.ts"
 export { createFakeDestinationRepository } from "./fake-destination-repository.ts"
 export { createFakeDestinationSyncRunRepository } from "./fake-destination-sync-run-repository.ts"

--- a/packages/domain/destinations/src/use-cases/run-destination-sync.test.ts
+++ b/packages/domain/destinations/src/use-cases/run-destination-sync.test.ts
@@ -1,0 +1,353 @@
+import {
+  ChSqlClient,
+  DestinationId,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  SqlClient,
+  TraceId,
+  UserId,
+} from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import type { SpanDetail } from "@domain/spans"
+import { SpanRepository } from "@domain/spans"
+import { createFakeSpanRepository } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { POSTHOG_US_INGESTION_HOST } from "../constants.ts"
+import type { Destination } from "../entities/destination.ts"
+import { createDestination } from "../entities/destination.ts"
+import { NonRetryableDeliveryError, RetryableDeliveryError } from "../errors.ts"
+import { DestinationDeliverers } from "../ports/destination-deliverer.ts"
+import { DestinationMappers } from "../ports/destination-mapper.ts"
+import { DestinationRepository } from "../ports/destination-repository.ts"
+import { DestinationSyncRunRepository } from "../ports/destination-sync-run-repository.ts"
+import { createFakeDestinationDeliverer } from "../testing/fake-destination-deliverer.ts"
+import { createFakeDestinationMapper } from "../testing/fake-destination-mapper.ts"
+import { createFakeDestinationRepository } from "../testing/fake-destination-repository.ts"
+import { createFakeDestinationSyncRunRepository } from "../testing/fake-destination-sync-run-repository.ts"
+import { runDestinationSyncUseCase } from "./run-destination-sync.ts"
+
+const cuid = (seed: string) => seed.padEnd(24, "0")
+
+const ORG_ID = OrganizationId(cuid("o"))
+const PROJECT_ID = ProjectId(cuid("p"))
+const USER_ID = UserId(cuid("u"))
+const DESTINATION_ID = DestinationId(cuid("d"))
+const TRACE_ID = "0123456789abcdef0123456789abcdef"
+
+const NOW = new Date("2026-06-01T12:00:00.000Z")
+// windowEnd = NOW − SAFETY_LAG (5 min)
+const WINDOW_END = new Date("2026-06-01T11:55:00.000Z")
+const CURSOR_AT = new Date("2026-06-01T10:00:00.000Z")
+
+const makeDestination = (overrides: Partial<Destination> = {}): Destination => ({
+  ...createDestination({
+    id: DESTINATION_ID,
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    name: "Acme PostHog",
+    config: {
+      kind: "posthog",
+      host: POSTHOG_US_INGESTION_HOST,
+      excludePayloads: false,
+      intervalMs: 300_000,
+      maxSpansPerRun: 50_000,
+    },
+    credentials: { kind: "posthog", apiKey: "phc_test" },
+    createdByUserId: USER_ID,
+    createdAt: CURSOR_AT,
+  }),
+  cursorIngestedAt: CURSOR_AT,
+  cursorSpanId: "",
+  ...overrides,
+})
+
+const stubSpan = (spanId: string, ingestedAt: Date): SpanDetail => ({
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  sessionId: SessionId("session-1"),
+  userId: ExternalUserId("user-1"),
+  userEmail: "",
+  traceId: TraceId(TRACE_ID),
+  spanId: SpanId(spanId),
+  parentSpanId: "",
+  apiKeyId: "",
+  simulationId: SimulationId(""),
+  startTime: new Date("2026-06-01T10:30:00.000Z"),
+  endTime: new Date("2026-06-01T10:30:01.000Z"),
+  name: "chat",
+  serviceName: "agent",
+  kind: "client",
+  statusCode: "ok",
+  statusMessage: "",
+  traceFlags: 0,
+  traceState: "",
+  errorType: "",
+  tags: [],
+  metadata: {},
+  eventsJson: "",
+  linksJson: "",
+  operation: "chat",
+  provider: "openai",
+  model: "gpt-4o",
+  responseModel: "",
+  tokensInput: 10,
+  tokensOutput: 5,
+  tokensCacheRead: 0,
+  tokensCacheCreate: 0,
+  tokensReasoning: 0,
+  costInputMicrocents: 0,
+  costOutputMicrocents: 0,
+  costTotalMicrocents: 0,
+  costIsEstimated: false,
+  timeToFirstTokenNs: 0,
+  isStreaming: false,
+  responseId: "",
+  finishReasons: [],
+  attrString: {},
+  attrInt: {},
+  attrFloat: {},
+  attrBool: {},
+  resourceString: {},
+  scopeName: "",
+  scopeVersion: "",
+  ingestedAt,
+  inputMessages: [],
+  outputMessages: [],
+  systemInstructions: [],
+  toolDefinitions: [],
+  toolCallId: "",
+  toolName: "",
+  toolOutput: "",
+  toolInput: "",
+})
+
+interface SetupOpts {
+  readonly seed?: Destination
+  readonly window?: { spans: readonly SpanDetail[]; nextCursor: { ingestedAt: Date; spanId: string } | null }
+  readonly deliveryFailure?: RetryableDeliveryError | NonRetryableDeliveryError
+  readonly mapperDropped?: number
+}
+
+const setup = (opts: SetupOpts) => {
+  const seed = opts.seed ?? makeDestination()
+  const { repo: destinationRepo, rows: destinationRows } = createFakeDestinationRepository([seed])
+  const { repo: syncRunRepo, rows: syncRunRows } = createFakeDestinationSyncRunRepository()
+  const { deliverer, deliveries, failWith } = createFakeDestinationDeliverer()
+  if (opts.deliveryFailure) failWith(opts.deliveryFailure)
+  const { mapper, mapped } = createFakeDestinationMapper(
+    opts.mapperDropped === undefined ? {} : { dropped: opts.mapperDropped },
+  )
+  const { repository: spanRepo } = createFakeSpanRepository({
+    listByIngestedAtWindow: () =>
+      Effect.succeed({
+        spans: opts.window?.spans ?? [],
+        nextCursor: opts.window?.nextCursor
+          ? { ingestedAt: opts.window.nextCursor.ingestedAt, spanId: SpanId(opts.window.nextCursor.spanId) }
+          : null,
+      }),
+  })
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+    Layer.succeed(ChSqlClient, createFakeChSqlClient()),
+    Layer.succeed(SpanRepository, spanRepo),
+    Layer.succeed(DestinationRepository, destinationRepo),
+    Layer.succeed(DestinationSyncRunRepository, syncRunRepo),
+    Layer.succeed(DestinationDeliverers, { posthog: deliverer }),
+    Layer.succeed(DestinationMappers, { posthog: mapper }),
+  )
+
+  return { destinationRows, syncRunRows, deliveries, mapped, layer }
+}
+
+describe("runDestinationSyncUseCase", () => {
+  it("skips a non-active destination", async () => {
+    const { destinationRows, syncRunRows, deliveries, layer } = setup({
+      seed: makeDestination({ status: "quarantined" }),
+    })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: makeDestination({ status: "quarantined" }), now: NOW }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(res.outcome).toBe("skipped")
+    expect(deliveries).toHaveLength(0)
+    expect(syncRunRows).toHaveLength(0)
+    expect(destinationRows[0]?.lastRunAt).toBeNull()
+  })
+
+  it("on an empty window advances the cursor to the window end and grows idle backoff", async () => {
+    const seed = makeDestination({ consecutiveEmptyRuns: 2 })
+    const { destinationRows, syncRunRows, deliveries, layer } = setup({ seed })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.outcome).toBe("empty")
+    expect(res.cursorAdvanced).toBe(true)
+    expect(deliveries).toHaveLength(0)
+    expect(destinationRows[0]?.cursorIngestedAt).toEqual(WINDOW_END)
+    expect(destinationRows[0]?.cursorSpanId).toBe("")
+    expect(destinationRows[0]?.consecutiveEmptyRuns).toBe(3)
+    expect(destinationRows[0]?.lastRunAt).toEqual(NOW)
+    expect(syncRunRows[0]?.status).toBe("succeeded")
+    expect(syncRunRows[0]?.spansRead).toBe(0)
+  })
+
+  it("delivers a window, advances the compound cursor, and resets idle backoff", async () => {
+    const seed = makeDestination({ consecutiveEmptyRuns: 3 })
+    const ingestedAt = new Date("2026-06-01T10:05:00.000Z")
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", ingestedAt), stubSpan("aaaaaaaaaaaaaaa2", ingestedAt)]
+    const nextCursor = { ingestedAt, spanId: "aaaaaaaaaaaaaaa2" }
+    const { destinationRows, syncRunRows, deliveries, layer } = setup({ seed, window: { spans, nextCursor } })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.outcome).toBe("delivered")
+    expect(res.spansRead).toBe(2)
+    expect(res.eventsSent).toBe(2)
+    expect(deliveries).toHaveLength(1)
+    expect(deliveries[0]?.context.window.start).toEqual(CURSOR_AT)
+    expect(deliveries[0]?.context.window.end).toEqual(nextCursor.ingestedAt)
+    expect(destinationRows[0]?.cursorIngestedAt).toEqual(nextCursor.ingestedAt)
+    expect(destinationRows[0]?.cursorSpanId).toBe("aaaaaaaaaaaaaaa2")
+    expect(destinationRows[0]?.consecutiveEmptyRuns).toBe(0)
+    expect(syncRunRows[0]?.status).toBe("succeeded")
+    expect(syncRunRows[0]?.eventsSent).toBe(2)
+  })
+
+  it("advances the cursor to a mid-batch span when the cap truncates a same-timestamp batch", async () => {
+    const seed = makeDestination()
+    // Two spans share an ingested_at; the cap cut the batch after the first.
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { destinationRows, layer } = setup({ seed, window: { spans, nextCursor } })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.outcome).toBe("delivered")
+    // Cursor lands on the last delivered (ingested_at, span_id) pair, not the window end.
+    expect(destinationRows[0]?.cursorIngestedAt).toEqual(CURSOR_AT)
+    expect(destinationRows[0]?.cursorSpanId).toBe("aaaaaaaaaaaaaaa1")
+  })
+
+  it("propagates a retryable delivery failure without advancing the cursor or recording the run", async () => {
+    const seed = makeDestination()
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { destinationRows, syncRunRows, layer } = setup({
+      seed,
+      window: { spans, nextCursor },
+      deliveryFailure: new RetryableDeliveryError({ kind: "posthog", reason: "upstream_5xx", upstreamStatus: 503 }),
+    })
+
+    const error = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer), Effect.flip),
+    )
+
+    expect(error._tag).toBe("RetryableDeliveryError")
+    expect(destinationRows[0]?.cursorIngestedAt).toEqual(CURSOR_AT)
+    expect(destinationRows[0]?.cursorSpanId).toBe("")
+    expect(destinationRows[0]?.consecutiveFailures).toBe(0)
+    expect(destinationRows[0]?.lastRunAt).toBeNull()
+    expect(syncRunRows).toHaveLength(0)
+  })
+
+  it("counts a non-retryable failure and quarantines at the threshold", async () => {
+    const seed = makeDestination({ consecutiveFailures: 4 })
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { destinationRows, syncRunRows, layer } = setup({
+      seed,
+      window: { spans, nextCursor },
+      deliveryFailure: new NonRetryableDeliveryError({
+        kind: "posthog",
+        reason: "invalid_api_key",
+        upstreamStatus: 401,
+      }),
+    })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.outcome).toBe("failed")
+    expect(res.quarantined).toBe(true)
+    expect(destinationRows[0]?.status).toBe("quarantined")
+    expect(destinationRows[0]?.consecutiveFailures).toBe(5)
+    expect(destinationRows[0]?.lastFailureMessage).toBe("[401] invalid_api_key")
+    // Cursor untouched on a failed run.
+    expect(destinationRows[0]?.cursorSpanId).toBe("")
+    expect(syncRunRows[0]?.status).toBe("failed")
+    expect(syncRunRows[0]?.error).toBe("[401] invalid_api_key")
+  })
+
+  it("counts a non-retryable failure below the threshold without quarantining", async () => {
+    const seed = makeDestination({ consecutiveFailures: 1 })
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { destinationRows, layer } = setup({
+      seed,
+      window: { spans, nextCursor },
+      deliveryFailure: new NonRetryableDeliveryError({
+        kind: "posthog",
+        reason: "invalid_api_key",
+        upstreamStatus: 401,
+      }),
+    })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.quarantined).toBe(false)
+    expect(destinationRows[0]?.status).toBe("active")
+    expect(destinationRows[0]?.consecutiveFailures).toBe(2)
+  })
+
+  it("aborts without bookkeeping when the optimistic cursor write is stale", async () => {
+    // The row holds a different cursor than the run started from → CAS rejects.
+    const rowCursor = new Date("2026-06-01T11:00:00.000Z")
+    const seedRow = makeDestination({ cursorIngestedAt: rowCursor, consecutiveEmptyRuns: 7 })
+    const runDestination = makeDestination({ cursorIngestedAt: CURSOR_AT })
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { destinationRows, syncRunRows, layer } = setup({ seed: seedRow, window: { spans, nextCursor } })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: runDestination, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.outcome).toBe("stale")
+    expect(destinationRows[0]?.cursorIngestedAt).toEqual(rowCursor)
+    expect(destinationRows[0]?.consecutiveEmptyRuns).toBe(7)
+    expect(destinationRows[0]?.lastRunAt).toBeNull()
+    expect(syncRunRows).toHaveLength(0)
+  })
+
+  it("rolls mapper drops into events_dropped on the sync run", async () => {
+    const seed = makeDestination()
+    const spans = [stubSpan("aaaaaaaaaaaaaaa1", CURSOR_AT)]
+    const nextCursor = { ingestedAt: CURSOR_AT, spanId: "aaaaaaaaaaaaaaa1" }
+    const { syncRunRows, layer } = setup({ seed, window: { spans, nextCursor }, mapperDropped: 3 })
+
+    const res = await Effect.runPromise(
+      runDestinationSyncUseCase({ destination: seed, now: NOW }).pipe(Effect.provide(layer)),
+    )
+
+    expect(res.eventsDropped).toBe(3)
+    expect(syncRunRows[0]?.eventsDropped).toBe(3)
+  })
+})

--- a/packages/domain/destinations/src/use-cases/run-destination-sync.ts
+++ b/packages/domain/destinations/src/use-cases/run-destination-sync.ts
@@ -1,0 +1,256 @@
+import {
+  type ChSqlClient,
+  type DestinationId,
+  type DestinationSyncRunId,
+  type RepositoryError,
+  SpanId,
+  type SqlClient,
+} from "@domain/shared"
+import { SpanRepository } from "@domain/spans"
+import { Effect } from "effect"
+import { DESTINATION_QUARANTINE_FAILURE_THRESHOLD, DESTINATION_SAFETY_LAG_MS } from "../constants.ts"
+import type { Destination } from "../entities/destination.ts"
+import { createDestinationSyncRun, type DestinationSyncRun } from "../entities/destination-sync-run.ts"
+import { type DeliveryError, isRetryableDeliveryError, type RetryableDeliveryError } from "../errors.ts"
+import { type DeliveryWindow, DestinationDeliverers } from "../ports/destination-deliverer.ts"
+import { DestinationMappers } from "../ports/destination-mapper.ts"
+import { type DestinationCursor, DestinationRepository } from "../ports/destination-repository.ts"
+import { DestinationSyncRunRepository } from "../ports/destination-sync-run-repository.ts"
+
+export interface RunDestinationSyncInput {
+  readonly destination: Destination
+  /** Injected for determinism; the worker passes wall-clock time. */
+  readonly now: Date
+}
+
+export type RunDestinationSyncOutcome = "skipped" | "empty" | "delivered" | "failed" | "stale"
+
+export interface RunDestinationSyncResult {
+  readonly outcome: RunDestinationSyncOutcome
+  readonly destinationId: DestinationId
+  readonly spansRead: number
+  readonly eventsSent: number
+  readonly eventsDropped: number
+  readonly cursorAdvanced: boolean
+  readonly quarantined: boolean
+  readonly syncRunId: DestinationSyncRunId | null
+}
+
+/**
+ * Retryable delivery failures propagate so the worker throws and BullMQ retries
+ * with the cursor untouched; exhausted-retry accounting lives in the worker's
+ * final-failure hook. Everything else is handled in-band.
+ */
+export type RunDestinationSyncError = RetryableDeliveryError | RepositoryError
+
+type Requirements =
+  | SqlClient
+  | ChSqlClient
+  | SpanRepository
+  | DestinationRepository
+  | DestinationSyncRunRepository
+  | DestinationDeliverers
+  | DestinationMappers
+
+const sanitizedFailureMessage = (error: DeliveryError): string =>
+  error.upstreamStatus === undefined ? error.reason : `[${error.upstreamStatus}] ${error.reason}`
+
+const isForward = (next: DestinationCursor, current: DestinationCursor): boolean =>
+  next.ingestedAt.getTime() > current.ingestedAt.getTime() ||
+  (next.ingestedAt.getTime() === current.ingestedAt.getTime() && next.spanId > current.spanId)
+
+const result = (
+  params: Partial<RunDestinationSyncResult> & { outcome: RunDestinationSyncOutcome; destinationId: DestinationId },
+): RunDestinationSyncResult => ({
+  spansRead: 0,
+  eventsSent: 0,
+  eventsDropped: 0,
+  cursorAdvanced: false,
+  quarantined: false,
+  syncRunId: null,
+  ...params,
+})
+
+/**
+ * Destination-agnostic sync engine: reads the spans window
+ * `(cursor, now − SAFETY_LAG]`, maps and delivers it, then advances the
+ * compound cursor only after the whole delivered window lands. The cursor
+ * always points at the end of fully delivered data — a retention backlog is
+ * caught up across capped runs, never silently skipped. Quarantine, idle
+ * backoff, and the sync-run audit row are all decided here; no vendor or
+ * backfill logic leaks into the engine.
+ */
+export const runDestinationSyncUseCase = (input: RunDestinationSyncInput) =>
+  Effect.gen(function* () {
+    const { destination, now } = input
+    yield* Effect.annotateCurrentSpan("destination.id", destination.id)
+    yield* Effect.annotateCurrentSpan("destination.kind", destination.kind)
+
+    if (destination.status !== "active") {
+      return result({ outcome: "skipped", destinationId: destination.id })
+    }
+
+    const startedAt = now
+    const windowEnd = new Date(now.getTime() - DESTINATION_SAFETY_LAG_MS)
+    const startCursor: DestinationCursor = {
+      ingestedAt: destination.cursorIngestedAt,
+      spanId: destination.cursorSpanId,
+    }
+
+    const destinations = yield* DestinationRepository
+    const syncRuns = yield* DestinationSyncRunRepository
+
+    const insertRun = (run: DestinationSyncRun) => syncRuns.insert(run)
+
+    const spans = yield* SpanRepository
+    const window = yield* spans.listByIngestedAtWindow({
+      organizationId: destination.organizationId,
+      projectId: destination.projectId,
+      cursor: { ingestedAt: startCursor.ingestedAt, spanId: SpanId(startCursor.spanId) },
+      windowEnd,
+      limit: destination.config.maxSpansPerRun,
+    })
+
+    if (window.spans.length === 0) {
+      const emptyTarget: DestinationCursor = { ingestedAt: windowEnd, spanId: "" }
+      const advances = isForward(emptyTarget, startCursor)
+      if (advances) {
+        const claimed = yield* destinations.advanceCursor({
+          id: destination.id,
+          expected: startCursor,
+          next: emptyTarget,
+        })
+        if (!claimed) return result({ outcome: "stale", destinationId: destination.id })
+      }
+
+      yield* destinations.updateRunState({
+        id: destination.id,
+        status: "active",
+        consecutiveFailures: 0,
+        consecutiveEmptyRuns: destination.consecutiveEmptyRuns + 1,
+        lastFailureMessage: destination.lastFailureMessage,
+        lastRunAt: now,
+      })
+
+      const run = createDestinationSyncRun({
+        organizationId: destination.organizationId,
+        destinationId: destination.id,
+        windowStart: startCursor.ingestedAt,
+        windowEnd: advances ? windowEnd : startCursor.ingestedAt,
+        status: "succeeded",
+        spansRead: 0,
+        eventsSent: 0,
+        eventsDropped: 0,
+        error: null,
+        startedAt,
+        finishedAt: now,
+      })
+      yield* insertRun(run)
+
+      return result({ outcome: "empty", destinationId: destination.id, cursorAdvanced: advances, syncRunId: run.id })
+    }
+
+    // Non-empty: the read is strictly after the cursor, so `nextCursor` is always present and forward.
+    const next = window.nextCursor
+    const deliveryWindow: DeliveryWindow = {
+      start: startCursor.ingestedAt,
+      end: next ? next.ingestedAt : windowEnd,
+    }
+
+    const mappers = yield* DestinationMappers
+    const mapped = yield* mappers[destination.kind].toEvents(window.spans, destination)
+
+    const deliverers = yield* DestinationDeliverers
+    const delivery = yield* deliverers[destination.kind]
+      .deliver(mapped.events, destination.config, destination.credentials, { window: deliveryWindow })
+      .pipe(Effect.result)
+
+    if (delivery._tag === "Failure") {
+      const error = delivery.failure
+      if (isRetryableDeliveryError(error)) {
+        return yield* Effect.fail(error)
+      }
+
+      const consecutiveFailures = destination.consecutiveFailures + 1
+      const quarantined = consecutiveFailures >= DESTINATION_QUARANTINE_FAILURE_THRESHOLD
+      const message = sanitizedFailureMessage(error)
+      yield* destinations.updateRunState({
+        id: destination.id,
+        status: quarantined ? "quarantined" : "active",
+        consecutiveFailures,
+        consecutiveEmptyRuns: destination.consecutiveEmptyRuns,
+        lastFailureMessage: message,
+        lastRunAt: now,
+      })
+
+      const run = createDestinationSyncRun({
+        organizationId: destination.organizationId,
+        destinationId: destination.id,
+        windowStart: deliveryWindow.start,
+        windowEnd: deliveryWindow.end,
+        status: "failed",
+        spansRead: window.spans.length,
+        eventsSent: 0,
+        eventsDropped: mapped.dropped,
+        error: message,
+        startedAt,
+        finishedAt: now,
+      })
+      yield* insertRun(run)
+
+      return result({
+        outcome: "failed",
+        destinationId: destination.id,
+        spansRead: window.spans.length,
+        eventsDropped: mapped.dropped,
+        quarantined,
+        syncRunId: run.id,
+      })
+    }
+
+    const claimed = yield* destinations.advanceCursor({
+      id: destination.id,
+      expected: startCursor,
+      next: next ? { ingestedAt: next.ingestedAt, spanId: next.spanId } : { ingestedAt: windowEnd, spanId: "" },
+    })
+    if (!claimed) return result({ outcome: "stale", destinationId: destination.id, spansRead: window.spans.length })
+
+    yield* destinations.updateRunState({
+      id: destination.id,
+      status: "active",
+      consecutiveFailures: 0,
+      consecutiveEmptyRuns: 0,
+      lastFailureMessage: destination.lastFailureMessage,
+      lastRunAt: now,
+    })
+
+    const eventsDropped = mapped.dropped + delivery.success.dropped
+    const run = createDestinationSyncRun({
+      organizationId: destination.organizationId,
+      destinationId: destination.id,
+      windowStart: deliveryWindow.start,
+      windowEnd: deliveryWindow.end,
+      status: "succeeded",
+      spansRead: window.spans.length,
+      eventsSent: delivery.success.delivered,
+      eventsDropped,
+      error: null,
+      startedAt,
+      finishedAt: now,
+    })
+    yield* insertRun(run)
+
+    return result({
+      outcome: "delivered",
+      destinationId: destination.id,
+      spansRead: window.spans.length,
+      eventsSent: delivery.success.delivered,
+      eventsDropped,
+      cursorAdvanced: true,
+      syncRunId: run.id,
+    })
+  }).pipe(Effect.withSpan("destinations.runDestinationSync")) as Effect.Effect<
+    RunDestinationSyncResult,
+    RunDestinationSyncError,
+    Requirements
+  >

--- a/packages/platform/db-postgres/src/repositories/destination-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/destination-repository.ts
@@ -178,6 +178,26 @@ export const DestinationRepositoryLive = Layer.effect(
           return rows.length > 0
         }),
 
+      updateRunState: ({ id, status, consecutiveFailures, consecutiveEmptyRuns, lastFailureMessage, lastRunAt }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .update(destinations)
+                .set({
+                  status,
+                  consecutiveFailures,
+                  consecutiveEmptyRuns,
+                  lastFailureMessage,
+                  lastRunAt,
+                  updatedAt: new Date(),
+                })
+                .where(and(eq(destinations.id, id), eq(destinations.organizationId, organizationId))),
+            )
+            .pipe(Effect.mapError((e) => toRepositoryError(e, "updateDestinationRunState")))
+        }),
+
       deleteByProjectId: (projectId) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>


### PR DESCRIPTION
## P1-6 (LAT-671) — `runDestinationSyncUseCase`

The destination-agnostic sync engine from `specs/data-destinations.md`, in `@domain/destinations`. No vendor/PostHog/backfill words leak into the engine.

### Engine (`use-cases/run-destination-sync.ts`)
- **Window math**: `windowEnd = now − SAFETY_LAG` (5 min); reads `(cursor, windowEnd]` ordered by `(ingested_at, span_id)`, capped at `maxSpansPerRun`. Backlog is never silently skipped — the cap's compound `nextCursor` carries over to the next run (a resumed destination catches up across capped runs).
- **CAS advance only after the whole window is delivered**; empty window advances the cursor to the window end (guarded against backward moves). A stale CAS aborts with no bookkeeping — the winning run owns it.
- **Failure/quarantine**: retryable delivery errors propagate so the worker throws → BullMQ retries with the cursor untouched (exhausted-retry accounting is the worker's hook). Non-retryable increments `consecutive_failures`; at the threshold (5) → `status='quarantined'`. Only a sanitized `[status] taxonomy` message is recorded, never raw response bodies.
- **Idle backoff**: `consecutive_empty_runs` increments on an empty run, resets on the first non-empty (which also resets `consecutive_failures`).
- Passes `{ window: { start, end } }` to the deliverer as delivery context (no vendor backfill logic in the engine).
- Writes a `destination_sync_runs` row: `spans_read`, `events_sent`, `events_dropped` (mapper + deliverer drops), sanitized `error`.

### Supporting changes
- New `DestinationMapper` port + `DestinationMappers` registry (mirrors `DestinationDeliverers`) so the engine maps spans→events by kind without knowing any vendor schema; `createPosthogMapper` binding injects `buildSpanUrl`/`maxEventBytes` at the wiring boundary.
- New `DestinationRepository.updateRunState` persists post-run bookkeeping (status, counters, `last_run_at`) **without touching the cursor** — kept separate from the optimistic `advanceCursor` so a stale run can't drag the cursor backwards. Implemented in the in-memory fake and the Postgres adapter.
- `DESTINATION_SAFETY_LAG_MS` constant.

### Tests (in-memory doubles, every branch — 38 pass in-package)
empty-window advance + backoff growth, delivered + backoff reset, cap-cut same-timestamp batch, retryable propagation, quarantine-at-N (+ below-threshold), stale-CAS abort, `events_dropped` rollup, non-active skip.

### Verification
- `pnpm --filter @domain/destinations typecheck` ✅ · `test` ✅ (38/38)
- `pnpm --filter @platform/db-postgres typecheck` ✅
- Hot path untouched: no diffs under `apps/ingest` or the span-ingestion worker.

### Note for reviewers
A successful run resets `consecutive_failures` to 0 (the "consecutive" semantics) — the spec only explicitly names credential-edit as a reset; flag if you'd prefer reset only on credential edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)