### PR TITLE
fix(ui): allow selecting across annotation highlights

### DIFF
--- a/packages/ui/src/components/genai-conversation/conversation.tsx
+++ b/packages/ui/src/components/genai-conversation/conversation.tsx
@@ -108,6 +108,25 @@ function normalizeMessage(message: GenAIMessage): GenAIMessage {
   return message
 }
 
+function hasSelectionInContainer(container: HTMLElement | null): boolean {
+  const selection = window.getSelection()
+  if (!container || !selection || selection.isCollapsed || selection.rangeCount === 0) return false
+  if (!selection.toString().trim()) return false
+
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i)
+    if (
+      container.contains(range.startContainer) ||
+      container.contains(range.endContainer) ||
+      container.contains(range.commonAncestorContainer)
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
 export function Conversation({
   messages,
   enableNavigator = false,
@@ -179,7 +198,7 @@ export function Conversation({
 
   const handleContainerClick = useCallback(
     (e: React.MouseEvent) => {
-      if (!onAnnotationClick) return
+      if (!onAnnotationClick || hasSelectionInContainer(containerRef.current)) return
       const target = (e.target as HTMLElement).closest<HTMLElement>("[data-annotation-id]")
       if (!target) return
 

--- a/packages/ui/src/components/genai-conversation/parts/highlight-segments.test.ts
+++ b/packages/ui/src/components/genai-conversation/parts/highlight-segments.test.ts
@@ -141,7 +141,7 @@ describe("highlightAttributes", () => {
     }
     const attrs = highlightAttributes(h)
     expect(attrs.className).toContain("cursor-pointer")
-    expect(attrs.className).toContain("hit-area-inline-y-2")
+    expect(attrs.className).not.toContain("hit-area-inline-y")
     expect(attrs["data-annotation-id"]).toBe("ann-1")
   })
 

--- a/packages/ui/src/components/genai-conversation/parts/highlight-segments.ts
+++ b/packages/ui/src/components/genai-conversation/parts/highlight-segments.ts
@@ -103,7 +103,7 @@ export function highlightAttributes(activeHighlight: HighlightRange | null): Hig
   const isClickable = isAnnotation && !!activeHighlight.id
   const isSearchMatch = activeHighlight.type === "search-literal" || activeHighlight.type === "search-token"
   const className = cn({
-    "cursor-pointer hit-area-inline-y-2": isClickable,
+    "cursor-pointer": isClickable,
     "bg-yellow-100 border-b-2 border-yellow-300 dark:bg-yellow-400/20 dark:border-yellow-400/50":
       activeHighlight.type === "selection",
     "bg-red-100 dark:bg-red-400/30": isAnnotation && activeHighlight.passed === false,

--- a/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.test.ts
+++ b/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.test.ts
@@ -125,7 +125,7 @@ describe("className generation", () => {
     expect(props(highlighted).className).toContain("bg-blue-100")
   })
 
-  it("adds cursor-pointer and hit-area when annotation has an id", () => {
+  it("adds cursor-pointer without an extended hit area when annotation has an id", () => {
     const h: HighlightRange = {
       messageIndex: 0,
       partIndex: 0,
@@ -139,7 +139,7 @@ describe("className generation", () => {
     run(tree, [h])
     const highlighted = children(tree).find((n) => props(n)["data-annotated-text"])
     expect(props(highlighted).className).toContain("cursor-pointer")
-    expect(props(highlighted).className).toContain("hit-area-inline-y-2")
+    expect(props(highlighted).className).not.toContain("hit-area-inline-y")
   })
 
   it("does not add cursor-pointer when annotation has no id", () => {


### PR DESCRIPTION
Fixes text selection around existing inline annotation highlights in the conversation view.

Previously, annotation highlights used an extended inline hit area, so starting a drag over highlighted text was captured as an annotation click target. That made it hard to select from inside an annotation and could open the existing annotation instead of preserving the user’s partial selection.

This removes the extended hit area from annotation highlight spans and keeps the existing click-to-open behavior on the actual highlighted text. The conversation click handler also ignores annotation clicks while there is an active text selection inside the conversation, so dragging across a highlight leaves the selection popover in control.

Validated with:

- `pnpm --filter @repo/ui test -- genai-conversation/parts/highlight-segments.test.ts genai-conversation/parts/source-mapped-text-plugin.test.ts`
- `pnpm --filter @repo/ui typecheck`
- `pnpm --filter @repo/ui check`
- Manual QA on `localhost:3000`: created an annotation, selected text starting inside it, and selected from before the annotation to a mid-annotation cursor position without opening the existing annotation popover.
