### PR TITLE
fix(onboarding): quiet sample project emails and poll behaviors

### DIFF
--- a/apps/web/src/domains/taxonomy/taxonomy.collection.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.collection.ts
@@ -120,12 +120,14 @@ export function useProjectBehaviours({
   segment,
   sortBy,
   timeRange,
+  pollUntilTopics,
 }: {
   readonly projectId: string
   readonly dimension: BehaviourDimension
   readonly segment: BehaviourSegment
   readonly sortBy: BehaviourSortBy
   readonly timeRange?: BehaviourTimeRangeRecord
+  readonly pollUntilTopics?: boolean
 }) {
   return useQuery({
     queryKey: projectBehavioursQueryKey({ projectId, dimension, segment, sortBy, timeRange }),
@@ -133,6 +135,7 @@ export function useProjectBehaviours({
       getProjectBehaviours({ data: { projectId, dimension, segment, sortBy, ...(timeRange ? { timeRange } : {}) } }),
     staleTime: 30_000,
     enabled: projectId.length > 0,
+    refetchInterval: (query) => (pollUntilTopics && (query.state.data?.topics.length ?? 0) === 0 ? 5_000 : false),
   })
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -93,12 +93,14 @@ function BehavioursPageContent() {
         : undefined,
     [timeFrom, timeTo],
   )
+  const isDemoProject = project.settings.isSample || isDemoProjectName(project.name)
   const { data, isLoading } = useProjectBehaviours({
     projectId: project.id,
     dimension: "topic",
     segment,
     sortBy: "category",
     ...(timeRange ? { timeRange } : {}),
+    pollUntilTopics: isDemoProject && segment === "all" && !timeRange,
   })
   const momentRange = useMemo((): BehaviourMomentRangeRecord | undefined => {
     if (!isBehaviourTrajectoryMetric(momentMetric)) return undefined
@@ -133,7 +135,6 @@ function BehavioursPageContent() {
   }, [activeBehaviourId, behaviourPath, topics])
   const setBehaviourPath = (path: readonly string[]) => setBehaviourPathParam(path.join("."))
   const hasNoBehaviours = !isLoading && topics.length === 0 && segment === "all" && !timeRange
-  const isDemoProject = project.settings.isSample || isDemoProjectName(project.name)
 
   if (hasNoBehaviours) {
     return (

--- a/apps/workers/src/workers/notifications.ts
+++ b/apps/workers/src/workers/notifications.ts
@@ -50,7 +50,7 @@ const requestLayer = Layer.mergeAll(
   UserRepositoryLive,
 )
 
-const createLayer = Layer.mergeAll(NotificationRepositoryLive, UserRepositoryLive)
+const createLayer = Layer.mergeAll(NotificationRepositoryLive, ProjectRepositoryLive, UserRepositoryLive)
 
 /**
  * Org-level Slack fan-out runs at the producer step (not per recipient).

--- a/packages/domain/notifications/src/use-cases/create-notification.test.ts
+++ b/packages/domain/notifications/src/use-cases/create-notification.test.ts
@@ -1,8 +1,11 @@
+import { createProject, ProjectRepository } from "@domain/projects"
+import { createFakeProjectRepository } from "@domain/projects/testing"
 import {
   generateId,
   NotificationId,
   type NotificationPreferences,
   OrganizationId,
+  ProjectId,
   SqlClient,
   UserId,
 } from "@domain/shared"
@@ -19,11 +22,13 @@ const cuid = (seed: string) => seed.padEnd(24, "0")
 
 interface SetupOpts {
   readonly user?: Partial<User>
+  readonly sampleProject?: boolean
 }
 
 function setup(opts: SetupOpts = {}) {
   const orgId = OrganizationId(cuid("o"))
   const userId = UserId(cuid("u"))
+  const projectId = ProjectId(cuid("p"))
 
   const { repository: userRepo, users } = createFakeUserRepository()
   users.set(userId, {
@@ -41,14 +46,24 @@ function setup(opts: SetupOpts = {}) {
   } satisfies User)
 
   const { repo: notificationRepo, rows } = createFakeNotificationRepository()
+  const { repository: projectRepo } = createFakeProjectRepository([
+    createProject({
+      id: projectId,
+      organizationId: orgId,
+      name: opts.sampleProject ? "Sample project" : "Project",
+      slug: opts.sampleProject ? "sample-project" : "project",
+      settings: opts.sampleProject ? { isSample: true } : null,
+    }),
+  ])
 
   const layer = Layer.mergeAll(
+    Layer.succeed(ProjectRepository, projectRepo),
     Layer.succeed(UserRepository, userRepo),
     Layer.succeed(NotificationRepository, notificationRepo),
     Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: orgId })),
   )
 
-  return { orgId, userId, rows, layer }
+  return { orgId, projectId, userId, rows, layer }
 }
 
 const incidentPayload = (alertIncidentId: string) => ({
@@ -109,6 +124,27 @@ describe("createNotificationUseCase", () => {
 
     expect(second.notification).toBeNull()
     expect(second.emailEligible).toBe(false)
+    expect(rows).toHaveLength(1)
+  })
+
+  it("suppresses email for sample-project notifications while keeping the in-app row", async () => {
+    const { orgId, projectId, userId, rows, layer } = setup({ sampleProject: true })
+    const alertIncidentId = cuid("ai")
+
+    const result = await Effect.runPromise(
+      createNotificationUseCase({
+        organizationId: orgId,
+        userId,
+        notificationId: NotificationId(generateId()),
+        kind: "incident.opened",
+        idempotencyKey: `incident.opened:${alertIncidentId}`,
+        projectId,
+        payload: incidentPayload(alertIncidentId),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.notification).not.toBeNull()
+    expect(result.emailEligible).toBe(false)
     expect(rows).toHaveLength(1)
   })
 

--- a/packages/domain/notifications/src/use-cases/create-notification.ts
+++ b/packages/domain/notifications/src/use-cases/create-notification.ts
@@ -1,3 +1,4 @@
+import { ProjectRepository } from "@domain/projects"
 import type {
   NotFoundError,
   NotificationId,
@@ -81,6 +82,16 @@ export const createNotificationUseCase = (input: CreateNotificationInput) =>
       return { notification: null, emailEligible: false } as const
     }
 
+    if (input.projectId !== null) {
+      const projects = yield* ProjectRepository
+      const project = yield* projects
+        .findById(input.projectId)
+        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+      if (project?.settings?.isSample === true) {
+        return { notification: inserted, emailEligible: false } as const
+      }
+    }
+
     // Read the recipient's prefs to decide email eligibility. Missing user
     // (impossible in practice — we just resolved them as a member) is
     // treated as "no email" rather than failing the insert.
@@ -95,5 +106,5 @@ export const createNotificationUseCase = (input: CreateNotificationInput) =>
   }).pipe(Effect.withSpan("notifications.createNotification")) as Effect.Effect<
     CreateNotificationResult,
     CreateNotificationError,
-    SqlClient | NotificationRepository | UserRepository
+    SqlClient | NotificationRepository | ProjectRepository | UserRepository
   >


### PR DESCRIPTION
## Summary

Stops sample-project incident notifications from sending email while still writing the in-app bell row. The notification creation step now checks the project anchor and marks notifications tied to `settings.isSample` projects as email-ineligible before evaluating user email preferences.

Also makes the sample/demo project behaviors blank slate poll until taxonomy topics are available, so the page swaps from the loading blank slate to behavior data without a manual refresh. Polling is limited to the default sample/demo empty state and stops once topics load.

## Verification

- `pnpm --filter @domain/notifications test -- create-notification.test.ts`
- `pnpm --filter @domain/notifications typecheck`
- `pnpm --filter @app/workers typecheck`
- `pnpm --filter @domain/notifications check`
- `pnpm --filter @app/workers check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`
- pre-commit `turbo format` + `knip`
