### PR TITLE
fix(demo): speed up sample project seeding

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -138,6 +138,17 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
   )
 }
 
+function SampleProjectStrip() {
+  return (
+    <div className="relative flex shrink-0 items-center justify-center gap-4 px-4 py-3 text-primary-foreground">
+      <Text.H6 color="white" className="text-center opacity-95">
+        This sample project uses lightweight seed data. Some features, including semantic search and behavior detail
+        drill-downs, may not be fully functional.
+      </Text.H6>
+    </div>
+  )
+}
+
 function ProjectLayout() {
   const { projectSlug } = Route.useParams()
   const projectFromLoader = Route.useLoaderData({ select: (data) => data.project })
@@ -157,6 +168,20 @@ function ProjectLayout() {
     return (
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col">
         <Outlet />
+      </div>
+    )
+  }
+
+  if (project.settings.isSample) {
+    return (
+      <div className="flex h-screen flex-col overflow-hidden bg-primary">
+        <SampleProjectStrip />
+        <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-t-2xl bg-background">
+          <ProjectSidebar project={project} projectSlug={projectSlug} />
+          <main className="flex-1 min-w-0 overflow-y-auto">
+            <Outlet />
+          </main>
+        </div>
       </div>
     )
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
-import { TagsIcon } from "lucide-react"
+import { Loader2Icon, TagsIcon } from "lucide-react"
 import { useMemo } from "react"
 import { type BehaviourSegment, useProjectBehaviours } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import type {
@@ -17,6 +17,8 @@ import { BehaviourDetailDrawer, BehavioursView } from "./-components/behaviours-
 
 const isBehaviourTrajectoryMetric = (value: string): value is BehaviourTrajectoryMetric =>
   value === "frequency" || value === "escalation" || value === "resolution" || value === "churnRisk" || value === "wins"
+
+const isDemoProjectName = (name: string) => /(^|\b)demo project(\b|$)/i.test(name)
 
 const findNodeByPath = (
   topics: readonly BehaviourNodeRecord[],
@@ -131,17 +133,28 @@ function BehavioursPageContent() {
   }, [activeBehaviourId, behaviourPath, topics])
   const setBehaviourPath = (path: readonly string[]) => setBehaviourPathParam(path.join("."))
   const hasNoBehaviours = !isLoading && topics.length === 0 && segment === "all" && !timeRange
+  const isDemoProject = project.settings.isSample || isDemoProjectName(project.name)
 
   if (hasNoBehaviours) {
     return (
       <Layout>
         <Layout.Content>
-          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
-            <TagsIcon className="h-8 w-8 text-muted-foreground" />
-            <Text.H3>No behaviors yet</Text.H3>
-            <Text.H5 color="foregroundMuted">
-              Live taxonomy behaviors will appear here after sessions have been clustered.
-            </Text.H5>
+          <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8 text-center">
+            <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+              {isDemoProject ? (
+                <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+              ) : (
+                <TagsIcon className="h-6 w-6 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <Text.H3>{isDemoProject ? "Sample behaviors are loading" : "No behaviors yet"}</Text.H3>
+              <Text.H5 color="foregroundMuted" centered>
+                {isDemoProject
+                  ? "We found the sample traces and signals. The behavior taxonomy is still being prepared — check back in about a minute."
+                  : "Live taxonomy behaviors will appear here after sessions have been clustered."}
+              </Text.H5>
+            </div>
           </div>
         </Layout.Content>
       </Layout>

--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -191,18 +191,47 @@ const pendingResetMutations = async (
   return resultSet.json<PendingMutation>()
 }
 
+const projectRowExists = async (
+  client: ClickHouseClient,
+  table: ClickHouseTable,
+  scope: SeedScope,
+): Promise<boolean> => {
+  const resultSet = await client.query({
+    query: `SELECT 1 FROM ${table}
+            WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}
+            LIMIT 1`,
+    query_params: { organizationId: scope.organizationId, projectId: scope.projectId },
+    format: "JSONEachRow",
+  })
+  return (await resultSet.json()).length > 0
+}
+
 /**
- * `ALTER TABLE … DELETE` is a heavyweight mutation that rewrites every part
- * holding matching rows; on the large shared production tables (e.g.
- * message_embeddings) it runs for minutes. Awaiting it with
+ * The reset only exists to keep Temporal retries / re-seeds idempotent — a
+ * freshly created demo project has no rows here, and these tables are all
+ * ReplacingMergeTree keyed by `(organization_id, project_id, …)` with
+ * deterministic snapshot rows, so a re-insert dedups on its own. So we delete
+ * only from tables that actually hold rows for this project. `(organization_id,
+ * project_id)` is the primary-key prefix on every table, making the existence
+ * check an index point-lookup; on the common fresh-project path all checks
+ * come back empty and no mutation runs at all.
+ *
+ * When a delete is warranted, `ALTER TABLE … DELETE` is a heavyweight mutation
+ * that rewrites parts and can run for minutes. Awaiting it with
  * `mutations_sync: "2"` holds the HTTP request open with no data flowing, so
  * the client's 30s `request_timeout` trips the socket and the activity fails
  * every retry. Instead we submit the mutations without waiting and poll
- * `system.mutations` with short queries until the project's deletes complete,
- * letting the activity's 30-minute start-to-close timeout be the real budget.
+ * `system.mutations` with short queries until they complete, letting the
+ * activity's 30-minute start-to-close timeout be the real budget.
  */
 const resetClickHouse = async (client: ClickHouseClient, scope: SeedScope) => {
-  for (const table of clickHouseTables) {
+  const presence = await Promise.all(
+    clickHouseTables.map(async (table) => ({ table, hasRows: await projectRowExists(client, table, scope) })),
+  )
+  const tablesToReset = presence.filter((entry) => entry.hasRows).map((entry) => entry.table)
+  if (tablesToReset.length === 0) return
+
+  for (const table of tablesToReset) {
     await client.command({
       query: `ALTER TABLE ${table} DELETE WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}`,
       query_params: { organizationId: scope.organizationId, projectId: scope.projectId },

--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer"
 import { createHash } from "node:crypto"
 import { createReadStream, existsSync, readdirSync, readFileSync } from "node:fs"
 import { createInterface } from "node:readline"
@@ -21,6 +22,8 @@ const clickHouseTables = [
   "session_moment_labels",
   "taxonomy_observations",
 ] as const
+
+const DEMO_SNAPSHOT_TRACE_LIMIT = 300
 
 type ClickHouseTable = (typeof clickHouseTables)[number]
 type SnapshotRow = Record<string, unknown>
@@ -143,6 +146,36 @@ const insertClickHouseRows = async (client: ClickHouseClient, table: ClickHouseT
   await client.insert({ table, values: rows, format: "JSONEachRow" })
 }
 
+const hardcodedEmbedding = (contentHash: string): readonly number[] => {
+  const embedding = Array.from({ length: 2048 }, () => 0)
+  const digest = Buffer.from(sha256([contentHash]), "hex")
+  for (let i = 0; i < digest.length; i += 2) {
+    embedding[digest[i]! % embedding.length] = digest[i + 1]! >= 128 ? 1 : -1
+  }
+  return embedding
+}
+
+const insertHardcodedMessageEmbeddings = async (
+  client: ClickHouseClient,
+  scope: SeedScope,
+  contentHashes: Iterable<string>,
+) => {
+  const insertedAt = formatClickHouseTimestamp(scope.timelineAnchor.toISOString(), 0)
+  const rows = [...contentHashes].map((contentHash) => ({
+    organization_id: scope.organizationId,
+    project_id: scope.projectId,
+    content_hash: contentHash,
+    embedding: hardcodedEmbedding(contentHash),
+    embedding_model: "voyage-4-large",
+    inserted_at: insertedAt,
+    retention_days: 30,
+  }))
+
+  for (let i = 0; i < rows.length; i += 1000) {
+    await insertClickHouseRows(client, "message_embeddings", rows.slice(i, i + 1000))
+  }
+}
+
 const importClickHouseTable = async (
   client: ClickHouseClient,
   table: ClickHouseTable,
@@ -151,10 +184,18 @@ const importClickHouseTable = async (
     readonly deltaMs: number
     readonly mapClusterId: (id: string) => string
     readonly mapRunId: (id: string) => string
+    readonly keep?: (row: SnapshotRow) => boolean
+    readonly afterKeep?: (row: SnapshotRow) => void
+    readonly limit?: number
   },
 ) => {
   const batch: SnapshotRow[] = []
+  let kept = 0
   for await (const row of readSnapshotRows(`clickhouse/${table}.jsonl.gz`)) {
+    if (input.limit !== undefined && kept >= input.limit) break
+    if (input.keep && !input.keep(row)) continue
+    input.afterKeep?.(row)
+    kept++
     batch.push(mapClickHouseRow(table, row, input))
     if (batch.length >= 1000) {
       await insertClickHouseRows(client, table, batch.splice(0))
@@ -425,7 +466,60 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     mapRunId,
   )
 
-  for (const table of clickHouseTables) {
-    await importClickHouseTable(input.clickhouseClient, table, { scope: input.scope, deltaMs, mapClusterId, mapRunId })
-  }
+  const traceIds = new Set<string>()
+  const contentHashes = new Set<string>()
+  const analysisKeys = new Set<string>()
+  const momentKeys = new Set<string>()
+  const analysisKey = (row: SnapshotRow) => `${String(row.session_id)}\0${String(row.analysis_hash)}`
+  const momentKey = (row: SnapshotRow) =>
+    `${String(row.session_id)}\0${String(row.analysis_hash)}\0${String(row.moment_id)}`
+
+  await importClickHouseTable(input.clickhouseClient, "trace_search_documents", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    limit: DEMO_SNAPSHOT_TRACE_LIMIT,
+    afterKeep: (row) => traceIds.add(String(row.trace_id)),
+  })
+  await importClickHouseTable(input.clickhouseClient, "trace_message_occurrences", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    keep: (row) => traceIds.has(String(row.trace_id)),
+    afterKeep: (row) => contentHashes.add(String(row.content_hash)),
+  })
+  await insertHardcodedMessageEmbeddings(input.clickhouseClient, input.scope, contentHashes)
+  await importClickHouseTable(input.clickhouseClient, "session_analyses", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    keep: (row) => Array.isArray(row.trace_ids) && row.trace_ids.some((traceId) => traceIds.has(String(traceId))),
+    afterKeep: (row) => analysisKeys.add(analysisKey(row)),
+  })
+  await importClickHouseTable(input.clickhouseClient, "session_semantic_moments", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    keep: (row) => traceIds.has(String(row.trace_id)) && analysisKeys.has(analysisKey(row)),
+    afterKeep: (row) => momentKeys.add(momentKey(row)),
+  })
+  await importClickHouseTable(input.clickhouseClient, "session_moment_labels", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    keep: (row) => momentKeys.has(momentKey(row)),
+  })
+  await importClickHouseTable(input.clickhouseClient, "taxonomy_observations", {
+    scope: input.scope,
+    deltaMs,
+    mapClusterId,
+    mapRunId,
+    keep: (row) => typeof row.assigned_cluster_id === "string" && row.assigned_cluster_id.length > 0,
+    limit: DEMO_SNAPSHOT_TRACE_LIMIT,
+  })
 }

--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -169,13 +169,55 @@ const readPostgresSnapshotRows = async (name: string): Promise<readonly Snapshot
   return rows
 }
 
+const RESET_MUTATION_POLL_INTERVAL_MS = 2_000
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+type PendingMutation = { readonly table: string; readonly latest_fail_reason: string }
+
+const pendingResetMutations = async (
+  client: ClickHouseClient,
+  scope: SeedScope,
+): Promise<readonly PendingMutation[]> => {
+  const resultSet = await client.query({
+    query: `SELECT table, latest_fail_reason
+            FROM system.mutations
+            WHERE table IN ({tables:Array(String)})
+              AND command LIKE {predicate:String}
+              AND is_done = 0`,
+    query_params: { tables: [...clickHouseTables], predicate: `%project_id = '${scope.projectId}'%` },
+    format: "JSONEachRow",
+  })
+  return resultSet.json<PendingMutation>()
+}
+
+/**
+ * `ALTER TABLE … DELETE` is a heavyweight mutation that rewrites every part
+ * holding matching rows; on the large shared production tables (e.g.
+ * message_embeddings) it runs for minutes. Awaiting it with
+ * `mutations_sync: "2"` holds the HTTP request open with no data flowing, so
+ * the client's 30s `request_timeout` trips the socket and the activity fails
+ * every retry. Instead we submit the mutations without waiting and poll
+ * `system.mutations` with short queries until the project's deletes complete,
+ * letting the activity's 30-minute start-to-close timeout be the real budget.
+ */
 const resetClickHouse = async (client: ClickHouseClient, scope: SeedScope) => {
   for (const table of clickHouseTables) {
     await client.command({
       query: `ALTER TABLE ${table} DELETE WHERE organization_id = {organizationId:String} AND project_id = {projectId:String}`,
       query_params: { organizationId: scope.organizationId, projectId: scope.projectId },
-      clickhouse_settings: { mutations_sync: "2" },
+      clickhouse_settings: { mutations_sync: "0" },
     })
+  }
+
+  for (;;) {
+    const pending = await pendingResetMutations(client, scope)
+    const failed = pending.find((mutation) => mutation.latest_fail_reason.length > 0)
+    if (failed) {
+      throw new Error(`Demo seed reset mutation failed on ${failed.table}: ${failed.latest_fail_reason}`)
+    }
+    if (pending.length === 0) return
+    await sleep(RESET_MUTATION_POLL_INTERVAL_MS)
   }
 }
 

--- a/packages/platform/db-clickhouse/src/seeds/scores/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/scores/index.ts
@@ -36,10 +36,10 @@ function createdAtForTau2Signal(scope: SeedScope, signalIndex: number, occurrenc
   )
 }
 
-function buildFailedTrajectoryIndexesByFamily() {
+function buildFailedTrajectoryIndexesByFamily(maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const byFamily = new Map<(typeof TAU2_SEED_SIGNAL_FAMILIES)[number]["key"], number[]>()
 
-  TAU2_SEED_TRAJECTORIES.forEach((trajectory, trajectoryIndex) => {
+  TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
     const family = classifyTau2SeedTrajectory(trajectory)
     if (family === null) return
 
@@ -51,12 +51,12 @@ function buildFailedTrajectoryIndexesByFamily() {
   return byFamily
 }
 
-function buildTau2SignalAnalyticsRows(scope: SeedScope) {
+function buildTau2SignalAnalyticsRows(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
   const familyKeys = TAU2_SEED_SIGNAL_FAMILIES.map((family) => family.key)
-  const failedByFamily = buildFailedTrajectoryIndexesByFamily()
-  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.flatMap((trajectory, index) =>
+  const failedByFamily = buildFailedTrajectoryIndexesByFamily(maxTrajectories)
+  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).flatMap((trajectory, index) =>
     trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
   )
 
@@ -177,9 +177,9 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
   ]
 }
 
-function buildAllAnalyticsRows(scope: SeedScope) {
+function buildAllAnalyticsRows(scope: SeedScope, maxTau2Trajectories?: number) {
   const lifecycleAnalyticsRows = buildLifecycleAnalyticsRows(scope)
-  const tau2SignalAnalyticsRows = buildTau2SignalAnalyticsRows(scope)
+  const tau2SignalAnalyticsRows = buildTau2SignalAnalyticsRows(scope, maxTau2Trajectories)
 
   return {
     lifecycleAnalyticsRows,
@@ -199,7 +199,7 @@ const seedScores: Seeder = {
         if (!ctx.quiet) console.log("  -> scores/tau2-support-analytics: already seeded, skipping")
         return
       }
-      const built = buildAllAnalyticsRows(ctx.scope)
+      const built = buildAllAnalyticsRows(ctx.scope, ctx.maxTau2Trajectories)
       yield* insertJsonEachRow(ctx.client, "scores", built.all)
       if (!ctx.quiet) {
         console.log(

--- a/packages/platform/db-clickhouse/src/seeds/seed-demo-project.ts
+++ b/packages/platform/db-clickhouse/src/seeds/seed-demo-project.ts
@@ -12,4 +12,4 @@ import { runSeeders } from "./runner.ts"
  * `bootstrapSeedScope`.
  */
 export const seedDemoProjectClickHouse = (params: { client: ClickHouseClient; scope: SeedScope }): Promise<void> =>
-  Effect.runPromise(runSeeders(allSeeders, { client: params.client, scope: params.scope }))
+  Effect.runPromise(runSeeders(allSeeders, { client: params.client, scope: params.scope, maxTau2Trajectories: 300 }))

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -585,10 +585,10 @@ function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
   return specs.map((spec) => createLargeConversationChatSpan({ scope, spec }))
 }
 
-function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
+function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length): SpanRow[] {
   const spans: SpanRow[] = []
 
-  TAU2_SEED_TRAJECTORIES.forEach((trajectory, trajectoryIndex) => {
+  TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
     const messages: readonly Tau2SeedTrajectoryMessage[] = trajectory.messages
     const traceId = scope.traceHex("tau2-trajectory", trajectoryIndex)
     const rootSpanId = scope.spanHex("tau2-trajectory-root", trajectoryIndex)
@@ -766,8 +766,8 @@ function buildTau2TrajectorySpans(scope: SeedScope): SpanRow[] {
   return spans
 }
 
-function buildAllFixedSpans(scope: SeedScope): SpanRow[] {
-  return [...buildTau2TrajectorySpans(scope), ...buildCompatibilitySupportSpans(scope)]
+function buildAllFixedSpans(scope: SeedScope, maxTau2Trajectories?: number): SpanRow[] {
+  return [...buildTau2TrajectorySpans(scope, maxTau2Trajectories), ...buildCompatibilitySupportSpans(scope)]
 }
 
 const seedFixedTraces: Seeder = {
@@ -782,7 +782,7 @@ const seedFixedTraces: Seeder = {
         if (!ctx.quiet) console.log("  -> spans/fixed-traces: already seeded, skipping")
         return
       }
-      const allFixedSpans = buildAllFixedSpans(ctx.scope)
+      const allFixedSpans = buildAllFixedSpans(ctx.scope, ctx.maxTau2Trajectories)
       // `insertJsonEachRow` chunks large inserts into multiple requests, so a
       // mid-insert failure can commit some batches but not others. The sentinel
       // above is read back from the `spans` table, so it must only become

--- a/packages/platform/db-clickhouse/src/seeds/types.ts
+++ b/packages/platform/db-clickhouse/src/seeds/types.ts
@@ -14,6 +14,7 @@ export interface SeedContext {
   readonly scope: SeedScope
   /** When true, seeders skip progress logs. Tests opt in. */
   readonly quiet?: boolean
+  readonly maxTau2Trajectories?: number
 }
 
 export interface Seeder {

--- a/packages/platform/db-postgres/src/seeds/scores/index.ts
+++ b/packages/platform/db-postgres/src/seeds/scores/index.ts
@@ -36,10 +36,10 @@ function createdAtForTau2Signal(scope: SeedScope, signalIndex: number, occurrenc
   )
 }
 
-function buildFailedTrajectoryIndexesByFamily() {
+function buildFailedTrajectoryIndexesByFamily(maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const byFamily = new Map<(typeof TAU2_SEED_SIGNAL_FAMILIES)[number]["key"], number[]>()
 
-  TAU2_SEED_TRAJECTORIES.forEach((trajectory, trajectoryIndex) => {
+  TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
     const family = classifyTau2SeedTrajectory(trajectory)
     if (family === null) return
 
@@ -58,12 +58,12 @@ function buildTau2Feedback(signalName: string, trajectory: Tau2SeedTrajectory): 
   )
 }
 
-function buildTau2SignalScoreRows(scope: SeedScope) {
+function buildTau2SignalScoreRows(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
   const familyKeys = TAU2_SEED_SIGNAL_FAMILIES.map((family) => family.key)
-  const failedByFamily = buildFailedTrajectoryIndexesByFamily()
-  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.flatMap((trajectory, index) =>
+  const failedByFamily = buildFailedTrajectoryIndexesByFamily(maxTrajectories)
+  const allFailedTrajectoryIndexes = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).flatMap((trajectory, index) =>
     trajectory.outcome === "failure" || trajectory.reward < 1 ? [index] : [],
   )
 
@@ -114,12 +114,12 @@ function buildTau2SignalScoreRows(scope: SeedScope) {
   })
 }
 
-function buildTau2ControlScoreRows(scope: SeedScope) {
+function buildTau2ControlScoreRows(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length) {
   const orgId = scope.organizationId
   const projectId = scope.projectId
-  const successIndexes = TAU2_SEED_TRAJECTORIES.flatMap((trajectory, index) =>
-    trajectory.outcome === "success" && trajectory.reward >= 1 ? [index] : [],
-  ).slice(0, 6)
+  const successIndexes = TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories)
+    .flatMap((trajectory, index) => (trajectory.outcome === "success" && trajectory.reward >= 1 ? [index] : []))
+    .slice(0, 6)
 
   return successIndexes.map((trajectoryIndex, index) => {
     const trajectory = TAU2_SEED_TRAJECTORIES[trajectoryIndex]!
@@ -160,9 +160,9 @@ function buildTau2ControlScoreRows(scope: SeedScope) {
   })
 }
 
-function buildAllScoreRows(scope: SeedScope) {
-  const tau2ControlScoreRows = buildTau2ControlScoreRows(scope)
-  const tau2SignalScoreRows = buildTau2SignalScoreRows(scope)
+function buildAllScoreRows(scope: SeedScope, maxTau2Trajectories?: number) {
+  const tau2ControlScoreRows = buildTau2ControlScoreRows(scope, maxTau2Trajectories)
+  const tau2SignalScoreRows = buildTau2SignalScoreRows(scope, maxTau2Trajectories)
 
   return {
     tau2ControlScoreRows,
@@ -186,7 +186,7 @@ const seedScores: Seeder = {
   run: (ctx: SeedContext) =>
     Effect.tryPromise({
       try: async () => {
-        const built = buildAllScoreRows(ctx.scope)
+        const built = buildAllScoreRows(ctx.scope, ctx.maxTau2Trajectories)
         const allScoreRows = built.all
         for (const row of allScoreRows) {
           const { id, ...set } = row

--- a/packages/platform/db-postgres/src/seeds/seed-demo-project.ts
+++ b/packages/platform/db-postgres/src/seeds/seed-demo-project.ts
@@ -50,7 +50,13 @@ export const seedDemoProjectPostgres = (params: { client: PostgresClient; scope:
 
   const program = Effect.gen(function* () {
     const ctx = yield* buildContext
-    yield* runSeeders(contentSeeders, ctx)
+    yield* runSeeders(contentSeeders, { ...ctx, maxTau2Trajectories: 300 })
+    yield* Effect.promise(() =>
+      params.client.pool.query("DELETE FROM latitude.notifications WHERE organization_id = $1 AND project_id = $2", [
+        params.scope.organizationId,
+        params.scope.projectId,
+      ]),
+    )
   })
 
   return Effect.runPromise(program.pipe(Effect.provide(repositoriesLayer)))

--- a/packages/platform/db-postgres/src/seeds/types.ts
+++ b/packages/platform/db-postgres/src/seeds/types.ts
@@ -26,6 +26,7 @@ export interface SeedContext {
    * created at runtime via the backoffice. See {@link SeedScope}.
    */
   readonly scope: SeedScope
+  readonly maxTau2Trajectories?: number
 }
 
 export class SeedError extends Data.TaggedError("SeedError")<{


### PR DESCRIPTION
## Summary

Speeds up demo/sample project seeding and makes the sample-project UI clearer while derived data is still catching up.

The workflow now keeps the existing ClickHouse reset optimization, seeds a smaller tau2 corpus for runtime-created demo projects, imports only a small derived snapshot slice, and writes deterministic hardcoded trace-search embeddings instead of replaying the full exported embedding payload. Runtime demo-project Postgres seeding also deletes seeded notification rows at the end so creating a demo project does not email real organization members through the notification pipeline.

## User-facing behavior

- Demo/sample projects load traces and signals much faster.
- The Behaviors empty state now explains that sample behaviors are still loading and asks the user to check back shortly.
- Sample projects show a sandbox-style top strip warning that lightweight seed data means some features, including semantic search and behavior detail drill-downs, may not be fully functional.

## Notes

The full bootstrap seed remains unchanged. The smaller corpus and hardcoded embeddings are scoped to runtime demo-project creation.

## Verification

- `pnpm --filter @app/workflows typecheck`
- `pnpm --filter @platform/db-postgres typecheck`
- `pnpm --filter @platform/db-clickhouse typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/workflows test src/workflows/seed-demo-project-workflow.test.ts`
- pre-commit `turbo format` + `knip`

UI changes are included; attach a screenshot of the sample-project strip / behaviors blank slate for reviewer context.
