### PR TITLE
fix(destinations): lower read page cap to 2k; runs table fills viewport height

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-runs-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-runs-table.tsx
@@ -110,15 +110,13 @@ export function DestinationRunsTable({ destinationId }: { readonly destinationId
   })
 
   return (
-    <div className="flex min-w-0 flex-col gap-2">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
       <InfiniteTable
         data={runs}
         isLoading={isLoading}
         columns={columns}
         getRowKey={(run) => run.id}
         infiniteScroll={infiniteScroll}
-        scrollAreaLayout="intrinsic"
-        className="max-h-[420px]"
         blankSlate="No data syncronization runs yet."
       />
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
@@ -54,7 +54,7 @@ function DestinationDetailPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
       <BackLink projectSlug={projectSlug} />
       <DestinationCard
         projectId={project.id}

--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -3,16 +3,19 @@ export const DESTINATION_INTERVAL_MS_MAX = 3_600_000
 export const DESTINATION_INTERVAL_MS_DEFAULT = 300_000
 
 /**
- * Hard-coded source read page size — not user-configurable. A window read
- * serializes its whole page to JSONEachRow in one ClickHouse response; span rows
- * carry KB–MB payloads, so a large page balloons `ParallelFormattingOutputFormat`
- * — a 35k-row page cost 4.2 GiB and 16s in production, tripping the server-wide
- * OvercommitTracker and resetting the client socket. Sizing a ClickHouse read
- * page isn't a product knob, so it lives here rather than in a destination's
- * config. Cursor pagination chains the rest — a smaller page just means more,
- * cheaper windows (the 1M-record backfill cap ≈ 200 pages).
+ * Hard ceiling on a single source read page, independent of (and clamping) the
+ * configured `maxRecordsPerRun`. A window read serializes its whole page to
+ * JSONEachRow in one ClickHouse response; span rows carry KB–MB payloads, so a
+ * large page balloons `ParallelFormattingOutputFormat` — a 35k-row page cost
+ * 4.2 GiB and 16s in production, tripping the server-wide OvercommitTracker and
+ * resetting the client socket. Clamping the read page keeps every run bounded
+ * regardless of a destination's stored config (legacy rows hold the old 50k
+ * default). Cursor pagination already chains the rest, so smaller pages just
+ * mean more, cheaper windows. Lowered to 2k after 5k still hit the per-query
+ * 4 GiB `max_memory_usage` guard on destinations with large LLM payloads
+ * (~785 KiB/row) — at 2k a window peaks ~1.5 GiB, well under the guard.
  */
-export const DESTINATION_READ_PAGE_SIZE = 5_000
+export const DESTINATION_READ_PAGE_SIZE = 2_000
 
 /**
  * Hard cap on records imported by a single backfill. A destination connected to
@@ -22,7 +25,7 @@ export const DESTINATION_READ_PAGE_SIZE = 5_000
  * window holds at most this many, newest first). Deliberately an operational/
  * product bound on backfill duration + ClickHouse read volume — NOT a
  * PostHog-derived limit: PostHog exposes no rate limit on `/batch/` capture, so
- * there's no published throughput to size against. 1M ≈ 200 read pages.
+ * there's no published throughput to size against. 1M ≈ 500 read pages.
  */
 export const DESTINATION_MAX_RECORDS_PER_BACKFILL = 1_000_000
 


### PR DESCRIPTION
Two destination fixes.

## 1. Lower the backfill/sync read page cap (5k → 2k)

PR #3623 contained the **server-wide** ClickHouse OOM (OvercommitTracker killing unrelated tenants' queries) by capping a window read at 4 GiB via `max_memory_usage`. That worked — but it exposed a follow-on failure now visible in prod:

- **Datadog issue [`736c6ee4-6be6-11f1-b5f3-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issues/736c6ee4-6be6-11f1-b5f3-da7ad0900005)** (first-seen on v0.3.11): `runBackfillWindow` → `RepositoryError: Query memory limit exceeded: would use 3.75 GiB … maximum: 3.73 GiB`.

That's the **per-query 4 GiB guard firing**: destinations with large LLM payloads (~785 KiB/row) still blow it at a 5,000-row page, so the window fails all 5 BullMQ attempts and the backfill chain stalls (records a `failed` run, clears the marker). No longer dangerous to the server, but the backfill can't finish.

Lowering `DESTINATION_READ_PAGE_MAX` to **2,000** keeps a window's peak ~1.5 GiB — comfortably under the 4 GiB guard — so these backfills make progress again. It's purely more, cheaper windows (cursor pagination already chains them; the 1M-record backfill cap ≈ 500 pages). The clamp is `min(config.maxRecordsPerRun, DESTINATION_READ_PAGE_MAX)`, so this bounds every destination regardless of stored config.

## 2. Runs table fills the viewport

The destination detail page's runs table was hard-capped at `max-h-[420px]` with `scrollAreaLayout="intrinsic"`, leaving large empty space below ~9 rows. Switched to `InfiniteTable`'s default `fill` mode and let the page/table flex to the available height (the settings layout already provides a bounded, scrollable content column), so the table grows to the viewport and scrolls internally with a sticky header.

## Verification
- `@domain/destinations` 145 tests ✅, typecheck (`@domain/destinations`, `@app/web`) ✅, biome ✅
- After deploy, occurrences of issue `736c6ee4…` should drop to zero and stalled backfills resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)