### PR TITLE
Improve onboarding with seeded sample projects

### DIFF
--- a/apps/web/src/domains/organizations/organizations.functions.ts
+++ b/apps/web/src/domains/organizations/organizations.functions.ts
@@ -64,7 +64,7 @@ export const createOrganization = createServerFn({ method: "POST" })
         actorUserId: userId,
         name: data.name,
         slug,
-        defaultProjectName: "My project",
+        defaultProjectName: `${data.name.trim()}'s project`,
       }).pipe(
         withPostgres(
           Layer.mergeAll(ApiKeyRepositoryLive, ProjectRepositoryLive, OutboxEventWriterLive),

--- a/apps/web/src/domains/projects/projects.collection.ts
+++ b/apps/web/src/domains/projects/projects.collection.ts
@@ -74,6 +74,8 @@ export function createProjectMutation(name: string) {
       notifications: undefined,
       escalation: undefined,
       onboardingType: undefined,
+      onboardingCompleted: undefined,
+      isSample: undefined,
       sampling: undefined,
     },
     firstTraceAt: null,

--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -37,7 +37,7 @@ export const resolveDefaultProjectSlug = createServerFn({
   )
 
   const cookieMatch = cookieSlug ? projects.find((p) => p.slug === cookieSlug) : undefined
-  const target = cookieMatch ?? projects[0]
+  const target = cookieMatch ?? projects.find((project) => project.settings?.isSample !== true) ?? projects[0]
   return target?.slug ?? null
 })
 
@@ -65,6 +65,8 @@ export const toRecord = (project: Project) => ({
     notifications: project.settings?.notifications,
     escalation: project.settings?.escalation,
     onboardingType: project.settings?.onboardingType,
+    onboardingCompleted: project.settings?.onboardingCompleted,
+    isSample: project.settings?.isSample,
     sampling: project.settings?.sampling,
   },
   firstTraceAt: project.firstTraceAt ? project.firstTraceAt.toISOString() : null,
@@ -149,6 +151,26 @@ export const updateProject = createServerFn({ method: "POST" })
         withTracing,
       ),
     )
+    return toRecord(project)
+  })
+
+export const completeProjectOnboarding = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }): Promise<ProjectRecord> => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const project = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ProjectRepository
+        const current = yield* repo.findById(ProjectId(data.projectId))
+        return yield* updateProjectUseCase({
+          id: current.id,
+          settings: { ...(current.settings ?? {}), onboardingCompleted: true },
+        })
+      }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId), withTracing),
+    )
+
     return toRecord(project)
   })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -9,8 +9,11 @@ import {
   listAvailableFlaggers,
 } from "../../../../../domains/flaggers/flaggers.functions.ts"
 import type { FlaggerPresetSlug } from "../../../../../domains/flaggers/presets.ts"
+import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
+import { completeProjectOnboarding, updateProject } from "../../../../../domains/projects/projects.functions.ts"
 import { countTracesByProject } from "../../../../../domains/traces/traces.functions.ts"
 import { submitOnboarding } from "../../../../../domains/users/user.functions.ts"
+import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler } from "../../../../../lib/form-server-action.ts"
 import { CarouselSlide, CarouselTrack } from "./onboarding/carousel-track.tsx"
