### PR TITLE
feat(spans): map Flue telemetry I/O + add Flue/Eve example apps

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -123,11 +123,11 @@
     },
     "packages/telemetry/typescript": {
       "entry": [
-        "examples/**/*.ts"
+        "examples/*.ts"
       ],
       "project": [
         "src/**/*.ts",
-        "examples/**/*.ts"
+        "examples/*.ts"
       ],
       "ignore": [
         "src/constants/**/*.ts"

--- a/packages/domain/spans/src/otlp/content/flue.ts
+++ b/packages/domain/spans/src/otlp/content/flue.ts
@@ -1,0 +1,148 @@
+/**
+ * Content parser for Flue telemetry (@flue/opentelemetry).
+ *
+ * Flue carries model/usage metadata on gen_ai.* attributes but serializes the
+ * model turn's conversation into custom flue.turn.* attributes. OTel attributes
+ * are primitives, so every structured value below is a JSON string.
+ *
+ *   flue.turn.input  — { systemPrompt?: string, messages: LlmMessage[], tools?: LlmTool[] }
+ *   flue.turn.output — LlmAssistantMessage ({ role: "assistant", content: [...] })
+ *
+ * LlmMessage is discriminated by `role`:
+ *   user        — { role: "user", content: string | (text | image)[] }
+ *   assistant   — { role: "assistant", content: (text | thinking | toolCall)[] }
+ *   toolResult  — { role: "toolResult", toolCallId, toolName, content: (text | image)[], isError }
+ *
+ * Content blocks are discriminated by `type`:
+ *   text     — { type: "text", text }
+ *   thinking — { type: "thinking", thinking }
+ *   image    — { type: "image", data (base64), mimeType }
+ *   toolCall — { type: "toolCall", id, name, arguments }
+ */
+import type { GenAIMessage, GenAISystem } from "rosetta-ai"
+import type { ToolDefinition } from "../../entities/span.ts"
+import type { OtlpKeyValue } from "../types.ts"
+import type { ParsedContent } from "./index.ts"
+import { toToolDefinition } from "./utils.ts"
+
+function rawString(attrs: readonly OtlpKeyValue[], key: string): string | undefined {
+  return attrs.find((a) => a.key === key)?.value?.stringValue
+}
+
+function rawJson(attrs: readonly OtlpKeyValue[], key: string): unknown {
+  const raw = rawString(attrs, key)
+  if (raw === undefined) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+type Part = Record<string, unknown>
+
+function blockToPart(block: unknown): Part | undefined {
+  if (!block || typeof block !== "object") return undefined
+  const obj = block as Record<string, unknown>
+
+  switch (obj.type) {
+    case "text":
+      return typeof obj.text === "string" && obj.text ? { type: "text", content: obj.text } : undefined
+    case "thinking":
+      return typeof obj.thinking === "string" && obj.thinking ? { type: "reasoning", content: obj.thinking } : undefined
+    case "image":
+      return typeof obj.data === "string" && obj.data
+        ? {
+            type: "uri",
+            modality: "image",
+            uri: `data:${obj.mimeType ?? "application/octet-stream"};base64,${obj.data}`,
+          }
+        : undefined
+    case "toolCall":
+      return { type: "tool_call", id: obj.id, name: obj.name, arguments: obj.arguments }
+    default:
+      return undefined
+  }
+}
+
+function contentToParts(content: unknown): Part[] {
+  if (typeof content === "string") return content ? [{ type: "text", content }] : []
+  if (!Array.isArray(content)) return []
+  return content.map(blockToPart).filter(Boolean) as Part[]
+}
+
+function toolResultResponse(content: unknown): unknown {
+  if (!Array.isArray(content)) return content
+  const text = content
+    .filter(
+      (b): b is { text: string } => !!b && typeof b === "object" && typeof (b as { text?: unknown }).text === "string",
+    )
+    .map((b) => b.text)
+    .join("\n")
+  return text || content
+}
+
+function messageToGenAI(message: unknown): GenAIMessage | undefined {
+  if (!message || typeof message !== "object") return undefined
+  const obj = message as Record<string, unknown>
+
+  if (obj.role === "toolResult") {
+    return {
+      role: "tool",
+      parts: [{ type: "tool_call_response", id: obj.toolCallId, response: toolResultResponse(obj.content) }],
+    } as unknown as GenAIMessage
+  }
+
+  if (obj.role === "user" || obj.role === "assistant") {
+    const parts = contentToParts(obj.content)
+    if (parts.length === 0) return undefined
+    return { role: obj.role, parts } as unknown as GenAIMessage
+  }
+
+  return undefined
+}
+
+function parseInput(attrs: readonly OtlpKeyValue[]): {
+  inputMessages: GenAIMessage[]
+  systemInstructions: GenAISystem
+  toolDefinitions: ToolDefinition[]
+} {
+  const input = rawJson(attrs, "flue.turn.input") as
+    | { systemPrompt?: unknown; messages?: unknown; tools?: unknown }
+    | undefined
+  if (!input || typeof input !== "object") {
+    return { inputMessages: [], systemInstructions: [], toolDefinitions: [] }
+  }
+
+  const systemInstructions: GenAISystem =
+    typeof input.systemPrompt === "string" && input.systemPrompt
+      ? ([{ type: "text", content: input.systemPrompt }] as unknown as GenAISystem)
+      : []
+
+  const inputMessages = Array.isArray(input.messages)
+    ? (input.messages.map(messageToGenAI).filter(Boolean) as GenAIMessage[])
+    : []
+
+  const toolDefinitions = Array.isArray(input.tools)
+    ? (input.tools.map(toToolDefinition).filter(Boolean) as ToolDefinition[])
+    : []
+
+  return { inputMessages, systemInstructions, toolDefinitions }
+}
+
+function parseOutput(attrs: readonly OtlpKeyValue[]): GenAIMessage[] {
+  const output = rawJson(attrs, "flue.turn.output")
+  const message = messageToGenAI(output)
+  return message ? [message] : []
+}
+
+export function parseFlue(attrs: readonly OtlpKeyValue[]): ParsedContent {
+  const { inputMessages, systemInstructions, toolDefinitions } = parseInput(attrs)
+
+  return {
+    inputMessages,
+    outputMessages: parseOutput(attrs),
+    systemInstructions,
+    toolDefinitions,
+  }
+}

--- a/packages/domain/spans/src/otlp/content/index.ts
+++ b/packages/domain/spans/src/otlp/content/index.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from "../../entities/span.ts"
 import { stringAttr } from "../attributes.ts"
 import type { OtlpKeyValue } from "../types.ts"
 import { parseClaudeCode } from "./claude-code.ts"
+import { parseFlue } from "./flue.ts"
 import { parseGenAICurrent } from "./genai.ts"
 import { parseGenAIDeprecated } from "./genai_deprecated.ts"
 import { parseLiveKit } from "./livekit.ts"
@@ -69,6 +70,10 @@ const PARSERS: readonly ContentParser[] = [
       hasKey(attrs, "lk.response.function_calls") ||
       hasKey(attrs, "lk.function_tools"),
     parse: parseLiveKit,
+  },
+  {
+    canHandle: (attrs) => hasKey(attrs, "flue.turn.input") || hasKey(attrs, "flue.turn.output"),
+    parse: parseFlue,
   },
   {
     canHandle: (attrs) => hasKey(attrs, "user_prompt"), // Claude Code

--- a/packages/domain/spans/src/otlp/tests/flue.test.ts
+++ b/packages/domain/spans/src/otlp/tests/flue.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+import { parseContent } from "../content/index.ts"
+import type { OtlpKeyValue } from "../types.ts"
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+
+const SYSTEM_PROMPT = "You are a precise translator. Return only the requested translation."
+
+describe("parseContent (Flue)", () => {
+  it("parses a model turn from flue.turn.input / flue.turn.output", () => {
+    const input = {
+      systemPrompt: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: [{ type: "text", text: 'Translate this to Spanish: "Good morning"' }] }],
+      tools: [
+        {
+          name: "finish",
+          description: "Call this tool when the task is complete.",
+          parameters: { type: "object", properties: { translation: { type: "string" } }, required: ["translation"] },
+        },
+      ],
+    }
+    const output = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "finish",
+          arguments: { translation: "Buenos días", confidence: "high" },
+        },
+      ],
+    }
+
+    const result = parseContent([
+      str("gen_ai.operation.name", "chat"),
+      str("gen_ai.request.model", "gpt-4o-mini"),
+      str("flue.turn.input", JSON.stringify(input)),
+      str("flue.turn.output", JSON.stringify(output)),
+    ])
+
+    expect(result.systemInstructions).toEqual([{ type: "text", content: SYSTEM_PROMPT }])
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "text", content: 'Translate this to Spanish: "Good morning"' }] },
+    ])
+    expect(result.outputMessages).toEqual([
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool_call",
+            id: "call_1",
+            name: "finish",
+            arguments: { translation: "Buenos días", confidence: "high" },
+          },
+        ],
+      },
+    ])
+    expect(result.toolDefinitions).toEqual([
+      {
+        name: "finish",
+        description: "Call this tool when the task is complete.",
+        parameters: { type: "object", properties: { translation: { type: "string" } }, required: ["translation"] },
+      },
+    ])
+  })
+
+  it("maps assistant thinking to a reasoning part and preserves text", () => {
+    const output = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "The user wants a greeting." },
+        { type: "text", text: "Hello there!" },
+      ],
+    }
+
+    const result = parseContent([str("flue.turn.output", JSON.stringify(output))])
+
+    expect(result.outputMessages).toEqual([
+      {
+        role: "assistant",
+        parts: [
+          { type: "reasoning", content: "The user wants a greeting." },
+          { type: "text", content: "Hello there!" },
+        ],
+      },
+    ])
+  })
+
+  it("maps prior toolCall and toolResult history into assistant and tool messages", () => {
+    const input = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "What is 2+2?" }] },
+        { role: "assistant", content: [{ type: "toolCall", id: "call_9", name: "add", arguments: { a: 2, b: 2 } }] },
+        {
+          role: "toolResult",
+          toolCallId: "call_9",
+          toolName: "add",
+          content: [{ type: "text", text: "4" }],
+          isError: false,
+        },
+      ],
+    }
+
+    const result = parseContent([str("flue.turn.input", JSON.stringify(input))])
+
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "text", content: "What is 2+2?" }] },
+      { role: "assistant", parts: [{ type: "tool_call", id: "call_9", name: "add", arguments: { a: 2, b: 2 } }] },
+      { role: "tool", parts: [{ type: "tool_call_response", id: "call_9", response: "4" }] },
+    ])
+  })
+
+  it("accepts user content given as a plain string", () => {
+    const input = { messages: [{ role: "user", content: "Just a string" }] }
+
+    const result = parseContent([str("flue.turn.input", JSON.stringify(input))])
+
+    expect(result.inputMessages).toEqual([{ role: "user", parts: [{ type: "text", content: "Just a string" }] }])
+  })
+
+  it("maps inline image content to a data-uri part", () => {
+    const input = {
+      messages: [{ role: "user", content: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }] }],
+    }
+
+    const result = parseContent([str("flue.turn.input", JSON.stringify(input))])
+
+    expect(result.inputMessages).toEqual([
+      { role: "user", parts: [{ type: "uri", modality: "image", uri: "data:image/png;base64,aGVsbG8=" }] },
+    ])
+  })
+
+  it("degrades gracefully on malformed flue.turn.input JSON", () => {
+    const output = { role: "assistant", content: [{ type: "text", text: "ok" }] }
+
+    const result = parseContent([
+      str("flue.turn.input", "{ not valid json"),
+      str("flue.turn.output", JSON.stringify(output)),
+    ])
+
+    expect(result.inputMessages).toEqual([])
+    expect(result.outputMessages).toEqual([{ role: "assistant", parts: [{ type: "text", content: "ok" }] }])
+  })
+
+  it("returns empty content when no Flue attributes are present", () => {
+    const result = parseContent([str("gen_ai.operation.name", "chat")])
+
+    expect(result.inputMessages).toEqual([])
+    expect(result.outputMessages).toEqual([])
+    expect(result.systemInstructions).toEqual([])
+    expect(result.toolDefinitions).toEqual([])
+  })
+})

