### PR TITLE
feat(sandbox): wake an archived sandbox when entering via the live toggle

### DIFF
--- a/apps/web/src/domains/sandbox/sandbox-lifecycle.functions.ts
+++ b/apps/web/src/domains/sandbox/sandbox-lifecycle.functions.ts
@@ -2,8 +2,8 @@ import { ProjectRepository } from "@domain/projects"
 import {
   DEFAULT_SANDBOX_NAME,
   deleteSandboxUseCase,
+  findOrCreateActiveSandboxUseCase,
   findOrCreateLinkedSandboxProjectUseCase,
-  findOrCreateSandboxUseCase,
   reactivateSandboxUseCase,
 } from "@domain/sandboxes"
 import { OrganizationId, projectIdSchema } from "@domain/shared"
@@ -56,9 +56,11 @@ export const reactivateSandbox = createServerFn({ method: "POST" })
 
 /**
  * Everything the sidebar toggle needs to land inside the sandbox, in one call:
- * find-or-create the org's single sandbox, then find-or-create the sandbox
- * project mirroring the given live project. The flow spans two RLS scopes
- * (parent org, then sandbox org), so it composes one scoped use-case run each.
+ * find-or-create the org's single sandbox, wake it if it was asleep, then
+ * find-or-create the sandbox project mirroring the given live project. The flow
+ * spans two RLS scopes (parent org, then sandbox org), so it composes one
+ * scoped use-case run each. Entering via the toggle always lands in an active
+ * sandbox — the "asleep" state is only reachable by navigating to it directly.
  */
 export const enterSandboxProject = createServerFn({ method: "POST" })
   .inputValidator(z.object({ projectId: projectIdSchema }))
