### PR TITLE
fix(observability): preserve non-Error throw details instead of "[object Object]"

### DIFF
--- a/packages/observability/src/record-span-exception.test.ts
+++ b/packages/observability/src/record-span-exception.test.ts
@@ -37,6 +37,55 @@ describe("recordSpanExceptionForDatadog", () => {
     })
   })
 
+  it("preserves a thrown non-Error object's own message instead of [object Object]", () => {
+    const recordException = vi.fn()
+    const setAttributes = vi.fn()
+    const span = { recordException, setAttributes } as unknown as Span
+
+    recordSpanExceptionForDatadog(span, { name: "EmailTransportError", message: "SMTP 421 service not available" })
+
+    expect(setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ "error.message": "SMTP 421 service not available" }),
+    )
+    expect(recordException).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "EmailTransportError", message: "SMTP 421 service not available" }),
+    )
+  })
+
+  it("JSON-serializes a thrown object that has no message field", () => {
+    const recordException = vi.fn()
+    const setAttributes = vi.fn()
+    const span = { recordException, setAttributes } as unknown as Span
+
+    recordSpanExceptionForDatadog(span, { code: "ECONNRESET", syscall: "read" })
+
+    const message = setAttributes.mock.calls[0]?.[0]["error.message"]
+    expect(message).not.toBe("[object Object]")
+    expect(message).toContain("ECONNRESET")
+    expect(message).toContain("read")
+  })
+
+  it("falls back to String() for a circular non-Error object", () => {
+    const recordException = vi.fn()
+    const setAttributes = vi.fn()
+    const span = { recordException, setAttributes } as unknown as Span
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    expect(() => recordSpanExceptionForDatadog(span, circular)).not.toThrow()
+    expect(setAttributes).toHaveBeenCalledTimes(1)
+  })
+
+  it("records a plain string throw as the message", () => {
+    const recordException = vi.fn()
+    const setAttributes = vi.fn()
+    const span = { recordException, setAttributes } as unknown as Span
+
+    recordSpanExceptionForDatadog(span, "boom")
+
+    expect(setAttributes).toHaveBeenCalledWith(expect.objectContaining({ "error.message": "boom" }))
+  })
+
   it("leaves non-web stacks unchanged apart from file protocol removal", () => {
     const recordException = vi.fn()
     const setAttributes = vi.fn()

--- a/packages/observability/src/record-span-exception.ts
+++ b/packages/observability/src/record-span-exception.ts
@@ -1,6 +1,30 @@
 import type { Span } from "@opentelemetry/api"
 
-const toError = (value: unknown): Error => (value instanceof Error ? value : new Error(String(value)))
+const safeStringify = (value: object): string => {
+  try {
+    const json = JSON.stringify(value)
+    if (json && json !== "{}") return json
+  } catch {
+    // circular or otherwise non-serializable — fall through to String()
+  }
+  return String(value)
+}
+
+// A thrown non-Error (e.g. a transport rejecting with `{ statusCode, response }`)
+// would otherwise stringify to the useless "[object Object]", erasing the real
+// cause before it reaches Datadog. Prefer the object's own `message`, then a
+// JSON dump, and carry its `name` so grouping survives.
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value
+  if (value === null || typeof value !== "object") return new Error(String(value))
+
+  const record = value as { message?: unknown; name?: unknown }
+  const message =
+    typeof record.message === "string" && record.message.length > 0 ? record.message : safeStringify(value)
+  const error = new Error(message)
+  if (typeof record.name === "string" && record.name.length > 0) error.name = record.name
+  return error
+}
 
 /**
  * Strip `file://` protocol from stack traces so Datadog can match frames


### PR DESCRIPTION
## Problem

`toError` in `packages/observability/src/record-span-exception.ts` converted any non-`Error` throw with `String(value)`. A thrown plain object (e.g. an email transport rejecting with `{ statusCode, response }`) became the literal `"[object Object]"`, destroying the real cause before it reached Datadog.

Because the span exception is fingerprinted on that line, **every non-Error throw across the whole platform collapsed into one unreadable Error Tracking issue** (`[object Object]`), masking unrelated failures.

**Datadog issue:** [`33d21d8e-5c1d-11f1-b246-da7ad0900005`](https://app.datadoghq.eu/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2233d21d8e-5c1d-11f1-b246-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D) — first seen ~May 31, recurring (last Jun 20), surfaced via the `notification-email send` worker job.

## Fix

Fix the **source**, not the sink (`toError` is the single chokepoint, so this restores error visibility platform-wide):

- Prefer a thrown object's own string `message`.
- Otherwise emit a **circular-safe** `JSON.stringify` dump (falls back to `String()` if unserializable).
- Carry the object's `name` onto the synthesized `Error` so grouping survives.
- `Error` instances and primitives are unchanged.

## Tests

Extended `record-span-exception.test.ts`:
- object with `message` → records that message (not `[object Object]`)
- object without `message` → JSON-serialized, contains the real fields
- circular object → does not throw
- plain string throw → recorded as-is

Confirmed the two object-message cases **fail without the fix** (produce `[object Object]`) and **pass with it**. `pnpm --filter @repo/observability typecheck` and `biome check` clean.

## Verification

This is an observability fix — it does not change job behavior. After deploy, occurrences on the issue above stop being `[object Object]` and carry the real error (e.g. the actual `notification-email` transport failure, currently invisible), which then becomes separately triageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)