### PR TITLE
fix(demo-project): remap snapshot trace/session ids to seeded project

### DIFF
--- a/apps/workflows/src/activities/demo-project-snapshot.test.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.test.ts
@@ -1,0 +1,30 @@
+import { seedTraceHex } from "@domain/shared/seeding"
+import { demoSeedTraceSlots } from "@platform/db-clickhouse/seeding"
+import { describe, expect, it } from "vitest"
+import { buildTraceIdRemap } from "./demo-project-snapshot.ts"
+
+const SOURCE_PROJECT_ID = "yvl1e78evmwfs2mosyjb08rc"
+const TARGET_PROJECT_ID = "an3s1qhl5twcq2nbkajayw1u"
+
+describe("buildTraceIdRemap", () => {
+  it("maps every demo trace slot from the source project's id to the target's", () => {
+    const remap = buildTraceIdRemap(SOURCE_PROJECT_ID, TARGET_PROJECT_ID)
+
+    expect(remap.size).toEqual(demoSeedTraceSlots.length)
+    for (const slot of demoSeedTraceSlots) {
+      const source = seedTraceHex(SOURCE_PROJECT_ID, slot.traceKey, slot.index)
+      const target = seedTraceHex(TARGET_PROJECT_ID, slot.traceKey, slot.index)
+      expect(remap.get(source)).toEqual(target)
+    }
+  })
+
+  it("leaves ids that aren't seeded trace slots untouched (literal session ids)", () => {
+    const remap = buildTraceIdRemap(SOURCE_PROJECT_ID, TARGET_PROJECT_ID)
+    expect(remap.has("session-anthropic-demo")).toBe(false)
+    expect(remap.has("seed-large-conversation-1")).toBe(false)
+  })
+
+  it("is empty when source and target projects are the same", () => {
+    expect(buildTraceIdRemap(SOURCE_PROJECT_ID, SOURCE_PROJECT_ID).size).toEqual(0)
+  })
+})

--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -4,8 +4,9 @@ import { createReadStream, existsSync, readdirSync, readFileSync } from "node:fs
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
 import { createGunzip } from "node:zlib"
-import type { SeedScope } from "@domain/shared/seeding"
+import { type SeedScope, seedTraceHex } from "@domain/shared/seeding"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
+import { demoSeedTraceSlots } from "@platform/db-clickhouse/seeding"
 import type { PostgresClient } from "@platform/db-postgres"
 
 const sourceSnapshotDir = fileURLToPath(new URL("../seed-snapshots/demo-project-derived-v1/", import.meta.url))
@@ -22,8 +23,6 @@ const clickHouseTables = [
   "session_moment_labels",
   "taxonomy_observations",
 ] as const
-
-const DEMO_SNAPSHOT_TRACE_LIMIT = 300
 
 type ClickHouseTable = (typeof clickHouseTables)[number]
 type SnapshotRow = Record<string, unknown>
