### PR TITLE
perf(web): build conversation span maps client-side, drop redundant trace fetch

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -1,3 +1,4 @@
+import { SpanId } from "@domain/shared"
 import type { SpanMessagesData } from "@domain/spans"
 import { buildConversationSpanMaps } from "@domain/spans"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
@@ -168,7 +169,12 @@ export const useSpanDetail = ({
 }
 
 const asMessageSpans = (records: readonly SpanMessagesRecord[]): readonly SpanMessagesData[] =>
-  records as unknown as readonly SpanMessagesData[]
+  records.map((record) => ({
+    ...record,
+    spanId: SpanId(record.spanId),
+    inputMessages: record.inputMessages as readonly GenAIMessage[],
+    outputMessages: record.outputMessages as readonly GenAIMessage[],
+  }))
 
 export function useSessionConversationSpanMaps({
   projectId,
@@ -210,7 +216,8 @@ export function useSessionConversationSpanMaps({
       })
       return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
     },
-    enabled: enabled && projectId.length > 0 && sessionId.length > 0 && allMessages !== undefined,
+    enabled:
+      enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0 && allMessages !== undefined,
   })
 }
 

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -210,8 +210,7 @@ export function useSessionConversationSpanMaps({
       })
       return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
     },
-    enabled:
-      enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0 && allMessages !== undefined,
+    enabled: enabled && projectId.length > 0 && sessionId.length > 0 && allMessages !== undefined,
   })
 }
 

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -233,7 +233,12 @@ export function useConversationSpanMaps({
     queryKey: ["conversationSpanMaps", scope?.sandboxOrgId, projectId, traceId],
     queryFn: async () => {
       const spans = await listConversationMessageSpans({
-        data: { ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}), projectId, traceId, startTime: startTime ?? "" },
+        data: {
+          ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}),
+          projectId,
+          traceId,
+          startTime: startTime ?? "",
+        },
       })
       return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
     },

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -1,16 +1,20 @@
+import type { SpanMessagesData } from "@domain/spans"
+import { buildConversationSpanMaps } from "@domain/spans"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import { createCollection, useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
 import { use } from "react"
+import type { GenAIMessage } from "rosetta-ai"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { TraceScopeContext } from "../traces/trace-scope.tsx"
 import {
   getSpanDetail,
+  listConversationMessageSpans,
+  listSessionConversationMessageSpans,
   listSpansBySession,
   listSpansByTrace,
-  mapConversationToSpans,
-  mapSessionConversationToSpans,
   type SpanDetailRecord,
+  type SpanMessagesRecord,
   type SpanRecord,
 } from "./spans.functions.ts"
 
@@ -163,12 +167,16 @@ export const useSpanDetail = ({
   })
 }
 
+const asMessageSpans = (records: readonly SpanMessagesRecord[]): readonly SpanMessagesData[] =>
+  records as unknown as readonly SpanMessagesData[]
+
 export function useSessionConversationSpanMaps({
   projectId,
   sessionId,
   latestTraceId,
   sessionStartTime,
   sessionEndTime,
+  allMessages,
   enabled = true,
 }: {
   readonly projectId: string
@@ -176,6 +184,7 @@ export function useSessionConversationSpanMaps({
   readonly latestTraceId: string
   readonly sessionStartTime: string
   readonly sessionEndTime: string
+  readonly allMessages: readonly GenAIMessage[] | undefined
   readonly enabled?: boolean
 }) {
   const scope = use(TraceScopeContext)
@@ -189,35 +198,46 @@ export function useSessionConversationSpanMaps({
       sessionStartTime,
       sessionEndTime,
     ],
-    queryFn: () =>
-      mapSessionConversationToSpans({
+    queryFn: async () => {
+      const spans = await listSessionConversationMessageSpans({
         data: {
           ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}),
           projectId,
           sessionId,
-          latestTraceId,
           sessionStartTime,
           sessionEndTime,
         },
-      }),
-    enabled: enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0,
+      })
+      return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
+    },
+    enabled:
+      enabled && projectId.length > 0 && sessionId.length > 0 && latestTraceId.length > 0 && allMessages !== undefined,
   })
 }
 
 export function useConversationSpanMaps({
   projectId,
   traceId,
+  startTime,
+  allMessages,
   enabled = true,
 }: {
   readonly projectId: string
   readonly traceId: string
+  readonly startTime: string | undefined
+  readonly allMessages: readonly GenAIMessage[] | undefined
   readonly enabled?: boolean
 }) {
   const scope = use(TraceScopeContext)
   return useQuery({
     queryKey: ["conversationSpanMaps", scope?.sandboxOrgId, projectId, traceId],
-    queryFn: () =>
-      mapConversationToSpans({ data: { ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}), projectId, traceId } }),
-    enabled: enabled && projectId.length > 0 && traceId.length > 0,
+    queryFn: async () => {
+      const spans = await listConversationMessageSpans({
+        data: { ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}), projectId, traceId, startTime: startTime ?? "" },
+      })
+      return buildConversationSpanMaps(allMessages ?? [], asMessageSpans(spans))
+    },
+    enabled:
+      enabled && projectId.length > 0 && traceId.length > 0 && startTime !== undefined && allMessages !== undefined,
   })
 }

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,13 +1,13 @@
 import { ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
-import type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode } from "@domain/spans"
-import { buildConversationSpanMaps, SpanRepository, TraceRepository } from "@domain/spans"
-import { AIEmbedLive, withAi } from "@platform/ai"
-import { SpanRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import type { Operation, Span, SpanDetail, SpanKind, SpanMessagesData, SpanStatusCode } from "@domain/spans"
+import { SpanRepository } from "@domain/spans"
+import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
+import type { GenAIMessage } from "rosetta-ai"
 import { z } from "zod"
-import { getClickhouseClient, getRedisClient } from "../../server/clients.ts"
+import { getClickhouseClient } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
 
 const dateTimeParamSchema = z
@@ -198,89 +198,82 @@ export const listSpansBySession = createServerFn({ method: "GET" })
     return spans.map(serializeSpan)
   })
 
