### PR TITLE
feat(web): cache hit rate column + filter on session/trace tables (LAT-687)

### DIFF
--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -38,6 +38,7 @@ import {
 } from "@platform/db-clickhouse"
 import { SignalRepositoryLive, TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
+import { cacheHitRate } from "@repo/utils"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
@@ -64,6 +65,11 @@ const serializeSession = (session: Session) => ({
   tokensCacheCreate: session.tokensCacheCreate,
   tokensReasoning: session.tokensReasoning,
   tokensTotal: session.tokensTotal,
+  cacheHitRate: cacheHitRate({
+    input: session.tokensInput,
+    cacheRead: session.tokensCacheRead,
+    cacheCreate: session.tokensCacheCreate,
+  }),
   costInputMicrocents: session.costInputMicrocents,
   costOutputMicrocents: session.costOutputMicrocents,
   costTotalMicrocents: session.costTotalMicrocents,

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -35,6 +35,7 @@ import {
   withClickHouse,
 } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
+import { cacheHitRate } from "@repo/utils"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
@@ -61,6 +62,7 @@ export interface TraceRecord {
   readonly tokensCacheCreate: number
   readonly tokensReasoning: number
   readonly tokensTotal: number
+  readonly cacheHitRate: number | null
   readonly costInputMicrocents: number
   readonly costOutputMicrocents: number
   readonly costTotalMicrocents: number
@@ -92,6 +94,11 @@ export const toTraceRecord = (trace: Trace): TraceRecord => ({
   tokensCacheCreate: trace.tokensCacheCreate,
   tokensReasoning: trace.tokensReasoning,
   tokensTotal: trace.tokensTotal,
+  cacheHitRate: cacheHitRate({
+    input: trace.tokensInput,
+    cacheRead: trace.tokensCacheRead,
+    cacheCreate: trace.tokensCacheCreate,
+  }),
   costInputMicrocents: trace.costInputMicrocents,
   costOutputMicrocents: trace.costOutputMicrocents,
   costTotalMicrocents: trace.costTotalMicrocents,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -9,7 +9,7 @@ import {
   TagList,
   Tooltip,
 } from "@repo/ui"
-import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
+import { formatCount, formatDuration, formatPercentage, formatPrice, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { type MouseEvent, type ReactNode, useCallback, useMemo } from "react"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
@@ -28,6 +28,7 @@ export const TRACE_COLUMN_OPTIONS = [
   { id: "duration", label: "Duration" },
   { id: "ttft", label: "Time To First Token", defaultHidden: true },
   { id: "cost", label: "Cost" },
+  { id: "cacheHitRate", label: "Cache Hit Rate" },
   { id: "sessionId", label: "Session ID" },
   { id: "userId", label: "User ID" },
   { id: "models", label: "Models" },
@@ -259,6 +260,13 @@ export function ProjectTracesTable({
               ),
             }
           : {}),
+      },
+      {
+        key: "cacheHitRate",
+        header: "Cache Hit Rate",
+        align: "end",
+        width: 130,
+        render: (trace) => <span>{trace.cacheHitRate === null ? "-" : formatPercentage(trace.cacheHitRate)}</span>,
       },
       {
         key: "sessionId",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   Tooltip,
 } from "@repo/ui"
-import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
+import { formatCount, formatDuration, formatPercentage, formatPrice, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { useQueries } from "@tanstack/react-query"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
@@ -54,6 +54,7 @@ export const SESSION_COLUMN_OPTIONS = [
   { id: "duration", label: "Duration" },
   { id: "ttft", label: "Time To First Token", defaultHidden: true },
   { id: "cost", label: "Cost" },
+  { id: "cacheHitRate", label: "Cache Hit Rate" },
   { id: "sessionId", label: "Session ID" },
   { id: "userId", label: "User ID" },
   { id: "models", label: "Models" },
@@ -428,6 +429,16 @@ export function SessionsView({
             isLoading={sessionMetricsLoading}
           />
         ),
+      },
+      {
+        key: "cacheHitRate",
+        header: "Cache Hit Rate",
+        align: "end",
+        width: 130,
+        render: (row) => {
+          const rate = field(row, "cacheHitRate")
+          return <span>{rate === null ? "-" : formatPercentage(rate)}</span>
+        },
       },
       {
         key: "sessionId",

--- a/packages/domain/shared/src/trace-filter-fields.ts
+++ b/packages/domain/shared/src/trace-filter-fields.ts
@@ -94,6 +94,16 @@ export const TRACE_FILTER_FIELDS = [
   { field: "errorCount", type: "numberRange", label: "Error Count" },
   { field: "tokensInput", type: "numberRange", label: "Tokens Input" },
   { field: "tokensOutput", type: "numberRange", label: "Tokens Output" },
+  {
+    // Wire value is an integer percentage (0–100), not a 0–1 ratio: the
+    // numberRange UI rounds wire values to integers, so a fractional scale
+    // would collapse small percentages to 0. The SQL divides by 100.
+    field: "cacheHitRate",
+    type: "numberRange",
+    label: "Cache Hit Rate (%)",
+    tooltip: "Share of input tokens served from cache. Low values on large sessions often signal broken caching.",
+    displayStep: 1,
+  },
 ] as const satisfies readonly TraceFilterField[]
 
 export type TraceFilterFieldName = (typeof TRACE_FILTER_FIELDS)[number]["field"]

--- a/packages/platform/db-clickhouse/src/registries/helpers.test.ts
+++ b/packages/platform/db-clickhouse/src/registries/helpers.test.ts
@@ -1,0 +1,50 @@
+import type { FilterCondition } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { buildClickHouseWhere } from "../filter-builder.ts"
+import { buildCacheHitRateClause } from "./helpers.ts"
+
+describe("buildCacheHitRateClause", () => {
+  it("builds a divide-by-zero-guarded HAVING ratio for gte, treating the value as a percentage", () => {
+    const cond: FilterCondition = { op: "gte", value: 80 }
+    const { clause, params } = buildCacheHitRateClause(cond, "f_0")
+    expect(clause).toBe(
+      "((tokens_input + tokens_cache_read + tokens_cache_create) > 0 AND " +
+        "(tokens_cache_read / (tokens_input + tokens_cache_read + tokens_cache_create)) >= {f_0:Float64} / 100)",
+    )
+    expect(params).toEqual({ f_0: 80 })
+  })
+
+  it("supports lte for finding broken-cache (low-rate) rows", () => {
+    const { clause, params } = buildCacheHitRateClause({ op: "lte", value: 50 }, "f_1")
+    expect(clause).toContain(") <= {f_1:Float64} / 100)")
+    expect(params).toEqual({ f_1: 50 })
+  })
+
+  it("rejects non-comparison operators", () => {
+    expect(() => buildCacheHitRateClause({ op: "contains", value: "x" }, "f_0")).toThrow(
+      /Unsupported cacheHitRate filter operator/,
+    )
+  })
+})
+
+describe("cacheHitRate via buildClickHouseWhere", () => {
+  const registry = {
+    cacheHitRate: { kind: "synthetic", buildClause: buildCacheHitRateClause },
+  } as const
+
+  it("compiles a min/max range into two guarded clauses with Float64 params", () => {
+    const { clauses, params } = buildClickHouseWhere(
+      {
+        cacheHitRate: [
+          { op: "gte", value: 80 },
+          { op: "lte", value: 95 },
+        ],
+      },
+      registry,
+    )
+    expect(clauses).toHaveLength(2)
+    expect(clauses[0]).toContain(">= {f_0:Float64} / 100")
+    expect(clauses[1]).toContain("<= {f_1:Float64} / 100")
+    expect(params).toEqual({ f_0: 80, f_1: 95 })
+  })
+})

--- a/packages/platform/db-clickhouse/src/registries/helpers.ts
+++ b/packages/platform/db-clickhouse/src/registries/helpers.ts
@@ -56,6 +56,38 @@ export function buildStatusClause(
   }
 }
 
+const COMPARISON_SQL_OPS: Readonly<Record<string, string>> = {
+  eq: "=",
+  neq: "!=",
+  gt: ">",
+  gte: ">=",
+  lt: "<",
+  lte: "<=",
+}
+
+const CACHE_HIT_RATE_DENOM = "(tokens_input + tokens_cache_read + tokens_cache_create)"
+const CACHE_HIT_RATE_EXPR = `(tokens_cache_read / ${CACHE_HIT_RATE_DENOM})`
+
+/**
+ * Cache hit rate is a ratio of aggregated token sums, so it filters via HAVING
+ * against the SELECT aliases (`tokens_cache_read` etc. are `sum(...) AS ...`).
+ * Rows with no input-side tokens have an undefined rate and must not match any
+ * threshold, so the divide-by-zero is guarded explicitly. The wire value is an
+ * integer percentage (0–100), so it is divided by 100 to compare against the
+ * 0..1 ratio.
+ */
+export function buildCacheHitRateClause(
+  cond: FilterCondition,
+  paramPrefix: string,
+): { readonly clause: string; readonly params: Record<string, unknown> } {
+  const sqlOp = COMPARISON_SQL_OPS[cond.op]
+  if (!sqlOp) throw new Error(`Unsupported cacheHitRate filter operator: ${cond.op}`)
+  return {
+    clause: `(${CACHE_HIT_RATE_DENOM} > 0 AND ${CACHE_HIT_RATE_EXPR} ${sqlOp} {${paramPrefix}:Float64} / 100)`,
+    params: { [paramPrefix]: cond.value },
+  }
+}
+
 const HAS_LLM_ACTIVITY_FRAGMENT = "(tokens_total > 0 OR length(models) > 0)"
 
 export function buildHasLlmActivityClause(

--- a/packages/platform/db-clickhouse/src/registries/session-fields.ts
+++ b/packages/platform/db-clickhouse/src/registries/session-fields.ts
@@ -1,5 +1,10 @@
 import type { ChFieldRegistry } from "../filter-builder.ts"
-import { buildHasLlmActivityClause, buildStatusClause, mapDateTime64UtcQueryParam } from "./helpers.ts"
+import {
+  buildCacheHitRateClause,
+  buildHasLlmActivityClause,
+  buildStatusClause,
+  mapDateTime64UtcQueryParam,
+} from "./helpers.ts"
 
 export const SESSION_FIELD_REGISTRY: ChFieldRegistry = {
   status: { kind: "synthetic", buildClause: buildStatusClause },
@@ -23,5 +28,6 @@ export const SESSION_FIELD_REGISTRY: ChFieldRegistry = {
   traceCount: { column: "trace_count", chType: "UInt64" },
   tokensInput: { column: "tokens_input", chType: "UInt64" },
   tokensOutput: { column: "tokens_output", chType: "UInt64" },
+  cacheHitRate: { kind: "synthetic", buildClause: buildCacheHitRateClause },
   startTime: { column: "start_time", chType: "DateTime64(9, 'UTC')", mapValue: mapDateTime64UtcQueryParam },
 }

--- a/packages/platform/db-clickhouse/src/registries/trace-fields.ts
+++ b/packages/platform/db-clickhouse/src/registries/trace-fields.ts
@@ -1,6 +1,6 @@
 import type { SessionOnlyFilterFieldName, TraceFilterFieldName } from "@domain/shared"
 import type { ChFieldRegistry } from "../filter-builder.ts"
-import { buildStatusClause, mapDateTime64UtcQueryParam } from "./helpers.ts"
+import { buildCacheHitRateClause, buildStatusClause, mapDateTime64UtcQueryParam } from "./helpers.ts"
 
 type InternalField = "startTime"
 
@@ -29,5 +29,6 @@ export const TRACE_FIELD_REGISTRY: ChFieldRegistry<
   errorCount: { column: "error_count", chType: "UInt64" },
   tokensInput: { column: "tokens_input", chType: "UInt64" },
   tokensOutput: { column: "tokens_output", chType: "UInt64" },
+  cacheHitRate: { kind: "synthetic", buildClause: buildCacheHitRateClause },
   startTime: { column: "start_time", chType: "DateTime64(9, 'UTC')", mapValue: mapDateTime64UtcQueryParam },
 }

--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest"
 import {
+  cacheHitRate,
   formatBytes,
   formatCount,
   formatDuration,
+  formatPercentage,
   formatPrice,
   isBlankCHString,
   normalizeCHString,
@@ -123,6 +125,33 @@ describe("formatPrice", () => {
     expect(formatPrice(0.0000075)).toBe("$0.0000075")
     expect(formatPrice(0.0001)).toBe("$0.0001")
     expect(formatPrice(0.0009)).toBe("$0.0009")
+  })
+})
+
+describe("formatPercentage", () => {
+  it("formats whole percentages without decimals", () => {
+    expect(formatPercentage(0.8)).toBe("80%")
+    expect(formatPercentage(1)).toBe("100%")
+    expect(formatPercentage(0)).toBe("0%")
+  })
+
+  it("shows up to one decimal for fractional percentages", () => {
+    expect(formatPercentage(0.3333)).toBe("33.3%")
+    expect(formatPercentage(0.9962)).toBe("99.6%")
+  })
+})
+
+describe("cacheHitRate", () => {
+  it("is cacheRead over total input (input + cacheRead + cacheCreate)", () => {
+    expect(cacheHitRate({ input: 10, cacheRead: 80, cacheCreate: 10 })).toBe(0.8)
+  })
+
+  it("returns null when there are no input-side tokens (undefined, not 0)", () => {
+    expect(cacheHitRate({ input: 0, cacheRead: 0, cacheCreate: 0 })).toBeNull()
+  })
+
+  it("is 0 when nothing was served from cache but input exists", () => {
+    expect(cacheHitRate({ input: 100, cacheRead: 0, cacheCreate: 0 })).toBe(0)
   })
 })
 

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -85,6 +85,41 @@ export function formatPrice(price: number): string {
   return `$${s}`
 }
 
+const percentageFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+  useGrouping: false,
+})
+
+/**
+ * Format a 0..1 ratio as a percentage string.
+ *
+ * Examples: `0.8` -> `"80%"`, `0.3333` -> `"33.3%"`, `1` -> `"100%"`, `0` -> `"0%"`
+ */
+export function formatPercentage(ratio: number): string {
+  return `${percentageFormatter.format(ratio * 100)}%`
+}
+
+/**
+ * Fraction of input tokens served from the provider's prompt cache:
+ * `cacheRead / (input + cacheRead + cacheCreate)`. Token counts are additive,
+ * so the denominator is the total input. Returns `null` when there are no
+ * input-side tokens — the rate is undefined, not 0, and should render as "—".
+ */
+export function cacheHitRate({
+  input,
+  cacheRead,
+  cacheCreate,
+}: {
+  input: number
+  cacheRead: number
+  cacheCreate: number
+}): number | null {
+  const totalInput = input + cacheRead + cacheCreate
+  if (totalInput <= 0) return null
+  return cacheRead / totalInput
+}
+
 const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"]
 
 /**

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,9 +10,11 @@ export {
 export { CryptoError, decrypt, encodeUtf8, encrypt, hash, toBuffer } from "./crypto.ts"
 export { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
 export {
+  cacheHitRate,
   formatBytes,
   formatCount,
   formatDuration,
+  formatPercentage,
   formatPrice,
   isBlankCHString,
   normalizeCHString,


### PR DESCRIPTION
Adds **cache hit rate** to the traces and sessions tables — both a column and a range filter. Cache hit rate = `cacheRead / (input + cacheRead + cacheCreate)`, the metric Teeming uses to spot broken caching (a low rate on a large session usually means an error — e.g. the 7× overcharge from randomized tool order).

## Changes

### Column
- New **Cache Hit Rate** column on both tables, right-aligned, visible by default (toggleable; existing saved layouts can opt in).
- Renders **`-`** when there are no input-side tokens (undefined rate, not `0%`), so non-LLM rows don't read as zero-cache.
- Session rows show the **token-weighted** session aggregate; expanded trace rows show per-trace rates.

### Filter
- New **Cache Hit Rate (%)** range filter — auto-rendered by the existing `numberRange` sidebar (no new UI component).
- Translates to a divide-by-zero-guarded **`HAVING`** clause on the aggregated token aliases, in both ClickHouse field registries (shared `buildCacheHitRateClause`):
  ```sql
  ( (tokens_input + tokens_cache_read + tokens_cache_create) > 0
    AND tokens_cache_read / (tokens_input + tokens_cache_read + tokens_cache_create) >= {p:Float64} / 100 )
  ```
- Gives both directions: `≤ 50%` to hunt broken-cache sessions, `≥ 80%` to confirm healthy ones.

### Shared helpers (`@repo/utils`)
- `cacheHitRate({ input, cacheRead, cacheCreate })` → ratio, or `null` when the denominator is 0.
- `formatPercentage(ratio)` → `"80%"`, `"33.3%"`.
- Placed in `@repo/utils` (already a universal dep) so LAT-689/690/691 reuse the same definition — no new package edges.

## Notable detail
The filter's wire value is an **integer percentage (0–100)**, not a 0–1 ratio: the `numberRange` UI rounds wire values to integers (`Math.round(value * displayScale)`), so a fractional scale silently collapsed any sub-50% input to `0`. The SQL divides by 100. Documented at the field def so it isn't "fixed" back.

## Scope / no migration
Token sums already flow to the frontend and are aggregated in the `traces`/`sessions` rollups, so **no ClickHouse schema, API, or migration changes**. Aggregate cache-hit % across filtered sessions + over-time graphs are LAT-689; not in scope here.

## Verification
- Live-verified by the author against local data: column renders, the filter min field holds typed values (the reset-to-0 bug is fixed), and filtering narrows rows.
- Tests: `@repo/utils` (cacheHitRate null/0/ratio, formatPercentage) and `@platform/db-clickhouse` (`helpers.test.ts`: clause SQL, lte, bad-op throw, range integration). Typecheck clean across `@repo/utils`, `@domain/shared`, `@platform/db-clickhouse`, `@app/web`.

Fixes LAT-687

🤖 Generated with [Claude Code](https://claude.com/claude-code)