### PR TITLE
fix(destinations): bound backfill/sync window reads to avoid ClickHouse OOM

### DIFF
--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -4,7 +4,20 @@ export const DESTINATION_INTERVAL_MS_DEFAULT = 300_000
 
 export const DESTINATION_MAX_RECORDS_PER_RUN_MIN = 1_000
 export const DESTINATION_MAX_RECORDS_PER_RUN_MAX = 50_000
-export const DESTINATION_MAX_RECORDS_PER_RUN_DEFAULT = 50_000
+export const DESTINATION_MAX_RECORDS_PER_RUN_DEFAULT = 5_000
+
+/**
+ * Hard ceiling on a single source read page, independent of (and clamping) the
+ * configured `maxRecordsPerRun`. A window read serializes its whole page to
+ * JSONEachRow in one ClickHouse response; span rows carry KB–MB payloads, so a
+ * large page balloons `ParallelFormattingOutputFormat` — a 35k-row page cost
+ * 4.2 GiB and 16s in production, tripping the server-wide OvercommitTracker and
+ * resetting the client socket. Clamping the read page keeps every run bounded
+ * regardless of a destination's stored config (legacy rows hold the old 50k
+ * default). Cursor pagination already chains the rest, so smaller pages just
+ * mean more, cheaper windows.
+ */
+export const DESTINATION_READ_PAGE_MAX = 5_000
 
 /**
  * Hard cap on records imported by a single backfill. A destination connected to
@@ -14,7 +27,7 @@ export const DESTINATION_MAX_RECORDS_PER_RUN_DEFAULT = 50_000
  * window holds at most this many, newest first). Deliberately an operational/
  * product bound on backfill duration + ClickHouse read volume — NOT a
  * PostHog-derived limit: PostHog exposes no rate limit on `/batch/` capture, so
- * there's no published throughput to size against. 1M ≈ 20 live-sync windows.
+ * there's no published throughput to size against. 1M ≈ 200 read pages.
  */
 export const DESTINATION_MAX_RECORDS_PER_BACKFILL = 1_000_000
 

