### PR TITLE
fix(destinations): late-materialize the window read to bound memory by page

### DIFF
--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -3,19 +3,17 @@ export const DESTINATION_INTERVAL_MS_MAX = 3_600_000
 export const DESTINATION_INTERVAL_MS_DEFAULT = 300_000
 
 /**
- * Hard ceiling on a single source read page, independent of (and clamping) the
- * configured `maxRecordsPerRun`. A window read serializes its whole page to
- * JSONEachRow in one ClickHouse response; span rows carry KB–MB payloads, so a
- * large page balloons `ParallelFormattingOutputFormat` — a 35k-row page cost
- * 4.2 GiB and 16s in production, tripping the server-wide OvercommitTracker and
- * resetting the client socket. Clamping the read page keeps every run bounded
- * regardless of a destination's stored config (legacy rows hold the old 50k
- * default). Cursor pagination already chains the rest, so smaller pages just
- * mean more, cheaper windows. Lowered to 2k after 5k still hit the per-query
- * 4 GiB `max_memory_usage` guard on destinations with large LLM payloads
- * (~785 KiB/row) — at 2k a window peaks ~1.5 GiB, well under the guard.
+ * Source read page: rows fetched (and delivered) per window. NOT a ClickHouse
+ * memory bound — `listByIngestedAtWindow` late-materializes, so the wide payload
+ * columns (KB–MB LLM messages) are read only for the spans on this page; a 5k
+ * page over a full window peaks ~250 MiB regardless of window size (the per-query
+ * 4 GiB `max_memory_usage` guard is just defense-in-depth). The real ceiling is
+ * worker heap — it holds a page of `SpanDetail` plus the mapped events — and the
+ * destination's delivery batch, so this is an operational size, not a safety
+ * limit. Cursor pagination chains the rest; a bigger page = fewer, larger
+ * windows. 1M backfill cap ≈ 200 pages.
  */
-export const DESTINATION_READ_PAGE_SIZE = 2_000
+export const DESTINATION_READ_PAGE_SIZE = 5_000
 
 /**
  * Hard cap on records imported by a single backfill. A destination connected to
@@ -25,7 +23,7 @@ export const DESTINATION_READ_PAGE_SIZE = 2_000
  * window holds at most this many, newest first). Deliberately an operational/
  * product bound on backfill duration + ClickHouse read volume — NOT a
  * PostHog-derived limit: PostHog exposes no rate limit on `/batch/` capture, so
- * there's no published throughput to size against. 1M ≈ 500 read pages.
+ * there's no published throughput to size against. 1M ≈ 200 read pages.
  */
 export const DESTINATION_MAX_RECORDS_PER_BACKFILL = 1_000_000
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -288,6 +288,46 @@ describe("SpanRepository", () => {
       })
     })
 
