### PR TITLE
chore: drop stale langchain knip ignore entry

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -135,7 +135,6 @@
       "ignoreDependencies": [
         "@sentry/node",
         "dd-trace",
-        "langchain",
         "together-ai"
       ]
     },


### PR DESCRIPTION
`pnpm knip` reported one lingering configuration hint:

```
Configuration hints (1)
langchain  packages/telemetry/typescript  knip.json  Remove from ignoreDependencies
```

The bare `langchain` package is no longer a dependency of
`@latitude-data/telemetry` (only the scoped `@langchain/*` and
`@traceloop/instrumentation-langchain` packages remain), so the
`ignoreDependencies` entry is dead config. Removing it clears the hint.

Pre-existing (the entry dates back to #3138) — unrelated to the token-analytics
work; surfaced while QA-ing knip on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)