### PR TITLE
chore(release): add --yes and fail loudly on non-TTY in release.sh

### DIFF
--- a/.agents/skills/production-release/SKILL.md
+++ b/.agents/skills/production-release/SKILL.md
@@ -47,8 +47,11 @@ constraint:
    `X.Y.Z`.
 5. Commit both with the exact message `release: vX.Y.Z` and push to
    `origin/development`.
-5. Run `scripts/release.sh` (without an explicit version) so it tags the latest
-   `origin/development` commit with the next patch version.
+5. Run `scripts/release.sh --yes` (without an explicit version) so it tags the
+   latest `origin/development` commit with the next patch version. The `--yes`
+   flag is required when running non-interactively (agent or CI): the script's
+   confirmation prompt cannot be answered without a terminal, and without
+   `--yes` it exits with an error rather than tagging.
 
 Still obey all release invariants: never tag local-only commits, never promote
 via `main`, and stop to ask if the working tree or branch state makes the
@@ -81,7 +84,9 @@ release unsafe or ambiguous.
 5. Commit the changelog update with message `release: vX.Y.Z` (matching the
    release version exactly) and push it to `origin/development`.
 6. Run `scripts/release.sh [version]`. Use `--dry` first when you want to preview
-   the release summary without tagging.
+   the release summary without tagging. Pass `--yes` to skip the confirmation
+   prompt — always required when running without a terminal (agent or CI),
+   otherwise the script errors out instead of tagging.
 
 ## Changelog style
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,7 @@ export GIT_PAGER=cat
 
 usage() {
   cat <<EOF
-Usage: $0 [--patch|--minor|--major] [--dry] [version]
+Usage: $0 [--patch|--minor|--major] [--dry] [--yes] [version]
 
 Tags the latest origin/development commit for production and pushes the tag. Production deploys are
 triggered by pushed vX.Y.Z tags.
@@ -17,7 +17,8 @@ component. If no release tag exists yet, it starts at v0.1.0.
 
 Before tagging, prints a summary of the changes that will be deployed and asks
 for confirmation. Use --dry to print the summary only without creating or
-pushing the tag.
+pushing the tag. Use --yes to skip the confirmation prompt (required when
+running without a terminal, e.g. an agent or CI).
 
 Examples:
   $0
@@ -25,12 +26,14 @@ Examples:
   $0 --major
   $0 v1.2.3
   $0 --dry
+  $0 --yes
 EOF
 }
 
 bump_kind="patch"
 version=""
 dry_run=0
+assume_yes=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -52,6 +55,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --dry | --dry-run)
       dry_run=1
+      shift
+      ;;
+    -y | --yes)
+      assume_yes=1
       shift
       ;;
     v*)
@@ -163,14 +170,20 @@ if [ "${dry_run}" -eq 1 ]; then
   exit 0
 fi
 
-read -r -p "Tag latest origin/development commit ${target_sha} as ${version} and push to origin? [y/N] " response
-case "${response}" in
-  [yY] | [yY][eE][sS]) ;;
-  *)
-    echo "Aborted. No tag created."
-    exit 0
-    ;;
-esac
+if [ "${assume_yes}" -ne 1 ]; then
+  if [ ! -t 0 ]; then
+    echo "No terminal available to confirm the release. Re-run with --yes to tag ${version} non-interactively."
+    exit 1
+  fi
+  read -r -p "Tag latest origin/development commit ${target_sha} as ${version} and push to origin? [y/N] " response
+  case "${response}" in
+    [yY] | [yY][eE][sS]) ;;
+    *)
+      echo "Aborted. No tag created."
+      exit 0
+      ;;
+  esac
+fi
 
 echo "Tagging ${target_sha} as ${version}..."
 git tag "${version}" "${target_sha}"


### PR DESCRIPTION
## Why

During the v0.3.16 release, `scripts/release.sh` appeared to "fail" to push the tag when run from a non-interactive shell (an agent). It wasn't a real failure — the script confirms the production tag with an interactive `read` prompt. Without a terminal, `read` hits EOF, the empty answer falls into the default case, and the script prints `Aborted. No tag created.` and **exits `0`**. A silent no-op that looks like success and leaves no tag pushed.

## What

- Add a `-y | --yes` flag to `scripts/release.sh` that skips the confirmation prompt.
- When stdin is not a TTY and `--yes` was not passed, exit `1` with a clear message instead of silently aborting with `0`.
- Document the `--yes` requirement for non-interactive (agent / CI) runs in the `production-release` skill.

### Behavior matrix

| Context | Before | After |
| --- | --- | --- |
| Human in terminal | prompt | prompt (unchanged) |
| Agent/CI, no `--yes` | silent abort, exit `0` | clear error, exit `1` |
| Agent/CI with `--yes` | n/a | tags directly, no prompt |

## Notes

- Interactive human runs are unchanged.
- This only affects future releases; the v0.3.16 tag was already pushed (via `printf 'y\n' | ./scripts/release.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)