### PR TITLE
fix(web): settings scroll layout + flagger catalog visibility

### DIFF
--- a/apps/web/src/domains/flaggers/flaggers.functions.ts
+++ b/apps/web/src/domains/flaggers/flaggers.functions.ts
@@ -1,5 +1,6 @@
 import {
   configureProjectFlaggersForOnboardingUseCase,
+  FLAGGER_DEFAULT_SAMPLING,
   FLAGGER_STRATEGY_SLUGS,
   FlaggerRepository,
   type FlaggerSlug,
@@ -54,6 +55,34 @@ const toFlaggerRecord = (flagger: {
 
 export type FlaggerRecord = ReturnType<typeof toFlaggerRecord>
 
+// A registered strategy a project has no stored row for yet: shown disabled in
+// settings without writing to the DB. The placeholder id is the slug; the real
+// row (with a real id) replaces it on the next read once the user enables it.
+const toMissingFlaggerRecord = (slug: FlaggerSlug, organizationId: string, projectId: string): FlaggerRecord => {
+  const strategy = getFlaggerStrategy(slug)
+  const details = strategy && isLlmCapableStrategy(strategy) ? strategy.annotator : strategy?.details
+  const epoch = new Date(0).toISOString()
+
+  return {
+    id: slug,
+    organizationId,
+    projectId,
+    slug,
+    name: details?.name ?? humanizeSlug(slug),
+    description: details?.description ?? "Flags matching trace behavior for review.",
+    instructions:
+      strategy && isLlmCapableStrategy(strategy)
+        ? strategy.annotator.instructions
+        : "Runs deterministically from telemetry data and does not call an LLM.",
+    enabled: false,
+    sampling: FLAGGER_DEFAULT_SAMPLING,
+    mode: strategy && isLlmCapableStrategy(strategy) ? "llm" : "deterministic",
+    suppressedBy: strategy?.suppressedBy ?? [],
+    createdAt: epoch,
+    updatedAt: epoch,
+  }
+}
+
 const toAvailableFlaggerRecord = (slug: FlaggerSlug) => {
   const strategy = getFlaggerStrategy(slug)
   const details = strategy && isLlmCapableStrategy(strategy) ? strategy.annotator : strategy?.details
@@ -83,14 +112,21 @@ export const listFlaggersByProject = createServerFn({ method: "GET" })
     const projectId = ProjectId(data.projectId)
     const client = getPostgresClient()
 
-    const flaggers = await Effect.runPromise(
+    const stored = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* FlaggerRepository
         return yield* repo.listByProject({ projectId })
       }).pipe(withPostgres(FlaggerRepositoryLive, client, orgId), withTracing),
     )
 
-    return flaggers.map(toFlaggerRecord)
+    // Render the full strategy catalog: stored rows carry the project's config,
+    // and any strategy without a row (e.g. one shipped after the project was
+    // provisioned) shows disabled until the user enables it — no back-fill.
+    const storedBySlug = new Map(stored.map((flagger) => [flagger.slug, flagger]))
+    return FLAGGER_STRATEGY_SLUGS.map((slug) => {
+      const row = storedBySlug.get(slug)
+      return row ? toFlaggerRecord(row) : toMissingFlaggerRecord(slug, organizationId, data.projectId)
+    })
   })
 
 export const configureProjectFlaggersForOnboarding = createServerFn({ method: "POST" })
