### PR TITLE
Add custom redaction to agent telemetry packages

### DIFF
--- a/docs/telemetry/claude-code.md
+++ b/docs/telemetry/claude-code.md
@@ -86,8 +86,49 @@ Restart Claude Code after saving.
 Treat this as full-fidelity telemetry. Latitude receives the content needed to reconstruct Claude Code turns, including prompts, responses, tool input/output, and system context when available.
 
 - Telemetry runs for each turn until disabled or uninstalled.
-- Use `LATITUDE_REDACT_ATTRIBUTES` and `LATITUDE_REDACT_MASK` for custom local attribute masking before export.
 - Disable telemetry before working with sensitive material you do not want sent to Latitude.
+
+## Custom redaction
+
+If you want to keep telemetry enabled but mask specific span attributes before they leave your machine, set `LATITUDE_REDACT_ATTRIBUTES` in your Claude Code environment. Redaction happens locally, after the content gate and before the OTLP export.
+
+`LATITUDE_REDACT_ATTRIBUTES` accepts a JSON array (or comma-separated list) of patterns. Each pattern can be:
+
+- An **exact attribute name** — `"gen_ai.tool.call.arguments"`
+- A **regex source string** — `"^gen_ai\\.(input|output)\\.messages$"` (anchored match)
+- A **`/pattern/flags` string** — `"/^gen_ai\\.tool\\.call\\.(arguments|result)$/i"`
+
+`LATITUDE_REDACT_MASK` sets the replacement value (default: `******`). Set it to `[]` to replace message arrays with an empty array instead of a string.
+
+### Examples
+
+Redact all prompt and response messages, plus tool arguments and results:
+
+```bash
+LATITUDE_REDACT_ATTRIBUTES='["/^gen_ai\\.(input|output)\\.messages$/", "/^gen_ai\\.tool\\.call\\.(arguments|result)$/"]' \
+LATITUDE_REDACT_MASK='[]' \
+claude
+```
+
+Redact only a specific custom attribute by exact name:
+
+```bash
+LATITUDE_REDACT_ATTRIBUTES='["user_prompt"]' \
+claude
+```
+
+To persist redaction settings, add them to the `env` block in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_PROJECT": "your-project-slug",
+    "LATITUDE_REDACT_ATTRIBUTES": "[\"/^gen_ai\\\\.(input|output)\\\\.messages$/\"]",
+    "LATITUDE_REDACT_MASK": "[]"
+  }
+}
+```
 
 ## Troubleshooting
 

--- a/docs/telemetry/claude-code.md
+++ b/docs/telemetry/claude-code.md
@@ -86,7 +86,7 @@ Restart Claude Code after saving.
 Treat this as full-fidelity telemetry. Latitude receives the content needed to reconstruct Claude Code turns, including prompts, responses, tool input/output, and system context when available.
 
 - Telemetry runs for each turn until disabled or uninstalled.
-- Latitude does not redact secrets from captured content.
+- Use `LATITUDE_REDACT_ATTRIBUTES` and `LATITUDE_REDACT_MASK` for custom local attribute masking before export.
 - Disable telemetry before working with sensitive material you do not want sent to Latitude.
 
 ## Troubleshooting

--- a/docs/telemetry/openclaw.md
+++ b/docs/telemetry/openclaw.md
@@ -102,8 +102,8 @@ Set `config.allowConversationAccess` to `false` for structural-only telemetry wh
 By default, Latitude receives the content needed to reconstruct OpenClaw runs, including prompts, responses, system instructions, tool input/output, model metadata, and token usage.
 
 - Use `--no-content` when you only want structural telemetry.
+- Use `config.redact` for custom local attribute masking before export.
 - Telemetry runs for each agent run until disabled or uninstalled.
-- Latitude does not redact secrets from captured content.
 - Disable telemetry before working with sensitive material you do not want sent to Latitude.
 
 ## Troubleshooting

--- a/docs/telemetry/openclaw.md
+++ b/docs/telemetry/openclaw.md
@@ -102,9 +102,58 @@ Set `config.allowConversationAccess` to `false` for structural-only telemetry wh
 By default, Latitude receives the content needed to reconstruct OpenClaw runs, including prompts, responses, system instructions, tool input/output, model metadata, and token usage.
 
 - Use `--no-content` when you only want structural telemetry.
-- Use `config.redact` for custom local attribute masking before export.
 - Telemetry runs for each agent run until disabled or uninstalled.
 - Disable telemetry before working with sensitive material you do not want sent to Latitude.
+
+## Custom redaction
+
+If you want to keep content capture enabled but mask specific span attributes before they leave the gateway, add a `redact` block to `config` in `~/.openclaw/openclaw.json`. Redaction happens locally, after the content gate and before the OTLP export.
+
+`redact.attributes` accepts an array of patterns. Each pattern can be:
+
+- An **exact attribute name** — `"gen_ai.tool.call.arguments"`
+- A **regex source string** — `"^gen_ai\\.(input|output)\\.messages$"` (anchored match)
+- A **`/pattern/flags` string** — `"/^gen_ai\\.tool\\.call\\.(arguments|result)$/i"`
+
+`redact.mask` sets the replacement value (default: `******`). Set it to `"[]"` to replace message arrays with an empty array instead of a string.
+
+### Examples
+
+Redact all prompt and response messages using `openclaw config set`:
+
+```bash
+openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.redact' \
+  '{"attributes":["/^gen_ai\\.(input|output)\\.messages$/"],"mask":"[]"}'
+openclaw gateway restart
+```
+
+Or hand-edit `~/.openclaw/openclaw.json` directly:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "@latitude-data/openclaw-telemetry": {
+        "config": {
+          "redact": {
+            "attributes": [
+              "/^gen_ai\\.(input|output)\\.messages$/",
+              "/^gen_ai\\.tool\\.call\\.(arguments|result)$/"
+            ],
+            "mask": "[]"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing:
+
+```bash
+openclaw gateway restart
+```
 
 ## Troubleshooting
 

--- a/docs/telemetry/pi-coding-agent.md
+++ b/docs/telemetry/pi-coding-agent.md
@@ -90,9 +90,46 @@ The installer stores config in `~/.pi/agent/latitude-telemetry.json`. Environmen
 
 Use `--staging`, `--dev`, or `--base-url=<url>` during install to target a non-production Latitude ingest endpoint.
 
+## Custom redaction
+
+If you want to keep content capture enabled but mask specific span attributes before they leave your machine, use `redact` in `~/.pi/agent/latitude-telemetry.json` or the `LATITUDE_REDACT_ATTRIBUTES` environment variable. Redaction happens locally, after the content gate and before the OTLP export.
+
+`redact.attributes` (or `LATITUDE_REDACT_ATTRIBUTES`) accepts an array of patterns. Each pattern can be:
+
+- An **exact attribute name** — `"gen_ai.tool.call.arguments"`
+- A **regex source string** — `"^gen_ai\\.(input|output)\\.messages$"` (anchored match)
+- A **`/pattern/flags` string** — `"/^gen_ai\\.tool\\.call\\.(arguments|result)$/i"`
+
+`redact.mask` (or `LATITUDE_REDACT_MASK`) sets the replacement value (default: `******`). Set it to `"[]"` to replace message arrays with an empty array instead of a string.
+
+### Via config file
+
+Add a `redact` block to `~/.pi/agent/latitude-telemetry.json`:
+
+```json
+{
+  "redact": {
+    "attributes": [
+      "/^gen_ai\\.(input|output)\\.messages$/",
+      "gen_ai.tool.call.arguments",
+      "gen_ai.tool.call.result"
+    ],
+    "mask": "[]"
+  }
+}
+```
+
+### Via environment variable
+
+```bash
+LATITUDE_REDACT_ATTRIBUTES='["/^gen_ai\\.(input|output)\\.messages$/", "gen_ai.tool.call.arguments"]' \
+LATITUDE_REDACT_MASK='[]' \
+pi
+```
+
 ## Captured data and privacy
 
-Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Use `--no-content` for structural-only telemetry or configure custom redaction with `redact` in `~/.pi/agent/latitude-telemetry.json` / `LATITUDE_REDACT_ATTRIBUTES`.
+Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Use `--no-content` for structural-only telemetry or configure custom redaction as described above.
 
 Disable telemetry before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
 

--- a/docs/telemetry/pi-coding-agent.md
+++ b/docs/telemetry/pi-coding-agent.md
@@ -90,7 +90,13 @@ The installer stores config in `~/.pi/agent/latitude-telemetry.json`. Environmen
 
 Use `--staging`, `--dev`, or `--base-url=<url>` during install to target a non-production Latitude ingest endpoint.
 
-## Custom redaction
+## Captured data and privacy
+
+Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Use `--no-content` for structural-only telemetry or configure custom redaction as described below.
+
+Disable telemetry before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
+
+### Custom redaction
 
 If you want to keep content capture enabled but mask specific span attributes before they leave your machine, use `redact` in `~/.pi/agent/latitude-telemetry.json` or the `LATITUDE_REDACT_ATTRIBUTES` environment variable. Redaction happens locally, after the content gate and before the OTLP export.
 
@@ -102,7 +108,7 @@ If you want to keep content capture enabled but mask specific span attributes be
 
 `redact.mask` (or `LATITUDE_REDACT_MASK`) sets the replacement value (default: `******`). Set it to `"[]"` to replace message arrays with an empty array instead of a string.
 
-### Via config file
+#### Via config file
 
 Add a `redact` block to `~/.pi/agent/latitude-telemetry.json`:
 
@@ -119,19 +125,13 @@ Add a `redact` block to `~/.pi/agent/latitude-telemetry.json`:
 }
 ```
 
