### PR TITLE
fix(web): let monitor incidents table fill the viewport

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index.tsx
@@ -223,55 +223,61 @@ function MonitorDetailPage() {
           }
         />
 
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6 pt-2">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {isLoading || !monitor ? (
-            <Skeleton className="h-48 w-full" />
+            <div className="p-6 pt-2">
+              <Skeleton className="h-48 w-full" />
+            </div>
           ) : (
             <>
-              <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4">
-                <Text.H6 color="foregroundMuted">Configuration</Text.H6>
-                <div className="flex flex-row flex-wrap content-start items-start gap-x-8 gap-y-4">
-                  <ConfigField label="Status">
-                    {muted ? <Status variant="neutral" label="Muted" /> : <Status variant="success" label="Live" />}
-                  </ConfigField>
-                  {description ? (
-                    <ConfigField label="Target">
-                      <Text.H5 color="foreground">{description.label}</Text.H5>
+              <div className="flex shrink-0 flex-col gap-4 p-6 pt-2">
+                <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4">
+                  <Text.H6 color="foregroundMuted">Configuration</Text.H6>
+                  <div className="flex flex-row flex-wrap content-start items-start gap-x-8 gap-y-4">
+                    <ConfigField label="Status">
+                      {muted ? <Status variant="neutral" label="Muted" /> : <Status variant="success" label="Live" />}
                     </ConfigField>
-                  ) : null}
-                  {alert ? (
-                    <ConfigField label="Trigger">
-                      <SeverityStatus
-                        severity={alert.severity}
-                        label={`${ALERT_INCIDENT_KIND_LABEL[alert.kind]} · ${alert.severity}`}
-                      />
+                    {description ? (
+                      <ConfigField label="Target">
+                        <Text.H5 color="foreground">{description.label}</Text.H5>
+                      </ConfigField>
+                    ) : null}
+                    {alert ? (
+                      <ConfigField label="Trigger">
+                        <SeverityStatus
+                          severity={alert.severity}
+                          label={`${ALERT_INCIDENT_KIND_LABEL[alert.kind]} · ${alert.severity}`}
+                        />
+                      </ConfigField>
+                    ) : null}
+                    <ConfigField label="Incidents">
+                      <Text.H5 color="foreground">{incidentStats ? formatCount(incidentStats.total) : "—"}</Text.H5>
                     </ConfigField>
-                  ) : null}
-                  <ConfigField label="Incidents">
-                    <Text.H5 color="foreground">{incidentStats ? formatCount(incidentStats.total) : "—"}</Text.H5>
-                  </ConfigField>
+                  </div>
+                  {monitor.description ? <Text.H6 color="foregroundMuted">{monitor.description}</Text.H6> : null}
                 </div>
-                {monitor.description ? <Text.H6 color="foregroundMuted">{monitor.description}</Text.H6> : null}
+
+                {target ? (
+                  <MonitorMetricChart
+                    projectId={project.id}
+                    projectSlug={projectSlug}
+                    monitor={monitor}
+                    fromMs={window.fromMs}
+                    toMs={window.toMs}
+                    bucketMs={window.bucketMs}
+                  />
+                ) : null}
               </div>
 
-              {target ? (
-                <MonitorMetricChart
-                  projectId={project.id}
-                  projectSlug={projectSlug}
-                  monitor={monitor}
-                  fromMs={window.fromMs}
-                  toMs={window.toMs}
-                  bucketMs={window.bucketMs}
-                />
-              ) : null}
-
-              <div className="flex min-w-0 flex-col gap-3">
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 px-6 pb-6">
                 <Text.H6 color="foregroundMuted">Incidents</Text.H6>
                 <MonitorIncidentsTable projectId={project.id} projectSlug={projectSlug} monitorId={monitor.id} />
               </div>
 
               {target ? (
-                <MonitorMatchingTraces projectSlug={projectSlug} projectId={project.id} target={target} />
+                <div className="shrink-0 px-6 pb-6">
+                  <MonitorMatchingTraces projectSlug={projectSlug} projectId={project.id} target={target} />
+                </div>
               ) : null}
             </>
           )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/monitor-incidents-table.tsx
@@ -6,6 +6,7 @@ import {
   type MonitorIncidentRecord,
   useMonitorIncidents,
 } from "../../../../../../domains/monitors/monitors.collection.ts"
+import { listingLayoutIntrinsicScroll } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { IncidentResolveConfirmModal } from "./incident-resolve-confirm-modal.tsx"
 import { IncidentStatus } from "./incident-status.tsx"
 
@@ -93,18 +94,15 @@ const incidentColumns = (onResolve?: (incidentId: string) => void): InfiniteTabl
 
 const INCIDENT_DEFAULT_SORTING = { column: "status", direction: "desc" } as const
 
-const INCIDENT_TABLE_CLASS = "max-h-[min(28rem,50vh)]"
-
 export function MonitorIncidentsTableSkeleton() {
   return (
     <InfiniteTable<MonitorIncidentRecord>
+      {...listingLayoutIntrinsicScroll.infiniteTable}
       data={[]}
       isLoading
       columns={incidentColumns()}
       getRowKey={(incident) => incident.id}
       defaultSorting={INCIDENT_DEFAULT_SORTING}
-      scrollAreaLayout="intrinsic"
-      className={INCIDENT_TABLE_CLASS}
     />
   )
 }
@@ -153,6 +151,7 @@ export function MonitorIncidentsTable({
   return (
     <>
       <InfiniteTable
+        {...listingLayoutIntrinsicScroll.infiniteTable}
         data={incidents}
         isLoading={isLoading}
         columns={incidentColumns(setResolveTarget)}
@@ -161,8 +160,6 @@ export function MonitorIncidentsTable({
         renderRowLink={renderRowLink}
         defaultSorting={INCIDENT_DEFAULT_SORTING}
         blankSlate="No incidents yet."
-        scrollAreaLayout="intrinsic"
-        className={INCIDENT_TABLE_CLASS}
       />
       <IncidentResolveConfirmModal projectId={projectId} incidentId={resolveTarget} onOpenChange={setResolveTarget} />
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Monitor detail is a full page now, but the incidents table still used a panel-era `max-h-[min(28rem,50vh)]` cap that left a large empty gap below it when many incidents were present.

This PR removes that cap and lays out the page so the incidents section grows into the remaining viewport height below the configuration card and metric chart. The table uses the same `listingLayoutIntrinsicScroll` pattern as other full-height list views: short lists stay compact, longer lists scroll inside the expanded area.

Matching traces stays below the incidents block when a monitor has a target.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67806eca-0070-4eb6-98f4-296cb2e5d01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67806eca-0070-4eb6-98f4-296cb2e5d01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

