### PR TITLE
Add preset monitor creation flows

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/advanced-monitor-create-fields.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/advanced-monitor-create-fields.tsx
@@ -1,0 +1,52 @@
+import { Input, Textarea } from "@repo/ui"
+import { AlertCardForm } from "./alert-card-form.tsx"
+import type { AlertDraft, AlertFieldErrors } from "./alert-form-helpers.ts"
+
+export interface AdvancedMonitorCreateValue {
+  readonly name: string
+  readonly description: string
+  readonly alert: AlertDraft
+  readonly nameError: string | undefined
+  readonly alertErrors: AlertFieldErrors
+}
+
+export function AdvancedMonitorCreateFields({
+  value,
+  onChange,
+  projectId,
+  projectSlug,
+}: {
+  readonly value: AdvancedMonitorCreateValue
+  readonly onChange: (next: AdvancedMonitorCreateValue) => void
+  readonly projectId: string
+  readonly projectSlug: string
+}) {
+  const set = (patch: Partial<AdvancedMonitorCreateValue>) => onChange({ ...value, ...patch })
+
+  return (
+    <>
+      <Input
+        required
+        label="Name"
+        placeholder="Tool error spikes"
+        value={value.name}
+        onChange={(event) => set({ name: event.target.value, nameError: undefined })}
+        {...(value.nameError ? { errors: [value.nameError] } : {})}
+      />
+      <Textarea
+        label="Description"
+        placeholder="What is this monitor for?"
+        value={value.description}
+        onChange={(event) => set({ description: event.target.value })}
+        minRows={2}
+      />
+      <AlertCardForm
+        value={value.alert}
+        onChange={(alert) => set({ alert, alertErrors: {} })}
+        projectId={projectId}
+        projectSlug={projectSlug}
+        errors={value.alertErrors}
+      />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
@@ -17,6 +17,7 @@ import {
   draftWithKind,
   kindsForDraft,
   type LookbackUnit,
+  type MetricDirection,
   previewAlertSentence,
   type UserAlertKind,
   type WindowUnit,
@@ -110,9 +111,9 @@ const COMPARISON_OPTIONS: { label: string; value: ComparisonMode }[] = [
   { label: "times more than", value: "timesMoreThan" },
 ]
 
-const TARGET_COMPARISON_OPTIONS: { label: string; value: ComparisonMode }[] = [
-  { label: "or higher", value: "times" },
-  { label: "times more than", value: "timesMoreThan" },
+const TARGET_DIRECTION_OPTIONS: { label: string; value: MetricDirection }[] = [
+  { label: "above", value: "above" },
+  { label: "below", value: "below" },
 ]
 
 const BASELINE_KIND_OPTIONS: { label: string; value: BaselineKind }[] = [
@@ -181,7 +182,12 @@ function ThresholdWindowForm({
     />
   )
 
-  const comparisonOptions = targetMode ? TARGET_COMPARISON_OPTIONS : COMPARISON_OPTIONS
+  const comparisonOptions = targetMode
+    ? [
+        { label: "absolute", value: "times" as const },
+        { label: value.direction === "below" ? "times less than" : "times more than", value: "timesMoreThan" as const },
+      ]
+    : COMPARISON_OPTIONS
   const leadIn = targetMode ? "Alert when the metric is" : "Alert when traces are detected"
 
   // The amount doubles as the sensitivity in expected mode; snap an out-of-range
@@ -199,6 +205,16 @@ function ThresholdWindowForm({
         <Text.H5M>Threshold</Text.H5M>
         <div className="flex flex-wrap items-center gap-2 -mt-1">
           <Text.H5 color="foregroundMuted">{leadIn}</Text.H5>
+          {targetMode ? (
+            <Select<MetricDirection>
+              name="direction"
+              width="auto"
+              options={TARGET_DIRECTION_OPTIONS}
+              value={value.direction}
+              onChange={(direction) => onChange({ direction })}
+              {...(disabled ? { disabled: true } : {})}
+            />
+          ) : null}
           {amountInput}
           {absoluteUnit ? <Text.H5 color="foregroundMuted">{absoluteUnit}</Text.H5> : null}
           <Select<ComparisonMode>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.ts
@@ -6,6 +6,7 @@ import {
   type AlertDuration,
   type AlertIncidentCondition,
   type AlertMetricThreshold,
+  type AlertMetricThresholdDirection,
   type AlertSeverity,
   type MonitorMetric,
   metricValueFromStored,
@@ -31,6 +32,7 @@ export type UserAlertKind =
   | "metric.escalating"
 export type ComparisonMode = "times" | "timesMoreThan"
 export type WindowUnit = "minutes" | "hours" | "days"
+export type MetricDirection = AlertMetricThresholdDirection
 /** `average`/`period` carry a `lookback`; `expected` is the dynamically-learned baseline (no window). */
 export type BaselineKind = "average" | "period" | "expected"
 export type LookbackUnit = "minutes" | "hours" | "days"
@@ -48,6 +50,7 @@ export interface AlertDraft {
   /** The aggregate measured for unified targets; ignored in saved-search mode. */
   readonly metric: MonitorMetric
   readonly severity: AlertSeverity
+  readonly direction: MetricDirection
   readonly comparison: ComparisonMode
   /** count (absolute) · factor (multiplier) · sensitivity (expected) — see `comparison`/`baselineKind`. */
   readonly amount: number
@@ -65,6 +68,7 @@ export const emptyAlertDraft = (overrides?: Partial<AlertDraft>): AlertDraft => 
   target: null,
   metric: { kind: "count" },
   severity: SEVERITY_FOR_KIND["savedSearch.match"],
+  direction: "above",
   comparison: "times",
   amount: 100,
   baselineKind: "average",
@@ -109,6 +113,7 @@ export const draftWithKind = (draft: AlertDraft, kind: UserAlertKind): AlertDraf
     target: draft.target,
     metric: draft.metric,
     severity: draft.severity,
+    direction: draft.direction,
   })
 
 export interface AlertFieldErrors {
@@ -190,8 +195,10 @@ export const draftToCondition = (draft: AlertDraft): AlertIncidentCondition | nu
   if (draft.target !== null) {
     if (draft.kind === "event.matched") return null
     const threshold = draftToMetricThreshold(draft)
-    if (draft.kind === "metric.threshold") return { kind: "metric.threshold", metric: draft.metric, threshold }
-    return { kind: "metric.escalating", metric: draft.metric, threshold, window }
+    if (draft.kind === "metric.threshold") {
+      return { kind: "metric.threshold", metric: draft.metric, threshold, direction: draft.direction }
+    }
+    return { kind: "metric.escalating", metric: draft.metric, threshold, direction: draft.direction, window }
   }
   if (draft.kind === "savedSearch.match") return null
   const threshold = draftToCountThreshold(draft)
@@ -300,13 +307,19 @@ export const recordToAlertDraft = (alert: MonitorAlertRecord, target?: MonitorTa
     }
   }
   if (condition?.kind === "metric.threshold") {
-    return { ...base, metric: condition.metric, ...metricThresholdToDraftFields(condition.threshold, condition.metric) }
+    return {
+      ...base,
+      metric: condition.metric,
+      direction: condition.direction ?? "above",
+      ...metricThresholdToDraftFields(condition.threshold, condition.metric),
+    }
   }
   if (condition?.kind === "metric.escalating") {
     const window = minutesToWindow(condition.window.minutes)
     return {
       ...base,
       metric: condition.metric,
+      direction: condition.direction ?? "above",
       ...metricThresholdToDraftFields(condition.threshold, condition.metric),
       windowAmount: window.amount,
       windowUnit: window.unit,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-create-modal.tsx
@@ -1,5 +1,5 @@
 import { Button, CloseTrigger, Input, Modal, Textarea, useToast } from "@repo/ui"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 import { monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
 import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
@@ -28,12 +28,14 @@ export function MonitorCreateModal({
   initialAlert,
   onClose,
   onCreated,
+  bodyPrefix,
 }: {
   readonly projectId: string
   readonly projectSlug: string
   readonly initialAlert?: AlertDraft
   readonly onClose: () => void
   readonly onCreated?: (slug: string) => void
+  readonly bodyPrefix?: ReactNode
 }) {
   const { toast } = useToast()
   const create = useCreateMonitor(projectId)
@@ -108,6 +110,7 @@ export function MonitorCreateModal({
       }
     >
       <div className="flex flex-col gap-4">
+        {bodyPrefix}
         <Input
           required
           autoFocus

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-create-modal.tsx
@@ -1,5 +1,5 @@
 import { Button, CloseTrigger, Input, Modal, Textarea, useToast } from "@repo/ui"
-import { type ReactNode, useState } from "react"
+import { useState } from "react"
 import { monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
 import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
@@ -28,14 +28,12 @@ export function MonitorCreateModal({
   initialAlert,
   onClose,
   onCreated,
-  bodyPrefix,
 }: {
   readonly projectId: string
   readonly projectSlug: string
   readonly initialAlert?: AlertDraft
   readonly onClose: () => void
   readonly onCreated?: (slug: string) => void
-  readonly bodyPrefix?: ReactNode
 }) {
   const { toast } = useToast()
   const create = useCreateMonitor(projectId)
@@ -110,7 +108,6 @@ export function MonitorCreateModal({
       }
     >
       <div className="flex flex-col gap-4">
-        {bodyPrefix}
         <Input
           required
           autoFocus

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-mode-switch.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-mode-switch.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@repo/ui"
+
+export type MonitorCreateMode = "recommended" | "advanced"
+
+export function MonitorModeSwitch({
+  mode,
+  onModeChange,
+}: {
+  readonly mode: MonitorCreateMode
+  readonly onModeChange: (mode: MonitorCreateMode) => void
+}) {
+  return (
+    <div className="flex rounded-lg bg-muted p-1">
+      {(["recommended", "advanced"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onModeChange(option)}
+          className={cn("flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors", {
+            "bg-background text-foreground shadow-sm": mode === option,
+            "text-muted-foreground hover:text-foreground": mode !== option,
+          })}
+        >
+          {option === "recommended" ? "Recommended" : "Advanced"}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/target-monitors-menu.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/target-monitors-menu.tsx
@@ -15,10 +15,13 @@ import {
 import { useNavigate } from "@tanstack/react-router"
 import { BellPlusIcon, ChevronDownIcon } from "lucide-react"
 import { useState } from "react"
+import { describeMonitorTarget } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useMonitorsForTarget } from "../../../../../../domains/monitors/monitors.collection.ts"
 import type { MonitorRecord } from "../../../../../../domains/monitors/monitors.functions.ts"
 import { targetAlertDraft } from "./alert-form-helpers.ts"
 import { MonitorCreateModal } from "./monitor-create-modal.tsx"
+import { ToolMonitorCreateModal } from "./tool-monitor-create-modal.tsx"
+import { UserMonitorCreateModal } from "./user-monitor-create-modal.tsx"
 
 function stableStringify(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`
@@ -79,13 +82,30 @@ export function TargetMonitorsMenu({
       ? fetchedMonitors.filter((monitor) => sameTargetScope(monitor.target, createTarget))
       : fetchedMonitors
 
+  const targetDescription = describeMonitorTarget(createTarget)
   const createModal = createOpen ? (
-    <MonitorCreateModal
-      projectId={projectId}
-      projectSlug={projectSlug}
-      initialAlert={targetAlertDraft(createTarget)}
-      onClose={() => setCreateOpen(false)}
-    />
+    targetDescription?.kind === "tool" || targetDescription?.kind === "allTools" ? (
+      <ToolMonitorCreateModal
+        projectId={projectId}
+        projectSlug={projectSlug}
+        target={createTarget}
+        onClose={() => setCreateOpen(false)}
+      />
+    ) : targetDescription?.kind === "user" || targetDescription?.kind === "allUsers" ? (
+      <UserMonitorCreateModal
+        projectId={projectId}
+        projectSlug={projectSlug}
+        target={createTarget}
+        onClose={() => setCreateOpen(false)}
+      />
+    ) : (
+      <MonitorCreateModal
+        projectId={projectId}
+        projectSlug={projectSlug}
+        initialAlert={targetAlertDraft(createTarget)}
+        onClose={() => setCreateOpen(false)}
+      />
+    )
   ) : null
 
   if (monitors.length === 0) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
@@ -1,0 +1,285 @@
+import type { MonitorTarget } from "@domain/monitors"
+import { Button, cn, Icon, Modal, Text, useToast } from "@repo/ui"
+import { AlertTriangleIcon, GaugeIcon, TrendingDownIcon, TrendingUpIcon, ZapIcon } from "lucide-react"
+import { useState } from "react"
+import { describeMonitorTarget, monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
+import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
+import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
+import { AdvancedMonitorCreateFields, type AdvancedMonitorCreateValue } from "./advanced-monitor-create-fields.tsx"
+import {
+  type AlertDraft,
+  alertFieldErrorsFrom,
+  draftToAlertDraft,
+  draftToTarget,
+  hasAlertFieldErrors,
+  targetAlertDraft,
+} from "./alert-form-helpers.ts"
+
+interface ToolMonitorPreset {
+  readonly id: string
+  readonly name: string
+  readonly description: string
+  readonly icon: typeof AlertTriangleIcon
+  readonly draft: AlertDraft
+}
+
+const presetDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): AlertDraft =>
+  targetAlertDraft(target, {
+    kind: "metric.escalating",
+    comparison: "timesMoreThan",
+    baselineKind: "expected",
+    amount: 3,
+    windowAmount: 15,
+    windowUnit: "minutes",
+    ...overrides,
+  })
+
+function ModeSwitch({
+  mode,
+  onModeChange,
+}: {
+  readonly mode: "recommended" | "advanced"
+  readonly onModeChange: (mode: "recommended" | "advanced") => void
+}) {
+  return (
+    <div className="flex rounded-lg bg-muted p-1">
+      {(["recommended", "advanced"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onModeChange(option)}
+          className={cn("flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors", {
+            "bg-background text-foreground shadow-sm": mode === option,
+            "text-muted-foreground hover:text-foreground": mode !== option,
+          })}
+        >
+          {option === "recommended" ? "Recommended" : "Advanced"}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[] => {
+  const allTools = describeMonitorTarget(target)?.kind === "allTools"
+  if (allTools) {
+    return [
+      {
+        id: "failures-increased",
+        name: "Tool failures increased",
+        description: "Opens an incident when the overall tool error rate stays higher than expected.",
+        icon: AlertTriangleIcon,
+        draft: presetDraft(target, { metric: { kind: "errorRate" }, severity: "high" }),
+      },
+      {
+        id: "latency-increased",
+        name: "Tool latency increased",
+        description: "Opens an incident when p95 latency across tool calls stays higher than expected.",
+        icon: GaugeIcon,
+        draft: presetDraft(target, { metric: { kind: "p95", field: "duration" }, severity: "medium" }),
+      },
+      {
+        id: "usage-spike",
+        name: "Tool usage spiked",
+        description: "Opens an incident when total tool call volume stays higher than expected.",
+        icon: TrendingUpIcon,
+        draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium", windowAmount: 30 }),
+      },
+      {
+        id: "usage-drop",
+        name: "Tool usage dropped",
+        description: "Opens an incident when total tool call volume stays lower than expected.",
+        icon: TrendingDownIcon,
+        draft: presetDraft(target, {
+          metric: { kind: "count" },
+          direction: "below",
+          severity: "medium",
+          windowAmount: 60,
+        }),
+      },
+      {
+        id: "cost-spike",
+        name: "Tool cost spiked",
+        description: "Opens an incident when total tool-call cost stays higher than expected.",
+        icon: ZapIcon,
+        draft: presetDraft(target, { metric: { kind: "sum", field: "cost" }, severity: "medium", windowAmount: 30 }),
+      },
+    ]
+  }
+
+  return [
+    {
+      id: "failing",
+      name: "Tool is failing",
+      description: "Opens an incident when the tool's error rate stays higher than expected.",
+      icon: AlertTriangleIcon,
+      draft: presetDraft(target, { metric: { kind: "errorRate" }, severity: "high" }),
+    },
+    {
+      id: "slow",
+      name: "Tool is slow",
+      description: "Opens an incident when p95 latency stays higher than expected.",
+      icon: GaugeIcon,
+      draft: presetDraft(target, { metric: { kind: "p95", field: "duration" }, severity: "medium" }),
+    },
+    {
+      id: "usage-spike",
+      name: "Usage spiked",
+      description: "Opens an incident when call volume stays higher than expected.",
+      icon: TrendingUpIcon,
+      draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium" }),
+    },
+    {
+      id: "usage-drop",
+      name: "Usage dropped",
+      description: "Opens an incident when call volume stays lower than expected.",
+      icon: TrendingDownIcon,
+      draft: presetDraft(target, {
+        metric: { kind: "count" },
+        direction: "below",
+        severity: "medium",
+        windowAmount: 30,
+      }),
+    },
+    {
+      id: "overusing",
+      name: "Agent is overusing it",
+      description: "Opens an incident when calls stay unusually elevated, a common sign of loops or retries.",
+      icon: ZapIcon,
+      draft: presetDraft(target, { metric: { kind: "count" }, severity: "high", amount: 2 }),
+    },
+  ]
+}
+
+export function ToolMonitorCreateModal({
+  projectId,
+  projectSlug,
+  target,
+  onClose,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly target: MonitorTarget
+  readonly onClose: () => void
+}) {
+  const create = useCreateMonitor(projectId)
+  const { toast } = useToast()
+  const presets = toolMonitorPresets(target)
+  const [mode, setMode] = useState<"recommended" | "advanced">("recommended")
+  const [selectedPresetId, setSelectedPresetId] = useState(presets[0]?.id ?? "")
+  const [advancedValue, setAdvancedValue] = useState<AdvancedMonitorCreateValue>({
+    name: "",
+    description: "",
+    nameError: undefined,
+    alert: targetAlertDraft(target),
+    alertErrors: {},
+  })
+  const targetName = monitorTargetName(target) ?? "this tool"
+
+  const modeSwitch = <ModeSwitch mode={mode} onModeChange={setMode} />
+
+  const createPreset = async () => {
+    const preset = presets.find((entry) => entry.id === selectedPresetId)
+    if (!preset) return
+    const alertTarget = draftToTarget(preset.draft)
+    try {
+      await create.mutateAsync({
+        name: `${preset.name} — ${targetName}`,
+        description: preset.description,
+        alerts: [draftToAlertDraft(preset.draft)],
+        ...(alertTarget ? { target: alertTarget } : {}),
+      })
+      toast({ description: "Monitor created." })
+      onClose()
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  const createAdvanced = async () => {
+    const trimmedName = advancedValue.name.trim()
+    if (trimmedName.length === 0) {
+      setAdvancedValue({ ...advancedValue, nameError: "Name is required" })
+      return
+    }
+    const target = draftToTarget(advancedValue.alert)
+    try {
+      await create.mutateAsync({
+        name: trimmedName,
+        ...(advancedValue.description.trim() ? { description: advancedValue.description.trim() } : {}),
+        alerts: [draftToAlertDraft(advancedValue.alert)],
+        ...(target ? { target } : {}),
+      })
+      toast({ description: "Monitor created." })
+      onClose()
+    } catch (error) {
+      const fieldErrors = extractFieldErrors(error)
+      const nameErr = fieldErrors?.name?.[0]
+      const errors = alertFieldErrorsFrom(fieldErrors, 0)
+      if (nameErr || hasAlertFieldErrors(errors)) {
+        setAdvancedValue({ ...advancedValue, ...(nameErr ? { nameError: nameErr } : {}), alertErrors: errors })
+        return
+      }
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      size="large"
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+      title="New tool monitor"
+      description={`Choose a recommended aggregate monitor for ${targetName}, or switch to the advanced form.`}
+      footer={
+        <Button
+          disabled={create.isPending || (mode === "recommended" && !selectedPresetId)}
+          isLoading={create.isPending}
+          onClick={() => void (mode === "advanced" ? createAdvanced() : createPreset())}
+        >
+          {create.isPending ? "Creating" : "Create monitor"}
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {modeSwitch}
+        {mode === "advanced" ? (
+          <AdvancedMonitorCreateFields
+            value={advancedValue}
+            onChange={setAdvancedValue}
+            projectId={projectId}
+            projectSlug={projectSlug}
+          />
+        ) : null}
+        {mode === "recommended"
+          ? presets.map((preset) => {
+              const selected = preset.id === selectedPresetId
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  disabled={create.isPending}
+                  onClick={() => setSelectedPresetId(preset.id)}
+                  className={cn(
+                    "flex w-full cursor-pointer items-start gap-3 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60",
+                    { "border-primary bg-muted": selected, "border-border": !selected },
+                  )}
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+                    <Icon icon={preset.icon} size="sm" color="foregroundMuted" />
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <Text.H5M>{preset.name}</Text.H5M>
+                    <Text.H6 color="foregroundMuted">{preset.description}</Text.H6>
+                  </div>
+                </button>
+              )
+            })
+          : null}
+      </div>
+    </Modal>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
@@ -14,6 +14,7 @@ import {
   hasAlertFieldErrors,
   targetAlertDraft,
 } from "./alert-form-helpers.ts"
+import { type MonitorCreateMode, MonitorModeSwitch } from "./monitor-mode-switch.tsx"
 
 interface ToolMonitorPreset {
   readonly id: string
@@ -33,32 +34,6 @@ const presetDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): Ale
     windowUnit: "minutes",
     ...overrides,
   })
-
-function ModeSwitch({
-  mode,
-  onModeChange,
-}: {
-  readonly mode: "recommended" | "advanced"
-  readonly onModeChange: (mode: "recommended" | "advanced") => void
-}) {
-  return (
-    <div className="flex rounded-lg bg-muted p-1">
-      {(["recommended", "advanced"] as const).map((option) => (
-        <button
-          key={option}
-          type="button"
-          onClick={() => onModeChange(option)}
-          className={cn("flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors", {
-            "bg-background text-foreground shadow-sm": mode === option,
-            "text-muted-foreground hover:text-foreground": mode !== option,
-          })}
-        >
-          {option === "recommended" ? "Recommended" : "Advanced"}
-        </button>
-      ))}
-    </div>
-  )
-}
 
 const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[] => {
   const allTools = describeMonitorTarget(target)?.kind === "allTools"
@@ -165,7 +140,7 @@ export function ToolMonitorCreateModal({
   const create = useCreateMonitor(projectId)
   const { toast } = useToast()
   const presets = toolMonitorPresets(target)
-  const [mode, setMode] = useState<"recommended" | "advanced">("recommended")
+  const [mode, setMode] = useState<MonitorCreateMode>("recommended")
   const [selectedPresetId, setSelectedPresetId] = useState(presets[0]?.id ?? "")
   const [advancedValue, setAdvancedValue] = useState<AdvancedMonitorCreateValue>({
     name: "",
@@ -176,7 +151,7 @@ export function ToolMonitorCreateModal({
   })
   const targetName = monitorTargetName(target) ?? "this tool"
 
-  const modeSwitch = <ModeSwitch mode={mode} onModeChange={setMode} />
+  const modeSwitch = <MonitorModeSwitch mode={mode} onModeChange={setMode} />
 
   const createPreset = async () => {
     const preset = presets.find((entry) => entry.id === selectedPresetId)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
@@ -1,0 +1,252 @@
+import type { MonitorTarget } from "@domain/monitors"
+import { Button, cn, Icon, Modal, Text, useToast } from "@repo/ui"
+import { AlertTriangleIcon, CoinsIcon, GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react"
+import { useState } from "react"
+import { describeMonitorTarget, monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
+import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
+import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
+import { AdvancedMonitorCreateFields, type AdvancedMonitorCreateValue } from "./advanced-monitor-create-fields.tsx"
+import {
+  type AlertDraft,
+  alertFieldErrorsFrom,
+  draftToAlertDraft,
+  draftToTarget,
+  hasAlertFieldErrors,
+  targetAlertDraft,
+} from "./alert-form-helpers.ts"
+
+interface UserMonitorPreset {
+  readonly id: string
+  readonly name: string
+  readonly description: string
+  readonly icon: typeof AlertTriangleIcon
+  readonly draft: AlertDraft
+}
+
+function ModeSwitch({
+  mode,
+  onModeChange,
+}: {
+  readonly mode: "recommended" | "advanced"
+  readonly onModeChange: (mode: "recommended" | "advanced") => void
+}) {
+  return (
+    <div className="flex rounded-lg bg-muted p-1">
+      {(["recommended", "advanced"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onModeChange(option)}
+          className={cn("flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors", {
+            "bg-background text-foreground shadow-sm": mode === option,
+            "text-muted-foreground hover:text-foreground": mode !== option,
+          })}
+        >
+          {option === "recommended" ? "Recommended" : "Advanced"}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+const targetWithFilter = (
+  target: MonitorTarget,
+  filterSet: NonNullable<MonitorTarget["filterSet"]>,
+): MonitorTarget => ({
+  ...target,
+  filterSet: { ...(target.filterSet ?? {}), ...filterSet },
+})
+
+const presetDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): AlertDraft =>
+  targetAlertDraft(target, {
+    kind: "metric.escalating",
+    comparison: "timesMoreThan",
+    baselineKind: "expected",
+    amount: 3,
+    windowAmount: 30,
+    windowUnit: "minutes",
+    ...overrides,
+  })
+
+const userMonitorPresets = (target: MonitorTarget): readonly UserMonitorPreset[] => {
+  const allUsers = describeMonitorTarget(target)?.kind === "allUsers"
+  const subject = allUsers ? "users" : "this user"
+  return [
+    {
+      id: "errors",
+      name: allUsers ? "Users are having errors" : "User is having errors",
+      description: `Opens an incident when failed traces for ${subject} stay higher than expected.`,
+      icon: AlertTriangleIcon,
+      draft: presetDraft(targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }), {
+        metric: { kind: "count" },
+        severity: "high",
+      }),
+    },
+    {
+      id: "slow",
+      name: allUsers ? "Users are seeing slow responses" : "User is seeing slow responses",
+      description: `Opens an incident when p95 trace latency for ${subject} stays higher than expected.`,
+      icon: GaugeIcon,
+      draft: presetDraft(target, { metric: { kind: "p95", field: "duration" }, severity: "medium", windowAmount: 15 }),
+    },
+    {
+      id: "activity-spike",
+      name: "Activity spiked",
+      description: `Opens an incident when trace volume for ${subject} stays higher than expected.`,
+      icon: TrendingUpIcon,
+      draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium" }),
+    },
+    {
+      id: "activity-drop",
+      name: "Activity dropped",
+      description: `Opens an incident when trace volume for ${subject} stays lower than expected.`,
+      icon: TrendingDownIcon,
+      draft: presetDraft(target, {
+        metric: { kind: "count" },
+        direction: "below",
+        severity: "medium",
+        windowAmount: 60,
+      }),
+    },
+    {
+      id: "cost-spike",
+      name: "Cost spiked",
+      description: `Opens an incident when total cost for ${subject} stays higher than expected.`,
+      icon: CoinsIcon,
+      draft: presetDraft(target, { metric: { kind: "sum", field: "cost" }, severity: "medium" }),
+    },
+  ]
+}
+
+export function UserMonitorCreateModal({
+  projectId,
+  projectSlug,
+  target,
+  onClose,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly target: MonitorTarget
+  readonly onClose: () => void
+}) {
+  const create = useCreateMonitor(projectId)
+  const { toast } = useToast()
+  const presets = userMonitorPresets(target)
+  const [mode, setMode] = useState<"recommended" | "advanced">("recommended")
+  const [selectedPresetId, setSelectedPresetId] = useState(presets[0]?.id ?? "")
+  const [advancedValue, setAdvancedValue] = useState<AdvancedMonitorCreateValue>({
+    name: "",
+    description: "",
+    nameError: undefined,
+    alert: targetAlertDraft(target),
+    alertErrors: {},
+  })
+  const targetName = monitorTargetName(target) ?? "this user"
+
+  const modeSwitch = <ModeSwitch mode={mode} onModeChange={setMode} />
+
+  const createPreset = async () => {
+    const preset = presets.find((entry) => entry.id === selectedPresetId)
+    if (!preset) return
+    const alertTarget = draftToTarget(preset.draft)
+    try {
+      await create.mutateAsync({
+        name: `${preset.name} — ${targetName}`,
+        description: preset.description,
+        alerts: [draftToAlertDraft(preset.draft)],
+        ...(alertTarget ? { target: alertTarget } : {}),
+      })
+      toast({ description: "Monitor created." })
+      onClose()
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  const createAdvanced = async () => {
+    const trimmedName = advancedValue.name.trim()
+    if (trimmedName.length === 0) {
+      setAdvancedValue({ ...advancedValue, nameError: "Name is required" })
+      return
+    }
+    const target = draftToTarget(advancedValue.alert)
+    try {
+      await create.mutateAsync({
+        name: trimmedName,
+        ...(advancedValue.description.trim() ? { description: advancedValue.description.trim() } : {}),
+        alerts: [draftToAlertDraft(advancedValue.alert)],
+        ...(target ? { target } : {}),
+      })
+      toast({ description: "Monitor created." })
+      onClose()
+    } catch (error) {
+      const fieldErrors = extractFieldErrors(error)
+      const nameErr = fieldErrors?.name?.[0]
+      const errors = alertFieldErrorsFrom(fieldErrors, 0)
+      if (nameErr || hasAlertFieldErrors(errors)) {
+        setAdvancedValue({ ...advancedValue, ...(nameErr ? { nameError: nameErr } : {}), alertErrors: errors })
+        return
+      }
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      size="large"
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+      title="New user monitor"
+      description={`Choose a recommended aggregate monitor for ${targetName}, or switch to the advanced form.`}
+      footer={
+        <Button
+          disabled={create.isPending || (mode === "recommended" && !selectedPresetId)}
+          isLoading={create.isPending}
+          onClick={() => void (mode === "advanced" ? createAdvanced() : createPreset())}
+        >
+          {create.isPending ? "Creating" : "Create monitor"}
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {modeSwitch}
+        {mode === "advanced" ? (
+          <AdvancedMonitorCreateFields
+            value={advancedValue}
+            onChange={setAdvancedValue}
+            projectId={projectId}
+            projectSlug={projectSlug}
+          />
+        ) : null}
+        {mode === "recommended"
+          ? presets.map((preset) => {
+              const selected = preset.id === selectedPresetId
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  disabled={create.isPending}
+                  onClick={() => setSelectedPresetId(preset.id)}
+                  className={cn(
+                    "flex w-full cursor-pointer items-start gap-3 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60",
+                    { "border-primary bg-muted": selected, "border-border": !selected },
+                  )}
+                >
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+                    <Icon icon={preset.icon} size="sm" color="foregroundMuted" />
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <Text.H5M>{preset.name}</Text.H5M>
+                    <Text.H6 color="foregroundMuted">{preset.description}</Text.H6>
+                  </div>
+                </button>
+              )
+            })
+          : null}
+      </div>
+    </Modal>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
@@ -14,6 +14,7 @@ import {
   hasAlertFieldErrors,
   targetAlertDraft,
 } from "./alert-form-helpers.ts"
+import { type MonitorCreateMode, MonitorModeSwitch } from "./monitor-mode-switch.tsx"
 
 interface UserMonitorPreset {
   readonly id: string
@@ -21,32 +22,6 @@ interface UserMonitorPreset {
   readonly description: string
   readonly icon: typeof AlertTriangleIcon
   readonly draft: AlertDraft
-}
-
-function ModeSwitch({
-  mode,
-  onModeChange,
-}: {
-  readonly mode: "recommended" | "advanced"
-  readonly onModeChange: (mode: "recommended" | "advanced") => void
-}) {
-  return (
-    <div className="flex rounded-lg bg-muted p-1">
-      {(["recommended", "advanced"] as const).map((option) => (
-        <button
-          key={option}
-          type="button"
-          onClick={() => onModeChange(option)}
-          className={cn("flex-1 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium transition-colors", {
-            "bg-background text-foreground shadow-sm": mode === option,
-            "text-muted-foreground hover:text-foreground": mode !== option,
-          })}
-        >
-          {option === "recommended" ? "Recommended" : "Advanced"}
-        </button>
-      ))}
-    </div>
-  )
 }
 
 const targetWithFilter = (
@@ -132,7 +107,7 @@ export function UserMonitorCreateModal({
   const create = useCreateMonitor(projectId)
   const { toast } = useToast()
   const presets = userMonitorPresets(target)
-  const [mode, setMode] = useState<"recommended" | "advanced">("recommended")
+  const [mode, setMode] = useState<MonitorCreateMode>("recommended")
   const [selectedPresetId, setSelectedPresetId] = useState(presets[0]?.id ?? "")
   const [advancedValue, setAdvancedValue] = useState<AdvancedMonitorCreateValue>({
     name: "",
@@ -143,7 +118,7 @@ export function UserMonitorCreateModal({
   })
   const targetName = monitorTargetName(target) ?? "this user"
 
-  const modeSwitch = <ModeSwitch mode={mode} onModeChange={setMode} />
+  const modeSwitch = <MonitorModeSwitch mode={mode} onModeChange={setMode} />
 
   const createPreset = async () => {
     const preset = presets.find((entry) => entry.id === selectedPresetId)

--- a/packages/domain/monitors/src/helpers.ts
+++ b/packages/domain/monitors/src/helpers.ts
@@ -114,7 +114,7 @@ const formatMetricThreshold = (
     return `${direction === "below" ? "under" : "over"} ${formatMetricValue(threshold.value, metric)}`
   }
   if (threshold.mode === "multiplier") {
-    return `${direction === "below" ? "less than" : "more than"} ${threshold.factor} times ${formatBaseline(threshold.baseline)}`
+    return `${threshold.factor} times ${direction === "below" ? "less than" : "more than"} ${formatBaseline(threshold.baseline)}`
   }
   const comparator = direction === "below" ? "less than expected" : "more than expected"
   return threshold.sensitivity === undefined ? comparator : `${threshold.sensitivity} times ${comparator}`

--- a/packages/domain/monitors/src/helpers.ts
+++ b/packages/domain/monitors/src/helpers.ts
@@ -105,16 +105,19 @@ const formatMetric = (metric: MonitorMetric): string => {
 }
 
 /** Threshold phrase for the unified `metric.*` kinds; absolute carries a stored float `value` rendered with its unit. */
-const formatMetricThreshold = (threshold: AlertMetricThreshold, metric: MonitorMetric): string => {
+const formatMetricThreshold = (
+  threshold: AlertMetricThreshold,
+  metric: MonitorMetric,
+  direction: "above" | "below" = "above",
+): string => {
   if (threshold.mode === "absolute") {
-    return `over ${formatMetricValue(threshold.value, metric)}`
+    return `${direction === "below" ? "under" : "over"} ${formatMetricValue(threshold.value, metric)}`
   }
   if (threshold.mode === "multiplier") {
-    return `${threshold.factor} times more than ${formatBaseline(threshold.baseline)}`
+    return `${direction === "below" ? "less than" : "more than"} ${threshold.factor} times ${formatBaseline(threshold.baseline)}`
   }
-  return threshold.sensitivity === undefined
-    ? "more than expected"
-    : `${threshold.sensitivity} times more than expected`
+  const comparator = direction === "below" ? "less than expected" : "more than expected"
+  return threshold.sensitivity === undefined ? comparator : `${threshold.sensitivity} times ${comparator}`
 }
 
 const targetSubject = (context?: HumanReadableAlertContext): string => context?.targetName ?? "the target"
@@ -149,13 +152,14 @@ export function formatHumanReadableAlert(alert: HumanReadableAlertInput, context
   }
 
   if (alert.kind === "metric.threshold" && alert.condition?.kind === "metric.threshold") {
-    return `Opens an incident when ${formatMetric(alert.condition.metric)} for ${targetSubject(context)} is ${formatMetricThreshold(alert.condition.threshold, alert.condition.metric)}.`
+    return `Opens an incident when ${formatMetric(alert.condition.metric)} for ${targetSubject(context)} is ${formatMetricThreshold(alert.condition.threshold, alert.condition.metric, alert.condition.direction)}.`
   }
 
   if (alert.kind === "metric.escalating" && alert.condition?.kind === "metric.escalating") {
     return `Opens an incident when ${formatMetric(alert.condition.metric)} for ${targetSubject(context)} is ${formatMetricThreshold(
       alert.condition.threshold,
       alert.condition.metric,
+      alert.condition.direction,
     )}, sustained for at least ${formatWindowMinutes(alert.condition.window.minutes)}.`
   }
 

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
@@ -66,6 +66,12 @@ describe("evaluateMetricAlert (metric.threshold)", () => {
     expect(notMet.isMet).toBe(false)
   })
 
+  it("does not fire an absolute below-threshold alert on an empty window (no data is not a drop)", async () => {
+    const evaluation = await runThreshold([], target({ kind: "count" }), { mode: "absolute", value: 5 }, "below")
+    expect(evaluation.value).toBe(0)
+    expect(evaluation.isMet).toBe(false)
+  })
+
   it("does not fire an above-threshold multiplier alert when current and baseline are both zero", async () => {
     const evaluation = await runThreshold([], target({ kind: "count" }), {
       mode: "multiplier",

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
@@ -26,13 +26,14 @@ const runThreshold = (
   events: readonly Date[],
   t: MetricSeriesTarget,
   threshold: Parameters<typeof evaluateMetricAlert>[0]["condition"]["threshold"],
+  direction: Parameters<typeof evaluateMetricAlert>[0]["condition"]["direction"] = "above",
 ) =>
   Effect.runPromise(
     evaluateMetricAlert({
       organizationId,
       projectId,
       target: t,
-      condition: { kind: "metric.threshold", metric: t.metric, threshold },
+      condition: { kind: "metric.threshold", metric: t.metric, threshold, direction },
       now,
     }).pipe(
       Effect.provide(createFakeMetricSeriesReader(events).layer),
@@ -52,6 +53,14 @@ describe("evaluateMetricAlert (metric.threshold)", () => {
   it("absolute mode does not fire below the threshold", async () => {
     const events = [minutesAgo(1), minutesAgo(2), minutesAgo(3)]
     const notMet = await runThreshold(events, target({ kind: "count" }), { mode: "absolute", value: 5 })
+    expect(notMet.isMet).toBe(false)
+  })
+
+  it("supports below-threshold metric alerts", async () => {
+    const events = [minutesAgo(1), minutesAgo(2), minutesAgo(3)]
+    const met = await runThreshold(events, target({ kind: "count" }), { mode: "absolute", value: 5 }, "below")
+    const notMet = await runThreshold(events, target({ kind: "count" }), { mode: "absolute", value: 2 }, "below")
+    expect(met.isMet).toBe(true)
     expect(notMet.isMet).toBe(false)
   })
 

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.test.ts
@@ -10,6 +10,8 @@ const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
 const now = new Date("2026-06-01T12:00:00.000Z")
 const minutesAgo = (m: number) => new Date(now.getTime() - m * 60 * 1000)
+const weeksAgoMinutesAgo = (weeks: number, minutes: number) =>
+  new Date(now.getTime() - weeks * 7 * 24 * 60 * 60 * 1000 - minutes * 60 * 1000)
 
 // The fake reader counts seeded event times per window/bucket regardless of metric
 // kind — so it exercises the threshold/window math; per-metric aggregation is the
@@ -64,6 +66,52 @@ describe("evaluateMetricAlert (metric.threshold)", () => {
     expect(notMet.isMet).toBe(false)
   })
 
+  it("does not fire an above-threshold multiplier alert when current and baseline are both zero", async () => {
+    const evaluation = await runThreshold([], target({ kind: "count" }), {
+      mode: "multiplier",
+      factor: 1,
+      baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+    })
+    expect(evaluation.value).toBe(0)
+    expect(evaluation.threshold).toBe(0)
+    expect(evaluation.isMet).toBe(false)
+  })
+
+  it("supports below-threshold multiplier alerts", async () => {
+    const baselineEvents = [6, 10, 15, 20, 25, 30, 35, 40, 45, 50].map((m) => minutesAgo(m))
+    const evaluation = await runThreshold(
+      baselineEvents,
+      target({ kind: "count" }),
+      {
+        mode: "multiplier",
+        factor: 1,
+        baseline: { kind: "average", lookback: { unit: "hours", hours: 1 } },
+      },
+      "below",
+    )
+    expect(evaluation.value).toBe(0)
+    expect(evaluation.threshold).toBeCloseTo(10 / 12)
+    expect(evaluation.isMet).toBe(true)
+  })
+
+  it("supports below-expected alerts", async () => {
+    const historical = Array.from({ length: 4 }, (_unused, index) =>
+      Array.from({ length: 100 }, () => weeksAgoMinutesAgo(index + 1, 1)),
+    ).flat()
+    const evaluation = await runThreshold(
+      historical,
+      target({ kind: "count" }),
+      {
+        mode: "expected",
+        sensitivity: 3,
+      },
+      "below",
+    )
+    expect(evaluation.value).toBe(0)
+    expect(evaluation.threshold).toBeGreaterThan(0)
+    expect(evaluation.isMet).toBe(true)
+  })
+
   it("multiplier normalizes the baseline for accumulating metrics but not intensive ones", async () => {
     // 2 events in the last 5 min; 12 in the last hour (baseline window). The 10 older
     // events sit strictly before the 5-min boundary (6 min ago onward).
@@ -92,13 +140,14 @@ describe("evaluateMetricEscalatingAlert (metric.escalating)", () => {
     events: readonly Date[],
     t: MetricSeriesTarget,
     threshold: Parameters<typeof evaluateMetricEscalatingAlert>[0]["condition"]["threshold"],
+    direction: Parameters<typeof evaluateMetricEscalatingAlert>[0]["condition"]["direction"] = "above",
   ) =>
     Effect.runPromise(
       evaluateMetricEscalatingAlert({
         organizationId,
         projectId,
         target: t,
-        condition: { kind: "metric.escalating", metric: t.metric, threshold, window: { minutes: 10 } },
+        condition: { kind: "metric.escalating", metric: t.metric, threshold, direction, window: { minutes: 10 } },
         now,
       }).pipe(
         Effect.provide(createFakeMetricSeriesReader(events).layer),
@@ -121,5 +170,13 @@ describe("evaluateMetricEscalatingAlert (metric.escalating)", () => {
       value: 3,
     })
     expect(evalResult.perBucketThreshold).toBe(3)
+  })
+
+  it("computes a below-expected per-bucket threshold", async () => {
+    const historical = Array.from({ length: 4 }, (_unused, index) =>
+      Array.from({ length: 100 }, () => weeksAgoMinutesAgo(index + 1, 1)),
+    ).flat()
+    const evalResult = await run(historical, target({ kind: "count" }), { mode: "expected", sensitivity: 3 }, "below")
+    expect(evalResult.perBucketThreshold).toBeGreaterThan(0)
   })
 })

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
@@ -108,13 +108,21 @@ export const evaluateMetricAlert = (
       )
       thresholdValue = seasonalThreshold(historical, threshold, direction)
     }
-    const isMet = isMetricThresholdMet(value, thresholdValue, direction)
+    let isMet = isMetricThresholdMet(value, thresholdValue, direction)
 
     // Only the firing branch backtracks `startedAt`; gate on `isMet`, not the metric
     // value (an intensive metric like avg/errorRate can be 0 with real activity).
     const firstEventInWindow = isMet
       ? yield* reader.firstEventAt({ organizationId, projectId, target, from, to: now })
       : null
+
+    // An absolute `below` threshold has no baseline of "normal", so an empty window (no
+    // events) is missing data, not a usage drop — don't fire. Multiplier/expected `below`
+    // are exempt: their baseline (recent/seasonal) plus the `threshold > 0` guard already
+    // suppress the truly-no-traffic case while still catching a busy target going silent.
+    if (isMet && direction === "below" && threshold.mode === "absolute" && firstEventInWindow === null) {
+      isMet = false
+    }
 
     return {
       isMet,

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
@@ -8,6 +8,7 @@ import type {
   AlertIncidentMetricEscalatingCondition,
   AlertIncidentMetricThresholdCondition,
   AlertMetricThreshold,
+  AlertMetricThresholdDirection,
   ChSqlClient,
   MonitorMetric,
   OrganizationId,
@@ -48,16 +49,24 @@ export interface MetricAlertEvaluation {
   readonly baselineValue?: number
 }
 
+const sigmaEffective = (observed: number, expected: number): number =>
+  Math.max(observed, Math.sqrt(Math.max(0, expected)), 1.0)
+
 const seasonalThreshold = (
   historical: readonly number[],
   threshold: Extract<AlertMetricThreshold, { mode: "expected" }>,
+  direction: AlertMetricThresholdDirection,
 ): number => {
   const sensitivity = threshold.sensitivity ?? DEFAULT_ESCALATION_SENSITIVITY_K
   const expected = mean(historical)
-  // Widen the band when the sample is thin (mirrors the seasonal detector).
   const kAdj = historical.length < MIN_SEASONAL_SAMPLES ? sensitivity + 1 : sensitivity
-  return seasonalAnomalyThreshold(expected, sampleStddev(historical, expected), kAdj)
+  const stddev = sampleStddev(historical, expected)
+  if (direction === "below") return Math.max(0, expected - kAdj * sigmaEffective(stddev, expected))
+  return seasonalAnomalyThreshold(expected, stddev, kAdj)
 }
+
+export const isMetricThresholdMet = (value: number, threshold: number, direction: AlertMetricThresholdDirection) =>
+  direction === "below" ? threshold > 0 && value <= threshold : value >= threshold
 
 /**
  * Evaluate one `metric.threshold` alert at `now` over the monitor's target
@@ -79,19 +88,17 @@ export const evaluateMetricAlert = (
     const value = yield* valueIn(from, now)
 
     const threshold = condition.threshold
+    const direction = condition.direction ?? "above"
     let thresholdValue: number
     let baselineValue: number | undefined
-    let isMet: boolean
     if (threshold.mode === "absolute") {
       thresholdValue = threshold.value
-      isMet = value >= thresholdValue
     } else if (threshold.mode === "multiplier") {
       const window = baselineWindow(threshold.baseline, now)
       baselineValue = yield* valueIn(window.from, window.to)
       // Accumulating metrics need the baseline rescaled to the current window; intensive metrics don't.
       const scale = accumulating ? windowMs / window.lengthMs : 1
       thresholdValue = threshold.factor * baselineValue * scale
-      isMet = value > 0 && value >= thresholdValue
     } else {
       const historical = yield* Effect.all(
         Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
@@ -100,9 +107,9 @@ export const evaluateMetricAlert = (
         }),
         { concurrency: "unbounded" },
       )
-      thresholdValue = seasonalThreshold(historical, threshold)
-      isMet = value > 0 && value > thresholdValue
+      thresholdValue = seasonalThreshold(historical, threshold, direction)
     }
+    const isMet = isMetricThresholdMet(value, thresholdValue, direction)
 
     // Only the firing branch backtracks `startedAt`; gate on `isMet`, not the metric
     // value (an intensive metric like avg/errorRate can be 0 with real activity).
@@ -155,6 +162,7 @@ export const evaluateMetricEscalatingAlert = (
     const bucketValues = yield* reader.seriesPerBucket({ organizationId, projectId, target, from, to: now, bucketMs })
 
     const threshold = condition.threshold
+    const direction = condition.direction ?? "above"
     let perBucketThreshold: number
     let baselineValue: number | undefined
     if (threshold.mode === "absolute") {
@@ -173,7 +181,7 @@ export const evaluateMetricEscalatingAlert = (
         }),
         { concurrency: "unbounded" },
       )
-      perBucketThreshold = seasonalThreshold(historical, threshold)
+      perBucketThreshold = seasonalThreshold(historical, threshold, direction)
     }
 
     // The open decision is downstream (state machine); always resolve the backtrace

--- a/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
+++ b/packages/domain/monitors/src/use-cases/evaluate-metric-alert.ts
@@ -49,8 +49,7 @@ export interface MetricAlertEvaluation {
   readonly baselineValue?: number
 }
 
-const sigmaEffective = (observed: number, expected: number): number =>
-  Math.max(observed, Math.sqrt(Math.max(0, expected)), 1.0)
+const sigmaEffective = (stddev: number, mean: number): number => Math.max(stddev, Math.sqrt(Math.max(0, mean)), 1.0)
 
 const seasonalThreshold = (
   historical: readonly number[],
@@ -66,7 +65,7 @@ const seasonalThreshold = (
 }
 
 export const isMetricThresholdMet = (value: number, threshold: number, direction: AlertMetricThresholdDirection) =>
-  direction === "below" ? threshold > 0 && value <= threshold : value >= threshold
+  direction === "below" ? threshold > 0 && value <= threshold : threshold > 0 ? value >= threshold : value > 0
 
 /**
  * Evaluate one `metric.threshold` alert at `now` over the monitor's target

--- a/packages/domain/monitors/src/use-cases/run-metric-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-metric-monitor-alert.ts
@@ -9,6 +9,7 @@ import {
   type EvaluateMetricAlertError,
   evaluateMetricAlert,
   evaluateMetricEscalatingAlert,
+  isMetricThresholdMet,
 } from "./evaluate-metric-alert.ts"
 import { closeMetricIncident, openMetricIncident } from "./metric-incident-writer.ts"
 
@@ -26,6 +27,11 @@ export interface RunMetricMonitorAlertResult {
 }
 
 export type RunMetricMonitorAlertError = EvaluateMetricAlertError | RepositoryError
+
+const countNonPassingBuckets = (bucketValues: readonly number[], threshold: number, direction: "above" | "below") => {
+  if (direction === "above") return countFailingBuckets(bucketValues, threshold)
+  return bucketValues.filter((value) => !isMetricThresholdMet(value, threshold, direction)).length
+}
 
 /**
  * State machine for the unified `event.*`/`metric.*` alerts over a monitor's
@@ -104,9 +110,10 @@ export const runMetricMonitorAlertUseCase = (input: RunMetricMonitorAlertInput) 
           const evaluation = yield* evaluateMetricEscalatingAlert({ organizationId, projectId, target, condition, now })
           const open = yield* alertIncidentRepository.findOpenByMonitorAlertId(alert.id)
           const maxFail = maxFailingBuckets(evaluation.bucketValues.length)
+          const direction = condition.direction ?? "above"
 
           if (open === null) {
-            const failing = countFailingBuckets(evaluation.bucketValues, evaluation.perBucketThreshold)
+            const failing = countNonPassingBuckets(evaluation.bucketValues, evaluation.perBucketThreshold, direction)
             if (failing > maxFail) return { transition: "none" } satisfies RunMetricMonitorAlertResult
             const entrySignals: SavedSearchEntrySignals = {
               evaluatedThreshold: evaluation.perBucketThreshold,
@@ -122,7 +129,7 @@ export const runMetricMonitorAlertUseCase = (input: RunMetricMonitorAlertInput) 
           const frozenThreshold = isSavedSearchEntrySignals(open.entrySignals)
             ? open.entrySignals.evaluatedThreshold
             : evaluation.perBucketThreshold
-          if (countFailingBuckets(evaluation.bucketValues, frozenThreshold) <= maxFail) {
+          if (countNonPassingBuckets(evaluation.bucketValues, frozenThreshold, direction) <= maxFail) {
             return { transition: "none" } satisfies RunMetricMonitorAlertResult
           }
           const reader = yield* MetricSeriesReader

--- a/packages/domain/monitors/src/use-cases/run-metric-monitor-alert.ts
+++ b/packages/domain/monitors/src/use-cases/run-metric-monitor-alert.ts
@@ -115,6 +115,16 @@ export const runMetricMonitorAlertUseCase = (input: RunMetricMonitorAlertInput) 
           if (open === null) {
             const failing = countNonPassingBuckets(evaluation.bucketValues, evaluation.perBucketThreshold, direction)
             if (failing > maxFail) return { transition: "none" } satisfies RunMetricMonitorAlertResult
+            // An absolute `below` gate has no baseline of "normal", so a window with no
+            // events is missing data, not a sustained drop — don't open. Multiplier/expected
+            // are exempt (baseline + `threshold > 0` guard handle the no-traffic case).
+            if (
+              direction === "below" &&
+              condition.threshold.mode === "absolute" &&
+              evaluation.firstEventInWindow === null
+            ) {
+              return { transition: "none" } satisfies RunMetricMonitorAlertResult
+            }
             const entrySignals: SavedSearchEntrySignals = {
               evaluatedThreshold: evaluation.perBucketThreshold,
               ...(evaluation.baselineValue !== undefined ? { baselineCount: evaluation.baselineValue } : {}),

--- a/packages/domain/shared/src/alert-incident-condition.ts
+++ b/packages/domain/shared/src/alert-incident-condition.ts
@@ -96,6 +96,9 @@ export type MonitorMetric = z.infer<typeof monitorMetricSchema>
  * {@link alertCountThresholdSchema}, but `absolute` takes a float `value` (not an
  * int `count`) — error-rate (0.1), p95 latency, cost, etc. aren't whole numbers.
  */
+export const alertMetricThresholdDirectionSchema = z.enum(["above", "below"])
+export type AlertMetricThresholdDirection = z.infer<typeof alertMetricThresholdDirectionSchema>
+
 export const alertMetricThresholdSchema = z.discriminatedUnion("mode", [
   z.object({ mode: z.literal("absolute"), value: z.number().positive() }),
   z.object({ mode: z.literal("multiplier"), factor: z.number().positive(), baseline: alertBaselineSchema }),
@@ -108,6 +111,7 @@ export const alertIncidentMetricThresholdConditionSchema = z.object({
   kind: z.literal("metric.threshold"),
   metric: monitorMetricSchema,
   threshold: alertMetricThresholdSchema,
+  direction: alertMetricThresholdDirectionSchema.optional(),
 })
 export type AlertIncidentMetricThresholdCondition = z.infer<typeof alertIncidentMetricThresholdConditionSchema>
 
@@ -116,6 +120,7 @@ export const alertIncidentMetricEscalatingConditionSchema = z.object({
   kind: z.literal("metric.escalating"),
   metric: monitorMetricSchema,
   threshold: alertMetricThresholdSchema,
+  direction: alertMetricThresholdDirectionSchema.optional(),
   window: z.object({ minutes: z.number().int().min(5) }),
 })
 export type AlertIncidentMetricEscalatingCondition = z.infer<typeof alertIncidentMetricEscalatingConditionSchema>


### PR DESCRIPTION
## Summary

Adds recommended monitor creation flows for tool and user targets. Target monitor creation now opens a single modal with a Recommended/Advanced segmented control: Recommended shows opinionated aggregate monitor presets, while Advanced exposes the existing full monitor form in the same modal shell.

Tool presets cover failing tools, slow tools, usage spikes/drops, overuse for individual tools, and fleet-level all-tools monitors. User presets cover user errors, slow responses, activity spikes/drops, and cost spikes for both individual users and all-user traffic.

The metric monitor condition schema now supports an optional `above`/`below` direction for unified metric alerts, enabling usage-drop presets without changing saved-search monitor behavior.

## Validation

- `pnpm --filter @domain/monitors test -- src/use-cases/evaluate-metric-alert.test.ts`
- `pnpm --filter @domain/shared typecheck`
- `pnpm --filter @domain/monitors typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`
- pre-commit format + knip

Please attach screenshots or a short screen recording of the new monitor preset modal for reviewer context.