### PR TITLE
fix(web): span tree not updating when navigating traces

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -71,13 +71,10 @@ export const useSpansByTraceCollection = ({
 }) => {
   const scope = use(TraceScopeContext)
   const collection = getSpansByTraceCollection(projectId, traceId, startTimeFrom, startTimeTo, scope?.sandboxOrgId)
-  return useLiveQuery((q) => q.from({ span: collection }), [
-    projectId,
-    traceId,
-    startTimeFrom,
-    startTimeTo,
-    scope?.sandboxOrgId,
-  ])
+  return useLiveQuery(
+    (q) => q.from({ span: collection }),
+    [projectId, traceId, startTimeFrom, startTimeTo, scope?.sandboxOrgId],
+  )
 }
 
 const makeSpansBySessionCollection = (
@@ -135,13 +132,10 @@ export const useSpansBySessionCollection = ({
 }) => {
   const scope = use(TraceScopeContext)
   const collection = getSpansBySessionCollection(projectId, sessionId, startTimeFrom, startTimeTo, scope?.sandboxOrgId)
-  return useLiveQuery((q) => q.from({ span: collection }), [
-    projectId,
-    sessionId,
-    startTimeFrom,
-    startTimeTo,
-    scope?.sandboxOrgId,
-  ])
+  return useLiveQuery(
+    (q) => q.from({ span: collection }),
+    [projectId, sessionId, startTimeFrom, startTimeTo, scope?.sandboxOrgId],
+  )
 }
 
 export const useSpanDetail = ({

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -71,7 +71,13 @@ export const useSpansByTraceCollection = ({
 }) => {
   const scope = use(TraceScopeContext)
   const collection = getSpansByTraceCollection(projectId, traceId, startTimeFrom, startTimeTo, scope?.sandboxOrgId)
-  return useLiveQuery((q) => q.from({ span: collection }))
+  return useLiveQuery((q) => q.from({ span: collection }), [
+    projectId,
+    traceId,
+    startTimeFrom,
+    startTimeTo,
+    scope?.sandboxOrgId,
+  ])
 }
 
 const makeSpansBySessionCollection = (
@@ -129,7 +135,13 @@ export const useSpansBySessionCollection = ({
 }) => {
   const scope = use(TraceScopeContext)
   const collection = getSpansBySessionCollection(projectId, sessionId, startTimeFrom, startTimeTo, scope?.sandboxOrgId)
-  return useLiveQuery((q) => q.from({ span: collection }))
+  return useLiveQuery((q) => q.from({ span: collection }), [
+    projectId,
+    sessionId,
+    startTimeFrom,
+    startTimeTo,
+    scope?.sandboxOrgId,
+  ])
 }
 
 export const useSpanDetail = ({


### PR DESCRIPTION
Fixes #3614

## Problem

The span tree view does not update when navigating between traces inside a session — it keeps showing the first trace's spans.

## Root cause

`useSpansByTraceCollection` (and `useSpansBySessionCollection`) build a **per-`traceId`** TanStack DB collection (cached by a key including `traceId`), but passed the query to `useLiveQuery` with **no dependency array**:

```ts
return useLiveQuery((q) => q.from({ span: collection }))
```

Without deps, `useLiveQuery` compiles the query once on mount and stays bound to the `collection` reference captured then. When `traceId` changes, the hook receives a *new* collection but the live query keeps reading the *old* one.

This only surfaces when `TraceDetailBody` isn't remounted on trace change:
- The standalone drawer (`project-explorer.tsx`) has `key={activeTraceId}`, so it remounts and masks the bug.
- The **session panel** (`session-detail-drawer/trace-slot.tsx`) renders `TraceDetailBody` with **no key**, so navigating traces inside a session keeps the stale live query.

## Fix

Add dependency arrays to both spans `useLiveQuery` calls so the query re-binds whenever a collection-keying input changes (`projectId`, `traceId`/`sessionId`, time bounds, sandbox org scope). This matches the per-key pattern already used in `flaggers.collection.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)