### PR TITLE
feat(destinations): ProjectDeleted deletion cascade (LAT-672)

### DIFF
--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -30,6 +30,7 @@
     "@domain/billing": "workspace:*",
     "@domain/conversation-intelligence": "workspace:*",
     "@domain/datasets": "workspace:*",
+    "@domain/destinations": "workspace:*",
     "@domain/email": "workspace:*",
     "@domain/evaluations": "workspace:*",
     "@domain/events": "workspace:*",

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -43,6 +43,7 @@ import { createAnnotationScoresWorker } from "./workers/annotation-scores.ts"
 import { createApiKeysWorker } from "./workers/api-keys.ts"
 import { createBillingWorker } from "./workers/billing.ts"
 import { createBillingOverageWorker } from "./workers/billing-overage.ts"
+import { createDestinationsWorker } from "./workers/destinations.ts"
 import { createDeterministicFlaggersWorker } from "./workers/deterministic-flaggers.ts"
 import { createAlertIncidentsWorker } from "./workers/domain-events/alert-incidents.ts"
 import { createInvitationEmailWorker } from "./workers/domain-events/invitation-email.ts"
@@ -186,6 +187,7 @@ const bootstrap = async () => {
     createNotificationsWorker(ctx)
     createNotificationEmailerWorker(ctx)
     createNotificationSlackWorker(ctx)
+    createDestinationsWorker({ consumer: ctx.consumer })
     createApiKeysWorker(ctx)
     createBillingWorker({ consumer: ctx.consumer, postgresClient: ctx.postgresClient })
     createBillingOverageWorker({ consumer: ctx.consumer, workflowStarter: ctx.workflowStarter })

--- a/apps/workers/src/workers/destinations.ts
+++ b/apps/workers/src/workers/destinations.ts
@@ -1,0 +1,41 @@
+import { deleteProjectDestinationsUseCase } from "@domain/destinations"
+import type { QueueConsumer } from "@domain/queue"
+import { OrganizationId, ProjectId } from "@domain/shared"
+import { DestinationRepositoryLive, DestinationSyncRunRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { createLogger, withTracing } from "@repo/observability"
+import { Effect, Layer } from "effect"
+import { getPostgresClient } from "../clients.ts"
+
+const logger = createLogger("destinations")
+
+interface DestinationsDeps {
+  consumer: QueueConsumer
+}
+
+const deleteByProjectLayer = Layer.mergeAll(DestinationRepositoryLive, DestinationSyncRunRepositoryLive)
+
+export const createDestinationsWorker = ({ consumer }: DestinationsDeps) => {
+  const pgClient = getPostgresClient()
+
+  consumer.subscribe("destinations", {
+    "delete-by-project": (payload) =>
+      deleteProjectDestinationsUseCase({
+        organizationId: OrganizationId(payload.organizationId),
+        projectId: ProjectId(payload.projectId),
+      }).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() =>
+            logger.info(`destinations.delete-by-project projectId=${payload.projectId} deleted=${result.deleted}`),
+          ),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() =>
+            logger.error(`destinations.delete-by-project failed projectId=${payload.projectId}`, error),
+          ),
+        ),
+        withPostgres(deleteByProjectLayer, pgClient, OrganizationId(payload.organizationId)),
+        Effect.asVoid,
+        withTracing,
+      ),
+  })
+}

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -423,7 +423,7 @@ describe("domain-events dispatcher", () => {
     expect(published).toEqual([])
   })
 