@@ -44,6 +43,24 @@ const timestampColumnsByTable: Record<ClickHouseTable, readonly string[]> = {
   session_semantic_moments: ["start_time", "end_time", "indexed_at"],
   session_moment_labels: ["indexed_at"],
   taxonomy_observations: ["start_time", "end_time", "indexed_at"],
+}
+
+// Columns holding seeded trace/session ids that the snapshot carries from the
+// SOURCE project verbatim. Single-trace sessions key `session_id` by the trace
+// id, so session columns go through the same trace-id remap; literal session
+// ids (e.g. `seed-large-conversation-1`, `session-anthropic-demo`) aren't in
+// the map and pass through unchanged.
+const remapColumnsByTable: Record<
+  ClickHouseTable,
+  { readonly ids: readonly string[]; readonly idArrays: readonly string[] }
+> = {
+  trace_search_documents: { ids: ["trace_id"], idArrays: [] },
+  message_embeddings: { ids: [], idArrays: [] },
+  trace_message_occurrences: { ids: ["trace_id", "session_id"], idArrays: [] },
+  session_analyses: { ids: ["session_id"], idArrays: ["trace_ids"] },
+  session_semantic_moments: { ids: ["trace_id", "session_id"], idArrays: [] },
+  session_moment_labels: { ids: ["session_id"], idArrays: [] },
+  taxonomy_observations: { ids: ["session_id"], idArrays: [] },
 }
 
 const postgresTimestampColumns = new Set([
@@ -114,6 +131,24 @@ const mapObservationId = (sourceId: unknown, scope: SeedScope): unknown =>
     ? sha256(["snapshot:taxonomy-observation", scope.projectId, sourceId]).slice(0, 32)
     : sourceId
 
+/**
+ * Maps the source project's seeded trace ids onto the target project's. Both
+ * are `seedTraceHex(projectId, traceKey, index)`, so regenerating every demo
+ * trace slot under each project id yields the source→target translation. The
+ * snapshot stores the source project's ids verbatim, while the actual
+ * traces/spans are seeded fresh under the target project — without this the
+ * imported derived data references traces that don't exist.
+ */
+export const buildTraceIdRemap = (sourceProjectId: string, targetProjectId: string): ReadonlyMap<string, string> => {
+  const remap = new Map<string, string>()
+  for (const slot of demoSeedTraceSlots) {
+    const source = seedTraceHex(sourceProjectId, slot.traceKey, slot.index)
+    const target = seedTraceHex(targetProjectId, slot.traceKey, slot.index)
+    if (source !== target) remap.set(source, target)
+  }
+  return remap
+}
+
 const mapClickHouseRow = (
   table: ClickHouseTable,
   row: SnapshotRow,
@@ -122,11 +157,19 @@ const mapClickHouseRow = (
     readonly deltaMs: number
     readonly mapClusterId: (id: string) => string
     readonly mapRunId: (id: string) => string
+    readonly traceIdRemap: ReadonlyMap<string, string>
   },
 ): SnapshotRow => {
   const mapped: SnapshotRow = { ...row, organization_id: input.scope.organizationId, project_id: input.scope.projectId }
   for (const column of timestampColumnsByTable[table])
     mapped[column] = formatClickHouseTimestamp(mapped[column], input.deltaMs)
+
+  const remapId = (value: unknown): unknown =>
+    typeof value === "string" ? (input.traceIdRemap.get(value) ?? value) : value
+  const remapColumns = remapColumnsByTable[table]
+  for (const column of remapColumns.ids) mapped[column] = remapId(mapped[column])
+  for (const column of remapColumns.idArrays)
+    if (Array.isArray(mapped[column])) mapped[column] = (mapped[column] as readonly unknown[]).map(remapId)
 
   if (table === "taxonomy_observations") {
     mapped.observation_id = mapObservationId(mapped.observation_id, input.scope)
@@ -184,18 +227,15 @@ const importClickHouseTable = async (
     readonly deltaMs: number
     readonly mapClusterId: (id: string) => string
     readonly mapRunId: (id: string) => string
+    readonly traceIdRemap: ReadonlyMap<string, string>
     readonly keep?: (row: SnapshotRow) => boolean
     readonly afterKeep?: (row: SnapshotRow) => void
-    readonly limit?: number
   },
 ) => {
   const batch: SnapshotRow[] = []
-  let kept = 0
   for await (const row of readSnapshotRows(`clickhouse/${table}.jsonl.gz`)) {
-    if (input.limit !== undefined && kept >= input.limit) break
     if (input.keep && !input.keep(row)) continue
     input.afterKeep?.(row)
-    kept++
     batch.push(mapClickHouseRow(table, row, input))
     if (batch.length >= 1000) {
       await insertClickHouseRows(client, table, batch.splice(0))
@@ -439,6 +479,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
   const deltaMs = utcDay(input.scope.timelineAnchor) - utcDay(new Date(manifest.sourceTimelineAnchorIso))
   const mapClusterId = (id: string) => stableId("taxonomy-cluster", id, input.scope)
   const mapRunId = (id: string) => stableId("taxonomy-run", id, input.scope)
+  const traceIdRemap = buildTraceIdRemap(manifest.sourceProjectId, input.scope.projectId)
 
   await resetClickHouse(input.clickhouseClient, input.scope)
   await resetPostgres(input.postgresClient, input.scope)
@@ -479,7 +520,13 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
-    limit: DEMO_SNAPSHOT_TRACE_LIMIT,
+    traceIdRemap,
+    // Import a trace's derived data only if that trace is in the seeded slice
+    // (`traceIdRemap` is keyed by the seeded source trace ids). A blind row
+    // limit here would pick traces spread across the full corpus, most of which
+    // aren't seeded under the target project — leaving their sessions pointing
+    // at non-existent traces (the permanent-skeleton bug this fix exists for).
+    keep: (row) => traceIdRemap.has(String(row.trace_id)),
     afterKeep: (row) => traceIds.add(String(row.trace_id)),
   })
   await importClickHouseTable(input.clickhouseClient, "trace_message_occurrences", {
@@ -487,6 +534,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
+    traceIdRemap,
     keep: (row) => traceIds.has(String(row.trace_id)),
     afterKeep: (row) => contentHashes.add(String(row.content_hash)),
   })
@@ -496,6 +544,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
+    traceIdRemap,
     keep: (row) => Array.isArray(row.trace_ids) && row.trace_ids.some((traceId) => traceIds.has(String(traceId))),
     afterKeep: (row) => analysisKeys.add(analysisKey(row)),
   })
@@ -504,6 +553,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
+    traceIdRemap,
     keep: (row) => traceIds.has(String(row.trace_id)) && analysisKeys.has(analysisKey(row)),
     afterKeep: (row) => momentKeys.add(momentKey(row)),
   })
