### PR TITLE
feat(spans): ingest OpenClaw's native OpenTelemetry exporter

### DIFF
--- a/docs/telemetry/openclaw.md
+++ b/docs/telemetry/openclaw.md
@@ -1,164 +1,112 @@
 # OpenClaw telemetry
 
-Stream OpenClaw agent runs into Latitude as traces. After setup, agent runs appear in your project's **Traces** view with model calls, tool calls, token usage, timing, agent names, and nested subagent activity.
+Stream OpenClaw agent runs into Latitude as traces. After setup, agent runs appear in your project's **Traces** view with model calls, tool calls, token usage, cost, timing, and nested subagent activity — as a proper `invoke_agent → chat → execute_tool` tree.
+
+The recommended way is OpenClaw's **official OpenTelemetry exporter** (the bundled `@openclaw/diagnostics-otel` plugin), pointed at Latitude's OTLP ingest. It follows OpenTelemetry GenAI semantic conventions and is maintained by OpenClaw — see [OpenClaw's OpenTelemetry docs](https://docs.openclaw.ai/gateway/opentelemetry).
+
+> **Deprecated:** the previous `@latitude-data/openclaw-telemetry` plugin (and its `…-cli` installer) is replaced by the native exporter below. See [Migrating from the Latitude plugin](#migrating-from-the-latitude-plugin).
 
 ## Prerequisites
 
 - A [Latitude account](https://console.latitude.so/login) with a project
-- OpenClaw installed locally
-- Node.js available on your `PATH`
+- OpenClaw 2026.6 or newer
+- A Latitude **API key** and your **project slug** (project sidebar → **Settings → API Keys**)
 
-## Install
+## Setup
 
-1. In Latitude, copy your project slug from the project sidebar.
-2. Create or copy an API key from **Settings → API Keys**.
-3. Run the installer:
+### 1. Install the exporter
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli install
+openclaw plugins install clawhub:@openclaw/diagnostics-otel
 ```
 
-The installer prompts for your API key and project slug, installs the OpenClaw telemetry plugin, enables it, and validates the configuration.
+### 2. Point it at Latitude
 
-You can also pass values directly:
-
-```bash
-npx -y @latitude-data/openclaw-telemetry-cli install \
-  --api-key=lat_xxx \
-  --project=your-project-slug \
-  --yes
-```
-
-## Restart and verify
-
-Restart the OpenClaw gateway if the installer did not do it for you:
-
-```bash
-openclaw gateway restart
-```
-
-Send a message to an agent, then open your Latitude project and go to **Traces**. The new trace should appear within a few seconds.
-
-## Structural-only telemetry
-
-If you want trace structure without prompt, response, or tool content, install with:
-
-```bash
-npx -y @latitude-data/openclaw-telemetry-cli install --no-content
-```
-
-Structural-only traces still include timing, model, token usage, agent names, and run structure. Message content and tool input/output are omitted.
-
-## Disable or uninstall
-
-To pause telemetry, set the environment variable on the gateway process:
-
-```bash
-export LATITUDE_OPENCLAW_ENABLED=0
-```
-
-Restart the gateway for the change to take effect.
-
-To remove the integration:
-
-```bash
-npx -y @latitude-data/openclaw-telemetry-cli uninstall
-openclaw gateway restart
-```
-
-## Manual configuration
-
-If you manage OpenClaw configuration yourself, install the plugin and add it to `~/.openclaw/openclaw.json`:
-
-```bash
-openclaw plugins install @latitude-data/openclaw-telemetry
-```
-
-```json
-{
-  "plugins": {
-    "allow": ["@latitude-data/openclaw-telemetry"],
-    "entries": {
-      "@latitude-data/openclaw-telemetry": {
-        "enabled": true,
-        "hooks": {
-          "allowConversationAccess": true
-        },
-        "config": {
-          "apiKey": "lat_xxx",
-          "project": "your-project-slug",
-          "allowConversationAccess": true
-        }
-      }
-    }
-  }
-}
-```
-
-Set `config.allowConversationAccess` to `false` for structural-only telemetry while keeping `hooks.allowConversationAccess` set to `true`.
-
-## Captured data and privacy
-
-By default, Latitude receives the content needed to reconstruct OpenClaw runs, including prompts, responses, system instructions, tool input/output, model metadata, and token usage.
-
-- Use `--no-content` when you only want structural telemetry.
-- Telemetry runs for each agent run until disabled or uninstalled.
-- Disable telemetry before working with sensitive material you do not want sent to Latitude.
-
-## Custom redaction
-
-If you want to keep content capture enabled but mask specific span attributes before they leave the gateway, add a `redact` block to `config` in `~/.openclaw/openclaw.json`. Redaction happens locally, after the content gate and before the OTLP export.
-
-`redact.attributes` accepts an array of patterns. Each pattern can be:
-
-- An **exact attribute name** — `"gen_ai.tool.call.arguments"`
-- A **regex source string** — `"^gen_ai\\.(input|output)\\.messages$"` (anchored match)
-- A **`/pattern/flags` string** — `"/^gen_ai\\.tool\\.call\\.(arguments|result)$/i"`
-
-`redact.mask` sets the replacement value (default: `******`). Set it to `"[]"` to replace message arrays with an empty array instead of a string.
-
-### Examples
-
-Redact all prompt and response messages using `openclaw config set`:
-
-```bash
-openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.redact' \
-  '{"attributes":["/^gen_ai\\.(input|output)\\.messages$/"],"mask":"[]"}'
-openclaw gateway restart
-```
-
-Or hand-edit `~/.openclaw/openclaw.json` directly:
+Add the `diagnostics.otel` block to `~/.openclaw/openclaw.json`. Latitude's ingest accepts OTLP/HTTP (protobuf) at `/v1/traces` and authenticates with your API key; the project is selected with the `X-Latitude-Project` header.
 
 ```jsonc
 {
-  "plugins": {
-    "entries": {
-      "@latitude-data/openclaw-telemetry": {
-        "config": {
-          "redact": {
-            "attributes": [
-              "/^gen_ai\\.(input|output)\\.messages$/",
-              "/^gen_ai\\.tool\\.call\\.(arguments|result)$/"
-            ],
-            "mask": "[]"
-          }
-        }
+  "diagnostics": {
+    "otel": {
+      "enabled": true,
+      "traces": true,
+      "protocol": "http/protobuf",
+      "tracesEndpoint": "https://ingest.latitude.so/v1/traces",
+      "headers": {
+        "Authorization": "Bearer lat_xxx",
+        "X-Latitude-Project": "your-project-slug"
+      },
+      "captureContent": {
+        "enabled": true,
+        "inputMessages": true,
+        "outputMessages": true,
+        "toolInputs": true,
+        "toolOutputs": true,
+        "systemPrompt": true
       }
     }
   }
 }
 ```
 
-Restart the gateway after editing:
+The same keys can be set non-interactively:
+
+```bash
+openclaw config set 'diagnostics.otel.enabled' true
+openclaw config set 'diagnostics.otel.traces' true
+openclaw config set 'diagnostics.otel.protocol' '"http/protobuf"'
+openclaw config set 'diagnostics.otel.tracesEndpoint' '"https://ingest.latitude.so/v1/traces"'
+openclaw config set 'diagnostics.otel.headers' \
+  '{"Authorization":"Bearer lat_xxx","X-Latitude-Project":"your-project-slug"}'
+openclaw config set 'diagnostics.otel.captureContent' \
+  '{"enabled":true,"inputMessages":true,"outputMessages":true,"toolInputs":true,"toolOutputs":true,"systemPrompt":true}'
+```
+
+### 3. Restart and verify
 
 ```bash
 openclaw gateway restart
 ```
 
+Send a message to an agent, then open your Latitude project and go to **Traces** — the run should appear within a few seconds.
+
+## Structural-only telemetry
+
+To capture trace structure (timing, model, token usage, cost, run/tool shape) without prompt, response, or tool content, set `captureContent.enabled` to `false`:
+
+```bash
+openclaw config set 'diagnostics.otel.captureContent.enabled' false
+openclaw gateway restart
+```
+
+## Captured data and privacy
+
+With `captureContent.enabled = true`, Latitude receives the content needed to reconstruct runs — prompts, responses, system instructions, and tool input/output — plus model metadata, token usage, and cost. The granular `captureContent.*` flags let you capture some kinds of content and not others. Content is **not** exported unless you opt in. Disable capture (or telemetry entirely) before working with sensitive material you don't want sent to Latitude.
+
+## Disable
+
+Pause the exporter without uninstalling:
+
+```bash
+openclaw config set 'diagnostics.otel.enabled' false
+openclaw gateway restart
+```
+
+## Migrating from the Latitude plugin
+
+If you previously installed `@latitude-data/openclaw-telemetry`, remove it and switch to the native exporter above:
+
+```bash
+openclaw plugins uninstall @latitude-data/openclaw-telemetry --force
+openclaw plugins install clawhub:@openclaw/diagnostics-otel
+# add the diagnostics.otel config from step 2, then:
+openclaw gateway restart
+```
+
+The native exporter produces the same Traces view (and a cleaner `invoke_agent → chat → execute_tool` structure), so no changes are needed on the Latitude side.
+
 ## Troubleshooting
 
-**No traces appear.** Restart the gateway, confirm the API key and project slug are correct, and send a new agent message.
+**No traces appear.** Restart the gateway, confirm the API key and project slug are correct, and send a new agent message. A `401`/`403` from ingest means the API key isn't valid for that project's organization.
 
-**Need more diagnostics.** Set `LATITUDE_DEBUG=1` on the gateway process and trigger another run.
-
-**Traces show timing but no content.** Structural-only mode is enabled. Reinstall without `--no-content` or set `config.allowConversationAccess` to `true`.
+**Traces show timing but no content.** `captureContent.enabled` is `false` — set it to `true` and restart.

--- a/packages/domain/spans/src/otlp/dropped-spans.test.ts
+++ b/packages/domain/spans/src/otlp/dropped-spans.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { isDroppedSpan } from "./dropped-spans.ts"
+
+describe("isDroppedSpan", () => {
+  it("drops OpenClaw's orphan usage span", () => {
+    expect(isDroppedSpan("openclaw", "openclaw.model.usage")).toBe(true)
+  })
+
+  it("keeps other OpenClaw spans", () => {
+    expect(isDroppedSpan("openclaw", "openclaw.model.call")).toBe(false)
+    expect(isDroppedSpan("openclaw", "openclaw.run")).toBe(false)
+    expect(isDroppedSpan("openclaw", "openclaw.tool.execution")).toBe(false)
+  })
+
+  it("is scoped — a same-named span from another scope is not dropped", () => {
+    expect(isDroppedSpan("other-scope", "openclaw.model.usage")).toBe(false)
+  })
+})

--- a/packages/domain/spans/src/otlp/dropped-spans.ts
+++ b/packages/domain/spans/src/otlp/dropped-spans.ts
@@ -1,0 +1,16 @@
+/**
+ * Spans that are pure noise or redundant with data already carried elsewhere,
+ * and must not be ingested. Keeping the rules here keeps source-specific quirks
+ * out of the generic transform.
+ */
+const DROPPED_SPANS: ReadonlyArray<{ readonly scope: string; readonly name: string }> = [
+  // OpenClaw's diagnostics-otel emits a standalone `openclaw.model.usage` span in
+  // its own (unparented) trace, duplicating per-call usage that already rides on
+  // the model.call spans inside the run trace (read in resolvers/usage.ts). Drop
+  // it so it doesn't surface as an orphan one-span trace/session.
+  { scope: "openclaw", name: "openclaw.model.usage" },
+]
+
+export function isDroppedSpan(scopeName: string, spanName: string): boolean {
+  return DROPPED_SPANS.some((rule) => rule.scope === scopeName && rule.name === spanName)
+}

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -68,6 +68,12 @@ const CLAUDE_CODE_OPERATION: Record<string, string> = {
   tool: "execute_tool",
 }
 
+const OPENCLAW_TELEMETRY_SCOPE = "openclaw"
+const OPENCLAW_SPAN_OPERATION: Record<string, Operation> = {
+  "openclaw.run": "invoke_agent",
+  "openclaw.tool.execution": "execute_tool",
+}
+
 const CLAUDE_CODE_NATIVE_SPAN_PREFIX = "claude_code."
 
 /**
@@ -101,6 +107,10 @@ export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: s
     stringAttr(spanAttrs, "openinference.span.kind") === "AGENT"
   ) {
     return "chat"
+  }
+  if (scopeName === OPENCLAW_TELEMETRY_SCOPE) {
+    const mapped = OPENCLAW_SPAN_OPERATION[spanName]
+    if (mapped) return mapped
   }
   return first(operationCandidates, spanAttrs) ?? operationFromClaudeCodeNativeSpanName(spanName) ?? "unspecified"
 }

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -1018,4 +1018,8 @@ describe("resolveStatusCode", () => {
     expect(resolveStatusCode([strAttr("openclaw.outcome", "error")], "unset", "openclaw")).toBe("error")
     expect(resolveStatusCode([strAttr("openclaw.outcome", "abandoned")], "unset", "openclaw")).toBe("error")
   })
+
+  it("lets a failing outcome override an OTel ok status", () => {
+    expect(resolveStatusCode([strAttr("openclaw.outcome", "abandoned")], "ok", "openclaw")).toBe("error")
+  })
 })

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest"
 import type { OtlpEvent, OtlpKeyValue } from "../types.ts"
 import { resolveAttributes } from "./index.ts"
 import { resolvePerformance } from "./performance.ts"
+import { resolveStatusCode } from "./status.ts"
 import { resolveToolExecution } from "./tool-execution.ts"
+import { resolveUsage } from "./usage.ts"
 import { first, fromFloat, fromInt, fromString, fromStringArray } from "./utils.ts"
 
 function strAttr(key: string, value: string): OtlpKeyValue {
@@ -287,6 +289,30 @@ describe("resolveAttributes", () => {
         const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.operation).toBe(expected)
       }
+    })
+
+    it("maps OpenClaw diagnostics-otel run/tool spans by name (scope `openclaw`)", () => {
+      expect(
+        resolveAttributes({ spanAttrs: [], statusCode: "unset", spanName: "openclaw.run", scopeName: "openclaw" })
+          .operation,
+      ).toBe("invoke_agent")
+      expect(
+        resolveAttributes({
+          spanAttrs: [strAttr("gen_ai.tool.name", "bash")],
+          statusCode: "unset",
+          spanName: "openclaw.tool.execution",
+          scopeName: "openclaw",
+        }).operation,
+      ).toBe("execute_tool")
+      // model.call keeps its gen_ai.operation.name (not overridden by the scope map).
+      expect(
+        resolveAttributes({
+          spanAttrs: [strAttr("gen_ai.operation.name", "chat")],
+          statusCode: "unset",
+          spanName: "openclaw.model.call",
+          scopeName: "openclaw",
+        }).operation,
+      ).toBe("chat")
     })
 
     it("maps OpenLLMetry request types", () => {
@@ -915,5 +941,81 @@ describe("resolveToolExecution", () => {
       expect(result.toolInput).toBe("")
       expect(result.toolOutput).toBe("")
     })
+  })
+})
+
+describe("resolveUsage — embedded message usage (OpenClaw)", () => {
+  // OpenClaw buries usage + provider cost in the assistant message JSON instead
+  // of flat gen_ai.usage.* attrs. Tokens are additive (input excludes cache).
+  const outputMessages = (usage: unknown) =>
+    strAttr("openclaw.content.output_messages", JSON.stringify([{ role: "assistant", content: [], usage }]))
+
+  it("reads additive tokens + provider cost (not estimated), folding cache into input", () => {
+    const u = resolveUsage({
+      attrs: [
+        outputMessages({
+          input: 951,
+          output: 127,
+          cacheRead: 20864,
+          cacheWrite: 0,
+          reasoningTokens: 0,
+          totalTokens: 21942,
+          cost: { input: 0.004755, output: 0.00381, cacheRead: 0.010432, cacheWrite: 0, total: 0.018997 },
+        }),
+      ],
+      provider: "openai",
+      model: "gpt-5.5",
+    })
+    expect(u.tokensInput).toBe(951) // additive — not reduced by cache
+    expect(u.tokensOutput).toBe(127)
+    expect(u.tokensCacheRead).toBe(20864)
+    expect(u.tokensCacheCreate).toBe(0)
+    expect(u.tokensReasoning).toBe(0)
+    expect(u.costInputMicrocents).toBe(1_518_700) // (0.004755 + 0.010432) * 1e8
+    expect(u.costOutputMicrocents).toBe(381_000)
+    expect(u.costTotalMicrocents).toBe(1_899_700)
+    expect(u.costIsEstimated).toBe(false)
+  })
+
+  it("falls back to flat gen_ai.usage.* attrs when there is no embedded usage", () => {
+    const u = resolveUsage({
+      attrs: [intAttr("gen_ai.usage.input_tokens", 100), intAttr("gen_ai.usage.output_tokens", 20)],
+      provider: "openai",
+      model: "gpt-5.5",
+    })
+    expect(u.tokensInput).toBe(100)
+    expect(u.tokensOutput).toBe(20)
+  })
+
+  it("ignores output_messages that carry no usage object", () => {
+    const u = resolveUsage({
+      attrs: [strAttr("openclaw.content.output_messages", JSON.stringify([{ role: "assistant", content: [] }]))],
+      provider: "openai",
+      model: "gpt-5.5",
+    })
+    expect(u.tokensInput).toBe(0)
+    expect(u.tokensOutput).toBe(0)
+  })
+})
+
+describe("resolveStatusCode", () => {
+  it("passes the OTel status through for non-OpenClaw scopes", () => {
+    expect(resolveStatusCode([], "unset", "openinference")).toBe("unset")
+    expect(resolveStatusCode([], "ok", "openinference")).toBe("ok")
+    expect(resolveStatusCode([], "error", "openinference")).toBe("error")
+  })
+
+  it("treats unset OpenClaw spans as ok (success is signalled out-of-band, not via OTel status)", () => {
+    expect(resolveStatusCode([], "unset", "openclaw")).toBe("ok")
+    expect(resolveStatusCode([strAttr("openclaw.outcome", "completed")], "unset", "openclaw")).toBe("ok")
+  })
+
+  it("keeps OpenClaw spans the plugin explicitly marked as error", () => {
+    expect(resolveStatusCode([], "error", "openclaw")).toBe("error")
+  })
+
+  it("marks an OpenClaw span as error when its outcome is not a success value", () => {
+    expect(resolveStatusCode([strAttr("openclaw.outcome", "error")], "unset", "openclaw")).toBe("error")
+    expect(resolveStatusCode([strAttr("openclaw.outcome", "abandoned")], "unset", "openclaw")).toBe("error")
   })
 })

--- a/packages/domain/spans/src/otlp/resolvers/status.ts
+++ b/packages/domain/spans/src/otlp/resolvers/status.ts
@@ -1,0 +1,28 @@
+import type { SpanStatusCode } from "../../entities/span.ts"
+import { stringAttr } from "../attributes.ts"
+import type { OtlpKeyValue } from "../types.ts"
+
+// OpenClaw's diagnostics-otel plugin sets the OTel span status only on problems
+// (e.g. `openclaw.liveness.warning` arrives `error`) and signals success via the
+// `openclaw.outcome` attribute (`completed`) rather than an explicit OK — so
+// successful spans arrive `unset` and would render as the neutral/gray status.
+// Derive a real status from the outcome so success shows as ok and genuine
+// failures (outcome not completed, or an OTel error) show as error.
+const OPENCLAW_SCOPE = "openclaw"
+const OPENCLAW_OK_OUTCOMES = new Set(["completed", "ok", "success"])
+
+export function resolveStatusCode(
+  spanAttrs: readonly OtlpKeyValue[],
+  otelStatusCode: SpanStatusCode,
+  scopeName: string,
+): SpanStatusCode {
+  if (scopeName !== OPENCLAW_SCOPE) return otelStatusCode
+  // The plugin flags real failures on the OTel status; trust it when set.
+  if (otelStatusCode === "error") return "error"
+
+  const outcome = stringAttr(spanAttrs, "openclaw.outcome")
+  if (outcome && !OPENCLAW_OK_OUTCOMES.has(outcome.toLowerCase())) return "error"
+
+  // `completed`/success, or `unset` with no failure signal → a successful span.
+  return "ok"
+}

--- a/packages/domain/spans/src/otlp/resolvers/usage.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage.ts
@@ -126,10 +126,11 @@ function extractEmbeddedUsage(outputMessagesJson: string): OpenclawUsage | undef
   try {
     const parsed: unknown = JSON.parse(outputMessagesJson)
     if (!Array.isArray(parsed)) return undefined
-    const withUsage = parsed.find(
-      (m): m is { usage: OpenclawUsage } =>
-        !!m && typeof m === "object" && typeof (m as { usage?: unknown }).usage === "object",
-    )
+    const withUsage = parsed.find((m): m is { usage: OpenclawUsage } => {
+      if (!m || typeof m !== "object") return false
+      const usage = (m as { usage?: unknown }).usage
+      return usage !== null && typeof usage === "object"
+    })
     return withUsage?.usage
   } catch {
     return undefined

--- a/packages/domain/spans/src/otlp/resolvers/usage.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage.ts
@@ -1,4 +1,5 @@
 import { computeTokenCost, getCostSpec } from "@domain/models"
+import { stringAttr } from "../attributes.ts"
 import type { OtlpKeyValue } from "../types.ts"
 import { resolveTokens } from "./usage/tokens.ts"
 import { first, fromFloat } from "./utils.ts"
@@ -85,6 +86,103 @@ export interface ResolvedUsage {
   readonly costIsEstimated: boolean
 }
 
+// ─── OpenClaw embedded usage ──────────────────────────────
+//
+// OpenClaw's diagnostics-otel plugin never emits flat gen_ai.usage.* attrs. It
+// buries per-call usage — and the provider's real cost (USD) — inside the
+// assistant message JSON on `openclaw.content.output_messages`:
+//
+//   [{ role, content, usage: { input, output, cacheRead, cacheWrite,
+//        reasoningTokens, totalTokens, cost: { input, output, total, … } } }]
+//
+// `input` is ADDITIVE (excludes cache), matching ResolvedUsage's contract, so
+// fields map straight across with no inclusive/additive inference. The same
+// totals also ride on a standalone `openclaw.model.usage` span the plugin emits
+// in its own orphan trace (dropped at ingest, see otlp/dropped-spans.ts) — this
+// per-call copy lives on the model.call span inside the run trace.
+
+interface OpenclawCost {
+  readonly input?: unknown
+  readonly output?: unknown
+  readonly cacheRead?: unknown
+  readonly cacheWrite?: unknown
+  readonly total?: unknown
+}
+
+interface OpenclawUsage {
+  readonly input?: unknown
+  readonly output?: unknown
+  readonly cacheRead?: unknown
+  readonly cacheWrite?: unknown
+  readonly reasoningTokens?: unknown
+  readonly cost?: OpenclawCost
+}
+
+function nonNegative(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? Math.max(0, v) : 0
+}
+
+function extractEmbeddedUsage(outputMessagesJson: string): OpenclawUsage | undefined {
+  try {
+    const parsed: unknown = JSON.parse(outputMessagesJson)
+    if (!Array.isArray(parsed)) return undefined
+    const withUsage = parsed.find(
+      (m): m is { usage: OpenclawUsage } =>
+        !!m && typeof m === "object" && typeof (m as { usage?: unknown }).usage === "object",
+    )
+    return withUsage?.usage
+  } catch {
+    return undefined
+  }
+}
+
+function resolveEmbeddedMessageUsage(
+  attrs: readonly OtlpKeyValue[],
+  provider: string,
+  model: string,
+): ResolvedUsage | null {
+  const raw = stringAttr(attrs, "openclaw.content.output_messages")
+  if (!raw) return null
+  const usage = extractEmbeddedUsage(raw)
+  if (!usage) return null
+
+  const tokensInput = nonNegative(usage.input)
+  const tokensOutput = nonNegative(usage.output)
+  const tokensCacheRead = nonNegative(usage.cacheRead)
+  const tokensCacheCreate = nonNegative(usage.cacheWrite)
+  const tokensReasoning = nonNegative(usage.reasoningTokens)
+  if (tokensInput + tokensOutput + tokensCacheRead + tokensCacheCreate + tokensReasoning === 0) return null
+
+  const tokens = { tokensInput, tokensOutput, tokensCacheRead, tokensCacheCreate, tokensReasoning }
+  const cost = usage.cost && typeof usage.cost === "object" ? usage.cost : undefined
+
+  if (cost && typeof cost.total === "number") {
+    // Provider-supplied cost (USD) — fold cache costs into the input side so
+    // input + output == total, keeping the provider's authoritative total.
+    return {
+      ...tokens,
+      costInputMicrocents: usdToMicrocents(
+        nonNegative(cost.input) + nonNegative(cost.cacheRead) + nonNegative(cost.cacheWrite),
+      ),
+      costOutputMicrocents: usdToMicrocents(nonNegative(cost.output)),
+      costTotalMicrocents: usdToMicrocents(nonNegative(cost.total)),
+      costIsEstimated: false,
+    }
+  }
+
+  // No embedded cost — estimate from the tokens, same as flat-attr spans.
+  const estimation = estimateCostFromTokens({ provider, model, ...tokens })
+  const costInputMicrocents = estimation?.input ?? 0
+  const costOutputMicrocents = estimation?.output ?? 0
+  return {
+    ...tokens,
+    costInputMicrocents,
+    costOutputMicrocents,
+    costTotalMicrocents: costInputMicrocents + costOutputMicrocents,
+    costIsEstimated: estimation !== undefined,
+  }
+}
+
 interface ResolveUsageInput {
   readonly attrs: readonly OtlpKeyValue[]
   readonly provider: string
@@ -92,6 +190,11 @@ interface ResolveUsageInput {
 }
 
 export function resolveUsage({ attrs, provider, model }: ResolveUsageInput): ResolvedUsage {
+  // Some instrumentations carry usage in the message payload rather than as flat
+  // gen_ai.usage.* attrs (OpenClaw) — prefer that when present.
+  const embedded = resolveEmbeddedMessageUsage(attrs, provider, model)
+  if (embedded) return embedded
+
   const {
     input: tokensInput,
     output: tokensOutput,

--- a/packages/domain/spans/src/otlp/tests/openclaw.test.ts
+++ b/packages/domain/spans/src/otlp/tests/openclaw.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import type { SpanDetail } from "../../entities/span.ts"
+import type { TransformContext } from "../transform.ts"
+import { transformOtlpToSpans } from "../transform.ts"
+import type { OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpSpan } from "../types.ts"
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+function int(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(value) } }
+}
+
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+const SCOPE_NAME = "openclaw"
+
+const CONTEXT: TransformContext = {
+  organizationId: "org_test",
+  apiKeyId: "key_test",
+  ingestedAt: new Date("2026-06-23T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
+}
+
+// The assistant message OpenClaw puts on `openclaw.content.output_messages`,
+// with usage + provider cost (USD) embedded — additive tokens (input excludes
+// cache; totalTokens = input + output + cacheRead).
+const OUTPUT_MESSAGES = JSON.stringify([
+  {
+    role: "assistant",
+    content: [{ type: "text", text: "done" }],
+    model: "gpt-5.5",
+    usage: {
+      input: 951,
+      output: 127,
+      cacheRead: 20864,
+      cacheWrite: 0,
+      reasoningTokens: 0,
+      totalTokens: 21942,
+      cost: { input: 0.004755, output: 0.00381, cacheRead: 0.010432, cacheWrite: 0, total: 0.018997 },
+    },
+  },
+])
+
+function span(spanId: string, name: string, attributes: OtlpKeyValue[]): OtlpSpan {
+  return {
+    traceId: TRACE_ID,
+    spanId,
+    name,
+    startTimeUnixNano: "1700000000000000000",
+    endTimeUnixNano: "1700000001000000000",
+    attributes,
+  } as OtlpSpan
+}
+
+function buildTrace(): OtlpExportTraceServiceRequest {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [str("service.name", "openclaw-gateway")] },
+        scopeSpans: [
+          {
+            scope: { name: SCOPE_NAME, version: "2026.6.9" },
+            spans: [
+              span("1111111111111111", "openclaw.run", []),
+              span("2222222222222222", "openclaw.model.call", [
+                str("gen_ai.operation.name", "chat"),
+                str("gen_ai.system", "openai"),
+                str("gen_ai.request.model", "gpt-5.5"),
+                str("openclaw.content.output_messages", OUTPUT_MESSAGES),
+              ]),
+              span("3333333333333333", "openclaw.tool.execution", [str("gen_ai.tool.name", "bash")]),
+              // Orphan usage span the plugin emits as its own root — must be dropped.
+              span("4444444444444444", "openclaw.model.usage", [
+                int("gen_ai.usage.input_tokens", 43123),
+                int("gen_ai.usage.output_tokens", 287),
+              ]),
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe("OpenClaw diagnostics-otel ingest", () => {
+  let spans: SpanDetail[]
+  const find = (name: string) => spans.find((s) => s.name === name)
+
+  beforeAll(() => {
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as SpanDetail[]
+  })
+
+  it("drops the orphan openclaw.model.usage span", () => {
+    expect(find("openclaw.model.usage")).toBeUndefined()
+    expect(spans).toHaveLength(3)
+  })
+
+  it("classifies run/tool spans by name (scope openclaw)", () => {
+    expect(find("openclaw.run")?.operation).toBe("invoke_agent")
+    const tool = find("openclaw.tool.execution")
+    expect(tool?.operation).toBe("execute_tool")
+    expect(tool?.toolName).toBe("bash")
+  })
+
+  it("resolves successful spans to ok status even though OTel status arrives unset", () => {
+    // OpenClaw signals success out-of-band, not via OTel status — so these would
+    // otherwise render with the neutral/gray status in the waterfall.
+    expect(find("openclaw.run")?.statusCode).toBe("ok")
+    expect(find("openclaw.model.call")?.statusCode).toBe("ok")
+    expect(find("openclaw.tool.execution")?.statusCode).toBe("ok")
+  })
+
+  it("reads tokens from the embedded usage on the model.call span (additive, no inference)", () => {
+    const call = find("openclaw.model.call")
+    expect(call?.operation).toBe("chat")
+    expect(call?.tokensInput).toBe(951)
+    expect(call?.tokensOutput).toBe(127)
+    expect(call?.tokensCacheRead).toBe(20864)
+    expect(call?.tokensCacheCreate).toBe(0)
+    expect(call?.tokensReasoning).toBe(0)
+  })
+
+  it("uses the provider's real cost (not estimated), folding cache cost into input", () => {
+    const call = find("openclaw.model.call")
+    // input + cacheRead + cacheWrite = 0.004755 + 0.010432 + 0 = 0.015187 USD
+    expect(call?.costInputMicrocents).toBe(1_518_700)
+    expect(call?.costOutputMicrocents).toBe(381_000)
+    expect(call?.costTotalMicrocents).toBe(1_899_700)
+    expect(call?.costIsEstimated).toBe(false)
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -2,8 +2,10 @@ import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, Spa
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
 import { stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
+import { isDroppedSpan } from "./dropped-spans.ts"
 import { resolveAttributes } from "./resolvers/index.ts"
 import { resolvePerformance } from "./resolvers/performance.ts"
+import { resolveStatusCode } from "./resolvers/status.ts"
 import { resolveToolExecution } from "./resolvers/tool-execution.ts"
 import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpResource, OtlpSpan } from "./types.ts"
 
@@ -123,7 +125,8 @@ function transformSpan({
   const spanAttrs = span.attributes ?? []
   const spanEvents = span.events ?? []
   const resourceAttrs = resource?.attributes ?? []
-  const statusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
+  const otelStatusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
+  const statusCode = resolveStatusCode(spanAttrs, otelStatusCode, scopeName)
 
   const resolved = resolveAttributes({
     spanAttrs,
@@ -241,6 +244,7 @@ export function transformOtlpToSpans(
       const scopeName = scopeSpans.scope?.name ?? ""
       const scopeVersion = scopeSpans.scope?.version ?? ""
       for (const span of scopeSpans.spans ?? []) {
+        if (isDroppedSpan(scopeName, span.name ?? "")) continue
         const projectId = resolveSpanProjectId(span.attributes ?? [], resourceAttrs, context)
         if (!projectId) {
           rejectedSpans++

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -1,5 +1,12 @@
 # @latitude-data/openclaw-telemetry-cli
 
+> [!WARNING]
+> **Deprecated.** This installs the deprecated `@latitude-data/openclaw-telemetry`
+> plugin. Use OpenClaw's official [`@openclaw/diagnostics-otel`](https://docs.openclaw.ai/gateway/opentelemetry)
+> exporter pointed at Latitude instead — setup at
+> [Latitude docs → OpenClaw telemetry](https://docs.latitude.so/telemetry/openclaw).
+> No longer maintained.
+
 One-shot installer for the [`@latitude-data/openclaw-telemetry`](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme) OpenClaw plugin. Wraps `openclaw plugins install` + the manual `openclaw config set` flow into a single `npx -y` command, with TTY prompts, CI flags, dry-run, custom config dir, upgrade detection, and the gateway restart.
 
 For details on the plugin runtime itself — what it sends, the span tree, and the manual install flow — see the [runtime README](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme).

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -1,5 +1,15 @@
 # @latitude-data/openclaw-telemetry
 
+> [!WARNING]
+> **Deprecated.** Use OpenClaw's official OpenTelemetry exporter — the bundled
+> [`@openclaw/diagnostics-otel`](https://docs.openclaw.ai/gateway/opentelemetry)
+> plugin — pointed at Latitude's OTLP ingest instead. It follows OpenTelemetry
+> GenAI semantic conventions, is maintained by OpenClaw, and produces a cleaner
+> `invoke_agent → chat → execute_tool` trace tree.
+>
+> **Setup:** [Latitude docs → OpenClaw telemetry](https://docs.latitude.so/telemetry/openclaw).
+> This package is no longer maintained and will receive no further updates.
+
 OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) as OTLP traces — full system prompt, message history, assistant output, token usage, tool I/O, and the running agent's name on every span.
 
 ## Requirements


### PR DESCRIPTION
## Summary

OpenClaw now ships an official OpenTelemetry exporter (`@openclaw/diagnostics-otel`) that follows GenAI semantic conventions and is maintained by OpenClaw. This PR makes Latitude ingest its spans cleanly, **recommends it over our hand-rolled `@latitude-data/openclaw-telemetry` plugin**, and deprecates the old plugin.

All OpenClaw-specific handling is scoped to `scope_name = "openclaw"` and lives in the resolver layer — the generic `transform.ts` stays brand-agnostic.

## Ingest handling (`@domain/spans`)

- **Operation** (`resolvers/operation.ts`): classify `openclaw.run` → `invoke_agent` and `openclaw.tool.execution` → `execute_tool` (model calls already resolve to `chat` via `gen_ai.operation.name`). Fixes the trace structure + Tools facet / `tool_name` extraction.
- **Usage** (`resolvers/usage.ts`): OpenClaw never emits flat `gen_ai.usage.*` attrs — it buries per-call tokens **and the provider's real cost (USD)** inside the assistant-message JSON on `openclaw.content.output_messages`. We read it there (additive tokens, no inclusive/additive inference; real cost so `costIsEstimated = false`).
- **Status** (`resolvers/status.ts`): OpenClaw signals success out-of-band via `openclaw.outcome` and leaves the OTel status `unset` on success, so bars rendered gray. Derive `ok`/`error` from the outcome (OTel `error` and non-`completed` outcomes → `error`).
- **Drop** (`dropped-spans.ts`): the standalone `openclaw.model.usage` span is emitted in its own orphan trace and duplicates usage that already rides on the `model.call` spans — drop it at ingest so it doesn't surface as a phantom trace/session.

## Deprecation + docs

- README deprecation banners on `@latitude-data/openclaw-telemetry` + its CLI, pointing to the native exporter.
- Rewrote `docs/telemetry/openclaw.md` to recommend `@openclaw/diagnostics-otel` with a production-ingest config example (auth headers + `captureContent`), a "Migrating from the Latitude plugin" section, and a link to OpenClaw's OTel docs.

## Testing

- `pnpm --filter @domain/spans test` — 867 passing, incl. new unit tests for `resolveUsage` (embedded usage), `resolveStatusCode`, `isDroppedSpan`, and an end-to-end `transformOtlpToSpans` test for OpenClaw (drop + tokens + real cost + operation/status classification).
- `pnpm --filter @domain/spans typecheck` — clean.
- Validated end-to-end against real OpenClaw spans in local ClickHouse (per-call usage sums to the orphan span's totals; status/operation/tool resolve correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)