@@ -40,6 +43,8 @@ export type OnboardingForm = ReturnType<typeof _onboardingFormTypeHelper>
 export function OnboardingFlow({
   projectId,
   projectSlug,
+  projectName: initialProjectName,
+  persistedProjectName,
   onboardingType,
   slackEnvConfigured,
   initialStep,
@@ -49,6 +54,8 @@ export function OnboardingFlow({
 }: {
   readonly projectId: string
   readonly projectSlug: string
+  readonly projectName: string
+  readonly persistedProjectName: string
   readonly onboardingType: "code-agents" | "prod-traces" | undefined
   readonly slackEnvConfigured: boolean
   readonly initialStep?: OnboardingStep
@@ -109,8 +116,11 @@ export function OnboardingFlow({
   })
 
   const [stackChoice, setStackChoice] = useState<StackChoice | null>(null)
+  const [projectName, setProjectName] = useState(initialProjectName)
   const [selectedFlaggerSlugs, setSelectedFlaggerSlugs] = useState<ReadonlySet<string> | null>(null)
   const [isSavingFlaggers, setIsSavingFlaggers] = useState(false)
+  const { data: allProjects = [] } = useProjectsCollection()
+  const sampleProject = allProjects.find((project) => project.id !== projectId && project.settings.isSample === true)
 
   const form = useForm({
     defaultValues: {
@@ -173,8 +183,18 @@ export function OnboardingFlow({
   }
 
   const handleConfigureFlaggers = async () => {
+    const trimmedProjectName = projectName.trim()
+    if (!trimmedProjectName) {
+      toast({ variant: "destructive", description: "Project name is required" })
+      return
+    }
+
     setIsSavingFlaggers(true)
     try {
+      if (trimmedProjectName !== persistedProjectName) {
+        await updateProject({ data: { id: projectId, name: trimmedProjectName } })
+        await getQueryClient().invalidateQueries({ queryKey: ["projects"] })
+      }
       await configureProjectFlaggersForOnboarding({
         data: {
           projectId,
@@ -240,8 +260,15 @@ export function OnboardingFlow({
     }
   })
 
-  const handleSkipToTraces = () => {
-    void onOpenProjectTraces(projectId)
+  const handleOpenSampleProject = async () => {
+    if (!sampleProject) return
+    try {
+      await completeProjectOnboarding({ data: { projectId } })
+      await getQueryClient().invalidateQueries({ queryKey: ["projects"] })
+      await navigate({ to: "/projects/$projectSlug", params: { projectSlug: sampleProject.slug } })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
   }
 
   const telemetryBackStep: OnboardingStep = slackStepEnabled ? "slack" : "flaggers"
@@ -282,6 +309,8 @@ export function OnboardingFlow({
             enabledFlaggerSlugs={enabledFlaggerSlugs}
             toggleFlaggerSelection={toggleFlaggerSelection}
             applyFlaggerPreset={applyFlaggerPreset}
+            projectName={projectName}
+            onProjectNameChange={setProjectName}
             isSavingFlaggers={isSavingFlaggers}
             onBack={() => goToStep("stack")}
             onContinue={() => void handleConfigureFlaggers()}
@@ -297,8 +326,9 @@ export function OnboardingFlow({
             stackChoice={stackChoice}
             traceReceived={traceReceived}
             projectSlug={projectSlug}
+            sampleProjectSlug={sampleProject?.slug}
             onBack={() => goToStep(telemetryBackStep)}
-            onSkip={handleSkipToTraces}
+            onOpenSampleProject={() => void handleOpenSampleProject()}
           />
         )}
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
@@ -91,8 +91,8 @@ export function Left({
                     }
                   >
                     <span>
-                      This is the project you'll connect your own telemetry to. A separate sample project is being
-                      prepared so you can explore Latitude with data right away.
+                      This is the project you'll connect your own telemetry to. Latitude is also preparing a separate
+                      sample project when demo data is available.
                     </span>
                   </Tooltip>
                 </span>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx
@@ -1,5 +1,5 @@
-import { Button, cn, Icon, Text } from "@repo/ui"
-import { Check } from "lucide-react"
+import { Button, cn, Icon, Input, Text, Tooltip } from "@repo/ui"
+import { Check, Info } from "lucide-react"
 import { useMemo } from "react"
 import {
   FLAGGER_ONBOARDING_ORDER,
@@ -21,6 +21,8 @@ export function Left({
   enabledFlaggerSlugs,
   toggleFlaggerSelection,
   applyFlaggerPreset,
+  projectName,
+  onProjectNameChange,
   isSavingFlaggers,
   onBack,
   onContinue,
@@ -31,6 +33,8 @@ export function Left({
   readonly enabledFlaggerSlugs: ReadonlySet<string>
   readonly toggleFlaggerSelection: (slug: string) => void
   readonly applyFlaggerPreset: (enabledSlugs: ReadonlyArray<FlaggerPresetSlug>) => void
+  readonly projectName: string
+  readonly onProjectNameChange: (name: string) => void
   readonly isSavingFlaggers: boolean
   readonly onBack: () => void
   readonly onContinue: () => void
@@ -63,13 +67,43 @@ export function Left({
               Latitude inspects all incoming traces and creates issues when they detect common failure patterns. Choose
               the patterns you want to monitor.
             </Text.H4>
-            <Text.H5 color="foregroundMuted">
-              You can fine-tune sampling rates per flagger later in Project settings.
-            </Text.H5>
           </div>
         </div>
 
         <div className="flex flex-col gap-6">
+          <div className="flex w-full max-w-md flex-col gap-2">
+            <Input
+              type="text"
+              label={
+                <span className="flex flex-row items-center gap-2">
+                  Project name
+                  <Tooltip
+                    asChild
+                    side="top"
+                    trigger={
+                      <button
+                        type="button"
+                        className="inline-flex text-muted-foreground"
+                        aria-label="Project name info"
+                      >
+                        <Icon icon={Info} size="sm" />
+                      </button>
+                    }
+                  >
+                    <span>
+                      This is the project you'll connect your own telemetry to. A separate sample project is being
+                      prepared so you can explore Latitude with data right away.
+                    </span>
+                  </Tooltip>
+                </span>
+              }
+              value={projectName}
+              onChange={(event) => onProjectNameChange(event.target.value)}
+              placeholder="My project"
+              aria-label="Project name"
+            />
+          </div>
+
           <div className="flex flex-row flex-wrap gap-2">
             {FLAGGER_USE_CASE_PRESETS.map((preset) => {
               const isActive = activePresetId === preset.id

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
@@ -10,14 +10,16 @@ export function Left({
   stackChoice,
   traceReceived,
   projectSlug,
+  sampleProjectSlug,
   onBack,
-  onSkip,
+  onOpenSampleProject,
 }: {
   readonly stackChoice: StackChoice | null
   readonly traceReceived: boolean
   readonly projectSlug: string
+  readonly sampleProjectSlug: string | undefined
   readonly onBack: () => void
-  readonly onSkip: () => void
+  readonly onOpenSampleProject: () => void
 }) {
   const isProductionAgent = stackChoice === "production-agent"
   const heading = isProductionAgent
@@ -56,9 +58,11 @@ export function Left({
           <Button variant="outline" onClick={onBack}>
             Back
           </Button>
-          <Button variant="ghost" onClick={onSkip}>
-            Skip for now
-          </Button>
+          {sampleProjectSlug ? (
+            <Button variant="ghost" onClick={onOpenSampleProject}>
+              Explore sample project
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -369,6 +369,7 @@ export function ProjectExplorer({ projectSlug, mode }: { readonly projectSlug: s
   // project is genuinely unconnected — distinct from a connected project whose
   // traces aged out, or an empty filtered result.
   const isConnected = currentProject.firstTraceAt != null
+  const onboardingCompleted = currentProject.settings.onboardingCompleted === true
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
 
   if (isTracesCountLoading && !hasActiveFilters && !hasSearchQuery) {
@@ -380,7 +381,7 @@ export function ProjectExplorer({ projectSlug, mode }: { readonly projectSlug: s
   }
 
   // Never connected + nothing to show → onboarding-style connect experience.
-  if (!isConnected && hasNoTraces) {
+  if (!isConnected && hasNoTraces && !onboardingCompleted) {
     return (
       <Layout>
         <TracesEmptyOnboarding
@@ -393,8 +394,8 @@ export function ProjectExplorer({ projectSlug, mode }: { readonly projectSlug: s
     )
   }
 
-  // Connected before, but currently empty (e.g. retention) → minimal placeholder.
-  if (isConnected && hasNoTraces) {
+  // Connected before, or onboarding was completed by exploring the sample project → minimal placeholder.
+  if ((isConnected || onboardingCompleted) && hasNoTraces) {
     return (
       <Layout>
         <TracesEmptyState />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 import { isSlackConfigured } from "../../../../domains/integrations/integrations.functions.ts"
+import { useOrganizationsCollection } from "../../../../domains/organizations/organizations.collection.ts"
+import { useAuthenticatedOrganizationId } from "../../-route-data.ts"
 import { ONBOARDING_STEPS, OnboardingFlow } from "./-components/onboarding-flow.tsx"
 import { useRouteProject } from "./-route-data.ts"
 
@@ -23,12 +25,19 @@ function ProjectOnboardingPage() {
   const { slackEnvConfigured } = Route.useLoaderData()
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
+  const organizationId = useAuthenticatedOrganizationId()
+  const { data: organizations = [] } = useOrganizationsCollection()
+  const organization = organizations.find((org) => org.id === organizationId)
+  const suggestedProjectName =
+    project.name === "My project" && organization ? `${organization.name}'s project` : project.name
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <OnboardingFlow
         projectId={project.id}
         projectSlug={project.slug}
+        projectName={suggestedProjectName}
+        persistedProjectName={project.name}
         onboardingType={project.settings.onboardingType}
         slackEnvConfigured={slackEnvConfigured}
         initialStep={search.step}

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -215,6 +215,33 @@ describe("domain-events dispatcher", () => {
     expect(published.some((p) => p.queue === "posthog-analytics")).toBe(true)
   })
 
+  it("routes SampleProjectCreated to the demo seed project task", async () => {
+    const { consumer, published } = setupDispatcher()
+
+    const payload = {
+      organizationId: "org-1",
+      projectId: "sample-1",
+      queueAssigneeUserIds: ["user-1"],
+      apiKeyId: "key-1",
+      timelineAnchorIso: "2026-06-16T00:00:00.000Z",
+    }
+    const envelope = makeEnvelope("SampleProjectCreated", payload, "org-1")
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
+
+    expect(published).toHaveLength(1)
+    expect(published[0]).toMatchObject({
+      queue: "projects",
+      task: "seedDemo",
+      payload,
+      options: {
+        dedupeKey: "projects:seed-demo:sample-1",
+        attempts: 10,
+        backoff: { type: "exponential", delayMs: 1_000 },
+      },
+    })
+  })
+
   it("fails on unhandled events", async () => {
     const { consumer } = setupDispatcher()
 

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -229,8 +229,8 @@ describe("domain-events dispatcher", () => {
 
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
-    expect(published).toHaveLength(1)
-    expect(published[0]).toMatchObject({
+    const seedDemoPublish = published.find((p) => p.queue === "projects" && p.task === "seedDemo")
+    expect(seedDemoPublish).toMatchObject({
       queue: "projects",
       task: "seedDemo",
       payload,
@@ -240,6 +240,7 @@ describe("domain-events dispatcher", () => {
         backoff: { type: "exponential", delayMs: 1_000 },
       },
     })
+    expect(published.some((p) => p.queue === "posthog-analytics")).toBe(true)
   })
 
   it("fails on unhandled events", async () => {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -305,6 +305,13 @@ export const createDomainEventsWorker = ({
     // applied automatically below because both events are on the whitelist.
     OrganizationCreated: () => Effect.void,
 
+    SampleProjectCreated: (event) =>
+      pub.publish("projects", "seedDemo", event.payload, {
+        dedupeKey: `projects:seed-demo:${event.payload.projectId}`,
+        attempts: 10,
+        backoff: { type: "exponential", delayMs: 1_000 },
+      }),
+
     ProjectCreated: (event) =>
       pub.publish("projects", "provision", event.payload, {
         dedupeKey: `projects:provision:${event.payload.projectId}`,

--- a/apps/workers/src/workers/projects.ts
+++ b/apps/workers/src/workers/projects.ts
@@ -5,7 +5,7 @@ import { OrganizationId, ProjectId } from "@domain/shared"
 import { OutboxEventWriterLive, type PostgresClient, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { createLogger, withTracing } from "@repo/observability"
 import { Data, Effect, Layer } from "effect"
-import { getPostgresClient } from "../clients.ts"
+import { getPostgresClient, getWorkflowStarter } from "../clients.ts"
 import { provisionFlaggers, provisionSystemMonitors } from "../services/provisioning.ts"
 
 const logger = createLogger("projects")
@@ -51,6 +51,29 @@ export const createProjectsWorker = ({ consumer, postgresClient }: ProjectsDeps)
           flaggersProvisioned: results.length,
           results: results.map((r) => r.slug),
           systemMonitorsProvisioned: monitors.length,
+        })
+      }).pipe(withTracing),
+
+    seedDemo: (payload) =>
+      Effect.gen(function* () {
+        const workflowStarter = yield* Effect.promise(() => getWorkflowStarter())
+        yield* workflowStarter
+          .start(
+            "seedDemoProjectWorkflow",
+            {
+              organizationId: payload.organizationId,
+              projectId: payload.projectId,
+              queueAssigneeUserIds: payload.queueAssigneeUserIds,
+              apiKeyId: payload.apiKeyId,
+              timelineAnchorIso: payload.timelineAnchorIso,
+            },
+            { workflowId: `projects:seed-demo:${payload.projectId}` },
+          )
+          .pipe(Effect.catchTag("WorkflowAlreadyStartedError", () => Effect.void))
+
+        logger.info("Demo project seed workflow started", {
+          organizationId: payload.organizationId,
+          projectId: payload.projectId,
         })
       }).pipe(withTracing),
 

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -471,4 +471,11 @@ export interface EventPayloads {
     readonly projectId: string
     readonly projectName: string
   }
+  SampleProjectCreated: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly queueAssigneeUserIds: readonly string[]
+    readonly apiKeyId: string
+    readonly timelineAnchorIso: string
+  }
 }

--- a/packages/domain/feature-flags/src/registry.ts
+++ b/packages/domain/feature-flags/src/registry.ts
@@ -38,12 +38,6 @@ export const FEATURE_FLAGS = {
     name: "Test Mode sandbox",
     description: "Enables the Live ⇄ Sandbox switcher and the sandbox namespace for isolated development traces.",
   },
-  tools: {
-    emoji: "🔧",
-    name: "Tools dashboard",
-    description:
-      "Project-level analytics for LLM tools: every defined and called tool with usage, failure and latency metrics.",
-  },
   destinations: {
     emoji: "📤",
     name: "Data destinations",
@@ -55,6 +49,12 @@ export const FEATURE_FLAGS = {
     name: "Sandboxed evaluation runtime",
     description:
       "Executes evaluation scripts in the QuickJS sandbox runtime (full script execution) instead of the template-extraction MVP bridge.",
+  },
+  tools: {
+    emoji: "🔧",
+    name: "Tools dashboard",
+    description:
+      "Project-level analytics for LLM tools: every defined and called tool with usage, failure and latency metrics.",
   },
 } as const satisfies Record<
   string,

--- a/packages/domain/organizations/src/use-cases/provision-organization-workspace.test.ts
+++ b/packages/domain/organizations/src/use-cases/provision-organization-workspace.test.ts
@@ -89,14 +89,6 @@ describe("provisionOrganizationWorkspaceUseCase", () => {
       },
     })
     expect(writtenEvents[2]).toMatchObject({
-      eventName: "SampleProjectCreated",
-      organizationId: ORG_ID,
-      payload: {
-        organizationId: ORG_ID,
-        queueAssigneeUserIds: ["user-1"],
-      },
-    })
-    expect(writtenEvents[3]).toMatchObject({
       eventName: "OrganizationCreated",
       aggregateId: ORG_ID,
       organizationId: ORG_ID,
@@ -105,6 +97,14 @@ describe("provisionOrganizationWorkspaceUseCase", () => {
         actorUserId: "user-1",
         name: "Acme",
         slug: "acme",
+      },
+    })
+    expect(writtenEvents[3]).toMatchObject({
+      eventName: "SampleProjectCreated",
+      organizationId: ORG_ID,
+      payload: {
+        organizationId: ORG_ID,
+        queueAssigneeUserIds: ["user-1"],
       },
     })
     const apiKeys = [...savedApiKeys.values()]

--- a/packages/domain/organizations/src/use-cases/provision-organization-workspace.test.ts
+++ b/packages/domain/organizations/src/use-cases/provision-organization-workspace.test.ts
@@ -68,7 +68,7 @@ describe("provisionOrganizationWorkspaceUseCase", () => {
     )
 
     expect(transactionCalls).toBe(1)
-    expect(writtenEvents).toHaveLength(3)
+    expect(writtenEvents).toHaveLength(4)
     expect(writtenEvents[0]).toMatchObject({
       eventName: "ApiKeyCreated",
       organizationId: ORG_ID,
@@ -89,6 +89,14 @@ describe("provisionOrganizationWorkspaceUseCase", () => {
       },
     })
     expect(writtenEvents[2]).toMatchObject({
+      eventName: "SampleProjectCreated",
+      organizationId: ORG_ID,
+      payload: {
+        organizationId: ORG_ID,
+        queueAssigneeUserIds: ["user-1"],
+      },
+    })
+    expect(writtenEvents[3]).toMatchObject({
       eventName: "OrganizationCreated",
       aggregateId: ORG_ID,
       organizationId: ORG_ID,
@@ -103,9 +111,16 @@ describe("provisionOrganizationWorkspaceUseCase", () => {
     expect(apiKeys).toHaveLength(1)
     expect(apiKeys[0]?.name).toBe(DEFAULT_API_KEY_NAME)
     expect(apiKeys[0]?.token.startsWith(SANDBOX_API_KEY_TOKEN_PREFIX)).toBe(false)
-    expect(savedProjects).toHaveLength(1)
+    expect(savedProjects).toHaveLength(2)
     expect(savedProjects[0]).toMatchObject({ name: "My project", slug: "my-project", organizationId: ORG_ID })
+    expect(savedProjects[1]).toMatchObject({
+      name: "Sample project",
+      slug: "sample-project",
+      organizationId: ORG_ID,
+      settings: { isSample: true },
+    })
     expect(result.defaultApiKey).toMatchObject({ name: DEFAULT_API_KEY_NAME })
     expect(result.defaultProject).toMatchObject({ name: "My project", slug: "my-project" })
+    expect(result.sampleProject).toMatchObject({ name: "Sample project", slug: "sample-project" })
   })
 })

--- a/packages/domain/organizations/src/use-cases/provision-organization-workspace.ts
+++ b/packages/domain/organizations/src/use-cases/provision-organization-workspace.ts
@@ -87,7 +87,23 @@ export const provisionOrganizationWorkspaceUseCase = Effect.fn("organizations.pr
           slug: sampleProjectSlug,
           settings: { isSample: true },
         })
+        // Skip createProjectUseCase so sample data seeding is the only side effect for this project.
         yield* projectRepo.save(sampleProject)
+
+        yield* outboxEventWriter
+          .write({
+            eventName: "OrganizationCreated",
+            aggregateType: "organization",
+            aggregateId: input.organizationId,
+            organizationId: input.organizationId,
+            payload: {
+              organizationId: input.organizationId,
+              actorUserId: input.actorUserId,
+              name: input.name,
+              slug: input.slug,
+            },
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
 
         yield* outboxEventWriter
           .write({
@@ -101,21 +117,6 @@ export const provisionOrganizationWorkspaceUseCase = Effect.fn("organizations.pr
               queueAssigneeUserIds: [input.actorUserId],
               apiKeyId: defaultApiKey.id,
               timelineAnchorIso: new Date().toISOString(),
-            },
-          })
-          .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
-
-        yield* outboxEventWriter
-          .write({
-            eventName: "OrganizationCreated",
-            aggregateType: "organization",
-            aggregateId: input.organizationId,
-            organizationId: input.organizationId,
-            payload: {
-              organizationId: input.organizationId,
-              actorUserId: input.actorUserId,
-              name: input.name,
-              slug: input.slug,
             },
           })
           .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))

--- a/packages/domain/organizations/src/use-cases/provision-organization-workspace.ts
+++ b/packages/domain/organizations/src/use-cases/provision-organization-workspace.ts
@@ -1,8 +1,15 @@
 import { DEFAULT_API_KEY_NAME, type GenerateApiKeyError, generateApiKeyUseCase } from "@domain/api-keys"
 import { OutboxEventWriter } from "@domain/events"
-import { type CreateProjectError, createProjectUseCase } from "@domain/projects"
+import {
+  type CreateProjectError,
+  createProject,
+  createProjectUseCase,
+  InvalidProjectNameError,
+  ProjectRepository,
+} from "@domain/projects"
 import {
   type ConcurrentSqlTransactionError,
+  generateSlug,
   type OrganizationId,
   type RepositoryError,
   SqlClient,
@@ -18,6 +25,8 @@ export interface ProvisionOrganizationWorkspaceInput {
   readonly defaultProjectName: string
 }
 
+const DEFAULT_SAMPLE_PROJECT_NAME = "Sample project"
+
 export interface ProvisionOrganizationWorkspaceResult {
   readonly defaultApiKey: {
     readonly id: string
@@ -25,6 +34,11 @@ export interface ProvisionOrganizationWorkspaceResult {
     readonly token: string
   }
   readonly defaultProject: {
+    readonly id: string
+    readonly name: string
+    readonly slug: string
+  }
+  readonly sampleProject: {
     readonly id: string
     readonly name: string
     readonly slug: string
@@ -58,6 +72,39 @@ export const provisionOrganizationWorkspaceUseCase = Effect.fn("organizations.pr
           actorUserId: input.actorUserId,
         })
 
+        const projectRepo = yield* ProjectRepository
+        const sampleProjectSlug = yield* generateSlug({
+          name: DEFAULT_SAMPLE_PROJECT_NAME,
+          count: (slug) => projectRepo.countBySlug(slug),
+        }).pipe(
+          Effect.catchTag("InvalidSlugInputError", (error) =>
+            Effect.fail(new InvalidProjectNameError({ field: DEFAULT_SAMPLE_PROJECT_NAME, message: error.reason })),
+          ),
+        )
+        const sampleProject = createProject({
+          organizationId: input.organizationId,
+          name: DEFAULT_SAMPLE_PROJECT_NAME,
+          slug: sampleProjectSlug,
+          settings: { isSample: true },
+        })
+        yield* projectRepo.save(sampleProject)
+
+        yield* outboxEventWriter
+          .write({
+            eventName: "SampleProjectCreated",
+            aggregateType: "project",
+            aggregateId: sampleProject.id,
+            organizationId: input.organizationId,
+            payload: {
+              organizationId: input.organizationId,
+              projectId: sampleProject.id,
+              queueAssigneeUserIds: [input.actorUserId],
+              apiKeyId: defaultApiKey.id,
+              timelineAnchorIso: new Date().toISOString(),
+            },
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
+
         yield* outboxEventWriter
           .write({
             eventName: "OrganizationCreated",
@@ -83,6 +130,11 @@ export const provisionOrganizationWorkspaceUseCase = Effect.fn("organizations.pr
             id: defaultProject.id,
             name: defaultProject.name,
             slug: defaultProject.slug,
+          },
+          sampleProject: {
+            id: sampleProject.id,
+            name: sampleProject.name,
+            slug: sampleProject.slug,
           },
         }
       }),

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -398,6 +398,13 @@ const _registry = {
       readonly projectId: string
       readonly traceId: string
     }
+    seedDemo: {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly queueAssigneeUserIds: readonly string[]
+      readonly apiKeyId: string
+      readonly timelineAnchorIso: string
+    }
   }>(),
 
   "api-keys": payloads<{

--- a/packages/domain/shared/src/settings.ts
+++ b/packages/domain/shared/src/settings.ts
@@ -75,6 +75,8 @@ export const projectSettingsSchema = z.object({
   notifications: notificationsSettingSchema.optional(),
   escalation: escalationSettingSchema.optional(),
   onboardingType: z.enum(["prod-traces", "code-agents"]).optional(),
+  onboardingCompleted: z.boolean().optional(),
+  isSample: z.boolean().optional(),
   sampling: samplingSettingSchema.optional(),
 })
 

--- a/packages/platform/analytics-posthog/src/whitelist.test.ts
+++ b/packages/platform/analytics-posthog/src/whitelist.test.ts
@@ -5,6 +5,7 @@ describe("PostHog whitelist", () => {
   it("includes lifecycle and adoption events", () => {
     expect(POSTHOG_TRACKED_EVENTS.has("OrganizationCreated")).toBe(true)
     expect(POSTHOG_TRACKED_EVENTS.has("ProjectCreated")).toBe(true)
+    expect(POSTHOG_TRACKED_EVENTS.has("SampleProjectCreated")).toBe(true)
     expect(POSTHOG_TRACKED_EVENTS.has("UserSignedUp")).toBe(true)
     expect(POSTHOG_TRACKED_EVENTS.has("MemberJoined")).toBe(true)
     expect(POSTHOG_TRACKED_EVENTS.has("MemberInvited")).toBe(true)

--- a/packages/platform/analytics-posthog/src/whitelist.ts
+++ b/packages/platform/analytics-posthog/src/whitelist.ts
@@ -10,6 +10,7 @@ export type TrackedEventName = keyof EventPayloads & string
 export const POSTHOG_TRACKED_EVENTS = new Set<TrackedEventName>([
   "OrganizationCreated",
   "ProjectCreated",
+  "SampleProjectCreated",
   "UserSignedUp",
   "UserOnboardingCompleted", // Not sent to Posthog, but used to enrich person properties
   "MemberJoined",


### PR DESCRIPTION
## what changed

New organizations now get two projects during workspace provisioning:

- the user's default project, named from the organization (`<org name>'s project`)
- a separate `Sample project`, marked with `settings.isSample`

The sample project emits a `SampleProjectCreated` domain event. The domain-events worker publishes a `projects:seedDemo` task, and the projects worker starts `seedDemoProjectWorkflow` for that project. This kicks off the existing demo seeding path early so trace search embeddings and taxonomy data can be prepared while the user is still moving through onboarding.

Onboarding now lets the user rename their default project in the flaggers step. The telemetry step replaces “Skip for now” with an “Explore sample project” action when the sample project exists. Clicking it marks onboarding completed on the user project and navigates to the sample project.

The user project still shows the normal no-traces blank state after onboarding is completed via the sample-project path, instead of falling through to an empty sessions/traces table.

https://github.com/user-attachments/assets/15092dce-bf20-42e3-8c82-6a47cd8f3ac7


## validation

- `pnpm --filter @domain/shared typecheck`
- `pnpm --filter @domain/events typecheck`
- `pnpm --filter @domain/organizations typecheck`
- `pnpm --filter @domain/queue typecheck`
- `pnpm --filter @app/workers typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @domain/organizations test -- provision-organization-workspace.test.ts`
- `pnpm --filter @app/workers test -- domain-events.test.ts`
- `pnpm --filter @app/web check`
- pre-commit `turbo format` + `knip`

## reviewer note

This includes onboarding UI changes; screenshots or a short recording of the flaggers and telemetry steps will help review.