@@ -76,7 +78,7 @@ export const enterSandboxProject = createServerFn({ method: "POST" })
     )
 
     const { sandboxOrganizationId, createdNow } = await Effect.runPromise(
-      findOrCreateSandboxUseCase({
+      findOrCreateActiveSandboxUseCase({
         parentOrganizationId: organizationId,
         actorUserId: userId,
         name: DEFAULT_SANDBOX_NAME,

--- a/apps/web/src/routes/_authenticated/-components/sandbox-switcher.tsx
+++ b/apps/web/src/routes/_authenticated/-components/sandbox-switcher.tsx
@@ -13,9 +13,10 @@ import { toUserMessage } from "../../../lib/errors.ts"
  * Flipping the toggle asks the server to find-or-create the org's one sandbox
  * **and** a sandbox project mirroring the current live project (linked by its
  * stable id), then navigates into it — the browser session's active org never
- * changes. If the sandbox is archived we still navigate into it — the gray
- * strip surfaces "Activate", which is the intended entry point for waking it.
- * The sandbox sidebar renders the same toggle *on*; here it is always *off*.
+ * changes. An asleep sandbox is woken on entry, so the toggle always lands in
+ * an active one; the gray "Activate" strip is only reachable by navigating to
+ * an archived sandbox directly. The sandbox sidebar renders the same toggle
+ * *on*; here it is always *off*.
  */
 export function SandboxSwitcher({ collapsed, projectId }: { readonly collapsed: boolean; readonly projectId: string }) {
   const router = useRouter()

--- a/packages/domain/sandboxes/src/index.ts
+++ b/packages/domain/sandboxes/src/index.ts
@@ -43,6 +43,7 @@ export {
   type DeleteSandboxInput,
   deleteSandboxUseCase,
 } from "./use-cases/delete-sandbox.ts"
+export { findOrCreateActiveSandboxUseCase } from "./use-cases/find-or-create-active-sandbox.ts"
 export {
   type FindOrCreateLinkedSandboxProjectInput,
   findOrCreateLinkedSandboxProjectUseCase,

--- a/packages/domain/sandboxes/src/use-cases/find-or-create-active-sandbox.ts
+++ b/packages/domain/sandboxes/src/use-cases/find-or-create-active-sandbox.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import { type FindOrCreateSandboxInput, findOrCreateSandboxUseCase } from "./find-or-create-sandbox.ts"
+import { reactivateSandboxUseCase } from "./reactivate-sandbox.ts"
+
+/**
+ * The org's single sandbox, resolved for *entry*: find-or-create it, then wake
+ * it if it was asleep, so flipping the live→sandbox toggle always lands in an
+ * active sandbox. A freshly created sandbox is already active — only the
+ * resolved-existing path may need waking, and reactivation is idempotent on an
+ * already-active one. The "asleep" UI is then only reachable by navigating to
+ * an archived sandbox directly. `createdNow` is forwarded so a caller can still
+ * roll back a sandbox it just created if a follow-up step fails.
+ */
+export const findOrCreateActiveSandboxUseCase = Effect.fn("sandboxes.findOrCreateActiveSandbox")(function* (
+  input: FindOrCreateSandboxInput,
+) {
+  const result = yield* findOrCreateSandboxUseCase(input)
+  if (!result.createdNow) {
+    yield* reactivateSandboxUseCase({
+      sandboxOrganizationId: result.sandboxOrganizationId,
+      actorUserId: input.actorUserId,
+    })
+  }
+  return result
+})

--- a/packages/domain/sandboxes/src/use-cases/sandbox-lifecycle.test.ts
+++ b/packages/domain/sandboxes/src/use-cases/sandbox-lifecycle.test.ts
@@ -14,6 +14,7 @@ import { SandboxAccessDeniedError, SandboxActiveCapReachedError } from "../error
 import { SandboxRepository } from "../ports/sandbox-repository.ts"
 import { createFakeSandboxRepository } from "../testing/fake-sandbox-repository.ts"
 import { createSandboxUseCase } from "./create-sandbox.ts"
+import { findOrCreateActiveSandboxUseCase } from "./find-or-create-active-sandbox.ts"
 import { findOrCreateSandboxUseCase } from "./find-or-create-sandbox.ts"
 import { reactivateSandboxUseCase } from "./reactivate-sandbox.ts"
 
@@ -229,5 +230,92 @@ describe("findOrCreateSandbox (unit)", () => {
     )
 
     expect(failure(exit)).toBeInstanceOf(SandboxAccessDeniedError)
+  })
+})
+
+describe("findOrCreateActiveSandbox (entry) (unit)", () => {
+  it("wakes an archived sandbox on entry", async () => {
+    const existing = OrganizationId(generateId())
+    const { layer, sandbox } = buildLayer({ seedSandbox: { organizationId: existing, status: "archived" } })
+
+    const result = await Effect.runPromise(
+      findOrCreateActiveSandboxUseCase({
+        parentOrganizationId: PARENT_ORG_ID,
+        actorUserId: ADMIN_USER_ID,
+        name: "Sandbox",
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result).toEqual({ sandboxOrganizationId: existing, createdNow: false })
+    expect(sandbox.sandboxes.get(existing)?.status).toBe("active")
+    expect(sandbox.sandboxes.size).toBe(1)
+  })
+
+  it("leaves an already-active sandbox active (idempotent wake)", async () => {
+    const existing = OrganizationId(generateId())
+    const { layer, sandbox } = buildLayer({ seedSandbox: { organizationId: existing, status: "active" } })
+
+    const result = await Effect.runPromise(
+      findOrCreateActiveSandboxUseCase({
+        parentOrganizationId: PARENT_ORG_ID,
+        actorUserId: ADMIN_USER_ID,
+        name: "Sandbox",
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result).toEqual({ sandboxOrganizationId: existing, createdNow: false })
+    expect(sandbox.sandboxes.get(existing)?.status).toBe("active")
+  })
+
+  it("creates an active sandbox on first entry without a second wake step", async () => {
+    const { layer, sandbox } = buildLayer()
+
+    const result = await Effect.runPromise(
+      findOrCreateActiveSandboxUseCase({
+        parentOrganizationId: PARENT_ORG_ID,
+        actorUserId: ADMIN_USER_ID,
+        name: "Sandbox",
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.createdNow).toBe(true)
+    expect(sandbox.sandboxes.get(result.sandboxOrganizationId)?.status).toBe("active")
+    expect(sandbox.sandboxes.size).toBe(1)
+  })
+
+  it("refuses a non-member of the parent org", async () => {
+    const { layer } = buildLayer({ isMember: false })
+
+    const exit = await Effect.runPromiseExit(
+      findOrCreateActiveSandboxUseCase({
+        parentOrganizationId: PARENT_ORG_ID,
+        actorUserId: ADMIN_USER_ID,
+        name: "Sandbox",
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(failure(exit)).toBeInstanceOf(SandboxAccessDeniedError)
+  })
+
+  it("prefers an active sibling over an archived one, leaving the archived asleep", async () => {
+    const activeId = OrganizationId(generateId())
+    const archivedId = OrganizationId(generateId())
+    const { layer, sandbox } = buildLayer({ seedSandbox: { organizationId: activeId, status: "active" } })
+    sandbox.sandboxes.set(
+      archivedId,
+      createSandbox({ organizationId: archivedId, createdByUserId: ADMIN_USER_ID, status: "archived" }),
+    )
+    sandbox.parentByOrganizationId.set(archivedId, PARENT_ORG_ID)
+
+    const result = await Effect.runPromise(
+      findOrCreateActiveSandboxUseCase({
+        parentOrganizationId: PARENT_ORG_ID,
+        actorUserId: ADMIN_USER_ID,
+        name: "Sandbox",
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result).toEqual({ sandboxOrganizationId: activeId, createdNow: false })
+    expect(sandbox.sandboxes.get(archivedId)?.status).toBe("archived")
   })
 })


### PR DESCRIPTION
## What

Flipping the live→sandbox toggle resolved the org's single sandbox **without waking it**, so an idle (archived / "asleep") sandbox dropped users into the inert *"This sandbox is asleep — Activate"* shell. This makes entry **wake** the sandbox, so the toggle always lands in an active sandbox. The asleep state is now only reachable by navigating to an archived sandbox directly — which is the intended behavior.

## How

- New domain use-case **`findOrCreateActiveSandboxUseCase`** (`@domain/sandboxes`) composes `findOrCreateSandboxUseCase` + a conditional `reactivateSandboxUseCase`. Both steps share the admin/parent RLS scope, so they collapse into one Effect over the existing `sandboxCapLayers`.
  - Wake is **skipped** for a freshly created sandbox (already active).
  - Wake is **idempotent** on an already-active sandbox.
  - `findOrCreateSandbox` still prefers an active sibling, so entry never wakes the wrong sandbox.
- `enterSandboxProject` now calls the single use-case instead of two separate runs.
- Updated stale doc comments in `enterSandboxProject` and `SandboxSwitcher`.

The in-sandbox `Activate` button and the direct-navigation asleep state are untouched — they remain the explicit wake path for someone who lands on an archived sandbox via a direct URL.

## Tests

New `findOrCreateActiveSandbox (entry)` suite in `sandbox-lifecycle.test.ts`:
- wakes an archived sandbox on entry (the core behavior)
- idempotent on an already-active sandbox
- creates an active sandbox on first entry (no redundant wake)
- refuses a non-member of the parent org
- prefers an active sibling, leaving the archived asleep

`@domain/sandboxes`: 21 passed. Typecheck clean for `@domain/sandboxes` and `@app/web`. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)