### PR TITLE
Stream trace conversations in chunks

### DIFF
--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -15,6 +15,7 @@ import {
   countTracesByProject,
   getSessionMomentIntelligence,
   getTraceCohortSummary,
+  getTraceConversationChunk,
   getTraceDetail,
   getTraceDistinctValues,
   getTraceDistribution,
@@ -23,6 +24,7 @@ import {
   getTraceTimeHistogramByProject,
   listTracesByProject,
   type SessionMomentIntelligenceRecord,
+  type TraceConversationChunkRecord,
   type TraceDetailRecord,
   type TraceRecord,
 } from "./traces.functions.ts"
@@ -32,6 +34,7 @@ const sessionMomentIntelligenceQueryKey = (projectId: string, sessionId: string)
   ["sessionMomentIntelligence", projectId, sessionId] as const
 
 const BATCH_SIZE = 50
+const CONVERSATION_CHUNK_SIZE = 25
 
 export function useTracesInfiniteScroll({
   projectId,
@@ -285,6 +288,42 @@ export function useTraceDetail({
     },
     enabled: enabled && projectId.length > 0 && traceId.length > 0,
   })
+}
+
+export function useTraceConversationMessages({
+  projectId,
+  traceId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly enabled?: boolean
+}) {
+  const scope = use(TraceScopeContext)
+  const query = useInfiniteQuery({
+    queryKey: [...traceScopeKey(scope), "traceConversation", projectId, traceId],
+    queryFn: async ({ pageParam }): Promise<TraceConversationChunkRecord> => {
+      const result = await getTraceConversationChunk({
+        data: {
+          ...traceScopeData(scope),
+          projectId,
+          traceId,
+          offset: pageParam,
+          limit: CONVERSATION_CHUNK_SIZE,
+        },
+      })
+      return result as TraceConversationChunkRecord
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.messages.length : undefined),
+    enabled: enabled && projectId.length > 0 && traceId.length > 0,
+  })
+
+  const messages = useMemo(() => query.data?.pages.flatMap((page) => page.messages) ?? [], [query.data])
+  const totalMessages = query.data?.pages[0]?.totalMessages ?? 0
+  const payloadBytes = query.data?.pages[0]?.payloadBytes ?? 0
+
+  return { ...query, messages, totalMessages, payloadBytes }
 }
 
 export function useSessionMomentIntelligence({

--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -320,6 +320,7 @@ export function useTraceConversationMessages({
   })
 
   const messages = useMemo(() => query.data?.pages.flatMap((page) => page.messages) ?? [], [query.data])
+  // Every chunk carries whole-conversation metadata; page 0 is the stable header.
   const totalMessages = query.data?.pages[0]?.totalMessages ?? 0
   const payloadBytes = query.data?.pages[0]?.payloadBytes ?? 0
 

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -18,6 +18,7 @@ import type {
 } from "@domain/spans"
 import {
   getTraceCohortSummaryUseCase,
+  getTraceConversationChunkUseCase,
   getTraceSearchHighlightsUseCase,
   mergeTraceHistogramTimeFilters,
   TraceRepository,
@@ -429,26 +430,6 @@ export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
     )
   })
 
-const parseClickHouseNumber = (value: string | number | undefined): number => {
-  const numeric = Number(value)
-  return Number.isFinite(numeric) ? numeric : 0
-}
-
-const parseMessageJson = (json: string): GenAIMessage | null => {
-  try {
-    const parsed = JSON.parse(json)
-    return parsed && typeof parsed === "object" ? (parsed as GenAIMessage) : null
-  } catch {
-    return null
-  }
-}
-
-type TraceConversationChunkRow = {
-  readonly total_messages: string | number
-  readonly payload_bytes: string | number
-  readonly messages: readonly string[]
-}
-
 export const getTraceDetail = createServerFn({ method: "GET" })
   .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: z.string() }))
   .handler(async ({ data }) => {
@@ -457,15 +438,13 @@ export const getTraceDetail = createServerFn({ method: "GET" })
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* TraceRepository
-        const page = yield* repo.listByProjectId({
-          organizationId: orgId,
-          projectId: ProjectId(data.projectId),
-          options: {
-            limit: 1,
-            filters: { traceId: [{ op: "eq", value: data.traceId }] },
-          },
-        })
-        const trace = page.items[0]
+        const trace = yield* repo
+          .findMetadataByTraceId({
+            organizationId: orgId,
+            projectId: ProjectId(data.projectId),
+            traceId: TraceId(data.traceId),
+          })
+          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
         return trace ? serializeTraceMetadataDetail(trace) : null
       }).pipe(
         withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
@@ -492,57 +471,17 @@ export const getTraceConversationChunk = createServerFn({ method: "GET" })
     const offset = data.offset ?? 0
     const limit = data.limit ?? 25
 
-    const result = await getClickhouseClient().query({
-      query: `SELECT
-                length(all_messages) AS total_messages,
-                arraySum(message -> length(message), all_messages) AS payload_bytes,
-                arraySlice(all_messages, {offset:UInt64} + 1, {limit:UInt64}) AS messages
-              FROM (
-                SELECT arrayConcat(
-                  if(
-                    length(JSONExtractArrayRaw(system_instructions_json)) > 0,
-                    [concat('{"role":"system","parts":', system_instructions_json, '}')],
-                    []
-                  ),
-                  JSONExtractArrayRaw(last_input_messages_json),
-                  JSONExtractArrayRaw(output_messages_json)
-                ) AS all_messages
-                FROM (
-                  SELECT
-                    argMinIfMerge(system_instructions) AS system_instructions_json,
-                    argMaxIfMerge(last_input_messages) AS last_input_messages_json,
-                    argMaxIfMerge(output_messages) AS output_messages_json
-                  FROM traces
-                  WHERE organization_id = {organizationId:String}
-                    AND project_id = {projectId:String}
-                    AND trace_id = {traceId:FixedString(32)}
-                  GROUP BY organization_id, project_id, trace_id
-                  LIMIT 1
-                )
-              )`,
-      query_params: { organizationId: orgId, projectId: data.projectId, traceId: data.traceId, offset, limit },
-      format: "JSONEachRow",
-    })
-    const rows = await result.json<TraceConversationChunkRow>()
-    const row = rows[0]
-    if (!row) {
-      return { messages: [], offset, limit, totalMessages: 0, hasMore: false, payloadBytes: 0 } as never
-    }
+    const result = await Effect.runPromise(
+      getTraceConversationChunkUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        traceId: TraceId(data.traceId),
+        offset,
+        limit,
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
 
-    const totalMessages = parseClickHouseNumber(row.total_messages)
-    const messages = row.messages.flatMap((message) => {
-      const parsed = parseMessageJson(message)
-      return parsed ? [parsed] : []
-    })
-
-    return {
-      messages,
-      offset,
-      limit,
-      totalMessages,
-      hasMore: offset + messages.length < totalMessages,
-      payloadBytes: parseClickHouseNumber(row.payload_bytes),
-    } as never
+    return result as never
   })
 
 const DISTINCT_COLUMNS = ["tags", "models", "providers", "serviceNames", "tools", "definedTools"] as const

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -10,7 +10,6 @@ import {
 import type {
   CohortSummary,
   Trace,
-  TraceDetail,
   TraceDistinctColumn,
   TraceDistribution,
   TraceMetrics,
@@ -141,13 +140,22 @@ export interface TraceDetailRecord extends TraceRecord {
   readonly allMessages: readonly GenAIMessage[]
 }
 
-const serializeTraceDetail = (trace: TraceDetail): TraceDetailRecord => ({
+const serializeTraceMetadataDetail = (trace: Trace): TraceDetailRecord => ({
   ...toTraceRecord(trace),
-  systemInstructions: trace.systemInstructions,
-  inputMessages: trace.inputMessages,
-  outputMessages: trace.outputMessages,
-  allMessages: trace.allMessages,
+  systemInstructions: [],
+  inputMessages: [],
+  outputMessages: [],
+  allMessages: [],
 })
+
+export interface TraceConversationChunkRecord {
+  readonly messages: readonly GenAIMessage[]
+  readonly offset: number
+  readonly limit: number
+  readonly totalMessages: number
+  readonly hasMore: boolean
+  readonly payloadBytes: number
+}
 
 const traceListCursorSchema = z.object({
   sortValue: z.string(),
@@ -421,6 +429,26 @@ export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
     )
   })
 
+const parseClickHouseNumber = (value: string | number | undefined): number => {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : 0
+}
+
+const parseMessageJson = (json: string): GenAIMessage | null => {
+  try {
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === "object" ? (parsed as GenAIMessage) : null
+  } catch {
+    return null
+  }
+}
+
+type TraceConversationChunkRow = {
+  readonly total_messages: string | number
+  readonly payload_bytes: string | number
+  readonly messages: readonly string[]
+}
+
 export const getTraceDetail = createServerFn({ method: "GET" })
   .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: z.string() }))
   .handler(async ({ data }) => {
@@ -429,14 +457,16 @@ export const getTraceDetail = createServerFn({ method: "GET" })
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* TraceRepository
-        const detail = yield* repo
-          .findByTraceId({
-            organizationId: orgId,
-            projectId: ProjectId(data.projectId),
-            traceId: TraceId(data.traceId),
-          })
-          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-        return detail ? serializeTraceDetail(detail) : null
+        const page = yield* repo.listByProjectId({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          options: {
+            limit: 1,
+            filters: { traceId: [{ op: "eq", value: data.traceId }] },
+          },
+        })
+        const trace = page.items[0]
+        return trace ? serializeTraceMetadataDetail(trace) : null
       }).pipe(
         withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
@@ -444,12 +474,75 @@ export const getTraceDetail = createServerFn({ method: "GET" })
       ),
     )
 