@@ -512,6 +562,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
+    traceIdRemap,
     keep: (row) => momentKeys.has(momentKey(row)),
   })
   await importClickHouseTable(input.clickhouseClient, "taxonomy_observations", {
@@ -519,7 +570,13 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     deltaMs,
     mapClusterId,
     mapRunId,
-    keep: (row) => typeof row.assigned_cluster_id === "string" && row.assigned_cluster_id.length > 0,
-    limit: DEMO_SNAPSHOT_TRACE_LIMIT,
+    traceIdRemap,
+    // Behaviours read sessions from here; keep only observations whose session
+    // is a seeded single-trace session (`session_id` is the trace id), so every
+    // behaviour's "associated session" resolves to a real seeded trace.
+    keep: (row) =>
+      typeof row.assigned_cluster_id === "string" &&
+      row.assigned_cluster_id.length > 0 &&
+      traceIdRemap.has(String(row.session_id)),
   })
 }

--- a/packages/domain/shared/src/seed-scope.ts
+++ b/packages/domain/shared/src/seed-scope.ts
@@ -116,6 +116,14 @@ const SPAN_HEX_LENGTH = 16
 const deriveTraceHex = (projectId: string, key: string, index: number): string =>
   sha256(["trace", projectId, key, index]).toString("hex").slice(0, TRACE_HEX_LENGTH)
 
+/**
+ * Project-scoped trace hex, matching `SeedScope.traceHex`, but callable
+ * without building a full scope. The demo-project snapshot import uses it to
+ * regenerate a `(traceKey, index)` slot under two different project ids and so
+ * map the source project's seeded trace ids onto the target project's.
+ */
+export const seedTraceHex = (projectId: string, key: string, index = 0): string => deriveTraceHex(projectId, key, index)
+
 const deriveSpanHex = (projectId: string, key: string, index: number): string =>
   sha256(["span", projectId, key, index]).toString("hex").slice(0, SPAN_HEX_LENGTH)
 

--- a/packages/platform/db-clickhouse/src/seeds/seed-demo-project.ts
+++ b/packages/platform/db-clickhouse/src/seeds/seed-demo-project.ts
@@ -3,6 +3,32 @@ import type { SeedScope } from "@domain/shared/seeding"
 import { Effect } from "effect"
 import { allSeeders } from "./all.ts"
 import { runSeeders } from "./runner.ts"
+import { spanTraceSlots } from "./spans/index.ts"
+import type { TraceSlot } from "./types.ts"
+
+export type { TraceSlot } from "./types.ts"
+
+/**
+ * How many tau2 trajectories the demo seed writes. The full corpus has 1568,
+ * but the demo only needs a representative slice — capping keeps sample-project
+ * provisioning fast. The snapshot import selects derived data for exactly this
+ * seeded slice (via {@link demoSeedTraceSlots}), so both must use this same cap.
+ */
+export const DEMO_TAU2_TRAJECTORY_LIMIT = 300
+
+/**
+ * Every deterministic trace the demo seed *actually* writes, as
+ * `(traceKey, index)` slots — i.e. `spanTraceSlots` with the tau2 trajectories
+ * capped to {@link DEMO_TAU2_TRAJECTORY_LIMIT}, matching `maxTau2Trajectories`
+ * below. Consumed by the demo-project snapshot import both to remap the source
+ * project's trace/session ids onto the freshly seeded project's ids and to
+ * select which derived rows to import: a derived row whose trace isn't in this
+ * set has no seeded trace to point at, so importing it would resurrect the
+ * permanent-skeleton bug.
+ */
+export const demoSeedTraceSlots: readonly TraceSlot[] = spanTraceSlots.filter(
+  (slot) => slot.traceKey !== "tau2-trajectory" || slot.index < DEMO_TAU2_TRAJECTORY_LIMIT,
+)
 
 /**
  * Run every per-project ClickHouse seeder against the supplied scope —
@@ -12,4 +38,10 @@ import { runSeeders } from "./runner.ts"
  * `bootstrapSeedScope`.
  */
 export const seedDemoProjectClickHouse = (params: { client: ClickHouseClient; scope: SeedScope }): Promise<void> =>
