### PR TITLE
fix(backoffice): hide non-visible taxonomy clusters

### DIFF
--- a/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.test.ts
@@ -24,6 +24,9 @@ const CATEGORY = makeId("cat-tax-checkout")
 const SUBCATEGORY = makeId("clu-tax-card")
 const UNCATEGORIZED = makeId("clu-tax-uncat")
 const OTHER_SUBCATEGORY = makeId("clu-tax-other")
+const DEPRECATED_CLUSTER = makeId("clu-tax-deprecated")
+const EMPTY_CLUSTER = makeId("clu-tax-empty")
+const PENDING_CLUSTER = makeId("clu-tax-pending")
 
 const centroid = {
   base: [],
@@ -124,10 +127,62 @@ describe("AdminTaxonomyRepositoryLive.getProjectTaxonomy", () => {
         createdAt: baseTime,
         updatedAt: baseTime,
       },
+      {
+        id: DEPRECATED_CLUSTER,
+        organizationId: ORG,
+        projectId: PROJECT,
+        parentClusterId: CATEGORY,
+        depth: 1,
+        path: `${CATEGORY}/`,
+        name: "Deprecated cluster",
+        description: "Should not be returned.",
+        centroid,
+        observationCount: 99,
+        state: "deprecated",
+        firstObservedAt: baseTime,
+        lastObservedAt: baseTime,
+        clusteredAt: baseTime,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: EMPTY_CLUSTER,
+        organizationId: ORG,
+        projectId: PROJECT,
+        parentClusterId: CATEGORY,
+        depth: 1,
+        path: `${CATEGORY}/`,
+        name: "Empty cluster",
+        description: "Should not be returned.",
+        centroid,
+        observationCount: 0,
+        firstObservedAt: baseTime,
+        lastObservedAt: baseTime,
+        clusteredAt: baseTime,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: PENDING_CLUSTER,
+        organizationId: ORG,
+        projectId: PROJECT,
+        parentClusterId: CATEGORY,
+        depth: 1,
+        path: `${CATEGORY}/`,
+        name: "Pending",
+        description: "Should not be returned.",
+        centroid,
+        observationCount: 99,
+        firstObservedAt: baseTime,
+        lastObservedAt: baseTime,
+        clusteredAt: baseTime,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
     ])
   })
 