--- a/packages/telemetry/typescript/examples/eve-app/.env.example
+++ b/packages/telemetry/typescript/examples/eve-app/.env.example
@@ -1,0 +1,7 @@
+# Latitude (local instance)
+LATITUDE_API_KEY=your-latitude-api-key
+LATITUDE_PROJECT_SLUG=your-project-slug
+LATITUDE_TELEMETRY_URL=http://localhost:3002
+
+# OpenAI (direct provider used by agent/agent.ts)
+OPENAI_API_KEY=your-openai-key

--- a/packages/telemetry/typescript/examples/eve-app/.gitignore
+++ b/packages/telemetry/typescript/examples/eve-app/.gitignore
@@ -1,0 +1,16 @@
+node_modules
+.env*
+.eve
+.vercel
+.workflow-data
+.next
+.output
+.nitro
+dist
+.DS_Store
+*.tsbuildinfo
+
+# example env is committed
+!.env.example
+# lockfile excluded; deps are pinned in package.json
+pnpm-lock.yaml

--- a/packages/telemetry/typescript/examples/eve-app/.vercelignore
+++ b/packages/telemetry/typescript/examples/eve-app/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+.env*
+.eve
+.workflow-data
+.next
+.output
+.nitro
+dist

--- a/packages/telemetry/typescript/examples/eve-app/README.md
+++ b/packages/telemetry/typescript/examples/eve-app/README.md
@@ -1,0 +1,61 @@
+# Eve → Latitude example
+
+A minimal [Eve](https://eve.dev) agent that exports its turn, step, model-call,
+and tool spans to Latitude.
+
+Eve is built on the Vercel AI SDK and exports standard OpenTelemetry spans
+(`ai.eve.turn`, `ai.streamText`, `ai.toolCall`, …) through whatever exporter you
+register in `agent/instrumentation.ts`. Latitude already understands Vercel AI
+SDK spans plus Eve's `eve.*` attributes, so no Latitude SDK is required — the
+exporter points straight at Latitude's OTLP endpoint. See
+[`agent/instrumentation.ts`](agent/instrumentation.ts).
+
+> This is a standalone Eve project (its own `package.json`, `pnpm-workspace.yaml`,
+> and `ai@7` beta). It is intentionally excluded from the monorepo workspace so
+> its large dependency tree never lands in the repo lockfile.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `agent/instrumentation.ts` | `registerOTel(...)` with an OTLP exporter aimed at Latitude. Auto-discovered at startup. |
+| `agent/agent.ts` | Declares the model. Uses the OpenAI provider directly (`@ai-sdk/openai`) to avoid the Vercel AI Gateway. |
+| `agent/instructions.md` | The agent's system prompt. |
+
+## Run it
+
+```bash
+pnpm install
+cp .env.example .env.local   # fill in LATITUDE_API_KEY, LATITUDE_PROJECT_SLUG, OPENAI_API_KEY
+                             # point LATITUDE_TELEMETRY_URL at your instance (http://localhost:3002 for local)
+```
+
+Start the dev server headless and send a turn over the built-in eve channel:
+
+```bash
+pnpm exec eve dev --no-ui --port 2000
+
+# in another shell:
+curl -X POST http://localhost:2000/eve/v1/session \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"What is the capital of France?"}'
+```
+
+## What you'll see in Latitude
+
+Spans under service `eve-app`, with `eve.session.id` read into the trace's
+session id:
+
+```
+ai.eve.turn                      {eve.session.id}
+  └─ invoke_agent gpt-4o-mini    (gen_ai.* model turn: provider, tokens, cost)
+       └─ chat gpt-4o-mini
+            └─ fetch POST .../v1/responses
+```
+
+## Recording inputs/outputs
+
+Eve records full message history and model outputs on spans by default
+(`recordInputs` / `recordOutputs`). Set them to `false` in
+`agent/instrumentation.ts` for sensitive or regulated data — see the
+[Eve docs](https://docs.latitude.so/telemetry/frameworks/eve).

--- a/packages/telemetry/typescript/examples/eve-app/agent/agent.ts
+++ b/packages/telemetry/typescript/examples/eve-app/agent/agent.ts
@@ -1,0 +1,7 @@
+import { openai } from "@ai-sdk/openai";
+import { defineAgent } from "eve";
+
+// Direct provider (no Vercel AI Gateway): reads OPENAI_API_KEY from the env.
+export default defineAgent({
+  model: openai("gpt-4o-mini"),
+});

--- a/packages/telemetry/typescript/examples/eve-app/agent/channels/eve.ts
+++ b/packages/telemetry/typescript/examples/eve-app/agent/channels/eve.ts
@@ -1,0 +1,15 @@
+import { eveChannel } from "eve/channels/eve";
+import { localDev, placeholderAuth, vercelOidc } from "eve/channels/auth";
+
+export default eveChannel({
+  auth: [
+    // Open on localhost for `eve dev` and the REPL; ignored in production.
+    localDev(),
+    // Lets the eve TUI and your Vercel deployments reach the deployed agent.
+    vercelOidc(),
+    // This placeholder will not allow browser requests in production.
+    // Replace it with your app's auth provider, like Auth.js or Clerk,
+    // or use none() for a public demo.
+    placeholderAuth(),
+  ],
+});

--- a/packages/telemetry/typescript/examples/eve-app/agent/instructions.md
+++ b/packages/telemetry/typescript/examples/eve-app/agent/instructions.md
@@ -1,0 +1,3 @@
+# Identity
+
+You are a concise, friendly geography assistant. Answer in one short sentence.

--- a/packages/telemetry/typescript/examples/eve-app/agent/instrumentation.ts
+++ b/packages/telemetry/typescript/examples/eve-app/agent/instrumentation.ts
@@ -1,0 +1,20 @@
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { defineInstrumentation } from "eve/instrumentation";
+import { registerOTel } from "@vercel/otel";
+
+// eve auto-discovers this file and runs it at startup, implicitly enabling
+// telemetry. eve emits standard Vercel AI SDK spans (ai.eve.turn, ai.streamText,
+// ai.toolCall, …) carrying eve.* attributes; Latitude ingests them directly.
+export default defineInstrumentation({
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPTraceExporter({
+        url: `${process.env.LATITUDE_TELEMETRY_URL ?? "https://ingest.latitude.so"}/v1/traces`,
+        headers: {
+          Authorization: `Bearer ${process.env.LATITUDE_API_KEY!}`,
+          "X-Latitude-Project": process.env.LATITUDE_PROJECT_SLUG!,
+        },
+      }),
+    }),
+});

