### PR TITLE
feat(telemetry): support Eve framework instrumentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
               "telemetry/frameworks/langchain",
               "telemetry/frameworks/llamaindex",
               "telemetry/frameworks/mastra",
+              "telemetry/frameworks/eve",
               "telemetry/frameworks/strands",
               "telemetry/frameworks/livekit"
             ]

--- a/docs/telemetry/frameworks/eve.mdx
+++ b/docs/telemetry/frameworks/eve.mdx
@@ -1,0 +1,116 @@
+---
+title: Eve
+description: Connect your Eve-powered agent to Latitude for observability.
+---
+
+## Overview
+
+This guide shows you how to send traces from an agent built with **[Eve](https://eve.dev)** to Latitude.
+
+Eve is built on the **Vercel AI SDK** and exports standard OpenTelemetry spans (`ai.streamText`, `ai.toolCall`, …) through whatever exporter you register in `agent/instrumentation.ts`. Because Latitude already understands Vercel AI SDK spans, you can point Eve's OTel exporter straight at Latitude's OTLP endpoint — no Latitude SDK required.
+
+<Check>
+  You'll keep building with Eve exactly as you do today. The exporter simply
+  sends your traces to Latitude alongside any other observability backend.
+</Check>
+
+<Note>
+  The Eve integration is **TypeScript only**.
+</Note>
+
+---
+
+## Requirements
+
+- A **Latitude account** and **API key**
+- A **Latitude project slug**
+- An **Eve** project (with an `agent/instrumentation.ts` file)
+
+---
+
+## Steps
+
+<Steps>
+
+  <Step title="Install">
+    <CodeGroup>
+      ```bash npm
+      npm install @vercel/otel @opentelemetry/exporter-trace-otlp-http
+      ```
+
+      ```bash pnpm
+      pnpm add @vercel/otel @opentelemetry/exporter-trace-otlp-http
+      ```
+
+      ```bash yarn
+      yarn add @vercel/otel @opentelemetry/exporter-trace-otlp-http
+      ```
+
+      ```bash bun
+      bun add @vercel/otel @opentelemetry/exporter-trace-otlp-http
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Point the exporter at Latitude">
+    In `agent/instrumentation.ts`, register an OTLP exporter that targets Latitude's ingestion endpoint. Eve auto-discovers this file and runs it at startup, which implicitly enables telemetry.
+
+    ```ts
+    import { defineInstrumentation } from "eve/instrumentation"
+    import { registerOTel } from "@vercel/otel"
+    import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+
+    export default defineInstrumentation({
+      setup: ({ agentName }) =>
+        registerOTel({
+          serviceName: agentName,
+          traceExporter: new OTLPTraceExporter({
+            url: "https://ingest.latitude.so/v1/traces",
+            headers: {
+              Authorization: `Bearer ${process.env.LATITUDE_API_KEY!}`,
+              "X-Latitude-Project": process.env.LATITUDE_PROJECT_SLUG!,
+            },
+          }),
+        }),
+    })
+    ```
+
+    <Note>
+      Eve records full message history and model outputs on spans by default
+      (`recordInputs` / `recordOutputs`). Set them to `false` for sensitive or
+      regulated data.
+    </Note>
+  </Step>
+
+  <Step title="Group turns into sessions (optional)">
+    Eve tags every turn with `eve.session.id`, which Latitude reads automatically to group related traces into a session — no extra work needed.
+
+    To also associate traces with an end user, return a `user.id` attribute from the `step.started` event so it lands on the spans:
+
+    ```ts
+    export default defineInstrumentation({
+      setup: ({ agentName }) => registerOTel({ /* … */ }),
+      events: {
+        "step.started"(input) {
+          return {
+            runtimeContext: {
+              "user.id": input.channel.metadata.triggeringUserId ?? "",
+            },
+          }
+        },
+      },
+    })
+    ```
+  </Step>
+
+</Steps>
+
+---
+
+## Seeing Your Traces
+
+Once connected, traces appear automatically in Latitude:
+
+1. Open your **project** in the Latitude dashboard
+2. Each turn shows input/output messages, model, token usage, latency, and errors
+3. Eve turns, model calls, and tool executions appear as nested spans, grouped by session

--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -91,6 +91,7 @@ export const sessionIdCandidates = [
   fromString("traceloop.association.properties.session_id"), // Traceloop / OpenLLMetry
   fromString("langsmith.trace.session_id"), // LangSmith
   fromString("session_id"), // Datadog / HoneyHive
+  fromString("eve.session.id"), // Eve framework
 
   // Fallbacks
   // These do not actually represent sessions, they represent specific threads.
@@ -98,6 +99,7 @@ export const sessionIdCandidates = [
   fromString("wandb.thread_id"), // W&B Weave
   fromString("ai.telemetry.metadata.threadId"), // Opik (via Vercel AI SDK metadata)
   fromString("gen_ai.conversation.id"), // GenAI semconv
+  fromString("eve.turn.id"), // Eve framework (per-turn thread fallback)
 ]
 
 export const userIdCandidates = [

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -445,6 +445,18 @@ describe("resolveAttributes", () => {
       const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
       expect(result.sessionId).toBe("sess-456")
     })
+
+    it("resolves from Eve eve.session.id", () => {
+      const attrs: OtlpKeyValue[] = [strAttr("eve.session.id", "eve-sess-789")]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.sessionId).toBe("eve-sess-789")
+    })
+
+    it("falls back to Eve eve.turn.id when no session id is present", () => {
+      const attrs: OtlpKeyValue[] = [strAttr("eve.turn.id", "eve-turn-1")]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.sessionId).toBe("eve-turn-1")
+    })
   })
 
   describe("error type", () => {

--- a/packages/telemetry/typescript/src/sdk/span-filter.test.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.test.ts
@@ -29,6 +29,7 @@ describe("isGenAiOrLlmAttributeSpan", () => {
     expect(isGenAiOrLlmAttributeSpan(mockSpan({ attributes: { "gen_ai.request.model": "gpt-4" } }))).toBe(true)
     expect(isGenAiOrLlmAttributeSpan(mockSpan({ attributes: { "llm.model_name": "x" } }))).toBe(true)
     expect(isGenAiOrLlmAttributeSpan(mockSpan({ attributes: { "openinference.span.kind": "CHAIN" } }))).toBe(true)
+    expect(isGenAiOrLlmAttributeSpan(mockSpan({ attributes: { "eve.session.id": "sess-1" } }))).toBe(true)
     expect(isGenAiOrLlmAttributeSpan(mockSpan({ attributes: { "http.route": "/api" } }))).toBe(false)
   })
 })

--- a/packages/telemetry/typescript/src/sdk/span-filter.ts
+++ b/packages/telemetry/typescript/src/sdk/span-filter.ts
@@ -89,6 +89,8 @@ export function isGenAiOrLlmAttributeSpan(span: ReadableSpan): boolean {
     if (key === OPENINFERENCE_KIND || key.startsWith("openinference.")) return true
     // Vercel AI SDK uses ai.* prefix
     if (key.startsWith("ai.")) return true
+    // Eve framework grouping spans carry only eve.* attributes
+    if (key.startsWith("eve.")) return true
     // Latitude context attributes
     if (key.startsWith("latitude.")) return true
   }


### PR DESCRIPTION
## Summary

[Eve](https://eve.dev) is a TypeScript agent framework built on the **Vercel AI SDK**. It exports plain OpenTelemetry spans (`ai.streamText`, `ai.toolCall`, …) via `@vercel/otel` to any OTLP-compatible backend — which means Latitude's existing Vercel AI SDK ingestion path already handles Eve's LLM calls, tool calls/results, models, and token usage **with no changes** once the exporter is pointed at `https://ingest.latitude.so/v1/traces`.

This PR closes the two remaining gaps so Eve traces land in Latitude fully formed, plus adds a docs page.

## Changes

- **Session grouping** (`packages/domain/spans/src/otlp/resolvers/identity.ts`): recognize `eve.session.id` as a session identifier, with `eve.turn.id` as a per-turn thread-level fallback. Without this, Eve turns wouldn't collapse into Latitude sessions, since Eve uses `eve.session.id` rather than the standard `session.id`.
- **Smart filter** (`packages/telemetry/typescript/src/sdk/span-filter.ts`): whitelist the `eve.` attribute prefix in `isGenAiOrLlmAttributeSpan`. Eve's `ai.eve.turn` grouping span carries only `eve.*` attributes, so it would be dropped by the SDK's `LatitudeSpanProcessor` smart filter (orphaning its children's trace tree). Raw OTLP exporters are unaffected (no filter), but this keeps the grouping span when the Latitude SDK processor is used.
- **Docs**: add `docs/telemetry/frameworks/eve.mdx` (registered in `docs.json`) with the OTLP exporter setup recipe and optional `step.started` → `user.id` mapping.

## Why these are low-risk

- Both code changes are additive: a new session-id candidate appended after the existing ones (existing precedence unchanged) and one new attribute-prefix branch in the filter.
- The content-parser dispatch is attribute-based (keys off `ai.prompt` / `ai.prompt.messages`), so Eve's Vercel AI SDK spans already route to `parseVercel` — no new parser needed.

## Tests

- `packages/domain/spans/src/otlp/resolvers/resolvers.test.ts`: `eve.session.id` resolves as session id; `eve.turn.id` used as fallback.
- `packages/telemetry/typescript/src/sdk/span-filter.test.ts`: `eve.*` attribute span passes the smart filter.

Both suites pass; both packages typecheck; `pnpm format` and `pnpm knip` clean.

## Not included (follow-ups, validated against a live Eve trace)

- Whether Eve's `step.started` `runtimeContext` keys land on child LLM spans vs. only the turn span (affects the `user.id` mapping recipe).
- OTel context (`traceparent`) propagation across Eve subagent boundaries for cross-trace linkage — Eve's `\$eve.parent`/`\$eve.root` lineage tags live on Vercel Workflow runs, not on OTel spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)