-  Effect.runPromise(runSeeders(allSeeders, { client: params.client, scope: params.scope, maxTau2Trajectories: 300 }))
+  Effect.runPromise(
+    runSeeders(allSeeders, {
+      client: params.client,
+      scope: params.scope,
+      maxTau2Trajectories: DEMO_TAU2_TRAJECTORY_LIMIT,
+    }),
+  )

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -3,7 +3,7 @@ import { CUSTOMER_USERS, EMPLOYEE_USERS, type SeedScope, type SeedUser, seedUser
 import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
 import { isSentinelPresent } from "../idempotency.ts"
-import type { Seeder } from "../types.ts"
+import type { Seeder, TraceSlot } from "../types.ts"
 import type { SpanRow } from "./span-builders.ts"
 
 function formatClickHouseTimestamp(date: Date): string {
@@ -313,100 +313,100 @@ function createCompatibilityChatSpan(opts: {
   }
 }
 
-export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
-  const specs = [
-    {
-      traceKey: "lifecycle",
-      index: 0,
-      daysAgo: 12,
-      userPrompt: "Can you check whether my delivered keyboard return is still eligible?",
-      assistantResponse:
-        "I need to authenticate you first, then inspect the delivered order and item status before confirming return eligibility.",
-      tags: ["support", "lifecycle", "tau2-retail"],
-      metadata: { seed: "tau2-compatibility", story: "retail-return-lifecycle" },
-      user: CUSTOMER_USERS[0],
-    },
-    {
-      traceKey: "lifecycle",
-      index: 1,
-      daysAgo: 11,
-      userPrompt: "I accidentally cancelled my order. Can you undo it immediately?",
-      assistantResponse:
-        "Cancelled orders cannot be reinstated automatically. I can help place a new order or transfer you for an out-of-scope exception review.",
-      tags: ["support", "lifecycle", "tau2-retail"],
-      metadata: { seed: "tau2-compatibility", story: "cancelled-order-policy" },
-      user: CUSTOMER_USERS[1],
-    },
-    {
-      traceKey: "lifecycle",
-      index: 2,
-      daysAgo: 10,
-      userPrompt: "My phone has no service and I need it fixed before I leave the airport.",
-      assistantResponse:
-        "Let's troubleshoot step by step. I will inspect the device state, verify SIM and roaming settings, then run a speed test before calling this resolved.",
-      tags: ["support", "lifecycle", "tau2-telecom"],
-      metadata: { seed: "tau2-compatibility", story: "telecom-troubleshooting" },
-      user: CUSTOMER_USERS[2],
-    },
-    {
-      traceKey: "lifecycle",
-      index: 3,
-      daysAgo: 9,
-      userPrompt: "Can you waive this mobile data fee as a courtesy?",
-      assistantResponse:
-        "I need to verify the account and policy eligibility before discussing credits. I cannot promise a waiver before review.",
-      tags: ["support", "lifecycle", "tau2-telecom"],
-      // Same user as the troubleshooting trace so one profile accumulates
-      // multiple issue occurrences.
-      metadata: { seed: "tau2-compatibility", story: "telecom-credit-policy" },
-      user: CUSTOMER_USERS[2],
-    },
-    {
-      traceKey: "lifecycle",
-      index: 4,
-      daysAgo: 8,
-      userPrompt: "Should I get the premium credit card if I already have a corporate travel card?",
-      assistantResponse:
-        "I need to compare the card fees, rewards, and your subscription benefits against the policy documents before recommending a product.",
-      tags: ["support", "lifecycle", "tau2-banking"],
-      metadata: { seed: "tau2-compatibility", story: "banking-knowledge-grounding" },
-      user: CUSTOMER_USERS[3],
-    },
-    {
-      traceKey: "annotation-demo",
-      index: 0,
-      daysAgo: 2,
-      userPrompt: "I want to return my gaming keyboard and mouse now that I quit gaming.",
-      assistantResponse:
-        "I authenticated the account, checked both delivered orders, and requested returns for the eligible keyboard and mouse to the original payment methods.",
-      tags: ["support", "annotation", "tau2-retail"],
-      metadata: { seed: "tau2-compatibility", story: "annotation-ui-polish" },
-      user: CUSTOMER_USERS[0],
-    },
-    {
-      traceKey: "code-block-demo",
-      index: 0,
-      daysAgo: 1,
-      userPrompt: "How do I fetch a trace with the Latitude Node SDK?",
-      assistantResponse:
-        "Set your API key in the `Authorization` header, then call the SDK. Here's a minimal example:\n\n" +
-        "```ts\n" +
-        'import { Latitude } from "@latitude-data/sdk"\n\n' +
-        "const sdk = new Latitude(process.env.LATITUDE_API_KEY!)\n" +
-        'const trace = await sdk.traces.get("trace-id")\n' +
-        "console.log(trace.spans.length)\n" +
-        "```\n\n" +
-        "Keep the key in an environment variable — never hard-code it.",
-      tags: ["support", "developer", "code-example"],
-      metadata: { seed: "tau2-compatibility", story: "code-block-rendering" },
-      user: EMPLOYEE_USERS[0],
-      serviceName: "developer-support-agent",
-      systemInstruction:
-        "You are a developer support AI agent. Help users integrate the Latitude SDK and API, and include short, correct code examples when useful.",
-    },
-  ] as const
+const COMPATIBILITY_TRACE_SPECS = [
+  {
+    traceKey: "lifecycle",
+    index: 0,
+    daysAgo: 12,
+    userPrompt: "Can you check whether my delivered keyboard return is still eligible?",
+    assistantResponse:
+      "I need to authenticate you first, then inspect the delivered order and item status before confirming return eligibility.",
+    tags: ["support", "lifecycle", "tau2-retail"],
+    metadata: { seed: "tau2-compatibility", story: "retail-return-lifecycle" },
+    user: CUSTOMER_USERS[0],
+  },
+  {
+    traceKey: "lifecycle",
+    index: 1,
+    daysAgo: 11,
+    userPrompt: "I accidentally cancelled my order. Can you undo it immediately?",
+    assistantResponse:
+      "Cancelled orders cannot be reinstated automatically. I can help place a new order or transfer you for an out-of-scope exception review.",
+    tags: ["support", "lifecycle", "tau2-retail"],
+    metadata: { seed: "tau2-compatibility", story: "cancelled-order-policy" },
+    user: CUSTOMER_USERS[1],
+  },
+  {
+    traceKey: "lifecycle",
+    index: 2,
+    daysAgo: 10,
+    userPrompt: "My phone has no service and I need it fixed before I leave the airport.",
+    assistantResponse:
+      "Let's troubleshoot step by step. I will inspect the device state, verify SIM and roaming settings, then run a speed test before calling this resolved.",
+    tags: ["support", "lifecycle", "tau2-telecom"],
+    metadata: { seed: "tau2-compatibility", story: "telecom-troubleshooting" },
+    user: CUSTOMER_USERS[2],
+  },
+  {
+    traceKey: "lifecycle",
+    index: 3,
+    daysAgo: 9,
+    userPrompt: "Can you waive this mobile data fee as a courtesy?",
+    assistantResponse:
+      "I need to verify the account and policy eligibility before discussing credits. I cannot promise a waiver before review.",
+    tags: ["support", "lifecycle", "tau2-telecom"],
+    // Same user as the troubleshooting trace so one profile accumulates
+    // multiple issue occurrences.
+    metadata: { seed: "tau2-compatibility", story: "telecom-credit-policy" },
+    user: CUSTOMER_USERS[2],
+  },
+  {
+    traceKey: "lifecycle",
+    index: 4,
+    daysAgo: 8,
+    userPrompt: "Should I get the premium credit card if I already have a corporate travel card?",
+    assistantResponse:
+      "I need to compare the card fees, rewards, and your subscription benefits against the policy documents before recommending a product.",
+    tags: ["support", "lifecycle", "tau2-banking"],
+    metadata: { seed: "tau2-compatibility", story: "banking-knowledge-grounding" },
+    user: CUSTOMER_USERS[3],
+  },
+  {
+    traceKey: "annotation-demo",
+    index: 0,
+    daysAgo: 2,
+    userPrompt: "I want to return my gaming keyboard and mouse now that I quit gaming.",
+    assistantResponse:
+      "I authenticated the account, checked both delivered orders, and requested returns for the eligible keyboard and mouse to the original payment methods.",
+    tags: ["support", "annotation", "tau2-retail"],
+    metadata: { seed: "tau2-compatibility", story: "annotation-ui-polish" },
+    user: CUSTOMER_USERS[0],
+  },
+  {
+    traceKey: "code-block-demo",
+    index: 0,
+    daysAgo: 1,
+    userPrompt: "How do I fetch a trace with the Latitude Node SDK?",
+    assistantResponse:
+      "Set your API key in the `Authorization` header, then call the SDK. Here's a minimal example:\n\n" +
+      "```ts\n" +
+      'import { Latitude } from "@latitude-data/sdk"\n\n' +
+      "const sdk = new Latitude(process.env.LATITUDE_API_KEY!)\n" +
+      'const trace = await sdk.traces.get("trace-id")\n' +
+      "console.log(trace.spans.length)\n" +
+      "```\n\n" +
+      "Keep the key in an environment variable — never hard-code it.",
+    tags: ["support", "developer", "code-example"],
+    metadata: { seed: "tau2-compatibility", story: "code-block-rendering" },
+    user: EMPLOYEE_USERS[0],
+    serviceName: "developer-support-agent",
+    systemInstruction:
+      "You are a developer support AI agent. Help users integrate the Latitude SDK and API, and include short, correct code examples when useful.",
+  },
+] as const
 
-  return specs.map((spec) => createCompatibilityChatSpan({ scope, ...spec }))
+export function buildCompatibilitySupportSpans(scope: SeedScope): SpanRow[] {
+  return COMPATIBILITY_TRACE_SPECS.map((spec) => createCompatibilityChatSpan({ scope, ...spec }))
 }
 
 type LargeConversationSpec = {
@@ -548,41 +548,41 @@ function createLargeConversationChatSpan(opts: { scope: SeedScope; spec: LargeCo
   }
 }
 
-function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
-  const specs: readonly LargeConversationSpec[] = [
-    {
-      traceKey: "large-conversation",
-      index: 0,
-      sessionId: "seed-large-conversation-1",
-      daysAgo: 1,
-      turnCount: 120,
-      scenario: "return eligibility investigation with repeated shipping and payment updates",
-      serviceName: "load-test-retail-support-agent",
-      user: CUSTOMER_USERS[4],
-    },
-    {
-      traceKey: "large-conversation",
-      index: 1,
-      sessionId: "seed-large-conversation-2",
-      daysAgo: 1,
-      turnCount: 240,
-      scenario: "telecom outage troubleshooting with many device-state checkpoints",
-      serviceName: "load-test-telecom-support-agent",
-      user: CUSTOMER_USERS[5],
-    },
-    {
-      traceKey: "large-conversation",
-      index: 2,
-      sessionId: "seed-large-conversation-3",
-      daysAgo: 1,
-      turnCount: 420,
-      scenario: "travel itinerary exception review with long-running policy comparisons",
-      serviceName: "load-test-travel-support-agent",
-      user: CUSTOMER_USERS[6],
-    },
-  ]
+const LARGE_CONVERSATION_SPECS: readonly LargeConversationSpec[] = [
+  {
+    traceKey: "large-conversation",
+    index: 0,
+    sessionId: "seed-large-conversation-1",
+    daysAgo: 1,
+    turnCount: 120,
+    scenario: "return eligibility investigation with repeated shipping and payment updates",
+    serviceName: "load-test-retail-support-agent",
+    user: CUSTOMER_USERS[4],
+  },
+  {
+    traceKey: "large-conversation",
+    index: 1,
+    sessionId: "seed-large-conversation-2",
+    daysAgo: 1,
+    turnCount: 240,
+    scenario: "telecom outage troubleshooting with many device-state checkpoints",
+    serviceName: "load-test-telecom-support-agent",
+    user: CUSTOMER_USERS[5],
+  },
+  {
+    traceKey: "large-conversation",
+    index: 2,
+    sessionId: "seed-large-conversation-3",
+    daysAgo: 1,
+    turnCount: 420,
+    scenario: "travel itinerary exception review with long-running policy comparisons",
+    serviceName: "load-test-travel-support-agent",
+    user: CUSTOMER_USERS[6],
+  },
+]
 
-  return specs.map((spec) => createLargeConversationChatSpan({ scope, spec }))
+function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
+  return LARGE_CONVERSATION_SPECS.map((spec) => createLargeConversationChatSpan({ scope, spec }))
 }
 
 function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length): SpanRow[] {
@@ -821,3 +821,14 @@ const seedLargeConversationTraces: Seeder = {
 }
 
 export const fixedTraceSeeders: readonly Seeder[] = [seedFixedTraces, seedLargeConversationTraces]
+
+/**
+ * Every deterministic trace this module seeds, as `(traceKey, index)` slots.
+ * Must stay in lockstep with the builders above; the demo-project snapshot
+ * import enumerates these to remap trace ids across projects.
+ */
+export const fixedTraceSlots: readonly TraceSlot[] = [
+  ...TAU2_SEED_TRAJECTORIES.map((_, index) => ({ traceKey: "tau2-trajectory", index })),
+  ...LARGE_CONVERSATION_SPECS.map((spec) => ({ traceKey: spec.traceKey, index: spec.index })),
+  ...COMPATIBILITY_TRACE_SPECS.map((spec) => ({ traceKey: spec.traceKey, index: spec.index })),
+]

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -1,10 +1,10 @@
 import { type SeedScope, TraceId } from "@domain/shared/seeding"
 import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
-import type { SeedContext, Seeder } from "../types.ts"
-import { fixedTraceSeeders } from "./fixed-traces.ts"
+import type { SeedContext, Seeder, TraceSlot } from "../types.ts"
+import { fixedTraceSeeders, fixedTraceSlots } from "./fixed-traces.ts"
 import { generateAllSpans, type SpanRow, type TraceConfig } from "./generator.ts"
-import { orphanFragmentSeeders } from "./orphan-fragments.ts"
+import { orphanFragmentSeeders, orphanFragmentTraceSlots } from "./orphan-fragments.ts"
 
 const TRACE_COUNT = 2000
 const BATCH_SIZE = 500
@@ -51,3 +51,10 @@ export const runSpansSeed = (
   })
 
 export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders]