--- a/packages/telemetry/typescript/examples/eve-app/package.json
+++ b/packages/telemetry/typescript/examples/eve-app/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "eve-app",
+  "version": "0.0.0",
+  "type": "module",
+  "imports": {
+    "#*": "./agent/*",
+    "#evals/*": "./evals/*"
+  },
+  "scripts": {
+    "build": "eve build",
+    "dev": "eve dev",
+    "start": "eve start",
+    "typecheck": "tsgo"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "4.0.0-beta.74",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.213.0",
+    "@vercel/connect": "0.2.2",
+    "@vercel/otel": "2.1.3",
+    "ai": "7.0.0-beta.178",
+    "eve": "^0.11.5",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "24.x",
+    "@typescript/native-preview": "7.0.0-dev.20260523.1"
+  },
+  "overrides": {
+    "ai": "7.0.0-beta.178"
+  },
+  "resolutions": {
+    "ai": "7.0.0-beta.178"
+  },
+  "engines": {
+    "node": "24.x"
+  }
+}

--- a/packages/telemetry/typescript/examples/eve-app/pnpm-workspace.yaml
+++ b/packages/telemetry/typescript/examples/eve-app/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+minimumReleaseAgeExclude:
+  - eve
+allowBuilds:
+  sharp: false
+# Compatibility for eve releases with an incomplete runtime manifest.
+packageExtensions:
+  "eve@>=0.6.0-beta.13 <=0.7.0":
+    dependencies:
+      oxc-parser: 0.134.0

