### PR TITLE
fix(core): stop enterprise setup from promoting every user to admin

### DIFF
--- a/apps/web/src/actions/admin/users/setUserAdminAction.ts
+++ b/apps/web/src/actions/admin/users/setUserAdminAction.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { z } from 'zod'
+
+import { withAdmin } from '../../procedures'
+import { setUserAdmin } from '@latitude-data/core/services/users/setAdmin'
+import { unsafelyFindUserByEmail } from '@latitude-data/core/queries/users/findByEmail'
+import { NotFoundError } from '@latitude-data/constants/errors'
+
+export const setUserAdminAction = withAdmin
+  .inputSchema(
+    z.object({
+      userEmail: z.string(),
+      admin: z.boolean(),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const user = await unsafelyFindUserByEmail({
+      email: parsedInput.userEmail,
+    })
+
+    if (!user) {
+      throw new NotFoundError(
+        `Not found user with email: ${parsedInput.userEmail}`,
+      )
+    }
+
+    return setUserAdmin(user, parsedInput.admin).then((r) => r.unwrap())
+  })

--- a/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/AdminToggle/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/AdminToggle/index.tsx
@@ -32,6 +32,7 @@ export function AdminToggle({ userEmail, isAdmin }: Props) {
         description: error.message || 'Failed to update admin access',
         variant: 'destructive',
       })
+      router.refresh()
     },
   })
 

--- a/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/AdminToggle/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/AdminToggle/index.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { SwitchToggle } from '@latitude-data/web-ui/atoms/Switch'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { useToast } from '@latitude-data/web-ui/atoms/Toast'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { setUserAdminAction } from '$/actions/admin/users/setUserAdminAction'
+
+type Props = {
+  userEmail: string
+  isAdmin: boolean
+}
+
+export function AdminToggle({ userEmail, isAdmin }: Props) {
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const { execute, isPending } = useLatitudeAction(setUserAdminAction, {
+    onSuccess: ({ data }) => {
+      toast({
+        title: 'Admin access updated',
+        description: data.admin
+          ? `${data.email} is now an admin`
+          : `${data.email} is no longer an admin`,
+      })
+      router.refresh()
+    },
+    onError: (error) => {
+      toast({
+        title: 'Error',
+        description: error.message || 'Failed to update admin access',
+        variant: 'destructive',
+      })
+    },
+  })
+
+  return (
+    <div className='flex flex-row items-center justify-between p-4 bg-muted/30 rounded-lg'>
+      <div className='flex flex-col gap-1'>
+        <Text.H5>Admin Access</Text.H5>
+        <Text.H6 color='foregroundMuted'>
+          Grant or revoke platform admin (backoffice) access
+        </Text.H6>
+      </div>
+      <SwitchToggle
+        checked={isAdmin}
+        disabled={isPending}
+        onCheckedChange={(checked) => execute({ userEmail, admin: checked })}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/UserDashboard/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/search/user/[email]/_components/UserDashboard/index.tsx
@@ -15,6 +15,7 @@ import { FREE_PLANS } from '@latitude-data/core/plans'
 
 import { ImpersonateUserButton } from '../ImpersonateUserButton'
 import { UpdateEmailModal } from '../UpdateEmailModal'
+import { AdminToggle } from '../AdminToggle'
 import { DashboardHeader } from '$/app/(admin)/backoffice/search/_components/DashboardHeader'
 import { DataTable } from '$/app/(admin)/backoffice/search/_components/DataTable'
 import { useRecentSearches } from '$/app/(admin)/backoffice/search/_hooks/useRecentSearches'
@@ -304,6 +305,7 @@ export function UserDashboard({ user }: Props) {
                     Update Email
                   </Button>
                 </div>
+                <AdminToggle userEmail={user.email} isAdmin={user.admin} />
               </div>
             )}
           </div>

--- a/packages/core/scripts/setup.ts
+++ b/packages/core/scripts/setup.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, ne } from 'drizzle-orm'
+import { and, asc, eq, isNull, ne } from 'drizzle-orm'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import fs from 'fs'
@@ -82,27 +82,44 @@ function getAllPromptlFiles(
   return files
 }
 