+
+/**
+ * Catalog of every deterministic trace the demo seed writes, as
+ * `(traceKey, index)` slots. The ambient `generateAllSpans` traces are not
+ * included — they are not part of the demo seed (`allSeeders`).
+ */
+export const spanTraceSlots: readonly TraceSlot[] = [...fixedTraceSlots, ...orphanFragmentTraceSlots]

--- a/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/orphan-fragments.ts
@@ -2,7 +2,7 @@ import type { SeedScope } from "@domain/shared/seeding"
 import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
 import { isSentinelPresent } from "../idempotency.ts"
-import type { Seeder } from "../types.ts"
+import type { Seeder, TraceSlot } from "../types.ts"
 import type { SpanRow } from "./span-builders.ts"
 
 function formatClickHouseTimestamp(date: Date): string {
@@ -299,3 +299,14 @@ const seedOrphanFragments: Seeder = {
 }
 
 export const orphanFragmentSeeders: readonly Seeder[] = [seedOrphanFragments]
+
+/**
+ * Trace slots for the orphan-fragment traces. Each spec seeds one trace at
+ * the default index 0 via `scope.traceHex(traceKey)`; their LLM span carries a
+ * literal `sessionId`, so the snapshot remap only needs to translate the
+ * (project-scoped) trace ids.
+ */
+export const orphanFragmentTraceSlots: readonly TraceSlot[] = ORPHAN_FRAGMENT_SPECS.map((spec) => ({
+  traceKey: spec.traceKey,
+  index: 0,
+}))

--- a/packages/platform/db-clickhouse/src/seeds/spans/trace-slots.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/trace-slots.test.ts
@@ -1,0 +1,43 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID, seedTraceHex } from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { spanSeeders, spanTraceSlots } from "./index.ts"
+
+// Records inserted span rows and reports every sentinel check as "not seeded"
+// so each seeder runs its full body once.
+const recordingClient = (insertedSpans: Record<string, unknown>[]): ClickHouseClient =>
+  ({
+    query: async () => ({ json: async () => [{ present: "0" }] }),
+    insert: async ({ table, values }: { table: string; values: ReadonlyArray<Record<string, unknown>> }) => {
+      if (table === "spans") insertedSpans.push(...values)
+    },
+  }) as unknown as ClickHouseClient
+
+describe("spanTraceSlots", () => {
+  it("regenerates exactly the trace ids the demo span seeders emit", async () => {
+    const insertedSpans: Record<string, unknown>[] = []
+    const scope = createSeedScope({
+      organizationId: SEED_ORG_ID,
+      projectId: SEED_PROJECT_ID,
+      timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
+      queueAssigneeUserIds: [],
+      apiKeyId: SEED_API_KEY_ID,
+    })
+
+    for (const seeder of spanSeeders) {
+      await Effect.runPromise(seeder.run({ client: recordingClient(insertedSpans), scope, quiet: true }))
+    }
+
+    const seededTraceIds = new Set(insertedSpans.map((span) => span.trace_id as string))
+    const slotTraceIds = new Set(spanTraceSlots.map((slot) => seedTraceHex(scope.projectId, slot.traceKey, slot.index)))
+
+    expect(seededTraceIds.size).toBeGreaterThan(0)
+    expect([...slotTraceIds].sort()).toEqual([...seededTraceIds].sort())
+  })
+
+  it("has no duplicate slots", () => {
+    const keys = spanTraceSlots.map((slot) => `${slot.traceKey}:${slot.index}`)
+    expect(new Set(keys).size).toEqual(keys.length)
+  })
+})