--- a/packages/telemetry/typescript/examples/eve-app/tsconfig.json
+++ b/packages/telemetry/typescript/examples/eve-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["agent/**/*.ts", "evals/**/*.ts", ".eve/**/*.d.ts"]
+}

--- a/packages/telemetry/typescript/examples/flue-app/.env.example
+++ b/packages/telemetry/typescript/examples/flue-app/.env.example
@@ -1,0 +1,7 @@
+# Latitude (local instance)
+LATITUDE_API_KEY=your-latitude-api-key
+LATITUDE_PROJECT_SLUG=your-project-slug
+LATITUDE_TELEMETRY_URL=http://localhost:3002
+
+# OpenAI (Flue resolves provider credentials from standard env vars)
+OPENAI_API_KEY=your-openai-key

--- a/packages/telemetry/typescript/examples/flue-app/.gitignore
+++ b/packages/telemetry/typescript/examples/flue-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.flue-build/
+.env
+package-lock.json

--- a/packages/telemetry/typescript/examples/flue-app/README.md
+++ b/packages/telemetry/typescript/examples/flue-app/README.md
@@ -1,0 +1,60 @@
+# Flue → Latitude example
+
+A minimal [Flue](https://flueframework.com) project that exports its workflow,
+operation, model-turn, and tool spans to Latitude.
+
+Flue emits OpenTelemetry spans itself through `@flue/opentelemetry`, so there is
+no provider-specific `instrumentations` entry. You initialize the Latitude SDK
+(which configures the OpenTelemetry provider + exporter) and register Flue's
+observer. See [`src/telemetry.ts`](src/telemetry.ts).
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/telemetry.ts` | Initializes `Latitude` and registers `createOpenTelemetryObserver()`. Imported for its side effects. |
+| `src/app.ts` | Flue HTTP entrypoint; imports `./telemetry.ts` so telemetry is live before any workflow runs. |
+| `src/workflows/translate.ts` | A one-prompt workflow that translates text via `openai/gpt-4o-mini`. |
+
+## Run it
+
+```bash
+npm install
+cp .env.example .env   # fill in LATITUDE_API_KEY, LATITUDE_PROJECT_SLUG, OPENAI_API_KEY
+                       # point LATITUDE_TELEMETRY_URL at your instance (http://localhost:3002 for local)
+```
+
+One-shot (note: a one-shot process can exit before spans flush — prefer the dev
+server below when verifying ingestion):
+
+```bash
+npm run run:translate
+```
+
+Long-running server (recommended for verifying ingestion — the process stays up
+so spans flush):
+
+```bash
+npm run dev   # serves on http://localhost:3583
+curl 'http://localhost:3583/workflows/translate?wait=result' \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Good morning","language":"Spanish"}'
+```
+
+## What you'll see in Latitude
+
+A trace under service `flue-example`:
+
+```
+flue.workflow translate
+  └─ flue.operation prompt
+       └─ chat gpt-4o-mini      (gen_ai.* model turn: provider, tokens, cost)
+            └─ flue.tool finish
+```
+
+## Exporting content
+
+Flue omits prompts, completions, tool values, and logs by default. This example
+opts every event in via `exportContent: (event) => event` so the conversation is
+visible. Sanitize per-event before enabling that on data you can't store — see
+the [Flue docs](https://docs.latitude.so/telemetry/frameworks/flue).

--- a/packages/telemetry/typescript/examples/flue-app/flue.config.ts
+++ b/packages/telemetry/typescript/examples/flue-app/flue.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@flue/cli/config';
+
+export default defineConfig({
+	target: 'node',
+});

--- a/packages/telemetry/typescript/examples/flue-app/package.json
+++ b/packages/telemetry/typescript/examples/flue-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "latitude-flue-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "flue dev --target node",
+    "run:translate": "flue run translate --target node --payload '{\"text\":\"Hello world\",\"language\":\"French\"}'"
+  },
+  "dependencies": {
+    "@flue/opentelemetry": "1.0.0-beta.1",
+    "@flue/runtime": "1.0.0-beta.2",
+    "@latitude-data/telemetry": "3.1.1",
+    "@opentelemetry/api": "1.9.1",
+    "hono": "4.12.26",
+    "valibot": "1.4.1"
+  },
+  "devDependencies": {
+    "@flue/cli": "1.0.0-beta.1"
+  }
+}

--- a/packages/telemetry/typescript/examples/flue-app/src/app.ts
+++ b/packages/telemetry/typescript/examples/flue-app/src/app.ts
@@ -1,0 +1,8 @@
+import { flue } from "@flue/runtime/routing"
+import { Hono } from "hono"
+import "./telemetry.ts"
+
+const app = new Hono()
+app.route("/", flue())
+
+export default app

--- a/packages/telemetry/typescript/examples/flue-app/src/telemetry.ts
+++ b/packages/telemetry/typescript/examples/flue-app/src/telemetry.ts
@@ -1,0 +1,15 @@
+import { createOpenTelemetryObserver } from "@flue/opentelemetry"
+import { observe } from "@flue/runtime"
+import { Latitude } from "@latitude-data/telemetry"
+
+new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
+  serviceName: "flue-example",
+  disableBatch: true,
+})
+
+// Flue omits prompts, completions, tool values, and logs by default. This
+// example opts every event in so the full conversation shows up in Latitude.
+// Sanitize per-event before enabling this on data you can't store.
+observe(createOpenTelemetryObserver({ exportContent: (event) => event }))

--- a/packages/telemetry/typescript/examples/flue-app/src/workflows/translate.ts
+++ b/packages/telemetry/typescript/examples/flue-app/src/workflows/translate.ts
@@ -1,0 +1,24 @@
+import { createAgent, type FlueContext, type WorkflowRouteHandler } from "@flue/runtime"
+import * as v from "valibot"
+import "../telemetry.ts"
+
+export const route: WorkflowRouteHandler = async (_c, next) => next()
+
+const translator = createAgent(() => ({
+  model: "openai/gpt-4o-mini",
+  instructions: "You are a precise translator. Return only the requested translation.",
+}))
+
+export async function run({ init, payload }: FlueContext<{ text: string; language: string }>) {
+  const harness = await init(translator)
+  const session = await harness.session()
+
+  const { data } = await session.prompt(`Translate this to ${payload.language}: "${payload.text}"`, {
+    result: v.object({
+      translation: v.string(),
+      confidence: v.picklist(["low", "medium", "high"]),
+    }),
+  })
+
+  return data
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,10 @@ packages:
   - packages/**
   - "!packages/telemetry/python/**"
   - "!packages/platform/op-gepa/python/**"
+  - "!packages/telemetry/typescript/examples/flue-app"
+  - "!packages/telemetry/typescript/examples/flue-app/**"
+  - "!packages/telemetry/typescript/examples/eve-app"
+  - "!packages/telemetry/typescript/examples/eve-app/**"
   - infra
   - tools/*
 


### PR DESCRIPTION
## Summary

Two related pieces of work for Flue/Eve telemetry, surfaced while testing the recently-added framework support end to end.

### 1. `fix(spans)` — map Flue conversation content
Flue (`@flue/opentelemetry`) reports model/usage on the standard `gen_ai.*` attributes but serializes the model-turn conversation into proprietary `flue.turn.input` / `flue.turn.output` JSON. The OTLP span→message extractor had no parser for those keys, so Flue traces showed model/tokens/cost but **empty input/output messages** (Eve, which rides the Vercel AI SDK `ai.*` spans, already worked).

Added a Flue content parser (modeled on the LiveKit one) registered in the `PARSERS` registry, gated on `flue.turn.*` presence:
- `flue.turn.input` → system instructions + input messages + tool definitions
- `flue.turn.output` → assistant message
- block mapping: `text`→text, `thinking`→reasoning, `toolCall`→tool_call, `image`→uri, `toolResult`→tool/`tool_call_response`
- 7 unit tests built from real captured payload shapes.

### 2. `chore(telemetry)` — runnable Flue + Eve example apps
Self-contained example projects under `packages/telemetry/typescript/examples/` that exercise both integrations end to end (`flue-app`, `eve-app`). Their heavy, beta-pinned dependency trees are excluded from the pnpm workspace so they never enter the monorepo lockfile/CI; the telemetry package's knip globs are scoped to top-level example scripts so the apps aren't analyzed as part of the package.

## Verification
- `pnpm --filter @domain/spans test` → 662 passed (incl. 7 new Flue cases); typecheck clean.
- End-to-end against a local instance: re-ran `flue-app` through the live ingest pipeline and confirmed in ClickHouse the Flue `chat` span now stores `system_instructions` / `input_messages` / `output_messages` (user prompt + assistant `tool_call`) — previously all empty.
- `pnpm knip` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)