### PR TITLE
feat(flaggers): add low-cache-hit-rate flagger

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -600,7 +600,8 @@
                 "trashing",
                 "tool-call-errors",
                 "output-schema-validation",
-                "empty-response"
+                "empty-response",
+                "low-cache-hit-rate"
               ]
             },
             "additionalProperties": {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -294,6 +294,9 @@
               },
               "empty-response": {
                 "type": "boolean"
+              },
+              "low-cache-hit-rate": {
+                "type": "boolean"
               }
             },
             "description": "Enable or disable specific flaggers for the project. Keys are flagger slugs; values are the new `enabled` state. Omitted slugs are left untouched."

--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -37,6 +37,7 @@ export const FLAGGER_USE_CASE_PRESETS = [
       "forgetting",
       "output-schema-validation",
       "frustration",
+      "low-cache-hit-rate",
     ],
   },
   {
@@ -49,13 +50,20 @@ export const FLAGGER_USE_CASE_PRESETS = [
     id: "tool-workflow-agent",
     label: "Tool workflow agent",
     description: "Agents that coordinate tools, APIs, and structured workflows.",
-    enabledSlugs: ["tool-call-errors", "trashing", "output-schema-validation", "empty-response", "laziness"],
+    enabledSlugs: [
+      "tool-call-errors",
+      "trashing",
+      "output-schema-validation",
+      "empty-response",
+      "laziness",
+      "low-cache-hit-rate",
+    ],
   },
   {
     id: "knowledge-base-agent",
     label: "Knowledge-base agent",
     description: "RAG and documentation assistants that need to preserve context and answer directly.",
-    enabledSlugs: ["forgetting", "refusal", "empty-response", "frustration", "laziness"],
+    enabledSlugs: ["forgetting", "refusal", "empty-response", "frustration", "laziness", "low-cache-hit-rate"],
   },
   {
     id: "structured-extraction-agent",
@@ -97,6 +105,12 @@ export const FLAGGER_GROUPS = [
     description: "LLM-based detection of failure modes in the agent's own output.",
     slugs: ["refusal", "laziness", "forgetting", "trashing"],
   },
+  {
+    id: "cost-efficiency",
+    label: "Cost & efficiency",
+    description: "Free deterministic checks for token waste and broken caching.",
+    slugs: ["low-cache-hit-rate"],
+  },
 ] as const satisfies ReadonlyArray<FlaggerGroup>
 
 // Compile-time assertion: FLAGGER_GROUPS must cover every FLAGGER_STRATEGY_SLUG. If a new slug
@@ -114,6 +128,7 @@ const ONBOARDING_GROUP_ORDER: ReadonlyArray<(typeof FLAGGER_GROUPS)[number]["id"
   "user-signals",
   "agent-behavior",
   "response-validity",
+  "cost-efficiency",
 ]
 
 export const FLAGGER_ONBOARDING_ORDER: ReadonlyArray<FlaggerPresetSlug> = ONBOARDING_GROUP_ORDER.flatMap(

--- a/packages/domain/flaggers/src/flagger-strategies/index.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/index.ts
@@ -3,6 +3,7 @@ import { forgettingStrategy } from "./forgetting.ts"
 import { frustrationStrategy } from "./frustration.ts"
 import { jailbreakingStrategy } from "./jailbreaking.ts"
 import { lazinessStrategy } from "./laziness.ts"
+import { lowCacheHitRateStrategy } from "./low-cache-hit-rate.ts"
 import { nsfwStrategy } from "./nsfw.ts"
 import { outputSchemaValidationStrategy } from "./output-schema-validation.ts"
 import { refusalStrategy } from "./refusal.ts"
@@ -30,6 +31,7 @@ const STRATEGY_REGISTRY = {
   "tool-call-errors": toolCallErrorsStrategy,
   "output-schema-validation": outputSchemaValidationStrategy,
   "empty-response": emptyResponseStrategy,
+  "low-cache-hit-rate": lowCacheHitRateStrategy,
 } satisfies Record<FlaggerSlug, FlaggerStrategy>
 
 ;(() => {
@@ -78,6 +80,7 @@ export {
   frustrationStrategy,
   jailbreakingStrategy,
   lazinessStrategy,
+  lowCacheHitRateStrategy,
   nsfwStrategy,
   outputSchemaValidationStrategy,
   refusalStrategy,

--- a/packages/domain/flaggers/src/flagger-strategies/low-cache-hit-rate.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/low-cache-hit-rate.test.ts
@@ -1,0 +1,104 @@
+import type { TraceDetail } from "@domain/spans"
+import { describe, expect, it } from "vitest"
+
+import { lowCacheHitRateStrategy } from "./low-cache-hit-rate.ts"
+import { assistant, makeTrace, user } from "./test-helpers.ts"
+
+type Tokens = Pick<TraceDetail, "tokensInput" | "tokensCacheRead" | "tokensCacheCreate">
+
+const multiTurn = [user("a long first question"), assistant("a long answer"), user("a follow-up"), assistant("more")]
+
+const makeCacheTrace = (messages: readonly TraceDetail["allMessages"][number][], tokens: Tokens): TraceDetail => ({
+  ...makeTrace(messages),
+  ...tokens,
+})
+
+describe("lowCacheHitRateStrategy.detectDeterministically", () => {
+  describe("matched on low hit rate", () => {
+    it("matches a large multi-turn trace whose cache is active but barely read", () => {
+      // 4% hit rate: caching is on (8k written) but almost nothing is read back.
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 40_000,
+        tokensCacheRead: 2_000,
+        tokensCacheCreate: 8_000,
+      })
+      const result = lowCacheHitRateStrategy.detectDeterministically?.(trace)
+      expect(result?.kind).toBe("matched")
+      if (result?.kind === "matched") {
+        expect(result.feedback).toContain("Low cache hit rate (4%)")
+        expect(result.feedback).toContain("50K input tokens")
+      }
+    })
+
+    it("matches at the input-volume boundary (exactly the minimum)", () => {
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 18_000,
+        tokensCacheRead: 1_000,
+        tokensCacheCreate: 1_000,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace).kind).toBe("matched")
+    })
+  })
+
+  describe("no-match guards against false positives", () => {
+    it("no-match on a single-turn trace (nothing to read back yet)", () => {
+      const trace = makeCacheTrace([user("one big prompt"), assistant("answer")], {
+        tokensInput: 40_000,
+        tokensCacheRead: 0,
+        tokensCacheCreate: 30_000,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match when total input is below the minimum (caching not worth it)", () => {
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 4_000,
+        tokensCacheRead: 0,
+        tokensCacheCreate: 1_000,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match when no cache was ever written (caching absent/unsupported)", () => {
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 50_000,
+        tokensCacheRead: 0,
+        tokensCacheCreate: 0,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match on a healthy hit rate", () => {
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 5_000,
+        tokensCacheRead: 40_000,
+        tokensCacheCreate: 5_000,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match exactly at the hit-rate threshold (30%)", () => {
+      const trace = makeCacheTrace(multiTurn, {
+        tokensInput: 60_000,
+        tokensCacheRead: 30_000,
+        tokensCacheCreate: 10_000,
+      })
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match on an empty trace with no tokens", () => {
+      expect(lowCacheHitRateStrategy.detectDeterministically?.(makeTrace([]))).toEqual({ kind: "no-match" })
+    })
+  })
+
+  describe("hasRequiredContext", () => {
+    it("is true when there are any input-side tokens", () => {
+      const trace = makeCacheTrace(multiTurn, { tokensInput: 1, tokensCacheRead: 0, tokensCacheCreate: 0 })
+      expect(lowCacheHitRateStrategy.hasRequiredContext(trace)).toBe(true)
+    })
+
+    it("is false when there are no input-side tokens", () => {
+      expect(lowCacheHitRateStrategy.hasRequiredContext(makeTrace([]))).toBe(false)
+    })
+  })
+})

--- a/packages/domain/flaggers/src/flagger-strategies/low-cache-hit-rate.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/low-cache-hit-rate.ts
@@ -1,0 +1,26 @@
+import type { TraceDetail } from "@domain/spans"
+import { detectLowCacheHitRateFlagger } from "../helpers.ts"
+import type { DetectionResult, FlaggerStrategy } from "./types.ts"
+
+/**
+ * Deterministic-only strategy. Flags large multi-turn traces where prompt
+ * caching is active but the cache hit rate is unexpectedly low — the signature
+ * of a broken cache implementation that silently multiplies token cost. Reads
+ * the trace's aggregated token counts; never calls an LLM.
+ */
+export const lowCacheHitRateStrategy: FlaggerStrategy = {
+  details: {
+    name: "Low cache hit rate",
+    description:
+      "Flags large multi-turn traces where caching is active but the hit rate is unexpectedly low, signaling broken caching, without calling an LLM.",
+  },
+
+  hasRequiredContext(trace: TraceDetail): boolean {
+    return trace.tokensInput + trace.tokensCacheRead + trace.tokensCacheCreate > 0
+  },
+
+  detectDeterministically(trace: TraceDetail): DetectionResult {
+    const result = detectLowCacheHitRateFlagger(trace)
+    return result.matched ? { kind: "matched", feedback: result.feedback } : { kind: "no-match" }
+  },
+}

--- a/packages/domain/flaggers/src/flagger-strategies/types.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/types.ts
@@ -13,6 +13,7 @@ export const FLAGGER_STRATEGY_SLUGS = [
   "tool-call-errors",
   "output-schema-validation",
   "empty-response",
+  "low-cache-hit-rate",
 ] as const
 
 export type FlaggerSlug = (typeof FLAGGER_STRATEGY_SLUGS)[number]

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -1,4 +1,5 @@
 import type { TraceDetail } from "@domain/spans"
+import { cacheHitRate, formatCount, formatPercentage } from "@repo/utils"
 
 type TraceMessagesOnly = Pick<TraceDetail, "allMessages">
 
@@ -6,6 +7,19 @@ const TOOL_RESULT_ERROR_STATUSES = new Set(["error", "failed", "failure"])
 const EXPECTED_TOOL_HTTP_STATUS_MIN = 400
 const EXPECTED_TOOL_HTTP_STATUS_MAX = 499
 const ERROR_SNIPPET_MAX_LENGTH = 160
+
+// Below this fraction of input tokens served from cache, caching is essentially
+// not working: a healthy multi-turn agent re-reads the great majority of its
+// repeated context. Kept conservative (30%) so only clearly-broken caching is
+// flagged, not merely suboptimal hit rates.
+const LOW_CACHE_HIT_RATE_THRESHOLD = 0.3
+// Caching only matters at scale — providers require ~1k tokens per cache block,
+// and a low rate on a small prompt is not a meaningful overcharge.
+const MIN_TOTAL_INPUT_TOKENS = 20_000
+// Caching only pays off when earlier context is re-sent on a later turn; a
+// single-turn trace has nothing to read back, so cacheCreate>0 / cacheRead=0 is
+// expected there, not broken. Four messages guarantees at least one follow-up.
+const MIN_CACHEABLE_MESSAGES = 4
 
 export type DeterministicFlaggerMatch =
   | { readonly matched: true; readonly feedback: string; readonly messageIndex?: number | undefined }
@@ -256,4 +270,33 @@ export function detectEmptyResponseFlagger(trace: TraceDetail): DeterministicFla
   }
 
   return NO_MATCH
+}
+
+type CacheTrace = Pick<TraceDetail, "allMessages" | "tokensInput" | "tokensCacheRead" | "tokensCacheCreate">
+
+/**
+ * Flags large multi-turn traces where prompt caching is active but the hit rate
+ * is unexpectedly low — the signal a broken cache implementation produces (e.g.
+ * nondeterministic prompt/tool-payload ordering, session resets, or context
+ * compaction), which can multiply token cost. Guards against false positives:
+ * single-turn or tiny-input traces, and traces where no cache was ever written,
+ * never match. Never calls an LLM.
+ */
+export function detectLowCacheHitRateFlagger(trace: CacheTrace): DeterministicFlaggerMatch {
+  if (trace.allMessages.length < MIN_CACHEABLE_MESSAGES) return NO_MATCH
+  if (trace.tokensCacheCreate <= 0) return NO_MATCH
+
+  const totalInput = trace.tokensInput + trace.tokensCacheRead + trace.tokensCacheCreate
+  if (totalInput < MIN_TOTAL_INPUT_TOKENS) return NO_MATCH
+
+  const rate = cacheHitRate({
+    input: trace.tokensInput,
+    cacheRead: trace.tokensCacheRead,
+    cacheCreate: trace.tokensCacheCreate,
+  })
+  if (rate === null || rate >= LOW_CACHE_HIT_RATE_THRESHOLD) return NO_MATCH
+
+  return match(
+    `Low cache hit rate (${formatPercentage(rate)}) on a large multi-turn trace (${formatCount(totalInput)} input tokens): most context was re-sent uncached instead of read from cache. This usually means a broken cache implementation (nondeterministic prompt or tool-payload ordering, session resets, or context compaction) and can multiply token cost.`,
+  )
 }

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -26,6 +26,7 @@ export {
   jailbreakingStrategy,
   lazinessStrategy,
   listFlaggerStrategySlugs,
+  lowCacheHitRateStrategy,
   MAX_EXCERPT_LENGTH,
   MAX_SNIPPET_EXCERPT_LENGTH,
   MAX_STAGES_PER_PROMPT,
@@ -45,6 +46,7 @@ export { FLAGGER_STRATEGY_SLUGS } from "./flagger-strategies/types.ts"
 export {
   type DeterministicFlaggerMatch,
   detectEmptyResponseFlagger,
+  detectLowCacheHitRateFlagger,
   detectOutputSchemaValidationFlagger,
   detectToolCallErrorsFlagger,
 } from "./helpers.ts"

--- a/packages/sdk/python/src/latitude_sdk/projects/types/update_project_body_flaggers.py
+++ b/packages/sdk/python/src/latitude_sdk/projects/types/update_project_body_flaggers.py
@@ -25,5 +25,8 @@ class UpdateProjectBodyFlaggers(UniversalBaseModel):
         typing.Optional[bool], FieldMetadata(alias="output-schema-validation")
     ] = None
     empty_response: typing_extensions.Annotated[typing.Optional[bool], FieldMetadata(alias="empty-response")] = None
+    low_cache_hit_rate: typing_extensions.Annotated[
+        typing.Optional[bool], FieldMetadata(alias="low-cache-hit-rate")
+    ] = None
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/packages/sdk/typescript/src/api/resources/projects/client/requests/UpdateProjectBody.ts
+++ b/packages/sdk/typescript/src/api/resources/projects/client/requests/UpdateProjectBody.ts
@@ -29,5 +29,6 @@ export namespace UpdateProjectBody {
         "tool-call-errors"?: boolean | undefined;
         "output-schema-validation"?: boolean | undefined;
         "empty-response"?: boolean | undefined;
+        "low-cache-hit-rate"?: boolean | undefined;
     }
 }


