### PR TITLE
fix(web): hide "First seen older" badge in behaviour drawer

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -312,7 +312,9 @@ export function BehaviourDetailDrawer({
               {parentName ? <BehaviourBadge label={parentName} icon={TagIcon} /> : null}
               <BehaviourBadge label={`${formatCount(node.subtreeSessionCount)} sessions`} icon={TagIcon} />
               <BehaviourBadge label={trendLabel(node.trend.status)} icon={trendIcon(node.trend.status)} />
-              <BehaviourBadge label={`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`} icon={SparklesIcon} />
+              {node.firstSeenLabel === "older" ? null : (
+                <BehaviourBadge label={`First seen ${node.firstSeenLabel.replaceAll("_", " ")}`} icon={SparklesIcon} />
+              )}
             </div>
             <div className="flex flex-col gap-2">
               <Text.H2>{cluster.name}</Text.H2>


### PR DESCRIPTION
## What

The behaviour detail drawer rendered a malformed **"First seen older"** badge.

`firstSeenLabel` is a coarse bucket — `"today" | "this_week" | "older"` (`packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts`). The drawer string-templated it straight into `` `First seen ${label.replaceAll("_", " ")}` `` (`behaviours-view.tsx:315`). That reads fine for `today`/`this_week` but produces the nonsensical "First seen older" for anything beyond the window.

## Change

Drop the badge entirely when first seen is older than the window (`older` bucket). No info is lost — the exact date still shows in the line right below: *"First seen {date} · Last seen {relative}"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)