### PR TITLE
feat(web): standardize token analytics categories + tooltip (LAT-688)

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
@@ -82,22 +82,22 @@ describe("buildTokenSegments", () => {
     const segments = buildTokenSegments(data)
     const byLabel = Object.fromEntries(segments.map((s) => [s.label, s.value]))
 
-    expect(byLabel.Prompt).toBe(100)
-    expect(byLabel["Cache Read"]).toBe(30)
+    expect(byLabel.Input).toBe(100)
+    expect(byLabel["Cached Input"]).toBe(30)
     expect(byLabel["Cache Write"]).toBe(20)
-    expect(byLabel.Completion).toBe(50)
+    expect(byLabel.Output).toBe(50)
     expect(byLabel.Reasoning).toBe(10)
   })
 
   it("does not treat cache write as an output subcategory", () => {
-    // Regression: prior bug subtracted tokensCacheCreate from completion.
+    // Regression: prior bug subtracted tokensCacheCreate from output.
     const data = makeUsage({ tokensOutput: 80, tokensCacheCreate: 500 })
     const segments = buildTokenSegments(data)
-    const completion = segments.find((s) => s.label === "Completion")
-    expect(completion?.value).toBe(80)
+    const output = segments.find((s) => s.label === "Output")
+    expect(output?.value).toBe(80)
   })
 
