### PR TITLE
feat(web): per-turn index in the session drawer

### DIFF
--- a/apps/web/src/lib/hooks/useInView.ts
+++ b/apps/web/src/lib/hooks/useInView.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from "react"
+
+/**
+ * Reports when an element first scrolls into view (sticky once seen). Uses a
+ * callback ref so the observer wires up the moment the node mounts. `rootMargin`
+ * expands the viewport to prefetch slightly ahead; intermediate scroll
+ * containers are clipped automatically, so a viewport root works inside nested
+ * `overflow` containers.
+ */
+export function useInView<T extends Element>({ rootMargin = "0px" }: { rootMargin?: string } = {}) {
+  const [inView, setInView] = useState(false)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  const ref = useCallback(
+    (node: T | null) => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+      if (!node) return
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((entry) => entry.isIntersecting)) {
+            setInView(true)
+            observer.disconnect()
+            observerRef.current = null
+          }
+        },
+        { rootMargin },
+      )
+      observer.observe(node)
+      observerRef.current = observer
+    },
+    [rootMargin],
+  )
+
+  return [ref, inView] as const
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -14,11 +14,13 @@ import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextI
 import { useMemo } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import { SessionOutlierBadge, type SessionOutlierMetric } from "../session-outlier-badge.tsx"
 import { DurationBar } from "../trace-detail-drawer/duration-bar.tsx"
 import { computeSessionDurationBreakdown } from "../trace-detail-drawer/duration-composition.ts"
 import { ModelFilterLink } from "../trace-detail-drawer/tabs/spans-tab/model-filter-link.tsx"
 import { UsageSummary } from "../trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx"
+import { TurnTrajectory } from "./turn-trajectory.tsx"
 
 // Sessions only expose percentile filters for duration/TTFT/cost
 // (`PERCENTILE_SESSION_FILTER_FIELDS`), so the tokens badge stays informational
