### PR TITLE
fix(destinations): lower read page to 2k to keep bull-board responsive during backfill

### DIFF
--- a/packages/domain/destinations/src/constants.ts
+++ b/packages/domain/destinations/src/constants.ts
@@ -4,16 +4,20 @@ export const DESTINATION_INTERVAL_MS_DEFAULT = 300_000
 
 /**
  * Source read page: rows fetched (and delivered) per window. NOT a ClickHouse
- * memory bound — `listByIngestedAtWindow` late-materializes, so the wide payload
- * columns (KB–MB LLM messages) are read only for the spans on this page; a 5k
- * page over a full window peaks ~250 MiB regardless of window size (the per-query
- * 4 GiB `max_memory_usage` guard is just defense-in-depth). The real ceiling is
- * worker heap — it holds a page of `SpanDetail` plus the mapped events — and the
- * destination's delivery batch, so this is an operational size, not a safety
- * limit. Cursor pagination chains the rest; a bigger page = fewer, larger
- * windows. 1M backfill cap ≈ 200 pages.
+ * memory bound — `listByIngestedAtWindow` late-materializes, so wide payload
+ * columns are read only for the spans on this page (a page over a full window
+ * peaks well under the per-query 4 GiB `max_memory_usage` guard regardless of
+ * window size). The binding constraint is the **worker event loop**: each window
+ * does synchronous main-thread work (JSON-parse the ClickHouse response, map
+ * spans → events, serialize the delivery batch) that scales with page size, and
+ * the workers process co-hosts the bull-board dashboard — so a large page blocks
+ * the loop in long bursts and the dashboard HTTP times out (502) during heavy
+ * backfill. 2k keeps each burst short enough that the dashboard stays responsive;
+ * cursor pagination just chains more, lighter windows. (Decoupling bull-board
+ * onto its own process — the Workbench migration — is the real fix; this caps the
+ * blast radius until then.) 1M backfill cap ≈ 500 pages.
  */
-export const DESTINATION_READ_PAGE_SIZE = 5_000
+export const DESTINATION_READ_PAGE_SIZE = 2_000
 
 /**
  * Hard cap on records imported by a single backfill. A destination connected to


### PR DESCRIPTION
## Problem

Triggering a destination backfill reproducibly takes the **bull-board dashboard 502** for the duration; cancelling the backfill recovers it. Because users then cancel mid-run (~89%), the backfill chain never drains and `coverage_start_at` never advances — leaving the historical gap unfilled.

**Root cause:** `apps/workers/src/server.ts` mounts bull-board (`@bull-board/hono`) in the **same process as the BullMQ workers** — one shared Node event loop. Each backfill window does synchronous main-thread work that scales with page size:
- `JSON.parse` the ClickHouse response (~5,000 rows, tens of MiB),
- map spans → PostHog events,
- `JSON.stringify` the delivery batch.

At a 5k page these bursts block the event loop long enough that the co-hosted dashboard's HTTP handler can't answer before the gateway times out → 502. (Verified the workers are otherwise healthy during backfill: no errors, no OOM — peak ~1.3 GB of a 2 GiB limit — no restarts; avg CPU low because the blocking is bursty single-thread, not sustained.)

## Fix

Lower `DESTINATION_READ_PAGE_SIZE` **5,000 → 2,000**. Each window's synchronous burst shrinks ~2.5×, leaving gaps for the dashboard to respond, so it stays up during backfill and users stop needing to cancel → the chain can complete and `coverage_start_at` advances.

**Free on the DB side:** late-materialization already decoupled ClickHouse memory from page size (a window peaks well under the 4 GiB guard regardless), so this only reduces Node-side per-window work. Cost is just more, lighter windows (1M backfill cap ≈ 500 pages).

## Scope

This is a **mitigation**, not the cure. The architectural fix is decoupling bull-board onto its own process (the staged Workbench migration) so dashboard HTTP never shares an event loop with heavy job processing. This PR caps the blast radius until then.

- `@domain/destinations`: typecheck + 143 tests pass; biome clean.
- No schema/data change; backfill semantics unchanged (idempotent, cursor-resumable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)