@@ -136,13 +172,20 @@ export const updateFlagger = createServerFn({ method: "POST" })
     const client = getPostgresClient()
 
     const flagger = await Effect.runPromise(
-      updateFlaggerUseCase({
-        organizationId,
-        projectId,
-        slug: data.slug,
-        enabled: data.enabled,
-        sampling: data.sampling,
-        actorUserId: userId,
+      Effect.gen(function* () {
+        // Ensure a row exists for strategies the project was never provisioned
+        // (shown disabled in settings); idempotent, then the update applies the
+        // user's enabled/sampling values.
+        const repo = yield* FlaggerRepository
+        yield* repo.saveManyForProject({ projectId, slugs: [data.slug] })
+        return yield* updateFlaggerUseCase({
+          organizationId,
+          projectId,
+          slug: data.slug,
+          enabled: data.enabled,
+          sampling: data.sampling,
+          actorUserId: userId,
+        })
       }).pipe(
         withPostgres(Layer.mergeAll(FlaggerRepositoryLive, OutboxEventWriterLive), client, orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),

--- a/apps/web/src/domains/flaggers/flaggers.functions.ts
+++ b/apps/web/src/domains/flaggers/flaggers.functions.ts
@@ -119,9 +119,6 @@ export const listFlaggersByProject = createServerFn({ method: "GET" })
       }).pipe(withPostgres(FlaggerRepositoryLive, client, orgId), withTracing),
     )
 
-    // Render the full strategy catalog: stored rows carry the project's config,
-    // and any strategy without a row (e.g. one shipped after the project was
-    // provisioned) shows disabled until the user enables it — no back-fill.
     const storedBySlug = new Map(stored.map((flagger) => [flagger.slug, flagger]))
     return FLAGGER_STRATEGY_SLUGS.map((slug) => {
       const row = storedBySlug.get(slug)
@@ -129,7 +126,9 @@ export const listFlaggersByProject = createServerFn({ method: "GET" })
     })
   })
 