--- a/packages/platform/db-clickhouse/src/seeds/types.ts
+++ b/packages/platform/db-clickhouse/src/seeds/types.ts
@@ -21,3 +21,16 @@ export interface Seeder {
   readonly name: string
   readonly run: (ctx: SeedContext) => Effect.Effect<void, unknown>
 }
+
+/**
+ * A deterministic seeded-trace identity. Every fixed/demo trace id is
+ * `scope.traceHex(traceKey, index)`, so a `(traceKey, index)` pair regenerates
+ * the same id under any project. The demo-project snapshot import enumerates
+ * the full slot catalog to remap the source project's trace/session ids onto
+ * the freshly seeded project's ids — without it, the imported derived data
+ * points at traces that only exist under the source project.
+ */
+export interface TraceSlot {
+  readonly traceKey: string
+  readonly index: number
+}


### PR DESCRIPTION
## Problem

In the **Behaviours** panel (Conversation intelligence), clicking an *Associated session* opens a trace panel that **never loads** — it sits on skeletons forever (see the linked report). This affects every demo/sample project, not a single org.

## Root cause

Demo projects build telemetry in two paths that disagree on trace ids:

- **Traces & spans** are seeded fresh, with `trace_id = seedTraceHex(projectId, traceKey, index)` — **project-scoped**.
- **Derived analysis data** (`session_analyses`, `taxonomy_observations`, `trace_search_documents`, `trace_message_occurrences`, …) is imported from a pre-baked snapshot exported from a fixed *source* project. `mapClickHouseRow` remapped `organization_id` / `project_id` / timestamps / cluster + run ids — but **never `trace_id` / `session_id` / `trace_ids`**.

