### PR TITLE
fix(signals): combine scores signal_id column+index ALTER (unblock staging CH migration)

### DIFF
--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00035_add_signal_id_to_scores.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00035_add_signal_id_to_scores.sql
@@ -15,5 +15,8 @@ ALTER TABLE scores ON CLUSTER default
 ALTER TABLE scores ON CLUSTER default UPDATE signal_id = issue_id WHERE issue_id != '';
 
 -- +goose Down
-ALTER TABLE scores ON CLUSTER default DROP INDEX IF EXISTS idx_signal_id;
-ALTER TABLE scores ON CLUSTER default DROP COLUMN IF EXISTS signal_id;
+-- Single ALTER for the same reason as Up: two sequential DROPs would race the
+-- replicated metadata version (code 517) on rollback.
+ALTER TABLE scores ON CLUSTER default
+  DROP INDEX IF EXISTS idx_signal_id,
+  DROP COLUMN IF EXISTS signal_id;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00035_add_signal_id_to_scores.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00035_add_signal_id_to_scores.sql
@@ -3,8 +3,13 @@
 
 -- Signals (was Issues): add signal_id alongside issue_id. New rows dual-write both;
 -- this backfills historical rows. issue_id is kept until a later cleanup phase.
-ALTER TABLE scores ON CLUSTER default ADD COLUMN IF NOT EXISTS signal_id FixedString(24) DEFAULT '' CODEC(ZSTD(1));
-ALTER TABLE scores ON CLUSTER default ADD INDEX IF NOT EXISTS idx_signal_id signal_id TYPE bloom_filter(0.01) GRANULARITY 2;
+-- The column and index are added in a SINGLE ALTER: on a Replicated table two
+-- back-to-back `ALTER ... ON CLUSTER` statements race the metadata version, and the
+-- ADD INDEX fails with code 517 ("replica doesn't catch up with latest ALTER") because
+-- the replica hasn't applied the ADD COLUMN's bump yet. One ALTER = one metadata bump.
+ALTER TABLE scores ON CLUSTER default
+  ADD COLUMN IF NOT EXISTS signal_id FixedString(24) DEFAULT '' CODEC(ZSTD(1)),
+  ADD INDEX IF NOT EXISTS idx_signal_id signal_id TYPE bloom_filter(0.01) GRANULARITY 2;
 -- Async mutation: existing rows backfill in the background; reads tolerate the window via
 -- dual-write (new rows) + the if(signal_id, issue_id) fallback in the MV backfill below.
 ALTER TABLE scores ON CLUSTER default UPDATE signal_id = issue_id WHERE issue_id != '';

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00035_add_signal_id_to_scores.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00035_add_signal_id_to_scores.sql
@@ -13,5 +13,7 @@ ALTER TABLE scores
 ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != '';
 
 -- +goose Down
-ALTER TABLE scores DROP INDEX IF EXISTS idx_signal_id;
-ALTER TABLE scores DROP COLUMN IF EXISTS signal_id;
+-- Single ALTER to match the clustered variant (avoids the rollback metadata race).
+ALTER TABLE scores
+  DROP INDEX IF EXISTS idx_signal_id,
+  DROP COLUMN IF EXISTS signal_id;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00035_add_signal_id_to_scores.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00035_add_signal_id_to_scores.sql
@@ -3,8 +3,11 @@
 
 -- Signals (was Issues): add signal_id alongside issue_id. New rows dual-write both;
 -- this backfills historical rows. issue_id is kept until a later cleanup phase.
-ALTER TABLE scores ADD COLUMN IF NOT EXISTS signal_id FixedString(24) DEFAULT '' CODEC(ZSTD(1));
-ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_signal_id signal_id TYPE bloom_filter(0.01) GRANULARITY 2;
+-- Column + index in a SINGLE ALTER to match the clustered variant, which must combine
+-- them to avoid a replicated-metadata race (code 517) between two sequential ALTERs.
+ALTER TABLE scores
+  ADD COLUMN IF NOT EXISTS signal_id FixedString(24) DEFAULT '' CODEC(ZSTD(1)),
+  ADD INDEX IF NOT EXISTS idx_signal_id signal_id TYPE bloom_filter(0.01) GRANULARITY 2;
 -- Async mutation: existing rows backfill in the background; reads tolerate the window via
 -- dual-write (new rows) + the if(signal_id, issue_id) fallback in the MV backfill below.
 ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != '';


### PR DESCRIPTION
The Signals Phase 1 PR (#3608) merged but **never deployed to staging**: the deploy's migration step failed, so the ECS rollout never ran. This fixes the migration so the deploy completes.

## what was wrong

Postgres migrated fine, then the ClickHouse step died on `00035_add_signal_id_to_scores.sql`:

```
00035: ALTER TABLE scores ADD INDEX IF NOT EXISTS idx_signal_id ...
code: 517, replica metadata version is 0, common metadata is 1. Please retry
```

The migration ran **two back-to-back `ALTER TABLE scores ON CLUSTER default` statements** — `ADD COLUMN signal_id`, then `ADD INDEX idx_signal_id`. On a Replicated table each `ON CLUSTER` ALTER bumps the table's replicated metadata version, and the `ADD INDEX` is rejected (code 517) because the local replica hasn't yet applied the `ADD COLUMN`'s bump.

The retry loop can't recover: each retry re-runs the whole migration, and `ADD COLUMN IF NOT EXISTS` is itself an `ON CLUSTER` ALTER that bumps the common version **again** every attempt (even though the column already exists). The replica stays exactly one version behind — `0/1`, `1/2`, … `19/20` — and it gives up after 20 tries. It's a deterministic ordering race, not transient lag, so the runner's "increase retries" hint doesn't apply.

It only surfaced on the replicated staging cluster. `chdb`, used in local and CI tests, is single-node — no replicas, no metadata catch-up — so a migration with sequential `ALTER`s applies cleanly there.

## the fix

Combine the column and index into a **single** `ALTER`, so there's one atomic metadata bump and `ON CLUSTER` waits for every replica before returning:

```sql
ALTER TABLE scores ON CLUSTER default
  ADD COLUMN IF NOT EXISTS signal_id FixedString(24) DEFAULT '' CODEC(ZSTD(1)),
  ADD INDEX IF NOT EXISTS idx_signal_id signal_id TYPE bloom_filter(0.01) GRANULARITY 2;
```

No second `ALTER` means nothing to race against. The `ALTER ... UPDATE` backfill stays a separate statement (it's a mutation, and it wasn't the failure). The unclustered variant gets the same single-statement form for parity. The end state is identical — `signal_id` column + `idx_signal_id` index.

It re-runs safely on staging's partially-migrated table: `00035`'s `ADD COLUMN` did land during the failed attempts, so `signal_id` already exists there — `IF NOT EXISTS` makes the combined `ALTER` add only the missing index.

## why edit the migration instead of adding a new one

CH migrations are normally append-only, but `00035` **never applied successfully on any cluster** (it fails deterministically), goose records only successes and tracks by version — not checksum — and the runner is **stuck on `00035`**, so a later migration can't run until this one passes. Editing it in place is the only way to unblock the pipeline.

## after merge

The deploy re-runs migrations: Postgres is already applied (idempotent by version), CH `00035` now succeeds, `00036` (the hourly-buckets MV rebuild) runs, then the ECS rollout deploys the new image — which also clears the current half-migrated state on staging (Postgres renamed to `signals`, app still on the old image).

Refs #3608.