-async function migrateExistingUsersToAdmins() {
-  console.log('\n--- Migrating existing users to admins ---')
+/**
+ * Guarantees the instance always has at least one platform admin without
+ * indiscriminately promoting every user. If an admin already exists this is a
+ * no-op; otherwise the oldest user is promoted.
+ */
+async function ensureAtLeastOneAdmin() {
+  console.log('\n--- Ensuring at least one admin exists ---')
 
-  const nonAdminUsers = await database
-    .select()
+  const existingAdmin = await database
+    .select({ id: users.id })
     .from(users)
-    .where(eq(users.admin, false))
+    .where(eq(users.admin, true))
+    .limit(1)
+    .then((rows) => rows[0])
 
-  if (nonAdminUsers.length === 0) {
-    console.log('✓ All users are already admins')
+  if (existingAdmin) {
+    console.log('✓ An admin already exists')
     return
   }
 
-  console.log(`Found ${nonAdminUsers.length} non-admin users to migrate`)
+  const firstUser = await database
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .orderBy(asc(users.createdAt))
+    .limit(1)
+    .then((rows) => rows[0])
+
+  if (!firstUser) {
+    console.log('✓ No users yet, nothing to promote')
+    return
+  }
 
   await database
     .update(users)
     .set({ admin: true })
-    .where(eq(users.admin, false))
+    .where(eq(users.id, firstUser.id))
 
-  console.log(`✓ Migrated ${nonAdminUsers.length} users to admins`)
+  console.log(`✓ Promoted ${firstUser.email} to admin`)
 }
 
 async function migrateExistingWorkspacesToEnterprise() {
@@ -161,7 +178,7 @@ async function main() {
 
   console.log('Starting setup...')
 
-  await migrateExistingUsersToAdmins()
+  await ensureAtLeastOneAdmin()
   await migrateExistingWorkspacesToEnterprise()
 
   // 1. Find or create user

--- a/packages/core/src/queries/users/exists.ts
+++ b/packages/core/src/queries/users/exists.ts
@@ -1,0 +1,13 @@
+import { Database, database } from '../../client'
+import { users } from '../../schema/models/users'
+
+/**
+ * Returns whether the instance has at least one user. Used to detect the very
+ * first user setting up a self-hosted instance.
+ */
+export async function unsafelyCheckIfAnyUserExists(
+  db: Database = database,
+): Promise<boolean> {
+  const rows = await db.select({ id: users.id }).from(users).limit(1)
+  return rows.length > 0
+}

--- a/packages/core/src/services/users/setAdmin.test.ts
+++ b/packages/core/src/services/users/setAdmin.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { setUserAdmin } from './setAdmin'
+import * as factories from '../../tests/factories'
+
+describe('setUserAdmin', () => {
+  it('grants admin access to a non-admin user', async () => {
+    const user = await factories.createUser()
+
+    const result = await setUserAdmin(user, true)
+
+    expect(result.ok).toBe(true)
+    expect(result.unwrap().admin).toBe(true)
+  })
+
+  it('revokes admin access when other admins remain', async () => {
+    const first = await factories.createUser()
+    const second = await factories.createUser()
+    await setUserAdmin(first, true).then((r) => r.unwrap())
+    const secondAdmin = await setUserAdmin(second, true).then((r) => r.unwrap())
+
+    const result = await setUserAdmin(secondAdmin, false)
+
+    expect(result.ok).toBe(true)
+    expect(result.unwrap().admin).toBe(false)
+  })
+
+  it('rejects revoking admin access from the last admin', async () => {
+    const user = await factories.createUser()
+    const admin = await setUserAdmin(user, true).then((r) => r.unwrap())
+
+    const result = await setUserAdmin(admin, false)
+
+    expect(result.ok).toBe(false)
+    expect(result.error!.message).toBe('Cannot remove the last admin')
+  })
+
+  it('is a no-op when the value is unchanged', async () => {
+    const user = await factories.createUser()
+
+    const result = await setUserAdmin(user, false)
+
+    expect(result.ok).toBe(true)
+    expect(result.unwrap().admin).toBe(false)
+  })
+})

--- a/packages/core/src/services/users/setAdmin.ts
+++ b/packages/core/src/services/users/setAdmin.ts
@@ -1,0 +1,38 @@
+import { eq } from 'drizzle-orm'
+
+import { type User } from '../../schema/models/types/User'
+import { BadRequestError } from '../../lib/errors'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { users } from '../../schema/models/users'
+import { updateUser } from './update'
+
+/**
+ * Grants or revokes platform (backoffice) admin access for a user.
+ *
+ * Revoking is rejected when the target is the only remaining admin, so the
+ * instance can never be left without an admin.
+ */
+export async function setUserAdmin(
+  user: User,
+  admin: boolean,
+  transaction = new Transaction(),
+) {
+  if (user.admin === admin) return Result.ok(user)
+
+  return transaction.call(async (tx) => {
+    if (!admin) {
+      const remainingAdmins = await tx
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.admin, true))
+        .limit(2)
+
+      if (remainingAdmins.length <= 1) {
+        return Result.error(new BadRequestError('Cannot remove the last admin'))
+      }
+    }
+
+    return updateUser(user, { admin }, transaction)
+  })
+}

--- a/packages/core/src/services/users/setupService.test.ts
+++ b/packages/core/src/services/users/setupService.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import setupService, { NEW_SIGNUPS_DISABLED_MESSAGE } from './setupService'
 import { SubscriptionPlan } from '../../plans'
 import { unsafelyFindUserByEmail } from '../../queries/users/findByEmail'
+import { unsafelyCheckIfAnyUserExists } from '../../queries/users/exists'
 import * as envModule from '@latitude-data/env'
 
 vi.mock('../../events/publisher', () => ({
@@ -11,9 +12,17 @@ vi.mock('../../events/publisher', () => ({
   },
 }))
 
+vi.mock('../../queries/users/exists', () => ({
+  unsafelyCheckIfAnyUserExists: vi.fn(),
+}))
+
+const mockedCheckIfAnyUserExists = vi.mocked(unsafelyCheckIfAnyUserExists)
+
 describe('setupService', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+
+    mockedCheckIfAnyUserExists.mockResolvedValue(false)
 
     vi.spyOn(envModule, 'env', 'get').mockReturnValue({
       ...envModule.env,
@@ -111,6 +120,8 @@ describe('setupService', () => {
     })
 
     it('creates the first user with admin=true and enterprise plan', async () => {
+      mockedCheckIfAnyUserExists.mockResolvedValue(false)
+
       const result = await setupService({
         email: 'enterprise@example.com',
         name: 'Enterprise User',
@@ -129,24 +140,20 @@ describe('setupService', () => {
     })
 
     it('does not make subsequent users admin', async () => {
-      const first = await setupService({
-        email: 'first-enterprise@example.com',
-        name: 'First Enterprise User',
-        companyName: 'First Enterprise Company',
-        defaultProviderName: 'OpenAI',
-        defaultProviderApiKey: 'test-api-key',
-      }).then((r) => r.unwrap())
+      mockedCheckIfAnyUserExists.mockResolvedValue(true)
 
-      const second = await setupService({
+      const result = await setupService({
         email: 'second-enterprise@example.com',
         name: 'Second Enterprise User',
         companyName: 'Second Enterprise Company',
         defaultProviderName: 'OpenAI',
         defaultProviderApiKey: 'test-api-key',
-      }).then((r) => r.unwrap())
+      })
 
-      expect(first.user.admin).toBe(true)
-      expect(second.user.admin).toBe(false)
+      expect(result.ok).toBe(true)
+      const { user } = result.unwrap()
+
+      expect(user.admin).toBe(false)
     })
   })
 })

--- a/packages/core/src/services/users/setupService.test.ts
+++ b/packages/core/src/services/users/setupService.test.ts
@@ -103,12 +103,14 @@ describe('setupService', () => {
   })
 
   describe('when LATITUDE_ENTERPRISE_MODE is true', () => {
-    it('creates user with admin=true and enterprise plan', async () => {
+    beforeEach(() => {
       vi.spyOn(envModule, 'env', 'get').mockReturnValue({
         ...envModule.env,
         LATITUDE_ENTERPRISE_MODE: true,
       } as typeof envModule.env)
+    })
 
+    it('creates the first user with admin=true and enterprise plan', async () => {
       const result = await setupService({
         email: 'enterprise@example.com',
         name: 'Enterprise User',
@@ -124,6 +126,27 @@ describe('setupService', () => {
       expect(workspace.currentSubscription.plan).toBe(
         SubscriptionPlan.EnterpriseV1,
       )
+    })
+
+    it('does not make subsequent users admin', async () => {
+      const first = await setupService({
+        email: 'first-enterprise@example.com',
+        name: 'First Enterprise User',
+        companyName: 'First Enterprise Company',
+        defaultProviderName: 'OpenAI',
+        defaultProviderApiKey: 'test-api-key',
+      }).then((r) => r.unwrap())
+
+      const second = await setupService({
+        email: 'second-enterprise@example.com',
+        name: 'Second Enterprise User',
+        companyName: 'Second Enterprise Company',
+        defaultProviderName: 'OpenAI',
+        defaultProviderApiKey: 'test-api-key',
+      }).then((r) => r.unwrap())
+
+      expect(first.user.admin).toBe(true)
+      expect(second.user.admin).toBe(false)
     })
   })
 })

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -12,6 +12,7 @@ import { createMembership } from '../memberships/create'
 import { createProviderApiKey } from '../providerApiKeys'
 import { createWorkspace } from '../workspaces'
 import { createUser } from './createUser'
+import { users } from '../../schema/models/users'
 import { UserTitle } from '@latitude-data/constants/users'
 import { createDatasetOnboarding } from '../onboardingResources/createDatasetOnboarding'
 
@@ -46,14 +47,23 @@ export default async function setupService(
     return Result.error(new BadRequestError(NEW_SIGNUPS_DISABLED_MESSAGE))
   }
 
-  return transaction.call(async () => {
+  return transaction.call(async (tx) => {
+    // In enterprise (self-hosted) mode only the first user to set up the
+    // instance becomes a platform admin. Subsequent signups and invited users
+    // default to non-admin.
+    const isFirstUser = await tx
+      .select({ id: users.id })
+      .from(users)
+      .limit(1)
+      .then((rows) => rows.length === 0)
+
     const user = await createUser(
       {
         email,
         name,
         confirmedAt: new Date(),
         title,
-        admin: env.LATITUDE_ENTERPRISE_MODE === true,
+        admin: env.LATITUDE_ENTERPRISE_MODE === true && isFirstUser,
       },
       transaction,
     ).then((r) => r.unwrap())

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -12,7 +12,7 @@ import { createMembership } from '../memberships/create'
 import { createProviderApiKey } from '../providerApiKeys'
 import { createWorkspace } from '../workspaces'
 import { createUser } from './createUser'
-import { users } from '../../schema/models/users'
+import { unsafelyCheckIfAnyUserExists } from '../../queries/users/exists'
 import { UserTitle } from '@latitude-data/constants/users'
 import { createDatasetOnboarding } from '../onboardingResources/createDatasetOnboarding'
 
@@ -51,11 +51,7 @@ export default async function setupService(
     // In enterprise (self-hosted) mode only the first user to set up the
     // instance becomes a platform admin. Subsequent signups and invited users
     // default to non-admin.
-    const isFirstUser = await tx
-      .select({ id: users.id })
-      .from(users)
-      .limit(1)
-      .then((rows) => rows.length === 0)
+    const isFirstUser = !(await unsafelyCheckIfAnyUserExists(tx))
 
     const user = await createUser(
       {


### PR DESCRIPTION
## Problem

A self-hosted/enterprise customer reported that **all invited users were being converted to platform admins**.

`users.admin` is the platform/backoffice **super-admin** flag (gates `/backoffice`, admin procedures, cross-workspace search, billing, Latte debug) — not a workspace role.

## Root cause

The container startup command runs the setup script on **every boot**:

```
# packages/core/docker/Dockerfile:40
CMD sh -c "... && pnpm --filter @latitude-data/core scripts:setup"
```

In enterprise mode, `scripts/setup.ts` → `main()` called `migrateExistingUsersToAdmins()`, which did:

```sql
UPDATE users SET admin = true WHERE admin = false;
```

This indiscriminately promoted **every** user across all workspaces. So users invited correctly with `admin: false` (via `inviteUser` → `createUser`) were re-promoted to platform admin on every deploy/restart. The in-app invite flow itself was never the problem — this startup step overwrote it each boot.

## Fix

- Replace `migrateExistingUsersToAdmins` with **`ensureAtLeastOneAdmin`**: keeps the original intent (the instance always has at least one admin) but only promotes a **single** user (the oldest) when none exists, and is a no-op when an admin is already present.
- Harden `setupService` so that in enterprise mode only the **first** user of an empty instance becomes admin; subsequent signups/invited users default to non-admin.

## Backoffice admin toggle

Adds an **"Admin Access" toggle** to the Admin Tools section of the backoffice user detail page (`/backoffice/search/user/:email`) so an existing admin can grant/revoke platform admin access for any user.

- Gated by the `withAdmin` procedure (backoffice middleware).
- New core service `setUserAdmin` **rejects revoking the last remaining admin** (covers the last admin trying to demote themselves) — the instance can never be left without an admin.

## Notes / follow-up

- This stops *future* re-promotion. Instances that already ran the old script have everyone at `admin: true` already — demoting them is a separate, deliberate data migration (not included here).

## Verification

- `pnpm test src/services/users/setupService.test.ts` → 6/6 pass
- `pnpm test src/services/users/setAdmin.test.ts` → 4/4 pass
- `pnpm tc` (core + web) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)