### PR TITLE
Hide behaviors when fewer than two clusters are available

### DIFF
--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -236,6 +236,9 @@ const intelligenceFromAggregate = (aggregate: ClusterAnalysisAggregate | null): 
 const flattenNodes = (nodes: readonly ProjectBehaviourNode[]): readonly ProjectBehaviourNode[] =>
   nodes.flatMap((node) => [node, ...flattenNodes(node.children)])
 
+const countBehaviourNodes = (nodes: readonly BehaviourNodeRecord[]): number =>
+  nodes.reduce((sum, node) => sum + 1 + countBehaviourNodes(node.children), 0)
+
 interface WeightedIntelligence {
   readonly intelligence: BehaviourIntelligenceSummaryRecord
   readonly weight: number
@@ -438,7 +441,8 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
         const topics = result.topics.map((topic) =>
           toBehaviourNodeRecord(topic, aggregatesByClusterId, positionsByClusterId),
         )
-        return { topics: data.segment === "high_escalation" ? pruneToHighEscalation(topics) : topics }
+        const displayTopics = data.segment === "high_escalation" ? pruneToHighEscalation(topics) : topics
+        return { topics: countBehaviourNodes(displayTopics) >= 2 ? displayTopics : [] }
       }).pipe(
         withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
         withClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),


### PR DESCRIPTION
This PR hides the behaviors surface when the final display tree has fewer than two clusters. Low-volume projects can otherwise show a one-row behavior table, which does not give users a useful clustering view.

The gate runs in the web taxonomy server function after the existing segment filtering and high-escalation pruning, so the route receives an empty topics list and uses the existing no-behaviors state.

Validation:
- pnpm --filter @app/web typecheck
- pnpm --filter @app/web check