### PR TITLE
spec: revise signals — trackers model + phased build plan (LAT-664)

### DIFF
--- a/dev-docs/signals.md
+++ b/dev-docs/signals.md
@@ -1,0 +1,273 @@
+# Signals
+
+A **Signal** is a tracked bucket of traces. Signals are the top-level observability entity of the reliability system: a signal defines *what* to watch, its **members** are the traces that exhibit it, and any signal can be watched over time by a **Monitor**.
+
+Signals unify two formerly separate systems — **Issues** (auto-created buckets of failed/annotated scores, monitored invisibly) and the user-configured alerting that ran over **Saved Searches** — into one model. A signal's members are its **Scores**; a signal is watched by a **Monitor**; a monitor owns **Alerts**; a fired alert opens an **Incident**, which is what notifies.
+
+```
+                tracker runs at ingest        monitors aggregate         alerts fire on        records the
+                (or annotation lands)         the score stream           conditions            firing
+  Trace ──────▶ SIGNAL ─────────────────────▶ MONITOR ─────────────────▶ ALERT ──────────────▶ INCIDENT ──▶ notifications
+                membership = its SCORES        (a metric over the
+                (write-time materialized)       signal's scores/traces)
+```
+
+Signals live in `@domain/signals` (the evolved `@domain/issues` package). The shared enums (`SignalOrigin`, `SignalTrackerType`, `ScoreSourceType`, alert kinds, conditions, severities) live in `@domain/shared` so the signals, monitors, scores, and notifications domains can reference them without a circular dependency.
+
+> **Spec**: `specs/signals.md` carries the design decisions, trade-offs, and the phased build plan. This doc describes the intended final system; consult the spec for phase status while the system is under construction.
+
+Related docs:
+
+- [scores.md](./scores.md) — the canonical scores model and the Postgres/ClickHouse split that signal membership rides on.
+- [monitors.md](./monitors.md) — the monitor / alert / incident machinery; signals are one monitor target type.
+- [evaluations.md](./evaluations.md) — the LLM-judge generation/alignment/execution stack that backs `llm_as_judge` trackers.
+- [conversation-intelligence.md](./conversation-intelligence.md) — the moment-label anchor matching that the semantic runner generalizes.
+- [reliability.md](./reliability.md) — the cross-domain reliability loop that produces scores.
+- [notifications.md](./notifications.md) — incidents drive notifications; the monitor mute gate is the only seam.
+- [domain-errors.md](./domain-errors.md) — `@domain/issues`/`@domain/signals` is the reference implementation for per-package error layout.
+
+## Why membership is materialized at write time
+
+Two structural decisions carry the whole model, and both follow from a single cost constraint: counting and alerting over *semantic* membership is only affordable if each trace's verdict is computed once, on arrival, and remembered.
+
+1. **A signal's occurrences ARE its scores.** There is no separate occurrence ledger. Every membership-bearing event — a tracker run, an annotation, a future custom push — writes a `scores` row carrying `signal_id`. A signal's membership is the subset of those rows that *matched* (`value >= threshold`). This collapses the former inconsistency where issues counted scores and saved searches counted traces into one counting unit, and reuses the entire scores pipeline.
+2. **Membership is materialized at write time.** A tracker is evaluated against each in-scope trace once, on arrival, and the verdict is frozen as a score (`passed`). Membership reads never re-apply a threshold at query time.
+
+The reasoning:
+
+- **Semantic search answers a different question than filters do.** A filter is a per-row yes/no — each row passes on its own merits, so filters stack for free. Semantic search with a vector index answers "the ~1,000 items *most similar in the entire corpus*". Combine them and the filter can only discard from those 1,000: "user frustration" + "last 7 days" returns whichever of the corpus-wide top-1,000 happen to be recent — maybe 30, maybe 0 — while thousands of genuinely matching traces from this week sit far down the global ranking and are never returned. Counting correctly means scoring every trace in the window: a full scan.
+- **Tracking over time multiplies that cost forever.** An alert on "last-5-minutes match count vs its historical average" needs μ and σ over every historical bucket — the verdict for every trace in the corpus — recomputed on every evaluation, even though each trace's verdict is frozen the moment it arrives. The only affordable fix is "score each trace once, on arrival, and remember it", which is write-time materialization.
+- **"Occurrences are scores" is the cheap way to remember it, given the existing storage split.** `scores` is already a Postgres-canonical + ClickHouse-analytics split, and immutable scores skip straight to ClickHouse ([scores.md](./scores.md)). A pure-tracker match is immutable by construction (a value, no feedback, nothing to draft), so it goes ClickHouse-only and never touches the canonical mutable Postgres path. Mutable membership (judge feedback, human/flagger annotations) is bounded — sampled or human-paced — and takes the canonical path as it does today. So one ledger scales without a second table.
+
+Consequences that hold throughout the system:
+
+- **Query-time semantic search stays an exploration tool** — a ranked best-effort sample on the Traces page. There are no counts, histograms, or alerts over a raw semantic query; the path to set semantics is "create a signal".
+- **Anything needing set semantics** — charts, baselines, alerts, "every matching trace" — must be a signal whose tracker decides membership per trace at ingest.
+- **History is immutable under definition edits.** Editing a tracker changes membership *forward only* (a definition-changed marker appears on charts); existing scores keep their frozen `passed`.
+
+## Concepts
+
+### Signal
+
+A signal's members are the traces with a *matching* score for that signal. A signal carries:
+
+- **origin** — `user` (built deliberately by a person) or `system` (auto-created by Latitude; see [Discovery](#discovery-sinks-and-promotion)). Origin distinguishes hand-built from discovered signals and is a list filter/column.
+- **`tracker`** (jsonb, nullable, **at most one per signal**) — the membership detector run at write time. A `NULL` tracker is a **sink**: no write-time detection, with membership coming only from annotations. Sinks are how discovered signals work.
+- **`filters`** (a `FilterSet`, nullable) — a cheap, row-local pre-gate restricting which traces the tracker is even run against (e.g. `service = checkout`, or above p90 latency). Empty/absent means all traces. `filters` is only meaningful alongside a tracker — it gates tracker execution.
+- **triage metadata** — a single `priority` and a single `assignee` (multi-assignee deferred), carried over from issues.
+- **lifecycle** — `resolved` / `ignored` / `escalating`, carried over from issues. Lifecycle stays on the signal row; it is not relocated onto a monitor.
+
+Invariants:
+
+- **A `user`-origin signal must have a tracker.** Users cannot create a tracker-less signal. Tracker-less (`NULL`) signals exist only as `system`-origin sinks. This keeps "plain filter slices" out of signals — those stay **saved searches** + monitors. (A broad `filters`-only signal would write a score per trace; banning user-created tracker-less signals removes that write-amplification footgun entirely.)
+- **One tracker per signal.** A bucket has at most one detector. A concept that needs two detectors — e.g. semantic *and* judge for the same behavior — is one signal *promoted* from one tracker to another, or two signals; never one signal with two trackers.
+- **Signals per project are capped** per plan, which bounds tracker matching cost and pure-tracker score write volume.
+
+### Tracker
+
+The write-time detector embedded on a signal (`signals.tracker` jsonb, discriminated by `type`). Three types:
+
+```ts
+export const SIGNAL_TRACKER_TYPES = ["semantic_similarity", "script", "llm_as_judge"] as const
+export type SignalTrackerType = (typeof SIGNAL_TRACKER_TYPES)[number]
+
+export type SignalTracker =
+  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
+  | { type: "script";              source: string;            threshold: number }   // sandbox JS
+  | { type: "llm_as_judge";        threshold: number }   // detector lives in evaluations.signal_id (1:1)
+
+export type SemanticAnchors = {
+  anchors: string[]                  // positive anchor phrases (1..n); best match wins
+  contrastAnchors?: string[]         // a trace matches only if best-positive ALSO beats best-contrast by `margin`
+  margin?: number                    // required positive-vs-contrast separation (default per constants)
+  roles?: ("user" | "assistant")[]   // optionally restrict which turns are compared
+}
+```
+
+- **`semantic_similarity`** and **`script`** are **pure** detectors — deterministic, no `feedback`. `script` runs through the sandbox runtime (`specs/sandbox-runtime.md`); `semantic_similarity` runs through the native batch anchor runner (the conversation-intelligence path), not the sandbox. The semantic detector value is `max(chunk · positiveAnchor)`, and a trace matches only when the best positive anchor also beats the best contrast anchor by `margin`. This multi-anchor + contrast + margin shape is proven in production for conversation-intelligence moment labels and adopted wholesale, generalizing those labels' static per-kind gate into the uniform per-tracker `threshold`.
+- **`llm_as_judge`** is **not** stored inline. Its config is an `evaluations` row linked by `evaluations.signal_id` (1:1); the tracker jsonb records only `{ type, threshold }`. The judge script, alignment state, and `optimize-evaluation` workflow stay in `@domain/evaluations` (see [evaluations.md](./evaluations.md)). A judge tracker can be authored directly (judge criteria → compiled to a backing evaluation linked to the signal), with alignment ground truth accruing as annotations arrive; the same type also arises automatically via the sink → promotion path. Both paths land on the same backing-evaluation shape.
+- A tracker's **`threshold`** is the membership cutoff over the detector value (semantic emits continuous similarity; judges emit ≈{0,1}; scripts emit whatever they compute). Threshold and definition edits apply **forward only** — existing scores are never re-evaluated.
+
+`semantic_similarity` anchor embeddings are not a column. They are embedded once on save and Redis-cached under an org-prefixed key, exactly as moment-label anchors are today; nothing searches anchors via SQL.
+
+### Score as the membership ledger
+
+Every membership-bearing event writes a `scores` row carrying `signal_id`; nothing else records membership. The widened source enum:
+
+```ts
+export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as const
+export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
+//   tracker — written by the signal's tracker at ingest    (source_id = signal id; a judge tracker score
+//             may keep the evaluation id as source_id to preserve evaluation-source dashboards)
+//   flagger — automatic flagger annotation                 (source_id = flagger key)
+//   user    — human annotation (UI / API / queue)          (source_id = user id / sentinel)
+//   custom  — public /scores push  [post-MVP]              (source_id = caller tag)
+```
+
+- **`passed` is the materialized membership flag.** The tracker host freezes `matched = (value >= tracker.threshold)` at write time and stores it as `passed`; `value` is retained for confidence and sort. A signal's occurrences are therefore `scores WHERE signal_id = ? AND passed = true`, with no runtime threshold. (A judge "exhibits" the behavior at `passed:false` under the historical problem-detector polarity; this is normalized to exhibition during migration.)
+- **Non-matches are written too**, mirroring how evaluations persist both `passed:true` and `passed:false`. A tracker writes a score on every run, matched or not. The matched rows are occurrences; the non-matched rows give exact pass-rate and denominators without read-time estimation. (Lever if pure-tracker non-match volume ever hurts: switch pure trackers to match-only and derive the denominator from `filters` over traces at read time. The default is write-both.)
+- **The write path routes by mutability**, reusing the existing scores Postgres/ClickHouse split:
+
+  | Score | Mutable? | Store |
+  | --- | --- | --- |
+  | `tracker` / `llm_as_judge` (pass + fail; has `feedback`; sampled → bounded) | yes (feedback) | Postgres-canonical + ClickHouse |
+  | `tracker` / `semantic_similarity` · `script` (matched + non-matched; no feedback; per in-scope trace) | no | **ClickHouse-analytics only** (immutable on arrival; skip the canonical Postgres row) |
+  | `user` / `flagger` annotation (draftable, editable) | yes | Postgres-canonical + ClickHouse |
+
+Pure-tracker scores carry `signal_id` at write time, so they are immutable on arrival and go straight to ClickHouse — they never push trace-volume writes through the canonical mutable Postgres path. This is the mechanism that makes "occurrences are scores" scale.
+
+## Data model
+
+No new tables: every entity evolves a table that already exists. The unified `event.*`/`metric.*` alert model, `MonitorMetric`, and the `monitors.target_*` columns are shared with [monitors.md](./monitors.md).
+
+### Postgres: `signals`
+
+The `signals` table is the former `issues` table, evolved in place (rows, centroid, and embeddings are kept). It is organization-scoped under the standard RLS org-isolation policy and follows the no-FK rule.
+
+- `origin varchar(16)` — `SignalOrigin` (`user` | `system`).
+- `tracker jsonb null` — `SignalTracker`; `NULL` = sink.
+- `filters jsonb null` — `FilterSet` pre-gate; only meaningful alongside a tracker.
+- `priority varchar(16) null` — `low` | `medium` | `high` | `urgent`.
+- `assignee_id varchar(24) null` — single assignee.
+- `centroid jsonb null` and `centroid_embedding vector(2048) null` — the decayed weighted centroid and its derived pgvector, used for sink similarity routing in discovery. Both are nullable because user-created tracker signals have no centroid; only discovery sinks cluster.
+- `clustered_at timestamptz null` — last centroid/cluster refresh (nullable for the same reason).
+- `search_document tsvector GENERATED` — `setweight(name 'A') || setweight(description 'B')`, with a GIN index for the lexical side of hybrid sink search.
+- `resolved_at` / `ignored_at` / `escalated_at timestamptz null` — lifecycle timestamps. `escalated_at` is dormant; "escalating" is derived from open `alert_incidents`.
+- `deleted_at timestamptz null` — signals are soft-deleted (issues were not).
+
+Indexes of note:
+
+- partial unique `(organization_id, project_id, slug) WHERE deleted_at IS NULL` — per-project slug uniqueness among non-deleted signals.
+- GIN `(search_document)` — lexical boost in hybrid sink search.
+- partial btree `(organization_id, project_id, ignored_at, resolved_at, created_at) WHERE deleted_at IS NULL` — project-scoped lifecycle filtering.
+- partial btree `(organization_id, project_id) WHERE deleted_at IS NULL AND tracker IS NOT NULL` — "list active tracked signals" for the matching pipeline.
+
+There is intentionally **no** approximate vector index on `centroid_embedding`: signals per project are bounded (hundreds to low thousands), and an exact project-scoped scan outperforms an approximate index at that scale.
+
+### Postgres: `scores`
+
+`scores.signal_id varchar(24) null` is the former `issue_id`. `scores.source_type varchar(32)` is the former `source`, carrying `ScoreSourceType`. `passed` is the materialized membership flag (above); `value` is retained for confidence/sort. The canonical idempotency unique index keys one tracker score per `(source_id, trace)`. See [scores.md](./scores.md) for the full row shape, the draft/publication lifecycle, and the at-most-once ClickHouse sync.
+
+### Postgres: `evaluations`
+
+`evaluations.signal_id varchar(24) NOT NULL` is the former `issue_id` (still required — a judge tracker always backs a signal). Everything else about the evaluation entity is unchanged; see [evaluations.md](./evaluations.md).
+
+### Postgres: `monitors`
+
+A monitor targets a signal via `monitors.target_signal_id varchar(24) null` (alongside the existing saved-search/raw-stream `target_*` columns). `is_default boolean` marks the auto-provisioned per-signal occurrences monitor, with a partial unique index `(target_signal_id) WHERE is_default AND deleted_at IS NULL` (one default monitor per signal) and a firing-scan index `(organization_id, target_signal_id) WHERE deleted_at IS NULL`. The `metric` column (`MonitorMetric`) is shared with all monitor targets. See [monitors.md](./monitors.md) for the monitor entity, alerts, and incidents.
+
+### ClickHouse: `scores`
+
+The analytics table gains `signal_id FixedString(24) DEFAULT ''` (the empty-string sentinel for "no signal"). It is the single signal counting/aggregate surface monitors read: occurrence count is `WHERE signal_id = ? AND passed`. Field aggregates (`avg`/`p95`/`sum` of `duration`/`cost`/`tokens`) join the matched `trace_id` back to the traces analytics — the score's own `duration`/`tokens`/`cost` are the *judge's*, not the trace's. The `source` skip index is sized for the four `source_type` values. Pure-tracker scores are written ClickHouse-only; judge/annotation scores follow the canonical Postgres → ClickHouse sync. ClickHouse migrations are append-only (see [scores.md](./scores.md) and the ClickHouse skill).
+
+## The matching pipeline (write-time)
+
+A single **signal matching pipeline** runs every active *tracked* signal's detector against incoming traces. It generalizes the former evaluation-oriented write path (`EvaluationTrigger`: filter / turn / debounce / sampling), and evaluations become one runner inside it.
+
+- The **filters pre-gate** is shared — one row-local pass per trace over all active signals' `filters`. Out-of-gate traces never reach a tracker.
+- The **sandbox runner** executes `script` trackers (and `llm_as_judge` trackers' generated scripts) in the shared sandboxed JS runtime (`specs/sandbox-runtime.md`).
+- The **semantic runner** compares a trace's content-chunk embeddings (already produced at ingest for trace search and semantic moments) against Redis-cached anchor embeddings — one batch pass over a trace's chunks against all anchor sets. It subsumes the conversation-intelligence moment-label anchor pass.
+- Evaluation-specific options (`sampling`, `turn`, `debounce`) remain runner-level settings on the backing evaluation, not pipeline concepts.
+
+A run writes a score (matched or not) with `signal_id` and `source_type = 'tracker'`, routed Postgres/ClickHouse by mutability (above). **Sinks (`tracker IS NULL`) are not in this pipeline** — they receive membership only via annotations.
+
+The active-signal set is loaded through `SignalRepository.listActiveTracked(projectId)`, Redis-cached under an org-prefixed key. The pipeline runs as a `signals:match` queue task off `TracesIngested` (batched per project), with a separate `signals:semanticMatch` hop joining the content embeddings produced at ingest.
+
+## Discovery: sinks and promotion
+
+Automatic discovery produces **sink signals** (origin `system`, no tracker), reusing the flagger + annotation + centroid + hybrid-search + locked-serialization machinery unchanged (see [issues.md](./issues.md) for the discovery pipeline internals and the bounded locked serialization invariant).
+
+```
+flaggers (trace-end) + human annotations
+   └─ each writes an annotation score (source_type = 'flagger' | 'user')
+   └─ discovery routes the score (centroid + hybrid search + locked serialization):
+        ├─ to an existing sink signal      → +1 occurrence
+        └─ or creates a new sink signal    → origin 'system', tracker NULL
+   └─ once a sink has enough evidence, the user can PROMOTE it:
+        └─ generate an llm_as_judge tracker from its accumulated annotations
+           (the former "Monitor issue" → optimize-evaluation; workflow id evaluations:generate:${signalId})
+        └─ the accumulated annotation scores become the alignment ground truth
+           (positives = annotations marked as exhibiting; negatives = traces annotated as passing
+            elsewhere; zero-annotation traces excluded)
+        └─ the signal now auto-detects forward; old annotation occurrences stay, the judge adds
+           tracker-sourced ones
+```
+
+A signal's life is therefore **sink (annotation-fed) → optionally promoted to a tracker (detector-fed)**, with identity and occurrence history preserved across the promotion. This is the bridge between auto-discovery and hand-built trackers; it reuses the entire existing discovery + `optimize-evaluation` + alignment machinery.
+
+**Annotation assignment is allowed exactly on tracker-less (sink) signals.** A tracker-backed signal is detector-driven; traces are not hand-assigned into it. While annotating, the UI suggests existing sinks via hybrid search over `search_document` (lexical) + `centroid_embedding` (the discovery path); the user links explicitly or lets discovery route.
+
+## Lifecycle and triage
+
+Lifecycle (`resolved` / `ignored` / `escalating`) stays on the signal row, carried over from issues:
+
+- **Resolve** sets `resolved_at = now` and closes any open sustained incidents silently (no recovery notification).
+- **Ignore** sets `ignored_at = now`. Scores keep recording; nothing notifies.
+- **Delete** soft-deletes the signal and its monitors, archives the backing evaluation, and enqueues ClickHouse score cleanup for the signal.
+- **Escalating** is not a stored flag — it is derived from an open escalating `alert_incidents` row on the signal's monitor.
+- **Regression** — the first datapoint after `resolved_at` clears fires the `event.regressed` alert.
+
+Triage `priority` and `assignee_id` behave as they did for issues: the list groups by priority and filters by assignee, and incident notification payloads snapshot them for rendering.
+
+## Monitors, alerts, and incidents on signals
+
+A signal is one **monitor target type**. A monitor watches one signal over time; monitors never own detection (that lives on the signal's tracker). A signal monitor owns:
+
+- a **target** — the signal, via `monitors.target_signal_id`.
+- a **metric** (`MonitorMetric`) — `count` of matching scores (default), `errorRate`, or `avg`/`p95`/`sum` of `duration`/`cost`/`tokens`. Field aggregates read the matched traces (`score.trace_id → traces`).
+- **mute** (`muted_at`) — notifications off; evaluation and incident recording continue.
+
+Signal monitors use the unified, target-on-monitor alert kinds (with `source_type`/`source_id` null):
+
+- **`event.matched`** — a new matching score entered the signal (point).
+- **`event.regressed`** — the first datapoint after the signal's `resolved_at` clears it (point, no condition, severity high, **not user-creatable**). This is the only genuinely new alert kind.
+- **`metric.threshold`** — absolute / multiplier / expected, with direction (point).
+- **`metric.escalating`** — sustained. The former two "is this escalating?" implementations (the issue seasonal detector over score counts, and the saved-search bucketed sustained-gate over trace-match counts) merge into one evaluator: every target yields the same per-bucket count series → per-bucket threshold → open/close state machine. The seasonal detector (`evaluateSeasonalEscalation`) survives as the threshold function of `expected` mode (knob: `sensitivity`).
+
+Every signal gets a **default monitor** provisioned at creation: the occurrences (`count`) monitor carrying a high-severity `metric.escalating` alert in `expected` mode plus an `event.regressed` alert — the same coverage issues get today, now explicit and per-signal. The metric series is read from ClickHouse through `SignalScoreReader` (`count WHERE signal_id = ? AND passed`; aggregates over matched traces; per-bucket series for the escalation machine), mirroring `SavedSearchMatchReader`. Incidents are unchanged from [monitors.md](./monitors.md): same `alert_incidents` lifecycle, backtracked `started_at`/`ended_at`, and snapshotting of the firing alert's `condition` and the monitor's target definition so closed incidents stay self-describing after edits.
+
+## Main flows
+
+`[reuse]` marks existing machinery used unchanged.
+
+- **Trace ingest → tracker → score.** `TracesIngested` → domain-events dispatcher → `signals:match` (batched per project) → `matchTracesToSignalsUseCase`: load `listActiveTracked`, run the `filters` pre-gate per signal, dispatch to the script/judge/semantic runner, and write a score (matched or not) with `signal_id`, `source_type='tracker'` — pure trackers ClickHouse-only, judges Postgres-canonical + ClickHouse. The pipeline then publishes `monitors:evaluate` on a leading-edge throttle `[reuse shape]`.
+- **Create a signal manually.** `createSignalUseCase { origin: 'user', tracker, filters? }`: embed + Redis-cache anchors (semantic), compile (script, rejecting `ScriptCompileError` at save), or create the backing evaluation (judge); provision the default monitor; enqueue `signals:backfill` for pure trackers.
+- **Annotation → sink routing.** A flagger or human annotation writes an annotation score (`source_type 'flagger'|'user'`), then `ScoreCreated` drives discovery (centroid + hybrid search + locked serialization) to assign to an existing sink or create a new `system`-origin tracker-less sink `[reuse]`.
+- **Monitor evaluation → alert → incident → notification.** `evaluateMonitorUseCase` reads the signal target via `SignalScoreReader`, computes the per-bucket metric series, and runs each active alert's state machine; incidents open/close and drive notifications through the mute gate `[reuse]`.
+- **Promote a sink to a judge tracker.** `promoteSignalUseCase` sets `tracker = { type:'llm_as_judge', threshold }` and starts `optimize-evaluation` (`evaluations:generate:${signalId}`), building the alignment set from the signal's annotation scores; the frontend polls `getSignalAlignmentState` via `workflow.describe()` `[reuse shape]`.
+
+## Product surface
+
+A **Signals** nav item replaces **Issues**: a single list holding hand-built and discovered signals together, with `origin` (auto/manual), tracker type, priority, assignee, trend, monitors, and last incident as columns/filters on one surface. Former issue URLs (`/projects/$slug/issues/...`) and `?issueId=` deep links redirect to the corresponding signal pages.
+
+- **Signal detail page** — definition (tracker + filters), monitor charts, alerts, incidents, and member traces in one context. Sinks show their annotation evidence and a **Promote** action; judge-backed signals show the linked evaluation/alignment sections (confusion matrix, realign).
+- **Creating a signal** — one builder, three entry points (Signals list, "Create signal from this search", the annotation flow), one rule: **never let users define membership blind**. The builder always shows a live preview — a bounded query-time evaluation over recent traces (an exact scan over a recent window using existing content embeddings for `semantic`; the sandbox dry-run harness against sample traces for `script`/`llm_as_judge`). The tracker picker offers Semantic, Script, and LLM-as-judge.
+- **Creating a monitor** — target = a signal; metric = Occurrences (count) or an aggregate; alerts = the existing card stack, copied from the monitors surface.
+- **Monitors list** — one row per monitor with a **Target** column deep-linked to the signal, status (Live / Muted / Resolved / Escalating), metric, and last incident.
+
+## API / SDK / MCP
+
+Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/signals`, following the monitors routes as the template (`defineApiEndpoint`, a `createSignalsRoutes` factory, and rich `.describe()` field docs that propagate to both the TS SDK and MCP tools; regen via `pnpm openapi:emit` / `pnpm mcp:emit` / SDK generate).
+
+| Method | Path | Operation id |
+| --- | --- | --- |
+| GET / POST | `/` | `listSignals` / `createSignal` |
+| GET / PATCH / DELETE | `/{signalSlug}` | `getSignal` / `updateSignal` / `deleteSignal` |
+| GET | `/{signalSlug}/traces` | `listSignalTraces` |
+| POST | `/{signalSlug}/resolve`, `/ignore`, `/promote` | `resolveSignal` / `ignoreSignal` / `promoteSignal` |
+
+- `createSignal` accepts a `tracker` of any of the three types plus optional `filters`, and rejects tracker-less creation (sinks are system-only).
+- Monitors gain `signal` as a target type in their existing API.
+- `custom`-source score push (the `/scores` API accepting a caller-supplied `signal_id`) is post-MVP; today `/scores` refuses caller-supplied ownership ([scores.md](./scores.md)).
+
+## Package layout and errors
+
+`@domain/signals` is the evolved `@domain/issues` package and remains the **reference implementation** for per-package error layout (`src/errors.ts` with specific `Data.TaggedError` classes implementing `HttpError`, per-flow union types, shared infrastructure errors in `@domain/shared`). See [domain-errors.md](./domain-errors.md) and the effect-and-errors skill. Tracker authoring adds save-time validation errors (e.g. `ScriptCompileError` for `script` trackers) and the reject-tracker-less-user-signal rule.
+
+## See also
+
+- Design spec: `specs/signals.md` (decisions, trade-offs, phased build plan).
+- `specs/sandbox-runtime.md` — the execution contract for `script` and `llm_as_judge` trackers.
+- [issues.md](./issues.md) — the discovery pipeline, centroid math, and locked serialization that sinks reuse.
+- [monitors.md](./monitors.md), [scores.md](./scores.md), [evaluations.md](./evaluations.md), [conversation-intelligence.md](./conversation-intelligence.md).
+- Skills: `.agents/skills/async-jobs-and-events/SKILL.md`, `.agents/skills/database-postgres/SKILL.md`, `.agents/skills/database-clickhouse/SKILL.md`, `.agents/skills/api-endpoints/SKILL.md`.

--- a/specs/signals.md
+++ b/specs/signals.md
@@ -1,565 +1,554 @@
 # Signals
 
-> **Documentation**: eventual durable homes `dev-docs/signals.md` and an updated `dev-docs/monitors.md`; related current docs: `dev-docs/issues.md`, `dev-docs/scores.md`, `dev-docs/monitors.md`, `dev-docs/notifications.md`, `dev-docs/conversation-intelligence.md`.
+> **Documentation**: eventual durable homes `dev-docs/signals.md` and an updated `dev-docs/monitors.md`; related current docs: `dev-docs/issues.md`, `dev-docs/scores.md`, `dev-docs/monitors.md`, `dev-docs/notifications.md`, `dev-docs/conversation-intelligence.md`, `dev-docs/evaluations.md`.
 >
-> **Depends on**: `specs/sandbox-runtime.md` — the execution contract for evaluation/rule/script detectors: every detector returns `Score(value, feedback?)` with `value` = signal-exhibition strength, and the host derives membership as `value >= signals.threshold`.
+> **Depends on**: `specs/sandbox-runtime.md` — the execution contract for `llm_as_judge` and `script` trackers: a tracker run returns `Score(value, feedback?)` with `value` = signal-exhibition strength, and the host derives membership as `value >= tracker.threshold`. (Phase 0/1 of that spec are built; Phase 2 — rule/script codegen + dry-run harness — is the substrate this spec consumes.)
 >
 > **Supersedes (conceptually)**: `specs/monitors.md` and `specs/alerts.md`. Those specs remain accurate descriptions of what is *currently built*; this spec defines the model that replaces their framing. Do not retire them until the migration phases are underway.
 >
-> **Origin**: LAT-664 ("Consolidate monitor situation") — this spec consolidates the two proposals discussed there and the final comment posted on the issue.
+> **Origin**: LAT-664 ("Consolidate monitor situation"), extended through spec review into the **trackers** model below. This revision **reverses** the original spec's "no automatic discovery" stance and its separate-occurrence-ledger design — see [Decisions](#decisions) for what changed and why.
 
 ## Purpose
 
-Latitude currently has two parallel tracking systems with overlapping names and separate UIs: **Issues** (auto-created buckets of failed scores, invisibly monitored) and **Monitors** (user-configured alerts over **Saved Searches**). This spec restructures both around four concepts in a pipeline:
+Latitude has two parallel tracking systems with overlapping names and separate UIs: **Issues** (auto-created buckets of failed/annotated scores, monitored invisibly) and **Monitors** (user-configured alerts over **Saved Searches**). This spec consolidates both around a small set of concepts:
 
 ```
-                 signals create            monitors aggregate         alerts fire on        records the
-                 occurrence rows           the occurrence stream      conditions            firing
-  Trace ───────▶ SIGNAL ─────────────────▶ MONITOR ─────────────────▶ ALERT ──────────────▶ INCIDENT ──▶ notifications
-                 (write-time matching)     (or saved searches, tools,
-                                            raw telemetry streams)
+                tracker runs at ingest        monitors aggregate         alerts fire on        records the
+                (or annotation lands)         the score stream           conditions            firing
+  Trace ──────▶ SIGNAL ─────────────────────▶ MONITOR ─────────────────▶ ALERT ──────────────▶ INCIDENT ──▶ notifications
+                membership = its SCORES        (a metric over the
+                (write-time materialized)       signal's scores/traces)
 ```
 
 The one-line mental model for users and docs:
 
-> Latitude groups your traces into **Signals** — buckets you define deliberately, from the Signals page or while annotating. Any signal — or saved search, tool, or your raw traffic — can be watched with **Monitors**; monitors have **Alerts**, and a fired alert opens an **Incident**, which is what notifies you.
+> Latitude groups your traces into **Signals** — buckets you define with a **Tracker** (an LLM judge, a script, or semantic similarity), plus the buckets Latitude discovers for you automatically from annotations. A signal's members are its **Scores**. Any signal can be watched with a **Monitor**; monitors have **Alerts**, and a fired alert opens an **Incident**, which is what notifies you.
 
-Signal membership is **materialized at write time** — each trace is matched once at ingest and the verdict is remembered as an occurrence row. This is the load-bearing decision of the spec and it is forced, not a preference; the full rationale lives at the end ("Why signal membership is materialized at write time").
+Two structural decisions carry the whole spec and are stated up front:
+
+1. **A signal's occurrences ARE its scores.** There is no separate occurrence ledger. Every tracker run, every annotation, every (future) custom push writes a `scores` row carrying `signal_id`; the signal's membership is the subset of those rows that *matched* (`value >= threshold`). This collapses today's inconsistency (issues count scores, saved searches count traces) into one counting unit and reuses the entire scores pipeline. Rationale + the scaling argument that makes it safe: ["Why membership is materialized at write time"](#why-membership-is-materialized-at-write-time).
+2. **Membership is materialized at write time.** A tracker is evaluated against each in-scope trace once, on arrival, and the verdict is frozen as a score. This is forced, not a preference (same section).
 
 ## Concepts
 
 ### Signal
 
-**A signal is a tracked bucket of traces: one definition, evaluated per trace at ingest, materialized forever.**
+**A signal is a tracked bucket of traces.** Its members are the traces with a *matching* score for that signal. A signal has:
 
-- A signal's definition has two orthogonal parts:
-  - a **scope**: an optional `FilterSet` restricting which traces are considered at all ("traces above the p90 latency", "traces tagged `foo`"). Row-local and cheap, evaluated first; empty scope = all traces.
-  - a **matcher** (`SignalType`): the membership test run on in-scope traces — a semantic anchor set, an aligned evaluation, a structured code rule, or a sandboxed JS script.
+- an **origin**: `user` (built deliberately by a person) or `system` (auto-created by Latitude — see [Discovery](#discovery-sinks-and-promotion)). Origin is the differentiator between hand-built and discovered signals.
+- an optional **`filters`** (a `FilterSet`): a cheap, row-local pre-gate restricting which traces the tracker is even run against ("only `service = checkout`", "only traces above p90 latency"). Empty/absent = all traces. `filters` is only meaningful alongside a tracker — it gates tracker execution.
+- an optional **`tracker`** (a jsonb column, **one per signal**): the membership detector run at write time. `NULL` tracker = a **sink** (no write-time detection; membership comes only from annotations — this is how discovered signals work).
+- **triage metadata**: priority and a single assignee, carried over from issues (multi-assignee deferred).
+- a **lifecycle**: `resolved` / `ignored` / `escalating` etc., carried over from issues **unchanged for the MVP** (it stays on the signal row; it is not relocated onto a monitor).
 
-  Any matcher composes with any scope: an evaluation that only runs on slow traces, a semantic anchor only checked against traces tagged `foo`. The scope doubles as a cost pre-gate: out-of-scope traces never reach the matchers. Pure filter slices are deliberately *not* signals (decision 4) — that job belongs to saved searches + monitors.
-- Signals carry **triage metadata** — priority and assignees — but **no lifecycle**. You create or delete signals; resolve/ignore semantics live on monitors.
-- Signals are **always created proactively** (decision 2): from the Signals page builder, from a saved search (pre-filling scope and anchors — flow F), or from the annotation flow ("explain the problem, point at 3–4 example traces, get a signal with a generated aligned evaluation"). Today's issues migrate into signals; no pipeline creates them automatically anymore.
-- **Moment labels** (conversation intelligence) are provisioned as default per-project signals with `type = 'semantic'` — their existing anchor sets (`MOMENT_LABEL_ANCHORS`) carry over verbatim, since the semantic config adopts the same shape (multiple positive anchors + contrast anchors + margin; each kind's static gate becomes the signal's `threshold`).
-- Every signal gets a **default monitor** provisioned at creation — the same monitoring issues get today: an occurrences monitor carrying a high-severity `metric.escalating` alert in `expected` mode (the seasonal heuristic, so a firing is a high-signal event rather than noise) plus the `event.regressed` event alert.
+Constraints:
 
-### Saved search
+- **Users cannot create a tracker-less signal.** A `user`-origin signal must have a tracker. Tracker-less (`NULL`) signals exist only as `system`-origin sinks. This deliberately keeps "plain filter slices" out of signals — those stay **saved searches** (a broad `filters`-only signal would write a score per trace; banning user-created tracker-less signals removes that footgun entirely).
+- **One tracker per signal.** A bucket has at most one detector. (A concept that needs two detectors — e.g. semantic *and* judge for "frustration" — is one signal that gets *promoted* from one tracker to another, or two signals; it is not one signal with two trackers.)
 
-**A virtual view over traces, kept as a concept — and the only home for pure filter tracking.** The exploration bookmark on the Traces page: a stored `query + filterSet` evaluated at read time. Saved searches are directly monitorable (filters are cheap and correct at query time — `SavedSearchMatchReader` machinery reused unchanged). When a user wants a *deeper* membership test (semantic, rule, evaluation, script), the path is **Create signal from this search**, which pre-fills the scope from the filters and the semantic anchor from a semantic prompt.
+### Tracker
+
+**The write-time detector embedded on a signal** (`signals.tracker` jsonb, discriminated by `type`). Three types:
+
+```ts
+export const SIGNAL_TRACKER_TYPES = ["semantic_similarity", "script", "llm_as_judge"] as const
+export type SignalTrackerType = (typeof SIGNAL_TRACKER_TYPES)[number]
+
+export type SignalTracker =
+  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
+  | { type: "script";              source: string;            threshold: number }   // sandbox JS
+  | { type: "llm_as_judge";        threshold: number }   // backed by evaluations.signal_id (1:1)
+
+// Proven in production for conversation-intelligence moment labels (multi-anchor + contrast +
+// margin), adopted wholesale. Detector value = max(chunk · positiveAnchor); membership is the
+// uniform per-tracker `threshold`, generalizing moment labels' static per-kind gate:
+export type SemanticAnchors = {
+  anchors: string[]                  // positive anchor phrases (1..n); best match wins
+  contrastAnchors?: string[]         // a trace matches only if best-positive ALSO beats
+                                     //   best-contrast by `margin`
+  margin?: number                    // required positive-vs-contrast separation (default per constants)
+  roles?: ("user" | "assistant")[]   // optionally restrict which turns are compared
+}
+```
+
+- **`semantic_similarity`** and **`script`** are **pure** detectors (no `feedback`, deterministic). `script` runs through the sandbox runtime (`specs/sandbox-runtime.md`); `semantic_similarity` runs through the native batch anchor runner (the conversation-intelligence path), not the sandbox.
+- **`llm_as_judge`** is **not** stored inline — its config is an `evaluations` row linked by `evaluations.signal_id` (1:1). The tracker jsonb only records `{ type, threshold }`; the judge script, alignment state, and `optimize-evaluation` workflow stay in `@domain/evaluations` exactly as today. Users can create a judge tracker directly (authoring the judge criteria → compiled to a backing evaluation linked to the signal); alignment ground truth then accrues as annotations arrive on the signal. The same tracker type is *also* produced automatically via the sink → promotion path ([Discovery](#discovery-sinks-and-promotion)) — both paths land on the same backing-evaluation shape.
+- A tracker's **`threshold`** is the membership cutoff over the detector value, per `specs/sandbox-runtime.md` (semantic emits continuous similarity; judges emit ≈{0,1}; scripts emit whatever they compute). Threshold/definition edits apply **forward only** (a definition-changed marker on charts), never retroactively.
+
+### Score (the membership ledger)
+
+**A signal's occurrences are its scores.** Every membership-bearing event writes a `scores` row carrying `signal_id`; nothing else records membership.
+
+```ts
+export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as const
+export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
+// 'tracker' — written by the signal's tracker at ingest (source_id = signal_id; judge scores
+//             may keep the evaluation id to preserve evaluation-source dashboards)
+// 'flagger' — written by an automatic flagger annotation (source_id = flagger key)
+// 'user'    — written by a human annotation (source_id = user id / UI / API / queue cuid)
+// 'custom'  — pushed through the public /scores API (source_id = user-defined)  [POST-MVP]
+```
+
+- **Membership = the matched subset.** A trace is a member of a signal when it has a score for that signal with `value >= threshold` (judge "exhibits" = `passed:false` under today's problem-detector polarity, normalized to exhibition at migration). The signal's occurrence count is that subset.
+- **Non-matches are written too** (consistent with how evaluations already persist `passed:true` *and* `passed:false`): a tracker writes a score on **every** run, matched or not. The matched rows are occurrences; the non-matched rows give exact pass-rate, denominators, and dashboards without read-time estimation. (Lever if pure-tracker non-match volume ever hurts: switch pure trackers to match-only and compute the denominator from `filters` over traces at read time. MVP default is write-both.)
+- **Write path routes by mutability** (the existing scores PG/CH split — `dev-docs/scores.md`):
+
+  | Score | Mutable? | Store |
+  | --- | --- | --- |
+  | `tracker` / `llm_as_judge` (pass + fail; has `feedback`; sampled → bounded) | yes (feedback) | Postgres-canonical + ClickHouse, as today |
+  | `tracker` / `semantic_similarity` · `script` (matched + non-matched; no feedback; runs per in-scope trace) | no | **ClickHouse-analytics only** (immutable, skip the canonical Postgres row) |
+  | `user` / `flagger` annotation (draftable, editable) | yes | Postgres-canonical + ClickHouse, as today |
+
+  Pure-tracker scores carry `signal_id` at write time, so they are immutable on arrival and go straight to ClickHouse — they never push trace-volume writes through the canonical mutable Postgres path. This is the mechanism that lets "occurrences are scores" scale (see the rationale section).
 
 ### Monitor
 
-**A monitor watches one target over time.** Monitors never own filter definitions; they own:
+**A monitor watches one signal over time.** Monitors never own detection — that lives on the signal's tracker. A monitor owns:
 
-- a **target**: a signal, a saved search, a **tool** (from the Tools dashboard — telemetry-emergent, addressed by name), or a raw stream — `traces`, `spans`, or `sessions` as a whole (e.g. "avg latency of all traffic"). `target_id` is required for signal/saved-search/tool targets; raw streams have none.
-- a **metric**: event/occurrence count (default), or an aggregate over the matched traces — `avg` / `sum` / `p95` of `duration`, `ttft`, `cost`, `tokens`, or `errors`.
+- a **target**: a signal (`monitors.target_signal_id` = signal CUID). (Saved-search and raw-stream targets remain available via the existing `target_*` columns; this spec focuses on signal targets. Saved searches stay the home for plain filter tracking — `SavedSearchMatchReader` reused unchanged.)
+- a **metric** (`MonitorMetric`, already exists): `count` of matching scores (default), `errorRate`, or `avg`/`p95`/`sum` of `duration`/`cost`/`tokens`. Field aggregates read the matched traces (`score.trace_id → traces`); the score's own cost/tokens are the *judge's*, not the trace's.
 - **mute** (`muted_at`): notifications off; evaluation and incident recording continue.
-- the **lifecycle**: *active* (default), *escalating* (derived: an open sustained incident exists), *resolved* (manual `resolved_at` anchor, or derived from a long quiet period). The first datapoint after `resolved_at` fires an `event.regressed` alert and clears the anchor.
 
-Tool targets get **no default monitor** (the inventory is telemetry-emergent and can be large — tool monitors are opt-in) and no deletion cascade (tools aren't Postgres rows). Tool *metrics* belong here; *judgments* about tool behavior belong to signals — `SignalRule`'s `part: 'toolCall'`, or any matcher scoped with the `tools` filter field.
-
-"Resolve a signal" resolves its default monitor; "ignore" mutes it. The signal page keeps one-click triage; it just writes to the monitor underneath.
+Every signal gets a **default monitor** provisioned at creation — the occurrences (`count`) monitor carrying the same alerts issues get today: a high-severity `metric.escalating` alert in `expected` mode plus an `event.regressed` alert.
 
 ### Alert
 
-**A condition on a monitor.** Two flavors (Sentry-shaped, as in the original proposal):
+**A condition on a monitor.** Two flavors (Sentry-shaped, carried over from the monitors model):
 
-- **Event alerts** fire on discrete events in the target stream: a new matching trace, a regression.
-- **Metric alerts** fire on the monitor's aggregated value: threshold (absolute / multiplier / expected), and sustained escalation.
+- **Event alerts** — `event.matched` (a new matching score entered the signal), `event.regressed` (a datapoint after the monitor's resolve anchor).
+- **Metric alerts** — `metric.threshold` (absolute / multiplier / expected) and `metric.escalating` (sustained).
 
-Today "is this escalating?" has two unrelated implementations that differ only in their input: the issue path runs the seasonal detector (`evaluateSeasonalEscalation`) over per-issue **score counts**; the saved-search path runs a bucketed sustained-gate over query-time **trace-match counts** (whose `expected` mode already calls the same detector). The logic shape is identical: *per-bucket count series → per-bucket threshold → open/close state machine*. Since every monitor target now yields that same input shape, the two merge into **one** `metric.escalating` evaluator; the seasonal detector survives as the threshold function of `expected` mode (knob: `sensitivity`), and issue escalation stops being special — it is just the default monitor's escalating alert in that mode.
+The two unrelated "is this escalating?" implementations (the issue seasonal detector over score counts, and the saved-search bucketed sustained-gate over trace-match counts) **merge into one** `metric.escalating` evaluator: every monitor target now yields the same *per-bucket count series → per-bucket threshold → open/close state machine* shape. The seasonal detector (`evaluateSeasonalEscalation`) survives as the threshold function of `expected` mode (knob: `sensitivity`); issue escalation stops being special — it is the default monitor's escalating alert in that mode.
 
 ### Incident
 
-**Unchanged.** Same `alert_incidents` lifecycle (point vs sustained), same backtracked `started_at`/`ended_at`, same notifications pipeline (`incident.event` / `incident.opened` / `incident.closed`). Incidents continue to snapshot the firing alert's `condition`, and additionally snapshot the monitor's **target definition** at open time so closed incidents stay self-describing after edits.
+**Unchanged.** Same `alert_incidents` lifecycle (point vs sustained), backtracked `started_at`/`ended_at`, and notifications pipeline (`incident.event` / `incident.opened` / `incident.closed`). Incidents snapshot the firing alert's `condition`, and additionally snapshot the monitor's **target definition** at open time so closed incidents stay self-describing after edits.
 
 ## Data model
 
-### Shared enums (`@domain/shared`)
+**No new tables.** Every entity evolves a table that already exists: `issues` → `signals` (rename + columns), `scores` (rename + widened source), `evaluations` (rename), `monitors` (one target column), and the ClickHouse `scores` analytics table (one column). The original spec's `signal_occurrences` table is gone — "occurrences are scores". The unified `event.*`/`metric.*` alert model, `MonitorMetric`, and the `monitors.target_*` columns are **already built** (only `event.regressed` is genuinely new). `legend: ▸NEW ▸CHANGED ▸KEPT ▸DROPPED` is per-line below.
+
+### Shared enums (`@domain/shared`, `@domain/scores`)
 
 ```ts
-export const SIGNAL_ORIGINS = ["user", "annotation", "system"] as const
-export type SignalOrigin = (typeof SIGNAL_ORIGINS)[number]
-// 'user'       — built from the Signals page or from a saved search
-// 'annotation' — created through the annotation flow
-// 'system'     — provisioned by Latitude (moment labels)
+// NEW (@domain/shared)
+export const SIGNAL_ORIGINS = ["user", "system"] as const   // user = hand-built (must have a tracker); system = auto-created sink / provisioned
+export const SIGNAL_TRACKER_TYPES = ["semantic_similarity", "script", "llm_as_judge"] as const
 
-export const SIGNAL_TYPES = ["semantic", "evaluation", "rule", "script"] as const
-export type SignalType = (typeof SIGNAL_TYPES)[number]
+// CHANGED (@domain/scores): replaces SCORE_SOURCES = ["evaluation","annotation","custom"]
+export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as const
+//   tracker — written by the signal's tracker at ingest        (source_id = signal id; judge may keep evaluation id)
+//   flagger — automatic flagger annotation                     (source_id = flagger key)
+//   user    — human annotation (UI / API / queue)              (source_id = user id / sentinel)
+//   custom  — public /scores push  [POST-MVP]                  (source_id = caller tag)
 
-export const MONITOR_TARGET_TYPES = ["signal", "savedSearch", "tool", "traces", "spans", "sessions"] as const
-export type MonitorTargetType = (typeof MONITOR_TARGET_TYPES)[number]
-// 'signal' / 'savedSearch'        — a specific entity (target_id = its CUID)
-// 'tool'                          — a telemetry-emergent entity (target_id = the tool name)
-// 'traces' / 'spans' / 'sessions' — the project's whole raw stream (target_id null)
+// CHANGED (@domain/shared, alert-incident-kinds.ts): ALERT_INCIDENT_KINDS already contains
+// event.matched / metric.threshold / metric.escalating (unified, target-on-monitor) plus the
+// legacy issue.* / savedSearch.* kinds. The signals migration adds exactly ONE:
+//   + "event.regressed"   // a datapoint after the signal's resolved_at clears it; point; no condition; severity high
+// and retires issue.* / savedSearch.* once existing monitors migrate to signal targets.
 
-export const ALERT_KINDS = [
-  // event alerts (point) — target-agnostic names: they apply to any target
-  "event.matched",     //  ← savedSearch.match  (a new event entered the target stream)
-  "event.regressed",   //  ← issue.regressed    (a datapoint after monitor.resolved_at)
-  // metric alerts
-  "metric.threshold",  //  ← savedSearch.threshold (point; absolute | multiplier | expected)
-  "metric.escalating", //  ← issue.escalating + savedSearch.escalating (sustained; unified)
-] as const
-export type AlertKind = (typeof ALERT_KINDS)[number]
-// issue.new is retired with the discovery pipeline (decision 2): nothing is "discovered" anymore.
+// ALREADY EXISTS (@domain/shared, alert-incident-condition.ts) — reused verbatim:
+//   MonitorMetric         = { kind:"count" } | { kind:"errorRate" } | { kind:"avg"|"p95"|"sum"; field:"duration"|"cost"|"tokens" }
+//   AlertMetricThreshold  = absolute(value) | multiplier(factor, baseline) | expected(sensitivity)   // + direction above|below
+//   metric.threshold / metric.escalating conditions carry { metric, threshold, direction?, window? }
 
-// Severities, AlertCountThreshold (absolute | multiplier | expected) and
-// AlertBaseline carry over verbatim from the current model.
+// tracker config stored inline on the signal row (signals.tracker jsonb):
+export type SignalTracker =
+  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
+  | { type: "script";              source: string;            threshold: number }   // sandbox JS
+  | { type: "llm_as_judge";        threshold: number }   // detector lives in evaluations.signal_id (1:1)
 
-export type MonitorMetric =
-  | { kind: "count" }                                  // events/occurrences per bucket (the default)
-  | { kind: "avg" | "sum" | "p95";                     // aggregate over the matched traces' metrics
-      field: "duration" | "ttft" | "cost" | "tokens" | "errors" }
-```
-
-### Signal definition config (discriminated by `signals.type`)
-
-```ts
-// The scope is a top-level column (signals.scope), not part of the matcher config:
-// any matcher composes with any scope.
-export type SignalConfig =
-  | { type: "semantic";   semantic: SemanticAnchors }
-  | { type: "evaluation" }      // definition = the evaluations rows linked via evaluations.signal_id
-  | { type: "rule";       rule: SignalRule }
-  | { type: "script";     script: string }   // user-authored JS, shared sandbox runtime
-
-// Same shape as conversation intelligence's MOMENT_LABEL_ANCHORS — proven in production
-// for moment labels, adopted wholesale (multi-anchor + contrast + margin). The detector's
-// value is max(chunk · positiveAnchor); the membership cutoff is NOT config — it is the
-// uniform per-signal signals.threshold knob (specs/sandbox-runtime.md):
 export type SemanticAnchors = {
-  anchors: string[]            // positive anchor phrases (1..n); best match wins
-  contrastAnchors?: string[]   // negative anchors: a trace matches only if its best positive
-                               //   similarity ALSO beats its best contrast similarity by `margin`
-  margin?: number              // required positive-vs-contrast separation (default per constants)
-  roles?: ("user" | "assistant")[]  // optionally restrict which conversation turns are compared
-}
-
-// Structured, user-friendly matcher over parts of the trace conversation.
-// Compiled to a sandboxed script under the hood — rule, script, and evaluation
-// matchers all execute in the same sandbox runtime; rule is just a generated script.
-export type SignalRule = {
-  combinator: "and" | "or"
-  conditions: {
-    part: "input" | "output" | "system" | "toolCall" | "any"   // which part of the convo to test
-    check:
-      | { kind: "contains";    value: string; caseSensitive?: boolean }
-      | { kind: "regex";       pattern: string; flags?: string }
-      | { kind: "levenshtein"; value: string; maxDistance: number }
-      | { kind: "jsonSchema";  schema: Record<string, unknown> }   // tool args / structured outputs
-    negate?: boolean
-  }[]
+  anchors: string[]; contrastAnchors?: string[]; margin?: number; roles?: ("user" | "assistant")[]
 }
 ```
 
-- Every matcher executes through the sandbox-runtime contract (semantic via its native batch runner): the run returns `Score(value, feedback?)` with `value` = exhibition strength, and membership is `value >= signals.threshold`. Generated judges are phrased *as the signal* ("does this trace exhibit X?") so judge-yes = high value; legacy quality-phrased evaluations invert values (`1 − value`) or regenerate at migration.
-- `scope` reuses the shared `FilterSet`, including `gtePercentile` — so "traces above the p90 latency" is expressible today. Percentile operators are resolved against a periodically refreshed project estimate at ingest (slightly approximate at write time, exact during backfill).
-- For `evaluation` signals the scope plays the role of today's `EvaluationTrigger.filter` — see "One matching pipeline" below; `sampling`/`turn`/`debounce` stay evaluation-level settings.
-- Definition edits (anchors, threshold, scope) change membership **going forward only** (definition-changed marker on charts), never retroactively.
-- Threshold UX: MVP ships a fixed default (`0.5`; rules/judges emit ≈{0,1} so it is degenerate for them) with a sensitivity control for semantic signals; an iterative create-time calibration loop (show matches → tighten/loosen → repeat) is a possible post-MVP refinement.
-
-### Postgres: `signals` (evolves `issues`)
+### Postgres: `signals` (evolves `issues` in place — keep the rows)
 
 ```
-signals
-  id                  varchar(24) PK (CUID)
-  organization_id     varchar(24)            -- RLS, org-isolation policy
-  project_id          varchar(24)
-  slug                varchar(128)           -- unique per project among non-deleted
-  name                varchar(128)
-  description         text
-  origin              varchar(32)            -- SignalOrigin
-  type                varchar(32)            -- SignalType (the matcher)
-  config              jsonb                  -- SignalConfig (matcher parameters)
-  scope               jsonb                  -- FilterSet pre-gate; {} = all traces; composes with any type
-  threshold           float8 DEFAULT 0.5     -- membership cutoff over the detector value
-                                             --   (specs/sandbox-runtime.md); generalizes semantic
-                                             --   minSimilarity to every type; edits apply forward only
-  priority            varchar(16) null       -- IssuePriority, carried over (low/medium/high/urgent)
-  assignees           varchar(24)[]          -- multi-assignee (annotation_queues precedent)
-  search_document     tsvector GENERATED     -- name (A) + description (B); GIN
-  search_embedding    vector(2048) null      -- derived from name + description on save; used with
-                                             --   search_document for hybrid existing-signal
-                                             --   suggestions while annotating (decision 3)
-  deleted_at          timestamptz null
-  created_at, updated_at
+signals                                  -- was `issues`
+  id                  varchar(24) PK      ▸KEPT
+  organization_id     varchar(24)         ▸KEPT  -- RLS org-isolation policy
+  project_id          varchar(24)         ▸KEPT
+  slug                varchar(128)        ▸KEPT  -- unique per project among non-deleted
+  name                varchar(128)        ▸KEPT
+  description         text                ▸KEPT
+  origin              varchar(16)         ▸CHANGED  -- was `source` varchar(32); now SignalOrigin (user|system)
+  tracker             jsonb null          ▸NEW   -- SignalTracker; NULL = sink (membership via annotations only)
+  filters             jsonb null          ▸NEW   -- FilterSet pre-gate; only meaningful alongside a tracker
+  priority            varchar(16) null    ▸KEPT  -- low|medium|high|urgent
+  assignee_id         varchar(24) null    ▸KEPT  -- single assignee, as today (multi-assignee deferred)
+  centroid            jsonb null          ▸CHANGED  -- was NOT NULL; now nullable (user-created tracker signals have none)
+  centroid_embedding  vector(2048) null   ▸KEPT  -- derived from centroid; sink similarity routing (discovery)
+  search_document     tsvector GENERATED  ▸KEPT  -- setweight(name 'A') || setweight(description 'B'); GIN
+  clustered_at        timestamptz null    ▸CHANGED  -- was NOT NULL; nullable (only discovery sinks cluster)
+  resolved_at         timestamptz null    ▸KEPT  -- lifecycle (MVP: stays on the signal row, not the monitor)
+  ignored_at          timestamptz null    ▸KEPT  -- lifecycle
+  escalated_at        timestamptz null    ▸KEPT  -- dormant; "escalating" derived from open alert_incidents
+  deleted_at          timestamptz null    ▸NEW   -- issues were NOT soft-deleted; signals are (delete flow soft-deletes)
+  created_at, updated_at                  ▸KEPT
+  -- DROPPED: `uuid` (dormant legacy column)
 
-  unique (project_id, slug) WHERE deleted_at IS NULL
-  btree  (organization_id, project_id, created_at) WHERE deleted_at IS NULL
-  -- no ANN index on search_embedding: project-scoped exact scan, as issues today
+  unique  (organization_id, project_id, slug)  WHERE deleted_at IS NULL     ▸CHANGED  -- now partial (soft-delete)
+  gin     (search_document)                                                 ▸KEPT
+  btree   (organization_id, project_id, ignored_at, resolved_at, created_at) WHERE deleted_at IS NULL   ▸KEPT
+  btree   (organization_id, project_id)        WHERE deleted_at IS NULL AND tracker IS NOT NULL   ▸NEW  -- "list active tracked signals" (matching pipeline)
 ```
 
-Removed vs `issues`: `uuid` (dormant), `centroid` + `centroid_embedding` (discovery is gone — decision 2/3), `escalated_at` / `resolved_at` / `ignored_at` (→ monitor), `assignee_id` (→ `assignees`), `source` (→ `origin`).
+`semantic_similarity` anchor embeddings are **not** a column — embedded once on save and Redis-cached (org-prefixed key), exactly as moment-label anchors today. Nothing searches anchors via SQL.
 
-Semantic anchor embeddings are **not** a table column: anchors are embedded once on save and Redis-cached (org-prefixed key), exactly as moment-label anchors are today. Matching compares in-process at ingest; nothing ever searches anchors via SQL.
+### Postgres: `scores` (rename `issue_id`, widen the source)
 
-### Postgres: `monitors` (generalized, same table)
+```
+scores
+  id, organization_id, project_id                              ▸KEPT
+  session_id varchar(128) / trace_id varchar(32) / span_id varchar(16)   ▸KEPT (nullable)
+  source_type  varchar(32)   ▸CHANGED  -- was `source`; ScoreSourceType (tracker|flagger|user|custom)
+  source_id    varchar(128)  ▸KEPT
+  simulation_id varchar(24) null                               ▸KEPT
+  signal_id    varchar(24) null   ▸CHANGED  -- was `issue_id`
+  value double / passed bool / feedback text / metadata jsonb / error text / errored bool   ▸KEPT
+  duration bigint / tokens bigint / cost bigint                ▸KEPT  (ns / count / microcents)
+  drafted_at timestamptz null / annotator_id varchar(24) null  ▸KEPT
+  created_at, updated_at                                       ▸KEPT
+```
+
+- **`passed` IS the materialized membership flag.** The tracker host derives `matched = (value >= tracker.threshold)` at write time and stores it as `passed`; `value` is kept for confidence/sort. So **membership reads need no runtime threshold**: a signal's occurrences are `scores WHERE signal_id = ? AND passed = true`. This is also why threshold edits apply forward-only — old rows keep their frozen `passed`.
+- Index renames (same shapes, `issue`→`signal`): `scores_issue_lookup_idx` → `scores_signal_lookup_idx` (`WHERE signal_id IS NOT NULL`), `scores_issue_discovery_work_idx` → `scores_signal_discovery_work_idx`. The canonical idempotency unique index `scores_canonical_evaluation_trace_idx` flips its predicate `source='evaluation'` → `source_type='tracker'`, giving one tracker score per `(source_id, trace)`.
+- `custom` source is **POST-MVP**: it requires the public `/scores` API to accept a caller-supplied `signal_id` (today it refuses caller ownership — `dev-docs/scores.md`).
+
+### Postgres: `evaluations` (rename only)
+
+```
+evaluations
+  signal_id  varchar(24) NOT NULL   ▸CHANGED  -- was `issue_id` NOT NULL; still required (a judge tracker always backs a signal)
+  -- name, description, script, trigger, alignment, aligned_at, archived_at, deleted_at, timestamps  ▸KEPT
+  index evaluations_signal_lookup_idx (organization_id, project_id, signal_id, deleted_at)   ▸CHANGED (rename)
+```
+
+### Postgres: `monitors` (one new target column)
+
+The unified `target_*` + `metric` model already exists; signals just add a target column.
 
 ```
 monitors
-  id, organization_id, project_id, slug, name, description, system   -- unchanged
-  target_type     varchar(32)            -- 'signal' | 'savedSearch' | 'tool' | 'traces' | 'spans' | 'sessions'
-  target_id       varchar(128) null      -- entity CUID ('signal'/'savedSearch') or tool name ('tool');
-                                         --   NULL only for raw streams (= the whole project stream).
-                                         --   varchar(128), not 24: tool names are telemetry strings
-  metric          jsonb                  -- MonitorMetric: { kind: 'count' } (default) or
-                                         --   { kind: 'avg'|'sum'|'p95', field: duration|ttft|cost|tokens|errors }
-  is_default      boolean default false  -- the auto-provisioned per-signal monitor; triage writes here
-  resolved_at     timestamptz null       -- manual resolve anchor; cleared by the next datapoint
-  muted_at        timestamptz null       -- unchanged semantics
-  deleted_at, created_at, updated_at
+  id, organization_id, project_id, slug, name, description, system   ▸KEPT
+  target_stream          varchar(32) null   ▸KEPT  -- MonitorStream (traces|spans|sessions)
+  target_filter_set      jsonb null         ▸KEPT
+  target_query           text null          ▸KEPT
+  target_saved_search_id varchar(24) null   ▸KEPT
+  target_signal_id       varchar(24) null   ▸NEW   -- a signal target; signal monitor = this set + metric set, others null
+  metric                 jsonb null         ▸KEPT  -- MonitorMetric (already exists)
+  is_default             boolean default false   ▸NEW   -- the auto-provisioned per-signal occurrences monitor
+  muted_at, deleted_at, timestamps          ▸KEPT
 
-  partial unique (target_type, target_id) WHERE is_default AND deleted_at IS NULL
-  btree (organization_id, target_type, target_id) WHERE deleted_at IS NULL   -- firing scan
+  unique (project_id, slug) WHERE deleted_at IS NULL                          ▸KEPT
+  btree  (organization_id, project_id)      WHERE deleted_at IS NULL          ▸KEPT
+  partial unique (target_signal_id) WHERE is_default AND deleted_at IS NULL   ▸NEW  -- one default monitor per signal
+  btree  (organization_id, target_signal_id) WHERE deleted_at IS NULL         ▸NEW  -- "monitors watching signal X" firing scan
 ```
 
-### Postgres: `monitor_alerts` (same table; source columns dropped)
+### Postgres: `monitor_alerts` (no schema change)
 
-```
-monitor_alerts
-  id, organization_id, monitor_id
-  kind            varchar(64)            -- AlertKind
-  condition       jsonb null             -- AlertCountThreshold / escalating window / sensitivity; null for
-                                         --   parameterless kinds (event.matched, event.regressed)
-  severity        varchar(16)
-  deleted_at      timestamptz null       -- soft-delete preserved: incidents must stay attributable
-  created_at, updated_at
-```
+Reused as-is. A signal monitor's alerts use the **unified** kinds — `event.matched`, `event.regressed` (new), `metric.threshold`, `metric.escalating` — with `source_type`/`source_id` **null** (the target is the monitor's `target_signal_id`). `condition` (the `metric.*` variants already carry `{ metric, threshold, direction?, window? }`) and `severity` carry over. The only change is the enum addition above; `event.regressed` joins `KINDS_WITHOUT_CONDITION` (point, no params) and is **not** user-creatable.
 
-`source_type` / `source_id` are removed — the target lives on the monitor.
+### Postgres: `alert_incidents` (no required change)
 
-### Postgres: `alert_incidents` (near-unchanged)
+The unified model already resolves a signal incident's target by joining `monitor_alert_id → monitors.target_signal_id`; `source_type`/`source_id` stay null, `condition` snapshots the firing alert (metric included), and `entry_signals`/`exit_eligible_since`/backtracking carry over. **Optional hardening** (recommended, not required): add `target_snapshot jsonb` so a closed incident stays self-describing if its signal is later deleted — otherwise a deleted signal's closed incidents lose their target label.
 
-- `source_type` / `source_id` → `target_type` / `target_id` (values per the new enums).
-- `kind` values remapped from the legacy `issue.*` / `savedSearch.*` kinds (see the `ALERT_KINDS` mapping comments).
-- New: `target_snapshot jsonb null` — the monitor's `(target, metric)` and, for saved-search targets, the resolved `query + filterSet` at open time. Same rationale as the existing `condition` snapshot.
-- Everything else (`monitor_alert_id`, `condition`, `entry_signals`, `exit_eligible_since`, backtracking) carries over.
+### ClickHouse: `scores` analytics (one new column; append-only)
 
-### Postgres: renames only
-
-- `scores.issue_id` → `scores.signal_id`. All draft/immutability semantics in `dev-docs/scores.md` survive; the discovery-driven assignment paths are removed (assignment now comes from evaluation linkage or explicit annotation linking).
-- `evaluations.issue_id` → `evaluations.signal_id`. Alignment stays "predicted vs actual signal membership".
-- `saved_searches`: **untouched**.
-
-### ClickHouse: `signal_occurrences` (new; via `pnpm --filter @platform/db-clickhouse ch:create`)
+ClickHouse migrations are append-only (`ch:create`), so this is `ADD COLUMN`, not a rename:
 
 ```sql
-signal_occurrences
-  organization_id        LowCardinality(String)
-  project_id             LowCardinality(String)
-  signal_id              FixedString(24)
-  trace_id               FixedString(32)
-  span_id                FixedString(16)   DEFAULT ''      -- sentinel convention
-  session_id             FixedString(128)  DEFAULT ''
-  score_id               FixedString(24)   DEFAULT ''      -- set when a judgment (eval/annotation) backs it
-  value                  Float32                           -- the matching run's detector value (match
-                                                           --   strength: sort/confidence UI for free)
-  trace_started_at       DateTime64(9, 'UTC')              -- time axis = the trace's own start time
-  duration_ns            UInt64                            -- denormalized trace metrics so metric monitors
-  tokens_total           UInt64                            --   aggregate without joining traces
-  cost_total_microcents  UInt64
-  error_count            UInt32
-  ingested_at            DateTime64(3, 'UTC')              -- ReplacingMergeTree version
-
-ENGINE    ReplacingMergeTree(ingested_at)        -- Replicated* in clustered/
-PARTITION BY toYYYYMM(trace_started_at)
-ORDER BY  (organization_id, project_id, signal_id, trace_started_at, trace_id)
+ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT '';   -- NEW; backfill = old issue_id via one ALTER UPDATE, then issue_id deprecated
+-- `source` (FixedString(32)) now also carries tracker|flagger|user (no migration; values are not enum-constrained).
+--   bump skip index idx_source set(3) → set(4) to keep it selective for four values.
+-- everything else unchanged: value Float32, passed Bool, errored Bool, duration/tokens/cost UInt64, created_at.
 ```
 
-**Occurrences vs scores** (decision 6). Occurrences are the **membership ledger** ("this trace is in this signal"); scores are the **verdict ledger** ("this judge said pass/fail and why"). A semantic or rule match has no verdict, no feedback, nothing to draft — forcing it into `scores` would pollute evaluation analytics and push trace-volume writes through the canonical mutable Postgres path. Scores stop being the membership mechanism and keep the three jobs occurrences structurally cannot do:
+- **The CH `scores` table is the single signal counting/aggregate surface** monitors read; it loses its issue-trend special-casing. Occurrence count = `WHERE signal_id = ? AND passed`. Metric aggregates (`avg`/`p95`/`sum` of trace `duration`/`cost`/`tokens`) join the matched `trace_id` back to the traces analytics — the score's own duration/tokens/cost are the *judge's*, not the trace's.
+- Pure-tracker scores (semantic/script) are written **CH-only** (immutable on arrival); judge/annotation scores follow today's Postgres-canonical → CH sync.
 
-1. **Verdicts that don't match.** Occurrences record only matches; pass rates, error rates, and every confusion matrix also need the *passed* and *errored* runs — the rows that produce no occurrence.
-2. **Human feedback as alignment ground truth.** Annotations need a mutable, draft-able row, and alignment is literally human verdicts vs evaluation verdicts on the same traces. The unified score shape across sources is deliberate: human and machine judges emit exactly the same output — a verdict on a trace — with `source` recording who judged; alignment works because both sides live in one table with one shape. For signal-linked rows, `value` is **signal-exhibition strength** (generated judges are exhibition-phrased; legacy quality-phrased evaluations invert at migration) and `passed` is derived as `value >= threshold` at write time.
-3. **The public `/scores` API** for custom, user-pushed results (an existing machine-facing contract).
+## The matching pipeline (write-time)
 
-The two ledgers link where they meet: `score_id` is set on occurrences produced by judgment-bearing matchers, and `scores.signal_id` survives as the evidence label — not as membership. The ClickHouse score-analytics table loses its issue-trend role to `signal_occurrences` and remains for evaluation/custom source dashboards.
+Today's write-time machinery is evaluation-oriented (`EvaluationTrigger`: filter / turn / debounce / sampling decides when an evaluation runs). This generalizes into a single **signal matching pipeline** that runs every active *tracked* signal's detector against incoming traces; evaluations become one runner inside it:
 
-Design notes:
+- the **filters pre-gate** is shared (one pass per trace over all active signals' `filters`); out-of-gate traces never reach the tracker.
+- the **sandbox runner** executes `script` trackers (and `llm_as_judge` trackers' generated scripts) in the shared sandboxed JS runtime.
+- the **semantic runner** compares trace content-chunk embeddings (already produced at ingest for trace search and semantic moments) against Redis-cached anchor embeddings — one batch pass over a trace's chunks against all anchor sets.
+- evaluation-specific options (`sampling`, `turn`, `debounce`) remain runner-level settings on the backing evaluation, not pipeline concepts.
 
-- **Dedup unit is `(signal, trace)`**: a trace counts once per signal no matter how it matched or how late. Using `trace_started_at` (a deterministic property of the trace) as the time axis means a late matcher (an evaluation finishing minutes later, an annotation days later) produces a row with the *same sort key*, so ReplacingMergeTree collapses duplicates and histograms stay consistent without `FINAL` (reads use the standard dedup-safe aggregate shapes).
-- Metrics are **denormalized** so "avg cost of checkout-failure traces" is a single-table aggregate on the monitor-evaluation hot path.
-- Append-only; the only mutation is the rare `DELETE` by `signal_id` when a signal is hard-deleted, mirroring the score-deletion policy.
+A run writes a score (matched or not) with `signal_id`, `source_type = 'tracker'`, routed PG/CH per the table above. Sinks (`tracker IS NULL`) are not in this pipeline — they receive membership only via annotations.
 
-## UI
+## Discovery (sinks and promotion)
 
-### Navigation
-
-A **Signals** nav item replaces **Issues**: with discovery gone there is no auto-populated inbox to separate from user-built signals — it's one list, and issue URLs (`/projects/$slug/issues/...`) redirect into the corresponding signal pages. The **Monitors** item stays, generalized: the cross-target view of every active monitor in the project, whatever it watches.
+Automatic discovery is **kept**, reframed: it produces **sink signals** (origin `system`, no tracker), not a separate entity. The flagger + annotation machinery is unchanged.
 
 ```
-Traces
-Signals              ← replaces "Issues" (single list; nothing auto-appears)
-Monitors             ← stays: all monitors across targets (signals, saved searches, tools, raw streams)
-Datasets
-Settings
+flaggers (trace-end) + human annotations
+   └─ each writes an annotation score (source_type = 'flagger' | 'user')
+   └─ discovery routes the score (centroid + hybrid search + locked serialization, UNCHANGED):
+        ├─ to an existing sink signal      → +1 occurrence
+        └─ or creates a new sink signal    → origin 'system', tracker NULL
+   └─ once a sink has enough evidence, the user can PROMOTE it:
+        └─ generate an llm_as_judge tracker from its accumulated annotations
+           (today's "Monitor issue" → optimize-evaluation; deterministic workflow id
+            evaluations:generate:${signalId})
+        └─ the signal's accumulated annotation scores become the alignment ground truth
+           (positives = annotations marked exhibits; negatives = passing-annotated-elsewhere
+            traces; zero-annotation traces excluded — the alignment set is built from
+            annotations, and the judge is re-run against it, exactly as today)
+        └─ the signal now auto-detects forward; old annotation occurrences stay, the judge
+           adds tracker-sourced ones
 ```
 
-### Signals list
+So a signal's life is **sink (annotation-fed) → optionally promoted to a tracker (detector-fed)**, with identity and occurrence history preserved across the promotion. This is the bridge between auto-discovery and the hand-built trackers; it reuses the entire existing discovery + `optimize-evaluation` + alignment machinery.
 
-One table; triage (priority, assignee) and configuration (type, monitors) are columns/filters on the same surface.
-
-```
-┌──────────────────────────────────────────────────────────────────────────────────────┐
-│  Signals                                                              [ New signal ] │
-│  ──────────────────────────────────────────────────────────────────────────────────  │
-│  NAME                  TYPE        PRIORITY  TREND (14d)   MONITORS   LAST INCIDENT  │
-│  Refund hallucination  evaluation  high      ▂▃▂▅▇▅▃▂      2          ● Ongoing · 2h │
-│  Angry users           semantic    medium    ▁▁▂▂▁▂▁▁      1          Closed · 3d    │
-│  PII in answers        rule        high      ▂▂▃▃▃▂▃▃      1          —              │
-│  Refund requested 🔇   semantic    —         ▃▃▃▄▃▃▃▃      1 (muted)  —              │
-└──────────────────────────────────────────────────────────────────────────────────────┘
-```
-
-### Signal detail page — the center of gravity
-
-Definition, monitor charts, alerts, incidents, and member traces in one context. Annotation-born signals additionally show their linked evaluation/alignment sections.
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│  ← Signals / PII in answers                 [Resolve] [Ignore 🔇] [Edit] [⋯] │
-│  rule · output matches /\b\d{16}\b/ OR output contains "SSN"                  │
-│  scope: service = checkout                                                    │
-│  Priority: High ▾    Assignees: @ana @marc ▾                                  │
-│  ─────────────────────────────────────────────────────────────────────────── │
-│  MONITORS                                                    [ Add monitor ] │
-│  ┌─ Occurrences (default) ────────┐  ┌─ Avg cost ─────────────────────┐      │
-│  │ ▂▃▂▅▇▅▃▂   ⚑ definition edited │  │ ▃▃▄▅▅▆▆                        │      │
-│  │ 2 alerts · 1 firing            │  │ no alerts                      │      │
-│  └────────────────────────────────┘  └────────────────────────────────┘      │
-│                                                                              │
-│  ALERTS                                                        [ Add alert ] │
-│  • Occurrences > 2× 24h baseline        (metric)   High    fired 2h ago      │
-│  • Occurrences escalating (expected)    (metric)   High    never fired       │
-│  • New matching trace                   (event)    Low     fired 4m ago      │
-│                                                                              │
-│  INCIDENTS                                                                   │
-│  ● Ongoing   Occurrences > 2× baseline       opened 2h ago                   │
-│  ○ Closed    Occurrences escalating          3d ago · lasted 6h              │
-│                                                                              │
-│  TRACES                                                                      │
-│  …trace table reading signal_occurrences, paginated…                         │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-`[Resolve]` writes `resolved_at` on the default monitor; `[Ignore 🔇]` mutes it. Neither touches the signal row — but the page presents them as signal actions.
-
-### Creating a signal
-
-One builder, three entry points, one rule: **never let users define membership blind** — the builder always shows a live preview (a bounded query-time evaluation of the definition over recent traces; for `semantic`, an exact scan over a recent window using the existing content embeddings).
-
-```
-  Traces page                 Signals list                Annotation flow
-  "Create signal from         [ New signal ]              "Track this as a signal"
-   this search"                     │                            │
-        └───────────────┬───────────┘                            │
-                        ▼                                        ▼
-  ┌───────────────────────────────────────────┐   ┌──────────────────────────────────────┐
-  │  New signal                               │   │  Track failure mode                  │
-  │  Scope (optional filters):                │   │  What is going wrong?                │
-  │  ┌─────────────────────────────────────┐  │   │  ┌────────────────────────────────┐  │
-  │  │ service = checkout AND tag has foo  │  │   │  │ The agent promises refunds we  │  │
-  │  └─────────────────────────────────────┘  │   │  │ don't offer…                   │  │
-  │  Type:  ◉ Semantic    ○ Evaluation        │   │  └────────────────────────────────┘  │
-  │         ○ Rule        ○ Script            │   │  Example traces (3–4):               │
-  │  ┌─────────────────────────────────────┐  │   │  ☑ trace #a1f3   ☑ trace #b274      │
-  │  │ "user expresses frustration"        │  │   │  ☑ trace #c9d1   ☐ + add            │
-  │  │ + add anchor · + contrast anchor    │  │   │                                      │
-  │  └─────────────────────────────────────┘  │   │                                      │
-  │  ┌─────────────────────────────────────┐  │   │                                      │
-  │  │ Preview: 312 matches, last 7 days   │  │   │                                      │
-  │  │ …sample rows…                       │  │   │                                      │
-  │  └─────────────────────────────────────┘  │   │  → creates the signal and generates  │
-  │  Backfill last 14 days?  [✓]              │   │    its aligned evaluation             │
-  │              [ Create ]                   │   │              [ Create ]              │
-  └───────────────────────────────────────────┘   └──────────────────────────────────────┘
-```
-
-### Traces page
-
-- Saved searches keep their selector + save button. Each saved-search row offers **Create monitor** (the filter-tracking path) and **Create signal from this search** (scope pre-filled; semantic prompts become semantic anchors).
-- A semantic query shows a contract banner so the sample semantics are explicit: `Showing the most relevant results (ranked sample) — to track or count every match, create a signal.`
-
-### Creating a monitor
-
-```
-┌───────────────────────────────────────────────┐
-│  New monitor                                  │
-│  Watch:   ◉ Signal        [PII in answers ▾]  │
-│           ○ Saved search  [ … ▾]              │
-│           ○ Tool          [ … ▾]              │
-│           ○ All traces / spans / sessions     │
-│  Metric:  ◉ Occurrences   ○ Avg [cost ▾]      │
-│  Alerts:  (optional, card stack as today)     │
-│   • when value > [2]× [avg of last 7 days ▾]  │
-│              [ Create ]                       │
-└───────────────────────────────────────────────┘
-```
-
-### Monitors list
-
-Today's monitors dashboard, generalized: one row per monitor across all targets, with a **Target** column (signal / saved search / tool / raw stream, deep-linked to the target's own page), status (Live / Muted / Resolved / Escalating), metric, and last incident. Per-target monitor management still lives on each target's detail page (signal page, tool page, saved-search row); this list is the project-wide operational overview — "what is being watched right now, and what's firing".
-
-## One matching pipeline
-
-Today's write-time execution machinery is evaluation-oriented: `EvaluationTrigger` (filter / turn / debounce / sampling) decides when an evaluation runs against an incoming trace. This spec generalizes it into a single **signal matching pipeline** that owns "run every active signal's definition against incoming traces"; evaluations become one *runner* inside it rather than the pipeline itself:
-
-- the **scope gate** is shared (one pass per trace over all active signals' scopes);
-- the **sandbox runner** executes rule (compiled), script (user-authored), and evaluation (LLM-judge) matchers in the shared sandboxed JS runtime;
-- the **semantic runner** compares trace content-chunk embeddings (already produced at ingest for trace search and semantic moments) against the Redis-cached anchor embeddings;
-- evaluation-specific options (`sampling`, `turn`, `debounce`) remain runner-level settings, not pipeline concepts.
+**Annotation assignment is allowed exactly on tracker-less (sink) signals.** A tracker-backed signal is detector-driven; you do not hand-assign traces into it. While annotating, the UI suggests existing sinks via hybrid search over `search_document` (lexical) + `centroid_embedding` (the existing discovery path); the user links explicitly or lets discovery route.
 
 ## Main flows (callstacks)
 
-Names follow existing conventions; `@domain/signals` is the new domain package (evolved from `@domain/issues`). Existing machinery reused unchanged is marked `[reuse]`.
+`@domain/signals` is the evolved `@domain/issues` package. Existing machinery reused unchanged is marked `[reuse]`.
 
-### A. Trace ingest → matching → occurrences
+### A. Trace ingest → tracker → score
 
 ```
-span ingestion → ClickHouse spans insert → TracesIngested (outbox)            [reuse]
-└─ domain-events dispatcher (apps/workers/src/workers/domain-events.ts)       [reuse]
+span ingestion → ClickHouse spans insert → TracesIngested (outbox)             [reuse]
+└─ domain-events dispatcher                                                     [reuse]
    └─ signals:match (queue task, batched per project)
       └─ matchTracesToSignalsUseCase (@domain/signals)
-         ├─ SignalRepository.listActiveDefinitions(projectId)        -- Redis-cached, org-prefixed key
-         ├─ scope pre-gate: evaluate each signal's scope FilterSet against the trace
-         │    (row-local, in-process); out-of-scope traces never reach the matcher
-         ├─ type='rule'   → compiled script in the sandbox runner
-         ├─ type='script' → user script in the sandbox runner
-         └─ matches → SignalOccurrenceRepository.append (CH insert; idempotent via sort key)
-      └─ publishes monitors:evaluate (leading-edge throttle, 5 min)            [reuse shape]
+         ├─ SignalRepository.listActiveTracked(projectId)            -- Redis-cached, org-prefixed
+         ├─ filters pre-gate per signal (row-local, in-process)
+         ├─ script  → sandbox runner
+         ├─ judge   → evaluation runner (sampling/turn/debounce on the backing evaluation)
+         └─ write score (matched or not) with signal_id, source_type='tracker'
+              · pure (script): CH-analytics-only          · judge: Postgres-canonical + CH
+      └─ publishes monitors:evaluate (leading-edge throttle, 5 min)             [reuse shape]
 
-semantic matchers (separate hop — joins the content embeddings, which the ingest
-  pipeline already produces for trace search and semantic moments):            [reuse]
+semantic trackers (separate hop joining content embeddings produced at ingest): [reuse]
 trace_search_embeddings chunks written
 └─ signals:semanticMatch (queue task per trace)
-   └─ matchTraceToSemanticSignalsUseCase
-      ├─ load project anchor sets (Redis-cached embeddings, moment-label pattern;
-      │    includes system moment-label signals)
-      ├─ scope pre-gate: skip signals whose scope the trace fails
-      ├─ per signal: value = max(chunk · positiveAnchor); matched when
-      │    value ≥ signal.threshold AND best-positive − best-contrast ≥ margin
-      └─ SignalOccurrenceRepository.append
-
-evaluation matchers (third hop — the evaluation runner inside the pipeline; the
-  signal's scope plays the role of EvaluationTrigger.filter):                  [reuse]
-evaluation trigger fires → evaluation runs → failed non-errored score written
-  with scores.signal_id
-└─ after-commit: syncScoreAnalyticsUseCase                                     [reuse]
-   └─ + SignalOccurrenceRepository.append (score-backed: score_id set)
+   └─ load project anchor sets (Redis-cached, moment-label pattern; includes system moment signals)
+   └─ filters pre-gate; per signal value = max(chunk · positiveAnchor); matched when
+        value ≥ threshold AND best-positive − best-contrast ≥ margin
+   └─ write CH-analytics-only score (matched or not), source_type='tracker'
 ```
 
-### B. Deliberate signal creation from annotations
+### B. Create a signal manually (user origin, must have a tracker)
 
 ```
-UI: annotate → "Track this as a signal" → explanation + 3–4 example traces
-└─ createSignalFromAnnotationsUseCase (@domain/signals)
-   ├─ persist annotation scores for the examples (canonical scores path)       [reuse]
-   ├─ create signal { origin: 'annotation', type: 'evaluation', config: {} }
-   ├─ derive search_embedding from name + description
-   ├─ append score-backed occurrences for the example traces
-   ├─ provisionDefaultMonitorUseCase (occurrences monitor + high-severity
-   │    metric.escalating 'expected' alert + event.regressed alert — same
-   │    monitoring issues get today)
-   └─ start Temporal optimize-evaluation, workflow id evaluations:generate:${signalId}  [reuse]
-      └─ generates + aligns the evaluation; persists with evaluations.signal_id
-frontend polls getSignalAlignmentState (Temporal workflow.describe())           [reuse shape]
+UI: Signals page / "Create signal from this search" → builder (live preview required)
+└─ createSignalUseCase { origin: 'user', tracker, filters? }
+   ├─ semantic: embed + Redis-cache anchors
+   ├─ script:   compile (sandbox ScriptCompileError rejects at save time)
+   ├─ judge:    create backing evaluation (evaluations.signal_id); alignment accrues from annotations
+   ├─ provisionDefaultMonitorUseCase (count monitor + metric.escalating 'expected' + event.regressed)
+   └─ enqueue signals:backfill { signalId, window: 14d }   (pure trackers only)
 ```
 
-### C. Annotating against existing signals (replaces issue discovery)
-
-There is **no automatic discovery pipeline** (decision 2). When a user annotates, the UI *suggests* existing signals; the user links explicitly or creates a new signal.
+### C. Annotation → sink routing (auto-discovery)
 
 ```
-UI: user writes annotation feedback
-└─ suggestSignalsUseCase (@domain/signals)
-   └─ hybrid search over project signals: search_document (lexical)
-        + search_embedding (cosine over the embedded feedback) — exact scan, no rerank
-user action:
-  ├─ link to a suggested signal → published annotation score carries scores.signal_id
-  │    └─ SignalOccurrenceRepository.append (score-backed)
-  ├─ "Track this as a signal" → flow B
-  └─ neither → the score stays unowned; nothing is created automatically
-evaluation failures already carry signal_id at write time                       [reuse]
+flagger (trace-end) / human annotation
+└─ writes annotation score (source_type 'flagger'|'user'), draft/publish as today  [reuse]
+└─ ScoreCreated → discovery (centroid + hybrid search + locked serialization)      [reuse]
+     ├─ assign to existing sink signal  → +1 occurrence
+     └─ create new sink signal { origin: 'system', tracker: NULL }
 ```
 
 ### D. Monitor evaluation → alert → incident → notification
 
 ```
-triggers: monitors:evaluate (leading-edge throttle from occurrence/trace activity)
-        + 5-min sweep cron (closes + low-traffic opens)                         [reuse shape]
+triggers: monitors:evaluate (leading-edge throttle) + 5-min sweep cron            [reuse shape]
 └─ evaluateMonitorUseCase (@domain/monitors)
-   ├─ resolve target reader:
-   │    signal        → SignalOccurrenceReader (CH signal_occurrences)          [new]
-   │    savedSearch   → SavedSearchMatchReader (CH traces, query+filterSet)     [reuse]
-   │    tool          → ToolCallReader (CH execute_tool spans by tool_name;     [reuse shape]
-   │                      per-bucket call/error counts + latency aggregates —
-   │                      ToolAnalyticsRepository already computes these)
-   │    traces/spans/sessions → telemetry readers                               [reuse]
-   ├─ compute metric series (count / avg / sum / p95 per bucket)
+   ├─ signal target → SignalScoreReader (CH score-analytics: count where signal_id=? AND passed;
+   │    avg/sum/p95 over matched traces via score.trace_id → traces)               [new reader]
+   ├─ compute metric series per bucket
    └─ per active alert, run the kind's state machine:
-        event.matched      → point incident per throttle window with ≥1 event   [reuse shape]
-        event.regressed    → datapoint after monitor.resolved_at → point incident,
-                             clear resolved_at
-        metric.threshold   → absolute (one-time) / multiplier (rising edge,
-                             silent close) / expected                           [reuse]
-        metric.escalating  → ONE bucketed sustained-gate evaluator over any
-                             target series (replaces both the issue seasonal
-                             path and the saved-search machine; 'expected' mode
-                             wraps evaluateSeasonalEscalation)                  [merge]
-└─ alert_incidents insert/close (condition + target_snapshot snapshots)
-   → IncidentCreated / IncidentClosed (outbox)                                  [reuse]
-   → notifications:request-incident-notifications (mute gate: monitor.mutedAt)  [reuse]
-   → create-notification → in-app / email / Slack fan-out                       [reuse]
+        event.matched / event.regressed / metric.threshold / metric.escalating     [reuse / merge]
+└─ alert_incidents insert/close (condition + target_snapshot) → IncidentCreated    [reuse]
+   → notifications (mute gate: monitor.mutedAt) → in-app / email / Slack            [reuse]
 ```
 
 ### E. Triage from the signal page
 
 ```
-[Resolve] → resolveSignalUseCase
-   ├─ default monitor: resolved_at = now
-   └─ close open sustained incidents for its alerts (silent, as manual resolve today)
-[Ignore]  → muteSignalUseCase → default monitor: muted_at = now
-              (occurrences keep recording; nothing notifies)
-[Delete]  → deleteSignalUseCase → soft-delete signal; soft-delete its monitors;
-              archive linked evaluations; enqueue CH occurrence cleanup
+[Resolve] → resolveSignalUseCase: signal.resolved_at = now; close open sustained incidents (silent)
+[Ignore]  → ignoreSignalUseCase:  signal.ignored_at = now (scores keep recording; nothing notifies)
+[Delete]  → deleteSignalUseCase:  soft-delete signal + its monitors; archive backing evaluation;
+              enqueue CH score cleanup for the signal
 regression → flow D, event.regressed branch
 ```
 
-### F. Create signal from a saved search (with backfill)
+### F. Promote a sink to a judge tracker
 
 ```
-UI: saved-search row / traces page → "Create signal from this search"
-└─ opens the signal builder pre-filled:
-   ├─ scope            ← the search's filterSet
-   ├─ semantic prompt  → semantic matcher (anchors seeded from the prompt)
-   └─ lexical phrases  → rule matcher (contains conditions)
-└─ createSignalUseCase { origin: 'user' } + provisionDefaultMonitorUseCase
-└─ enqueue signals:backfill { signalId, window: 14d }   (rule/script matchers only)
-   └─ backfillSignalOccurrencesUseCase: evaluate the definition over historical
-      traces in batches → SignalOccurrenceRepository.append
-saved_searches row remains (still a bookmark; plain filter tracking stays
-  saved search + monitor — decision 4)
+UI: sink signal page → "Start tracking with a judge"
+└─ promoteSignalUseCase: set tracker = { type:'llm_as_judge', threshold }
+   └─ start optimize-evaluation (workflow id evaluations:generate:${signalId})      [reuse]
+      └─ build alignment set from the signal's annotation scores; generate + align the judge;
+         persist with evaluations.signal_id
+frontend polls getSignalAlignmentState (Temporal workflow.describe())               [reuse shape]
 ```
 
-## Why signal membership is materialized at write time
+## UI
 
-**1. Semantic search answers a different question than filters do.** A filter is a per-row yes/no ("is this trace from the last 7 days?") — each row passes on its own merits, so filters stack for free. Semantic search with a vector index answers "the ~1,000 items *most similar in the entire corpus*". Combine them and the filter can only discard from those 1,000: searching "user frustration" + filtering "last 7 days" returns *whichever of the corpus-wide top-1,000 happen to be recent* — maybe 30 results, maybe 0 — while thousands of genuinely frustrated traces from this week sit at #5,000 in the global ranking and are never returned. Doing it correctly means scoring every trace in the window: a full scan, which is why semantic trace search already times out on large projects.
+### Navigation
 
-**2. Tracking over time multiplies that cost forever.** Example: a semantic search "user frustration" with an alert when the last-5-minutes match count exceeds 1σ above its historical average. The 5-minute count is cheap; but μ and σ require the match count of *every historical bucket* — the semantic verdict for every trace in the corpus — recomputed on every evaluation, 288 times a day, even though each trace's verdict is frozen the moment it arrives. The only fix is "score each trace once, on arrival, and remember the result", which **is** write-time materialization; every caching scheme converges to it. Approximations don't help: a σ computed from undercounted buckets makes alerts fire on index noise.
+A **Signals** nav item replaces **Issues** (single list — hand-built and discovered signals together; `origin` distinguishes them and is a filter/column). Issue URLs (`/projects/$slug/issues/...`) redirect into the corresponding signal pages. **Monitors** stays, generalized to the cross-target operational view.
 
-Consequences carried through the whole spec:
+### Signals list
 
-- Query-time semantic search remains an **exploration** tool: a ranked best-effort sample on the Traces page. No counts, no histograms, no alerts over a semantic query.
-- Anything that needs **set** semantics — charts, baselines, alerts, "every matching trace" — must be a signal, whose membership is decided per trace at ingest and appended to an immutable occurrence stream.
-- A materialized history is immutable under definition edits: editing a signal changes membership *going forward* only (the chart gets a definition-changed marker). The "editing a virtual signal rewrites its history" policy problem disappears.
-- Occurrences become the universal counting unit (one occurrence = one matched trace), resolving today's inconsistency where issues count scores and saved searches count traces.
+One table; `origin` (auto/manual), tracker type, priority, assignee, trend, monitors, and last incident are columns/filters on the same surface.
+
+### Signal detail page
+
+Definition (tracker + filters), monitor charts, alerts, incidents, and member traces in one context. Sinks show their annotation evidence and a **Promote** action; judge-backed signals show the linked evaluation/alignment sections (confusion matrix, realign).
+
+### Creating a signal
+
+One builder, three entry points (Signals list, "Create signal from this search", annotation flow), one rule: **never let users define membership blind** — the builder always shows a live preview (a bounded query-time evaluation over recent traces; for `semantic`, an exact scan over a recent window using existing content embeddings; for `script`/`llm_as_judge`, the sandbox dry-run harness against sample traces). The tracker picker offers all three types — **Semantic**, **Script**, and **LLM-as-judge**.
+
+### Creating a monitor
+
+Target = a signal; metric = Occurrences (count) or an aggregate; alerts = the existing card stack. UI/UX copied from today's monitors surface (the tools/users monitor flows).
+
+### Monitors list
+
+Today's dashboard generalized: one row per monitor with a **Target** column (deep-linked to the signal), status (Live / Muted / Resolved / Escalating), metric, and last incident.
+
+## API / SDK / MCP
+
+Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/signals`, following the **monitors** routes as the template (`defineApiEndpoint`, `createSignalsRoutes` factory, rich `.describe()` field docs that propagate to both the TS SDK and MCP tools; regen via `pnpm openapi:emit` / `pnpm mcp:emit` / SDK generate).
+
+| Method | Path | Operation id |
+| --- | --- | --- |
+| GET / POST | `/` | `listSignals` / `createSignal` |
+| GET / PATCH / DELETE | `/{signalSlug}` | `getSignal` / `updateSignal` / `deleteSignal` |
+| GET | `/{signalSlug}/traces` | `listSignalTraces` |
+| POST | `/{signalSlug}/resolve`, `/ignore`, `/promote` | `resolveSignal` / `ignoreSignal` / `promoteSignal` |
+
+- `createSignal` accepts a `tracker` of any of the three types (`semantic_similarity`, `script`, `llm_as_judge`) and optional `filters`; rejects tracker-less creation (sinks are system-only).
+- Monitors gain `signal` as a target type in their existing API.
+- `custom`-source score push (the `/scores` API accepting `signal_id`) is **POST-MVP**.
+
+## Migration
+
+- **Issues → signals, in place.** Rename `issues` → `signals` (keep rows, centroid, embeddings); existing issues become `origin = 'system'` sinks (`tracker = NULL`) — their membership already comes from annotation/evaluation scores. Issue-linked evaluations become `llm_as_judge` trackers (`evaluations.signal_id`; the signal's `tracker` is set to `{ type:'llm_as_judge' }`). `scores.issue_id` → `signal_id`; `source` → `source_type` with the documented mapping.
+- **System monitors** become signal monitors (the three `issue.*` system monitors remap to the new `ALERT_KINDS` over signal targets).
+- **Semantic moments → default per-project signals** (soft requirement): the eight moment-label kinds (`MOMENT_LABEL_ANCHORS`) are provisioned as `origin = 'system'`, `tracker = { type:'semantic_similarity', semantic: <existing anchors>, threshold: <the kind's static gate> }`. The conversation-intelligence anchor matching becomes the semantic runner of the matching pipeline.
+- **Flaggers** stay as the trace-end auto-annotation engine feeding sinks (flow C). Where a flagger overlaps a moment label (e.g. `frustration`), consolidate to **one** signal — prefer the semantic moment-anchor tracker as the canonical detector and retire the overlapping flagger into it (soft requirement). Do not convert all 11 flaggers to trackers for the MVP; most keep feeding sinks via discovery.
+
+## Why membership is materialized at write time
+
+**1. Semantic search answers a different question than filters do.** A filter is a per-row yes/no — each row passes on its own merits, so filters stack for free. Semantic search with a vector index answers "the ~1,000 items *most similar in the entire corpus*". Combine them and the filter can only discard from those 1,000: "user frustration" + "last 7 days" returns *whichever of the corpus-wide top-1,000 happen to be recent* — maybe 30, maybe 0 — while thousands of genuinely frustrated traces from this week sit at #5,000 globally and are never returned. Counting correctly means scoring every trace in the window: a full scan (which is why semantic trace search already times out on large projects).
+
+**2. Tracking over time multiplies that cost forever.** An alert on "last-5-minutes match count vs its historical average" needs μ and σ over *every historical bucket* — the verdict for every trace in the corpus — recomputed on every evaluation (288×/day), even though each trace's verdict is frozen the moment it arrives. The only fix is "score each trace once, on arrival, and remember it" — which **is** write-time materialization.
+
+**3. "Occurrences are scores" is the cheap way to remember it — given the existing PG/CH split.** The objection to storing membership in `scores` is write amplification through the canonical mutable Postgres path. But `scores` is *already* a Postgres-canonical + ClickHouse-analytics split, and the rules already say immutable scores skip straight to ClickHouse. A pure-tracker match is immutable by construction (a value, no feedback, nothing to draft), so it goes **ClickHouse-only** and never touches Postgres. Mutable membership (judge feedback, human/flagger annotations) is bounded (sampled / human-paced) and takes the canonical path as it does today. So one ledger scales without a second table.
+
+Consequences carried through the spec:
+
+- Query-time semantic search remains an **exploration** tool: a ranked best-effort sample on the Traces page. No counts, histograms, or alerts over a semantic query — a banner says so, with "create a signal" as the path to set semantics.
+- Anything needing **set** semantics — charts, baselines, alerts, "every matching trace" — must be a signal whose tracker decides membership per trace at ingest.
+- History is immutable under definition edits: editing a tracker changes membership *forward only* (a definition-changed marker). The "editing a virtual signal rewrites its history" problem disappears.
 
 ## Decisions
 
-Settled during the design discussion (LAT-664 + spec review):
+Settled during design review (LAT-664 + spec revision):
 
-1. **Signal membership is materialized at write time** (see "Why signal membership is materialized at write time" — forced, not a preference).
-2. **No automatic issue discovery.** The clustering/discovery pipeline (similarity search + rerank + locked serialization auto-creating issues from scores) is removed. Signals are always created proactively by users — from the Signals page or from the annotation flow. Annotations are matched to *existing* signals via hybrid search suggestions; they never spawn signals on their own.
-3. **No routing centroid.** With discovery gone, the per-signal decayed centroid machinery is removed. Suggesting existing signals while annotating uses hybrid search over signal names/descriptions (lexical tsvector + one derived embedding).
-4. **No pure filter-type signals.** Plain filter slices are correct and cheap at query time, so they stay **saved searches + monitors**. Signals exist for matchers that *require* write-time evaluation (semantic, evaluation, rule, script). Filters appear on signals only as the **scope** pre-gate.
-5. **Signals per project are capped** to a fixed number per plan (this also bounds occurrence write amplification and ingest matching cost).
-6. **Scores are kept with a narrowed role** — they stop being the membership mechanism and remain the verdict ledger: evaluation pass/fail/error analytics, human-feedback ground truth for alignment, and the public `/scores` API (rationale under the occurrences table).
+1. **Membership is materialized at write time** (forced — see the rationale section).
+2. **A signal's occurrences ARE its scores.** No separate occurrence ledger; `signal_occurrences` is removed. Membership = scores with `passed = true` (the host freezes `passed = value >= threshold` at write); pure-tracker scores route ClickHouse-only so the single ledger scales. *(Reverses the original spec's two-ledger decision 6.)*
+3. **Automatic discovery is kept**, as sink signals (`origin = 'system'`, `tracker = NULL`) produced by the unchanged flagger + discovery machinery; centroid/embedding columns stay. *(Reverses the original spec's "no automatic discovery" decision 2.)*
+4. **One tracker per signal, stored as a jsonb column** (`signals.tracker`), not a separate table. Three types: `semantic_similarity`, `script`, `llm_as_judge`. There is **no** `annotation_sink` tracker — a sink is simply a tracker-less signal.
+5. **Trackers write every run** (matched and non-matched), mirroring how evaluations persist pass and fail today. Occurrences are the matched subset.
+6. **Users cannot create tracker-less signals.** Only `system`-origin sinks are tracker-less, which removes the pure-filter write-amplification footgun; `filters` is only a tracker pre-gate. Plain filter tracking stays saved searches + monitors.
+7. **Lifecycle stays on the signal row** for the MVP (resolve/ignore/escalating carried over from issues), not relocated onto the default monitor.
+8. **`semantic_similarity` and `llm_as_judge` are user-creatable in the MVP**; **`script` is post-MVP** (nothing depends on it — see the build plan). Judge trackers *also* arise automatically from the sink → promotion path, landing on the same backing-evaluation shape. **Custom-source scores** (`/scores` accepting `signal_id`) are POST-MVP.
+9. **Signals per project are capped** per plan (bounds tracker matching cost and pure-tracker score write volume).
+
+## Build plan (phased)
+
+> Each phase is an **independently shippable, behavior-preserving deploy** — production keeps working after every phase. Parallelism lives *within* a phase (tasks sharing dependencies run concurrently); phases themselves are mostly sequential, which is the deliberate price of safe incremental rollout. **MVP = Phases 1–4.** Every phase updates the relevant `dev-docs/*` as part of its definition of done (the "remember docs" requirement). Status legend: `[ ] pending`, `[~] in progress`, `[x] done`.
+>
+> **Incremental-schema note.** The data-model end state above is reached over several phases, not at once. `source_type`'s four values arrive in two steps (Phase 2 adds `tracker`; Phase 9 collapses `evaluation`→`tracker` and splits `annotation`→`user`/`flagger`). Monitoring unifies similarly — discovery-born signals keep the existing issue-event escalation path until Phase 5/9, while custom signals get the new signal-score path in Phase 4. Running two paths temporarily is intentional and non-breaking.
+
+### Phase 1 — Rename Issues → Signals `[MVP]`  · deps: none
+
+**Ships** the entire current system under the Signals name — discovery, monitors, alerts, notifications behave identically. **Safe because** it's a pure rename, no semantics change. **Exit gate:** full suite green; `/issues` URLs + `?issueId=` deep links redirect; SDK back-compat alias resolves; zero behavioral diff. Can be stacked PRs (schema+domain → API → web), each keeping the build green; no flag (it's a rename), but coordinate the SDK release.
+
+- **1a** `[ ]` PG rename migration (Drizzle Kit): `issues`→`signals`; `scores.issue_id`→`signal_id`, `evaluations.issue_id`→`signal_id`; rename dependent indexes + `organizationRLSPolicy("signals")`. Column semantics unchanged.
+- **1b** `[ ]` CH rename (`pnpm --filter @platform/db-clickhouse ch:create`, append-only): `ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT ''`; `ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != ''`; point `score-analytics-repository.ts` + `score-fields.ts` at `signal_id`; keep `issue_id` until Phase 9.
+- **1c** `[ ]` Domain rename `@domain/issues`→`@domain/signals`: folder + package name + all imports; `Issue*`→`Signal*` types/ports/use-cases; events `IssueCreated/Regressed/Escalated`→`Signal*`, `ScoreAssignedToIssue`→`ScoreAssignedToSignal`. **Keep internal alert-kind strings `issue.*`** (persisted in `alert_incidents.kind`; renamed in Phase 9) — only relabel `ALERT_INCIDENT_KIND_LABEL`.
+- **1d** `[ ]` Platform: `@platform/db-postgres` `issue-repository`→`signal-repository`, schema `issues.ts`→`signals.ts`, mappers.
+- **1e** `[ ]` API: `apps/api/src/routes/issues.ts`→`signals.ts`, op ids `listIssues`→`listSignals` etc., mount `/projects/:projectSlug/signals`; keep `/issues` as a deprecated alias to the same handlers; `pnpm openapi:emit && pnpm mcp:emit` + SDK generate.
+- **1f** `[ ]` Web: signals routes/pages/`-components`; `ProjectSidebar` nav; `/issues/...`→`/signals/...` redirect; `?issueId=` deep-link redirect.
+- **1g** `[ ]` Copy: notification templates + `ALERT_INCIDENT_KIND_LABEL` Issue→Signal wording (email/Slack/in-app).
+- **1h** `[ ]` Docs: `dev-docs/issues.md`→`dev-docs/signals.md`; fix references in `monitors.md`/`scores.md`/`reliability.md`; AGENTS.md skill glossary.
+
+### Phase 2 — Tracker substrate + custom semantic signals `[MVP]`  · deps: P1
+
+**Ships** user-created `semantic_similarity` signals; write-time matching populates them; the signal page shows matched traces + occurrence trend. (Alerting on custom signals arrives in P4.) **Safe because** it's additive schema + new code behind the `signals` flag; discovery/monitors untouched. **Exit gate:** create a semantic signal → new in-scope traces produce CH-only tracker scores → visible on the signal page; backfill works; existing signals/discovery unaffected.
+
+- **2a** `[ ]` Contracts (`@domain/shared`, `@domain/scores`): `SIGNAL_ORIGINS`, `SIGNAL_TRACKER_TYPES`, `SignalTracker`/`SemanticAnchors` zod; rename score `source`→`source_type` and **add value `tracker`** (values `{tracker, evaluation, annotation, custom}`; the `evaluation`→`tracker` collapse + `annotation` split are P9).
+- **2b** `[ ]` PG migration (additive): `signals.tracker jsonb null`, `filters jsonb null`, `origin varchar(16)` (backfill existing → `'system'`), `deleted_at` + partial-unique slug; make `centroid`/`clustered_at` nullable; add the `(org, project) WHERE deleted_at IS NULL AND tracker IS NOT NULL` "active tracked" index.
+- **2c** `[ ]` Scores CH-only write path (`@domain/scores`): a tracker-score writer that freezes `passed = value ≥ tracker.threshold` and **inserts straight to CH analytics, skipping the canonical Postgres row** for pure trackers — the one genuinely new write path; reuse `syncScoreAnalyticsUseCase`'s CH insert + at-most-once-by-id guard; idempotent per `(signal, trace)`.
+- **2d** `[ ]` Matching pipeline skeleton (`@domain/signals` + a `signals:match` worker off `TracesIngested` via the domain-events dispatcher): `matchTracesToSignalsUseCase`, `listActiveTracked(projectId)` Redis-cached (org-prefixed), shared `filters` pre-gate reusing row-local `FilterSet` evaluation. Generalized from `EvaluationTrigger`'s filter stage.
+- **2e** `[ ]` Semantic runner (`signals:semanticMatch` per trace, off `trace_search_embeddings`): load per-signal anchor embeddings (Redis-cached, reuse the conversation-intelligence anchor-cache pattern), `value = max(chunk · positiveAnchor)`, match on `value ≥ threshold ∧ bestPos − bestContrast ≥ margin` → CH-only tracker score. Generalize `@domain/conversation-intelligence` anchor matching from fixed `MOMENT_LABEL_ANCHORS` to per-signal anchors.
+- **2f** `[ ]` Backfill (`signals:backfill {signalId, window}`): `backfillSignalScoresUseCase` runs the detector over historical traces in batches → CH-only scores; enqueued on semantic-signal create.
+- **2g** `[ ]` Builder UI (semantic): `apps/web` signals `-components` — `filters` + anchors/contrast + threshold (sensitivity); **live preview** = bounded exact scan over a recent window using existing content embeddings. Entry points: "New signal", "Create signal from this search".
+- **2h** `[ ]` Signal CRUD API + MCP: `createSignal`/`updateSignal`/`deleteSignal` (reject tracker-less create for `origin=user`); MCP/SDK regen. Reuse the monitors route template.
+
+### Phase 3 — User-created LLM-as-judge signals `[MVP]`  · deps: P2 (substrate only — **not** the semantic runner)
+
+**Ships** a builder option to author a judge signal (describe the behavior + optional example traces → generated judge), running on the **existing** evaluation execution path. **Safe because** it reuses the proven evaluation generation/alignment/execution stack; additive UI. **Exit gate:** create a judge signal → it runs on live traffic via `EvaluationTrigger` → writes signal-linked scores → alignment shows accruing/aligned.
+
+- **3a** `[ ]` Standalone evaluation creation (`@domain/evaluations`): allow creating an evaluation linked to a fresh signal (not only via issue promotion); set the signal's `tracker = { type:'llm_as_judge', threshold }` and `evaluations.signal_id`.
+- **3b** `[ ]` Generation reuse: drive the existing `optimize-evaluation` workflow (`evaluations:generate:${signalId}`) from the builder; with example traces → aligned (reuse `collectAlignmentExamples` + `evaluateDraftAgainstExamples`); without → unaligned start, alignment accrues as annotations land.
+- **3c** `[ ]` Builder UI (judge): description + optional example-trace picker (reuse the annotation-flow picker); preview via the sandbox dry-run harness; alignment polled via `workflow.describe()` (reuse `getSignalAlignmentState`).
+- **3d** `[ ]` Execution linkage: verify the `EvaluationTrigger` path writes `signal_id`-bearing scores for a user-created (non-discovered) signal; polarity/`passed` normalized to exhibition.
+
+### Phase 4 — Monitors on signals `[MVP]` (hard-req 4)  · deps: P2
+
+**Ships** alerting on custom (and any) signals; users create monitors targeting a signal with a metric + alerts (tools/users monitor UX copied); each new signal gets a default monitor. **Safe because** it's additive monitor columns + a new reader; existing project-level system monitors keep covering discovery-born signals via the existing path. **Exit gate:** create a monitor on a signal → metric series computes from signal scores → alert fires → incident + notification.
+
+- **4a** `[ ]` PG migration (additive): `monitors.target_signal_id`, `is_default` + the two indexes.
+- **4b** `[ ]` `SignalScoreReader` (`@platform/db-clickhouse`): `count WHERE signal_id=? AND passed`; `avg`/`p95`/`sum` of trace `duration`/`cost`/`tokens` by joining matched `trace_id → traces`; `errorRate`; per-bucket series for the escalation machine. Mirrors `SavedSearchMatchReader`.
+- **4c** `[ ]` Signal monitor evaluation: wire signal targets into `evaluateMonitorUseCase`, reusing the unified `event.matched`/`metric.threshold`/`metric.escalating` state machines (`run-*-alert.ts`) over the `SignalScoreReader` series; `metric.escalating` `expected` mode reuses `evaluateSeasonalEscalation`.
+- **4d** `[ ]` `event.regressed` kind: add to `ALERT_INCIDENT_KINDS` (+ point lifecycle, no-condition, label, severity); fires on the first datapoint after the signal's `resolved_at` clears (mirror `issue.regressed`, signal-driven).
+- **4e** `[ ]` Default monitor provisioning: `provisionDefaultSignalMonitorUseCase` on signal create (count + `metric.escalating` expected + `event.regressed`, `is_default=true`); reuse `provisionSystemMonitorsUseCase` patterns.
+- **4f** `[ ]` Monitor-on-signal UI: create/edit (metric + alert card stack, copied from the tools/users monitor flow) on the signal page; monitors-list **Target** column deep-linking to the signal.
+- **4g** `[ ]` Monitors API + MCP: signal target on create/update; regen.
+
+> **— MVP line: Phases 1–4 —**
+
+### Phase 5 — Unify judge execution onto the tracker pipeline `[POST-MVP · internal]`  · deps: P2, P3
+
+**Ships** judge execution moved from the standalone `EvaluationTrigger` path into the Phase-2 matching pipeline (shared `filters` pre-gate, one sandbox runner). No user-facing change. **Safe because** parity-tested behind a flag, then cut over; retires the temporary two-path state.
+
+- **5a** `[ ]` Run judges through `matchTracesToSignalsUseCase`'s sandbox runner. **5b** `[ ]` Parity suite (every stored judge: old path vs pipeline → identical scores). **5c** `[ ]` Cut over; remove the standalone trigger path.
+
+### Phase 6 — Script (custom code) trackers `[POST-MVP · last]`  · deps: P2 (+ sandbox P2)
+
+**Ships** the `script` tracker type — raw user JS via the sandbox. Nothing depends on it. **Safe because** it's an additive type behind the flag.
+
+- **6a** `[ ]` Finish `specs/sandbox-runtime.md` P2 (dry-run harness + threshold membership) if outstanding.
+- **6b** `[ ]` `script` tracker in the matching pipeline (sandbox runner; CH-only pure scores; capability detection — a script calling `llm()` persists like a judge).
+- **6c** `[ ]` Builder + MCP authoring: compile-on-save validation (`ScriptCompileError`), dry-run against sample traces, and **surface the sandbox globals** (`conversation`, `llm()`, `z`, `Score/Passed/Failed`) in the MCP tool description (soft-req 1).
+
+### Phase 7 — Moments → default signals `[SOFT]`  · deps: P2
+
+- **7a** `[ ]` Provision the 8 `MOMENT_KINDS` as `origin=system` `semantic_similarity` signals (anchors = `MOMENT_LABEL_ANCHORS`, threshold = each kind's static gate) via the project-provision hook. **7b** `[ ]` The semantic runner subsumes the moment-label anchor pass (one matching path).
+
+### Phase 8 — Flagger consolidation `[SOFT]`  · deps: P7
+
+- **8a** `[ ]` For flaggers overlapping a moment/semantic signal (e.g. `frustration`), make the semantic signal canonical and retire the flagger from `provisionFlaggers`. **8b** `[ ]` Non-overlapping flaggers keep feeding sinks via discovery (unchanged).
+
+### Phase 9 — Taxonomy cleanup + legacy retirement `[POST-MVP]`  · deps: P1–P5
+
+- **9a** `[ ]` Finish `source_type`: remap `evaluation`→`tracker`, split `annotation`→`flagger` (sourceId=SYSTEM) / `user` (else) (PG + CH backfill).
+- **9b** `[ ]` Retire `issue.*` / `savedSearch.*` alert kinds once all monitors run on signal targets (breaking SDK — major bump).
+- **9c** `[ ]` Drop deprecated CH `issue_id` and any dormant columns.
+- **9d** `[ ]` `/scores` accepts caller-supplied `signal_id` for `custom`-source trackers (the POST-MVP custom-source path).

--- a/specs/signals.md
+++ b/specs/signals.md
@@ -1,16 +1,38 @@
 # Signals
 
-> **Documentation**: eventual durable homes `dev-docs/signals.md` and an updated `dev-docs/monitors.md`; related current docs: `dev-docs/issues.md`, `dev-docs/scores.md`, `dev-docs/monitors.md`, `dev-docs/notifications.md`, `dev-docs/conversation-intelligence.md`, `dev-docs/evaluations.md`.
+> **Documentation** — eventual durable homes: `dev-docs/signals.md` (new) and an updated `dev-docs/monitors.md`. Related current docs: `dev-docs/issues.md`, `dev-docs/scores.md`, `dev-docs/notifications.md`, `dev-docs/conversation-intelligence.md`, `dev-docs/evaluations.md`.
 >
-> **Depends on**: `specs/sandbox-runtime.md` — the execution contract for `llm_as_judge` and `script` trackers: a tracker run returns `Score(value, feedback?)` with `value` = signal-exhibition strength, and the host derives membership as `value >= tracker.threshold`. (Phase 0/1 of that spec are built; Phase 2 — rule/script codegen + dry-run harness — is the substrate this spec consumes.)
+> **Depends on** — `specs/sandbox-runtime.md`, the execution contract for `llm_as_judge` and `script` trackers: a tracker run returns `Score(value, feedback?)` where `value` is signal-exhibition strength, and the host derives membership as `value >= tracker.threshold`. Phases 0–1 of that spec are built; Phase 2 (rule/script codegen + dry-run harness) is the substrate this spec consumes.
 >
-> **Supersedes (conceptually)**: `specs/monitors.md` and `specs/alerts.md`. Those specs remain accurate descriptions of what is *currently built*; this spec defines the model that replaces their framing. Do not retire them until the migration phases are underway.
+> **Supersedes (conceptually)** — `specs/monitors.md` and `specs/alerts.md`. Those specs still accurately describe what is *currently built*; this spec defines the model that replaces their framing. Do not retire them until the migration phases are underway.
 >
-> **Origin**: LAT-664 ("Consolidate monitor situation"), extended through spec review into the **trackers** model below. This revision **reverses** the original spec's "no automatic discovery" stance and its separate-occurrence-ledger design — see [Decisions](#decisions) for what changed and why.
+> **Origin** — LAT-664 ("Consolidate monitor situation"), extended through spec review into the **trackers** model below. This revision reverses two stances of the original spec (no automatic discovery, separate occurrence ledger) — see [Decisions](#decisions).
+
+## Contents
+
+1. [Purpose](#purpose) — the problem and the consolidated model
+2. [Why membership is materialized at write time](#why-membership-is-materialized-at-write-time) — the foundational argument
+3. [Concepts](#concepts) — Signal, Tracker, Score, Monitor, Alert, Incident
+4. [Discovery: sinks and promotion](#discovery-sinks-and-promotion)
+5. [The matching pipeline](#the-matching-pipeline)
+6. [Main flows](#main-flows)
+7. [Data model](#data-model) — schemas, enums, and types
+8. [UI](#ui)
+9. [API / SDK / MCP](#api--sdk--mcp)
+10. [Migration](#migration)
+11. [Decisions](#decisions)
+12. [Tasks](#tasks)
+
+---
 
 ## Purpose
 
-Latitude has two parallel tracking systems with overlapping names and separate UIs: **Issues** (auto-created buckets of failed/annotated scores, monitored invisibly) and **Monitors** (user-configured alerts over **Saved Searches**). This spec consolidates both around a small set of concepts:
+Latitude has two parallel tracking systems with overlapping names and separate UIs:
+
+- **Issues** — auto-created buckets of failed or annotated scores, monitored invisibly.
+- **Monitors** — user-configured alerts over **Saved Searches**.
+
+This spec consolidates both around one small set of concepts:
 
 ```
                 tracker runs at ingest        monitors aggregate         alerts fire on        records the
@@ -24,10 +46,26 @@ The one-line mental model for users and docs:
 
 > Latitude groups your traces into **Signals** — buckets you define with a **Tracker** (an LLM judge, a script, or semantic similarity), plus the buckets Latitude discovers for you automatically from annotations. A signal's members are its **Scores**. Any signal can be watched with a **Monitor**; monitors have **Alerts**, and a fired alert opens an **Incident**, which is what notifies you.
 
-Two structural decisions carry the whole spec and are stated up front:
+Two structural decisions carry the whole spec. Both are stated here and argued in full under [Why membership is materialized at write time](#why-membership-is-materialized-at-write-time):
 
-1. **A signal's occurrences ARE its scores.** There is no separate occurrence ledger. Every tracker run, every annotation, every (future) custom push writes a `scores` row carrying `signal_id`; the signal's membership is the subset of those rows that *matched* (`value >= threshold`). This collapses today's inconsistency (issues count scores, saved searches count traces) into one counting unit and reuses the entire scores pipeline. Rationale + the scaling argument that makes it safe: ["Why membership is materialized at write time"](#why-membership-is-materialized-at-write-time).
-2. **Membership is materialized at write time.** A tracker is evaluated against each in-scope trace once, on arrival, and the verdict is frozen as a score. This is forced, not a preference (same section).
+1. **A signal's occurrences ARE its scores.** There is no separate occurrence ledger. Every tracker run, every annotation, and every (future) custom push writes a `scores` row carrying `signal_id`. A signal's membership is the subset of those rows that *matched* (`value >= threshold`). This collapses today's inconsistency — issues count scores, saved searches count traces — into one counting unit, and reuses the entire scores pipeline.
+2. **Membership is materialized at write time.** A tracker is evaluated against each in-scope trace once, on arrival, and the verdict is frozen as a score. This is forced by the cost model, not a preference.
+
+## Why membership is materialized at write time
+
+Both foundational decisions follow from a single constraint: counting and alerting over *semantic* membership is only affordable if each trace's verdict is computed once, on arrival, and remembered.
+
+**1. Semantic search answers a different question than filters do.** A filter is a per-row yes/no — each row passes on its own merits, so filters stack for free. Semantic search with a vector index answers "the ~1,000 items *most similar in the entire corpus*". Combine them and the filter can only discard from those 1,000: "user frustration" + "last 7 days" returns *whichever of the corpus-wide top-1,000 happen to be recent* — maybe 30, maybe 0 — while thousands of genuinely frustrated traces from this week sit at #5,000 globally and are never returned. Counting correctly means scoring every trace in the window: a full scan (which is why semantic trace search already times out on large projects).
+
+**2. Tracking over time multiplies that cost forever.** An alert on "last-5-minutes match count vs its historical average" needs μ and σ over *every historical bucket* — the verdict for every trace in the corpus — recomputed on every evaluation (288×/day), even though each trace's verdict is frozen the moment it arrives. The only fix is "score each trace once, on arrival, and remember it" — which **is** write-time materialization.
+
+**3. "Occurrences are scores" is the cheap way to remember it — given the existing PG/CH split.** The objection to storing membership in `scores` is write amplification through the canonical mutable Postgres path. But `scores` is *already* a Postgres-canonical + ClickHouse-analytics split, and the rules already say immutable scores skip straight to ClickHouse. A pure-tracker match is immutable by construction (a value, no feedback, nothing to draft), so it goes **ClickHouse-only** and never touches Postgres. Mutable membership (judge feedback, human/flagger annotations) is bounded (sampled / human-paced) and takes the canonical path as it does today. So one ledger scales without a second table.
+
+These consequences carry through the rest of the spec:
+
+- Query-time semantic search remains an **exploration** tool: a ranked best-effort sample on the Traces page. No counts, histograms, or alerts over a semantic query — a banner says so, with "create a signal" as the path to set semantics.
+- Anything needing **set** semantics — charts, baselines, alerts, "every matching trace" — must be a signal whose tracker decides membership per trace at ingest.
+- History is immutable under definition edits: editing a tracker changes membership *forward only* (a definition-changed marker). The "editing a virtual signal rewrites its history" problem disappears.
 
 ## Concepts
 
@@ -37,61 +75,30 @@ Two structural decisions carry the whole spec and are stated up front:
 
 - an **origin**: `user` (built deliberately by a person) or `system` (auto-created by Latitude — see [Discovery](#discovery-sinks-and-promotion)). Origin is the differentiator between hand-built and discovered signals.
 - an optional **`filters`** (a `FilterSet`): a cheap, row-local pre-gate restricting which traces the tracker is even run against ("only `service = checkout`", "only traces above p90 latency"). Empty/absent = all traces. `filters` is only meaningful alongside a tracker — it gates tracker execution.
-- an optional **`tracker`** (a jsonb column, **one per signal**): the membership detector run at write time. `NULL` tracker = a **sink** (no write-time detection; membership comes only from annotations — this is how discovered signals work).
+- an optional **`tracker`** (a jsonb column, **one per signal**): the membership detector run at write time. A `NULL` tracker means a **sink** — no write-time detection, with membership coming only from annotations. This is how discovered signals work.
 - **triage metadata**: priority and a single assignee, carried over from issues (multi-assignee deferred).
-- a **lifecycle**: `resolved` / `ignored` / `escalating` etc., carried over from issues **unchanged for the MVP** (it stays on the signal row; it is not relocated onto a monitor).
+- a **lifecycle**: `resolved` / `ignored` / `escalating` etc., carried over from issues **unchanged for the MVP**. It stays on the signal row; it is not relocated onto a monitor.
 
 Constraints:
 
-- **Users cannot create a tracker-less signal.** A `user`-origin signal must have a tracker. Tracker-less (`NULL`) signals exist only as `system`-origin sinks. This deliberately keeps "plain filter slices" out of signals — those stay **saved searches** (a broad `filters`-only signal would write a score per trace; banning user-created tracker-less signals removes that footgun entirely).
-- **One tracker per signal.** A bucket has at most one detector. (A concept that needs two detectors — e.g. semantic *and* judge for "frustration" — is one signal that gets *promoted* from one tracker to another, or two signals; it is not one signal with two trackers.)
+- **Users cannot create a tracker-less signal.** A `user`-origin signal must have a tracker. Tracker-less (`NULL`) signals exist only as `system`-origin sinks. This deliberately keeps "plain filter slices" out of signals — those stay **saved searches**. (A broad `filters`-only signal would write a score per trace; banning user-created tracker-less signals removes that footgun entirely.)
+- **One tracker per signal.** A bucket has at most one detector. A concept that needs two detectors — e.g. semantic *and* judge for "frustration" — is one signal that gets *promoted* from one tracker to another, or two signals. It is never one signal with two trackers.
 
 ### Tracker
 
-**The write-time detector embedded on a signal** (`signals.tracker` jsonb, discriminated by `type`). Three types:
+**The write-time detector embedded on a signal** — `signals.tracker` (jsonb, discriminated by `type`), at most one per signal. Three types: `semantic_similarity`, `script`, and `llm_as_judge`. Their shapes are defined once in [Data model → Shared contracts](#shared-contracts-domainshared-domainscores).
 
-```ts
-export const SIGNAL_TRACKER_TYPES = ["semantic_similarity", "script", "llm_as_judge"] as const
-export type SignalTrackerType = (typeof SIGNAL_TRACKER_TYPES)[number]
+- **`semantic_similarity`** and **`script`** are **pure** detectors — deterministic, no `feedback`. `script` runs through the sandbox runtime (`specs/sandbox-runtime.md`); `semantic_similarity` runs through the native batch anchor runner (the conversation-intelligence path), not the sandbox. The semantic detector value is `max(chunk · positiveAnchor)`, and a trace matches only when the best positive anchor also beats the best contrast anchor by `margin`. This multi-anchor + contrast + margin shape is proven in production for conversation-intelligence moment labels and is adopted wholesale, generalizing those labels' static per-kind gate into the uniform per-tracker `threshold`.
+- **`llm_as_judge`** is **not** stored inline. Its config is an `evaluations` row linked by `evaluations.signal_id` (1:1); the tracker jsonb records only `{ type, threshold }`. The judge script, alignment state, and `optimize-evaluation` workflow stay in `@domain/evaluations` exactly as today. Users can author a judge tracker directly (judge criteria → compiled to a backing evaluation linked to the signal), and alignment ground truth then accrues as annotations arrive on the signal. The same tracker type *also* arises automatically via the sink → promotion path ([Discovery](#discovery-sinks-and-promotion)); both paths land on the same backing-evaluation shape.
+- A tracker's **`threshold`** is the membership cutoff over the detector value, per `specs/sandbox-runtime.md` (semantic emits continuous similarity; judges emit ≈{0,1}; scripts emit whatever they compute). Threshold and definition edits apply **forward only** — a definition-changed marker appears on charts, and existing scores are never re-evaluated.
 
-export type SignalTracker =
-  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
-  | { type: "script";              source: string;            threshold: number }   // sandbox JS
-  | { type: "llm_as_judge";        threshold: number }   // backed by evaluations.signal_id (1:1)
+### Score — the membership ledger
 
-// Proven in production for conversation-intelligence moment labels (multi-anchor + contrast +
-// margin), adopted wholesale. Detector value = max(chunk · positiveAnchor); membership is the
-// uniform per-tracker `threshold`, generalizing moment labels' static per-kind gate:
-export type SemanticAnchors = {
-  anchors: string[]                  // positive anchor phrases (1..n); best match wins
-  contrastAnchors?: string[]         // a trace matches only if best-positive ALSO beats
-                                     //   best-contrast by `margin`
-  margin?: number                    // required positive-vs-contrast separation (default per constants)
-  roles?: ("user" | "assistant")[]   // optionally restrict which turns are compared
-}
-```
+**A signal's occurrences are its scores.** Every membership-bearing event writes a `scores` row carrying `signal_id`; nothing else records membership. A score's `source_type` is one of `tracker`, `flagger`, `user`, or `custom` (enum in [Data model](#shared-contracts-domainshared-domainscores)).
 
-- **`semantic_similarity`** and **`script`** are **pure** detectors (no `feedback`, deterministic). `script` runs through the sandbox runtime (`specs/sandbox-runtime.md`); `semantic_similarity` runs through the native batch anchor runner (the conversation-intelligence path), not the sandbox.
-- **`llm_as_judge`** is **not** stored inline — its config is an `evaluations` row linked by `evaluations.signal_id` (1:1). The tracker jsonb only records `{ type, threshold }`; the judge script, alignment state, and `optimize-evaluation` workflow stay in `@domain/evaluations` exactly as today. Users can create a judge tracker directly (authoring the judge criteria → compiled to a backing evaluation linked to the signal); alignment ground truth then accrues as annotations arrive on the signal. The same tracker type is *also* produced automatically via the sink → promotion path ([Discovery](#discovery-sinks-and-promotion)) — both paths land on the same backing-evaluation shape.
-- A tracker's **`threshold`** is the membership cutoff over the detector value, per `specs/sandbox-runtime.md` (semantic emits continuous similarity; judges emit ≈{0,1}; scripts emit whatever they compute). Threshold/definition edits apply **forward only** (a definition-changed marker on charts), never retroactively.
-
-### Score (the membership ledger)
-
-**A signal's occurrences are its scores.** Every membership-bearing event writes a `scores` row carrying `signal_id`; nothing else records membership.
-
-```ts
-export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as const
-export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
-// 'tracker' — written by the signal's tracker at ingest (source_id = signal_id; judge scores
-//             may keep the evaluation id to preserve evaluation-source dashboards)
-// 'flagger' — written by an automatic flagger annotation (source_id = flagger key)
-// 'user'    — written by a human annotation (source_id = user id / UI / API / queue cuid)
-// 'custom'  — pushed through the public /scores API (source_id = user-defined)  [POST-MVP]
-```
-
-- **Membership = the matched subset.** A trace is a member of a signal when it has a score for that signal with `value >= threshold` (judge "exhibits" = `passed:false` under today's problem-detector polarity, normalized to exhibition at migration). The signal's occurrence count is that subset.
-- **Non-matches are written too** (consistent with how evaluations already persist `passed:true` *and* `passed:false`): a tracker writes a score on **every** run, matched or not. The matched rows are occurrences; the non-matched rows give exact pass-rate, denominators, and dashboards without read-time estimation. (Lever if pure-tracker non-match volume ever hurts: switch pure trackers to match-only and compute the denominator from `filters` over traces at read time. MVP default is write-both.)
-- **Write path routes by mutability** (the existing scores PG/CH split — `dev-docs/scores.md`):
+- **Membership is the matched subset.** A trace is a member of a signal when it has a score for that signal with `value >= threshold`. (A judge "exhibits" the behavior at `passed:false` under today's problem-detector polarity; this is normalized to exhibition at migration.) The signal's occurrence count is exactly that subset.
+- **Non-matches are written too**, consistent with how evaluations already persist both `passed:true` *and* `passed:false`: a tracker writes a score on **every** run, matched or not. The matched rows are occurrences; the non-matched rows give exact pass-rate, denominators, and dashboards without read-time estimation. *(Lever, if pure-tracker non-match volume ever hurts: switch pure trackers to match-only and compute the denominator from `filters` over traces at read time. The MVP default is write-both.)*
+- **The write path routes by mutability**, reusing the existing scores PG/CH split (`dev-docs/scores.md`):
 
   | Score | Mutable? | Store |
   | --- | --- | --- |
@@ -99,13 +106,13 @@ export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
   | `tracker` / `semantic_similarity` · `script` (matched + non-matched; no feedback; runs per in-scope trace) | no | **ClickHouse-analytics only** (immutable, skip the canonical Postgres row) |
   | `user` / `flagger` annotation (draftable, editable) | yes | Postgres-canonical + ClickHouse, as today |
 
-  Pure-tracker scores carry `signal_id` at write time, so they are immutable on arrival and go straight to ClickHouse — they never push trace-volume writes through the canonical mutable Postgres path. This is the mechanism that lets "occurrences are scores" scale (see the rationale section).
+Pure-tracker scores carry `signal_id` at write time, so they are immutable on arrival and go straight to ClickHouse — they never push trace-volume writes through the canonical mutable Postgres path. This is the mechanism that makes "occurrences are scores" scale; see [Why membership is materialized at write time](#why-membership-is-materialized-at-write-time).
 
 ### Monitor
 
 **A monitor watches one signal over time.** Monitors never own detection — that lives on the signal's tracker. A monitor owns:
 
-- a **target**: a signal (`monitors.target_signal_id` = signal CUID). (Saved-search and raw-stream targets remain available via the existing `target_*` columns; this spec focuses on signal targets. Saved searches stay the home for plain filter tracking — `SavedSearchMatchReader` reused unchanged.)
+- a **target**: a signal (`monitors.target_signal_id` = signal CUID). Saved-search and raw-stream targets remain available via the existing `target_*` columns; this spec focuses on signal targets. Saved searches stay the home for plain filter tracking — `SavedSearchMatchReader` is reused unchanged.
 - a **metric** (`MonitorMetric`, already exists): `count` of matching scores (default), `errorRate`, or `avg`/`p95`/`sum` of `duration`/`cost`/`tokens`. Field aggregates read the matched traces (`score.trace_id → traces`); the score's own cost/tokens are the *judge's*, not the trace's.
 - **mute** (`muted_at`): notifications off; evaluation and incident recording continue.
 
@@ -115,32 +122,178 @@ Every signal gets a **default monitor** provisioned at creation — the occurren
 
 **A condition on a monitor.** Two flavors (Sentry-shaped, carried over from the monitors model):
 
-- **Event alerts** — `event.matched` (a new matching score entered the signal), `event.regressed` (a datapoint after the monitor's resolve anchor).
+- **Event alerts** — `event.matched` (a new matching score entered the signal) and `event.regressed` (a datapoint after the monitor's resolve anchor).
 - **Metric alerts** — `metric.threshold` (absolute / multiplier / expected) and `metric.escalating` (sustained).
 
-The two unrelated "is this escalating?" implementations (the issue seasonal detector over score counts, and the saved-search bucketed sustained-gate over trace-match counts) **merge into one** `metric.escalating` evaluator: every monitor target now yields the same *per-bucket count series → per-bucket threshold → open/close state machine* shape. The seasonal detector (`evaluateSeasonalEscalation`) survives as the threshold function of `expected` mode (knob: `sensitivity`); issue escalation stops being special — it is the default monitor's escalating alert in that mode.
+The two unrelated "is this escalating?" implementations — the issue seasonal detector over score counts, and the saved-search bucketed sustained-gate over trace-match counts — **merge into one** `metric.escalating` evaluator: every monitor target now yields the same *per-bucket count series → per-bucket threshold → open/close state machine* shape. The seasonal detector (`evaluateSeasonalEscalation`) survives as the threshold function of `expected` mode (knob: `sensitivity`); issue escalation stops being special — it is the default monitor's escalating alert in that mode.
 
 ### Incident
 
 **Unchanged.** Same `alert_incidents` lifecycle (point vs sustained), backtracked `started_at`/`ended_at`, and notifications pipeline (`incident.event` / `incident.opened` / `incident.closed`). Incidents snapshot the firing alert's `condition`, and additionally snapshot the monitor's **target definition** at open time so closed incidents stay self-describing after edits.
 
+## Discovery: sinks and promotion
+
+Automatic discovery is **kept**, reframed: it produces **sink signals** (origin `system`, no tracker), not a separate entity. The flagger + annotation machinery is unchanged.
+
+```
+flaggers (trace-end) + human annotations
+   └─ each writes an annotation score (source_type = 'flagger' | 'user')
+   └─ discovery routes the score (centroid + hybrid search + locked serialization, UNCHANGED):
+        ├─ to an existing sink signal      → +1 occurrence
+        └─ or creates a new sink signal    → origin 'system', tracker NULL
+   └─ once a sink has enough evidence, the user can PROMOTE it:
+        └─ generate an llm_as_judge tracker from its accumulated annotations
+           (today's "Monitor issue" → optimize-evaluation; deterministic workflow id
+            evaluations:generate:${signalId})
+        └─ the signal's accumulated annotation scores become the alignment ground truth
+           (positives = annotations marked exhibits; negatives = passing-annotated-elsewhere
+            traces; zero-annotation traces excluded — the alignment set is built from
+            annotations, and the judge is re-run against it, exactly as today)
+        └─ the signal now auto-detects forward; old annotation occurrences stay, the judge
+           adds tracker-sourced ones
+```
+
+So a signal's life is **sink (annotation-fed) → optionally promoted to a tracker (detector-fed)**, with identity and occurrence history preserved across the promotion. This is the bridge between auto-discovery and the hand-built trackers; it reuses the entire existing discovery + `optimize-evaluation` + alignment machinery.
+
+**Annotation assignment is allowed exactly on tracker-less (sink) signals.** A tracker-backed signal is detector-driven; you do not hand-assign traces into it. While annotating, the UI suggests existing sinks via hybrid search over `search_document` (lexical) + `centroid_embedding` (the existing discovery path); the user links explicitly or lets discovery route.
+
+## The matching pipeline
+
+Today's write-time machinery is evaluation-oriented (`EvaluationTrigger`: filter / turn / debounce / sampling decides when an evaluation runs). This generalizes into a single **signal matching pipeline** that runs every active *tracked* signal's detector against incoming traces; evaluations become one runner inside it.
+
+- the **filters pre-gate** is shared (one pass per trace over all active signals' `filters`); out-of-gate traces never reach the tracker.
+- the **sandbox runner** executes `script` trackers (and `llm_as_judge` trackers' generated scripts) in the shared sandboxed JS runtime.
+- the **semantic runner** compares trace content-chunk embeddings (already produced at ingest for trace search and semantic moments) against Redis-cached anchor embeddings — one batch pass over a trace's chunks against all anchor sets.
+- evaluation-specific options (`sampling`, `turn`, `debounce`) remain runner-level settings on the backing evaluation, not pipeline concepts.
+
+A run writes a score (matched or not) with `signal_id`, `source_type = 'tracker'`, routed PG/CH per the [Score routing table](#score--the-membership-ledger). Sinks (`tracker IS NULL`) are not in this pipeline — they receive membership only via annotations.
+
+## Main flows
+
+`@domain/signals` is the evolved `@domain/issues` package. Existing machinery reused unchanged is marked `[reuse]`.
+
+### A. Trace ingest → tracker → score
+
+```
+span ingestion → ClickHouse spans insert → TracesIngested (outbox)             [reuse]
+└─ domain-events dispatcher                                                     [reuse]
+   └─ signals:match (queue task, batched per project)
+      └─ matchTracesToSignalsUseCase (@domain/signals)
+         ├─ SignalRepository.listActiveTracked(projectId)            -- Redis-cached, org-prefixed
+         ├─ filters pre-gate per signal (row-local, in-process)
+         ├─ script  → sandbox runner
+         ├─ judge   → evaluation runner (sampling/turn/debounce on the backing evaluation)
+         └─ write score (matched or not) with signal_id, source_type='tracker'
+              · pure (script): CH-analytics-only          · judge: Postgres-canonical + CH
+      └─ publishes monitors:evaluate (leading-edge throttle, 5 min)             [reuse shape]
+
+semantic trackers (separate hop joining content embeddings produced at ingest): [reuse]
+trace_search_embeddings chunks written
+└─ signals:semanticMatch (queue task per trace)
+   └─ load project anchor sets (Redis-cached, moment-label pattern; includes system moment signals)
+   └─ filters pre-gate; per signal value = max(chunk · positiveAnchor); matched when
+        value ≥ threshold AND best-positive − best-contrast ≥ margin
+   └─ write CH-analytics-only score (matched or not), source_type='tracker'
+```
+
+### B. Create a signal manually (user origin, must have a tracker)
+
+```
+UI: Signals page / "Create signal from this search" → builder (live preview required)
+└─ createSignalUseCase { origin: 'user', tracker, filters? }
+   ├─ semantic: embed + Redis-cache anchors
+   ├─ script:   compile (sandbox ScriptCompileError rejects at save time)
+   ├─ judge:    create backing evaluation (evaluations.signal_id); alignment accrues from annotations
+   ├─ provisionDefaultMonitorUseCase (count monitor + metric.escalating 'expected' + event.regressed)
+   └─ enqueue signals:backfill { signalId, window: 14d }   (pure trackers only)
+```
+
+### C. Annotation → sink routing (auto-discovery)
+
+```
+flagger (trace-end) / human annotation
+└─ writes annotation score (source_type 'flagger'|'user'), draft/publish as today  [reuse]
+└─ ScoreCreated → discovery (centroid + hybrid search + locked serialization)      [reuse]
+     ├─ assign to existing sink signal  → +1 occurrence
+     └─ create new sink signal { origin: 'system', tracker: NULL }
+```
+
+### D. Monitor evaluation → alert → incident → notification
+
+```
+triggers: monitors:evaluate (leading-edge throttle) + 5-min sweep cron            [reuse shape]
+└─ evaluateMonitorUseCase (@domain/monitors)
+   ├─ signal target → SignalScoreReader (CH score-analytics: count where signal_id=? AND passed;
+   │    avg/sum/p95 over matched traces via score.trace_id → traces)               [new reader]
+   ├─ compute metric series per bucket
+   └─ per active alert, run the kind's state machine:
+        event.matched / event.regressed / metric.threshold / metric.escalating     [reuse / merge]
+└─ alert_incidents insert/close (condition + target_snapshot) → IncidentCreated    [reuse]
+   → notifications (mute gate: monitor.mutedAt) → in-app / email / Slack            [reuse]
+```
+
+### E. Triage from the signal page
+
+```
+[Resolve] → resolveSignalUseCase: signal.resolved_at = now; close open sustained incidents (silent)
+[Ignore]  → ignoreSignalUseCase:  signal.ignored_at = now (scores keep recording; nothing notifies)
+[Delete]  → deleteSignalUseCase:  soft-delete signal + its monitors; archive backing evaluation;
+              enqueue CH score cleanup for the signal
+regression → flow D, event.regressed branch
+```
+
+### F. Promote a sink to a judge tracker
+
+```
+UI: sink signal page → "Start tracking with a judge"
+└─ promoteSignalUseCase: set tracker = { type:'llm_as_judge', threshold }
+   └─ start optimize-evaluation (workflow id evaluations:generate:${signalId})      [reuse]
+      └─ build alignment set from the signal's annotation scores; generate + align the judge;
+         persist with evaluations.signal_id
+frontend polls getSignalAlignmentState (Temporal workflow.describe())               [reuse shape]
+```
+
 ## Data model
 
 **No new tables.** Every entity evolves a table that already exists: `issues` → `signals` (rename + columns), `scores` (rename + widened source), `evaluations` (rename), `monitors` (one target column), and the ClickHouse `scores` analytics table (one column). The original spec's `signal_occurrences` table is gone — "occurrences are scores". The unified `event.*`/`metric.*` alert model, `MonitorMetric`, and the `monitors.target_*` columns are **already built** (only `event.regressed` is genuinely new). `legend: ▸NEW ▸CHANGED ▸KEPT ▸DROPPED` is per-line below.
 
-### Shared enums (`@domain/shared`, `@domain/scores`)
+### Shared contracts (`@domain/shared`, `@domain/scores`)
+
+These are the single source of truth for the enums and tracker types referenced throughout the spec.
 
 ```ts
 // NEW (@domain/shared)
-export const SIGNAL_ORIGINS = ["user", "system"] as const   // user = hand-built (must have a tracker); system = auto-created sink / provisioned
+export const SIGNAL_ORIGINS = ["user", "system"] as const
+//   user   — hand-built by a person; MUST have a tracker
+//   system — auto-created sink / provisioned (may be tracker-less)
+
 export const SIGNAL_TRACKER_TYPES = ["semantic_similarity", "script", "llm_as_judge"] as const
+export type SignalTrackerType = (typeof SIGNAL_TRACKER_TYPES)[number]
+
+// tracker config stored inline on the signal row (signals.tracker jsonb), discriminated by type.
+// Proven in production for conversation-intelligence moment labels (multi-anchor + contrast +
+// margin), adopted wholesale. Semantic detector value = max(chunk · positiveAnchor); membership is
+// the uniform per-tracker `threshold`, generalizing moment labels' static per-kind gate:
+export type SignalTracker =
+  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
+  | { type: "script";              source: string;            threshold: number }   // sandbox JS
+  | { type: "llm_as_judge";        threshold: number }   // detector lives in evaluations.signal_id (1:1)
+
+export type SemanticAnchors = {
+  anchors: string[]                  // positive anchor phrases (1..n); best match wins
+  contrastAnchors?: string[]         // a trace matches only if best-positive ALSO beats
+                                     //   best-contrast by `margin`
+  margin?: number                    // required positive-vs-contrast separation (default per constants)
+  roles?: ("user" | "assistant")[]   // optionally restrict which turns are compared
+}
 
 // CHANGED (@domain/scores): replaces SCORE_SOURCES = ["evaluation","annotation","custom"]
 export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as const
-//   tracker — written by the signal's tracker at ingest        (source_id = signal id; judge may keep evaluation id)
-//   flagger — automatic flagger annotation                     (source_id = flagger key)
-//   user    — human annotation (UI / API / queue)              (source_id = user id / sentinel)
-//   custom  — public /scores push  [POST-MVP]                  (source_id = caller tag)
+export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
+//   tracker — written by the signal's tracker at ingest    (source_id = signal id; judge may keep the evaluation id to preserve evaluation-source dashboards)
+//   flagger — automatic flagger annotation                 (source_id = flagger key)
+//   user    — human annotation (UI / API / queue)          (source_id = user id / sentinel)
+//   custom  — public /scores push  [POST-MVP]              (source_id = caller tag)
 
 // CHANGED (@domain/shared, alert-incident-kinds.ts): ALERT_INCIDENT_KINDS already contains
 // event.matched / metric.threshold / metric.escalating (unified, target-on-monitor) plus the
@@ -152,16 +305,6 @@ export const SCORE_SOURCE_TYPES = ["tracker", "flagger", "user", "custom"] as co
 //   MonitorMetric         = { kind:"count" } | { kind:"errorRate" } | { kind:"avg"|"p95"|"sum"; field:"duration"|"cost"|"tokens" }
 //   AlertMetricThreshold  = absolute(value) | multiplier(factor, baseline) | expected(sensitivity)   // + direction above|below
 //   metric.threshold / metric.escalating conditions carry { metric, threshold, direction?, window? }
-
-// tracker config stored inline on the signal row (signals.tracker jsonb):
-export type SignalTracker =
-  | { type: "semantic_similarity"; semantic: SemanticAnchors; threshold: number }
-  | { type: "script";              source: string;            threshold: number }   // sandbox JS
-  | { type: "llm_as_judge";        threshold: number }   // detector lives in evaluations.signal_id (1:1)
-
-export type SemanticAnchors = {
-  anchors: string[]; contrastAnchors?: string[]; margin?: number; roles?: ("user" | "assistant")[]
-}
 ```
 
 ### Postgres: `signals` (evolves `issues` in place — keep the rows)
@@ -271,128 +414,6 @@ ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT '';   -- NEW; ba
 - **The CH `scores` table is the single signal counting/aggregate surface** monitors read; it loses its issue-trend special-casing. Occurrence count = `WHERE signal_id = ? AND passed`. Metric aggregates (`avg`/`p95`/`sum` of trace `duration`/`cost`/`tokens`) join the matched `trace_id` back to the traces analytics — the score's own duration/tokens/cost are the *judge's*, not the trace's.
 - Pure-tracker scores (semantic/script) are written **CH-only** (immutable on arrival); judge/annotation scores follow today's Postgres-canonical → CH sync.
 
-## The matching pipeline (write-time)
-
-Today's write-time machinery is evaluation-oriented (`EvaluationTrigger`: filter / turn / debounce / sampling decides when an evaluation runs). This generalizes into a single **signal matching pipeline** that runs every active *tracked* signal's detector against incoming traces; evaluations become one runner inside it:
-
-- the **filters pre-gate** is shared (one pass per trace over all active signals' `filters`); out-of-gate traces never reach the tracker.
-- the **sandbox runner** executes `script` trackers (and `llm_as_judge` trackers' generated scripts) in the shared sandboxed JS runtime.
-- the **semantic runner** compares trace content-chunk embeddings (already produced at ingest for trace search and semantic moments) against Redis-cached anchor embeddings — one batch pass over a trace's chunks against all anchor sets.
-- evaluation-specific options (`sampling`, `turn`, `debounce`) remain runner-level settings on the backing evaluation, not pipeline concepts.
-
-A run writes a score (matched or not) with `signal_id`, `source_type = 'tracker'`, routed PG/CH per the table above. Sinks (`tracker IS NULL`) are not in this pipeline — they receive membership only via annotations.
-
-## Discovery (sinks and promotion)
-
-Automatic discovery is **kept**, reframed: it produces **sink signals** (origin `system`, no tracker), not a separate entity. The flagger + annotation machinery is unchanged.
-
-```
-flaggers (trace-end) + human annotations
-   └─ each writes an annotation score (source_type = 'flagger' | 'user')
-   └─ discovery routes the score (centroid + hybrid search + locked serialization, UNCHANGED):
-        ├─ to an existing sink signal      → +1 occurrence
-        └─ or creates a new sink signal    → origin 'system', tracker NULL
-   └─ once a sink has enough evidence, the user can PROMOTE it:
-        └─ generate an llm_as_judge tracker from its accumulated annotations
-           (today's "Monitor issue" → optimize-evaluation; deterministic workflow id
-            evaluations:generate:${signalId})
-        └─ the signal's accumulated annotation scores become the alignment ground truth
-           (positives = annotations marked exhibits; negatives = passing-annotated-elsewhere
-            traces; zero-annotation traces excluded — the alignment set is built from
-            annotations, and the judge is re-run against it, exactly as today)
-        └─ the signal now auto-detects forward; old annotation occurrences stay, the judge
-           adds tracker-sourced ones
-```
-
-So a signal's life is **sink (annotation-fed) → optionally promoted to a tracker (detector-fed)**, with identity and occurrence history preserved across the promotion. This is the bridge between auto-discovery and the hand-built trackers; it reuses the entire existing discovery + `optimize-evaluation` + alignment machinery.
-
-**Annotation assignment is allowed exactly on tracker-less (sink) signals.** A tracker-backed signal is detector-driven; you do not hand-assign traces into it. While annotating, the UI suggests existing sinks via hybrid search over `search_document` (lexical) + `centroid_embedding` (the existing discovery path); the user links explicitly or lets discovery route.
-
-## Main flows (callstacks)
-
-`@domain/signals` is the evolved `@domain/issues` package. Existing machinery reused unchanged is marked `[reuse]`.
-
-### A. Trace ingest → tracker → score
-
-```
-span ingestion → ClickHouse spans insert → TracesIngested (outbox)             [reuse]
-└─ domain-events dispatcher                                                     [reuse]
-   └─ signals:match (queue task, batched per project)
-      └─ matchTracesToSignalsUseCase (@domain/signals)
-         ├─ SignalRepository.listActiveTracked(projectId)            -- Redis-cached, org-prefixed
-         ├─ filters pre-gate per signal (row-local, in-process)
-         ├─ script  → sandbox runner
-         ├─ judge   → evaluation runner (sampling/turn/debounce on the backing evaluation)
-         └─ write score (matched or not) with signal_id, source_type='tracker'
-              · pure (script): CH-analytics-only          · judge: Postgres-canonical + CH
-      └─ publishes monitors:evaluate (leading-edge throttle, 5 min)             [reuse shape]
-
-semantic trackers (separate hop joining content embeddings produced at ingest): [reuse]
-trace_search_embeddings chunks written
-└─ signals:semanticMatch (queue task per trace)
-   └─ load project anchor sets (Redis-cached, moment-label pattern; includes system moment signals)
-   └─ filters pre-gate; per signal value = max(chunk · positiveAnchor); matched when
-        value ≥ threshold AND best-positive − best-contrast ≥ margin
-   └─ write CH-analytics-only score (matched or not), source_type='tracker'
-```
-
-### B. Create a signal manually (user origin, must have a tracker)
-
-```
-UI: Signals page / "Create signal from this search" → builder (live preview required)
-└─ createSignalUseCase { origin: 'user', tracker, filters? }
-   ├─ semantic: embed + Redis-cache anchors
-   ├─ script:   compile (sandbox ScriptCompileError rejects at save time)
-   ├─ judge:    create backing evaluation (evaluations.signal_id); alignment accrues from annotations
-   ├─ provisionDefaultMonitorUseCase (count monitor + metric.escalating 'expected' + event.regressed)
-   └─ enqueue signals:backfill { signalId, window: 14d }   (pure trackers only)
-```
-
-### C. Annotation → sink routing (auto-discovery)
-
-```
-flagger (trace-end) / human annotation
-└─ writes annotation score (source_type 'flagger'|'user'), draft/publish as today  [reuse]
-└─ ScoreCreated → discovery (centroid + hybrid search + locked serialization)      [reuse]
-     ├─ assign to existing sink signal  → +1 occurrence
-     └─ create new sink signal { origin: 'system', tracker: NULL }
-```
-
-### D. Monitor evaluation → alert → incident → notification
-
-```
-triggers: monitors:evaluate (leading-edge throttle) + 5-min sweep cron            [reuse shape]
-└─ evaluateMonitorUseCase (@domain/monitors)
-   ├─ signal target → SignalScoreReader (CH score-analytics: count where signal_id=? AND passed;
-   │    avg/sum/p95 over matched traces via score.trace_id → traces)               [new reader]
-   ├─ compute metric series per bucket
-   └─ per active alert, run the kind's state machine:
-        event.matched / event.regressed / metric.threshold / metric.escalating     [reuse / merge]
-└─ alert_incidents insert/close (condition + target_snapshot) → IncidentCreated    [reuse]
-   → notifications (mute gate: monitor.mutedAt) → in-app / email / Slack            [reuse]
-```
-
-### E. Triage from the signal page
-
-```
-[Resolve] → resolveSignalUseCase: signal.resolved_at = now; close open sustained incidents (silent)
-[Ignore]  → ignoreSignalUseCase:  signal.ignored_at = now (scores keep recording; nothing notifies)
-[Delete]  → deleteSignalUseCase:  soft-delete signal + its monitors; archive backing evaluation;
-              enqueue CH score cleanup for the signal
-regression → flow D, event.regressed branch
-```
-
-### F. Promote a sink to a judge tracker
-
-```
-UI: sink signal page → "Start tracking with a judge"
-└─ promoteSignalUseCase: set tracker = { type:'llm_as_judge', threshold }
-   └─ start optimize-evaluation (workflow id evaluations:generate:${signalId})      [reuse]
-      └─ build alignment set from the signal's annotation scores; generate + align the judge;
-         persist with evaluations.signal_id
-frontend polls getSignalAlignmentState (Temporal workflow.describe())               [reuse shape]
-```
-
 ## UI
 
 ### Navigation
@@ -441,114 +462,147 @@ Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/s
 - **Semantic moments → default per-project signals** (soft requirement): the eight moment-label kinds (`MOMENT_LABEL_ANCHORS`) are provisioned as `origin = 'system'`, `tracker = { type:'semantic_similarity', semantic: <existing anchors>, threshold: <the kind's static gate> }`. The conversation-intelligence anchor matching becomes the semantic runner of the matching pipeline.
 - **Flaggers** stay as the trace-end auto-annotation engine feeding sinks (flow C). Where a flagger overlaps a moment label (e.g. `frustration`), consolidate to **one** signal — prefer the semantic moment-anchor tracker as the canonical detector and retire the overlapping flagger into it (soft requirement). Do not convert all 11 flaggers to trackers for the MVP; most keep feeding sinks via discovery.
 
-## Why membership is materialized at write time
-
-**1. Semantic search answers a different question than filters do.** A filter is a per-row yes/no — each row passes on its own merits, so filters stack for free. Semantic search with a vector index answers "the ~1,000 items *most similar in the entire corpus*". Combine them and the filter can only discard from those 1,000: "user frustration" + "last 7 days" returns *whichever of the corpus-wide top-1,000 happen to be recent* — maybe 30, maybe 0 — while thousands of genuinely frustrated traces from this week sit at #5,000 globally and are never returned. Counting correctly means scoring every trace in the window: a full scan (which is why semantic trace search already times out on large projects).
-
-**2. Tracking over time multiplies that cost forever.** An alert on "last-5-minutes match count vs its historical average" needs μ and σ over *every historical bucket* — the verdict for every trace in the corpus — recomputed on every evaluation (288×/day), even though each trace's verdict is frozen the moment it arrives. The only fix is "score each trace once, on arrival, and remember it" — which **is** write-time materialization.
-
-**3. "Occurrences are scores" is the cheap way to remember it — given the existing PG/CH split.** The objection to storing membership in `scores` is write amplification through the canonical mutable Postgres path. But `scores` is *already* a Postgres-canonical + ClickHouse-analytics split, and the rules already say immutable scores skip straight to ClickHouse. A pure-tracker match is immutable by construction (a value, no feedback, nothing to draft), so it goes **ClickHouse-only** and never touches Postgres. Mutable membership (judge feedback, human/flagger annotations) is bounded (sampled / human-paced) and takes the canonical path as it does today. So one ledger scales without a second table.
-
-Consequences carried through the spec:
-
-- Query-time semantic search remains an **exploration** tool: a ranked best-effort sample on the Traces page. No counts, histograms, or alerts over a semantic query — a banner says so, with "create a signal" as the path to set semantics.
-- Anything needing **set** semantics — charts, baselines, alerts, "every matching trace" — must be a signal whose tracker decides membership per trace at ingest.
-- History is immutable under definition edits: editing a tracker changes membership *forward only* (a definition-changed marker). The "editing a virtual signal rewrites its history" problem disappears.
-
 ## Decisions
 
-Settled during design review (LAT-664 + spec revision):
+### What this revision changed (vs the original LAT-664 spec)
 
-1. **Membership is materialized at write time** (forced — see the rationale section).
-2. **A signal's occurrences ARE its scores.** No separate occurrence ledger; `signal_occurrences` is removed. Membership = scores with `passed = true` (the host freezes `passed = value >= threshold` at write); pure-tracker scores route ClickHouse-only so the single ledger scales. *(Reverses the original spec's two-ledger decision 6.)*
-3. **Automatic discovery is kept**, as sink signals (`origin = 'system'`, `tracker = NULL`) produced by the unchanged flagger + discovery machinery; centroid/embedding columns stay. *(Reverses the original spec's "no automatic discovery" decision 2.)*
-4. **One tracker per signal, stored as a jsonb column** (`signals.tracker`), not a separate table. Three types: `semantic_similarity`, `script`, `llm_as_judge`. There is **no** `annotation_sink` tracker — a sink is simply a tracker-less signal.
-5. **Trackers write every run** (matched and non-matched), mirroring how evaluations persist pass and fail today. Occurrences are the matched subset.
-6. **Users cannot create tracker-less signals.** Only `system`-origin sinks are tracker-less, which removes the pure-filter write-amplification footgun; `filters` is only a tracker pre-gate. Plain filter tracking stays saved searches + monitors.
-7. **Lifecycle stays on the signal row** for the MVP (resolve/ignore/escalating carried over from issues), not relocated onto the default monitor.
-8. **`semantic_similarity` and `llm_as_judge` are user-creatable in the MVP**; **`script` is post-MVP** (nothing depends on it — see the build plan). Judge trackers *also* arise automatically from the sink → promotion path, landing on the same backing-evaluation shape. **Custom-source scores** (`/scores` accepting `signal_id`) are POST-MVP.
-9. **Signals per project are capped** per plan (bounds tracker matching cost and pure-tracker score write volume).
+- **Two ledgers → one.** "Occurrences are scores"; the separate `signal_occurrences` table is removed. *(Reverses the original spec's two-ledger decision 6.)* Rationale: [Why membership is materialized at write time](#why-membership-is-materialized-at-write-time).
+- **"No automatic discovery" → discovery kept**, reframed as sink signals (`origin = 'system'`, `tracker = NULL`) produced by the unchanged flagger + discovery machinery; centroid/embedding columns stay. *(Reverses the original spec's "no automatic discovery" decision 2.)* Detail: [Discovery](#discovery-sinks-and-promotion).
 
-## Build plan (phased)
+### Settled choices (each is detailed in the linked section)
 
-> Each phase is an **independently shippable, behavior-preserving deploy** — production keeps working after every phase. Parallelism lives *within* a phase (tasks sharing dependencies run concurrently); phases themselves are mostly sequential, which is the deliberate price of safe incremental rollout. **MVP = Phases 1–4.** Every phase updates the relevant `dev-docs/*` as part of its definition of done (the "remember docs" requirement). Status legend: `[ ] pending`, `[~] in progress`, `[x] done`.
+1. **Membership is materialized at write time** — forced by the cost model. → [Why](#why-membership-is-materialized-at-write-time)
+2. **A signal's occurrences ARE its scores** — membership = scores with `passed = true` (the host freezes `passed = value >= threshold` at write); pure-tracker scores route ClickHouse-only so the single ledger scales. → [Score](#score--the-membership-ledger)
+3. **Automatic discovery is kept** as sink signals. → [Discovery](#discovery-sinks-and-promotion)
+4. **One tracker per signal, stored as a jsonb column** (`signals.tracker`), not a separate table; three types (`semantic_similarity`, `script`, `llm_as_judge`); there is **no** `annotation_sink` tracker — a sink is simply a tracker-less signal. → [Tracker](#tracker)
+5. **Trackers write every run** (matched and non-matched), mirroring how evaluations persist pass and fail today; occurrences are the matched subset. → [Score](#score--the-membership-ledger)
+6. **Users cannot create tracker-less signals** — only `system`-origin sinks are tracker-less, which removes the pure-filter write-amplification footgun; `filters` is only a tracker pre-gate; plain filter tracking stays saved searches + monitors. → [Signal](#signal)
+7. **Lifecycle stays on the signal row** for the MVP (resolve/ignore/escalating carried over from issues), not relocated onto the default monitor. → [Signal](#signal)
+8. **`semantic_similarity` and `llm_as_judge` are user-creatable in the MVP; `script` is post-MVP** (nothing depends on it — see [Tasks](#tasks)). Judge trackers *also* arise automatically from the sink → promotion path, landing on the same backing-evaluation shape. **Custom-source scores** (`/scores` accepting `signal_id`) are POST-MVP.
+9. **Signals per project are capped** per plan — bounds tracker matching cost and pure-tracker score write volume.
+
+## Tasks
+
+> **Status legend** — `[ ] pending`, `[~] in progress`, `[x] complete`.
+>
+> Each phase is an **independently shippable, behavior-preserving deploy**: production keeps working after every phase. Parallelism lives *within* a phase (tasks sharing dependencies run concurrently); phases themselves are mostly sequential, which is the deliberate price of safe incremental rollout. **MVP = Phases 1–4.** Every phase updates the relevant `dev-docs/*` as part of its definition of done (the "remember docs" requirement).
 >
 > **Incremental-schema note.** The data-model end state above is reached over several phases, not at once. `source_type`'s four values arrive in two steps (Phase 2 adds `tracker`; Phase 9 collapses `evaluation`→`tracker` and splits `annotation`→`user`/`flagger`). Monitoring unifies similarly — discovery-born signals keep the existing issue-event escalation path until Phase 5/9, while custom signals get the new signal-score path in Phase 4. Running two paths temporarily is intentional and non-breaking.
 
-### Phase 1 — Rename Issues → Signals `[MVP]`  · deps: none
+### Phase 1 — Rename Issues → Signals `[MVP]`
 
-**Ships** the entire current system under the Signals name — discovery, monitors, alerts, notifications behave identically. **Safe because** it's a pure rename, no semantics change. **Exit gate:** full suite green; `/issues` URLs + `?issueId=` deep links redirect; SDK back-compat alias resolves; zero behavioral diff. Can be stacked PRs (schema+domain → API → web), each keeping the build green; no flag (it's a rename), but coordinate the SDK release.
+**Deps:** none.
+**Ships:** the entire current system under the Signals name — discovery, monitors, alerts, notifications behave identically.
+**Safe because:** it's a pure rename, no semantics change. Can be stacked PRs (schema+domain → API → web), each keeping the build green; no flag (it's a rename), but coordinate the SDK release.
 
-- **1a** `[ ]` PG rename migration (Drizzle Kit): `issues`→`signals`; `scores.issue_id`→`signal_id`, `evaluations.issue_id`→`signal_id`; rename dependent indexes + `organizationRLSPolicy("signals")`. Column semantics unchanged.
-- **1b** `[ ]` CH rename (`pnpm --filter @platform/db-clickhouse ch:create`, append-only): `ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT ''`; `ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != ''`; point `score-analytics-repository.ts` + `score-fields.ts` at `signal_id`; keep `issue_id` until Phase 9.
-- **1c** `[ ]` Domain rename `@domain/issues`→`@domain/signals`: folder + package name + all imports; `Issue*`→`Signal*` types/ports/use-cases; events `IssueCreated/Regressed/Escalated`→`Signal*`, `ScoreAssignedToIssue`→`ScoreAssignedToSignal`. **Keep internal alert-kind strings `issue.*`** (persisted in `alert_incidents.kind`; renamed in Phase 9) — only relabel `ALERT_INCIDENT_KIND_LABEL`.
-- **1d** `[ ]` Platform: `@platform/db-postgres` `issue-repository`→`signal-repository`, schema `issues.ts`→`signals.ts`, mappers.
-- **1e** `[ ]` API: `apps/api/src/routes/issues.ts`→`signals.ts`, op ids `listIssues`→`listSignals` etc., mount `/projects/:projectSlug/signals`; keep `/issues` as a deprecated alias to the same handlers; `pnpm openapi:emit && pnpm mcp:emit` + SDK generate.
-- **1f** `[ ]` Web: signals routes/pages/`-components`; `ProjectSidebar` nav; `/issues/...`→`/signals/...` redirect; `?issueId=` deep-link redirect.
-- **1g** `[ ]` Copy: notification templates + `ALERT_INCIDENT_KIND_LABEL` Issue→Signal wording (email/Slack/in-app).
-- **1h** `[ ]` Docs: `dev-docs/issues.md`→`dev-docs/signals.md`; fix references in `monitors.md`/`scores.md`/`reliability.md`; AGENTS.md skill glossary.
+- [ ] **P1-a** PG rename migration (Drizzle Kit): `issues`→`signals`; `scores.issue_id`→`signal_id`, `evaluations.issue_id`→`signal_id`; rename dependent indexes + `organizationRLSPolicy("signals")`. Column semantics unchanged.
+- [ ] **P1-b** CH rename (`pnpm --filter @platform/db-clickhouse ch:create`, append-only): `ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT ''`; `ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != ''`; point `score-analytics-repository.ts` + `score-fields.ts` at `signal_id`; keep `issue_id` until Phase 9.
+- [ ] **P1-c** Domain rename `@domain/issues`→`@domain/signals`: folder + package name + all imports; `Issue*`→`Signal*` types/ports/use-cases; events `IssueCreated/Regressed/Escalated`→`Signal*`, `ScoreAssignedToIssue`→`ScoreAssignedToSignal`. **Keep internal alert-kind strings `issue.*`** (persisted in `alert_incidents.kind`; renamed in Phase 9) — only relabel `ALERT_INCIDENT_KIND_LABEL`.
+- [ ] **P1-d** Platform: `@platform/db-postgres` `issue-repository`→`signal-repository`, schema `issues.ts`→`signals.ts`, mappers.
+- [ ] **P1-e** API: `apps/api/src/routes/issues.ts`→`signals.ts`, op ids `listIssues`→`listSignals` etc., mount `/projects/:projectSlug/signals`; keep `/issues` as a deprecated alias to the same handlers; `pnpm openapi:emit && pnpm mcp:emit` + SDK generate.
+- [ ] **P1-f** Web: signals routes/pages/`-components`; `ProjectSidebar` nav; `/issues/...`→`/signals/...` redirect; `?issueId=` deep-link redirect.
+- [ ] **P1-g** Copy: notification templates + `ALERT_INCIDENT_KIND_LABEL` Issue→Signal wording (email/Slack/in-app).
+- [ ] **P1-h** Docs: `dev-docs/issues.md`→`dev-docs/signals.md`; fix references in `monitors.md`/`scores.md`/`reliability.md`; AGENTS.md skill glossary.
 
-### Phase 2 — Tracker substrate + custom semantic signals `[MVP]`  · deps: P1
+**Exit gate:** full suite green; `/issues` URLs + `?issueId=` deep links redirect; SDK back-compat alias resolves; zero behavioral diff.
 
-**Ships** user-created `semantic_similarity` signals; write-time matching populates them; the signal page shows matched traces + occurrence trend. (Alerting on custom signals arrives in P4.) **Safe because** it's additive schema + new code behind the `signals` flag; discovery/monitors untouched. **Exit gate:** create a semantic signal → new in-scope traces produce CH-only tracker scores → visible on the signal page; backfill works; existing signals/discovery unaffected.
+### Phase 2 — Tracker substrate + custom semantic signals `[MVP]`
 
-- **2a** `[ ]` Contracts (`@domain/shared`, `@domain/scores`): `SIGNAL_ORIGINS`, `SIGNAL_TRACKER_TYPES`, `SignalTracker`/`SemanticAnchors` zod; rename score `source`→`source_type` and **add value `tracker`** (values `{tracker, evaluation, annotation, custom}`; the `evaluation`→`tracker` collapse + `annotation` split are P9).
-- **2b** `[ ]` PG migration (additive): `signals.tracker jsonb null`, `filters jsonb null`, `origin varchar(16)` (backfill existing → `'system'`), `deleted_at` + partial-unique slug; make `centroid`/`clustered_at` nullable; add the `(org, project) WHERE deleted_at IS NULL AND tracker IS NOT NULL` "active tracked" index.
-- **2c** `[ ]` Scores CH-only write path (`@domain/scores`): a tracker-score writer that freezes `passed = value ≥ tracker.threshold` and **inserts straight to CH analytics, skipping the canonical Postgres row** for pure trackers — the one genuinely new write path; reuse `syncScoreAnalyticsUseCase`'s CH insert + at-most-once-by-id guard; idempotent per `(signal, trace)`.
-- **2d** `[ ]` Matching pipeline skeleton (`@domain/signals` + a `signals:match` worker off `TracesIngested` via the domain-events dispatcher): `matchTracesToSignalsUseCase`, `listActiveTracked(projectId)` Redis-cached (org-prefixed), shared `filters` pre-gate reusing row-local `FilterSet` evaluation. Generalized from `EvaluationTrigger`'s filter stage.
-- **2e** `[ ]` Semantic runner (`signals:semanticMatch` per trace, off `trace_search_embeddings`): load per-signal anchor embeddings (Redis-cached, reuse the conversation-intelligence anchor-cache pattern), `value = max(chunk · positiveAnchor)`, match on `value ≥ threshold ∧ bestPos − bestContrast ≥ margin` → CH-only tracker score. Generalize `@domain/conversation-intelligence` anchor matching from fixed `MOMENT_LABEL_ANCHORS` to per-signal anchors.
-- **2f** `[ ]` Backfill (`signals:backfill {signalId, window}`): `backfillSignalScoresUseCase` runs the detector over historical traces in batches → CH-only scores; enqueued on semantic-signal create.
-- **2g** `[ ]` Builder UI (semantic): `apps/web` signals `-components` — `filters` + anchors/contrast + threshold (sensitivity); **live preview** = bounded exact scan over a recent window using existing content embeddings. Entry points: "New signal", "Create signal from this search".
-- **2h** `[ ]` Signal CRUD API + MCP: `createSignal`/`updateSignal`/`deleteSignal` (reject tracker-less create for `origin=user`); MCP/SDK regen. Reuse the monitors route template.
+**Deps:** P1.
+**Ships:** user-created `semantic_similarity` signals; write-time matching populates them; the signal page shows matched traces + occurrence trend. (Alerting on custom signals arrives in P4.)
+**Safe because:** it's additive schema + new code behind the `signals` flag; discovery/monitors untouched.
 
-### Phase 3 — User-created LLM-as-judge signals `[MVP]`  · deps: P2 (substrate only — **not** the semantic runner)
+- [ ] **P2-a** Contracts (`@domain/shared`, `@domain/scores`): `SIGNAL_ORIGINS`, `SIGNAL_TRACKER_TYPES`, `SignalTracker`/`SemanticAnchors` zod; rename score `source`→`source_type` and **add value `tracker`** (values `{tracker, evaluation, annotation, custom}`; the `evaluation`→`tracker` collapse + `annotation` split are P9).
+- [ ] **P2-b** PG migration (additive): `signals.tracker jsonb null`, `filters jsonb null`, `origin varchar(16)` (backfill existing → `'system'`), `deleted_at` + partial-unique slug; make `centroid`/`clustered_at` nullable; add the `(org, project) WHERE deleted_at IS NULL AND tracker IS NOT NULL` "active tracked" index.
+- [ ] **P2-c** Scores CH-only write path (`@domain/scores`): a tracker-score writer that freezes `passed = value ≥ tracker.threshold` and **inserts straight to CH analytics, skipping the canonical Postgres row** for pure trackers — the one genuinely new write path; reuse `syncScoreAnalyticsUseCase`'s CH insert + at-most-once-by-id guard; idempotent per `(signal, trace)`.
+- [ ] **P2-d** Matching pipeline skeleton (`@domain/signals` + a `signals:match` worker off `TracesIngested` via the domain-events dispatcher): `matchTracesToSignalsUseCase`, `listActiveTracked(projectId)` Redis-cached (org-prefixed), shared `filters` pre-gate reusing row-local `FilterSet` evaluation. Generalized from `EvaluationTrigger`'s filter stage.
+- [ ] **P2-e** Semantic runner (`signals:semanticMatch` per trace, off `trace_search_embeddings`): load per-signal anchor embeddings (Redis-cached, reuse the conversation-intelligence anchor-cache pattern), `value = max(chunk · positiveAnchor)`, match on `value ≥ threshold ∧ bestPos − bestContrast ≥ margin` → CH-only tracker score. Generalize `@domain/conversation-intelligence` anchor matching from fixed `MOMENT_LABEL_ANCHORS` to per-signal anchors.
+- [ ] **P2-f** Backfill (`signals:backfill {signalId, window}`): `backfillSignalScoresUseCase` runs the detector over historical traces in batches → CH-only scores; enqueued on semantic-signal create.
+- [ ] **P2-g** Builder UI (semantic): `apps/web` signals `-components` — `filters` + anchors/contrast + threshold (sensitivity); **live preview** = bounded exact scan over a recent window using existing content embeddings. Entry points: "New signal", "Create signal from this search".
+- [ ] **P2-h** Signal CRUD API + MCP: `createSignal`/`updateSignal`/`deleteSignal` (reject tracker-less create for `origin=user`); MCP/SDK regen. Reuse the monitors route template.
 
-**Ships** a builder option to author a judge signal (describe the behavior + optional example traces → generated judge), running on the **existing** evaluation execution path. **Safe because** it reuses the proven evaluation generation/alignment/execution stack; additive UI. **Exit gate:** create a judge signal → it runs on live traffic via `EvaluationTrigger` → writes signal-linked scores → alignment shows accruing/aligned.
+**Exit gate:** create a semantic signal → new in-scope traces produce CH-only tracker scores → visible on the signal page; backfill works; existing signals/discovery unaffected.
 
-- **3a** `[ ]` Standalone evaluation creation (`@domain/evaluations`): allow creating an evaluation linked to a fresh signal (not only via issue promotion); set the signal's `tracker = { type:'llm_as_judge', threshold }` and `evaluations.signal_id`.
-- **3b** `[ ]` Generation reuse: drive the existing `optimize-evaluation` workflow (`evaluations:generate:${signalId}`) from the builder; with example traces → aligned (reuse `collectAlignmentExamples` + `evaluateDraftAgainstExamples`); without → unaligned start, alignment accrues as annotations land.
-- **3c** `[ ]` Builder UI (judge): description + optional example-trace picker (reuse the annotation-flow picker); preview via the sandbox dry-run harness; alignment polled via `workflow.describe()` (reuse `getSignalAlignmentState`).
-- **3d** `[ ]` Execution linkage: verify the `EvaluationTrigger` path writes `signal_id`-bearing scores for a user-created (non-discovered) signal; polarity/`passed` normalized to exhibition.
+### Phase 3 — User-created LLM-as-judge signals `[MVP]`
 
-### Phase 4 — Monitors on signals `[MVP]` (hard-req 4)  · deps: P2
+**Deps:** P2 (substrate only — **not** the semantic runner).
+**Ships:** a builder option to author a judge signal (describe the behavior + optional example traces → generated judge), running on the **existing** evaluation execution path.
+**Safe because:** it reuses the proven evaluation generation/alignment/execution stack; additive UI.
 
-**Ships** alerting on custom (and any) signals; users create monitors targeting a signal with a metric + alerts (tools/users monitor UX copied); each new signal gets a default monitor. **Safe because** it's additive monitor columns + a new reader; existing project-level system monitors keep covering discovery-born signals via the existing path. **Exit gate:** create a monitor on a signal → metric series computes from signal scores → alert fires → incident + notification.
+- [ ] **P3-a** Standalone evaluation creation (`@domain/evaluations`): allow creating an evaluation linked to a fresh signal (not only via issue promotion); set the signal's `tracker = { type:'llm_as_judge', threshold }` and `evaluations.signal_id`.
+- [ ] **P3-b** Generation reuse: drive the existing `optimize-evaluation` workflow (`evaluations:generate:${signalId}`) from the builder; with example traces → aligned (reuse `collectAlignmentExamples` + `evaluateDraftAgainstExamples`); without → unaligned start, alignment accrues as annotations land.
+- [ ] **P3-c** Builder UI (judge): description + optional example-trace picker (reuse the annotation-flow picker); preview via the sandbox dry-run harness; alignment polled via `workflow.describe()` (reuse `getSignalAlignmentState`).
+- [ ] **P3-d** Execution linkage: verify the `EvaluationTrigger` path writes `signal_id`-bearing scores for a user-created (non-discovered) signal; polarity/`passed` normalized to exhibition.
 
-- **4a** `[ ]` PG migration (additive): `monitors.target_signal_id`, `is_default` + the two indexes.
-- **4b** `[ ]` `SignalScoreReader` (`@platform/db-clickhouse`): `count WHERE signal_id=? AND passed`; `avg`/`p95`/`sum` of trace `duration`/`cost`/`tokens` by joining matched `trace_id → traces`; `errorRate`; per-bucket series for the escalation machine. Mirrors `SavedSearchMatchReader`.
-- **4c** `[ ]` Signal monitor evaluation: wire signal targets into `evaluateMonitorUseCase`, reusing the unified `event.matched`/`metric.threshold`/`metric.escalating` state machines (`run-*-alert.ts`) over the `SignalScoreReader` series; `metric.escalating` `expected` mode reuses `evaluateSeasonalEscalation`.
-- **4d** `[ ]` `event.regressed` kind: add to `ALERT_INCIDENT_KINDS` (+ point lifecycle, no-condition, label, severity); fires on the first datapoint after the signal's `resolved_at` clears (mirror `issue.regressed`, signal-driven).
-- **4e** `[ ]` Default monitor provisioning: `provisionDefaultSignalMonitorUseCase` on signal create (count + `metric.escalating` expected + `event.regressed`, `is_default=true`); reuse `provisionSystemMonitorsUseCase` patterns.
-- **4f** `[ ]` Monitor-on-signal UI: create/edit (metric + alert card stack, copied from the tools/users monitor flow) on the signal page; monitors-list **Target** column deep-linking to the signal.
-- **4g** `[ ]` Monitors API + MCP: signal target on create/update; regen.
+**Exit gate:** create a judge signal → it runs on live traffic via `EvaluationTrigger` → writes signal-linked scores → alignment shows accruing/aligned.
+
+### Phase 4 — Monitors on signals `[MVP]` (hard-req 4)
+
+**Deps:** P2.
+**Ships:** alerting on custom (and any) signals; users create monitors targeting a signal with a metric + alerts (tools/users monitor UX copied); each new signal gets a default monitor.
+**Safe because:** it's additive monitor columns + a new reader; existing project-level system monitors keep covering discovery-born signals via the existing path.
+
+- [ ] **P4-a** PG migration (additive): `monitors.target_signal_id`, `is_default` + the two indexes.
+- [ ] **P4-b** `SignalScoreReader` (`@platform/db-clickhouse`): `count WHERE signal_id=? AND passed`; `avg`/`p95`/`sum` of trace `duration`/`cost`/`tokens` by joining matched `trace_id → traces`; `errorRate`; per-bucket series for the escalation machine. Mirrors `SavedSearchMatchReader`.
+- [ ] **P4-c** Signal monitor evaluation: wire signal targets into `evaluateMonitorUseCase`, reusing the unified `event.matched`/`metric.threshold`/`metric.escalating` state machines (`run-*-alert.ts`) over the `SignalScoreReader` series; `metric.escalating` `expected` mode reuses `evaluateSeasonalEscalation`.
+- [ ] **P4-d** `event.regressed` kind: add to `ALERT_INCIDENT_KINDS` (+ point lifecycle, no-condition, label, severity); fires on the first datapoint after the signal's `resolved_at` clears (mirror `issue.regressed`, signal-driven).
+- [ ] **P4-e** Default monitor provisioning: `provisionDefaultSignalMonitorUseCase` on signal create (count + `metric.escalating` expected + `event.regressed`, `is_default=true`); reuse `provisionSystemMonitorsUseCase` patterns.
+- [ ] **P4-f** Monitor-on-signal UI: create/edit (metric + alert card stack, copied from the tools/users monitor flow) on the signal page; monitors-list **Target** column deep-linking to the signal.
+- [ ] **P4-g** Monitors API + MCP: signal target on create/update; regen.
+
+**Exit gate:** create a monitor on a signal → metric series computes from signal scores → alert fires → incident + notification.
 
 > **— MVP line: Phases 1–4 —**
 
-### Phase 5 — Unify judge execution onto the tracker pipeline `[POST-MVP · internal]`  · deps: P2, P3
+### Phase 5 — Unify judge execution onto the tracker pipeline `[POST-MVP · internal]`
 
-**Ships** judge execution moved from the standalone `EvaluationTrigger` path into the Phase-2 matching pipeline (shared `filters` pre-gate, one sandbox runner). No user-facing change. **Safe because** parity-tested behind a flag, then cut over; retires the temporary two-path state.
+**Deps:** P2, P3.
+**Ships:** judge execution moved from the standalone `EvaluationTrigger` path into the Phase-2 matching pipeline (shared `filters` pre-gate, one sandbox runner). No user-facing change.
+**Safe because:** parity-tested behind a flag, then cut over; retires the temporary two-path state.
 
-- **5a** `[ ]` Run judges through `matchTracesToSignalsUseCase`'s sandbox runner. **5b** `[ ]` Parity suite (every stored judge: old path vs pipeline → identical scores). **5c** `[ ]` Cut over; remove the standalone trigger path.
+- [ ] **P5-a** Run judges through `matchTracesToSignalsUseCase`'s sandbox runner.
+- [ ] **P5-b** Parity suite (every stored judge: old path vs pipeline → identical scores).
+- [ ] **P5-c** Cut over; remove the standalone trigger path.
 
-### Phase 6 — Script (custom code) trackers `[POST-MVP · last]`  · deps: P2 (+ sandbox P2)
+**Exit gate:** parity suite green; standalone trigger path removed; no behavioral diff.
 
-**Ships** the `script` tracker type — raw user JS via the sandbox. Nothing depends on it. **Safe because** it's an additive type behind the flag.
+### Phase 6 — Script (custom code) trackers `[POST-MVP · last]`
 
-- **6a** `[ ]` Finish `specs/sandbox-runtime.md` P2 (dry-run harness + threshold membership) if outstanding.
-- **6b** `[ ]` `script` tracker in the matching pipeline (sandbox runner; CH-only pure scores; capability detection — a script calling `llm()` persists like a judge).
-- **6c** `[ ]` Builder + MCP authoring: compile-on-save validation (`ScriptCompileError`), dry-run against sample traces, and **surface the sandbox globals** (`conversation`, `llm()`, `z`, `Score/Passed/Failed`) in the MCP tool description (soft-req 1).
+**Deps:** P2 (+ sandbox P2).
+**Ships:** the `script` tracker type — raw user JS via the sandbox. Nothing depends on it.
+**Safe because:** it's an additive type behind the flag.
 
-### Phase 7 — Moments → default signals `[SOFT]`  · deps: P2
+- [ ] **P6-a** Finish `specs/sandbox-runtime.md` P2 (dry-run harness + threshold membership) if outstanding.
+- [ ] **P6-b** `script` tracker in the matching pipeline (sandbox runner; CH-only pure scores; capability detection — a script calling `llm()` persists like a judge).
+- [ ] **P6-c** Builder + MCP authoring: compile-on-save validation (`ScriptCompileError`), dry-run against sample traces, and **surface the sandbox globals** (`conversation`, `llm()`, `z`, `Score/Passed/Failed`) in the MCP tool description (soft-req 1).
 
-- **7a** `[ ]` Provision the 8 `MOMENT_KINDS` as `origin=system` `semantic_similarity` signals (anchors = `MOMENT_LABEL_ANCHORS`, threshold = each kind's static gate) via the project-provision hook. **7b** `[ ]` The semantic runner subsumes the moment-label anchor pass (one matching path).
+**Exit gate:** create a `script` signal → it compiles on save, dry-runs against samples, and produces tracker scores in the pipeline.
 
-### Phase 8 — Flagger consolidation `[SOFT]`  · deps: P7
+### Phase 7 — Moments → default signals `[SOFT]`
 
-- **8a** `[ ]` For flaggers overlapping a moment/semantic signal (e.g. `frustration`), make the semantic signal canonical and retire the flagger from `provisionFlaggers`. **8b** `[ ]` Non-overlapping flaggers keep feeding sinks via discovery (unchanged).
+**Deps:** P2.
 
-### Phase 9 — Taxonomy cleanup + legacy retirement `[POST-MVP]`  · deps: P1–P5
+- [ ] **P7-a** Provision the 8 `MOMENT_KINDS` as `origin=system` `semantic_similarity` signals (anchors = `MOMENT_LABEL_ANCHORS`, threshold = each kind's static gate) via the project-provision hook.
+- [ ] **P7-b** The semantic runner subsumes the moment-label anchor pass (one matching path).
 
-- **9a** `[ ]` Finish `source_type`: remap `evaluation`→`tracker`, split `annotation`→`flagger` (sourceId=SYSTEM) / `user` (else) (PG + CH backfill).
-- **9b** `[ ]` Retire `issue.*` / `savedSearch.*` alert kinds once all monitors run on signal targets (breaking SDK — major bump).
-- **9c** `[ ]` Drop deprecated CH `issue_id` and any dormant columns.
-- **9d** `[ ]` `/scores` accepts caller-supplied `signal_id` for `custom`-source trackers (the POST-MVP custom-source path).
+**Exit gate:** new projects provision the 8 moment signals; moment labeling runs through the semantic runner with no behavioral diff.
+
+### Phase 8 — Flagger consolidation `[SOFT]`
+
+**Deps:** P7.
+
+- [ ] **P8-a** For flaggers overlapping a moment/semantic signal (e.g. `frustration`), make the semantic signal canonical and retire the flagger from `provisionFlaggers`.
+- [ ] **P8-b** Non-overlapping flaggers keep feeding sinks via discovery (unchanged).
+
+**Exit gate:** overlapping flaggers retired into their semantic signal; non-overlapping flaggers still feed sinks.
+
+### Phase 9 — Taxonomy cleanup + legacy retirement `[POST-MVP]`
+
+**Deps:** P1–P5.
+
+- [ ] **P9-a** Finish `source_type`: remap `evaluation`→`tracker`, split `annotation`→`flagger` (sourceId=SYSTEM) / `user` (else) (PG + CH backfill).
+- [ ] **P9-b** Retire `issue.*` / `savedSearch.*` alert kinds once all monitors run on signal targets (breaking SDK — major bump).
+- [ ] **P9-c** Drop deprecated CH `issue_id` and any dormant columns.
+- [ ] **P9-d** `/scores` accepts caller-supplied `signal_id` for `custom`-source trackers (the POST-MVP custom-source path).
+
+**Exit gate:** `source_type` fully collapsed to the four-value enum; legacy `issue.*`/`savedSearch.*` kinds and `issue_id` removed; `custom`-source push live.


### PR DESCRIPTION
Revises `specs/signals.md` (the original LAT-664 unified-tracking spec) into a **tracker**-based model. Spec only — no code in this PR.

## the model

A **signal** is a tracked bucket of traces whose members are its **scores** — there is no separate occurrence ledger. A signal carries:

- an **origin** — `user` (hand-built) or `system` (auto-created);
- an optional **tracker** (a jsonb column, one per signal): the write-time detector, one of `semantic_similarity`, `script`, or `llm_as_judge`. A tracker-less signal is a **sink**;
- an optional **filters** `FilterSet` that pre-gates the tracker.

A tracker runs against each in-scope trace at ingest and writes a score; membership is the matched subset, where `passed = value ≥ threshold` is frozen at write time. Auto-discovery keeps working: flagger and human annotations route to (or create) tracker-less sink signals via the existing centroid + hybrid-search pipeline, and a sink can later be **promoted** to a judge tracker through today's "Monitor issue" / optimize-evaluation flow, with its accumulated annotations as the alignment ground truth.

## what changed from the prior spec

The original spec removed auto-discovery and added a separate `signal_occurrences` table. This revision reverses both:

- **Discovery stays**, modeled as tracker-less sink signals — the flagger and discovery machinery is reused unchanged.
- **Occurrences are scores.** `signal_occurrences` is dropped. Pure-tracker matches are immutable, so they write straight to the ClickHouse score-analytics table and skip the canonical Postgres row; judge and annotation scores keep the existing Postgres-canonical → ClickHouse path. That split is what lets a single ledger scale.
- **The tracker replaces the matcher-on-the-signal model**, and the `annotation_sink` tracker is gone — a sink is simply a signal with no tracker.

## data model

No new tables. `issues` → `signals` (adds `tracker`, `filters`, `origin`); `scores` gains `source_type` (with a new `tracker` value) and `signal_id`; `monitors` gains `target_signal_id`; the ClickHouse `scores` table gains `signal_id`. The unified `event.*` / `metric.*` alert kinds and `MonitorMetric` already exist — only `event.regressed` is new.

## build plan

The spec ends with a phased plan in which every phase is an independently shippable, non-breaking deploy. **MVP is phases 1–4:** rename issues→signals (behavior-identical), custom semantic signals, user-created judge signals (reusing the evaluation stack), and monitors on signals. Script trackers, unifying judge execution onto the tracker pipeline, moments→signals, and flagger consolidation are post-MVP.

Refs LAT-664.