-export const mapConversationToSpans = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: z.string() }))
-  .handler(
-    async ({ data }): Promise<{ messageSpanMap: Record<number, string>; toolCallSpanMap: Record<string, string> }> => {
-      const orgId = await resolveOrgScope(data)
-      const traceId = TraceId(data.traceId)
+export interface SpanMessagesRecord {
+  readonly spanId: string
+  readonly operation: Operation
+  readonly toolCallId: string
+  readonly toolName: string
+  readonly toolInput: string
+  readonly inputMessages: readonly GenAIMessage[]
+  readonly outputMessages: readonly GenAIMessage[]
+}
 
-      return Effect.runPromise(
-        Effect.gen(function* () {
-          const traceRepo = yield* TraceRepository
-          const spanRepo = yield* SpanRepository
+const serializeSpanMessages = (span: SpanMessagesData): SpanMessagesRecord => ({
+  spanId: span.spanId as string,
+  operation: span.operation,
+  toolCallId: span.toolCallId,
+  toolName: span.toolName,
+  toolInput: span.toolInput,
+  inputMessages: span.inputMessages,
+  outputMessages: span.outputMessages,
+})
 
-          const projectId = ProjectId(data.projectId)
-          const traceDetail = yield* traceRepo
-            .findByTraceId({ organizationId: orgId, projectId, traceId })
-            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-
-          if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
-
-          const startTimeFrom = new Date(traceDetail.startTime.getTime() - 60 * 1000)
-          const startTimeTo = new Date(traceDetail.startTime.getTime() + 24 * 60 * 60 * 1000)
-          const spans = yield* spanRepo.findMessagesForTrace({
-            organizationId: orgId,
-            projectId,
-            traceId,
-            startTimeFrom,
-            startTimeTo,
-          })
-
-          return buildConversationSpanMaps(traceDetail.allMessages, spans)
-        }).pipe(
-          withClickHouse(Layer.merge(TraceRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
-          withAi(AIEmbedLive, getRedisClient()),
-          withTracing,
-        ),
-      )
-    },
+// Returns the message-bearing spans for a trace. The caller pairs these with the
+// conversation it already holds (traceDetail.allMessages) via buildConversationSpanMaps,
+// so no redundant trace fetch happens here. `startTime` bounds the span scan on the
+// time-keyed spans table.
+export const listConversationMessageSpans = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      sandboxOrgId: z.string().optional(),
+      projectId: z.string(),
+      traceId: z.string(),
+      startTime: dateTimeParamSchema,
+    }),
   )
+  .handler(async ({ data }): Promise<SpanMessagesRecord[]> => {
+    const orgId = await resolveOrgScope(data)
+    const spans = await Effect.runPromise(
+      Effect.gen(function* () {
+        const spanRepo = yield* SpanRepository
+        return yield* spanRepo.findMessagesForTrace({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          traceId: TraceId(data.traceId),
+          startTimeFrom: new Date(data.startTime.getTime() - 60 * 1000),
+          startTimeTo: new Date(data.startTime.getTime() + 24 * 60 * 60 * 1000),
+        })
+      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+    return spans.map(serializeSpanMessages)
+  })
 
-export const mapSessionConversationToSpans = createServerFn({ method: "GET" })
+export const listSessionConversationMessageSpans = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       sessionId: z.string(),
-      latestTraceId: z.string(),
       sessionStartTime: dateTimeParamSchema,
       sessionEndTime: dateTimeParamSchema,
     }),
   )