--- a/packages/domain/destinations/src/ports/destination-source-reader.ts
+++ b/packages/domain/destinations/src/ports/destination-source-reader.ts
@@ -44,6 +44,7 @@ export interface DestinationSourceReader<TRecord> {
     readonly cursor: SourceCursor
     readonly windowEnd: Date
     readonly limit: number
+    readonly excludePayloads?: boolean
   }): Effect.Effect<SourceWindow<TRecord>, RepositoryError, ChSqlClient>
   /**
    * The most recent `limit` records of this source for a project, newest first —

--- a/packages/domain/destinations/src/sources/spans-source-reader.ts
+++ b/packages/domain/destinations/src/sources/spans-source-reader.ts
@@ -10,7 +10,7 @@ import { type DestinationSourceReader, DestinationSourceReaders } from "../ports
  * spans→PostHog mapper; the source-agnostic engine never references it directly.
  */
 export const createSpansSourceReader = (spanRepo: SpanRepositoryShape): DestinationSourceReader<SpanDetail> => ({
-  listWindow: ({ organizationId, projectId, cursor, windowEnd, limit }) =>
+  listWindow: ({ organizationId, projectId, cursor, windowEnd, limit, excludePayloads }) =>
     spanRepo
       .listByIngestedAtWindow({
         organizationId,
@@ -18,6 +18,7 @@ export const createSpansSourceReader = (spanRepo: SpanRepositoryShape): Destinat
         cursor: { ingestedAt: cursor.watermark, spanId: SpanId(cursor.id) },
         windowEnd,
         limit,
+        excludePayloads: excludePayloads ?? false,
       })
       .pipe(
         Effect.map((window) => ({

--- a/packages/domain/destinations/src/use-cases/backfill-destination.test.ts
+++ b/packages/domain/destinations/src/use-cases/backfill-destination.test.ts
@@ -15,7 +15,7 @@ import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testi
 import type { SpanDetail } from "@domain/spans"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
-import { POSTHOG_US_INGESTION_HOST } from "../constants.ts"
+import { DESTINATION_READ_PAGE_MAX, POSTHOG_US_INGESTION_HOST } from "../constants.ts"
 import { createDestination, type Destination } from "../entities/destination.ts"
 import { defaultSourceConfig, type SpansSourceConfig } from "../entities/destination-source.ts"
 import { createDestinationSourceState, type DestinationSourceState } from "../entities/destination-source-state.ts"
@@ -184,6 +184,8 @@ interface SetupOpts {
   readonly deliveryFailure?: NonRetryableDeliveryError | RetryableDeliveryError
   /** Cap floor the reader reports — simulates "the most-recent-N records start here". */
   readonly recentLimitFloor?: Date | null
+  /** Override the source reader (e.g. to capture the `limit` each window read is called with). */
+  readonly reader?: DestinationSourceReader<SpanDetail>
 }
 
 const setup = (opts: SetupOpts) => {
@@ -199,7 +201,7 @@ const setup = (opts: SetupOpts) => {
   )
   if (opts.deliveryFailure) failWith(opts.deliveryFailure)
   const { mapper } = createFakeDestinationMapper()
-  const reader = readerFromRecords(opts.records, opts.recentLimitFloor ?? null)
+  const reader = opts.reader ?? readerFromRecords(opts.records, opts.recentLimitFloor ?? null)
 
   const layer = Layer.mergeAll(
     Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
@@ -568,6 +570,26 @@ describe("runBackfillWindowUseCase (full drain)", () => {
 
     expect(stateRows[0]?.coverageStartAt).toEqual(start) // moved back to the chain's floor
     expect(stateRows[0]?.backfillStartedAt).toBeNull() // in-flight marker cleared on completion
+  })
+
+  it("clamps each window read to DESTINATION_READ_PAGE_MAX even when the config allows more", async () => {
+    const seenLimits: number[] = []
+    const base = readerFromRecords([stubSpan("a1", new Date("2026-05-20T00:00:00.000Z"))])
+    const reader: DestinationSourceReader<SpanDetail> = {
+      ...base,
+      listWindow: (input) => {
+        seenLimits.push(input.limit)
+        return base.listWindow(input)
+      },
+    }
+    // 50k is the legacy stored default; a single page that large blew ClickHouse's
+    // formatter past the server memory limit, so the read must page far smaller.
+    const { layer } = setup({ records: [], maxRecordsPerRun: 50_000, reader })
+
+    await drainBackfill(layer, new Date("2026-05-15T00:00:00.000Z"))
+
+    expect(seenLimits.length).toBeGreaterThan(0)
+    expect(Math.max(...seenLimits)).toBe(DESTINATION_READ_PAGE_MAX)
   })
 
   it("splits at the historical boundary so no delivered window straddles it", async () => {

--- a/packages/domain/destinations/src/use-cases/backfill-destination.ts
+++ b/packages/domain/destinations/src/use-cases/backfill-destination.ts
@@ -316,6 +316,7 @@ export const runBackfillWindowUseCase = (input: RunBackfillWindowInput) =>
       cursor,
       windowEnd: segmentEnd,
       limit,
+      excludePayloads: sourceState.config.excludePayloads,
     })
 
     if (window.records.length === 0) {

--- a/packages/domain/destinations/src/use-cases/backfill-destination.ts
+++ b/packages/domain/destinations/src/use-cases/backfill-destination.ts
@@ -1,7 +1,11 @@
 import type { QueuePublishError } from "@domain/queue"
 import type { ChSqlClient, DestinationId, DestinationSyncRunId, RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
-import { DESTINATION_BACKFILL_STALE_MS, DESTINATION_MAX_RECORDS_PER_BACKFILL } from "../constants.ts"
+import {
+  DESTINATION_BACKFILL_STALE_MS,
+  DESTINATION_MAX_RECORDS_PER_BACKFILL,
+  DESTINATION_READ_PAGE_MAX,
+} from "../constants.ts"
 import type { DestinationSource } from "../entities/destination-source.ts"
 import { createDestinationSyncRun } from "../entities/destination-sync-run.ts"
 import { type DeliveryError, isRetryableDeliveryError, sanitizedDeliveryFailureMessage } from "../errors.ts"
@@ -305,7 +309,7 @@ export const runBackfillWindowUseCase = (input: RunBackfillWindowInput) =>
     const deliverer = (yield* DestinationDeliverers)[destination.kind]
     const syncRuns = yield* DestinationSyncRunRepository
 
-    const limit = sourceState.config.maxRecordsPerRun
+    const limit = Math.min(sourceState.config.maxRecordsPerRun, DESTINATION_READ_PAGE_MAX)
     const window = yield* reader.listWindow({
       organizationId: destination.organizationId,
       projectId: destination.projectId,

--- a/packages/domain/destinations/src/use-cases/run-destination-sync.test.ts
+++ b/packages/domain/destinations/src/use-cases/run-destination-sync.test.ts
@@ -15,16 +15,24 @@ import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testi
 import type { SpanDetail } from "@domain/spans"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
-import { DESTINATION_IDLE_PAUSE_AFTER_EMPTY_RUNS, POSTHOG_US_INGESTION_HOST } from "../constants.ts"
+import {
+  DESTINATION_IDLE_PAUSE_AFTER_EMPTY_RUNS,
+  DESTINATION_READ_PAGE_MAX,
+  POSTHOG_US_INGESTION_HOST,
+} from "../constants.ts"
 import type { Destination } from "../entities/destination.ts"
 import { createDestination } from "../entities/destination.ts"
-import { defaultSourceConfig } from "../entities/destination-source.ts"
+import { defaultSourceConfig, type SpansSourceConfig } from "../entities/destination-source.ts"
 import { createDestinationSourceState, type DestinationSourceState } from "../entities/destination-source-state.ts"
 import { NonRetryableDeliveryError, RetryableDeliveryError } from "../errors.ts"
 import { DestinationDeliverers } from "../ports/destination-deliverer.ts"
 import { DestinationMappers } from "../ports/destination-mapper.ts"
 import { DestinationRepository } from "../ports/destination-repository.ts"
-import { DestinationSourceReaders, type SourceCursor } from "../ports/destination-source-reader.ts"
+import {
+  type DestinationSourceReader,
+  DestinationSourceReaders,
+  type SourceCursor,
+} from "../ports/destination-source-reader.ts"
 import { DestinationSourceStateRepository } from "../ports/destination-source-state-repository.ts"
 import { DestinationSyncRunRepository } from "../ports/destination-sync-run-repository.ts"
 import { createFakeDestinationDeliverer } from "../testing/fake-destination-deliverer.ts"
@@ -196,6 +204,44 @@ describe("runDestinationSyncUseCase", () => {
     expect(deliveries).toHaveLength(0)
     expect(syncRunRows).toHaveLength(0)
     expect(cursorRows[0]?.lastRunAt).toBeNull()
+  })
+
+  it("clamps the live window read to DESTINATION_READ_PAGE_MAX even when the config allows more", async () => {
+    const seenLimits: number[] = []
+    const base = staticSourceReader({ records: [], nextCursor: null })
+    const reader: DestinationSourceReader<SpanDetail> = {
+      ...base,
+      listWindow: (input) => {
+        seenLimits.push(input.limit)
+        return base.listWindow(input)
+      },
+    }
+    const { repo: destinationRepo, rows: destinationRows } = createFakeDestinationRepository([makeDestination()])
+    const cursor = makeCursor({
+      config: { ...(defaultSourceConfig(SOURCE) as SpansSourceConfig), maxRecordsPerRun: 50_000 },
+    })
+    const { repo: cursorRepo } = createFakeDestinationSourceStateRepository([cursor], destinationRows)
+    const { repo: syncRunRepo } = createFakeDestinationSyncRunRepository()
+    const { deliverer } = createFakeDestinationDeliverer()
+    const { mapper } = createFakeDestinationMapper()
+    const layer = Layer.mergeAll(
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(ChSqlClient, createFakeChSqlClient()),
+      Layer.succeed(DestinationSourceReaders, fakeSourceReaderRegistry(reader)),
+      Layer.succeed(DestinationRepository, destinationRepo),
+      Layer.succeed(DestinationSourceStateRepository, cursorRepo),
+      Layer.succeed(DestinationSyncRunRepository, syncRunRepo),
+      Layer.succeed(DestinationDeliverers, { posthog: deliverer }),
+      Layer.succeed(DestinationMappers, { posthog: { spans: mapper } }),
+    )
+
+    await Effect.runPromise(
+      runDestinationSyncUseCase({ destinationId: DESTINATION_ID, source: SOURCE, now: NOW }).pipe(
+        Effect.provide(layer),
+      ),
+    )
+
+    expect(seenLimits).toEqual([DESTINATION_READ_PAGE_MAX])
   })
 
   it("skips when the destination is missing", async () => {

--- a/packages/domain/destinations/src/use-cases/run-destination-sync.ts
+++ b/packages/domain/destinations/src/use-cases/run-destination-sync.ts
@@ -11,6 +11,7 @@ import { Effect } from "effect"
 import {
   DESTINATION_IDLE_PAUSE_AFTER_EMPTY_RUNS,
   DESTINATION_QUARANTINE_FAILURE_THRESHOLD,
+  DESTINATION_READ_PAGE_MAX,
   DESTINATION_SAFETY_LAG_MS,
 } from "../constants.ts"
 import type { Destination, DestinationKind } from "../entities/destination.ts"
@@ -405,7 +406,7 @@ export const runDestinationSyncUseCase = (input: RunDestinationSyncInput) =>
       projectId: destination.projectId,
       cursor: startCursor,
       windowEnd,
-      limit: sourceState.config.maxRecordsPerRun,
+      limit: Math.min(sourceState.config.maxRecordsPerRun, DESTINATION_READ_PAGE_MAX),
     })
 
     if (window.records.length === 0) {

--- a/packages/domain/destinations/src/use-cases/run-destination-sync.ts
+++ b/packages/domain/destinations/src/use-cases/run-destination-sync.ts
@@ -407,6 +407,7 @@ export const runDestinationSyncUseCase = (input: RunDestinationSyncInput) =>
       cursor: startCursor,
       windowEnd,
       limit: Math.min(sourceState.config.maxRecordsPerRun, DESTINATION_READ_PAGE_MAX),
+      excludePayloads: sourceState.config.excludePayloads,
     })
 
     if (window.records.length === 0) {

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -136,6 +136,7 @@ export interface SpanRepositoryShape {
     readonly cursor: SpanIngestionCursor
     readonly windowEnd: Date
     readonly limit: number
+    readonly excludePayloads?: boolean
   }): Effect.Effect<SpanIngestedAtWindow, RepositoryError, ChSqlClient>
 
   /**

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -322,6 +322,44 @@ describe("SpanRepository", () => {
       expect(exhausted.spans).toHaveLength(0)
       expect(exhausted.nextCursor).toBeNull()
     })
+
+    it("drops the heavy payload columns when excludePayloads is set, keeping the row shape", async () => {
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            span_id: "1111111111111111",
+            ingested_at: "2026-01-01 00:10:00.000",
+            input_messages: '[{"role":"user","content":"hi"}]',
+            output_messages: '[{"role":"assistant","content":"yo"}]',
+            tool_definitions: '[{"name":"t","description":"d","parameters":{}}]',
+            tool_input: "the-input",
+            tool_output: "the-output",
+          }),
+        ]),
+      )
+
+      const kept = await listWindow(startCursor, 10)
+      expect(kept.spans[0]?.inputMessages).toHaveLength(1)
+      expect(kept.spans[0]?.toolInput).toBe("the-input")
+
+      const stripped = await runCh(
+        repo.listByIngestedAtWindow({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          cursor: startCursor,
+          windowEnd: WINDOW_END,
+          limit: 10,
+          excludePayloads: true,
+        }),
+      )
+
+      expect(stripped.spans.map((span) => span.spanId)).toEqual(["1111111111111111"])
+      expect(stripped.spans[0]?.inputMessages).toEqual([])
+      expect(stripped.spans[0]?.outputMessages).toEqual([])
+      expect(stripped.spans[0]?.toolDefinitions).toEqual([])
+      expect(stripped.spans[0]?.toolInput).toBe("")
+      expect(stripped.spans[0]?.toolOutput).toBe("")
+    })
   })
 
   describe("findIngestedAtFloorForRecentLimit", () => {

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -73,6 +73,15 @@ const LIST_COLUMNS = `
   ingested_at
 `
 
+// `LIST_COLUMNS` plus the large payload columns a `SpanDetail` needs. Selected
+// explicitly (never `SELECT *`) so reads project exactly the typed row and skip
+// columns the mapper ignores — keeping the per-row width, and the formatter's
+// memory, bounded on paged window reads.
+const DETAIL_COLUMNS = `${LIST_COLUMNS},
+  input_messages, output_messages, system_instructions,
+  tool_definitions, tool_call_id, tool_input, tool_output
+`
+
 type SpanListRow = {
   organization_id: string
   project_id: string
@@ -478,9 +487,9 @@ export const SpanRepositoryLive = Layer.effect(
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              query: `SELECT *
+              query: `SELECT ${DETAIL_COLUMNS}
                     FROM (
-                      SELECT *, tool_names
+                      SELECT ${DETAIL_COLUMNS}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
@@ -506,6 +515,14 @@ export const SpanRepositoryLive = Layer.effect(
                 limit,
               },
               format: "JSONEachRow",
+              // A page is serialized to JSON in one response; parallel formatting buffers
+              // per-thread blocks that ballooned a large page to multi-GiB in production.
+              // Single-threaded formatting + a per-query memory cap keep one window's read
+              // from tripping the server-wide OvercommitTracker — it fails its own job instead.
+              clickhouse_settings: {
+                output_format_parallel_formatting: 0,
+                max_memory_usage: "4000000000",
+              },
             })
             return result.json<SpanDetailRow>()
           })
@@ -559,9 +576,9 @@ export const SpanRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT *
+                query: `SELECT ${DETAIL_COLUMNS}
                       FROM (
-                        SELECT *, tool_names
+                        SELECT ${DETAIL_COLUMNS}
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
@@ -638,7 +655,7 @@ export const SpanRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT *, tool_names
+                query: `SELECT ${DETAIL_COLUMNS}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -82,6 +82,15 @@ const DETAIL_COLUMNS = `${LIST_COLUMNS},
   tool_definitions, tool_call_id, tool_input, tool_output
 `
 
+// Same row shape as `DETAIL_COLUMNS`, but the heavy payload columns are returned
+// as empty literals — ClickHouse never reads them from storage. For consumers
+// that drop content payloads anyway (a destination with `excludePayloads`), this
+// keeps a window read off the largest columns, where the formatter's memory goes.
+const DETAIL_COLUMNS_NO_PAYLOADS = `${LIST_COLUMNS},
+  '' AS input_messages, '' AS output_messages, '' AS system_instructions,
+  '' AS tool_definitions, '' AS tool_call_id, '' AS tool_input, '' AS tool_output
+`
+
 type SpanListRow = {
   organization_id: string
   project_id: string
@@ -481,15 +490,17 @@ export const SpanRepositoryLive = Layer.effect(
       cursor,
       windowEnd,
       limit,
+      excludePayloads,
     }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const columns = excludePayloads ? DETAIL_COLUMNS_NO_PAYLOADS : DETAIL_COLUMNS
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              query: `SELECT ${DETAIL_COLUMNS}
+              query: `SELECT ${columns}
                     FROM (
-                      SELECT ${DETAIL_COLUMNS}
+                      SELECT ${columns}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
@@ -518,7 +529,10 @@ export const SpanRepositoryLive = Layer.effect(
               // A page is serialized to JSON in one response; parallel formatting buffers
               // per-thread blocks that ballooned a large page to multi-GiB in production.
               // Single-threaded formatting + a per-query memory cap keep one window's read
-              // from tripping the server-wide OvercommitTracker — it fails its own job instead.
+              // from tripping the server-wide OvercommitTracker (which kills unrelated
+              // tenants' queries). Far above the clamped page's expected peak, so it should
+              // never fire; if it does, the read fails as a retryable RepositoryError —
+              // BullMQ retries, then it's recorded as a failed sync run, not swallowed.
               clickhouse_settings: {
                 output_format_parallel_formatting: 0,
                 max_memory_usage: "4000000000",


### PR DESCRIPTION
## What

A destination's window read (live sync **and** backfill) serializes its whole page to JSON in a single ClickHouse response. Span rows carry KB–MB content payloads, and the page size (`maxRecordsPerRun`) defaulted to **50,000**, so the first wide window blew `ParallelFormattingOutputFormat` past the server memory limit — tripping the **server-wide OvercommitTracker** (which kills *unrelated tenants'* queries) and resetting the client socket.

Datadog issue: [`abbfad0c-6bc2-11f1-9ddf-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issues/abbfad0c-6bc2-11f1-9ddf-da7ad0900005)

## Root cause (validated against production ClickHouse)

From `system.query_log` on the failing org/project:

| Evidence | Value |
|---|---|
| Rows scanned / deduped | 68k physical → **35,251 unique** (1 partition) |
| Engine cost (scan + dedup + sort, no formatting) | **~35 ms**, negligible memory |
| Real query `memory_usage` | **4.2–4.35 GiB** (the "11.17 GiB" in the error was server RSS at OOM) |
| Failing allocation | **1.87 GiB chunk inside `ParallelFormattingOutputFormat`** |
| Runtime | **16–17 s** → some attempts died on `NETWORK_ERROR` (socket reset) instead of OOM |
| Same query, cursor advanced | **87 MiB** (tiny window) |
| `max_memory_usage` setting | **0 = unbounded** |

So the failure is **output serialization of an oversized page**, not query execution — and an unrelated cross-partition full-scan hypothesis was ruled out by the data. Cursor pagination already works; only the first wide page was fatal.

## Changes

- **Clamp every source read page to `DESTINATION_READ_PAGE_MAX` (5,000)** at both use-sites (backfill + live sync), independent of a destination's stored config — so already-stored `50,000` defaults are bounded too. Schema `MAX` is left at 50,000 so existing configs still parse; `DEFAULT` lowered to 5,000 for new destinations.
- **Project `DETAIL_COLUMNS` instead of `SELECT *`** in the span detail reads, so a read fetches/formats exactly the typed row (the sibling `listByTraceId` already did this).
- **`excludePayloads` now skips fetching the heavy payload columns** (input/output messages, tool defs/IO) — projected as empty literals, so ClickHouse never reads them from storage. A payload-excluding destination drops them in the mapper anyway.
- **Window read sets `output_format_parallel_formatting: 0` + a per-query `max_memory_usage` guardrail** so a pathological page fails its own job (retryable `RepositoryError` → BullMQ retry → recorded `failed` sync run) instead of OOM-ing the shared ClickHouse server.

## Tests

- Backfill + live-sync use-case tests assert the read limit is clamped to `DESTINATION_READ_PAGE_MAX` even when the config allows more (fails without the clamp).
- `db-clickhouse` repo test (chdb) asserts payloads are present normally and dropped (row shape intact) when `excludePayloads` is set.
- All `@domain/destinations` (145) and `@platform/db-clickhouse` (314) tests pass; typecheck + biome clean.

## Verification

After deploy, occurrences of issue `abbfad0c-6bc2-11f1-9ddf-da7ad0900005` should drop to zero. Backfills of large projects now proceed as more, cheaper windows (1M-record cap ≈ 200 pages) instead of one fatal page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)