-  it("routes ProjectDeleted to notifications:delete-by-project for cascade cleanup", async () => {
+  it("routes ProjectDeleted to notifications and destinations delete-by-project for cascade cleanup", async () => {
     const { consumer, published } = setupDispatcher()
 
     const envelope = makeEnvelope("ProjectDeleted", {
@@ -437,6 +437,10 @@ describe("domain-events dispatcher", () => {
     const notif = published.find((p) => p.queue === "notifications" && p.task === "delete-by-project")
     expect(notif?.payload).toEqual({ organizationId: "org-1", projectId: "proj-x" })
     expect(notif?.options?.dedupeKey).toBe("notifications:delete-by-project:proj-x")
+
+    const dest = published.find((p) => p.queue === "destinations" && p.task === "delete-by-project")
+    expect(dest?.payload).toEqual({ organizationId: "org-1", projectId: "proj-x" })
+    expect(dest?.options?.dedupeKey).toBe("destinations:delete-by-project:proj-x")
   })
 
   it("fans out whitelisted events to posthog-analytics:track in addition to the primary handler", async () => {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -391,17 +391,33 @@ export const createDomainEventsWorker = ({
     EvaluationDetectorDegraded: () => Effect.void,
     AnnotationQueueItemCompleted: () => Effect.void,
     ProjectDeleted: (event) =>
-      pub.publish(
-        "notifications",
-        "delete-by-project",
-        {
-          organizationId: event.payload.organizationId,
-          projectId: event.payload.projectId,
-        },
-        {
-          dedupeKey: `notifications:delete-by-project:${event.payload.projectId}`,
-        },
-      ),
+      Effect.all(
+        [
+          pub.publish(
+            "notifications",
+            "delete-by-project",
+            {
+              organizationId: event.payload.organizationId,
+              projectId: event.payload.projectId,
+            },
+            {
+              dedupeKey: `notifications:delete-by-project:${event.payload.projectId}`,
+            },
+          ),
+          pub.publish(
+            "destinations",
+            "delete-by-project",
+            {
+              organizationId: event.payload.organizationId,
+              projectId: event.payload.projectId,
+            },
+            {
+              dedupeKey: `destinations:delete-by-project:${event.payload.projectId}`,
+            },
+          ),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.asVoid),
     FlaggerToggled: () => Effect.void,
     SavedSearchCreated: () => Effect.void,
     // Impersonation events are audit-only — their value is being

--- a/packages/domain/destinations/src/index.ts
+++ b/packages/domain/destinations/src/index.ts
@@ -109,6 +109,11 @@ export type {
 } from "./use-cases/create-destination.ts"
 export { createDestinationUseCase } from "./use-cases/create-destination.ts"
 export type {
+  DeleteProjectDestinationsError,
+  DeleteProjectDestinationsInput,
+} from "./use-cases/delete-project-destinations.ts"
+export { deleteProjectDestinationsUseCase } from "./use-cases/delete-project-destinations.ts"
+export type {
   RunDestinationSyncError,
   RunDestinationSyncInput,
   RunDestinationSyncOutcome,

--- a/packages/domain/destinations/src/use-cases/delete-project-destinations.test.ts
+++ b/packages/domain/destinations/src/use-cases/delete-project-destinations.test.ts
@@ -1,0 +1,114 @@
+import { type DestinationId, OrganizationId, ProjectId, SqlClient, UserId } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { POSTHOG_US_INGESTION_HOST } from "../constants.ts"
+import { createDestination } from "../entities/destination.ts"
+import { createDestinationSyncRun, type DestinationSyncRun } from "../entities/destination-sync-run.ts"
+import { DestinationRepository } from "../ports/destination-repository.ts"
+import { DestinationSyncRunRepository } from "../ports/destination-sync-run-repository.ts"
+import { createFakeDestinationRepository } from "../testing/fake-destination-repository.ts"
+import { createFakeDestinationSyncRunRepository } from "../testing/fake-destination-sync-run-repository.ts"
+import { deleteProjectDestinationsUseCase } from "./delete-project-destinations.ts"
+
+const cuid = (seed: string) => seed.padEnd(24, "0")
+
+const orgId = OrganizationId(cuid("o"))
+const userId = UserId(cuid("u"))
+const targetProjectId = ProjectId(cuid("target"))
+const otherProjectId = ProjectId(cuid("other"))
+
+const destination = (id: string, projectId: ProjectId) =>
+  createDestination({
+    id: id as DestinationId,
+    organizationId: orgId,
+    projectId,
+    name: "Acme PostHog",
+    config: {
+      kind: "posthog",
+      host: POSTHOG_US_INGESTION_HOST,
+      excludePayloads: false,
+      intervalMs: 300_000,
+      maxSpansPerRun: 50_000,
+    },
+    credentials: { kind: "posthog", apiKey: "phc_test" },
+    createdByUserId: userId,
+  })
+
+const syncRun = (destinationId: string): DestinationSyncRun =>
+  createDestinationSyncRun({
+    organizationId: orgId,
+    destinationId: destinationId as DestinationId,
+    windowStart: new Date("2026-06-01T00:00:00Z"),
+    windowEnd: new Date("2026-06-01T00:05:00Z"),
+    status: "succeeded",
+    spansRead: 10,
+    eventsSent: 12,
+    eventsDropped: 0,
+    error: null,
+    startedAt: new Date("2026-06-01T00:05:00Z"),
+    finishedAt: new Date("2026-06-01T00:05:01Z"),
+  })
+
+function setup() {
+  const target = destination(cuid("dtarget"), targetProjectId)
+  const other = destination(cuid("dother"), otherProjectId)
+
+  const { repo: destinationRepo, rows: destinationRows } = createFakeDestinationRepository([target, other])
+  const { repo: syncRunRepo, rows: syncRunRows } = createFakeDestinationSyncRunRepository([
+    syncRun(target.id),
+    syncRun(other.id),
+  ])
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(DestinationRepository, destinationRepo),
+    Layer.succeed(DestinationSyncRunRepository, syncRunRepo),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: orgId })),
+  )
+
+  return { target, other, destinationRows, syncRunRows, layer }
+}
+
+describe("deleteProjectDestinationsUseCase", () => {
+  it("removes the project's destinations and their sync runs, leaving other projects untouched", async () => {
+    const { other, destinationRows, syncRunRows, layer } = setup()
+
+    const result = await Effect.runPromise(
+      deleteProjectDestinationsUseCase({ organizationId: orgId, projectId: targetProjectId }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(result.deleted).toBe(1)
+    expect(destinationRows.map((r) => r.id)).toEqual([other.id])
+    expect(syncRunRows.map((r) => r.destinationId)).toEqual([other.id])
+  })
+
+  it("stops the deleted project's destination from being selected by the sweep", async () => {
+    const { layer } = setup()
+
+    const due = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* deleteProjectDestinationsUseCase({ organizationId: orgId, projectId: targetProjectId })
+        const repo = yield* DestinationRepository
+        return yield* repo.listDue(new Date())
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(due.map((d) => d.projectId)).toEqual([otherProjectId])
+  })
+
+  it("is a no-op when the project has no destinations", async () => {
+    const { destinationRows, syncRunRows, layer } = setup()
+
+    const result = await Effect.runPromise(
+      deleteProjectDestinationsUseCase({ organizationId: orgId, projectId: ProjectId(cuid("empty")) }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(result.deleted).toBe(0)
+    expect(destinationRows).toHaveLength(2)
+    expect(syncRunRows).toHaveLength(2)
+  })
+})

--- a/packages/domain/destinations/src/use-cases/delete-project-destinations.ts
+++ b/packages/domain/destinations/src/use-cases/delete-project-destinations.ts
@@ -1,0 +1,40 @@
+import type { OrganizationId, ProjectId, RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { DestinationRepository } from "../ports/destination-repository.ts"
+import { DestinationSyncRunRepository } from "../ports/destination-sync-run-repository.ts"
+
+export interface DeleteProjectDestinationsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+}
+
+export type DeleteProjectDestinationsError = RepositoryError
+
+/**
+ * Cascade cleanup on `ProjectDeleted`. Removes the project's destinations and
+ * their `destination_sync_runs` rows. Without it the sweep keeps exporting the
+ * deleted project's residual ClickHouse spans — delivery keeps succeeding and
+ * quarantine never fires (a privacy hole, not just orphan rows). Per the no-FK
+ * platform rule, this referential integrity is application-layer.
+ */
+export const deleteProjectDestinationsUseCase = (input: DeleteProjectDestinationsInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
+    const destinations = yield* DestinationRepository
+    const deletedIds = yield* destinations.deleteByProjectId(input.projectId)
+
+    if (deletedIds.length === 0) {
+      return { deleted: 0 }
+    }
+
+    const syncRuns = yield* DestinationSyncRunRepository
+    yield* syncRuns.deleteByDestinationIds(deletedIds)
+
+    return { deleted: deletedIds.length }
+  }).pipe(Effect.withSpan("destinations.deleteProjectDestinations")) as Effect.Effect<
+    { readonly deleted: number },
+    DeleteProjectDestinationsError,
+    SqlClient | DestinationRepository | DestinationSyncRunRepository
+  >

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -562,6 +562,18 @@ const _registry = {
   sandboxes: payloads<{
     archiveIdle: Record<string, never>
   }>(),
+
+  destinations: payloads<{
+    /**
+     * Cascade cleanup. Fired by the domain-events worker on `ProjectDeleted`.
+     * The consumer deletes the project's destinations and their sync runs so
+     * the sweep stops exporting the deleted project's residual ClickHouse data.
+     */
+    "delete-by-project": {
+      readonly organizationId: string
+      readonly projectId: string
+    }
+  }>(),
 }
 
 export type TopicRegistry = typeof _registry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,7 +307,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -371,7 +371,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/web:
     dependencies:
@@ -658,6 +658,9 @@ importers:
       '@domain/datasets':
         specifier: workspace:*
         version: link:../../packages/domain/datasets
+      '@domain/destinations':
+        specifier: workspace:*
+        version: link:../../packages/domain/destinations
       '@domain/email':
         specifier: workspace:*
         version: link:../../packages/domain/email


### PR DESCRIPTION
## What

Implements **P1-9 (LAT-672)** from `specs/data-destinations.md` — the `ProjectDeleted` deletion cascade for data destinations. Mirrors the notifications cascade pattern exactly.

When a project is deleted, its destinations and their `destination_sync_runs` rows are removed so the sweep stops exporting the deleted project's residual ClickHouse spans. Without it, delivery keeps **succeeding** and quarantine never fires — a privacy hole, not just orphan rows. Org purge emits `ProjectDeleted` per project, so org deletion is covered transitively (no separate org handler).

## Changes

**Domain (`@domain/destinations`)**
- `deleteProjectDestinationsUseCase({ organizationId, projectId })` — deletes the project's destinations (`DestinationRepository.deleteByProjectId`, returns the IDs) then their sync runs (`DestinationSyncRunRepository.deleteByDestinationIds`). Returns `{ deleted }`, span-instrumented, no-ops when the project has none.
- Exported from `index.ts`; unit-tested with the existing in-memory doubles (removes rows + leaves other projects untouched; deleted destination drops out of `listDue` so the sweep stops selecting it; no-op path).

**Queue (`@domain/queue`)**
- New `destinations` topic with a `delete-by-project` task. (P1-7 will add `sweep`/`runSync` to the same topic.)

**Workers (`apps/workers`)**
- New `destinations.ts` worker consuming `destinations` / `delete-by-project`, invoking the use case under `withPostgres(...)` (RLS-scoped to the event org) + `withTracing` — structurally identical to the notifications handler.
- `domain-events.ts`: `ProjectDeleted` now fans out to **both** `notifications` and `destinations` `delete-by-project` via `Effect.all`.
- Registered the worker in `server.ts`; added the `@domain/destinations` dependency.
- Extended the existing `ProjectDeleted` routing test to assert the destinations route too.

## Tests
- `@domain/destinations` 32/32 · `@app/workers` domain-events 24/24 · `@domain/queue` 8/8.
- Typecheck clean for all touched files. No diffs under `apps/ingest`.

## Note
- Order: destinations are deleted first (to learn their IDs), then sync runs. On the rare crash between the two, a retry finds no destinations and skips the now-orphaned sync rows — but those are audit-only and pruned after 30 days by the sweep; the destination row (the sweep driver / privacy hole) is already gone. A project-scoped sync-run delete would need a new repo/port method beyond P1-3's merged surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)