### PR DESCRIPTION
## what

Adds a new deterministic flagger, `low-cache-hit-rate`, that flags traces where prompt caching is active but the cache hit rate is unexpectedly low. This is the highest-confidence signature of a broken cache implementation — the failure mode Teeming reported, where randomized tool-payload ordering broke caching, dropped the hit rate to near zero, and produced a ~7× token overcharge.

Like `tool-call-errors` and `empty-response`, it's deterministic-only: it reads the trace's aggregated token counts and never calls an LLM, so it runs free on every trace.

## the signal

A trace matches only when **all** of these hold:

- **Multi-turn** — `allMessages.length >= 4`. Caching only pays off when earlier context is re-sent on a later turn. A single-turn trace has nothing to read back yet, so `cacheCreate > 0 / cacheRead = 0` is expected there, not broken.
- **Caching is active** — `tokensCacheCreate > 0`. The provider actually wrote cache entries, which proves the content is cacheable and caching is enabled. This scopes the flag to *broken* caching rather than *absent/unsupported* caching, avoiding false positives for models/providers that don't cache at all.
- **Meaningful input volume** — total input (`input + cacheRead + cacheCreate`) `>= 20,000` tokens. Caching only matters at scale (providers require ~1k tokens per cache block), and a low rate on a small prompt isn't a meaningful overcharge.
- **Unexpectedly low hit rate** — `cacheHitRate < 0.3`. A healthy multi-turn agent reads back the large majority of its repeated context (typically 80–95%). Below 30% means most input is being re-sent uncached. The threshold is deliberately conservative so only clearly-broken caching is flagged, not merely suboptimal hit rates.

