### PR TITLE
feat(web): recolor trace/session usage & duration bars

### DIFF
--- a/apps/web/src/lib/conversation-timeline/build-activity-track.test.ts
+++ b/apps/web/src/lib/conversation-timeline/build-activity-track.test.ts
@@ -12,7 +12,7 @@ describe("buildActivityTrack", () => {
     expect(timeline.activity).toEqual([
       { category: "idle", timelineStartMs: 0, timelineEndMs: 500, durationMs: 500 },
       { category: "generation", timelineStartMs: 500, timelineEndMs: 10_000, durationMs: 9_500 },
-      { category: "tool", timelineStartMs: 10_000, timelineEndMs: 14_000, durationMs: 4_000 },
+      { category: "toolOk", timelineStartMs: 10_000, timelineEndMs: 14_000, durationMs: 4_000 },
       { category: "generation", timelineStartMs: 14_000, timelineEndMs: 20_000, durationMs: 6_000 },
       {
         category: "idle",
@@ -61,7 +61,29 @@ describe("buildActivityTrack", () => {
     )
     expect(segments).toEqual([
       { category: "idle", timelineStartMs: 0, timelineEndMs: 2_000, durationMs: 2_000 },
-      { category: "tool", timelineStartMs: 2_000, timelineEndMs: 4_000, durationMs: 2_000 },
+      { category: "toolOk", timelineStartMs: 2_000, timelineEndMs: 4_000, durationMs: 2_000 },
+      { category: "idle", timelineStartMs: 4_000, timelineEndMs: 10_000, durationMs: 6_000 },
+    ])
+  })
+
+  it("paints failed tool calls as their own category", () => {
+    const scale = buildTimelineScale([{ startMs: at(0), endMs: at(10_000) }])
+    const segments = buildActivityTrack(
+      [
+        span({
+          spanId: "tool",
+          traceId: "t1",
+          startMs: at(2_000),
+          endMs: at(4_000),
+          operation: "execute_tool",
+          isError: true,
+        }),
+      ],
+      scale,
+    )
+    expect(segments).toEqual([
+      { category: "idle", timelineStartMs: 0, timelineEndMs: 2_000, durationMs: 2_000 },
+      { category: "toolError", timelineStartMs: 2_000, timelineEndMs: 4_000, durationMs: 2_000 },
       { category: "idle", timelineStartMs: 4_000, timelineEndMs: 10_000, durationMs: 6_000 },
     ])
   })

--- a/apps/web/src/lib/conversation-timeline/build-activity-track.ts
+++ b/apps/web/src/lib/conversation-timeline/build-activity-track.ts
@@ -7,7 +7,7 @@ import { wallToTimeline } from "./timeline-scale.ts"
  * per-category totals, so the scrubber can paint what the agent was doing at
  * each moment.
  */
-export type ActivityCategory = "generation" | "tool" | "retrieval" | "other" | "idle"
+export type ActivityCategory = "generation" | "toolOk" | "toolError" | "retrieval" | "other" | "idle"
 type WorkCategory = Exclude<ActivityCategory, "idle">
 
 export interface ActivitySegment {
@@ -23,17 +23,18 @@ interface ActivitySpanInput {
   readonly startMs: number
   readonly endMs: number
   readonly operation: string
+  readonly isError: boolean
 }
 
-const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "tool", "retrieval", "other"]
+const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "toolError", "toolOk", "retrieval", "other"]
 
-function categoryFor(operation: string): WorkCategory {
+function categoryFor(operation: string, isError: boolean): WorkCategory {
   switch (operation) {
     case "chat":
     case "text_completion":
       return "generation"
     case "execute_tool":
-      return "tool"
+      return isError ? "toolError" : "toolOk"
     case "retrieval":
     case "reranker":
       return "retrieval"
@@ -55,7 +56,7 @@ function sweepWallSlices(spans: readonly ActivitySpanInput[]): WallSlice[] {
 
   const events = leaves
     .flatMap((s) => {
-      const category = categoryFor(s.operation)
+      const category = categoryFor(s.operation, s.isError)
       return [
         { t: s.startMs, category, delta: 1 },
         { t: s.endMs, category, delta: -1 },
@@ -63,7 +64,7 @@ function sweepWallSlices(spans: readonly ActivitySpanInput[]): WallSlice[] {
     })
     .sort((a, b) => a.t - b.t)
 
-  const active: Record<WorkCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0 }
+  const active: Record<WorkCategory, number> = { generation: 0, toolOk: 0, toolError: 0, retrieval: 0, other: 0 }
   const dominant = (): ActivityCategory => WORK_PRIORITY.find((c) => active[c] > 0) ?? "idle"
 
   const slices: WallSlice[] = []

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/conversation-timeline/timeline-track.tsx
@@ -43,7 +43,8 @@ export interface MarkerHover {
 
 const ACTIVITY_LABELS: Readonly<Record<ActivityCategory, string>> = {
   generation: "Generating",
-  tool: "Running tools",
+  toolOk: "Running tools",
+  toolError: "Failed tools",
   retrieval: "Retrieving",
   other: "Working",
   idle: "Waiting",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.test.ts
@@ -14,12 +14,14 @@ function span(partial: {
   operation: string
   start: number
   end: number
+  status?: string
 }): SpanRecord {
   return {
     spanId: partial.spanId,
     parentSpanId: partial.parentSpanId ?? "",
     traceId: partial.traceId ?? "t",
     operation: partial.operation,
+    statusCode: partial.status ?? "unset",
     startTime: new Date(partial.start).toISOString(),
     endTime: new Date(partial.end).toISOString(),
   } as unknown as SpanRecord
@@ -51,7 +53,16 @@ describe("computeDurationBreakdown", () => {
       span({ spanId: "b", operation: "execute_tool", start: 1500, end: 2000 }),
     ])
     expect(wallClockMs).toBe(2000)
-    expect(ms(segments)).toEqual({ generation: 1000, tool: 500, idle: 500 })
+    expect(ms(segments)).toEqual({ generation: 1000, toolOk: 500, idle: 500 })
+  })
+
+  it("splits tool time by status: failed tool calls are their own category", () => {
+    // tool ok [0,500] → failed tool [500,900], serial, no idle.
+    const { segments } = computeDurationBreakdown([
+      span({ spanId: "a", operation: "execute_tool", start: 0, end: 500 }),
+      span({ spanId: "b", operation: "execute_tool", start: 500, end: 900, status: "error" }),
+    ])
+    expect(ms(segments)).toEqual({ toolOk: 500, toolError: 400 })
   })
 
   it("does not double-count parallel siblings (priority resolves overlap)", () => {
@@ -116,7 +127,7 @@ describe("computeSessionDurationBreakdown", () => {
       span({ spanId: "b1", traceId: "B", operation: "chat", start: 10000, end: 11000 }),
     ])
     expect(wallClockMs).toBe(3000)
-    expect(ms(segments)).toEqual({ generation: 2000, tool: 500, idle: 500 })
+    expect(ms(segments)).toEqual({ generation: 2000, toolOk: 500, idle: 500 })
   })
 
   it("returns empty for no spans", () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/duration-composition.ts
@@ -17,7 +17,7 @@ import type { SpanRecord } from "../../../../../../domains/spans/spans.functions
  * serialization). That is plenty for trace-level durations.
  */
 
-export type DurationCategory = "generation" | "tool" | "retrieval" | "other" | "idle"
+export type DurationCategory = "generation" | "toolOk" | "toolError" | "retrieval" | "other" | "idle"
 type WorkCategory = Exclude<DurationCategory, "idle">
 
 export interface DurationSegment {
@@ -29,37 +29,40 @@ export interface DurationSegment {
   readonly hollow?: boolean
 }
 
-// Green is "generation/output" (matches completion + output cost). The other
-// work categories use warm tones (orange/amber) deliberately distinct from the
-// blue/purple of the token & cost bars, so the two never get confused. Other is
-// neutral slate; idle stays a hatched gray.
+// Blue = the model's own work (generation), the one hue shared with
+// completion/output in the token & cost bars. Tool time is split by outcome —
+// green for succeeded calls, red for failed — so the status colors are accurate
+// rather than decorative. Retrieval is violet; idle stays a hatched gray.
 export const DURATION_COLORS: Readonly<Record<DurationCategory, string>> = {
-  generation: "#4ade80",
-  tool: "#f97316",
-  retrieval: "#f59e0b",
-  other: "#94a3b8",
-  idle: "#cbd5e1",
+  generation: "hsl(var(--viz-blue))",
+  toolOk: "hsl(var(--viz-green))",
+  toolError: "hsl(var(--viz-red))",
+  retrieval: "hsl(var(--viz-violet))",
+  other: "hsl(var(--viz-gray))",
+  idle: "hsl(var(--viz-idle))",
 }
 
 const CATEGORY_LABELS: Readonly<Record<DurationCategory, string>> = {
   generation: "Generation",
-  tool: "Tools",
+  toolOk: "Tools",
+  toolError: "Failed tools",
   retrieval: "Retrieval",
   other: "Other",
   idle: "Idle",
 }
 
-// Canonical render order (also the overlap-resolution priority for work categories).
-const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "tool", "retrieval", "other"]
-const SEGMENT_ORDER: readonly DurationCategory[] = ["generation", "tool", "retrieval", "other", "idle"]
+// Canonical render order (also the overlap-resolution priority for work
+// categories). Failed tool time outranks succeeded so failures always surface.
+const WORK_PRIORITY: readonly WorkCategory[] = ["generation", "toolError", "toolOk", "retrieval", "other"]
+const SEGMENT_ORDER: readonly DurationCategory[] = ["generation", "toolOk", "toolError", "retrieval", "other", "idle"]
 
-function categoryFor(operation: string): WorkCategory {
+function categoryFor(operation: string, statusCode: string): WorkCategory {
   switch (operation) {
     case "chat":
     case "text_completion":
       return "generation"
     case "execute_tool":
-      return "tool"
+      return statusCode === "error" ? "toolError" : "toolOk"
     case "retrieval":
     case "reranker":
       return "retrieval"
@@ -96,11 +99,12 @@ export function computeDurationBreakdown(spans: readonly SpanRecord[]): {
   const parentIds = new Set(spans.map((s) => s.parentSpanId).filter((id) => id !== ""))
   const intervals: Interval[] = timed
     .filter(({ span }) => !parentIds.has(span.spanId))
-    .map(({ span, startMs, endMs }) => ({ startMs, endMs, category: categoryFor(span.operation) }))
+    .map(({ span, startMs, endMs }) => ({ startMs, endMs, category: categoryFor(span.operation, span.statusCode) }))
 
   const totals: Record<DurationCategory, number> = {
     generation: 0,
-    tool: 0,
+    toolOk: 0,
+    toolError: 0,
     retrieval: 0,
     other: 0,
     idle: 0,
@@ -116,7 +120,7 @@ export function computeDurationBreakdown(spans: readonly SpanRecord[]): {
     ])
     .sort((a, b) => a.t - b.t)
 
-  const active: Record<WorkCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0 }
+  const active: Record<WorkCategory, number> = { generation: 0, toolOk: 0, toolError: 0, retrieval: 0, other: 0 }
   const dominant = (): DurationCategory => WORK_PRIORITY.find((c) => active[c] > 0) ?? "idle"
 
   let cursor = wallStart
@@ -155,7 +159,14 @@ export function computeSessionDurationBreakdown(spans: readonly SpanRecord[]): {
     else byTrace.set(span.traceId, [span])
   }
 
-  const totals: Record<DurationCategory, number> = { generation: 0, tool: 0, retrieval: 0, other: 0, idle: 0 }
+  const totals: Record<DurationCategory, number> = {
+    generation: 0,
+    toolOk: 0,
+    toolError: 0,
+    retrieval: 0,
+    other: 0,
+    idle: 0,
+  }
   let wallClockMs = 0
   for (const traceSpans of byTrace.values()) {
     const breakdown = computeDurationBreakdown(traceSpans)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
@@ -148,4 +148,11 @@ describe("buildCostSegments", () => {
   it("returns no segments when both costs are zero", () => {
     expect(buildCostSegments(makeUsage())).toEqual([])
   })
+
+  it("falls back to a single total segment when only the total is known", () => {
+    const data = makeUsage({ costTotalMicrocents: 500 })
+    const segments = buildCostSegments(data)
+    expect(segments.map((s) => s.label)).toEqual(["Cost"])
+    expect(segments.map((s) => s.value)).toEqual([500])
+  })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -17,16 +17,17 @@ export interface UsageData {
 }
 
 const TOKEN_COLORS = {
-  cacheRead: "#d8b4fe",
-  cacheCreate: "#a855f7",
-  prompt: "#3b82f6",
-  reasoning: "#16a34a",
-  completion: "#4ade80",
+  cacheRead: "hsl(var(--viz-gold-faint))",
+  cacheCreate: "hsl(var(--viz-gold-soft))",
+  prompt: "hsl(var(--viz-gold))",
+  reasoning: "hsl(var(--viz-blue-soft))",
+  completion: "hsl(var(--viz-blue))",
 } as const
 
 const COST_COLORS = {
-  input: "#3b82f6",
-  output: "#4ade80",
+  input: "hsl(var(--viz-gold))",
+  output: "hsl(var(--viz-blue))",
+  total: "hsl(var(--viz-gray))",
 } as const
 
 export function hasAnyUsage(data: UsageData): boolean {
@@ -66,6 +67,11 @@ export function buildCostSegments(data: UsageData): SegmentBarItem[] {
   const segments: SegmentBarItem[] = []
   if (input > 0) segments.push({ label: "Input", value: input, color: COST_COLORS.input })
   if (output > 0) segments.push({ label: "Output", value: output, color: COST_COLORS.output })
+
+  // Cost reported only as a total (no input/output split) still fills the bar.
+  if (segments.length === 0 && data.costTotalMicrocents > 0) {
+    segments.push({ label: "Cost", value: data.costTotalMicrocents, color: COST_COLORS.total })
+  }
   return segments
 }
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -251,6 +251,16 @@
     0px 1px 2px -1px hsl(var(--background-shadow) / 0.1),
     0px 0px 6px 0px hsl(var(--background-shadow) / 0.04);
   --scrollbar: 217.9 11.92% 64.26%;
+  --viz-blue: 210 65% 60%;
+  --viz-blue-soft: 198 45% 70%;
+  --viz-gold: 44 78% 62%;
+  --viz-gold-soft: 46 60% 73%;
+  --viz-gold-faint: 48 50% 83%;
+  --viz-green: 148 40% 56%;
+  --viz-red: 8 58% 65%;
+  --viz-violet: 270 44% 64%;
+  --viz-gray: 220 10% 60%;
+  --viz-idle: 220 13% 80%;
 }
 
 .dark {
@@ -307,6 +317,16 @@
     0px 1px 3px -1px hsl(var(--background-shadow) / 0.3),
     0px 0px 8px 0px hsl(var(--background-shadow) / 0.2);
   --scrollbar: 217.9 11.92% 64.26%;
+  --viz-blue: 210 50% 52%;
+  --viz-blue-soft: 202 34% 54%;
+  --viz-gold: 42 54% 52%;
+  --viz-gold-soft: 42 42% 58%;
+  --viz-gold-faint: 44 34% 66%;
+  --viz-green: 147 36% 50%;
+  --viz-red: 8 50% 55%;
+  --viz-violet: 268 36% 58%;
+  --viz-gray: 220 10% 55%;
+  --viz-idle: 220 12% 42%;
 }
 
 /* Base styles */


### PR DESCRIPTION
## What

Recolors the trace/session **duration distribution** bars and the **conversation timeline/navigation** track to use a shared `--viz-*` CSS variable palette instead of hardcoded hex values.

- `duration-composition.ts` — duration categories now map to `--viz-blue` (generation), `--viz-green` (tool ok), `--viz-red` (tool error), `--viz-violet` (retrieval), `--viz-gray` (other), `--viz-idle` (idle).
- `build-activity-track.ts` / `timeline-track.tsx` — conversation activity track uses the same palette.
- `usage-summary.tsx` — usage bars aligned to the palette.
- `packages/ui/src/styles/globals.css` — defines the `--viz-*` tokens.

## Why

The original commit was authored locally but stranded on a deleted branch (`replay-session-simulation`, whose PR #3546 had already merged) and was never pushed. This brings it onto `development` so the new colors actually ship.

## Testing

- `pnpm --filter @app/web test` for the affected suites (`duration-composition`, `build-activity-track`, `usage-summary`) — all green.