### PR TITLE
fix(web): self-heal stale server-fn calls instead of erroring on deploy skew

### DIFF
--- a/apps/web/src/lib/stale-server-fn.test.ts
+++ b/apps/web/src/lib/stale-server-fn.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  isStaleServerFnError,
+  maybeReloadForStaleServerFn,
+  STALE_SERVER_FN_RELOAD_GUARD_MS,
+} from "./stale-server-fn.ts"
+
+const staleError = () => new Error("Server function info not found for abc123def456")
+
+const fakeStorage = (initial: Record<string, string> = {}) => {
+  const map = new Map(Object.entries(initial))
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    snapshot: () => Object.fromEntries(map),
+  }
+}
+
+describe("isStaleServerFnError", () => {
+  it("matches the TanStack stale server-fn error", () => {
+    expect(isStaleServerFnError(staleError())).toBe(true)
+  })
+
+  it("requires the full `…not found for <id>` shape, not just the phrase", () => {
+    // The phrase alone (without a function id) is not the resolver's error.
+    expect(isStaleServerFnError(new Error("Server function info not found"))).toBe(false)
+  })
+
+  it("ignores unrelated errors and non-Error values", () => {
+    expect(isStaleServerFnError(new Error("Database query failed"))).toBe(false)
+    expect(isStaleServerFnError("Server function info not found for abc123")).toBe(false)
+    expect(isStaleServerFnError(null)).toBe(false)
+    expect(isStaleServerFnError({ message: "Server function info not found for abc123" })).toBe(false)
+  })
+})
+
+describe("maybeReloadForStaleServerFn", () => {
+  it("reloads on a stale error when no reload happened before", () => {
+    const reload = vi.fn()
+    const storage = fakeStorage()
+
+    const reloaded = maybeReloadForStaleServerFn({ error: staleError(), reload, now: 1_000_000, storage })
+
+    expect(reloaded).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(storage.snapshot()).toMatchObject({ "latitude:stale-server-fn-reload-at": "1000000" })
+  })
+
+  it("does not reload for unrelated errors", () => {
+    const reload = vi.fn()
+    const reloaded = maybeReloadForStaleServerFn({
+      error: new Error("Boom"),
+      reload,
+      now: 1_000_000,
+      storage: fakeStorage(),
+    })
+
+    expect(reloaded).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it("suppresses a second reload within the guard window (no loop)", () => {
+    const reload = vi.fn()
+    const now = 1_000_000
+    const storage = fakeStorage({ "latitude:stale-server-fn-reload-at": String(now - 1_000) })
+
+    const reloaded = maybeReloadForStaleServerFn({ error: staleError(), reload, now, storage })
+
+    expect(reloaded).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it("reloads again once the guard window has elapsed", () => {
+    const reload = vi.fn()
+    const now = 1_000_000
+    const storage = fakeStorage({
+      "latitude:stale-server-fn-reload-at": String(now - STALE_SERVER_FN_RELOAD_GUARD_MS - 1),
+    })
+
+    const reloaded = maybeReloadForStaleServerFn({ error: staleError(), reload, now, storage })
+
+    expect(reloaded).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("still reloads when storage is unavailable", () => {
+    const reload = vi.fn()
+    const reloaded = maybeReloadForStaleServerFn({ error: staleError(), reload, now: 1_000_000, storage: null })
+
+    expect(reloaded).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/lib/stale-server-fn.ts
+++ b/apps/web/src/lib/stale-server-fn.ts
@@ -1,0 +1,51 @@
+/**
+ * A stale browser tab invokes a server-function hash from a previous build. The
+ * new deploy's resolver (`getServerFnById`) no longer has that hash, so TanStack
+ * Start throws "Server function info not found for <hash>". A hash from the
+ * *current* build always resolves, so this is exclusively a client-staleness
+ * condition — never a real fault in the running deploy. We treat it as expected
+ * on the server (no Datadog exception) and self-heal on the client (reload into
+ * the new build).
+ */
+// TanStack Start has no typed error or code for this: the generated server-fn
+// resolver (`getServerFnById`) throws a bare `Error`, which the server handler
+// serializes through seroval and the client rethrows with the message intact.
+// So the message is the only discriminant we have, on both sides. We match the
+// full `…not found for <id>` shape (not a loose substring) so an unrelated error
+// can't trip it. Coupling to this string is deliberate — re-verify it on
+// `@tanstack/react-start` upgrades (matched against start-server-core 1.167.x).
+const STALE_SERVER_FN_MESSAGE_PATTERN = /Server function info not found for \S+/
+
+export function isStaleServerFnError(error: unknown): boolean {
+  return error instanceof Error && STALE_SERVER_FN_MESSAGE_PATTERN.test(error.message)
+}
+
+// Reload at most once per window: if a stale-driven reload just happened and the
+// condition somehow persists (e.g. a CDN still serving stale HTML), don't spin.
+export const STALE_SERVER_FN_RELOAD_GUARD_MS = 10_000
+const RELOAD_GUARD_KEY = "latitude:stale-server-fn-reload-at"
+
+interface MaybeReloadArgs {
+  readonly error: unknown
+  readonly reload: () => void
+  readonly now: number
+  readonly storage: Pick<Storage, "getItem" | "setItem"> | null
+}
+
+/**
+ * Reloads the page when `error` is a stale-server-fn error, unless a reload
+ * already happened within the guard window. Returns whether it reloaded.
+ * `reload`/`now`/`storage` are injected so the decision is unit-testable.
+ */
+export function maybeReloadForStaleServerFn({ error, reload, now, storage }: MaybeReloadArgs): boolean {
+  if (!isStaleServerFnError(error)) return false
+
+  const lastReloadAt = Number(storage?.getItem(RELOAD_GUARD_KEY) ?? "")
+  if (Number.isFinite(lastReloadAt) && lastReloadAt > 0 && now - lastReloadAt < STALE_SERVER_FN_RELOAD_GUARD_MS) {
+    return false
+  }
+
+  storage?.setItem(RELOAD_GUARD_KEY, String(now))
+  reload()
+  return true
+}

--- a/apps/web/src/start.test.ts
+++ b/apps/web/src/start.test.ts
@@ -1,8 +1,11 @@
 import { NotFoundError, RepositoryError, UnauthorizedError } from "@domain/shared"
 import type { Span } from "@repo/observability"
+import { SpanStatusCode } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
 import { describe, expect, it, vi } from "vitest"
-import { recordRequestError, recordServerFnError } from "./start.ts"
+import { recordRequestError, recordRequestErrorUnlessStale, recordServerFnError } from "./start.ts"
+
+const staleServerFnError = () => new Error("Server function info not found for abc123def456")
 
 const fakeSpan = () => {
   const span = {
@@ -118,5 +121,32 @@ describe("recordRequestError", () => {
     recordRequestError(span, new Error("boom"))
 
     expect(span.recordException).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("recordRequestErrorUnlessStale", () => {
+  it("does NOT record a stale server-fn error and marks the span OK", () => {
+    const span = fakeSpan()
+    recordRequestErrorUnlessStale(span, staleServerFnError())
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setAttribute).toHaveBeenCalledWith("server_fn.stale", true)
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK })
+  })
+
+  it("records a non-stale 5xx server fault", () => {
+    const span = fakeSpan()
+    recordRequestErrorUnlessStale(span, new RepositoryError({ cause: new Error("boom"), operation: "findById" }))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+  })
+
+  it("leaves a 4xx client error unrecorded (delegates to recordRequestError)", () => {
+    const span = fakeSpan()
+    recordRequestErrorUnlessStale(span, new NotFoundError({ entity: "Sandbox", id: "org-123" }))
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+    expect(span.setAttribute).not.toHaveBeenCalledWith("server_fn.stale", true)
   })
 })

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -9,8 +9,17 @@ import {
 } from "@repo/observability"
 import { isHttpError } from "@repo/utils"
 import { createMiddleware, createStart } from "@tanstack/react-start"
+import { isStaleServerFnError, maybeReloadForStaleServerFn } from "./lib/stale-server-fn.ts"
 
 type Logger = ReturnType<typeof createLogger>
+
+const safeSessionStorage = (): Pick<Storage, "getItem" | "setItem"> | null => {
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
 
 type ServerFnMeta = {
   readonly id?: string
@@ -78,6 +87,21 @@ export const recordRequestError = (span: Span, error: unknown): void => {
 }
 
 /**
+ * Records a request-level error on its span, except a stale server-fn error:
+ * a stale client called a hash from an older build, which is expected churn
+ * around deploys (the client self-heals by reloading), so it's marked OK and
+ * kept out of Datadog rather than recorded as a fault in this deploy.
+ */
+export const recordRequestErrorUnlessStale = (span: Span, error: unknown): void => {
+  if (isStaleServerFnError(error)) {
+    span.setAttribute("server_fn.stale", true)
+    span.setStatus({ code: SpanStatusCode.OK })
+    return
+  }
+  recordRequestError(span, error)
+}
+
+/**
  * Records a thrown server-fn error onto its span and shapes it for re-throwing.
  * The re-thrown `Error` carries the original `httpStatus`/`httpMessage` (as
  * non-enumerable props, so they don't leak into the client-bound JSON message)
@@ -123,12 +147,32 @@ export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
         }
         return result
       } catch (error) {
-        recordRequestError(span, error)
+        recordRequestErrorUnlessStale(span, error)
         throw error
       } finally {
         span.end()
       }
     })
+  })
+
+// Client-side self-heal: when a stale tab calls a server-fn hash the current
+// build no longer has, reload once so the user lands on the new build instead
+// of an error boundary. See `./lib/stale-server-fn.ts`.
+export const staleServerFnReloadMiddleware = () =>
+  createMiddleware({ type: "function" }).client(async ({ next }) => {
+    try {
+      return await next()
+    } catch (error) {
+      if (typeof window !== "undefined") {
+        maybeReloadForStaleServerFn({
+          error,
+          reload: () => window.location.reload(),
+          now: Date.now(),
+          storage: safeSessionStorage(),
+        })
+      }
+      throw error
+    }
   })
 
 export const tracingFnMiddleware = ({ tracer, logger }: { tracer: Tracer; logger: Logger }) =>
@@ -212,6 +256,6 @@ export const startInstance = createStart(async () => {
 
   return {
     requestMiddleware: [tracingRequestMiddleware({ tracer })],
-    functionMiddleware: [tracingFnMiddleware({ tracer, logger })],
+    functionMiddleware: [staleServerFnReloadMiddleware(), tracingFnMiddleware({ tracer, logger })],
   }
 })


### PR DESCRIPTION
## Problem

A browser tab left open across a deploy calls a **server-function hash from the previous build**. The new server build's resolver (`getServerFnById`) no longer has that hash, so TanStack Start throws `Server function info not found for <hash>` (`@tanstack/start-server-core` → `handleServerAction`), which our `tracingRequestMiddleware` recorded as an exception and returned as a **500**.

This was the **#1 web error by volume — 189 occurrences / 30d** ([Datadog issue `b42b8026-5b49-11f1-aa94-da7ad0900005`](https://app.datadoghq.eu/error-tracking?query=&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22b42b8026-5b49-11f1-aa94-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D)), spiking around each deploy. It both polluted Error Tracking and silently broke the user's action (e.g. opening a session view).

A hash from the **current** build always resolves, so this is *exclusively* a client-staleness condition — never a fault in the running deploy. That makes it safe to special-case.

## Fix (two tiers)

**Tier 1 — server (`tracingRequestMiddleware`).** Classify the stale error as expected: skip `recordSpanExceptionForDatadog`, set the span `OK` + a `server_fn.stale` attribute, and re-throw. Stops it polluting Error Tracking; a genuine current-build resolver failure would have a different message and still be reported.

**Tier 2 — client (`staleServerFnReloadMiddleware`, new function middleware `.client()` phase).** When a stale call fails, `window.location.reload()` once so the tab pulls the new build and the user's action just works on retry instead of hitting the error boundary. Guarded against reload loops by a `sessionStorage` timestamp (`STALE_SERVER_FN_RELOAD_GUARD_MS`).

Shared predicate + reload decision live in `apps/web/src/lib/stale-server-fn.ts`, with `reload`/`now`/`storage` injected so the decision is pure and testable.

## Tests

`apps/web/src/lib/stale-server-fn.test.ts` (7 cases): predicate matches the TanStack message and rejects unrelated/non-Error values; reloads once on a stale error; ignores unrelated errors; suppresses a second reload inside the guard window (no loop); reloads again after the window; reloads when storage is unavailable. Full `@app/web` suite green (490 tests), `typecheck` + `biome` clean.

## Verification

- Server classification + reload decision are unit-covered.
- The end-to-end stale-tab flow (old tab → deploy → action → one reload → success) is best smoke-verified post-deploy; after this ships, occurrences on the issue above should drop toward zero and stale tabs should self-heal instead of 500ing.

Related but out of scope: the client-side `Failed to fetch dynamically imported module` (stale lazy chunk) is the same deploy-skew family surfaced through the React error boundary — can be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)