### PR TITLE
Add production maintenance redirect toggle

### DIFF
--- a/.agents/skills/managing-maintenance-windows/SKILL.md
+++ b/.agents/skills/managing-maintenance-windows/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: managing-maintenance-windows
+description: Enables or disables Latitude production maintenance mode by redirecting console.latitude.so to the Better Stack status page. Use when asked to start, stop, toggle, verify, or prepare a maintenance window.
+---
+
+# Managing maintenance windows
+
+Use this skill when a user asks to enable, disable, verify, or prepare Latitude's production maintenance window.
+
+## What maintenance mode does
+
+- Maintenance mode is an ALB-level switch in `infra/lib/alb.ts`.
+- When enabled, `console.latitude.so` redirects to `https://status.latitude.so/`.
+- API, ingest, and bull-board host rules continue forwarding normally.
+- The switch is controlled by the Pulumi production config key `enableWebMaintenanceRedirect`.
+- Do not implement this in `apps/web`: if the web service is unhealthy, app-level redirects may not run.
+
+## Enable maintenance mode
+
+From `infra/`:
+
+```bash
+pulumi config set enableWebMaintenanceRedirect true --stack production
+pulumi preview --stack production
+pulumi up --stack production
+```
+
+Then verify from outside the VPC:
+
+```bash
+curl -I https://console.latitude.so/
+```
+
+Expected result: an HTTP redirect with `Location: https://status.latitude.so/`.
+
+## Disable maintenance mode
+
+From `infra/`:
+
+```bash
+pulumi config rm enableWebMaintenanceRedirect --stack production
+pulumi preview --stack production
+pulumi up --stack production
+```
+
+Then verify:
+
+```bash
+curl -I https://console.latitude.so/
+```
+
+Expected result: it no longer redirects to `https://status.latitude.so/`. The console may return the normal app response or an auth redirect depending on the requested path.
+
+## Safety checklist
+
+Before enabling:
+
+1. Confirm the user wants the production console redirected.
+2. Confirm `https://status.latitude.so/` is live and has the relevant Better Stack maintenance or incident notice.
+3. Run `pulumi preview --stack production` and check that the ALB HTTPS listener default action changes from forwarding to redirecting.
+4. Apply only after the user has approved the production change, unless they already explicitly asked to execute it.
+
+Before disabling:
+
+1. Confirm the maintenance window is complete or the user explicitly asked to restore service.
+2. Run `pulumi preview --stack production` and check that the ALB HTTPS listener default action changes from redirecting back to forwarding.
+3. Verify `console.latitude.so` after `pulumi up`.
+
+## Notes for agents
+
+- Use `eval "$(mise env)"` if local shell commands cannot find `node`, `pnpm`, or Pulumi-related tooling.
+- Do not change the hardcoded redirect target to an incident-specific URL. The reusable target is the status page root, `https://status.latitude.so/`.
+- Do not redirect `api.latitude.so` or `ingest.latitude.so` unless the user asks for a broader infrastructure change.
+- If Pulumi credentials or stack access are unavailable, report the exact command the operator should run and do not fake success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ At a glance: **`apps/*`** own HTTP boundaries (validation, authz, routing to use
 
 Detailed policies, command examples, and code samples live under **`.agents/skills/<skill-name>/SKILL.md`**. Load narrow skills instead of memorizing the entire monorepo at once.
 
-**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **25** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
+**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **27** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
 
 ## Skill glossary
 
@@ -50,6 +50,7 @@ Detailed policies, command examples, and code samples live under **`.agents/skil
 | **Environment configuration** | [.agents/skills/env-configuration/SKILL.md](.agents/skills/env-configuration/SKILL.md) | **`LAT_*` / `VITE_LAT_*`**, `.env.example`, **`parseEnv` / `parseEnvOptional`** |
 | **Fix Datadog issues** | [.agents/skills/fix-datadog-issues/SKILL.md](.agents/skills/fix-datadog-issues/SKILL.md) | Finding, triaging, and fixing production errors from **Datadog Error Tracking** (`plugin:datadog:mcp`); picking which issue to work (occurrence/trend/recency, v2-only, prod-only), root-causing in code, reproducing with tests, commenting on the issue, and opening a PR to `development` |
 | **GitHub issues** | [.agents/skills/gh-issue/SKILL.md](.agents/skills/gh-issue/SKILL.md) | Creating clear, actionable GitHub issues for bugs, features, and improvements, optimized for LLM/actionability |
+| **Managing maintenance windows** | [.agents/skills/managing-maintenance-windows/SKILL.md](.agents/skills/managing-maintenance-windows/SKILL.md) | Enabling, disabling, verifying, or preparing production maintenance mode, which redirects **`console.latitude.so`** to the Better Stack status page with the Pulumi `enableWebMaintenanceRedirect` switch |
 | **Mintlify docs preview** | [.agents/skills/mintlify-preview/SKILL.md](.agents/skills/mintlify-preview/SKILL.md) | Running the public **Mintlify** docs site (`docs/`) locally for live preview (`mint dev`); **Node <25 (nvm v22) requirement**, keeping the CLI current, non-default port, page-path mapping |
 | **Notifications** | [.agents/skills/notifications/SKILL.md](.agents/skills/notifications/SKILL.md) | Adding a notification **kind**, **group**, or **channel**; in-app + email delivery; `NOTIFICATION_KIND_META` / `NOTIFICATION_GROUPS`; per-user prefs (`users.notification_preferences`); project-level gates (`projects.settings.notifications`); idempotency + cascade-on-`ProjectDeleted` |
 | **Production release** | [.agents/skills/production-release/SKILL.md](.agents/skills/production-release/SKILL.md) | Preparing a production release, updating `CHANGELOG.md` from the production diff, and pushing `vX.Y.Z` release tags with `scripts/release.sh` |

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -8,6 +8,8 @@ config:
   # Datadog Slack notification handle for the Slack #alerts channel.
   latitude-infra:datadogSlackAlertHandle: "@slack-alerts"
   latitude-infra:enableDatadogSynthetics: "true"
+  # Uncomment during planned console maintenance to redirect console.latitude.so to https://status.latitude.so/.
+  # latitude-infra:enableWebMaintenanceRedirect: "true"
   # Pinned to avoid automatic bastion replacement when AWS publishes newer AL2023 AMIs.
   latitude-infra:bastionAmiId: ami-00b105a12aa2a60eb
   # Temporal Cloud (workflows ECS task)

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -29,6 +29,7 @@ const bastionAmiId = config.require("bastionAmiId")
 const datadogSite = config.get("datadogSite") ?? "datadoghq.eu"
 const datadogSlackAlertHandle = config.get("datadogSlackAlertHandle") ?? "@slack-alerts"
 const enableDatadogSynthetics = config.getBoolean("enableDatadogSynthetics") ?? false
+const enableWebMaintenanceRedirect = config.getBoolean("enableWebMaintenanceRedirect") ?? false
 
 const temporalCloudAddress = config.get("temporalCloudAddress") ?? `${envConfig.region}.aws.api.temporal.io:7233`
 const temporalCloudNamespace = config.get("temporalCloudNamespace") ?? ""
@@ -72,6 +73,7 @@ const alb = createAlb(
   vpc.publicSubnets,
   securityGroups.alb,
   certificate.certificateValidation?.certificateArn ?? certificate.certificate.arn,
+  enableWebMaintenanceRedirect,
 )
 
 const _dns = createDnsRecords(name, envConfig, alb.alb, hostedZoneId)

--- a/infra/lib/alb.ts
+++ b/infra/lib/alb.ts
@@ -3,6 +3,8 @@ import type { Output } from "@pulumi/pulumi"
 import type { EnvironmentConfig } from "../config.ts"
 import type { Ec2SecurityGroup, Ec2Subnet, LbListener, LbLoadBalancer, LbTargetGroup } from "./types.ts"
 
+const STATUS_PAGE_URL = "https://status.latitude.so/"
+
 export interface AlbOutput {
   alb: LbLoadBalancer
   targetGroups: Record<string, LbTargetGroup>
@@ -16,6 +18,7 @@ export function createAlb(
   publicSubnets: Ec2Subnet[],
   securityGroup: Ec2SecurityGroup,
   certificateArn?: Output<string>,
+  enableWebMaintenanceRedirect = false,
 ): AlbOutput {
   const alb = new aws.lb.LoadBalancer(`${name}-alb`, {
     name: `${name}-alb`,
@@ -98,10 +101,19 @@ export function createAlb(
   let httpsListener: LbListener | undefined
 
   if (certificateArn) {
-    const defaultAction = {
-      type: "forward" as const,
-      targetGroupArn: targetGroups.web.arn,
-    }
+    const defaultActions = enableWebMaintenanceRedirect
+      ? [
+          {
+            type: "redirect" as const,
+            redirect: createRedirectAction(STATUS_PAGE_URL),
+          },
+        ]
+      : [
+          {
+            type: "forward" as const,
+            targetGroupArn: targetGroups.web.arn,
+          },
+        ]
 
     const rules = [
       {
@@ -124,7 +136,7 @@ export function createAlb(
       protocol: "HTTPS",
       sslPolicy: "ELBSecurityPolicy-TLS13-1-2-2021-06",
       certificateArn: certificateArn,
-      defaultActions: [defaultAction],
+      defaultActions,
     })
 
     const ruleNames = ["api", "ingest", "bull-board"] as const
@@ -156,5 +168,18 @@ export function createAlb(
     targetGroups,
     httpListener,
     httpsListener,
+  }
+}
+
+function createRedirectAction(url: string) {
+  const target = new URL(url)
+
+  return {
+    protocol: target.protocol.replace(":", "").toUpperCase(),
+    host: target.hostname,
+    port: target.port || (target.protocol === "https:" ? "443" : "80"),
+    path: `/${target.pathname.replace(/^\//, "")}`,
+    query: target.search.replace(/^\?/, ""),
+    statusCode: "HTTP_302" as const,
   }
 }


### PR DESCRIPTION
Adds a Pulumi config switch, `enableWebMaintenanceRedirect`, that changes the production ALB HTTPS listener default action from forwarding the web app to redirecting `console.latitude.so` to `https://status.latitude.so/`. Host-specific rules for API, ingest, and bull-board continue forwarding normally, so the toggle only affects console traffic that falls through to the web listener default.

The production stack config documents the switch as an opt-in value to uncomment during planned maintenance. This also adds an agent skill with the exact enable, disable, preview, and verification steps so future maintenance windows use the ALB-level redirect rather than an app-level fallback.

Validation: `pnpm --filter latitude-infra typecheck`.