### PR TITLE
feat(telemetry): Google ADK support + join tool calls and results for OpenInference traces

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -275,6 +275,7 @@ export function ConversationTab({
   searchQuery,
   focusMomentKind,
   focusMomentId,
+  navigateToSpan,
 }: {
   readonly projectId: string
   readonly session: SessionDetailRecord
@@ -285,6 +286,8 @@ export function ConversationTab({
   readonly focusMomentKind?: MomentKind | undefined
   /** Scrolls to this semantic moment when no label kind is focused. */
   readonly focusMomentId?: string | undefined
+  /** Navigates to a span in the session's single-trace Spans tab; enables the conversation's span-link affordances. */
+  readonly navigateToSpan?: ((spanId: string) => void) | undefined
 }) {
   const sessionId = session.sessionId
   // Annotations are an LLM-feedback feature — off under a sandbox scope.
@@ -385,6 +388,7 @@ export function ConversationTab({
       scrollContainerRef={scrollContainerRef}
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
       timeline={timeline}
+      {...(navigateToSpan ? { navigateToSpan } : {})}
       {...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {})}
       {...(searchQuery ? { searchQuery } : {})}
     />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -119,6 +119,12 @@ export function SessionSlot({
     onActiveTabChange("spans")
   }
 
+  function navigateToSpan(spanId: string) {
+    if (!singleTrace) return
+    setSelectedSpanId(spanId)
+    onActiveTabChange("spans")
+  }
+
   // Badge counts. Both queries are shared (same key) with the tab panes, so
   // mounting a tab doesn't refetch.
   const { data: annotationsData } = useAnnotationsBySession({
@@ -288,6 +294,7 @@ export function SessionSlot({
               isActive={effectiveActiveTab === "conversation"}
               focusMomentKind={focusMomentKind}
               focusMomentId={focusMomentId}
+              {...(singleTrace ? { navigateToSpan } : {})}
               {...(searchQuery ? { searchQuery } : {})}
             />
           </div>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -102,6 +102,7 @@
             "pages": [
               "telemetry/frameworks/vercel-ai-sdk",
               "telemetry/frameworks/openai-agents",
+              "telemetry/frameworks/google-adk",
               "telemetry/frameworks/langchain",
               "telemetry/frameworks/llamaindex",
               "telemetry/frameworks/mastra",

--- a/docs/telemetry/frameworks/google-adk.mdx
+++ b/docs/telemetry/frameworks/google-adk.mdx
@@ -1,0 +1,132 @@
+---
+title: Google ADK
+description: Connect your Google Agent Development Kit (ADK) application to Latitude for observability.
+---
+
+## Overview
+
+This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Google Agent Development Kit (ADK)** (`google-adk` for Python).
+
+Latitude includes dedicated instrumentation for Google ADK, so agent runs, model generations, and tool calls appear as traces.
+
+<Check>
+  You'll keep calling Google ADK exactly as you do today. Telemetry observes
+  agent runs, model calls, and tool calls as they happen.
+</Check>
+
+<Note>
+  Google ADK instrumentation is available in the **Python** SDK only.
+</Note>
+
+---
+
+## Requirements
+
+- A **Latitude account** and **API key**
+- A **Latitude project slug**
+- A project that uses **Google ADK** (`google-adk`)
+- A **Gemini API key** (set as `GOOGLE_API_KEY`)
+
+---
+
+## Steps
+
+<Steps>
+
+  <Step title="Install">
+    <CodeGroup>
+      ```bash pip
+      pip install latitude-telemetry google-adk
+      ```
+
+      ```bash uv
+      uv add latitude-telemetry google-adk
+      ```
+
+      ```bash poetry
+      poetry add latitude-telemetry google-adk
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Initialize and use">
+    ```python
+    import asyncio
+
+    import google.adk
+    from google.adk.agents import Agent
+    from google.adk.runners import InMemoryRunner
+    from google.genai import types
+
+    from latitude_telemetry import Latitude, capture
+
+    latitude = Latitude(
+        api_key="your-api-key",
+        project="your-project-slug",
+        instrumentations={"google_adk": google.adk},
+    )
+
+
+    def get_weather(city: str) -> dict:
+        """Returns the current weather for a city."""
+        return {"status": "success", "report": f"The weather in {city} is sunny."}
+
+
+    agent = Agent(
+        name="weather_agent",
+        model="gemini-2.5-flash",
+        description="Agent that answers weather questions using tools.",
+        instruction="Answer weather questions using get_weather.",
+        tools=[get_weather],
+    )
+
+
+    async def weather_agent_run():
+        runner = InMemoryRunner(agent=agent, app_name="weather_app")
+        await runner.session_service.create_session(
+            app_name="weather_app",
+            user_id="user_123",
+            session_id="session_abc",
+        )
+
+        async for event in runner.run_async(
+            user_id="user_123",
+            session_id="session_abc",
+            new_message=types.Content(
+                role="user",
+                parts=[types.Part(text="What's the weather in Barcelona?")],
+            ),
+        ):
+            if event.is_final_response() and event.content and event.content.parts:
+                return event.content.parts[0].text
+
+
+    capture("weather-agent-run", lambda: asyncio.run(weather_agent_run()))
+
+    latitude.shutdown()
+    ```
+  </Step>
+
+</Steps>
+
+---
+
+## What you get
+
+Each agent run shows up as a trace with nested spans:
+
+- **Agent spans** — agent name, instructions, and configured tools
+- **Generation spans** — model, input/output messages, and token usage
+- **Tool spans** — tool calls with input arguments and output
+
+Wrap a request or job with `capture()` to attach a `user_id`, `session_id`, `tags`, or `metadata` to every span produced inside.
+
+---
+
+## Seeing Your Traces
+
+Once connected, traces appear automatically in Latitude:
+
+1. Open your **project** in the Latitude dashboard
+2. Each agent run shows the full hierarchy of agent → generation → tool calls
+3. Token usage and latency are aggregated at every level

--- a/docs/telemetry/python.md
+++ b/docs/telemetry/python.md
@@ -133,6 +133,7 @@ Set the integration key on `instrumentations` to the SDK module your app imports
 | Together AI | `together` | `{"togetherai": together}` |
 | Vertex AI | `google-cloud-aiplatform` | `{"vertexai": vertexai}` |
 | Google AI Platform | `google-cloud-aiplatform` | `{"aiplatform": aiplatform}` |
+| Google ADK | `google-adk` | `{"google_adk": google.adk}` |
 | Google Generative AI | `google-generativeai` | `{"google_generativeai": genai}` |
 | Groq | `groq` | `{"groq": groq}` |
 | LiteLLM | `litellm` | `{"litellm": litellm}` |

--- a/packages/domain/spans/src/otlp/content/openinference.ts
+++ b/packages/domain/spans/src/otlp/content/openinference.ts
@@ -25,6 +25,7 @@ import type { ParsedContent } from "./index.ts"
 import { toToolDefinition } from "./utils.ts"
 
 interface ToolCallData {
+  id?: string
   name: string
   arguments: string
 }
@@ -41,6 +42,7 @@ interface ReassembledMessage {
   role: string
   content: MessageContent
   tool_calls?: { id: string; type: string; function: { name: string; arguments: string } }[]
+  tool_call_id?: string
 }
 
 const INPUT_PREFIX = "llm.input_messages."
@@ -78,7 +80,8 @@ function collectToolCallField(
   const msgToolCalls = getOrCreate(toolCalls, msgIndex, () => new Map())
   const tc = getOrCreate(msgToolCalls, parsed.index, () => ({ name: "", arguments: "" }))
 
-  if (parsed.field === "tool_call.function.name") tc.name = value
+  if (parsed.field === "tool_call.id") tc.id = value
+  else if (parsed.field === "tool_call.function.name") tc.name = value
   else if (parsed.field === "tool_call.function.arguments") tc.arguments = value
 }
 
@@ -127,6 +130,11 @@ function assembleMessages(
   if (maxIndex === -1) return []
 
   const messages: ReassembledMessage[] = []
+  // Tool calls awaiting a result, in document order. OpenInference (e.g. google-adk) omits the
+  // id linking an assistant tool_call to its tool result, so we pair them here and mint a shared
+  // id — otherwise the conversation view has no key to join the call to its response.
+  const pendingToolCalls: { id: string; name: string }[] = []
+
   for (let i = 0; i <= maxIndex; i++) {
     const msgFields = fields.get(i)
     const role = msgFields?.get("role") ?? "user"
@@ -136,11 +144,29 @@ function assembleMessages(
     const msgToolCalls = toolCalls.get(i)
     if (msgToolCalls && msgToolCalls.size > 0) {
       const sorted = [...msgToolCalls.entries()].sort(([a], [b]) => a - b)
-      msg.tool_calls = sorted.map(([j, tc]) => ({
-        id: `call_${i}_${j}`,
-        type: "function" as const,
-        function: { name: tc.name, arguments: tc.arguments },
-      }))
+      msg.tool_calls = sorted.map(([j, tc]) => {
+        const id = tc.id || `call_${i}_${j}`
+        pendingToolCalls.push({ id, name: tc.name })
+        return { id, type: "function" as const, function: { name: tc.name, arguments: tc.arguments } }
+      })
+    }
+
+    if (role === "tool") {
+      const explicitId = msgFields?.get("tool_call_id")
+      if (explicitId) {
+        msg.tool_call_id = explicitId
+        const consumed = pendingToolCalls.findIndex((p) => p.id === explicitId)
+        if (consumed >= 0) pendingToolCalls.splice(consumed, 1)
+      } else {
+        const toolName = msgFields?.get("name")
+        let idx = toolName ? pendingToolCalls.findIndex((p) => p.name === toolName) : -1
+        if (idx === -1 && pendingToolCalls.length > 0) idx = 0
+        const match = idx >= 0 ? pendingToolCalls[idx] : undefined
+        if (match) {
+          msg.tool_call_id = match.id
+          pendingToolCalls.splice(idx, 1)
+        }
+      }
     }
 
     messages.push(msg)

--- a/packages/domain/spans/src/otlp/tests/openinference.test.ts
+++ b/packages/domain/spans/src/otlp/tests/openinference.test.ts
@@ -627,3 +627,67 @@ describe("TravelPlanner trace — OpenInference (Arize Phoenix)", () => {
     })
   })
 })
+
+describe("OpenInference google-adk — tool call ↔ tool result pairing", () => {
+  // Mirrors the real ADK final call_llm span: assistant tool_call and tool result both omit ids.
+  function buildAdkFinalLlmSpan(): OtlpSpan {
+    return {
+      traceId: "11111111111111111111111111111111",
+      spanId: "1111111111111111",
+      name: "call_llm",
+      kind: 1,
+      startTimeUnixNano: "1710590400000000000",
+      endTimeUnixNano: "1710590401000000000",
+      attributes: [
+        str("openinference.span.kind", "LLM"),
+        str("llm.model_name", "gemini-2.5-flash"),
+        str("llm.input_messages.1.message.role", "user"),
+        str("llm.input_messages.1.message.contents.0.message_content.type", "text"),
+        str("llm.input_messages.1.message.contents.0.message_content.text", "What's the weather in Barcelona?"),
+        str("llm.input_messages.2.message.role", "model"),
+        str("llm.input_messages.2.message.tool_calls.0.tool_call.function.name", "get_weather"),
+        str("llm.input_messages.2.message.tool_calls.0.tool_call.function.arguments", '{"city": "Barcelona"}'),
+        str("llm.input_messages.3.message.role", "tool"),
+        str("llm.input_messages.3.message.name", "get_weather"),
+        str("llm.input_messages.3.message.content", '{"status": "success", "report": "sunny"}'),
+        str("llm.output_messages.0.message.role", "model"),
+        str("llm.output_messages.0.message.contents.0.message_content.type", "text"),
+        str("llm.output_messages.0.message.contents.0.message_content.text", "It's sunny in Barcelona."),
+      ],
+      status: { code: 1 },
+    }
+  }
+
+  const request: OtlpExportTraceServiceRequest = {
+    resourceSpans: [
+      {
+        resource: { attributes: [str("service.name", "adk")] },
+        scopeSpans: [
+          {
+            scope: { name: "openinference.instrumentation.google_adk", version: "0.1.15" },
+            spans: [buildAdkFinalLlmSpan()],
+          },
+        ],
+      },
+    ],
+  }
+
+  it("assigns the assistant tool_call and its tool result the same non-empty id", () => {
+    const span = transformOtlpToSpans(request, CONTEXT).spans[0]
+    if (!span) throw new Error("span not produced")
+
+    const assistant = span.inputMessages.find((m) => m.role === "assistant")
+    const tool = span.inputMessages.find((m) => m.role === "tool")
+    const toolCall = (assistant as { parts: { type: string; id?: string }[] }).parts.find((p) => p.type === "tool_call")
+    const toolResult = (tool as { parts: { type: string; id?: string | null }[] }).parts.find(
+      (p) => p.type === "tool_call_response",
+    )
+
+    const callId = (toolCall as { id?: string } | undefined)?.id
+    const resultId = (toolResult as { id?: string | null } | undefined)?.id
+
+    expect(callId).toBeTruthy()
+    expect(resultId).toBeTruthy()
+    expect(resultId).toBe(callId)
+  })
+})

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -20,6 +20,8 @@ export interface SpanMessagesData {
   readonly spanId: SpanId
   readonly operation: Operation
   readonly toolCallId: string
+  readonly toolName: string
+  readonly toolInput: string
   readonly inputMessages: readonly GenAIMessage[]
   readonly outputMessages: readonly GenAIMessage[]
 }

--- a/packages/domain/spans/src/use-cases/map-conversation-to-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/map-conversation-to-spans.test.ts
@@ -18,9 +18,27 @@ function makeSpan(
     spanId: SpanId(spanId),
     operation: "llm",
     toolCallId,
+    toolName: "",
+    toolInput: "",
     inputMessages: inputs,
     outputMessages: [output],
   }
+}
+
+function makeExecuteToolSpan(spanId: string, toolName: string, toolInput: string, toolCallId = ""): SpanMessagesData {
+  return {
+    spanId: SpanId(spanId),
+    operation: "execute_tool",
+    toolCallId,
+    toolName,
+    toolInput,
+    inputMessages: [],
+    outputMessages: [],
+  }
+}
+
+function toolCallMsg(id: string, name: string, args: Record<string, unknown>): GenAIMessage {
+  return { role: "assistant", parts: [{ type: "tool_call", id, name, arguments: args }] } as unknown as GenAIMessage
 }
 
 describe("buildConversationSpanMaps", () => {
@@ -126,6 +144,42 @@ describe("buildConversationSpanMaps", () => {
       const spanB = makeSpan("span-b", textMsg("assistant", "b"), [], "call-2")
       const { toolCallSpanMap } = buildConversationSpanMaps([], [spanA, spanB])
       expect(toolCallSpanMap).toEqual({ "call-1": "span-a", "call-2": "span-b" })
+    })
+  })
+
+  describe("cross-span fallback (id-less instrumentors)", () => {
+    it("links a conversation tool_call to its execute span by name+args when the ids differ", () => {
+      // OpenInference google-adk: tool span carries adk-… id, conversation tool_call has a synthetic id.
+      const execSpan = makeExecuteToolSpan("span-exec", "get_weather", '{"city": "Barcelona"}', "adk-123")
+      const messages: GenAIMessage[] = [toolCallMsg("call_2_0", "get_weather", { city: "Barcelona" })]
+
+      const { toolCallSpanMap } = buildConversationSpanMaps(messages, [execSpan])
+
+      expect(toolCallSpanMap["adk-123"]).toBe("span-exec")
+      expect(toolCallSpanMap.call_2_0).toBe("span-exec")
+    })
+
+    it("disambiguates same-named tool calls by arguments", () => {
+      const execBcn = makeExecuteToolSpan("span-bcn", "get_weather", '{"city": "Barcelona"}', "adk-1")
+      const execMad = makeExecuteToolSpan("span-mad", "get_weather", '{"city": "Madrid"}', "adk-2")
+      const messages: GenAIMessage[] = [
+        toolCallMsg("call_a", "get_weather", { city: "Madrid" }),
+        toolCallMsg("call_b", "get_weather", { city: "Barcelona" }),
+      ]
+
+      const { toolCallSpanMap } = buildConversationSpanMaps(messages, [execBcn, execMad])
+
+      expect(toolCallSpanMap.call_a).toBe("span-mad")
+      expect(toolCallSpanMap.call_b).toBe("span-bcn")
+    })
+
+    it("does not override a tool_call whose id already resolves to a span", () => {
+      const execSpan = makeExecuteToolSpan("span-exec", "get_weather", '{"city": "Barcelona"}', "real-id")
+      const messages: GenAIMessage[] = [toolCallMsg("real-id", "get_weather", { city: "Barcelona" })]
+
+      const { toolCallSpanMap } = buildConversationSpanMaps(messages, [execSpan])
+
+      expect(toolCallSpanMap).toEqual({ "real-id": "span-exec" })
     })
   })
 })

--- a/packages/domain/spans/src/use-cases/map-conversation-to-spans.ts
+++ b/packages/domain/spans/src/use-cases/map-conversation-to-spans.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "@repo/utils"
 import type { GenAIMessage } from "rosetta-ai"
 import type { SpanMessagesData } from "../ports/span-repository.ts"
 
@@ -37,6 +38,24 @@ function scoreContextMatch(spanInputs: readonly GenAIMessage[], preceding: reado
   return matches / Math.max(spanInputs.length, 1)
 }
 
+/** Canonical form of tool arguments (object or JSON string) so call and execute spans compare equal. */
+function canonicalizeToolArgs(value: unknown): string {
+  if (value === undefined || value === null) return ""
+  let parsed: unknown = value
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return value.replace(/\s+/g, "")
+    }
+  }
+  try {
+    return stableStringify(parsed)
+  } catch {
+    return String(value)
+  }
+}
+
 export function buildConversationSpanMaps(
   allMessages: readonly GenAIMessage[],
   spans: readonly SpanMessagesData[],
@@ -46,6 +65,31 @@ export function buildConversationSpanMaps(
   for (const span of spans) {
     if (span.toolCallId) {
       toolCallSpanMap[span.toolCallId] = span.spanId as string
+    }
+  }
+
+  // Cross-span fallback: OpenInference (e.g. google-adk) never carries the execute_tool span's
+  // call id onto the conversation messages, so a tool_call whose id doesn't resolve above is
+  // linked to its execute span by name+args+order — otherwise the tool result can't navigate.
+  const executeSpans = spans
+    .filter((span) => span.operation === "execute_tool" && span.toolName)
+    .map((span) => ({ spanId: span.spanId as string, name: span.toolName, args: canonicalizeToolArgs(span.toolInput) }))
+  if (executeSpans.length > 0) {
+    const consumed = new Set<number>()
+    for (const msg of allMessages) {
+      if (msg.role !== "assistant") continue
+      for (const part of msg.parts ?? []) {
+        if (part.type !== "tool_call") continue
+        const tc = part as { id?: string; name?: string; arguments?: unknown }
+        if (!tc.id || !tc.name || toolCallSpanMap[tc.id]) continue
+        const args = canonicalizeToolArgs(tc.arguments)
+        let idx = executeSpans.findIndex((s, k) => !consumed.has(k) && s.name === tc.name && s.args === args)
+        if (idx === -1) idx = executeSpans.findIndex((s, k) => !consumed.has(k) && s.name === tc.name)
+        const match = idx >= 0 ? executeSpans[idx] : undefined
+        if (!match) continue
+        consumed.add(idx)
+        toolCallSpanMap[tc.id] = match.spanId
+      }
     }
   }
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -226,6 +226,8 @@ type SpanMessagesRow = {
   span_id: string
   operation: string
   tool_call_id: string
+  tool_name: string
+  tool_input: string
   input_messages: string
   output_messages: string
 }
@@ -234,6 +236,8 @@ const toDomainSpanMessages = (row: SpanMessagesRow): SpanMessagesData => ({
   spanId: SpanId(row.span_id),
   operation: row.operation,
   toolCallId: row.tool_call_id,
+  toolName: normalizeCHString(row.tool_name),
+  toolInput: row.tool_input,
   inputMessages: parseMessages(row.input_messages),
   outputMessages: parseMessages(row.output_messages),
 })
@@ -606,9 +610,9 @@ export const SpanRepositoryLive = Layer.effect(
                 // merges all matching parts at query time and is the
                 // dominant memory cost for traces with heavy
                 // input/output_messages payloads.
-                query: `SELECT span_id, operation, tool_call_id, input_messages, output_messages
+                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
                       FROM (
-                        SELECT span_id, operation, tool_call_id, input_messages, output_messages, start_time
+                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
@@ -643,9 +647,9 @@ export const SpanRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT span_id, operation, tool_call_id, input_messages, output_messages
+                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
                       FROM (
-                        SELECT span_id, operation, tool_call_id, input_messages, output_messages, start_time
+                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-16
+
+### Added
+
+- **Google ADK (Agent Development Kit) auto-instrumentation** — new `"google_adk"` instrumentation key wires `openinference-instrumentation-google-adk` (Arize OpenInference) into the SDK. Spans cover agent runs, model generations, and tool calls. Pass `instrumentations={"google_adk": google.adk}` to `Latitude(...)` and install the `google-adk` package in your project.
+
+### Changed
+
+- Bumped `openinference-semantic-conventions` `0.1.25` → `0.1.30` (required by the Google ADK instrumentor), which transitively bumps the shared `openinference-instrumentation` `0.1.43` → `0.1.53` used by the dspy, litellm, and openai-agents instrumentations.
+
 ## [3.1.0] - 2026-06-12
 
 ### Added

--- a/packages/telemetry/python/README.md
+++ b/packages/telemetry/python/README.md
@@ -276,7 +276,7 @@ Registers LLM auto-instrumentations against a specific tracer provider.
 # InstrumentationName = Literal[
 #   "openai", "openai-agents", "anthropic", "bedrock", "cohere",
 #   "langchain", "llamaindex", "togetherai", "vertexai", "aiplatform",
-#   "aleph_alpha", "crewai", "dspy", "google_generativeai", "groq",
+#   "aleph_alpha", "crewai", "dspy", "google_adk", "google_generativeai", "groq",
 #   "haystack", "litellm", "mistralai", "ollama", "replicate",
 #   "sagemaker", "transformers", "watsonx",
 # ]
@@ -328,6 +328,7 @@ Set the integration's key on the `instrumentations` dict to the LLM SDK module t
 | `aleph_alpha`         | `aleph-alpha-client`        | `import aleph_alpha_client`                 |
 | `crewai`              | `crewai`                    | `import crewai`                             |
 | `dspy`                | `dspy-ai`                   | `import dspy`                               |
+| `google_adk`          | `google-adk`                | `import google.adk` → `google.adk`          |
 | `google_generativeai` | `google-generativeai`       | `from google import genai` → `genai`        |
 | `groq`                | `groq`                      | `import groq`                               |
 | `haystack`            | `haystack-ai`               | `import haystack`                           |

--- a/packages/telemetry/python/examples/.env.example
+++ b/packages/telemetry/python/examples/.env.example
@@ -29,6 +29,9 @@ TOGETHER_API_KEY=your-together-key
 # Google Gemini
 GEMINI_API_KEY=your-gemini-key
 
+# Google ADK (Agent Development Kit) — Gemini API key from Google AI Studio
+GOOGLE_API_KEY=your-google-api-key
+
 # Replicate
 REPLICATE_API_TOKEN=your-replicate-token
 

--- a/packages/telemetry/python/examples/README.md
+++ b/packages/telemetry/python/examples/README.md
@@ -83,6 +83,7 @@ uv add llama-index llama-index-llms-openai
 uv add haystack-ai
 uv add dspy-ai
 uv add crewai
+uv add google-adk
 ```
 
 4. Run an example:
@@ -99,6 +100,7 @@ uv run python examples/test_openai.py
 | ------------ | ---------------------- | ---------------------------------------- |
 | OpenAI       | `test_openai.py`        | `openai`                                 |
 | OpenAI Agents | `test_openai_agents.py` | `openai-agents`                          |
+| Google ADK    | `test_google_adk.py`   | `google-adk`                             |
 | Anthropic    | `test_anthropic.py`    | `anthropic`                              |
 | Groq         | `test_groq.py`         | `groq`                                   |
 | Mistral      | `test_mistral.py`      | `mistralai`                              |

--- a/packages/telemetry/python/examples/run_all.py
+++ b/packages/telemetry/python/examples/run_all.py
@@ -23,6 +23,7 @@ TESTS = {
     "cohere": ["COHERE_API_KEY"],
     "together": ["TOGETHER_API_KEY"],
     "gemini": ["GEMINI_API_KEY"],
+    "google_adk": ["GOOGLE_API_KEY"],
     "ollama": [],  # Local, no API key needed
     "litellm": ["OPENAI_API_KEY"],  # Using OpenAI as backend
     "replicate": ["REPLICATE_API_TOKEN"],

--- a/packages/telemetry/python/examples/test_google_adk.py
+++ b/packages/telemetry/python/examples/test_google_adk.py
@@ -1,0 +1,89 @@
+"""
+Test Google ADK (Agent Development Kit) instrumentation against local Latitude instance.
+
+Required env vars:
+- LATITUDE_API_KEY
+- LATITUDE_PROJECT_SLUG
+- GOOGLE_API_KEY (Gemini API key from Google AI Studio)
+
+Install: uv add google-adk
+"""
+
+import asyncio
+import os
+
+import google.adk
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+from latitude_telemetry import Latitude, capture
+
+# Initialize telemetry pointing to local instance
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations={"google_adk": google.adk},
+    disable_batch=True,
+)
+
+
+def get_weather(city: str) -> dict:
+    """Returns the current weather for a city."""
+    return {"status": "success", "report": f"The weather in {city} is sunny and 22°C."}
+
+
+agent = Agent(
+    name="weather_agent",
+    model="gemini-2.5-flash",
+    description="Agent that answers weather questions using tools.",
+    instruction="Answer weather questions concisely. Always call get_weather first.",
+    tools=[get_weather],
+)
+
+
+def test_google_adk_run():
+    """Run a tool-using ADK agent and capture the full agent/model/tool span hierarchy."""
+    app_name = "weather_app"
+    user_id = "user_123"
+    session_id = "example"
+
+    async def run_agent():
+        runner = InMemoryRunner(agent=agent, app_name=app_name)
+        await runner.session_service.create_session(
+            app_name=app_name,
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+        final_output = ""
+        async for event in runner.run_async(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=types.Content(
+                role="user",
+                parts=[types.Part(text="What's the weather in Barcelona?")],
+            ),
+        ):
+            if event.is_final_response() and event.content and event.content.parts:
+                text = event.content.parts[0].text
+                if text:
+                    final_output = text.strip()
+        return final_output
+
+    return capture(
+        "weather-agent-run",
+        lambda: asyncio.run(run_agent()),
+        {
+            "tags": ["python", "test", "google-adk"],
+            "session_id": "example",
+            "user_id": "user_123",
+            "metadata": {"test_type": "agent_run", "environment": "local"},
+        },
+    )
+
+
+if __name__ == "__main__":
+    output = test_google_adk_run()
+    print(f"Final output: {output}")
+    latitude.flush()

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.1.0"
+version = "3.2.0"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
@@ -15,13 +15,14 @@ dependencies = [
     "opentelemetry-sdk==1.38.0",
     "opentelemetry-exporter-otlp-proto-http==1.38.0",
     "opentelemetry-semantic-conventions-ai==0.4.13",
-    "openinference-semantic-conventions==0.1.25",
+    "openinference-semantic-conventions==0.1.30",
     "opentelemetry-instrumentation-alephalpha==0.50.1",
     "opentelemetry-instrumentation-anthropic==0.50.1",
     "opentelemetry-instrumentation-bedrock==0.50.1",
     "opentelemetry-instrumentation-cohere==0.50.1",
     "opentelemetry-instrumentation-crewai==0.50.1",
     "openinference-instrumentation-dspy==0.1.33",
+    "openinference-instrumentation-google-adk==0.1.15",
     "opentelemetry-instrumentation-google-generativeai==0.50.1",
     "opentelemetry-instrumentation-groq==0.50.1",
     "opentelemetry-instrumentation-haystack==0.50.1",

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/instrumentations.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/instrumentations.py
@@ -106,6 +106,11 @@ INTEGRATIONS: dict[InstrumentationName, IntegrationDef] = {
         instrumentor_class="DSPyInstrumentor",
         pypi_dist_name="dspy-ai",
     ),
+    "google_adk": IntegrationDef(
+        instrumentor_module="openinference.instrumentation.google_adk",
+        instrumentor_class="GoogleADKInstrumentor",
+        pypi_dist_name="google-adk",
+    ),
     "google_generativeai": IntegrationDef(
         instrumentor_module="opentelemetry.instrumentation.google_generativeai",
         instrumentor_class="GoogleGenerativeAiInstrumentor",

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
@@ -23,6 +23,7 @@ InstrumentationName = Literal[
     "aleph_alpha",
     "crewai",
     "dspy",
+    "google_adk",
     "google_generativeai",
     "groq",
     "haystack",

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1084,11 +1084,12 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.1.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },
     { name = "openinference-instrumentation-dspy" },
+    { name = "openinference-instrumentation-google-adk" },
     { name = "openinference-instrumentation-litellm" },
     { name = "openinference-instrumentation-openai-agents" },
     { name = "openinference-semantic-conventions" },
@@ -1137,9 +1138,10 @@ dev = [
 requires-dist = [
     { name = "openai-agents", specifier = "==0.15.1" },
     { name = "openinference-instrumentation-dspy", specifier = "==0.1.33" },
+    { name = "openinference-instrumentation-google-adk", specifier = "==0.1.15" },
     { name = "openinference-instrumentation-litellm", specifier = "==0.1.6" },
     { name = "openinference-instrumentation-openai-agents", specifier = "==1.4.2" },
-    { name = "openinference-semantic-conventions", specifier = "==0.1.25" },
+    { name = "openinference-semantic-conventions", specifier = "==0.1.30" },
     { name = "opentelemetry-api", specifier = "==1.38.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.38.0" },
     { name = "opentelemetry-instrumentation-alephalpha", specifier = "==0.50.1" },
@@ -1572,7 +1574,7 @@ wheels = [
 
 [[package]]
 name = "openinference-instrumentation"
-version = "0.1.43"
+version = "0.1.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-semantic-conventions" },
@@ -1580,9 +1582,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/65/f979c42c35406eed5568530bb779a5c34540a42af563bd9049392ecf050e/openinference_instrumentation-0.1.43.tar.gz", hash = "sha256:fa9e8c84f63bb579b48b3e4cea21c10fa5a78961a6db349057ebcd7a33b541dd", size = 23956, upload-time = "2026-01-26T09:10:28.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b6/c0e7e047ae4962f2755a3bc9141fdd6272c75c74e47dfc6aa71978a9b78f/openinference_instrumentation-0.1.53.tar.gz", hash = "sha256:3c0c145cf6e13cfa630b29d0e3ca806f3821470ffca7922f1590e3970fadd4da", size = 33712, upload-time = "2026-06-02T16:37:21.771Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/a3/61cb41c04ce05fa86654edac1e6e2c037d1caa828a4bc5bc3cd7a656fb62/openinference_instrumentation-0.1.43-py3-none-any.whl", hash = "sha256:f8b13f39da15202a50823733b245bb296147bb417eb873000c891164c9e68935", size = 30089, upload-time = "2026-01-26T09:10:27.231Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bb/01262d9945c476e15aa21bb9ca05b18604e525d73d9761cadb677f485198/openinference_instrumentation-0.1.53-py3-none-any.whl", hash = "sha256:f43695080eded47b1e03ff1b19cb5c23ea4409459cfe16c5b5748d5656832eb1", size = 40958, upload-time = "2026-06-02T16:37:20.69Z" },
 ]
 
 [[package]]
@@ -1601,6 +1603,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/0e/814f43679ace2de68c4b91eab24db08623dc3da447cd935caca7205d3b65/openinference_instrumentation_dspy-0.1.33.tar.gz", hash = "sha256:b4079a564b2866dfb37c71a9ba36661b8312141959e1110eb13db27e248e2cd8", size = 26803, upload-time = "2026-01-08T03:52:04.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/3c/7695eb832ffe7667e07911ad8ca8e92520e5c91562809ebbc2d8e15409c3/openinference_instrumentation_dspy-0.1.33-py3-none-any.whl", hash = "sha256:a0713d6c49f3f0178ff11acbe36785f2c09fdffa46e6442ca1d1c38b96d97526", size = 15360, upload-time = "2026-01-08T03:52:01.67Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-google-adk"
+version = "0.1.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/1a/f35f3f38dba763e3ab41a73c15125de6107b3dd1aacbff50201b945e7d89/openinference_instrumentation_google_adk-0.1.15.tar.gz", hash = "sha256:1c0c73ad3b128858486f2066ceba3690061cbb8755bcd97a58220d9a5a42cf8e", size = 14739, upload-time = "2026-05-22T21:10:48.449Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/24/dbddd058a5b837c5f50a42dd94b4d9e338dc362c3cf067a6620c18a7f5c3/openinference_instrumentation_google_adk-0.1.15-py3-none-any.whl", hash = "sha256:be6db6bb68922acae5103bbb72fda9b880a809309b49289fa23d685742de8ebe", size = 16661, upload-time = "2026-05-22T21:10:46.054Z" },
 ]
 
 [[package]]
@@ -1641,11 +1661,11 @@ wheels = [
 
 [[package]]
 name = "openinference-semantic-conventions"
-version = "0.1.25"
+version = "0.1.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/68/81c8a0b90334ff11e4f285e4934c57f30bea3ef0c0b9f99b65e7b80fae3b/openinference_semantic_conventions-0.1.25.tar.gz", hash = "sha256:f0a8c2cfbd00195d1f362b4803518341e80867d446c2959bf1743f1894fce31d", size = 12767, upload-time = "2025-11-05T01:37:45.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/51/8ba1182ee86fc79793d5ff2d11e7fdcda10ded2d01f3e46ca6fcf0568213/openinference_semantic_conventions-0.1.30.tar.gz", hash = "sha256:81fece76e09c83789e35c393b8b30523481eeabf1008745b955631a53e3221d9", size = 13391, upload-time = "2026-05-22T21:10:44.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/3d/dd14ee2eb8a3f3054249562e76b253a1545c76adbbfd43a294f71acde5c3/openinference_semantic_conventions-0.1.25-py3-none-any.whl", hash = "sha256:3814240f3bd61f05d9562b761de70ee793d55b03bca1634edf57d7a2735af238", size = 10395, upload-time = "2025-11-05T01:37:43.697Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/5b7e78cf0de38589b821bbe8e9c29c59a6e76edfb980488d0854cbb90f7c/openinference_semantic_conventions-0.1.30-py3-none-any.whl", hash = "sha256:36d946d3f95f699b7c4b12324ae9c1f02d6c7750df11eece56aa159cff430b3d", size = 10911, upload-time = "2026-05-22T21:10:43.04Z" },
 ]
 
 [[package]]

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,3 +1,5 @@
+import stringify from "fast-json-stable-stringify"
+
 const COUNT_UNITS = ["", "K", "M", "B", "T"]
 
 const countFractionFormatter = new Intl.NumberFormat("en-US", {
@@ -207,4 +209,9 @@ export function safeStringifyJson(value: unknown, fallback = ""): string {
   } catch {
     return String(value)
   }
+}
+
+/** Deterministic JSON serialization with sorted keys, so equal values stringify equal regardless of key order. */
+export function stableStringify(value: unknown): string {
+  return stringify(value)
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,6 +19,7 @@ export {
   parseCHDate,
   safeParseJson,
   safeStringifyJson,
+  stableStringify,
 } from "./format.ts"
 export * from "./http-errors.ts"
 export {


### PR DESCRIPTION
Adds Google ADK to the supported instrumentations in the Python Telemetry SDK, and fixes a tool call/result pairing bug surfaced while testing ADK traces end to end against a live instance.

## Google ADK telemetry

Registers the OpenInference `openinference-instrumentation-google-adk` (==0.1.15) instrumentor as the `google_adk` instrumentation, bumps the Python SDK to 3.2.0, and adds a runnable weather-agent example (`examples/test_google_adk.py`), a docs page (`docs/telemetry/frameworks/google-adk.mdx`), and the nav entry.

## The pairing bug

In an ADK agent run that calls a tool, the tool call and its result did not join in the conversation view, and the result couldn't navigate to the tool's execution span.

Root cause is upstream in OpenInference: it emits **no message-side ids**. The assistant message's `tool_call` has no `id`, and the tool-result message has no `tool_call_id`. The only real id (`adk-…`) lives on the separate `execute_tool` span (`gen_ai.tool.call.id`). Our ingest minted a synthetic id on the assistant tool_call (`call_2_0`) but left the result's id null, so the two halves carried unrelated ids and couldn't be paired or navigated. rosetta-ai is left untouched — it faithfully translates what it's given — and the canonicalization stays out of the shared `safeStringifyJson`, whose callers depend on pass-through strings and insertion-order keys.

The fix has three parts:

**Ingest-time pairing** (`openinference.ts`). The content parser keeps a document-order queue of pending tool_calls. Each `role:"tool"` message gets its `tool_call_id` from an explicit `message.tool_call_id`, or by pairing to the matching pending tool_call (by name, else FIFO) — minting one shared id for call and result. `ToolCallData` and `ReassembledMessage` gained the id fields this needs.

**Read-time cross-span navigation** (`map-conversation-to-spans.ts`). A conversation tool_call whose id doesn't already resolve to an `execute_tool` span is linked to that span by name + canonicalized args + order, guarded so traces that already carry real ids are untouched. `SpanMessagesData` — and both the trace and session message queries — now select `tool_name` and `tool_input` to support the match. Argument canonicalization uses a new shared `stableStringify` helper (wraps `fast-json-stable-stringify`, the dep `hash` already uses).

**Session UI** (`session-slot.tsx`, session `conversation-tab.tsx`). The session drawer reused the trace `ConversationTab` but never passed `navigateToSpan`, which gates both the message- and tool-call-level "view execution span" affordances. Wired it through for single-trace sessions (where the Spans tab exists), so the session conversation matches the trace drawer.

## Validation

Verified end to end against a local instance: re-ingested an ADK weather-agent run and confirmed via the API that the assistant `tool_call.id` and the tool-result `tool_call_response.id` are now equal and non-null (were `call_2_0` vs `null`). Confirmed in the UI that the tool result joins the call and "view execution span" navigates to the `execute_tool` span, from both the trace and session views. Unit tests cover the parser pairing and the cross-span fallback (`@domain/spans` 653 pass, `@platform/db-clickhouse` span-repository 11 pass); `@repo/utils` + `@domain/spans` + `@app/web` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)