-  it("returns categories with assigned and uncategorized subcategories for the project", async () => {
+  it("returns only taxonomy clusters visible to users", async () => {
     const result = await runWithLive(
       Effect.gen(function* () {
         const repo = yield* AdminTaxonomyRepository
@@ -139,7 +194,7 @@ describe("AdminTaxonomyRepositoryLive.getProjectTaxonomy", () => {
     expect(result.categories[0]?.id).toBe(CATEGORY)
     expect(result.categories[0]?.observationCount).toBe(10)
     expect(result.categories[0]?.subcategories.map((subcategory) => subcategory.id)).toEqual([SUBCATEGORY])
-    expect(result.uncategorized.map((subcategory) => subcategory.id)).toEqual([UNCATEGORIZED])
+    expect(result.uncategorized).toEqual([])
   })
 
   it("fails with NotFoundError for a non-existent project id", async () => {

--- a/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.ts
@@ -5,6 +5,7 @@ import {
   type AdminTaxonomySubcategory,
 } from "@domain/admin"
 import { NotFoundError, type ProjectId, SqlClient, type SqlClientShape } from "@domain/shared"
+import { isDisplayableTaxonomyName } from "@domain/taxonomy"
 import { and, asc, desc, eq, isNull } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
@@ -40,9 +41,6 @@ export const AdminTaxonomyRepositoryLive = Layer.effect(
             return yield* Effect.fail(new NotFoundError({ entity: "Project", id: projectId }))
           }
 
-          // The unified cluster tree replaced flat categories: depth-0 roots
-          // are the top-level groups and every descendant rolls up to its
-          // root (first path segment).
           const clusterRows = yield* sqlClient.query((db) =>
             db
               .select({
@@ -69,17 +67,22 @@ export const AdminTaxonomyRepositoryLive = Layer.effect(
               .orderBy(desc(taxonomyClusters.observationCount), asc(taxonomyClusters.name)),
           )
 
-          const rootRows = clusterRows.filter((row) => row.parentClusterId === null && row.state !== "merged")
+          const visibleRows = clusterRows.filter(
+            (row) => row.state === "active" && isDisplayableTaxonomyName(row.name) && row.observationCount > 0,
+          )
+          const rootRows = clusterRows.filter(
+            (row) => row.parentClusterId === null && row.state === "active" && isDisplayableTaxonomyName(row.name),
+          )
           const rootIds = new Set(rootRows.map((row) => row.id))
           const subcategoriesByRoot = new Map<string, AdminTaxonomySubcategory[]>()
-          const uncategorized: AdminTaxonomySubcategory[] = []
 
-          for (const row of clusterRows) {
+          for (const row of visibleRows) {
             if (row.parentClusterId === null) continue
             const rootId = row.path.split("/")[0] ?? ""
+            if (!rootIds.has(rootId)) continue
             const subcategory: AdminTaxonomySubcategory = {
               id: row.id,
-              categoryId: rootIds.has(rootId) ? rootId : null,
+              categoryId: rootId,
               name: row.name,
               description: row.description,
               observationCount: row.observationCount,
@@ -89,34 +92,33 @@ export const AdminTaxonomyRepositoryLive = Layer.effect(
               createdAt: row.createdAt,
               updatedAt: row.updatedAt,
             }
-            if (subcategory.categoryId === null) {
-              uncategorized.push(subcategory)
-              continue
-            }
-            const existing = subcategoriesByRoot.get(subcategory.categoryId) ?? []
+            const existing = subcategoriesByRoot.get(rootId) ?? []
             existing.push(subcategory)
-            subcategoriesByRoot.set(subcategory.categoryId, existing)
+            subcategoriesByRoot.set(rootId, existing)
           }
 
-          const categories: AdminTaxonomyCategory[] = rootRows.map((row) => {
+          const categories: AdminTaxonomyCategory[] = rootRows.flatMap((row) => {
             const subcategories = subcategoriesByRoot.get(row.id) ?? []
-            return {
-              id: row.id,
-              name: row.name,
-              description: row.description,
-              clusterCount: subcategories.length,
-              observationCount:
-                row.observationCount +
-                subcategories.reduce((sum, subcategory) => sum + subcategory.observationCount, 0),
-              state: row.state === "active" ? "active" : "deprecated",
-              clusteredAt: row.clusteredAt,
-              createdAt: row.createdAt,
-              updatedAt: row.updatedAt,
-              subcategories,
-            }
+            const observationCount =
+              row.observationCount + subcategories.reduce((sum, subcategory) => sum + subcategory.observationCount, 0)
+            if (observationCount === 0) return []
+            return [
+              {
+                id: row.id,
+                name: row.name,
+                description: row.description,
+                clusterCount: subcategories.length,
+                observationCount,
+                state: "active",
+                clusteredAt: row.clusteredAt,
+                createdAt: row.createdAt,
+                updatedAt: row.updatedAt,
+                subcategories,
+              },
+            ]
           })
 
-          return { categories, uncategorized } satisfies AdminProjectTaxonomy
+          return { categories, uncategorized: [] } satisfies AdminProjectTaxonomy
         }),
     }
   }),


### PR DESCRIPTION
Backoffice project taxonomy now mirrors the taxonomy users see instead of dumping every stored cluster row. The admin taxonomy repository filters out deprecated or merged clusters, placeholder names like `Pending`, zero-observation subcategories, and orphaned rows whose root is no longer part of the active taxonomy. Empty top-level categories are also dropped unless they contain visible children.

This keeps support/debugging views focused on the active taxonomy rather than internal taxonomy-gardening artifacts.

Validated with:
- `pnpm --filter @platform/db-postgres typecheck`
- `pnpm --filter @platform/db-postgres test -- admin-taxonomy-repository.test.ts`