### PR TITLE
fix(web): skip annotation queries without trace id

### DIFF
--- a/apps/web/src/domains/annotations/annotations.collection.test.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  listAnnotationCountsByTraceIds: vi.fn(),
+  listAnnotationsBySession: vi.fn(),
+  listAnnotationsByTrace: vi.fn(),
+  useMutation: vi.fn(),
+  useQueries: vi.fn(() => []),
+  useQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useQueryClient: vi.fn(() => ({
+    cancelQueries: vi.fn(),
+    getQueriesData: vi.fn(() => []),
+    invalidateQueries: vi.fn(),
+    setQueriesData: vi.fn(),
+    setQueryData: vi.fn(),
+  })),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: mocks.useMutation,
+  useQueries: mocks.useQueries,
+  useQuery: mocks.useQuery,
+  useQueryClient: mocks.useQueryClient,
+}))
+
+vi.mock("./annotations.functions.ts", () => ({
+  approveSystemAnnotation: vi.fn(),
+  createAnnotation: vi.fn(),
+  deleteAnnotation: vi.fn(),
+  listAnnotationCountsByTraceIds: mocks.listAnnotationCountsByTraceIds,
+  listAnnotationsBySession: mocks.listAnnotationsBySession,
+  listAnnotationsByTrace: mocks.listAnnotationsByTrace,
+  rejectSystemAnnotation: vi.fn(),
+  updateAnnotation: vi.fn(),
+}))
+
+import { useAnnotationsByTrace } from "./annotations.collection.ts"
+
+describe("useAnnotationsByTrace", () => {
+  beforeEach(() => {
+    mocks.useQuery.mockClear()
+  })
+
+  it("does not fetch when traceId is empty", () => {
+    useAnnotationsByTrace({ projectId: "project-1", traceId: "" })
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+  })
+
+  it("does not fetch when projectId is empty", () => {
+    useAnnotationsByTrace({ projectId: "", traceId: "0123456789abcdef0123456789abcdef" })
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+  })
+
+  it("fetches when ids are present and the query is enabled", () => {
+    useAnnotationsByTrace({ projectId: "project-1", traceId: "0123456789abcdef0123456789abcdef" })
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }))
+  })
+
+  it("honors explicit disabled state", () => {
+    useAnnotationsByTrace({ projectId: "project-1", traceId: "0123456789abcdef0123456789abcdef", enabled: false })
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }))
+  })
+})

--- a/apps/web/src/domains/annotations/annotations.collection.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.ts
@@ -71,7 +71,7 @@ export function useAnnotationsByTrace({
       listAnnotationsByTrace({
         data: { projectId, traceId, limit, offset, draftMode: effectiveDraftMode },
       }),
-    enabled,
+    enabled: enabled && projectId.length > 0 && traceId.length > 0,
   })
 }
 


### PR DESCRIPTION
## Summary

Skips the trace annotations query until both `projectId` and `traceId` are present. This prevents sessions with no latest output trace from calling `listAnnotationsByTrace` with `traceId: ""` and producing handled `BadRequestError` noise.

## Datadog issue

Fixes [Datadog Error Tracking issue b57f819e-50fd-11f1-88c6-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/b57f819e-50fd-11f1-88c6-da7ad0900005): `BadRequestError: Too small: expected string to have >=32 characters` in `web`.

Datadog samples showed `listAnnotationsByTrace` requests with an empty trace id. The session conversation path can have `latestTraceId === ""` when a session has no output trace, but `useAnnotationsByTrace` previously only respected the caller's `enabled` flag and did not guard the ids itself. The issue first appeared on Datadog at `95a6c05c275d81eea01cedef4007583dca9a6954`.

## Validation

- `pnpm --filter @app/web test -- annotations.collection.test.ts`
- `pnpm exec biome check apps/web/src/domains/annotations/annotations.collection.ts apps/web/src/domains/annotations/annotations.collection.test.ts`
- `pnpm --filter @app/web typecheck`