-### Via environment variable
+#### Via environment variable
 
 ```bash
 LATITUDE_REDACT_ATTRIBUTES='["/^gen_ai\\.(input|output)\\.messages$/", "gen_ai.tool.call.arguments"]' \
 LATITUDE_REDACT_MASK='[]' \
 pi
 ```
-
-## Captured data and privacy
-
-Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Use `--no-content` for structural-only telemetry or configure custom redaction as described above.
-
-Disable telemetry before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
 
 ## Troubleshooting
 

--- a/docs/telemetry/pi-coding-agent.md
+++ b/docs/telemetry/pi-coding-agent.md
@@ -85,14 +85,16 @@ The installer stores config in `~/.pi/agent/latitude-telemetry.json`. Environmen
 | `LATITUDE_PI_USER_ID` | Override `user.id` |
 | `LATITUDE_PI_USER_EMAIL` | Override user email |
 | `LATITUDE_PI_USER_NAME` | Override user display name |
+| `LATITUDE_REDACT_ATTRIBUTES` | JSON array or comma-separated custom attribute patterns to mask before export |
+| `LATITUDE_REDACT_MASK` | Mask value for custom redaction, default `******` |
 
 Use `--staging`, `--dev`, or `--base-url=<url>` during install to target a non-production Latitude ingest endpoint.
 
 ## Captured data and privacy
 
-Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Latitude does not redact secrets from captured content.
+Full-content mode sends prompts, responses, system instructions when available, tool inputs, and tool outputs. Use `--no-content` for structural-only telemetry or configure custom redaction with `redact` in `~/.pi/agent/latitude-telemetry.json` / `LATITUDE_REDACT_ATTRIBUTES`.
 
-Disable telemetry or use `--no-content` before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
+Disable telemetry before working with sensitive material you do not want sent to Latitude. Even `--no-content` mode still sends structural metadata such as cwd/session identifiers, model names, tool names, timing, token usage, and user/host identity.
 
 ## Troubleshooting
 

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -96,6 +96,8 @@ Everything the installer writes. Edit `~/.claude/settings.json` directly if you 
 | `BUN_OPTIONS` | written when `launchctl` isn't used (all non-macOS platforms, or macOS with `--no-launchctl`) | — | `--preload=<absolute-path-to-intercept.js>`. See "how it works" above. |
 | `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to pause the hook without uninstalling. |
 | `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
+| `LATITUDE_REDACT_ATTRIBUTES` | no | — | JSON array or comma-separated custom attribute patterns to mask before export. |
+| `LATITUDE_REDACT_MASK` | no | `******` | Mask value for custom redaction. |
 
 ### `hooks.Stop`
 
@@ -148,6 +150,14 @@ If that's not what you want, either:
 - Don't install the hook.
 - Set `LATITUDE_CLAUDE_CODE_ENABLED=0` in your shell before starting a sensitive session.
 - Run `uninstall`.
+
+For field-level PII controls while keeping the hook enabled, set `LATITUDE_REDACT_ATTRIBUTES` and optionally `LATITUDE_REDACT_MASK`. Patterns are exact strings, regex source strings, or `/pattern/flags` strings, and redaction happens before export.
+
+```bash
+LATITUDE_REDACT_ATTRIBUTES='["/^gen_ai\\.(input|output)\\.messages$/", "user_prompt", "/^gen_ai\\.tool\\.call\\.(arguments|result)$/"]' \
+LATITUDE_REDACT_MASK='[]' \
+claude
+```
 
 ## Supported surfaces
 

--- a/packages/telemetry/claude-code/src/config.ts
+++ b/packages/telemetry/claude-code/src/config.ts
@@ -1,9 +1,12 @@
+import { parseRedactEnv, type RedactConfig } from "./redaction.ts"
+
 interface Config {
   apiKey: string
   baseUrl: string
   project: string
   enabled: boolean
   debug: boolean
+  redact: RedactConfig | undefined
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -12,5 +15,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   const project = env.LATITUDE_PROJECT ?? ""
   const enabled = (env.LATITUDE_CLAUDE_CODE_ENABLED ?? "1") !== "0" && apiKey !== "" && project !== ""
   const debug = env.LATITUDE_DEBUG === "1"
-  return { apiKey, baseUrl, project, enabled, debug }
+  const redact = parseRedactEnv(env)
+  return { apiKey, baseUrl, project, enabled, debug, redact }
 }

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -139,6 +139,7 @@ async function main(): Promise<void> {
       context,
       conversationHistory,
       requestsByMessageId,
+      redact: config.redact,
     })
 
     // Long agentic turns produce payloads far beyond what a single POST can deliver,

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -771,6 +771,25 @@ describe("span size capping", () => {
   })
 })
 