-export const configureProjectFlaggersForOnboarding = createServerFn({ method: "POST" })
+export const configureProjectFlaggersForOnboarding = createServerFn({
+  method: "POST",
+})
   .inputValidator(
     z.object({
       projectId: z.string(),
@@ -172,20 +171,13 @@ export const updateFlagger = createServerFn({ method: "POST" })
     const client = getPostgresClient()
 
     const flagger = await Effect.runPromise(
-      Effect.gen(function* () {
-        // Ensure a row exists for strategies the project was never provisioned
-        // (shown disabled in settings); idempotent, then the update applies the
-        // user's enabled/sampling values.
-        const repo = yield* FlaggerRepository
-        yield* repo.saveManyForProject({ projectId, slugs: [data.slug] })
-        return yield* updateFlaggerUseCase({
-          organizationId,
-          projectId,
-          slug: data.slug,
-          enabled: data.enabled,
-          sampling: data.sampling,
-          actorUserId: userId,
-        })
+      updateFlaggerUseCase({
+        organizationId,
+        projectId,
+        slug: data.slug,
+        enabled: data.enabled,
+        sampling: data.sampling,
+        actorUserId: userId,
       }).pipe(
         withPostgres(Layer.mergeAll(FlaggerRepositoryLive, OutboxEventWriterLive), client, orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),

--- a/apps/web/src/domains/flaggers/presets.ts
+++ b/apps/web/src/domains/flaggers/presets.ts
@@ -94,6 +94,12 @@ export const FLAGGER_GROUPS = [
     slugs: ["empty-response", "tool-call-errors", "output-schema-validation"],
   },
   {
+    id: "cost-efficiency",
+    label: "Cost & efficiency",
+    description: "Free deterministic checks for token waste and broken caching.",
+    slugs: ["low-cache-hit-rate"],
+  },
+  {
     id: "user-signals",
     label: "User-side signals",
     description: "LLM-based detection of risky or unhappy user behavior.",
@@ -104,12 +110,6 @@ export const FLAGGER_GROUPS = [
     label: "Agent behavior",
     description: "LLM-based detection of failure modes in the agent's own output.",
     slugs: ["refusal", "laziness", "forgetting", "trashing"],
-  },
-  {
-    id: "cost-efficiency",
-    label: "Cost & efficiency",
-    description: "Free deterministic checks for token waste and broken caching.",
-    slugs: ["low-cache-hit-rate"],
   },
 ] as const satisfies ReadonlyArray<FlaggerGroup>
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -35,5 +35,6 @@ declare module "@tanstack/react-router" {
     readonly breadcrumb?: import("react").ComponentType
     /** When true, the project sidebar auto-collapses for this route. */
     readonly collapseSidebar?: boolean
+    readonly fillHeight?: boolean
   }
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
@@ -1,5 +1,6 @@
-import { Container } from "@repo/ui"
+import { Container, cn } from "@repo/ui"
 import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { useHasMatchStaticData } from "../../../../lib/hooks/use-router-selectors.ts"
 import { BreadcrumbText } from "../../-components/breadcrumb-ui.tsx"
 import { SettingsSubNav } from "./settings/-components/settings-sub-nav.tsx"
 
@@ -13,11 +14,16 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
 
 function SettingsLayout() {
   const { projectSlug } = Route.useParams()
+  const fillHeight = useHasMatchStaticData((staticData) => staticData?.fillHeight === true)
   return (
     <div className="flex h-full min-w-0">
       <SettingsSubNav projectSlug={projectSlug} />
-      <main className="flex-1 min-w-0 flex flex-col overflow-hidden">
-        <Container className="@container flex flex-1 min-h-0 flex-col gap-8 px-6 pt-6 overflow-y-auto">
+      <main className={cn("flex-1 min-w-0 flex flex-col", fillHeight ? "overflow-hidden" : "overflow-y-auto")}>
+        <Container
+          className={cn("@container flex flex-col gap-8 px-6 pt-6", {
+            "flex-1 min-h-0 overflow-hidden": fillHeight,
+          })}
+        >
           <Outlet />
         </Container>
       </main>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId.tsx
@@ -9,7 +9,10 @@ import { DestinationRunsTable } from "../-components/destination-runs-table.tsx"
 import { destinationsQueryKey } from "../-components/destinations-section.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId")(
-  { component: DestinationDetailPage },
+  {
+    staticData: { fillHeight: true },
+    component: DestinationDetailPage,
+  },
 )
 
 function BackLink({ projectSlug }: { readonly projectSlug: string }) {

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -75,6 +75,11 @@ export {
   draftFlaggerAnnotationWithBillingUseCase,
 } from "./use-cases/draft-flagger-annotation-with-billing.ts"
 export {
+  type FindOrCreateFlaggerError,
+  type FindOrCreateFlaggerInput,
+  findOrCreateFlaggerUseCase,
+} from "./use-cases/find-or-create-flagger.ts"
+export {
   type FlaggerAnnotateInput,
   type FlaggerAnnotateOutput,
   type FlaggerAnnotatorOutput,

--- a/packages/domain/flaggers/src/use-cases/find-or-create-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/find-or-create-flagger.test.ts
@@ -1,0 +1,82 @@
+import { FlaggerId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { FLAGGER_DEFAULT_SAMPLING } from "../constants.ts"
+import type { Flagger } from "../entities/flagger.ts"
+import { FLAGGER_DEFAULT_ENABLED } from "../entities/flagger.ts"
+import { FlaggerRepository } from "../ports/flagger-repository.ts"
+import { createFakeFlaggerRepository } from "../testing/fake-flagger-repository.ts"
+import { findOrCreateFlaggerUseCase } from "./find-or-create-flagger.ts"
+
+const ORG_ID = OrganizationId("o".repeat(24))
+const PROJECT_ID = ProjectId("p".repeat(24))
+
+const makeLayer = (repository: ReturnType<typeof createFakeFlaggerRepository>["repository"]) =>
+  Layer.mergeAll(
+    Layer.succeed(FlaggerRepository, repository),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+  )
+
+describe("findOrCreateFlaggerUseCase", () => {
+  it("returns the existing row untouched without creating a duplicate", async () => {
+    const seed: Flagger = {
+      id: FlaggerId("jailbreaking".padEnd(24, "x").slice(0, 24)),
+      organizationId: ORG_ID,
+      projectId: PROJECT_ID,
+      slug: "jailbreaking",
+      enabled: false,
+      sampling: 25,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    const { repository, flaggers } = createFakeFlaggerRepository([seed])
+
+    const result = await Effect.runPromise(
+      findOrCreateFlaggerUseCase({ projectId: PROJECT_ID, slug: "jailbreaking" }).pipe(
+        Effect.provide(makeLayer(repository)),
+      ),
+    )
+
+    expect(result?.id).toBe(seed.id)
+    expect(result?.enabled).toBe(false)
+    expect(result?.sampling).toBe(25)
+    expect(flaggers.size).toBe(1)
+  })
+
+  it("creates the row with defaults when the project has none for the slug", async () => {
+    const { repository, flaggers } = createFakeFlaggerRepository([])
+
+    const result = await Effect.runPromise(
+      findOrCreateFlaggerUseCase({ projectId: PROJECT_ID, slug: "low-cache-hit-rate" }).pipe(
+        Effect.provide(makeLayer(repository)),
+      ),
+    )
+
+    expect(result?.slug).toBe("low-cache-hit-rate")
+    expect(result?.projectId).toBe(PROJECT_ID)
+    expect(result?.organizationId).toBe(ORG_ID)
+    expect(result?.enabled).toBe(FLAGGER_DEFAULT_ENABLED)
+    expect(result?.sampling).toBe(FLAGGER_DEFAULT_SAMPLING)
+    expect(flaggers.size).toBe(1)
+  })
+
+  it("is idempotent: a second call returns the same row and creates no duplicate", async () => {
+    const { repository, flaggers } = createFakeFlaggerRepository([])
+
+    const first = await Effect.runPromise(
+      findOrCreateFlaggerUseCase({ projectId: PROJECT_ID, slug: "low-cache-hit-rate" }).pipe(
+        Effect.provide(makeLayer(repository)),
+      ),
+    )
+    const second = await Effect.runPromise(
+      findOrCreateFlaggerUseCase({ projectId: PROJECT_ID, slug: "low-cache-hit-rate" }).pipe(
+        Effect.provide(makeLayer(repository)),
+      ),
+    )
+
+    expect(first?.id).toBeDefined()
+    expect(second?.id).toBe(first?.id)
+    expect(flaggers.size).toBe(1)
+  })
+})

--- a/packages/domain/flaggers/src/use-cases/find-or-create-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/find-or-create-flagger.ts
@@ -1,0 +1,37 @@
+import type { ProjectId, RepositoryError } from "@domain/shared"
+import { Effect } from "effect"
+import type { FlaggerSlug } from "../flagger-strategies/types.ts"
+import { FlaggerRepository } from "../ports/flagger-repository.ts"
+
+export interface FindOrCreateFlaggerInput {
+  readonly projectId: ProjectId
+  readonly slug: FlaggerSlug
+}
+
+export type FindOrCreateFlaggerError = RepositoryError
+
+/**
+ * Returns the project's flagger row for `slug`, creating it with default
+ * `enabled`/`sampling` when the project was never provisioned that strategy
+ * (e.g. a flagger that shipped after the project existed). Idempotent via the
+ * repository's `(organization_id, project_id, slug)` unique index, so it is
+ * safe to run inside the update transaction and under concurrent callers.
+ */
+export const findOrCreateFlaggerUseCase = Effect.fn("flaggers.findOrCreateFlagger")(function* (
+  input: FindOrCreateFlaggerInput,
+) {
+  yield* Effect.annotateCurrentSpan("flagger.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("flagger.slug", input.slug)
+
+  const repository = yield* FlaggerRepository
+
+  const existing = yield* repository.findByProjectAndSlug({ projectId: input.projectId, slug: input.slug })
+  if (existing) return existing
+
+  const [created] = yield* repository.saveManyForProject({ projectId: input.projectId, slugs: [input.slug] })
+  if (created) return created
+
+  // Lost the insert race to a concurrent writer: the conflicting insert was
+  // ignored, so re-read the row that now exists.
+  return yield* repository.findByProjectAndSlug({ projectId: input.projectId, slug: input.slug })
+})

--- a/packages/domain/flaggers/src/use-cases/process-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/process-flaggers.test.ts
@@ -561,4 +561,89 @@ describe("processFlaggersUseCase", () => {
       expect(decision.action).not.toBe("failed")
     }
   })
+
+  describe("low-cache-hit-rate (deterministic, token-driven)", () => {
+    // A large multi-turn trace where caching is active but most context is
+    // re-sent uncached. Thresholds: >=4 messages, cacheCreate>0, total input
+    // >=20k tokens, cacheRead/total < 30%.
+    const multiTurnMessages: TraceDetail["allMessages"] = [
+      { role: "user", parts: [{ type: "text", content: "Summarize the attached contract." }] },
+      { role: "assistant", parts: [{ type: "text", content: "Here is the summary." }] },
+      { role: "user", parts: [{ type: "text", content: "Now compare it to last year's." }] },
+      { role: "assistant", parts: [{ type: "text", content: "Comparing the two versions." }] },
+    ]
+
+    it("writes a flagger-authored score on a low-cache-hit-rate match", async () => {
+      const trace: TraceDetail = {
+        ...makeTraceDetail(multiTurnMessages),
+        // total = 22_000 (>=20k), rate = 2_000 / 22_000 ≈ 9% (<30%), cacheCreate > 0
+        tokensInput: 18_000,
+        tokensCacheRead: 2_000,
+        tokensCacheCreate: 2_000,
+      }
+
+      const { result, scores } = await runUseCase(trace, [makeFlagger("low-cache-hit-rate", 0)], deps)
+
+      expect(decisionFor(result.decisions, "low-cache-hit-rate")).toEqual({
+        slug: "low-cache-hit-rate",
+        action: "matched-issue",
+      })
+      const annotationScores = [...scores.values()].filter(
+        (score) => score.sourceType === "annotation" && score.metadata?.flaggerSlug === "low-cache-hit-rate",
+      )
+      expect(annotationScores).toHaveLength(1)
+      expect(annotationScores[0]?.sourceId).toBe("SYSTEM")
+      expect(deps.enqueued).toEqual([])
+    })
+
+    it("drops with no-match when the cache hit rate is healthy", async () => {
+      const trace: TraceDetail = {
+        ...makeTraceDetail(multiTurnMessages),
+        // rate = 18_000 / 22_000 ≈ 82% (>=30%) → not a low-cache trace
+        tokensInput: 2_000,
+        tokensCacheRead: 18_000,
+        tokensCacheCreate: 2_000,
+      }
+
+      const { result, scores } = await runUseCase(trace, [makeFlagger("low-cache-hit-rate", 0)], deps)
+
+      expect(decisionFor(result.decisions, "low-cache-hit-rate")).toEqual({
+        slug: "low-cache-hit-rate",
+        action: "dropped",
+        reason: "no-match",
+      })
+      expect(scores.size).toBe(0)
+    })
+
+    it("drops with no-match when caching is inactive (no cache-create tokens)", async () => {
+      const trace: TraceDetail = {
+        ...makeTraceDetail(multiTurnMessages),
+        // 30k uncached input but caching never engaged → not a broken-cache signal
+        tokensInput: 30_000,
+        tokensCacheRead: 0,
+        tokensCacheCreate: 0,
+      }
+
+      const { result, scores } = await runUseCase(trace, [makeFlagger("low-cache-hit-rate", 0)], deps)
+
+      expect(decisionFor(result.decisions, "low-cache-hit-rate")).toEqual({
+        slug: "low-cache-hit-rate",
+        action: "dropped",
+        reason: "no-match",
+      })
+      expect(scores.size).toBe(0)
+    })
+
+    it("drops with missing-context when the trace has no token usage", async () => {
+      const trace = makeTraceDetail(multiTurnMessages)
+
+      const { result } = await runUseCase(trace, [makeFlagger("low-cache-hit-rate", 0)], deps)
+
+      expect(decisionFor(result.decisions, "low-cache-hit-rate")).toEqual({
+        slug: "low-cache-hit-rate",
+        action: "dropped",
+        reason: "missing-context",
+      })
+    })
+  })
 })

--- a/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
@@ -127,10 +127,10 @@ describe("updateFlaggerUseCase", () => {
     expect(deletedKeys).toEqual([`org:${ORG_ID}:flaggers:${PROJECT_ID}`])
   })
 
-  it("returns null and still evicts the cache when the row does not exist", async () => {
-    // Eviction runs unconditionally so a no-op update doesn't leave a stale
-    // cache entry around if the caller meant to invalidate state.
-    const { repository } = createFakeFlaggerRepository([])
+  it("creates the row when missing, applies the update, and evicts the cache", async () => {
+    // A strategy the project was never provisioned (shown disabled in settings)
+    // is created on demand so enabling it persists rather than being a no-op.
+    const { repository, flaggers } = createFakeFlaggerRepository([])
     const { layer: cacheLayer, deletedKeys } = createCacheLayer()
 
     const layer = Layer.mergeAll(
@@ -145,11 +145,13 @@ describe("updateFlaggerUseCase", () => {
         organizationId: ORG_ID,
         projectId: PROJECT_ID,
         slug: "jailbreaking",
-        enabled: false,
+        enabled: true,
       }).pipe(Effect.provide(layer)),
     )
 
-    expect(updated).toBeNull()
+    expect(updated?.slug).toBe("jailbreaking")
+    expect(updated?.enabled).toBe(true)
+    expect(flaggers.size).toBe(1)
     expect(deletedKeys).toEqual([`org:${ORG_ID}:flaggers:${PROJECT_ID}`])
   })
 
@@ -193,7 +195,7 @@ describe("updateFlaggerUseCase", () => {
     })
   })
 
-  it("does NOT emit FlaggerToggled when no matching row exists", async () => {
+  it("emits FlaggerToggled after creating a row that did not exist", async () => {
     const { repository } = createFakeFlaggerRepository([])
     const { layer: cacheLayer } = createCacheLayer()
     const { layer: outboxLayer, written } = createOutboxLayer()
@@ -210,11 +212,13 @@ describe("updateFlaggerUseCase", () => {
         organizationId: ORG_ID,
         projectId: PROJECT_ID,
         slug: "jailbreaking",
-        enabled: false,
+        enabled: true,
       }).pipe(Effect.provide(layer)),
     )
 
-    expect(written).toEqual([])
+    expect(written).toHaveLength(1)
+    expect(written[0]?.eventName).toBe("FlaggerToggled")
+    expect(written[0]?.payload).toMatchObject({ flaggerSlug: "jailbreaking", enabled: true })
   })
 
   it("succeeds even when no CacheStore is in the layer (eviction is best-effort)", async () => {

--- a/packages/domain/flaggers/src/use-cases/update-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect"
 import type { Flagger } from "../entities/flagger.ts"
 import type { FlaggerSlug } from "../flagger-strategies/types.ts"
 import { FlaggerRepository } from "../ports/flagger-repository.ts"
+import { findOrCreateFlaggerUseCase } from "./find-or-create-flagger.ts"
 import { evictProjectFlaggersUseCase } from "./get-project-flaggers.ts"
 
 export interface UpdateFlaggerInput {
@@ -34,6 +35,10 @@ export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function
   const updated = yield* sqlClient.transaction(
     Effect.gen(function* () {
       const repository = yield* FlaggerRepository
+      // Ensure a row exists for strategies the project was never provisioned
+      // (shown disabled in settings) so enabling one persists instead of being
+      // a silent no-op against a missing row.
+      yield* findOrCreateFlaggerUseCase({ projectId: input.projectId, slug: input.slug })
       const row = yield* repository.update({
         projectId: input.projectId,
         slug: input.slug,


### PR DESCRIPTION
## Summary

Two related settings fixes.

### Settings scroll layout
- Adds a `fillHeight` route static-data flag (alongside the existing `collapseSidebar`).
- The settings shell branches on it via the existing `useHasMatchStaticData` selector:
  - **Default routes** (flaggers, general, …) → full-width `main` scrolls, so the scrollbar sits at the viewport edge.
  - **`fillHeight` route** (destination detail) → `main` is a bounded, non-scrolling column and `Container` becomes `flex-1 min-h-0`, so the route owns its internal scroll. The destination runs table (`scrollAreaLayout="fill"`) then fills the available height and paginates internally instead of overflowing the centered container or being cropped.

This fixes the regression where moving the scroll onto the centered `Container` put the scrollbar in the middle of the layout and broke scrolling on every settings page.

### Flagger catalog visibility
- `listFlaggersByProject` now renders the **full strategy catalog**: stored rows carry the project's config, and any strategy without a row (e.g. `low-cache-hit-rate`, shipped after the project was provisioned) is synthesized as **disabled**. No back-fill / migration.
- `updateFlagger` ensures the row exists (idempotent `saveManyForProject`) before updating, because the repository `update` is UPDATE-only and would otherwise silently no-op when enabling a never-provisioned flagger. A row is created only when the user actually enables/configures a flagger — new flaggers show **off by default** until opted in, which is consistent with the pipeline only running flaggers that have rows.
- Reorders settings groups so the two free/deterministic groups (Response validity, Cost & efficiency) sit together ahead of the LLM-based groups (User-side signals, Agent behavior). Onboarding order is unchanged (`ONBOARDING_GROUP_ORDER`).

## Testing
- `pnpm --filter @app/web typecheck` passes.
- Manual: verify normal settings pages scroll at the viewport edge; destination detail table fills/paginates; flaggers settings shows the full catalog with new flaggers disabled, and enabling one persists across refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)