The hit rate uses the shared `cacheHitRate({ input, cacheRead, cacheCreate })` helper from `@repo/utils` (added in #3651) — the formula is not redefined here.

## granularity

The flagger framework operates per-trace, so the check runs on each trace's aggregated token counts. The resulting annotation is keyed with the trace's `sessionId`, so a match still surfaces at the session level the customer watches. No DB migration is needed — `flaggers.slug` is a `varchar(64)`, and provisioning iterates the strategy slug list automatically.

## reasoning on false positives

The four guards are defense-in-depth against the brief's hard constraint that single-turn or tiny-input traces must never flag. The residual edge case — a single large multi-message prompt (e.g. heavy few-shot) that writes cache and reads none — is rare and intentionally not special-cased; a single-turn tool loop that fails to reuse cache across rounds *is* a real cache problem and correctly flags.

"Caching entirely absent on a large multi-turn agent" is intentionally out of scope: `cacheCreate = 0` is ambiguous (could be a provider/model that doesn't support caching), so flagging it would risk cross-provider false positives.

## changes

- `low-cache-hit-rate` slug added to the `FLAGGER_STRATEGY_SLUGS` union and the strategy registry.
- `detectLowCacheHitRateFlagger` helper + `lowCacheHitRateStrategy` deterministic strategy, mirroring the existing deterministic strategies.
- Web settings: new "Cost & efficiency" flagger group (satisfies the compile-time group-exhaustiveness check) and the slug added to the multi-turn-heavy use-case presets (coding, tool-workflow, knowledge-base).
- Regenerated `apps/api/openapi.json` + `mcp.json` and the Fern TS/Python SDKs — additive, just the new optional slug key.

## tests

`low-cache-hit-rate.test.ts` covers a match, both threshold boundaries (input volume and hit rate), and each false-positive guard (single-turn, sub-threshold input, no cache written, healthy rate, empty trace). Full `@domain/flaggers` suite passes; package typecheck and web typecheck pass.

Fixes LAT-690

🤖 Generated with [Claude Code](https://claude.com/claude-code)