+describe("redaction", () => {
+  it("redacts matching attributes before export", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-redact",
+      turnStartNumber: 1,
+      turns: [baseTurn({ userText: "secret prompt", assistantText: "secret output" })],
+      redact: { attributes: ["/^gen_ai\\.(input|output)\\.messages$/", "user_prompt"], mask: "[]" },
+    })
+    const spans = otlpSpans(req)
+    const interaction = unwrap(spans.find((span) => span.name === "interaction"))
+    const llm = unwrap(spans.find((span) => span.name === "llm_request"))
+
+    expect(getAttr(interaction.attributes, "user_prompt")).toBe("[]")
+    expect(getAttr(interaction.attributes, "gen_ai.input.messages")).toBe("[]")
+    expect(getAttr(llm.attributes, "gen_ai.input.messages")).toBe("[]")
+    expect(getAttr(llm.attributes, "gen_ai.output.messages")).toBe("[]")
+  })
+})
+
 describe("chunkOtlpRequest", () => {
   it("returns the original request when it fits the budget", () => {
     const req = buildOtlpRequest({ sessionId: "sess-chunk", turnStartNumber: 1, turns: [baseTurn()] })

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
 import { arch, hostname, platform, release } from "node:os"
+import { type RedactConfig, redactAttributes } from "./redaction.ts"
 import type { AnthropicMessage, AnthropicMessageBlock, AnthropicSystem, StoredRequest } from "./request-store.ts"
 import type {
   AssistantCall,
@@ -44,6 +45,7 @@ export function buildOtlpRequest(opts: {
   context?: TraceContext | undefined
   conversationHistory?: Turn[] | undefined
   requestsByMessageId?: Map<string, StoredRequest> | undefined
+  redact?: RedactConfig | undefined
 }): OtlpExportRequest {
   const contextAttrs = buildContextAttrs(opts.context)
   const history = opts.conversationHistory ?? []
@@ -57,17 +59,23 @@ export function buildOtlpRequest(opts: {
     )
   })
 
+  const redact = opts.redact
+  const redactedSpans = redact ? spans.map((span) => redactSpan(span, redact)) : spans
   const rs: OtlpResourceSpans = {
     resource: { attributes: resourceAttrs() },
     scopeSpans: [
       {
         scope: { name: SCOPE_NAME, version: SCOPE_VERSION },
-        spans,
+        spans: redactedSpans,
       },
     ],
   }
 
   return { resourceSpans: [rs] }
+}
+
+function redactSpan(span: OtlpSpan, redact: RedactConfig): OtlpSpan {
+  return { ...span, attributes: redactAttributes(span.attributes, redact) }
 }
 
 function buildTurnSpans(

--- a/packages/telemetry/claude-code/src/redaction.ts
+++ b/packages/telemetry/claude-code/src/redaction.ts
@@ -1,0 +1,67 @@
+import type { OtlpKeyValue } from "./types.ts"
+
+export interface RedactConfig {
+  attributes: string[]
+  mask: string
+}
+
+export function parseRedactEnv(env: NodeJS.ProcessEnv): RedactConfig | undefined {
+  const attributes = parseAttributesEnv(env.LATITUDE_REDACT_ATTRIBUTES)
+  if (attributes.length === 0) return undefined
+  return { attributes, mask: env.LATITUDE_REDACT_MASK ?? "******" }
+}
+
+export function redactAttributes(attributes: OtlpKeyValue[], config: RedactConfig | undefined): OtlpKeyValue[] {
+  if (!config) return attributes
+  const matchers = config.attributes.map(toMatcher).filter((matcher): matcher is (key: string) => boolean => !!matcher)
+  if (matchers.length === 0) return attributes
+  return attributes.map((attr) =>
+    matchers.some((matches) => matches(attr.key)) ? redactedAttr(attr.key, config.mask) : attr,
+  )
+}
+
+function parseAttributes(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+}
+
+function parseAttributesEnv(value: string | undefined): string[] {
+  if (!value) return []
+  try {
+    const parsed = JSON.parse(value) as unknown
+    const attributes = parseAttributes(parsed)
+    if (attributes.length > 0) return attributes
+  } catch {}
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item !== "")
+}
+
+function toMatcher(pattern: string): ((key: string) => boolean) | undefined {
+  if (pattern.startsWith("/") && pattern.lastIndexOf("/") > 0) {
+    const end = pattern.lastIndexOf("/")
+    try {
+      const regex = new RegExp(pattern.slice(1, end), pattern.slice(end + 1))
+      return (key) => {
+        regex.lastIndex = 0
+        return regex.test(key)
+      }
+    } catch {
+      return undefined
+    }
+  }
+  try {
+    const regex = new RegExp(pattern)
+    return (key) => {
+      regex.lastIndex = 0
+      return key === pattern || regex.test(key)
+    }
+  } catch {
+    return (key) => key === pattern
+  }
+}
+
+function redactedAttr(key: string, mask: string): OtlpKeyValue {
+  return { key, value: { stringValue: mask } }
+}

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -211,6 +211,7 @@ Two blocks live under `plugins.entries["@latitude-data/openclaw-telemetry"]`:
 | `project` | yes | — | Slug of the project to route traces into. |
 | `baseUrl` | no | `https://ingest.latitude.so` | Override OTLP ingest origin. The CLI sets this only when `--staging` or `--dev` is passed. |
 | `allowConversationAccess` | no | `false` | When `true`, attach raw prompts, assistant responses, system instructions, and tool I/O to spans. When `false`, emit only timing, token usage, model name, agent id, and structural ids — same span tree, scrubbed payloads. **Must match `hooks.allowConversationAccess` below — see [The two flags](#the-two-flags).** |
+| `redact` | no | — | Custom local attribute redaction before export: `{ "attributes": ["/^gen_ai\\.(input|output)\\.messages$/"], "mask": "[]" }`. Patterns are exact strings, regex source strings, or `/pattern/flags` strings. |
 | `enabled` | no | `true` | Set to `false` to pause emission without uninstalling. |
 | `debug` | no | `false` | Log diagnostic lines to stderr (visible in the gateway log). |
 
@@ -244,6 +245,25 @@ The CLI's first-install default writes `allowConversationAccess: true` to both b
 For hand-edited configs, leaving `allowConversationAccess` out entirely produces **no traces** (not "structural-only traces") because `hooks.allowConversationAccess` defaults to `false` at OpenClaw's level and dispatch is blocked. Always set both keys explicitly.
 
 To pause emission without uninstalling, set `enabled: false` on the plugin entry, or `LATITUDE_OPENCLAW_ENABLED=0` in the gateway environment.
+
+For field-level PII controls while keeping content capture enabled, add `config.redact`. For example, to send empty message arrays for prompts/responses before anything leaves the gateway:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "@latitude-data/openclaw-telemetry": {
+        "config": {
+          "redact": {
+            "attributes": ["/^gen_ai\\.(input|output)\\.messages$/"],
+            "mask": "[]"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ## Supported OpenClaw versions
 

--- a/packages/telemetry/openclaw/src/config.test.ts
+++ b/packages/telemetry/openclaw/src/config.test.ts
@@ -60,6 +60,16 @@ describe("loadConfig", () => {
     expect(loadConfig({ apiKey: "k", project: "p", debug: true }).debug).toBe(true)
   })
 
+  it("reads custom redaction config from pluginConfig", () => {
+    const config = loadConfig({
+      apiKey: "k",
+      project: "p",
+      redact: { attributes: ["gen_ai.input.messages"], mask: "[]" },
+    })
+
+    expect(config.redact).toEqual({ attributes: ["gen_ai.input.messages"], mask: "[]" })
+  })
+
   // Regression guard against the OpenClaw 2026.4.25 `env-harvesting` security
   // rule: any source containing both `process.env` and a network-send call
   // (we have `fetch(` in postTraces) is flagged as potential credential

--- a/packages/telemetry/openclaw/src/config.ts
+++ b/packages/telemetry/openclaw/src/config.ts
@@ -1,3 +1,5 @@
+import { parseRedactConfig, type RedactConfig } from "./redaction.ts"
+
 export interface Config {
   apiKey: string
   baseUrl: string
@@ -11,6 +13,7 @@ export interface Config {
    * names, agent ids, and timings are unaffected.
    */
   allowConversationAccess: boolean
+  redact?: RedactConfig | undefined
 }
 
 const DEFAULT_BASE_URL = "https://ingest.latitude.so"
@@ -53,6 +56,7 @@ export function loadConfig(pluginConfig: Record<string, unknown> | undefined = u
     project,
     debug,
     allowConversationAccess,
+    redact: parseRedactConfig(fromOpts.redact),
     enabled: hasCreds && !explicitlyDisabled,
   }
 }

--- a/packages/telemetry/openclaw/src/otlp.test.ts
+++ b/packages/telemetry/openclaw/src/otlp.test.ts
@@ -174,6 +174,19 @@ describe("buildOtlpRequest", () => {
     expect(traceIds.size).toBe(1)
   })
 
+  it("redacts matching attributes before export", () => {
+    const req = buildOtlpRequest(makeAgentResult(), {
+      allowConversationAccess: true,
+      redact: { attributes: ["/^gen_ai\\.(input|output)\\.messages$/"], mask: "[]" },
+    })
+    const span = findSpanByName(req, "agent")
+    const attrs = attrMap(span?.attributes ?? [])
+
+    expect(attrs["gen_ai.input.messages"]).toBe("[]")
+    expect(attrs["gen_ai.output.messages"]).toBe("[]")
+    expect(attrs["openclaw.agent.name"]).toBe("router")
+  })
+
   it("encodes latitude.tags as a JSON-stringified string array (resolver contract)", () => {
     // The resolver in domain/spans/src/otlp/resolvers/enrichment.ts reads
     // `latitude.tags` via `fromJsonStringArray` — that helper expects a

--- a/packages/telemetry/openclaw/src/otlp.ts
+++ b/packages/telemetry/openclaw/src/otlp.ts
@@ -1,4 +1,5 @@
 import { arch, hostname, platform, release } from "node:os"
+import { type RedactConfig, redactAttributes } from "./redaction.ts"
 import type { AttrValue, BuildResult, SpanRecord } from "./span-builder.ts"
 import type { OtlpExportRequest, OtlpKeyValue, OtlpResourceSpans, OtlpSpan } from "./types.ts"
 
@@ -41,6 +42,7 @@ interface BuildOptions {
    * `latitude.captured.content` boolean are always emitted.
    */
   allowConversationAccess: boolean
+  redact?: RedactConfig | undefined
 }
 
 /** Build an OTLP export request for a single completed agent run. */
@@ -76,6 +78,7 @@ function toOtlpSpan(span: SpanRecord, options: BuildOptions): OtlpSpan {
   if (span.endMs !== undefined) {
     attrs.push(int("openclaw.duration_ms.computed", Math.max(0, span.endMs - span.startMs)))
   }
+  const redactedAttrs = redactAttributes(attrs, options.redact)
 
   const statusCode = span.outcome === "error" ? 2 : 1
   return {
@@ -89,7 +92,7 @@ function toOtlpSpan(span: SpanRecord, options: BuildOptions): OtlpSpan {
     kind: 1,
     startTimeUnixNano: startNs,
     endTimeUnixNano: endNs,
-    attributes: attrs,
+    attributes: redactedAttrs,
     status: { code: statusCode },
   }
 }

--- a/packages/telemetry/openclaw/src/plugin.ts
+++ b/packages/telemetry/openclaw/src/plugin.ts
@@ -222,7 +222,10 @@ export default function registerLatitudePlugin(api: OpenClawPluginApiLike, opts:
             return
           }
           opts.onEmit?.(result)
-          const payload = buildOtlpRequest(result, { allowConversationAccess: config.allowConversationAccess })
+          const payload = buildOtlpRequest(result, {
+            allowConversationAccess: config.allowConversationAccess,
+            redact: config.redact,
+          })
           void postTraces({
             baseUrl: config.baseUrl,
             apiKey: config.apiKey,

--- a/packages/telemetry/openclaw/src/redaction.ts
+++ b/packages/telemetry/openclaw/src/redaction.ts
@@ -1,0 +1,56 @@
+import type { OtlpKeyValue } from "./types.ts"
+
+export interface RedactConfig {
+  attributes: string[]
+  mask: string
+}
+
+export function parseRedactConfig(value: unknown): RedactConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const obj = value as Record<string, unknown>
+  const attributes = parseAttributes(obj.attributes)
+  if (attributes.length === 0) return undefined
+  return { attributes, mask: typeof obj.mask === "string" ? obj.mask : "******" }
+}
+
+export function redactAttributes(attributes: OtlpKeyValue[], config: RedactConfig | undefined): OtlpKeyValue[] {
+  if (!config) return attributes
+  const matchers = config.attributes.map(toMatcher).filter((matcher): matcher is (key: string) => boolean => !!matcher)
+  if (matchers.length === 0) return attributes
+  return attributes.map((attr) =>
+    matchers.some((matches) => matches(attr.key)) ? redactedAttr(attr.key, config.mask) : attr,
+  )
+}
+
+function parseAttributes(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+}
+
+function toMatcher(pattern: string): ((key: string) => boolean) | undefined {
+  if (pattern.startsWith("/") && pattern.lastIndexOf("/") > 0) {
+    const end = pattern.lastIndexOf("/")
+    try {
+      const regex = new RegExp(pattern.slice(1, end), pattern.slice(end + 1))
+      return (key) => {
+        regex.lastIndex = 0
+        return regex.test(key)
+      }
+    } catch {
+      return undefined
+    }
+  }
+  try {
+    const regex = new RegExp(pattern)
+    return (key) => {
+      regex.lastIndex = 0
+      return key === pattern || regex.test(key)
+    }
+  } catch {
+    return (key) => key === pattern
+  }
+}
+
+function redactedAttr(key: string, mask: string): OtlpKeyValue {
+  return { key, value: { stringValue: mask } }
+}

--- a/packages/telemetry/pi/README.md
+++ b/packages/telemetry/pi/README.md
@@ -28,6 +28,25 @@ Restart pi after installation so it can install and load the package.
 
 By default this captures full prompts, assistant responses, tool inputs, and tool outputs. Install with `--no-content` to keep structure, timing, token usage, model names, and tool names while scrubbing content fields.
 
+For field-level PII controls while keeping content capture enabled, add `redact` to `~/.pi/agent/latitude-telemetry.json` or set `LATITUDE_REDACT_ATTRIBUTES`. Patterns are exact strings, regex source strings, or `/pattern/flags` strings.
+
+```json
+{
+  "redact": {
+    "attributes": ["/^gen_ai\\.(input|output)\\.messages$/", "gen_ai.tool.call.arguments"],
+    "mask": "[]"
+  }
+}
+```
+
+Environment equivalent:
+
+```bash
+LATITUDE_REDACT_ATTRIBUTES='["/^gen_ai\\.(input|output)\\.messages$/"]' \
+LATITUDE_REDACT_MASK='[]' \
+pi
+```
+
 ## Disable
 
 ```bash

--- a/packages/telemetry/pi/src/config.ts
+++ b/packages/telemetry/pi/src/config.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import { hostname, userInfo } from "node:os"
 import { join } from "node:path"
+import { parseRedactConfig, parseRedactEnv } from "./redaction.ts"
 import type { RuntimeConfig, UserIdentity } from "./types.ts"
 
 export const configFileName = "latitude-telemetry.json"
@@ -15,6 +16,7 @@ interface FileConfig {
   allowConversationAccess?: boolean | undefined
   tags?: string[] | undefined
   metadata?: Record<string, string> | undefined
+  redact?: unknown
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig {
@@ -44,6 +46,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): RuntimeConfig 
     enabled,
     debug,
     allowConversationAccess,
+    redact: parseRedactEnv(env) ?? parseRedactConfig(file.redact),
     tags: file.tags ?? ["pi"],
     metadata: file.metadata ?? {},
     configSource,
@@ -93,6 +96,7 @@ function readFileConfig(path: string): FileConfig {
       allowConversationAccess: booleanValue(obj.allowConversationAccess),
       tags: stringArrayValue(obj.tags),
       metadata: stringRecordValue(obj.metadata),
+      redact: obj.redact,
     }
   } catch {
     return {}

--- a/packages/telemetry/pi/src/extension.ts
+++ b/packages/telemetry/pi/src/extension.ts
@@ -87,6 +87,7 @@ export default function latitudePiTelemetry(pi: PiExtensionAPI): void {
     const payload = buildOtlpRequest(result, {
       allowConversationAccess: config.allowConversationAccess,
       identity,
+      redact: config.redact,
     })
 
     const exportPromise = postTraces({

--- a/packages/telemetry/pi/src/otlp.test.ts
+++ b/packages/telemetry/pi/src/otlp.test.ts
@@ -94,4 +94,18 @@ describe("buildOtlpRequest", () => {
     expect(finishReasons?.value.arrayValue?.values).toEqual([{ stringValue: "stop" }])
     expect(finishReasons?.value.stringValue).toBeUndefined()
   })
+
+  it("redacts matching attributes after content gating", () => {
+    const req = buildOtlpRequest(result(), {
+      allowConversationAccess: true,
+      identity,
+      redact: { attributes: ["/^gen_ai\\.(input|output)\\.messages$/"], mask: "[]" },
+    })
+    const span = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const attrs = attrMap(span?.attributes ?? [])
+
+    expect(attrs["gen_ai.input.messages"]).toBe("[]")
+    expect(attrs["gen_ai.output.messages"]).toBe("[]")
+    expect(attrs["gen_ai.operation.name"]).toBe("chat")
+  })
 })

--- a/packages/telemetry/pi/src/otlp.ts
+++ b/packages/telemetry/pi/src/otlp.ts
@@ -1,4 +1,5 @@
 import { arch, hostname, platform, release } from "node:os"
+import { type RedactConfig, redactAttributes } from "./redaction.ts"
 import type {
   AttrValue,
   BuildResult,
@@ -15,10 +16,11 @@ const scopeName = "@latitude-data/pi-telemetry"
 interface BuildOptions {
   allowConversationAccess: boolean
   identity: UserIdentity
+  redact?: RedactConfig | undefined
 }
 
 export function buildOtlpRequest(result: BuildResult, options: BuildOptions): OtlpExportRequest {
-  const spans = result.spans.map((span) => toOtlpSpan(span, options.allowConversationAccess))
+  const spans = result.spans.map((span) => toOtlpSpan(span, options))
   const rs: OtlpResourceSpans = {
     resource: { attributes: resourceAttrs(options.identity) },
     scopeSpans: [{ scope: { name: scopeName, version: packageVersion }, spans }],
@@ -26,18 +28,19 @@ export function buildOtlpRequest(result: BuildResult, options: BuildOptions): Ot
   return { resourceSpans: [rs] }
 }
 
-function toOtlpSpan(span: BuildResult["spans"][number], allowConversationAccess: boolean): OtlpSpan {
+function toOtlpSpan(span: BuildResult["spans"][number], options: BuildOptions): OtlpSpan {
   const attrs: OtlpKeyValue[] = []
   for (const [rawKey, value] of Object.entries(span.attrs)) {
     if (value === undefined || value === null) continue
     const isGated = rawKey.endsWith(":gated")
-    if (isGated && !allowConversationAccess) continue
+    if (isGated && !options.allowConversationAccess) continue
     const key = isGated ? rawKey.slice(0, -":gated".length) : rawKey
     const encoded = encodeAttr(key, value)
     if (encoded) attrs.push(encoded)
   }
-  attrs.push(bool("latitude.captured.content", allowConversationAccess))
+  attrs.push(bool("latitude.captured.content", options.allowConversationAccess))
   if (span.endMs !== undefined) attrs.push(int("pi.duration_ms.computed", Math.max(0, span.endMs - span.startMs)))
+  const redactedAttrs = redactAttributes(attrs, options.redact)
 
   const statusCode = span.outcome === "error" ? 2 : 1
   return {
@@ -48,7 +51,7 @@ function toOtlpSpan(span: BuildResult["spans"][number], allowConversationAccess:
     kind: 1,
     startTimeUnixNano: msToNs(span.startMs),
     endTimeUnixNano: msToNs(span.endMs ?? span.startMs),
-    attributes: attrs,
+    attributes: redactedAttrs,
     status: span.errorMessage ? { code: statusCode, message: span.errorMessage } : { code: statusCode },
   }
 }

--- a/packages/telemetry/pi/src/redaction.ts
+++ b/packages/telemetry/pi/src/redaction.ts
@@ -1,0 +1,75 @@
+import type { OtlpKeyValue } from "./types.ts"
+
+export interface RedactConfig {
+  attributes: string[]
+  mask: string
+}
+
+export function parseRedactConfig(value: unknown): RedactConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const obj = value as Record<string, unknown>
+  const attributes = parseAttributes(obj.attributes)
+  if (attributes.length === 0) return undefined
+  return { attributes, mask: typeof obj.mask === "string" ? obj.mask : "******" }
+}
+
+export function parseRedactEnv(env: NodeJS.ProcessEnv): RedactConfig | undefined {
+  const attributes = parseAttributesEnv(env.LATITUDE_REDACT_ATTRIBUTES)
+  if (attributes.length === 0) return undefined
+  return { attributes, mask: env.LATITUDE_REDACT_MASK ?? "******" }
+}
+
+export function redactAttributes(attributes: OtlpKeyValue[], config: RedactConfig | undefined): OtlpKeyValue[] {
+  if (!config) return attributes
+  const matchers = config.attributes.map(toMatcher).filter((matcher): matcher is (key: string) => boolean => !!matcher)
+  if (matchers.length === 0) return attributes
+  return attributes.map((attr) =>
+    matchers.some((matches) => matches(attr.key)) ? redactedAttr(attr.key, config.mask) : attr,
+  )
+}
+
+function parseAttributes(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+}
+
+function parseAttributesEnv(value: string | undefined): string[] {
+  if (!value) return []
+  try {
+    const parsed = JSON.parse(value) as unknown
+    const attributes = parseAttributes(parsed)
+    if (attributes.length > 0) return attributes
+  } catch {}
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item !== "")
+}
+
+function toMatcher(pattern: string): ((key: string) => boolean) | undefined {
+  if (pattern.startsWith("/") && pattern.lastIndexOf("/") > 0) {
+    const end = pattern.lastIndexOf("/")
+    try {
+      const regex = new RegExp(pattern.slice(1, end), pattern.slice(end + 1))
+      return (key) => {
+        regex.lastIndex = 0
+        return regex.test(key)
+      }
+    } catch {
+      return undefined
+    }
+  }
+  try {
+    const regex = new RegExp(pattern)
+    return (key) => {
+      regex.lastIndex = 0
+      return key === pattern || regex.test(key)
+    }
+  } catch {
+    return (key) => key === pattern
+  }
+}
+
+function redactedAttr(key: string, mask: string): OtlpKeyValue {
+  return { key, value: { stringValue: mask } }
+}

--- a/packages/telemetry/pi/src/settings-file.ts
+++ b/packages/telemetry/pi/src/settings-file.ts
@@ -11,6 +11,12 @@ export interface PiTelemetryConfigFile {
   enabled: boolean
   debug?: boolean | undefined
   allowConversationAccess: boolean
+  redact?:
+    | {
+        attributes: string[]
+        mask?: string | undefined
+      }
+    | undefined
   tags: string[]
   metadata: Record<string, string>
 }

--- a/packages/telemetry/pi/src/setup.ts
+++ b/packages/telemetry/pi/src/setup.ts
@@ -230,6 +230,7 @@ function applyInstall({
     enabled: true,
     debug: existingConfig.debug ?? false,
     allowConversationAccess,
+    ...(existingConfig.redact ? { redact: existingConfig.redact } : {}),
     tags: existingConfig.tags ?? ["pi"],
     metadata: existingConfig.metadata ?? {},
   }

--- a/packages/telemetry/pi/src/types.ts
+++ b/packages/telemetry/pi/src/types.ts
@@ -1,3 +1,5 @@
+import type { RedactConfig } from "./redaction.ts"
+
 // OTLP wire types. We hand-roll the small JSON subset Latitude needs instead
 // of depending on the OpenTelemetry SDK inside the pi extension runtime.
 
@@ -108,6 +110,7 @@ export interface RuntimeConfig {
   enabled: boolean
   debug: boolean
   allowConversationAccess: boolean
+  redact?: RedactConfig | undefined
   tags: string[]
   metadata: Record<string, string>
   configSource: "env" | "file" | "none"


### PR DESCRIPTION
Adds local custom attribute redaction to the pi, OpenClaw, and Claude Code telemetry packages so users can keep content capture enabled while masking selected span attributes before OTLP export. This covers the agent telemetry integrations that do not use the TypeScript/Python SDK span processor path.

The new redaction config accepts exact attribute names, regex source strings, or `/pattern/flags` strings, with a configurable mask. Pi and Claude Code can read `LATITUDE_REDACT_ATTRIBUTES` / `LATITUDE_REDACT_MASK`; pi also persists `redact` in its config file, and OpenClaw reads `config.redact` from the plugin config. Redaction runs after the existing content gate and before the payload is sent.

Docs now describe the new knobs and include examples for redacting `gen_ai.input.messages`, `gen_ai.output.messages`, tool arguments/results, and user prompts.

Validated with:

- `pnpm --filter @latitude-data/pi-telemetry typecheck`
- `pnpm --filter @latitude-data/openclaw-telemetry typecheck`
- `pnpm --filter @latitude-data/claude-code-telemetry typecheck`
- `pnpm --filter @latitude-data/pi-telemetry test`
- `pnpm --filter @latitude-data/openclaw-telemetry test`
- `pnpm --filter @latitude-data/claude-code-telemetry test`