So the imported analysis references the *source* project's trace ids, which don't exist under the freshly-seeded project. The behaviour session's id is a phantom trace → `SessionDetailDrawer` falls back to the trace view with a non-existent id → permanent skeleton.

Verified against V2 production (project `an3s1qhl5twcq2nbkajayw1u`): **0 / 1578** analysis trace ids, **0** of 1578 search docs, and **0** of 24433 message occurrences overlap the actually-seeded traces. Proven numerically that a snapshot id = `seedTraceHex(sourceProjectId, "tau2-trajectory", i)` and a real trace = `seedTraceHex(targetProjectId, "tau2-trajectory", j)` — same seed slots, different project id.

## Fix

Both ends derive from `seedTraceHex(projectId, traceKey, index)`, so the source→target mapping is reconstructable:

1. **Expose a `(traceKey, index)` slot catalog** from the seed layer (`demoSeedTraceSlots` off `@platform/db-clickhouse/seeding`). Each span module (`fixed-traces.ts`, `orphan-fragments.ts`) exports its slots; the inline spec arrays were lifted to module scope so the catalog can't drift from the builders.
2. **Add `seedTraceHex(projectId, key, index)`** to `@domain/shared` to regenerate ids without building a full scope.
3. **Build the remap in `importDemoProjectDerivedSnapshot`** (`buildTraceIdRemap(sourceProjectId, targetProjectId)`) and apply it in `mapClickHouseRow` to the trace/session columns of each snapshot table (`trace_id`, `session_id`, `trace_ids[]`). Literal session ids (`seed-large-conversation-1`, `session-anthropic-demo`) aren't in the map and pass through unchanged.

## Tests

- **Drift guard** (`trace-slots.test.ts`): runs the real span seeders against a recording client and asserts the slot catalog regenerates *exactly* the seeded trace ids.
- **Remap unit test** (`demo-project-snapshot.test.ts`): every slot maps source→target, literal ids untouched, same-project is a no-op.

All touched packages typecheck, lint clean; existing demo-workflow and span-seed suites pass.

## Note on existing projects

This fixes **newly provisioned** demo projects. Already-provisioned ones (e.g. the one in the report) still hold the broken ids and need a re-seed / re-import to pick up the remap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)