@@ -36,12 +38,18 @@ function JsonBlock({ value }: { readonly value: unknown }) {
 
 export function MetadataTab({
   session,
+  traces,
+  traceNumberById,
+  onOpenTrace,
   filters,
   onFiltersChange,
   spansNavEnabled = false,
   onOpenSpansWithModel,
 }: {
   readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
+  readonly traceNumberById: ReadonlyMap<string, number>
+  readonly onOpenTrace: (traceId: string) => void
   readonly filters?: FilterSet | undefined
   readonly onFiltersChange?: ((filters: FilterSet) => void) | undefined
   readonly spansNavEnabled?: boolean
@@ -159,6 +167,15 @@ export function MetadataTab({
         />
         <UsageSummary data={session} costBadges={costBadgesNode} />
       </div>
+
+      <TurnTrajectory
+        traces={traces}
+        spans={spans ?? []}
+        traceNumberById={traceNumberById}
+        totalTraceCount={session.traceCount}
+        projectId={session.projectId}
+        onOpenTrace={onOpenTrace}
+      />
 
       <div className="flex flex-col gap-1">
         <Text.H6 color="foregroundMuted">Tags</Text.H6>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -244,6 +244,9 @@ export function SessionSlot({
         {effectiveActiveTab === "session" && (
           <MetadataTab
             session={session}
+            traces={traces}
+            traceNumberById={traceNumberById}
+            onOpenTrace={onOpenTrace}
             spansNavEnabled={Boolean(singleTrace)}
             {...(singleTrace ? { onOpenSpansWithModel: navigateToSpansWithModel } : {})}
             {...(filters ? { filters } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.tsx
@@ -1,0 +1,312 @@
+import { cn, DetailSection, type SegmentBarItem, Skeleton, Text, Tooltip } from "@repo/ui"
+import { formatCount, formatDuration, formatPrice } from "@repo/utils"
+import { ActivityIcon, ClockIcon, type LucideIcon, MessageSquareIcon, WrenchIcon } from "lucide-react"
+import { Fragment, type ReactNode, use, useMemo } from "react"
+import { useAnnotationCountsByTraceIds } from "../../../../../../domains/annotations/annotations.collection.ts"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import { TraceScopeContext } from "../../../../../../domains/traces/trace-scope.tsx"
+import { useTraceCohortSummary, useTraceDetail } from "../../../../../../domains/traces/traces.collection.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { useInView } from "../../../../../../lib/hooks/useInView.ts"
+import { computePerTraceBreakdowns, type TraceDurationBreakdown } from "../trace-detail-drawer/duration-composition.ts"
+import { SegmentBreakdownRows } from "../trace-detail-drawer/segment-breakdown-rows.tsx"
+import { formatDuration as formatDurationMs } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+import {
+  computeToolStatsByTrace,
+  computeTurnHealth,
+  inputPreview,
+  outputPreview,
+  type ToolStats,
+  type TurnHealth,
+} from "./turn-trajectory.utils.ts"
+
+const MICROCENTS_PER_DOLLAR = 100_000_000
+// Below this, a between-turn gap is noise (clock skew, fast back-to-back turns).
+const GAP_THRESHOLD_MS = 1_000
+
+const cost = (microcents: number) => formatPrice(microcents / MICROCENTS_PER_DOLLAR)
+
+function Chip({
+  icon: Icon,
+  count,
+  tooltip,
+}: {
+  readonly icon: LucideIcon
+  readonly count: number
+  readonly tooltip: string
+}) {
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <span className="inline-flex items-center gap-0.5 tabular-nums">
+          <Icon className="h-3 w-3" aria-hidden />
+          {count}
+        </span>
+      }
+    >
+      {tooltip}
+    </Tooltip>
+  )
+}
+
+function HealthDot({ health }: { readonly health: TurnHealth }) {
+  if (health.tone === "none") return <span className="size-1.5 shrink-0" aria-hidden />
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <span
+          className={cn("size-1.5 shrink-0 rounded-full", health.tone === "danger" ? "bg-rose-500" : "bg-amber-500")}
+          aria-hidden
+        />
+      }
+    >
+      {health.reason}
+    </Tooltip>
+  )
+}
+
+function MetaRow({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div className="flex flex-row items-center justify-between gap-4">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <Text.H6 color="foreground">{value}</Text.H6>
+    </div>
+  )
+}
+
+function TurnTooltip({
+  breakdown,
+  trace,
+}: {
+  readonly breakdown: TraceDurationBreakdown
+  readonly trace: TraceRecord
+}) {
+  const compSegments: SegmentBarItem[] = breakdown.segments.map((s) => ({
+    label: s.label,
+    value: s.ms,
+    color: s.color,
+  }))
+  return (
+    <div className="flex min-w-[160px] flex-col gap-2">
+      {compSegments.length > 0 && <SegmentBreakdownRows segments={compSegments} formatValue={formatDurationMs} />}
+      <div className="flex flex-col gap-1">
+        <MetaRow label="TTFT" value={trace.timeToFirstTokenNs > 0 ? formatDuration(trace.timeToFirstTokenNs) : "-"} />
+        <MetaRow label="Tokens" value={formatCount(trace.tokensTotal)} />
+        <MetaRow label="Cost" value={cost(trace.costTotalMicrocents)} />
+      </div>
+    </div>
+  )
+}
+
+function TurnCard({
+  trace,
+  number,
+  projectId,
+  breakdown,
+  health,
+  toolStats,
+  annotationCount,
+  model,
+  onOpen,
+}: {
+  readonly trace: TraceRecord
+  readonly number: number
+  readonly projectId: string
+  readonly breakdown: TraceDurationBreakdown | undefined
+  readonly health: TurnHealth
+  readonly toolStats: ToolStats | undefined
+  readonly annotationCount: number
+  readonly model: string | null
+  readonly onOpen: (traceId: string) => void
+}) {
+  const [cardRef, inView] = useInView<HTMLButtonElement>({ rootMargin: "200px" })
+  const { data: detail } = useTraceDetail({ projectId, traceId: trace.traceId, enabled: inView })
+  const input = detail ? inputPreview(detail.inputMessages) : ""
+  const output = detail ? outputPreview(detail.outputMessages) : ""
+  const showSkeleton = !detail
+
+  const durationText = formatDuration(trace.durationNs)
+  const meta: { key: string; node: ReactNode }[] = [
+    {
+      key: "duration",
+      node:
+        breakdown && breakdown.wallClockMs > 0 ? (
+          <Tooltip asChild trigger={<span className="tabular-nums">{durationText}</span>}>
+            <TurnTooltip breakdown={breakdown} trace={trace} />
+          </Tooltip>
+        ) : (
+          <span className="tabular-nums">{durationText}</span>
+        ),
+    },
+    { key: "cost", node: <span className="tabular-nums">{cost(trace.costTotalMicrocents)}</span> },
+  ]
+  if (toolStats && toolStats.tools > 0) {
+    meta.push({
+      key: "tools",
+      node: (
+        <Chip
+          icon={WrenchIcon}
+          count={toolStats.tools}
+          tooltip={`${toolStats.tools} tool ${toolStats.tools === 1 ? "call" : "calls"}${
+            toolStats.failed > 0 ? ` (${toolStats.failed} failed)` : ""
+          }`}
+        />
+      ),
+    })
+  }
+  if (annotationCount > 0) {
+    meta.push({
+      key: "annotations",
+      node: (
+        <Chip
+          icon={MessageSquareIcon}
+          count={annotationCount}
+          tooltip={`${annotationCount} ${annotationCount === 1 ? "annotation" : "annotations"}`}
+        />
+      ),
+    })
+  }
+
+  return (
+    <button
+      ref={cardRef}
+      type="button"
+      onClick={() => onOpen(trace.traceId)}
+      aria-label={`Open turn ${number}${health.tone === "none" ? "" : ` — ${health.reason}`}`}
+      className="flex w-full items-start gap-2 rounded-md px-2 py-2 text-left hover:bg-muted"
+    >
+      <div className="flex shrink-0 items-center gap-1.5 pt-px">
+        <HealthDot health={health} />
+        <div className="min-w-4 text-right tabular-nums">
+          <Text.H6 color="foregroundMuted" noWrap>
+            {number}
+          </Text.H6>
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="min-w-0">
+          {showSkeleton ? (
+            <Skeleton className="h-3 w-3/4" />
+          ) : input ? (
+            <Text.H6 color="foreground" ellipsis noWrap>
+              {input}
+            </Text.H6>
+          ) : null}
+        </div>
+
+        {(showSkeleton || output) && (
+          <div className="flex min-w-0 flex-row items-center gap-1">
+            <Text.H6 color="foregroundMuted" noWrap>
+              ↳
+            </Text.H6>
+            {showSkeleton ? (
+              <Skeleton className="h-3 w-1/2" />
+            ) : (
+              <Text.H6 color="foregroundMuted" ellipsis noWrap>
+                {output}
+              </Text.H6>
+            )}
+          </div>
+        )}
+
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-muted-foreground text-xs">
+          {meta.map((item, i) => (
+            <Fragment key={item.key}>
+              {i > 0 && <span aria-hidden>·</span>}
+              {item.node}
+            </Fragment>
+          ))}
+          {model && <span className="ml-auto truncate pl-2">{model}</span>}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+/**
+ * Per-turn index of a multi-trace session: one card per trace (turn), read
+ * oldest→newest. Each card previews the turn's input/output above a muted
+ * metadata line, with a health dot flagging errored or outlier (slow/expensive)
+ * turns. Previews fetch lazily as each card scrolls into view.
+ */
+export function TurnTrajectory({
+  traces,
+  spans,
+  traceNumberById,
+  totalTraceCount,
+  projectId,
+  onOpenTrace,
+}: {
+  readonly traces: readonly TraceRecord[]
+  readonly spans: readonly SpanRecord[]
+  readonly traceNumberById: ReadonlyMap<string, number>
+  readonly totalTraceCount: number
+  readonly projectId: string
+  readonly onOpenTrace: (traceId: string) => void
+}) {
+  const isSandbox = !!use(TraceScopeContext)
+  const chronological = useMemo(() => [...traces].reverse(), [traces])
+  const perTrace = useMemo(() => computePerTraceBreakdowns(spans), [spans])
+  const toolStats = useMemo(() => computeToolStatsByTrace(spans), [spans])
+  const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
+  const { data: annotationCounts } = useAnnotationCountsByTraceIds({ projectId, traceIds, enabled: !isSandbox })
+  const { data: cohorts } = useTraceCohortSummary({ projectId })
+
+  if (chronological.length <= 1) return null
+
+  return (
+    <DetailSection
+      icon={<ActivityIcon className="h-4 w-4" />}
+      label={`Turns (${chronological.length})`}
+      defaultOpen={chronological.length <= 12}
+      contentClassName="max-h-[28rem]"
+    >
+      {() => (
+        <div className="flex w-full flex-col gap-0.5">
+          {chronological.map((trace, i) => {
+            const counts = annotationCounts?.get(trace.traceId)
+            const prev = chronological[i - 1]
+            const gapMs = prev ? Date.parse(trace.startTime) - Date.parse(prev.endTime) : 0
+            const model =
+              trace.models.length > 0 && trace.models.join(", ") !== (prev?.models.join(", ") ?? "")
+                ? trace.models.join(", ")
+                : null
+
+            return (
+              <Fragment key={trace.traceId}>
+                {gapMs > GAP_THRESHOLD_MS && (
+                  <div className="flex items-center gap-2 px-2 py-0.5">
+                    <ClockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
+                    <Text.H6 color="foregroundMuted" noWrap>
+                      {formatDuration(gapMs * 1_000_000)}
+                    </Text.H6>
+                  </div>
+                )}
+                <TurnCard
+                  trace={trace}
+                  number={traceNumberById.get(trace.traceId) ?? i + 1}
+                  projectId={projectId}
+                  breakdown={perTrace.get(trace.traceId)}
+                  health={computeTurnHealth(trace, cohorts)}
+                  toolStats={toolStats.get(trace.traceId)}
+                  annotationCount={(counts?.positiveCount ?? 0) + (counts?.negativeCount ?? 0)}
+                  model={model}
+                  onOpen={onOpenTrace}
+                />
+              </Fragment>
+            )
+          })}
+
+          {totalTraceCount > chronological.length && (
+            <Text.H6 color="foregroundMuted">
+              {`Showing first ${chronological.length} of ${totalTraceCount} turns`}
+            </Text.H6>
+          )}
+        </div>
+      )}
+    </DetailSection>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.utils.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.utils.test.ts
@@ -1,0 +1,128 @@
+import type { CohortMetric, CohortSummary, MetricBaseline } from "@domain/spans"
+import type { GenAIMessage } from "rosetta-ai"
+import { describe, expect, it } from "vitest"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import { computeToolStatsByTrace, computeTurnHealth, inputPreview, outputPreview } from "./turn-trajectory.utils.ts"
+
+function textMsg(role: string, ...texts: string[]): GenAIMessage {
+  return { role, parts: texts.map((content) => ({ type: "text", content })) } as unknown as GenAIMessage
+}
+
+function toolMsg(role: string): GenAIMessage {
+  return { role, parts: [{ type: "tool_call", id: "t", name: "x", arguments: {} }] } as unknown as GenAIMessage
+}
+
+function span(partial: { traceId: string; operation: string; error?: boolean }): SpanRecord {
+  return {
+    traceId: partial.traceId,
+    operation: partial.operation,
+    statusCode: partial.error ? "error" : "ok",
+  } as unknown as SpanRecord
+}
+
+describe("computeToolStatsByTrace", () => {
+  it("counts execute_tool spans and failures per trace", () => {
+    const stats = computeToolStatsByTrace([
+      span({ traceId: "A", operation: "execute_tool" }),
+      span({ traceId: "A", operation: "execute_tool", error: true }),
+      span({ traceId: "A", operation: "chat" }),
+      span({ traceId: "B", operation: "execute_tool" }),
+    ])
+    expect(stats.get("A")).toEqual({ tools: 2, failed: 1 })
+    expect(stats.get("B")).toEqual({ tools: 1, failed: 0 })
+  })
+
+  it("omits traces with no tool calls", () => {
+    const stats = computeToolStatsByTrace([span({ traceId: "A", operation: "chat" })])
+    expect(stats.has("A")).toBe(false)
+  })
+})
+
+describe("inputPreview", () => {
+  it("returns the last user message text", () => {
+    expect(inputPreview([textMsg("user", "first"), textMsg("assistant", "reply"), textMsg("user", "second")])).toBe(
+      "second",
+    )
+  })
+
+  it("falls back to the last message with text when there is no user message", () => {
+    expect(inputPreview([textMsg("system", "sys"), textMsg("assistant", "answer")])).toBe("answer")
+  })
+
+  it("collapses whitespace and returns empty for no text", () => {
+    expect(inputPreview([textMsg("user", "  hello\n\n  world  ")])).toBe("hello world")
+    expect(inputPreview([toolMsg("user")])).toBe("")
+    expect(inputPreview([])).toBe("")
+  })
+})
+
+describe("outputPreview", () => {
+  it("returns the first assistant message with text, skipping tool-only messages", () => {
+    expect(outputPreview([textMsg("user", "q"), toolMsg("assistant"), textMsg("assistant", "final")])).toBe("final")
+  })
+
+  it("falls back to the first message with text when there is no assistant message", () => {
+    expect(outputPreview([textMsg("user", "only user")])).toBe("only user")
+  })
+
+  it("truncates long previews", () => {
+    const long = "a".repeat(500)
+    const result = outputPreview([textMsg("assistant", long)])
+    expect(result.endsWith("…")).toBe(true)
+    expect(result.length).toBe(161)
+  })
+})
+
+function baseline(metric: CohortMetric, over: Partial<MetricBaseline> = {}): MetricBaseline {
+  return { metric, sampleCount: 2000, p50: 100, p90: 200, p95: 300, p99: 400, ...over }
+}
+
+function cohorts(over: Partial<Record<CohortMetric, Partial<MetricBaseline>>> = {}): CohortSummary {
+  return {
+    count: 2000,
+    baselines: {
+      durationNs: baseline("durationNs", over.durationNs),
+      costTotalMicrocents: baseline("costTotalMicrocents", over.costTotalMicrocents),
+      tokensTotal: baseline("tokensTotal", over.tokensTotal),
+      timeToFirstTokenNs: baseline("timeToFirstTokenNs", over.timeToFirstTokenNs),
+    },
+  }
+}
+
+describe("computeTurnHealth", () => {
+  const ok = { errorCount: 0, durationNs: 150, costTotalMicrocents: 150 }
+
+  it("flags errors as danger regardless of cohort", () => {
+    expect(computeTurnHealth({ ...ok, errorCount: 2 }, undefined).tone).toBe("danger")
+  })
+
+  it("is neutral without a cohort and without errors", () => {
+    expect(computeTurnHealth(ok, undefined)).toEqual({ tone: "none", reason: "" })
+  })
+
+  it("flags a top-1% duration outlier as danger", () => {
+    expect(computeTurnHealth({ ...ok, durationNs: 500 }, cohorts())).toEqual({
+      tone: "danger",
+      reason: "Slow — top 1% of traces",
+    })
+  })
+
+  it("flags a top-1% cost outlier as danger when duration is normal", () => {
+    expect(computeTurnHealth({ ...ok, costTotalMicrocents: 500 }, cohorts()).reason).toBe(
+      "Expensive — top 1% of traces",
+    )
+  })
+
+  it("flags a top-5% duration outlier as warning", () => {
+    expect(computeTurnHealth({ ...ok, durationNs: 350 }, cohorts())).toEqual({
+      tone: "warning",
+      reason: "Slow — top 5% of traces",
+    })
+  })
+
+  it("stays neutral below p95 and when percentiles are gated to null", () => {
+    expect(computeTurnHealth({ ...ok, durationNs: 250 }, cohorts()).tone).toBe("none")
+    const gated = cohorts({ durationNs: { p95: null, p99: null } })
+    expect(computeTurnHealth({ ...ok, durationNs: 9999 }, gated).tone).toBe("none")
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.utils.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/turn-trajectory.utils.ts
@@ -1,0 +1,95 @@
+import { type CohortSummary, getMetricPercentileThreshold } from "@domain/spans"
+import type { GenAIMessage } from "rosetta-ai"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+
+const PREVIEW_MAX_CHARS = 160
+
+export interface TurnHealth {
+  readonly tone: "danger" | "warning" | "none"
+  readonly reason: string
+}
+
+/**
+ * The single "spot the bad ones" signal: red for an error or an extreme
+ * (top 1%) latency/cost outlier, amber for a top-5% outlier, nothing otherwise.
+ * Outlier levels come from the project cohort baselines.
+ */
+export function computeTurnHealth(
+  trace: { readonly errorCount: number; readonly durationNs: number; readonly costTotalMicrocents: number },
+  cohorts: CohortSummary | undefined,
+): TurnHealth {
+  if (trace.errorCount > 0) {
+    return { tone: "danger", reason: `${trace.errorCount} ${trace.errorCount === 1 ? "error" : "errors"}` }
+  }
+  if (!cohorts) return { tone: "none", reason: "" }
+
+  const exceeds = (metric: "durationNs" | "costTotalMicrocents", level: "p95" | "p99") => {
+    const threshold = getMetricPercentileThreshold(cohorts.baselines[metric], level)
+    return threshold !== null && trace[metric] >= threshold
+  }
+
+  if (exceeds("durationNs", "p99")) return { tone: "danger", reason: "Slow — top 1% of traces" }
+  if (exceeds("costTotalMicrocents", "p99")) return { tone: "danger", reason: "Expensive — top 1% of traces" }
+  if (exceeds("durationNs", "p95")) return { tone: "warning", reason: "Slow — top 5% of traces" }
+  if (exceeds("costTotalMicrocents", "p95")) return { tone: "warning", reason: "Expensive — top 5% of traces" }
+  return { tone: "none", reason: "" }
+}
+
+export interface ToolStats {
+  readonly tools: number
+  readonly failed: number
+}
+
+/** Per-trace tool-call counts from a flat set of session spans. */
+export function computeToolStatsByTrace(spans: readonly SpanRecord[]): Map<string, ToolStats> {
+  const stats = new Map<string, { tools: number; failed: number }>()
+  for (const span of spans) {
+    if (span.operation !== "execute_tool") continue
+    const entry = stats.get(span.traceId) ?? { tools: 0, failed: 0 }
+    entry.tools++
+    if (span.statusCode === "error") entry.failed++
+    stats.set(span.traceId, entry)
+  }
+  return stats
+}
+
+function messageText(message: GenAIMessage): string {
+  const texts: string[] = []
+  for (const part of message.parts ?? []) {
+    if (part.type === "text" && typeof part.content === "string") texts.push(part.content)
+  }
+  return texts.join(" ").replace(/\s+/g, " ").trim()
+}
+
+function clamp(text: string): string {
+  return text.length > PREVIEW_MAX_CHARS ? `${text.slice(0, PREVIEW_MAX_CHARS)}…` : text
+}
+
+/** The turn's prompt: text of the last user message (falls back to the last message with text). */
+export function inputPreview(messages: readonly GenAIMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role !== "user") continue
+    const text = messageText(message)
+    if (text) return clamp(text)
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const text = messageText(messages[i])
+    if (text) return clamp(text)
+  }
+  return ""
+}
+
+/** The turn's reply: text of the first assistant message (falls back to the first message with text). */
+export function outputPreview(messages: readonly GenAIMessage[]): string {
+  for (const message of messages) {
+    if (message.role !== "assistant") continue
+    const text = messageText(message)
+    if (text) return clamp(text)
+  }
+  for (const message of messages) {
+    const text = messageText(message)
+    if (text) return clamp(text)
+  }
+  return ""
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
 import {
   computeDurationBreakdown,
+  computePerTraceBreakdowns,
   computeSessionDurationBreakdown,
   type DurationCategory,
 } from "./duration-composition.ts"
@@ -121,5 +122,24 @@ describe("computeSessionDurationBreakdown", () => {
 
   it("returns empty for no spans", () => {
     expect(computeSessionDurationBreakdown([])).toEqual({ segments: [], wallClockMs: 0 })
+  })
+})
+
+describe("computePerTraceBreakdowns", () => {
+  it("returns an empty map for no spans", () => {
+    expect(computePerTraceBreakdowns([]).size).toBe(0)
+  })
+
+  it("groups spans by traceId and matches the per-trace breakdown", () => {
+    const spansA = [
+      span({ spanId: "a1", traceId: "A", operation: "chat", start: 0, end: 1000 }),
+      span({ spanId: "a2", traceId: "A", operation: "execute_tool", start: 1500, end: 2000 }),
+    ]
+    const spansB = [span({ spanId: "b1", traceId: "B", operation: "chat", start: 10000, end: 11000 })]
+    const result = computePerTraceBreakdowns([...spansA, ...spansB])
+
+    expect([...result.keys()].sort()).toEqual(["A", "B"])
+    expect(result.get("A")).toEqual(computeDurationBreakdown(spansA))
+    expect(result.get("B")).toEqual(computeDurationBreakdown(spansB))
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
@@ -137,6 +137,25 @@ export function computeDurationBreakdown(spans: readonly SpanRecord[]): {
   return { segments: toSegments(totals), wallClockMs }
 }
 
+export interface TraceDurationBreakdown {
+  readonly segments: DurationSegment[]
+  readonly wallClockMs: number
+}
+
+/** Per-trace composition, keyed by `traceId`, from a flat set of session spans. */
+export function computePerTraceBreakdowns(spans: readonly SpanRecord[]): Map<string, TraceDurationBreakdown> {
+  const byTrace = new Map<string, SpanRecord[]>()
+  for (const span of spans) {
+    const list = byTrace.get(span.traceId)
+    if (list) list.push(span)
+    else byTrace.set(span.traceId, [span])
+  }
+
+  const breakdowns = new Map<string, TraceDurationBreakdown>()
+  for (const [traceId, traceSpans] of byTrace) breakdowns.set(traceId, computeDurationBreakdown(traceSpans))
+  return breakdowns
+}
+
 /**
  * Session-level composition: the breakdown is computed **per trace** and then
  * summed, so the gaps *between* traces (user think-time between turns) are never
@@ -148,17 +167,9 @@ export function computeSessionDurationBreakdown(spans: readonly SpanRecord[]): {
   segments: DurationSegment[]
   wallClockMs: number
 } {
-  const byTrace = new Map<string, SpanRecord[]>()
-  for (const span of spans) {
-    const list = byTrace.get(span.traceId)
-    if (list) list.push(span)
-    else byTrace.set(span.traceId, [span])
-  }
-
   const totals: Record<DurationCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0, idle: 0 }
   let wallClockMs = 0
-  for (const traceSpans of byTrace.values()) {
-    const breakdown = computeDurationBreakdown(traceSpans)
+  for (const breakdown of computePerTraceBreakdowns(spans).values()) {
     wallClockMs += breakdown.wallClockMs
     for (const segment of breakdown.segments) totals[segment.category] += segment.ms
   }


### PR DESCRIPTION
Adds a **Turns** section to the Session tab of the session detail drawer: a per-turn index (one card per trace) for multi-trace sessions, sitting between the whole-session summary and the full Conversation transcript.

## what it adds

The Session tab previously collapsed a multi-turn session into single totals (one duration, one cost, etc.), so there was no way to see what each turn contained or which turn drove cost/latency without opening every trace. The Turns section lists each turn as a card with:

- input + output **preview** — what the turn was about and how it replied
- **duration · cost**, tool / error / annotation **chips**, and the **model** pinned right (shown only when it changes from the previous turn)
- a **health dot** flagging problem turns
- between-turn **gap rows** (clock + elapsed) surfacing think-time between turns, which the session duration breakdown deliberately excludes

Clicking a card opens that turn's trace. Only rendered for multi-trace sessions; single-trace sessions keep their existing Spans tab.

## health dot

Each turn is compared against the project-wide cohort baseline (`useTraceCohortSummary`), not its neighbors, so it's independent of the natural turn-over-turn cost ramp:

- red — the turn errored, or its duration/cost is in the project's top 1% (≥ p99)
- amber — top 5% (≥ p95)
- nothing otherwise

Percentiles are sample-gated (p95 needs ≥ 100 traces, p99 ≥ 1000), so on low-volume projects only errored turns light up — by design. Hovering the dot explains why.

## lazy previews

Message content isn't returned by list/collection queries, only by per-trace detail. Each card fetches its preview via `useTraceDetail` **only when it scrolls into view** (new `useInView` hook) and only while the section is open (`DetailSection` mounts its children on expand). Everything else is free: tool counts come from the already-loaded session spans, annotation counts from a batched hook, and the rest from `TraceRecord` aggregates.

The per-turn duration-composition tooltip reuses `computePerTraceBreakdowns`, extracted from `computeSessionDurationBreakdown` (no behavior change).

## decisions / follow-ups

- Turn-over-turn cost/latency deltas were prototyped and dropped: cost ramps every turn (each turn re-sends the accumulated context), so a per-turn delta just restates the ramp instead of signalling anything. The health dot, comparing against the project baseline, is the ramp-independent "is this turn off" signal instead.
- Moments per turn are deferred — that needs the message-index→trace map the Conversation tab builds.

## tests

Unit tests cover `computePerTraceBreakdowns`, `computeTurnHealth` (error / p95 / p99 / gated-null cases), per-turn tool-call stats, and input/output preview extraction. Typecheck and Biome clean.