-  it("emits segments in fixed order: Cache Read, Cache Write, Prompt, Reasoning, Completion", () => {
+  it("emits core categories in fixed order, reasoning before output when present", () => {
     const data = makeUsage({
       tokensInput: 1,
       tokensOutput: 1,
@@ -106,17 +106,28 @@ describe("buildTokenSegments", () => {
       tokensReasoning: 1,
     })
     const labels = buildTokenSegments(data).map((s) => s.label)
-    expect(labels).toEqual(["Cache Read", "Cache Write", "Prompt", "Reasoning", "Completion"])
+    expect(labels).toEqual(["Input", "Cached Input", "Cache Write", "Reasoning", "Output"])
   })
 
-  it("omits zero-value segments", () => {
+  it("always emits the four core categories even when cache is absent", () => {
+    // The whole point of the issue: a no-cache trace must still show cache
+    // categories (at 0) so it doesn't look like Latitude failed to capture them.
     const data = makeUsage({ tokensInput: 10, tokensOutput: 5 })
-    const labels = buildTokenSegments(data).map((s) => s.label)
-    expect(labels).toEqual(["Prompt", "Completion"])
+    const segments = buildTokenSegments(data)
+    expect(segments.map((s) => s.label)).toEqual(["Input", "Cached Input", "Cache Write", "Output"])
+    const byLabel = Object.fromEntries(segments.map((s) => [s.label, s.value]))
+    expect(byLabel["Cached Input"]).toBe(0)
+    expect(byLabel["Cache Write"]).toBe(0)
   })
 
-  it("returns no segments when usage is empty", () => {
-    expect(buildTokenSegments(makeUsage())).toEqual([])
+  it("omits reasoning when zero (model-dependent)", () => {
+    const data = makeUsage({ tokensInput: 10, tokensOutput: 5 })
+    expect(buildTokenSegments(data).some((s) => s.label === "Reasoning")).toBe(false)
+  })
+
+  it("still emits the four core categories (all zero) for empty usage", () => {
+    const labels = buildTokenSegments(makeUsage()).map((s) => s.label)
+    expect(labels).toEqual(["Input", "Cached Input", "Cache Write", "Output"])
   })
 
   it("segment sum equals computeTotalTokens", () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -45,18 +45,19 @@ export function computeTotalTokens(data: UsageData): number {
 }
 
 export function buildTokenSegments(data: UsageData): SegmentBarItem[] {
-  const prompt = data.tokensInput
-  const cacheRead = data.tokensCacheRead
-  const cacheCreate = data.tokensCacheCreate
-  const completion = data.tokensOutput
-  const reasoning = data.tokensReasoning
-
-  const segments: SegmentBarItem[] = []
-  if (cacheRead > 0) segments.push({ label: "Cache Read", value: cacheRead, color: TOKEN_COLORS.cacheRead })
-  if (cacheCreate > 0) segments.push({ label: "Cache Write", value: cacheCreate, color: TOKEN_COLORS.cacheCreate })
-  if (prompt > 0) segments.push({ label: "Prompt", value: prompt, color: TOKEN_COLORS.prompt })
-  if (reasoning > 0) segments.push({ label: "Reasoning", value: reasoning, color: TOKEN_COLORS.reasoning })
-  if (completion > 0) segments.push({ label: "Completion", value: completion, color: TOKEN_COLORS.completion })
+  // Core categories are always emitted (even at 0) so a no-cache trace reads as
+  // "Cached Input: 0" rather than looking like Latitude failed to capture cache.
+  // The bar drops zero segments; the tooltip breakdown keeps them.
+  const segments: SegmentBarItem[] = [
+    { label: "Input", value: data.tokensInput, color: TOKEN_COLORS.prompt },
+    { label: "Cached Input", value: data.tokensCacheRead, color: TOKEN_COLORS.cacheRead },
+    { label: "Cache Write", value: data.tokensCacheCreate, color: TOKEN_COLORS.cacheCreate },
+  ]
+  // Reasoning is model-dependent, so it only appears when the model reports it.
+  if (data.tokensReasoning > 0) {
+    segments.push({ label: "Reasoning", value: data.tokensReasoning, color: TOKEN_COLORS.reasoning })
+  }
+  segments.push({ label: "Output", value: data.tokensOutput, color: TOKEN_COLORS.completion })
   return segments
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -351,79 +351,83 @@ export function BehaviourDetailDrawer({
               <hr className="mx-2 flex-1 border-t-2 border-dashed border-border" />
             </div>
             <div className="flex flex-col gap-4 pt-2">
-            {intelligence ? (
-              <>
-                <div className={cn("grid gap-2", showDetectedSignalsChart ? "grid-cols-2" : "grid-cols-1")}>
-                  <BehaviourSessionsHistogram
-                    isLoading={behaviourSessionsLoading}
-                    buckets={behaviourSessionHistogram}
-                    height={96}
-                  />
-                  {showDetectedSignalsChart ? <DetectedSignalsChart signals={detectedSignals} /> : null}
-                </div>
-                {sessionFilterOptions.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {sessionFilterOptions.map((option) => (
-                      <MetricButton
-                        key={option.id}
-                        active={activeMomentKinds.includes(option.id)}
-                        label={option.label}
-                        valueText={option.valueText}
-                        color={option.color}
-                        onClick={() => {
-                          onMomentRangeChange(undefined)
-                          setSessionFilter((current) => (current === option.id && !momentRange ? "all" : option.id))
-                        }}
-                      />
-                    ))}
-                  </div>
-                ) : null}
-                <div className="flex flex-col gap-2 pt-4">
-                  <div className="flex items-center justify-between gap-2">
-                    <Text.H5>Associated sessions</Text.H5>
-                    {hasSessionFilters ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => {
-                          setSessionFilter("all")
-                          onMomentRangeChange(undefined)
-                        }}
-                      >
-                        <Icon icon={XIcon} size="xs" />
-                        Clear filters
-                      </Button>
-                    ) : null}
-                  </div>
-                  {momentRange ? (
-                    <TurnRangeSlider range={momentRange} maxTurn={momentRangeMaxTurn} onChange={onMomentRangeChange} />
-                  ) : null}
-                  <Text.H6 color="foregroundMuted">
-                    {momentRange
-                      ? selectedMomentRangeLabel(momentRange)
-                      : sessionFilter === "all"
-                        ? "All sessions for this behavior"
-                        : `Sessions matching ${sessionFilter.replaceAll("_", " ")}`}
-                  </Text.H6>
-                  {behaviourSessionsLoading ? (
-                    <Skeleton className="h-16 rounded-xl" />
-                  ) : behaviourSessions.length ? (
-                    <BehaviourSessionsTable
-                      sessions={behaviourSessions}
-                      activeSessionId={sessionOverlayId ?? undefined}
-                      onSessionClick={openSessionOverlay}
-                      hasMore={hasNextBehaviourSessionsPage === true}
-                      isLoadingMore={isFetchingNextBehaviourSessionsPage}
-                      onLoadMore={() => void fetchNextBehaviourSessionsPage()}
+              {intelligence ? (
+                <>
+                  <div className={cn("grid gap-2", showDetectedSignalsChart ? "grid-cols-2" : "grid-cols-1")}>
+                    <BehaviourSessionsHistogram
+                      isLoading={behaviourSessionsLoading}
+                      buckets={behaviourSessionHistogram}
+                      height={96}
                     />
-                  ) : (
-                    <Text.H5 color="foregroundMuted">No sessions match this filter.</Text.H5>
-                  )}
-                </div>
-              </>
-            ) : (
-              <Text.H5 color="foregroundMuted">Conversation intelligence is not available yet.</Text.H5>
-            )}
+                    {showDetectedSignalsChart ? <DetectedSignalsChart signals={detectedSignals} /> : null}
+                  </div>
+                  {sessionFilterOptions.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {sessionFilterOptions.map((option) => (
+                        <MetricButton
+                          key={option.id}
+                          active={activeMomentKinds.includes(option.id)}
+                          label={option.label}
+                          valueText={option.valueText}
+                          color={option.color}
+                          onClick={() => {
+                            onMomentRangeChange(undefined)
+                            setSessionFilter((current) => (current === option.id && !momentRange ? "all" : option.id))
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                  <div className="flex flex-col gap-2 pt-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <Text.H5>Associated sessions</Text.H5>
+                      {hasSessionFilters ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setSessionFilter("all")
+                            onMomentRangeChange(undefined)
+                          }}
+                        >
+                          <Icon icon={XIcon} size="xs" />
+                          Clear filters
+                        </Button>
+                      ) : null}
+                    </div>
+                    {momentRange ? (
+                      <TurnRangeSlider
+                        range={momentRange}
+                        maxTurn={momentRangeMaxTurn}
+                        onChange={onMomentRangeChange}
+                      />
+                    ) : null}
+                    <Text.H6 color="foregroundMuted">
+                      {momentRange
+                        ? selectedMomentRangeLabel(momentRange)
+                        : sessionFilter === "all"
+                          ? "All sessions for this behavior"
+                          : `Sessions matching ${sessionFilter.replaceAll("_", " ")}`}
+                    </Text.H6>
+                    {behaviourSessionsLoading ? (
+                      <Skeleton className="h-16 rounded-xl" />
+                    ) : behaviourSessions.length ? (
+                      <BehaviourSessionsTable
+                        sessions={behaviourSessions}
+                        activeSessionId={sessionOverlayId ?? undefined}
+                        onSessionClick={openSessionOverlay}
+                        hasMore={hasNextBehaviourSessionsPage === true}
+                        isLoadingMore={isFetchingNextBehaviourSessionsPage}
+                        onLoadMore={() => void fetchNextBehaviourSessionsPage()}
+                      />
+                    ) : (
+                      <Text.H5 color="foregroundMuted">No sessions match this filter.</Text.H5>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <Text.H5 color="foregroundMuted">Conversation intelligence is not available yet.</Text.H5>
+              )}
             </div>
           </div>
         </div>

--- a/packages/ui/src/components/segment-bar/segment-bar.tsx
+++ b/packages/ui/src/components/segment-bar/segment-bar.tsx
@@ -5,12 +5,13 @@ export interface SegmentBarItem {
 }
 
 export function SegmentBar({ segments }: { readonly segments: readonly SegmentBarItem[] }) {
-  const total = segments.reduce((sum, s) => sum + s.value, 0)
+  const visible = segments.filter((s) => s.value > 0)
+  const total = visible.reduce((sum, s) => sum + s.value, 0)
   if (total <= 0) return null
 
   return (
     <div className="flex flex-row w-full rounded overflow-hidden h-2">
-      {segments.map((s) => (
+      {visible.map((s) => (
         <div
           key={s.label}
           className="h-full min-w-1"

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -254,8 +254,8 @@
   --viz-blue: 210 65% 60%;
   --viz-blue-soft: 198 45% 70%;
   --viz-gold: 44 78% 62%;
-  --viz-gold-soft: 46 60% 73%;
-  --viz-gold-faint: 48 50% 83%;
+  --viz-gold-soft: 32 82% 57%;
+  --viz-gold-faint: 50 65% 85%;
   --viz-green: 148 40% 56%;
   --viz-red: 8 58% 65%;
   --viz-violet: 270 44% 64%;
@@ -320,8 +320,8 @@
   --viz-blue: 210 50% 52%;
   --viz-blue-soft: 202 34% 54%;
   --viz-gold: 42 54% 52%;
-  --viz-gold-soft: 42 42% 58%;
-  --viz-gold-faint: 44 34% 66%;
+  --viz-gold-soft: 30 60% 50%;
+  --viz-gold-faint: 47 44% 72%;
   --viz-green: 147 36% 50%;
   --viz-red: 8 50% 55%;
   --viz-violet: 268 36% 58%;


### PR DESCRIPTION
Closes the display half of LAT-688: standardize token analytics category names, always show the core categories, and make the cache colors distinguishable.

## Changes

### 1. Always show core categories (the actual bug)
Categories used to appear only when `value > 0`, so a trace with no cache rendered *without* cache rows — making it look like Latitude failed to capture cache. Now the four core categories (**Input, Cached Input, Cache Write, Output**) are always present in the tooltip breakdown, including zeros, so a no-cache trace reads as `Cached Input: 0`. **Reasoning** stays conditional (model-dependent). The stacked bar still only draws non-zero segments — `SegmentBar` now filters zero-value items so it never renders a 0-width sliver.

### 2. Standardized naming
| Before | After | Basis |
|---|---|---|
| Prompt | **Input** | Anthropic/OpenAI "input tokens" |
| Cache Read | **Cached Input** | OpenAI `cached_tokens` |
| Cache Write | **Cache Write** | Anthropic `cache_creation_input_tokens` |
| Completion | **Output** | "output tokens" |
| Reasoning | **Reasoning** | OpenAI `reasoning_tokens` |

Cache read and write stay **separate** categories (not merged into one "cached input") so **cache hit % = `cacheRead / (input + cacheRead + cacheWrite)`** stays computable — the metric Teeming asked for (and the related LAT-687).

### 3. Cache colors distinguishable by hue
The three warm segments (Input / Cached Input / Cache Write) were near-identical golds separated only by lightness. Now separated by **hue** — Cache Write → amber, Cached Input → paler straw, Input stays on the cost-input gold — while staying grouped against the blue output side. Both vars are used only by the token bar.

| Var | Before | After |
|---|---|---|
| `--viz-gold` (Input) | `44 78% 62%` | unchanged |
| `--viz-gold-soft` (Cache Write) | `46 60% 73%` | `32 82% 57%` |
| `--viz-gold-faint` (Cached Input) | `48 50% 83%` | `50 65% 85%` |

Dark theme mirrored.

## Out of scope (rest of LAT-688 / LAT-687)
Cache-hit % in the session/trace tables, aggregate analytics, and over-time graphs — separate follow-ups. See the LAT-688 comment for the full analysis (incl. why "cached output" was dropped: no provider caches output).

## Verification
- `usage-summary.test.ts`: 18 tests pass (new coverage: core categories always emitted incl. zeros; reasoning conditional; standardized labels/order).
- `@repo/ui` + `@app/web` typecheck clean.

Refs LAT-688, related LAT-687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)