### PR TITLE
fix(workers): restore quickjs-emscripten runtime dependency

### DIFF
--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -72,6 +72,7 @@
     "@repo/utils": "workspace:*",
     "effect": "catalog:",
     "fflate": "0.8.2",
+    "quickjs-emscripten": "catalog:",
     "tsx": "catalog:",
     "voyageai": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,7 +307,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -371,7 +371,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/web:
     dependencies:
@@ -793,6 +793,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      quickjs-emscripten:
+        specifier: 'catalog:'
+        version: 0.32.0
       tsx:
         specifier: 'catalog:'
         version: 4.21.0


### PR DESCRIPTION
## Problem

The **workers** app fails to start in staging:

```
Error: Cannot find module 'quickjs-emscripten'
Require stack:
- /app/apps/workers/dist/server.cjs
```

## Root cause

- `9ebeb7162` (*"fix(workers): externalize QuickJS runtime dependency"*) correctly did two things together: added `quickjs-emscripten` to `neverBundle` in `apps/workers/tsdown.config.ts` (so it's no longer inlined into `server.cjs`) **and** added `"quickjs-emscripten": "catalog:"` to `apps/workers/package.json` so it's installed at runtime.
- `87e6f3c8c` (PR #3606, *LAT-679 destinations observability*) then **accidentally dropped the `quickjs-emscripten` dependency line** from `apps/workers/package.json` — unrelated to that PR's scope, almost certainly a stale rebase/merge resolution. It left `neverBundle` intact.

Because the package stays externalized but is no longer a direct dependency, pnpm's strict layout only places it under `@platform/sandbox-quickjs/node_modules` (transitive), **not** in `apps/workers/node_modules`. The Docker runtime stage installs with `--frozen-lockfile --production`, so `require('quickjs-emscripten')` from the bundled `server.cjs` cannot resolve it → `MODULE_NOT_FOUND`.

## Fix

Restore the direct dependency (exactly what #3606 removed) and regenerate the lockfile so the `apps/workers` importer resolves `quickjs-emscripten@0.32.0`. `neverBundle` is left as-is — externalizing was the correct intent; only the manifest entry backing it was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)