-    // rosetta-ai GenAI types use [x: string]: unknown index signatures, but
-    // TanStack Start's Serialize<T> transforms those to [x: string]: {}.
-    // Since unknown is not assignable to {}, the handler rejects the return type.
-    // The runtime values are correct — this is a type-only bridge across the
-    // serialization boundary. The consumer (useTraceDetail) casts back.
     return result as never
+  })
+
+export const getTraceConversationChunk = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      sandboxOrgId: z.string().optional(),
+      projectId: z.string(),
+      traceId: z.string(),
+      offset: z.number().int().nonnegative().optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const orgId = await resolveOrgScope(data)
+    const offset = data.offset ?? 0
+    const limit = data.limit ?? 25
+
+    const result = await getClickhouseClient().query({
+      query: `SELECT
+                length(all_messages) AS total_messages,
+                arraySum(message -> length(message), all_messages) AS payload_bytes,
+                arraySlice(all_messages, {offset:UInt64} + 1, {limit:UInt64}) AS messages
+              FROM (
+                SELECT arrayConcat(
+                  if(
+                    length(JSONExtractArrayRaw(system_instructions_json)) > 0,
+                    [concat('{"role":"system","parts":', system_instructions_json, '}')],
+                    []
+                  ),
+                  JSONExtractArrayRaw(last_input_messages_json),
+                  JSONExtractArrayRaw(output_messages_json)
+                ) AS all_messages
+                FROM (
+                  SELECT
+                    argMinIfMerge(system_instructions) AS system_instructions_json,
+                    argMaxIfMerge(last_input_messages) AS last_input_messages_json,
+                    argMaxIfMerge(output_messages) AS output_messages_json
+                  FROM traces
+                  WHERE organization_id = {organizationId:String}
+                    AND project_id = {projectId:String}
+                    AND trace_id = {traceId:FixedString(32)}
+                  GROUP BY organization_id, project_id, trace_id
+                  LIMIT 1
+                )
+              )`,
+      query_params: { organizationId: orgId, projectId: data.projectId, traceId: data.traceId, offset, limit },
+      format: "JSONEachRow",
+    })
+    const rows = await result.json<TraceConversationChunkRow>()
+    const row = rows[0]
+    if (!row) {
+      return { messages: [], offset, limit, totalMessages: 0, hasMore: false, payloadBytes: 0 } as never
+    }
+
+    const totalMessages = parseClickHouseNumber(row.total_messages)
+    const messages = row.messages.flatMap((message) => {
+      const parsed = parseMessageJson(message)
+      return parsed ? [parsed] : []
+    })
+
+    return {
+      messages,
+      offset,
+      limit,
+      totalMessages,
+      hasMore: offset + messages.length < totalMessages,
+      payloadBytes: parseClickHouseNumber(row.payload_bytes),
+    } as never
   })
 
 const DISTINCT_COLUMNS = ["tags", "models", "providers", "serviceNames", "tools", "definedTools"] as const

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -45,6 +45,7 @@ export function useSessionTimeline({
     sessionStartTime: session.startTime,
     sessionEndTime: session.endTime,
     allMessages: traceDetail?.allMessages,
+    enabled: (traceDetail?.allMessages.length ?? 0) > 0,
   })
   const { data: annotationsData } = useAnnotationsBySession({
     projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -6,7 +6,7 @@ import {
   useSessionConversationSpanMaps,
   useSpansBySessionCollection,
 } from "../../../../../../domains/spans/spans.collection.ts"
-import { useTraceDetail } from "../../../../../../domains/traces/traces.collection.ts"
+import { useTraceConversationMessages, useTraceDetail } from "../../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import {
   buildConversationTimeline,
@@ -32,6 +32,11 @@ export function useSessionTimeline({
   readonly moments: readonly TimelineMomentInput[]
 }): ConversationTimeline | null {
   const { data: traceDetail } = useTraceDetail({ projectId, traceId: latestTraceId })
+  const conversation = useTraceConversationMessages({
+    projectId,
+    traceId: latestTraceId,
+    enabled: traceDetail != null,
+  })
   const { data: spans } = useSpansBySessionCollection({
     projectId,
     sessionId: session.sessionId,
@@ -44,8 +49,8 @@ export function useSessionTimeline({
     latestTraceId,
     sessionStartTime: session.startTime,
     sessionEndTime: session.endTime,
-    allMessages: traceDetail?.allMessages,
-    enabled: (traceDetail?.allMessages.length ?? 0) > 0,
+    allMessages: conversation.messages,
+    enabled: conversation.messages.length > 0,
   })
   const { data: annotationsData } = useAnnotationsBySession({
     projectId,
@@ -55,9 +60,9 @@ export function useSessionTimeline({
   const memberByUserId = useMemberByUserIdMap()
 
   return useMemo(() => {
-    if (!traceDetail || !spanMaps) return null
+    if (!traceDetail || !spanMaps || conversation.messages.length === 0) return null
     return buildConversationTimeline({
-      messages: traceDetail.allMessages,
+      messages: conversation.messages,
       spans: (spans ?? []).map(toTimelineSpan),
       messageSpanMap: spanMaps.messageSpanMap,
       toolCallSpanMap: spanMaps.toolCallSpanMap,
@@ -67,5 +72,5 @@ export function useSessionTimeline({
       ),
       moments,
     })
-  }, [traceDetail, spans, spanMaps, traces, annotationsData, moments, memberByUserId])
+  }, [traceDetail, spans, spanMaps, traces, annotationsData, moments, memberByUserId, conversation.messages])
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
@@ -3,6 +3,7 @@ import { useAnnotationsByTrace } from "../../../../../../domains/annotations/ann
 import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
 import { useConversationSpanMaps } from "../../../../../../domains/spans/spans.collection.ts"
 import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import { useTraceConversationMessages } from "../../../../../../domains/traces/traces.collection.ts"
 import type { TraceDetailRecord, TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import {
   buildConversationTimeline,
@@ -25,12 +26,17 @@ export function useTraceTimeline({
   readonly spans: readonly SpanRecord[] | undefined
   readonly annotationsEnabled: boolean
 }): ConversationTimeline | null {
+  const conversation = useTraceConversationMessages({
+    projectId,
+    traceId,
+    enabled: traceDetail != null,
+  })
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
     traceId,
     startTime: traceDetail?.startTime,
-    allMessages: traceDetail?.allMessages,
-    enabled: (traceDetail?.allMessages.length ?? 0) > 0,
+    allMessages: conversation.messages,
+    enabled: conversation.messages.length > 0,
   })
   const { data: annotationsData } = useAnnotationsByTrace({
     projectId,
@@ -41,9 +47,9 @@ export function useTraceTimeline({
   const memberByUserId = useMemberByUserIdMap()
 
   return useMemo(() => {
-    if (!traceDetail || !spanMaps) return null
+    if (!traceDetail || !spanMaps || conversation.messages.length === 0) return null
     return buildConversationTimeline({
-      messages: traceDetail.allMessages,
+      messages: conversation.messages,
       spans: (spans ?? []).map(toTimelineSpan),
       messageSpanMap: spanMaps.messageSpanMap,
       toolCallSpanMap: spanMaps.toolCallSpanMap,
@@ -53,5 +59,5 @@ export function useTraceTimeline({
       ),
       moments: [],
     })
-  }, [traceDetail, traceRecord, spans, spanMaps, annotationsData, memberByUserId])
+  }, [traceDetail, traceRecord, spans, spanMaps, annotationsData, memberByUserId, conversation.messages])
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
@@ -30,6 +30,7 @@ export function useTraceTimeline({
     traceId,
     startTime: traceDetail?.startTime,
     allMessages: traceDetail?.allMessages,
+    enabled: (traceDetail?.allMessages.length ?? 0) > 0,
   })
   const { data: annotationsData } = useAnnotationsByTrace({
     projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -343,6 +343,19 @@ export function ConversationTab({
     return map
   }, [moments])
 
+  const focusMessageIndex = useMemo(() => {
+    if (!moments) return undefined
+    if (focusMomentKind) {
+      return moments
+        .find((row) => row.labels.some((label) => label.kind === focusMomentKind))
+        ?.labels.find((label) => label.kind === focusMomentKind)?.lastMessageIndex
+    }
+    if (focusMomentId) {
+      return moments.find((row) => row.moment.momentId === focusMomentId)?.moment.firstMessageIndex
+    }
+    return undefined
+  }, [focusMomentId, focusMomentKind, moments])
+
   useScrollToFocusedMoment({
     scrollRef: scrollContainerRef,
     sessionId,
@@ -388,6 +401,7 @@ export function ConversationTab({
       scrollContainerRef={scrollContainerRef}
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
       timeline={timeline}
+      focusMessageIndex={focusMessageIndex}
       {...(navigateToSpan ? { navigateToSpan } : {})}
       {...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {})}
       {...(searchQuery ? { searchQuery } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -13,7 +13,7 @@ import {
 import { formatBytes } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { DownloadIcon } from "lucide-react"
-import { type ReactNode, type RefObject, useCallback, useMemo, useRef, useState } from "react"
+import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { useAuthSession } from "../../../../../../../domains/sessions/session.collection.ts"
 import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
@@ -42,6 +42,8 @@ import { findNearestMessageAnchor, flashElement } from "../../conversation-timel
 import { TimelineBar } from "../../conversation-timeline/timeline-bar.tsx"
 import { useViewportBand } from "../../conversation-timeline/use-viewport-band.ts"
 import { useScrollToFirstHighlight } from "./use-scroll-to-first-highlight.ts"
+
+const LOAD_MORE_THRESHOLD_PX = 1200
 
 function toSearchHighlightRanges(result: TraceSearchHighlightsResult | undefined): readonly HighlightRange[] {
   if (!result || result.highlights.length === 0) return []
@@ -226,12 +228,8 @@ function ConversationContent({
     [timeline, dismissSelectionUi, scrollToMessageAnchor],
   )
 
-  const maybeLoadMoreMessages = useCallback(() => {
-    const container = scrollRef.current
-    if (!container || !hasMoreMessages || isLoadingMoreMessages || autoLoadingMoreRef.current) return
-
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-    if (distanceFromBottom > 1200) return
+  const loadMoreMessages = useCallback(() => {
+    if (!hasMoreMessages || isLoadingMoreMessages || autoLoadingMoreRef.current) return
 
     autoLoadingMoreRef.current = true
     void Promise.resolve(onLoadMoreMessages())
@@ -239,7 +237,17 @@ function ConversationContent({
       .finally(() => {
         autoLoadingMoreRef.current = false
       })
-  }, [scrollRef, hasMoreMessages, isLoadingMoreMessages, onLoadMoreMessages])
+  }, [hasMoreMessages, isLoadingMoreMessages, onLoadMoreMessages])
+
+  const maybeLoadMoreMessages = useCallback(() => {
+    const container = scrollRef.current
+    if (!container) return
+
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+    if (distanceFromBottom > LOAD_MORE_THRESHOLD_PX) return
+
+    loadMoreMessages()
+  }, [scrollRef, loadMoreMessages])
 
   const handleMarkerClick = useCallback(
     (marker: TimelineMarker) => {
@@ -317,11 +325,18 @@ function ConversationContent({
     return { messageIndex: first.messageIndex, partIndex: first.partIndex }
   }, [searchHighlightsData])
 
+  // TODO(frontend-use-effect-policy): loading search target pages is a query-side effect keyed by async highlight results.
+  useEffect(() => {
+    if (!firstMatchHint || firstMatchHint.messageIndex < messages.length) return
+    loadMoreMessages()
+  }, [firstMatchHint, messages.length, loadMoreMessages])
+
   useScrollToFirstHighlight({
     scrollRef,
     traceId: traceDetail.traceId,
     searchQuery: effectiveSearchQuery,
     highlightsData: searchHighlightsData,
+    loadedMessageCount: messages.length,
   })
 
   if (textSelectionPopoverControlsRef) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -10,13 +10,17 @@ import {
   Skeleton,
   Text,
 } from "@repo/ui"
+import { formatBytes } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { DownloadIcon } from "lucide-react"
 import { type ReactNode, type RefObject, useCallback, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { useAuthSession } from "../../../../../../../domains/sessions/session.collection.ts"
 import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
-import { useTraceSearchHighlights } from "../../../../../../../domains/traces/traces.collection.ts"
+import {
+  useTraceConversationMessages,
+  useTraceSearchHighlights,
+} from "../../../../../../../domains/traces/traces.collection.ts"
 import type { TraceDetailRecord } from "../../../../../../../domains/traces/traces.functions.ts"
 import type {
   ConversationTimeline,
@@ -57,22 +61,28 @@ function toSearchHighlightRanges(result: TraceSearchHighlightsResult | undefined
  * `useAuthSession` (tree-agnostic), so it works the same in the sandbox tree,
  * which has no `_authenticated` match.
  */
-function StaffConversationDownloadButton({ traceDetail }: { readonly traceDetail: TraceDetailRecord }) {
+function StaffConversationDownloadButton({
+  traceId,
+  messages,
+}: {
+  readonly traceId: string
+  readonly messages: readonly unknown[]
+}) {
   const { isAdmin, isImpersonating } = useAuthSession()
   const isStaff = import.meta.env.DEV || isAdmin || isImpersonating
 
   const handleDownload = useCallback(() => {
-    const json = JSON.stringify(traceDetail.allMessages, null, 2)
+    const json = JSON.stringify(messages, null, 2)
     const blob = new Blob([json], { type: "application/json" })
     const url = URL.createObjectURL(blob)
     const a = document.createElement("a")
     a.href = url
-    a.download = `trace-${traceDetail.traceId.slice(0, 7)}-conversation.json`
+    a.download = `trace-${traceId.slice(0, 7)}-conversation-loaded.json`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-  }, [traceDetail])
+  }, [messages, traceId])
 
   if (!isStaff) return null
   return (
@@ -84,6 +94,7 @@ function StaffConversationDownloadButton({ traceDetail }: { readonly traceDetail
 
 function ConversationContent({
   traceDetail,
+  messages,
   navigateToSpan,
   projectId,
   isActive,
@@ -94,8 +105,14 @@ function ConversationContent({
   searchQuery,
   messageTrailingSlot,
   timeline,
+  totalMessages,
+  payloadBytes,
+  hasMoreMessages,
+  isLoadingMoreMessages,
+  onLoadMoreMessages,
 }: {
   readonly traceDetail: TraceDetailRecord
+  readonly messages: TraceDetailRecord["allMessages"]
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
   readonly projectId: string
   readonly isActive: boolean
@@ -109,6 +126,11 @@ function ConversationContent({
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
+  readonly totalMessages: number
+  readonly payloadBytes: number
+  readonly hasMoreMessages: boolean
+  readonly isLoadingMoreMessages: boolean
+  readonly onLoadMoreMessages: () => void
 }) {
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = scrollContainerRef ?? internalScrollRef
@@ -120,7 +142,8 @@ function ConversationContent({
     projectId,
     traceId: traceDetail.traceId,
     startTime: traceDetail.startTime,
-    allMessages: traceDetail.allMessages,
+    allMessages: messages,
+    enabled: messages.length > 0 && (annotationsEnabled || navigateToSpan !== undefined),
   })
 
   const band = useViewportBand({ scrollRef, timeline: timeline ?? null, isActive })
@@ -329,7 +352,7 @@ function ConversationContent({
         onPointerLeave={() => setHoveredMessageIndex(null)}
       >
         <Conversation
-          messages={traceDetail.allMessages}
+          messages={messages}
           enableNavigator
           scrollContainerRef={scrollRef}
           navigatorRef={navigatorRef}
@@ -365,6 +388,16 @@ function ConversationContent({
           {...(toolCallActions ? { toolCallActions } : {})}
           {...(messageTrailingSlot ? { messageTrailingSlot } : {})}
         />
+        {hasMoreMessages ? (
+          <div className="flex flex-col items-center gap-2 py-6">
+            <Text.H6 color="foregroundMuted">
+              Showing {messages.length} of {totalMessages} messages ({formatBytes(payloadBytes)} total payload)
+            </Text.H6>
+            <Button variant="outline" size="sm" onClick={onLoadMoreMessages} disabled={isLoadingMoreMessages}>
+              {isLoadingMoreMessages ? "Loading…" : "Load more messages"}
+            </Button>
+          </div>
+        ) : null}
         {annotationsEnabled ? (
           <AnnotationPopover
             position={textSelectionPopoverPosition}
@@ -387,7 +420,7 @@ function ConversationContent({
         ) : null}
       </div>
       <div className="absolute top-4 right-4 z-10 flex items-center gap-2">
-        <StaffConversationDownloadButton traceDetail={traceDetail} />
+        <StaffConversationDownloadButton traceId={traceDetail.traceId} messages={messages} />
         <ScrollNavigator
           ref={navigatorRef}
           scrollContainerRef={scrollRef}
@@ -455,7 +488,13 @@ export function ConversationTab({
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
 }) {
-  if (isDetailLoading) {
+  const conversation = useTraceConversationMessages({
+    projectId,
+    traceId: traceDetail?.traceId ?? "",
+    enabled: traceDetail != null,
+  })
+
+  if (isDetailLoading || (traceDetail && conversation.isLoading)) {
     return (
       <div className="flex flex-col gap-4 py-8 px-4 flex-1">
         <Skeleton className="h-20 w-full" />
@@ -478,6 +517,7 @@ export function ConversationTab({
       isActive={isActive}
       annotationsEnabled={annotationsEnabled}
       traceDetail={traceDetail}
+      messages={conversation.messages}
       navigateToSpan={navigateToSpan}
       projectId={projectId}
       scrollContainerRef={scrollContainerRef}
@@ -486,6 +526,11 @@ export function ConversationTab({
       searchQuery={searchQuery}
       messageTrailingSlot={messageTrailingSlot}
       timeline={timeline}
+      totalMessages={conversation.totalMessages}
+      payloadBytes={conversation.payloadBytes}
+      hasMoreMessages={conversation.hasNextPage}
+      isLoadingMoreMessages={conversation.isFetchingNextPage}
+      onLoadMoreMessages={() => void conversation.fetchNextPage()}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -130,13 +130,14 @@ function ConversationContent({
   readonly payloadBytes: number
   readonly hasMoreMessages: boolean
   readonly isLoadingMoreMessages: boolean
-  readonly onLoadMoreMessages: () => void
+  readonly onLoadMoreMessages: () => unknown
 }) {
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = scrollContainerRef ?? internalScrollRef
   const navigatorRef = useRef<ScrollNavigatorHandle>(null)
   const navItemRefs = useRef<(HTMLDivElement | null)[]>([])
   const clearSelectionRef = useRef<(() => void) | null>(null)
+  const autoLoadingMoreRef = useRef(false)
 
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
@@ -224,6 +225,21 @@ function ConversationContent({
     },
     [timeline, dismissSelectionUi, scrollToMessageAnchor],
   )
+
+  const maybeLoadMoreMessages = useCallback(() => {
+    const container = scrollRef.current
+    if (!container || !hasMoreMessages || isLoadingMoreMessages || autoLoadingMoreRef.current) return
+
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+    if (distanceFromBottom > 1200) return
+
+    autoLoadingMoreRef.current = true
+    void Promise.resolve(onLoadMoreMessages())
+      .catch(() => undefined)
+      .finally(() => {
+        autoLoadingMoreRef.current = false
+      })
+  }, [scrollRef, hasMoreMessages, isLoadingMoreMessages, onLoadMoreMessages])
 
   const handleMarkerClick = useCallback(
     (marker: TimelineMarker) => {
@@ -343,6 +359,7 @@ function ConversationContent({
       <div
         ref={scrollRef}
         className="flex min-w-0 flex-col py-8 px-4 overflow-y-auto overflow-x-hidden flex-1"
+        onScroll={maybeLoadMoreMessages}
         onPointerMove={(e) => {
           const anchor = e.target instanceof HTMLElement ? e.target.closest("[data-message-index]") : null
           const raw = anchor?.getAttribute("data-message-index")
@@ -393,9 +410,7 @@ function ConversationContent({
             <Text.H6 color="foregroundMuted">
               Showing {messages.length} of {totalMessages} messages ({formatBytes(payloadBytes)} total payload)
             </Text.H6>
-            <Button variant="outline" size="sm" onClick={onLoadMoreMessages} disabled={isLoadingMoreMessages}>
-              {isLoadingMoreMessages ? "Loading…" : "Load more messages"}
-            </Button>
+            {isLoadingMoreMessages ? <Text.H6 color="foregroundMuted">Loading more messages…</Text.H6> : null}
           </div>
         ) : null}
         {annotationsEnabled ? (
@@ -530,7 +545,7 @@ export function ConversationTab({
       payloadBytes={conversation.payloadBytes}
       hasMoreMessages={conversation.hasNextPage}
       isLoadingMoreMessages={conversation.isFetchingNextPage}
-      onLoadMoreMessages={() => void conversation.fetchNextPage()}
+      onLoadMoreMessages={() => conversation.fetchNextPage()}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -107,6 +107,7 @@ function ConversationContent({
   searchQuery,
   messageTrailingSlot,
   timeline,
+  focusMessageIndex,
   totalMessages,
   payloadBytes,
   hasMoreMessages,
@@ -128,6 +129,7 @@ function ConversationContent({
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
+  readonly focusMessageIndex?: number | undefined
   readonly totalMessages: number
   readonly payloadBytes: number
   readonly hasMoreMessages: boolean
@@ -331,6 +333,11 @@ function ConversationContent({
     loadMoreMessages()
   }, [firstMatchHint, messages.length, loadMoreMessages])
 
+  useEffect(() => {
+    if (focusMessageIndex === undefined || focusMessageIndex < messages.length) return
+    loadMoreMessages()
+  }, [focusMessageIndex, messages.length, loadMoreMessages])
+
   useScrollToFirstHighlight({
     scrollRef,
     traceId: traceDetail.traceId,
@@ -498,6 +505,7 @@ export function ConversationTab({
   searchQuery,
   messageTrailingSlot,
   timeline,
+  focusMessageIndex,
 }: {
   readonly traceDetail: TraceDetailRecord | null | undefined
   readonly isDetailLoading: boolean
@@ -517,6 +525,7 @@ export function ConversationTab({
   readonly messageTrailingSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
   /** Timeline for the minimap bar: null while loading, undefined when the feature is off. */
   readonly timeline?: ConversationTimeline | null | undefined
+  readonly focusMessageIndex?: number | undefined
 }) {
   const conversation = useTraceConversationMessages({
     projectId,
@@ -556,6 +565,7 @@ export function ConversationTab({
       searchQuery={searchQuery}
       messageTrailingSlot={messageTrailingSlot}
       timeline={timeline}
+      focusMessageIndex={focusMessageIndex}
       totalMessages={conversation.totalMessages}
       payloadBytes={conversation.payloadBytes}
       hasMoreMessages={conversation.hasNextPage}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/use-scroll-to-first-highlight.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/use-scroll-to-first-highlight.ts
@@ -43,13 +43,16 @@ export function useScrollToFirstHighlight({
   traceId,
   searchQuery,
   highlightsData,
+  loadedMessageCount,
 }: {
   readonly scrollRef: RefObject<HTMLDivElement | null>
   readonly traceId: string
   readonly searchQuery: string
   readonly highlightsData: TraceSearchHighlightsResult | undefined
+  readonly loadedMessageCount: number
 }): void {
   const lastScrolledKey = useRef<string | null>(null)
+  // TODO(frontend-use-effect-policy): observes rendered highlighted nodes after async search and chunk loading.
   useEffect(() => {
     if (!highlightsData || highlightsData.firstMatchIndex < 0) return
     if (!scrollRef.current) return
@@ -97,5 +100,5 @@ export function useScrollToFirstHighlight({
       observer.disconnect()
       window.clearTimeout(timeout)
     }
-  }, [highlightsData, scrollRef, traceId, searchQuery])
+  }, [highlightsData, scrollRef, traceId, searchQuery, loadedMessageCount])
 }

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -35,7 +35,7 @@ export {
   spanStatusCodeSchema,
   toolDefinitionSchema,
 } from "./entities/span.ts"
-export type { Trace, TraceDetail } from "./entities/trace.ts"
+export type { Trace, TraceConversationChunk, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
@@ -129,6 +129,8 @@ export type { GetSessionCohortSummaryInput } from "./use-cases/get-session-cohor
 export { getSessionCohortSummaryUseCase } from "./use-cases/get-session-cohort-summary.ts"
 export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
 export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
+export type { GetTraceConversationChunkInput } from "./use-cases/get-trace-conversation-chunk.ts"
+export { getTraceConversationChunkUseCase } from "./use-cases/get-trace-conversation-chunk.ts"
 export type {
   LoadTraceForTraceEndFound,
   LoadTraceForTraceEndResult,

--- a/packages/domain/spans/src/entities/trace.ts
+++ b/packages/domain/spans/src/entities/trace.ts
@@ -74,3 +74,12 @@ export const traceDetailSchema = traceSchema.extend({
 })
 
 export type TraceDetail = z.infer<typeof traceDetailSchema>
+
+export interface TraceConversationChunk {
+  readonly messages: readonly GenAIMessage[]
+  readonly offset: number
+  readonly limit: number
+  readonly totalMessages: number
+  readonly hasMore: boolean
+  readonly payloadBytes: number
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -56,7 +56,7 @@ export {
   spanStatusCodeSchema,
   toolDefinitionSchema,
 } from "./entities/span.ts"
-export type { Trace, TraceDetail } from "./entities/trace.ts"
+export type { Trace, TraceConversationChunk, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
@@ -220,6 +220,8 @@ export type {
 export { getTraceAnalyticsUseCase } from "./use-cases/get-trace-analytics.ts"
 export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
 export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
+export type { GetTraceConversationChunkInput } from "./use-cases/get-trace-conversation-chunk.ts"
+export { getTraceConversationChunkUseCase } from "./use-cases/get-trace-conversation-chunk.ts"
 export { getTraceSearchHighlightsUseCase } from "./use-cases/get-trace-search-highlights.ts"
 export type { IngestSpansInput, IngestSpansResult } from "./use-cases/ingest-spans.ts"
 export { ingestSpansUseCase } from "./use-cases/ingest-spans.ts"

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -10,7 +10,7 @@ import type {
 } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { CohortBaselineData } from "../cohort-baselines.ts"
-import type { Trace, TraceDetail } from "../entities/trace.ts"
+import type { Trace, TraceConversationChunk, TraceDetail } from "../entities/trace.ts"
 
 /**
  * Repository port for traces (ClickHouse materialized view).
@@ -84,6 +84,20 @@ export interface TraceRepositoryShape {
     readonly projectId: ProjectId
     readonly traceId: TraceId
   }): Effect.Effect<TraceDetail, NotFoundError | RepositoryError, ChSqlClient>
+
+  findMetadataByTraceId(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceId: TraceId
+  }): Effect.Effect<Trace, NotFoundError | RepositoryError, ChSqlClient>
+
+  findConversationChunk(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceId: TraceId
+    readonly offset: number
+    readonly limit: number
+  }): Effect.Effect<TraceConversationChunk, RepositoryError, ChSqlClient>
 
   matchesFiltersByTraceId(input: {
     readonly organizationId: OrganizationId

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -21,6 +21,9 @@ export const createFakeTraceRepository = (overrides?: Partial<TraceRepositorySha
     aggregateMetricsByProjectId: () => Effect.succeed(emptyTraceMetrics()),
     histogramByProjectId: () => Effect.succeed([]),
     findByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
+    findMetadataByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
+    findConversationChunk: () =>
+      Effect.succeed({ messages: [], offset: 0, limit: 0, totalMessages: 0, hasMore: false, payloadBytes: 0 }),
     matchesFiltersByTraceId: () => Effect.succeed(false),
     listMatchingFilterIdsByTraceId: () => Effect.succeed([]),
     listByTraceIds: () => Effect.succeed([]),

--- a/packages/domain/spans/src/use-cases/get-trace-conversation-chunk.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-conversation-chunk.ts
@@ -1,0 +1,17 @@
+import type { OrganizationId, ProjectId, TraceId } from "@domain/shared"
+import { Effect } from "effect"
+import { TraceRepository } from "../ports/trace-repository.ts"
+
+export interface GetTraceConversationChunkInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly traceId: TraceId
+  readonly offset: number
+  readonly limit: number
+}
+
+export const getTraceConversationChunkUseCase = (input: GetTraceConversationChunkInput) =>
+  Effect.gen(function* () {
+    const repo = yield* TraceRepository
+    return yield* repo.findConversationChunk(input)
+  })

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -24,6 +24,7 @@ import type {
   CohortBaselineData,
   MetricPercentiles,
   Trace,
+  TraceConversationChunk,
   TraceDetail,
   TraceDistribution,
   TraceListPage,
@@ -133,6 +134,12 @@ type TraceDetailRow = TraceListRow & {
   system_instructions: string
 }
 
+type TraceConversationChunkRow = {
+  total_messages: string | number
+  payload_bytes: string | number
+  messages: readonly string[]
+}
+
 /**
  * Per-bucket aggregations for the histogram, computed over the trace-deduped subquery
  * (`SELECT ${LIST_SELECT} ... GROUP BY trace_id`). One row per bucket; columns mirror the
@@ -165,6 +172,20 @@ const parseMessages = (json: string): GenAIMessage[] => {
   } catch {
     return []
   }
+}
+
+const parseMessage = (json: string): GenAIMessage | null => {
+  try {
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === "object" ? (parsed as GenAIMessage) : null
+  } catch {
+    return null
+  }
+}
+
+const parseClickHouseNumber = (value: string | number | undefined): number => {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : 0
 }
 
 const parseSystem = (json: string): GenAISystem => {
@@ -1404,6 +1425,110 @@ export const TraceRepositoryLive = Layer.effect(
                 return Effect.succeed(toDomainTraceDetail(first))
               }),
               Effect.mapError((error) => (isNotFoundError(error) ? error : toRepositoryError(error, "findByTraceId"))),
+            )
+        }),
+
+      findMetadataByTraceId: ({ organizationId, projectId, traceId }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT ${LIST_SELECT}
+                      FROM traces
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND trace_id = {traceId:FixedString(32)}
+                      GROUP BY organization_id, project_id, trace_id
+                      LIMIT 1`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  traceId,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<TraceListRow>()
+            })
+            .pipe(
+              Effect.flatMap((rows) => {
+                const first = rows[0]
+                if (!first) {
+                  return Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
+                }
+                return Effect.succeed(toBaseFields(first))
+              }),
+              Effect.mapError((error) =>
+                isNotFoundError(error) ? error : toRepositoryError(error, "findMetadataByTraceId"),
+              ),
+            )
+        }),
+
+      findConversationChunk: ({ organizationId, projectId, traceId, offset, limit }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                          length(all_messages) AS total_messages,
+                          arraySum(message -> length(message), all_messages) AS payload_bytes,
+                          arraySlice(all_messages, {offset:UInt64} + 1, {limit:UInt64}) AS messages
+                        FROM (
+                          SELECT arrayConcat(
+                            if(
+                              length(JSONExtractArrayRaw(system_instructions_json)) > 0,
+                              [concat('{"role":"system","parts":', system_instructions_json, '}')],
+                              []
+                            ),
+                            JSONExtractArrayRaw(last_input_messages_json),
+                            JSONExtractArrayRaw(output_messages_json)
+                          ) AS all_messages
+                          FROM (
+                            SELECT
+                              argMinIfMerge(system_instructions) AS system_instructions_json,
+                              argMaxIfMerge(last_input_messages) AS last_input_messages_json,
+                              argMaxIfMerge(output_messages) AS output_messages_json
+                            FROM traces
+                            WHERE organization_id = {organizationId:String}
+                              AND project_id = {projectId:String}
+                              AND trace_id = {traceId:FixedString(32)}
+                            GROUP BY organization_id, project_id, trace_id
+                            LIMIT 1
+                          )
+                        )`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  traceId,
+                  offset,
+                  limit,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<TraceConversationChunkRow>()
+            })
+            .pipe(
+              Effect.map((rows): TraceConversationChunk => {
+                const row = rows[0]
+                if (!row) return { messages: [], offset, limit, totalMessages: 0, hasMore: false, payloadBytes: 0 }
+
+                const totalMessages = parseClickHouseNumber(row.total_messages)
+                const messages = row.messages.flatMap((message) => {
+                  const parsed = parseMessage(message)
+                  return parsed ? [parsed] : []
+                })
+
+                return {
+                  messages,
+                  offset,
+                  limit,
+                  totalMessages,
+                  hasMore: offset + messages.length < totalMessages,
+                  payloadBytes: parseClickHouseNumber(row.payload_bytes),
+                }
+              }),
+              Effect.mapError((error) => toRepositoryError(error, "findConversationChunk")),
             )
         }),
 

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -409,6 +409,182 @@ export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
   return specs.map((spec) => createCompatibilityChatSpan({ scope, ...spec }))
 }
 
+type LargeConversationSpec = {
+  readonly traceKey: string
+  readonly index: number
+  readonly sessionId: string
+  readonly daysAgo: number
+  readonly turnCount: number
+  readonly scenario: string
+  readonly serviceName: string
+  readonly user: SeedUser | undefined
+}
+
+const LARGE_CONVERSATION_CONTEXT = [
+  "customer identity",
+  "order history",
+  "policy window",
+  "warehouse status",
+  "payment method",
+  "fraud review",
+  "shipping SLA",
+  "loyalty tier",
+  "prior escalation",
+  "inventory reservation",
+  "manager approval",
+  "refund ledger",
+] as const
+
+function largeConversationText(spec: LargeConversationSpec, turnIndex: number, role: "user" | "assistant"): string {
+  const checkpoint = turnIndex + 1
+  const context = Array.from({ length: 6 }, (_, index) => {
+    const item = LARGE_CONVERSATION_CONTEXT[(turnIndex + index) % LARGE_CONVERSATION_CONTEXT.length]
+    return `${item}: ${spec.scenario} checkpoint ${checkpoint}.${index + 1}`
+  }).join("; ")
+
+  if (role === "user") {
+    return `Large conversation seed ${spec.index + 1}, user turn ${checkpoint}. I need the assistant to keep every previous detail in mind while we test streamed conversation loading. ${context}. Please cross-check these facts before changing the recommendation.`
+  }
+
+  return `Large conversation seed ${spec.index + 1}, assistant turn ${checkpoint}. I am retaining the running case state, separating verified facts from pending checks, and keeping the recommendation conditional until the required evidence is complete. ${context}. Next I would verify the newest customer statement against the tool-backed record before committing to an outcome.`
+}
+
+function buildLargeConversationMessages(spec: LargeConversationSpec): Tau2Message[] {
+  return Array.from({ length: spec.turnCount }).flatMap((_, turnIndex) => [
+    { role: "user" as const, parts: [{ type: "text", content: largeConversationText(spec, turnIndex, "user") }] },
+    {
+      role: "assistant" as const,
+      parts: [{ type: "text", content: largeConversationText(spec, turnIndex, "assistant") }],
+    },
+  ])
+}
+
+function createLargeConversationChatSpan(opts: { scope: SeedScope; spec: LargeConversationSpec }): SpanRow {
+  const { scope, spec } = opts
+  const start = scope.dateDaysAgo(spec.daysAgo, 13 + spec.index, 15)
+  const traceId = scope.traceHex(spec.traceKey, spec.index)
+  const spanId = scope.spanHex(spec.traceKey, spec.index)
+  const inputMessages = buildLargeConversationMessages(spec)
+  const renderedMessageCount = inputMessages.length + 2
+  const outputMessages: Tau2Message[] = [
+    {
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          content: `Large conversation seed ${spec.index + 1} final answer. This trace intentionally contains ${renderedMessageCount} rendered messages so the conversation drawer must page through chunks instead of returning the whole payload at once.`,
+        },
+      ],
+    },
+  ]
+  const inputTokens = estimateTau2Tokens(inputMessages)
+  const outputTokens = estimateTau2Tokens(outputMessages)
+  const durationMs = spec.turnCount * 1200
+
+  return {
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    session_id: spec.sessionId,
+    user_id: spec.user?.id ?? "",
+    user_email: spec.user?.email ?? "",
+    trace_id: traceId,
+    span_id: spanId,
+    parent_span_id: "",
+    api_key_id: scope.apiKeyId,
+    simulation_id: "",
+    start_time: formatClickHouseTimestamp(start),
+    end_time: formatClickHouseTimestamp(new Date(start.getTime() + durationMs)),
+    name: "chat gpt-4.1 large conversation",
+    service_name: spec.serviceName,
+    kind: 1,
+    status_code: 1,
+    status_message: "",
+    error_type: "",
+    tags: ["support", "large-conversation", "streaming-fixture"],
+    metadata: {
+      seed: "large-conversation",
+      story: spec.scenario,
+      fixture: "conversation-streaming",
+      turnCount: String(spec.turnCount),
+    },
+    operation: "chat",
+    provider: "openai",
+    model: "gpt-4.1",
+    response_model: "gpt-4.1-2025-04-14",
+    tokens_input: inputTokens,
+    tokens_output: outputTokens,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: inputTokens * 25,
+    cost_output_microcents: outputTokens * 100,
+    cost_total_microcents: inputTokens * 25 + outputTokens * 100,
+    cost_is_estimated: 1,
+    time_to_first_token_ns: 260_000_000,
+    is_streaming: 1,
+    response_id: `seed-${spanId}`,
+    finish_reasons: ["stop"],
+    input_messages: JSON.stringify(inputMessages),
+    output_messages: JSON.stringify(outputMessages),
+    system_instructions: JSON.stringify([
+      {
+        type: "text",
+        content:
+          "You are a support agent in a deterministic load-test conversation. Preserve context across hundreds of turns and keep conclusions grounded in verified facts.",
+      },
+    ]),
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: {},
+    attr_int: {},
+    attr_float: { "gen_ai.request.temperature": 0 },
+    attr_bool: {},
+    resource_string: { "service.name": spec.serviceName },
+    scope_name: "openai-instrumentation",
+    scope_version: "1.0.0",
+  }
+}
+
+function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
+  const specs: readonly LargeConversationSpec[] = [
+    {
+      traceKey: "large-conversation",
+      index: 0,
+      sessionId: "seed-large-conversation-1",
+      daysAgo: 1,
+      turnCount: 120,
+      scenario: "return eligibility investigation with repeated shipping and payment updates",
+      serviceName: "load-test-retail-support-agent",
+      user: CUSTOMER_USERS[4],
+    },
+    {
+      traceKey: "large-conversation",
+      index: 1,
+      sessionId: "seed-large-conversation-2",
+      daysAgo: 1,
+      turnCount: 240,
+      scenario: "telecom outage troubleshooting with many device-state checkpoints",
+      serviceName: "load-test-telecom-support-agent",
+      user: CUSTOMER_USERS[5],
+    },
+    {
+      traceKey: "large-conversation",
+      index: 2,
+      sessionId: "seed-large-conversation-3",
+      daysAgo: 1,
+      turnCount: 420,
+      scenario: "travel itinerary exception review with long-running policy comparisons",
+      serviceName: "load-test-travel-support-agent",
+      user: CUSTOMER_USERS[6],
+    },
+  ]
+
+  return specs.map((spec) => createLargeConversationChatSpan({ scope, spec }))
+}
+
 function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
   const spans: SpanRow[] = []
 
@@ -624,4 +800,24 @@ const seedFixedTraces: Seeder = {
     }),
 }
 
-export const fixedTraceSeeders: readonly Seeder[] = [seedFixedTraces]
+const seedLargeConversationTraces: Seeder = {
+  name: "spans/large-conversation-traces",
+  run: (ctx) =>
+    Effect.gen(function* () {
+      const sentinel = ctx.scope.traceHex("large-conversation", 0)
+      const present = yield* isSentinelPresent(ctx.client, "spans", "trace_id = {sentinel:String}", { sentinel })
+      if (present) {
+        if (!ctx.quiet) console.log("  -> spans/large-conversation-traces: already seeded, skipping")
+        return
+      }
+
+      const spans = buildLargeConversationSpans(ctx.scope)
+      const sentinelSpans = spans.filter((span) => span.trace_id === sentinel)
+      const nonSentinelSpans = spans.filter((span) => span.trace_id !== sentinel)
+      yield* insertJsonEachRow(ctx.client, "spans", nonSentinelSpans)
+      yield* insertJsonEachRow(ctx.client, "spans", sentinelSpans)
+      if (!ctx.quiet) console.log(`  -> spans/large-conversation-traces: ${spans.length} streaming stress traces`)
+    }),
+}
+
+export const fixedTraceSeeders: readonly Seeder[] = [seedFixedTraces, seedLargeConversationTraces]


### PR DESCRIPTION
## Summary

This PR keeps trace detail metadata separate from conversation payloads so opening a large trace no longer loads the full message history into the web server response. The conversation tab now requests messages in 25-message chunks through a dedicated server function and appends the next page automatically when the user scrolls near the end.

The trace and session timeline hooks now build from the streamed conversation pages instead of `traceDetail.allMessages`, which is intentionally empty after the metadata-only detail fetch. That keeps the minimap/timeline working while the conversation loads incrementally.

## Seed coverage

Adds three deterministic ClickHouse seed traces tagged `large-conversation` / `streaming-fixture`, with sessions `seed-large-conversation-1`, `seed-large-conversation-2`, and `seed-large-conversation-3`. They provide increasingly large conversations for testing pagination and memory behavior locally.

https://github.com/user-attachments/assets/fdae352b-f83d-47fc-9e57-5da6fefaf4e7


## Validation

- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @platform/db-clickhouse check`
- `pnpm --filter @platform/db-clickhouse typecheck`