-  .handler(
-    async ({ data }): Promise<{ messageSpanMap: Record<number, string>; toolCallSpanMap: Record<string, string> }> => {
-      const orgId = await resolveOrgScope(data)
-
-      return Effect.runPromise(
-        Effect.gen(function* () {
-          const traceRepo = yield* TraceRepository
-          const spanRepo = yield* SpanRepository
-
-          const projectId = ProjectId(data.projectId)
-          const traceDetail = yield* traceRepo
-            .findByTraceId({ organizationId: orgId, projectId, traceId: TraceId(data.latestTraceId) })
-            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-
-          if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
-
-          const spans = yield* spanRepo.findMessagesForSession({
-            organizationId: orgId,
-            projectId,
-            sessionId: SessionId(data.sessionId),
-            startTimeFrom: new Date(data.sessionStartTime.getTime() - 60 * 1000),
-            startTimeTo: new Date(data.sessionEndTime.getTime() + 24 * 60 * 60 * 1000),
-          })
-
-          return buildConversationSpanMaps(traceDetail.allMessages, spans)
-        }).pipe(
-          withClickHouse(Layer.merge(TraceRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
-          withAi(AIEmbedLive, getRedisClient()),
-          withTracing,
-        ),
-      )
-    },
-  )
+  .handler(async ({ data }): Promise<SpanMessagesRecord[]> => {
+    const orgId = await resolveOrgScope(data)
+    const spans = await Effect.runPromise(
+      Effect.gen(function* () {
+        const spanRepo = yield* SpanRepository
+        return yield* spanRepo.findMessagesForSession({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          sessionId: SessionId(data.sessionId),
+          startTimeFrom: new Date(data.sessionStartTime.getTime() - 60 * 1000),
+          startTimeTo: new Date(data.sessionEndTime.getTime() + 24 * 60 * 60 * 1000),
+        })
+      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+    return spans.map(serializeSpanMessages)
+  })
 
 export const getSpanDetail = createServerFn({ method: "GET" })
   .inputValidator(

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -5,7 +5,6 @@ import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
-import type { GenAIMessage } from "rosetta-ai"
 import { z } from "zod"
 import { getClickhouseClient } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
@@ -204,8 +203,8 @@ export interface SpanMessagesRecord {
   readonly toolCallId: string
   readonly toolName: string
   readonly toolInput: string
-  readonly inputMessages: readonly GenAIMessage[]
-  readonly outputMessages: readonly GenAIMessage[]
+  readonly inputMessages: readonly object[]
+  readonly outputMessages: readonly object[]
 }
 
 const serializeSpanMessages = (span: SpanMessagesData): SpanMessagesRecord => ({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-session-timeline.ts
@@ -44,6 +44,7 @@ export function useSessionTimeline({
     latestTraceId,
     sessionStartTime: session.startTime,
     sessionEndTime: session.endTime,
+    allMessages: traceDetail?.allMessages,
   })
   const { data: annotationsData } = useAnnotationsBySession({
     projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/use-trace-timeline.ts
@@ -25,7 +25,12 @@ export function useTraceTimeline({
   readonly spans: readonly SpanRecord[] | undefined
   readonly annotationsEnabled: boolean
 }): ConversationTimeline | null {
-  const { data: spanMaps } = useConversationSpanMaps({ projectId, traceId })
+  const { data: spanMaps } = useConversationSpanMaps({
+    projectId,
+    traceId,
+    startTime: traceDetail?.startTime,
+    allMessages: traceDetail?.allMessages,
+  })
   const { data: annotationsData } = useAnnotationsByTrace({
     projectId,
     traceId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -119,6 +119,8 @@ function ConversationContent({
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
     traceId: traceDetail.traceId,
+    startTime: traceDetail.startTime,
+    allMessages: traceDetail.allMessages,
   })
 
   const band = useViewportBand({ scrollRef, timeline: timeline ?? null, isActive })


### PR DESCRIPTION
## Why

The conversation/session span-map server functions (`mapConversationToSpans`, `mapSessionConversationToSpans`) re-fetched the **full trace detail** via `findByTraceId` — decompressing the large `ZSTD` message columns — purely to obtain `allMessages`. But the client already holds `allMessages` from its own `useTraceDetail`. So every conversation view did the trace point lookup twice.

There was also a **latent correctness gap**: `messageSpanMap` is keyed by index into `allMessages`, yet the map was built on the server against a *second, independent* trace fetch. If that diverged from the copy the client renders (e.g. late-arriving spans changing the rollup aggregation between the two calls), messages would link to the wrong spans.

## What

- The server functions now return just the **message-bearing spans** (`SpanMessagesRecord[]`) and no longer call `findByTraceId`. Renamed to `listConversationMessageSpans` / `listSessionConversationMessageSpans` to match. The trace variant takes `startTime` from the client to bound the span scan; the session variant already received its window from the client.
- The hooks (`useConversationSpanMaps` / `useSessionConversationSpanMaps`) build the maps **client-side** via `buildConversationSpanMaps(allMessages, spans)`, keeping the same `{ messageSpanMap, toolCallSpanMap }` return shape — so downstream consumers are unchanged apart from passing `allMessages` (+ `startTime`).

Maps are now built against the **exact `allMessages` the client renders**, removing the duplicate point lookup *and* closing the index-misalignment gap.

## Notes

- `buildConversationSpanMaps` and `SpanMessagesData` are exported from `@domain/spans`'s **browser** entry, so importing them client-side is safe (no server/Effect code pulled into the bundle).
- Independent of the `traces` PRIMARY KEY migration PR, though they target the same slow path; the migration makes the remaining single `findByTraceId` (in `useTraceDetail`) cheap, and this removes the duplicate.
- Draft pending CI typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)