+    it("pages multiple spans by latest ingested_at, surfacing a re-ingested span at its newest version", async () => {
+      // Exercises late materialization end-to-end: the lean keyset picks the page's span_ids
+      // (deduped to newest ingested_at, ordered, limited), then the detail re-dedups them.
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({ span_id: "aaaaaaaaaaaaaaaa", ingested_at: "2026-01-01 00:10:00.000" }),
+          makeSpanRow({ span_id: "bbbbbbbbbbbbbbbb", ingested_at: "2026-01-01 00:20:00.000" }),
+          makeSpanRow({ span_id: "cccccccccccccccc", name: "c-old", ingested_at: "2026-01-01 00:15:00.000" }),
+          makeSpanRow({ span_id: "cccccccccccccccc", name: "c-new", ingested_at: "2026-01-01 00:30:00.000" }),
+          makeSpanRow({ span_id: "dddddddddddddddd", ingested_at: "2026-01-01 00:25:00.000" }),
+        ]),
+      )
+
+      const page1 = await listWindow(startCursor, 2)
+      expect(page1.spans.map((span) => span.spanId)).toEqual(["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"])
+      expect(page1.nextCursor).toEqual({
+        ingestedAt: new Date("2026-01-01T00:20:00.000Z"),
+        spanId: "bbbbbbbbbbbbbbbb",
+      })
+
+      // Resume: D (00:25) then C — which sorts last by its *newest* version (00:30), not 00:15.
+      const page2 = await listWindow(
+        { ingestedAt: new Date("2026-01-01T00:20:00.000Z"), spanId: SpanId("bbbbbbbbbbbbbbbb") },
+        2,
+      )
+      expect(page2.spans.map((span) => span.spanId)).toEqual(["dddddddddddddddd", "cccccccccccccccc"])
+      expect(page2.spans.find((span) => span.spanId === "cccccccccccccccc")?.name).toBe("c-new")
+      expect(page2.nextCursor).toEqual({
+        ingestedAt: new Date("2026-01-01T00:30:00.000Z"),
+        spanId: "cccccccccccccccc",
+      })
+
+      const page3 = await listWindow(
+        { ingestedAt: new Date("2026-01-01T00:30:00.000Z"), spanId: SpanId("cccccccccccccccc") },
+        2,
+      )
+      expect(page3.spans).toHaveLength(0)
+      expect(page3.nextCursor).toBeNull()
+    })
+
     it("includes rows up to windowEnd, excludes rows past it, and scopes by org and project", async () => {
       await runCh(
         insertJsonEachRow(ch.client, "spans", [

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -498,25 +498,47 @@ export const SpanRepositoryLive = Layer.effect(
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
+              // Late materialization: the inner `IN` subquery dedups the *whole* window
+              // (`ingested_at` isn't in the sort key, so the cursor can't prune — it scans
+              // every row for the org/project) but reads only `span_id`/`ingested_at`, so
+              // that sort stays in the low MiB. The outer query then reads the wide payload
+              // columns for just the ≤`limit` winning spans. Selecting the payloads inside
+              // the dedup instead made a single window peak multi-GiB and trip the per-query
+              // memory cap on payload-heavy projects (read bytes scaled with the window, not
+              // the page). Keep the two levels: the `IN` set must be deduped to latest-per-
+              // span before the page `LIMIT`, then the detail re-dedups the same rows.
               query: `SELECT ${columns}
                     FROM (
                       SELECT ${columns}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
-                        AND (
-                          ingested_at > {cursorIngestedAt:DateTime64(3, 'UTC')}
-                          OR (
-                            ingested_at = {cursorIngestedAt:DateTime64(3, 'UTC')}
-                            AND span_id > toFixedString({cursorSpanId:String}, 16)
+                        AND span_id IN (
+                          SELECT span_id
+                          FROM (
+                            SELECT span_id, ingested_at
+                            FROM spans
+                            WHERE organization_id = {organizationId:String}
+                              AND project_id = {projectId:String}
+                              AND (
+                                ingested_at > {cursorIngestedAt:DateTime64(3, 'UTC')}
+                                OR (
+                                  ingested_at = {cursorIngestedAt:DateTime64(3, 'UTC')}
+                                  AND span_id > toFixedString({cursorSpanId:String}, 16)
+                                )
+                              )
+                              AND ingested_at <= {windowEnd:DateTime64(3, 'UTC')}
+                            ORDER BY span_id, ingested_at DESC
+                            LIMIT 1 BY span_id
                           )
+                          ORDER BY ingested_at ASC, span_id ASC
+                          LIMIT {limit:UInt32}
                         )
                         AND ingested_at <= {windowEnd:DateTime64(3, 'UTC')}
                       ORDER BY span_id, ingested_at DESC
                       LIMIT 1 BY span_id
                     )
-                    ORDER BY ingested_at ASC, span_id ASC
-                    LIMIT {limit:UInt32}`,
+                    ORDER BY ingested_at ASC, span_id ASC`,
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
@@ -526,13 +548,11 @@ export const SpanRepositoryLive = Layer.effect(
                 limit,
               },
               format: "JSONEachRow",
-              // A page is serialized to JSON in one response; parallel formatting buffers
-              // per-thread blocks that ballooned a large page to multi-GiB in production.
-              // Single-threaded formatting + a per-query memory cap keep one window's read
-              // from tripping the server-wide OvercommitTracker (which kills unrelated
-              // tenants' queries). Far above the clamped page's expected peak, so it should
-              // never fire; if it does, the read fails as a retryable RepositoryError —
-              // BullMQ retries, then it's recorded as a failed sync run, not swallowed.
+              // Defense-in-depth: single-threaded formatting + a per-query memory cap so a
+              // pathological page fails its own job (retryable RepositoryError → BullMQ retry
+              // → recorded failed run) rather than tripping the server-wide OvercommitTracker
+              // and killing unrelated tenants' queries. With late materialization a window
+              // peaks well under this, so it should never fire.
               clickhouse_settings: {
                 output_format_parallel_formatting: 0,
                 max_memory_usage: "4000000000",


### PR DESCRIPTION
## Problem

The backfill/sync window read (`listByIngestedAtWindow`) dedups the whole `(cursor, windowEnd]` window with `LIMIT 1 BY span_id`. `ingested_at` isn't in the `spans` sort key, so the cursor can't prune — **every read scans all of the org/project's rows**. The query selected the wide payload columns (input/output messages, tool defs/IO) *inside* that dedup, so the sort materialized the whole window's payloads.

Result on a payload-heavy project: **~1.04 GiB read, ~3.5 GiB peak memory** per window — *regardless of the page `LIMIT`*. So it kept tripping the per-query 4 GiB guard added in #3623 and stalling the chain ([Datadog issue `736c6ee4-6be6-11f1-b5f3-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issues/736c6ee4-6be6-11f1-b5f3-da7ad0900005)), and lowering the page 5k→2k did nothing because **memory scaled with the window, not the page** (`query_log` showed `read_rows` 41k–70k no matter the page).

## Fix — late materialization

Two-phase within one query:
1. An inner `IN` subquery dedups the window reading **only `span_id` / `ingested_at`** → the sort stays in the low-MiB range even over the full window.
2. The outer query reads the wide payload columns for just the **≤`limit` winning spans**.

Same dedup/cursor/ordering semantics (latest `ingested_at` per span, keyset-resumable, `windowEnd`-scoped) — only the column-read volume changes.

## Verified against the failing project in prod (`query_log`)

| | Before | After (5k page, full window) |
|---|---|---|
| read bytes | 1.04 GiB | **69 MiB** |
| peak memory | ~3.5 GiB | **246 MiB** |
| duration | 1.5–3.3 s (then OOM) | 0.29 s |

Memory is now bounded by the **page**, not the window — so the existing **5,000** page is comfortable (the 4 GiB `max_memory_usage` guard stays as defense-in-depth).

## Notes

- Supersedes the page-size lever in #3628: with this fix the 5k page is safe, so #3628's 5k→2k change is no longer needed (its runs-table height fix is unrelated and can stand on its own).
- Tests: `@platform/db-clickhouse` 314 pass (incl. the `listByIngestedAtWindow` dedup / same-ms cursor-resume / windowEnd-scope / excludePayloads cases); typecheck + biome clean.
- Verification after deploy: occurrences of issue `736c6ee4…` drop to zero and the stalled backfill resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)