### PR TITLE
fix(web): keep expected 4xx out of Datadog Error Tracking

### DIFF
--- a/apps/web/src/start.test.ts
+++ b/apps/web/src/start.test.ts
@@ -1,0 +1,122 @@
+import { NotFoundError, RepositoryError, UnauthorizedError } from "@domain/shared"
+import type { Span } from "@repo/observability"
+import { isHttpError } from "@repo/utils"
+import { describe, expect, it, vi } from "vitest"
+import { recordRequestError, recordServerFnError } from "./start.ts"
+
+const fakeSpan = () => {
+  const span = {
+    recordException: vi.fn(),
+    setStatus: vi.fn(),
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+    end: vi.fn(),
+  }
+  return span as typeof span & Span
+}
+
+describe("recordServerFnError", () => {
+  it("does NOT report a 401 (UnauthorizedError) to Datadog", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new UnauthorizedError({ message: "No user in session" }))
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+    expect(info.isClientError).toBe(true)
+    expect(info.status).toBe(401)
+    expect(info.tag).toBe("UnauthorizedError")
+  })
+
+  it("does NOT report other 4xx client errors (e.g. 404) to Datadog", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new NotFoundError({ entity: "Sandbox", id: "org-123" }))
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+    expect(info.isClientError).toBe(true)
+    expect(info.status).toBe(404)
+  })
+
+  it("reports 5xx server faults (RepositoryError) to Datadog", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new RepositoryError({ cause: new Error("boom"), operation: "findById" }))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+    expect(span.setStatus).toHaveBeenCalledWith(expect.objectContaining({ code: expect.anything() }))
+    expect(info.isClientError).toBe(false)
+    expect(info.status).toBe(500)
+  })
+
+  it("reports unknown non-HTTP errors as 500", () => {
+    const span = fakeSpan()
+    const info = recordServerFnError(span, new Error("unexpected"))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+    expect(info.isClientError).toBe(false)
+    expect(info.status).toBe(500)
+  })
+
+  it("re-throwable error carries the serialized payload and original stack", () => {
+    const original = new UnauthorizedError({ message: "No user in session" })
+    const info = recordServerFnError(fakeSpan(), original)
+
+    expect(JSON.parse(info.error.message)).toEqual({
+      _tag: "UnauthorizedError",
+      message: "No user in session",
+      status: 401,
+    })
+    expect(info.error.stack).toBe(original.stack)
+  })
+
+  it("re-throwable error stays classifiable as an HttpError without leaking status into the JSON message", () => {
+    const info = recordServerFnError(fakeSpan(), new UnauthorizedError({ message: "Unauthorized" }))
+
+    // The request middleware relies on this to re-classify the re-thrown error.
+    expect(isHttpError(info.error)).toBe(true)
+    // ...but the client-bound message must remain just the serialized payload.
+    expect(Object.keys(JSON.parse(info.error.message))).toEqual(["_tag", "message", "status"])
+    expect(JSON.stringify(info.error)).not.toContain("httpStatus")
+  })
+})
+
+describe("recordRequestError", () => {
+  it("does NOT report the re-thrown 401 that propagates up from a server fn", () => {
+    // End-to-end: server fn throws 401 → recordServerFnError shapes it → it
+    // bubbles to the request middleware, which must also leave it unrecorded.
+    const reThrown = recordServerFnError(fakeSpan(), new UnauthorizedError({ message: "Unauthorized" })).error
+
+    const span = fakeSpan()
+    recordRequestError(span, reThrown)
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+  })
+
+  it("does NOT report a 4xx HttpError thrown directly at the request layer", () => {
+    const span = fakeSpan()
+    recordRequestError(span, new NotFoundError({ entity: "Sandbox", id: "org-123" }))
+
+    expect(span.recordException).not.toHaveBeenCalled()
+    expect(span.setStatus).not.toHaveBeenCalled()
+  })
+
+  it("reports a re-thrown 5xx server fault", () => {
+    const reThrown = recordServerFnError(
+      fakeSpan(),
+      new RepositoryError({ cause: new Error("boom"), operation: "findById" }),
+    ).error
+
+    const span = fakeSpan()
+    recordRequestError(span, reThrown)
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+    expect(span.setStatus).toHaveBeenCalledWith(expect.objectContaining({ code: expect.anything() }))
+  })
+
+  it("reports an unknown non-HTTP error (defaults to 500)", () => {
+    const span = fakeSpan()
+    recordRequestError(span, new Error("boom"))
+
+    expect(span.recordException).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -42,6 +42,67 @@ const getServerFnIdFromPath = (pathname: string): string | undefined => {
   return match?.[1]
 }
 
+type ServerFnErrorInfo = {
+  readonly error: Error
+  readonly tag: string | undefined
+  readonly message: string
+  readonly status: number
+  readonly isClientError: boolean
+}
+
+const errorTag = (e: unknown): string | undefined =>
+  typeof e === "object" && e !== null && "_tag" in (e as DomainError) ? (e as DomainError)._tag : undefined
+
+const errorStatus = (e: unknown): number => (isHttpError(e) ? e.httpStatus : 500)
+
+// A 4xx means the caller was rejected as designed (not logged in, no access,
+// bad input) — expected control flow, not a server fault. Such errors are kept
+// out of Datadog Error Tracking so real (5xx) bugs aren't buried; the span
+// still carries http.status_code for APM/metrics. Anything ≥ 500 or non-HTTP
+// (treated as 500) is recorded as before.
+const isExpectedClientError = (status: number): boolean => status >= 400 && status < 500
+
+/**
+ * Records a request-level error onto its span unless it's an expected 4xx.
+ * Used by the request middleware, which also sees the re-thrown server-fn error
+ * — see `recordServerFnError`, which tags that error with `httpStatus` so it
+ * stays classifiable here even though it is a plain `Error`.
+ */
+export const recordRequestError = (span: Span, error: unknown): void => {
+  if (isExpectedClientError(errorStatus(error))) return
+  recordSpanExceptionForDatadog(span, error)
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: error instanceof Error ? error.message : String(error),
+  })
+}
+
+/**
+ * Records a thrown server-fn error onto its span and shapes it for re-throwing.
+ * The re-thrown `Error` carries the original `httpStatus`/`httpMessage` (as
+ * non-enumerable props, so they don't leak into the client-bound JSON message)
+ * so the request middleware can recognise a 4xx and likewise skip recording it.
+ */
+export const recordServerFnError = (span: Span, e: unknown): ServerFnErrorInfo => {
+  const httpError = isHttpError(e)
+  const tag = errorTag(e)
+  const message = httpError ? e.httpMessage : e instanceof Error ? e.message : "Unknown error occurred"
+  const status = httpError ? e.httpStatus : 500
+  const isClientError = isExpectedClientError(status)
+
+  if (!isClientError) {
+    recordSpanExceptionForDatadog(span, e)
+    span.setStatus({ code: SpanStatusCode.ERROR, message })
+  }
+
+  const error = new Error(JSON.stringify({ _tag: tag, message, status }))
+  if (e instanceof Error && e.stack) error.stack = e.stack
+  Object.defineProperty(error, "httpStatus", { value: status })
+  Object.defineProperty(error, "httpMessage", { value: message })
+
+  return { error, tag, message, status, isClientError }
+}
+
 export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
   createMiddleware({ type: "request" }).server(async ({ next, request }) => {
     const url = new URL(request.url)
@@ -62,11 +123,7 @@ export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
         }
         return result
       } catch (error) {
-        recordSpanExceptionForDatadog(span, error)
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
-        })
+        recordRequestError(span, error)
         throw error
       } finally {
         span.end()
@@ -125,20 +182,10 @@ export const tracingFnMiddleware = ({ tracer, logger }: { tracer: Tracer; logger
         span.setStatus({ code: SpanStatusCode.OK })
         return result
       } catch (e) {
-        recordSpanExceptionForDatadog(span, e)
+        const { error, tag, message, status, isClientError } = recordServerFnError(span, e)
 
-        const httpError = isHttpError(e)
-        const tag =
-          typeof e === "object" && e !== null && "_tag" in (e as DomainError) ? (e as DomainError)._tag : undefined
-        const message = httpError ? e.httpMessage : e instanceof Error ? e.message : "Unknown error occurred"
-        const status = httpError ? e.httpStatus : 500
-
-        const payload = JSON.stringify({ _tag: tag, message, status })
-        const error = new Error(payload)
-
-        if (e instanceof Error && e.stack) error.stack = e.stack
-
-        logger.error({
+        const log = isClientError ? logger.warn : logger.error
+        log({
           _tag: tag,
           message,
           status,


### PR DESCRIPTION
## Problem

A **401 `UnauthorizedError`** thrown when accessing a sandbox without a valid session was being reported to **Datadog Error Tracking** as if it were a server fault ([monitor issue `d8e806a8-659b-11f1-8841-da7ad0900005`](https://app.datadoghq.eu/error-tracking?query=service%3A%2A&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22d8e806a8-659b-11f1-8841-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D), service `web`).

> Note: `@issue.id` is not a searchable facet in this org's index, so the issue was located by signature rather than id. The matching error surfaces in spans as `error.type: Error` with message `{"_tag":"UnauthorizedError","message":"Unauthorized","status":401}` on `GET` request spans (e.g. a page SSR load whose loader calls `assertAuthenticatedSession`).

## Root cause

The web tracing middleware in `apps/web/src/start.ts` recorded **every** thrown error to Datadog via `recordSpanExceptionForDatadog`, regardless of HTTP status, at **two** sites:

- `tracingFnMiddleware` records the *original* error on the **server-fn span** (resource = fn name, e.g. `annotations.listTraceAnnotations`).
- `tracingRequestMiddleware` records the *re-thrown payload* `Error` on the **request span** (resource `GET`) — and that re-thrown error is a plain `Error`, so it wasn't even classifiable by status.

So caller-driven 4xx (a 401 with no session, 404s, `ValidationError` 400s) opened Error Tracking issues and buried real 5xx bugs.

## Fix

Gate both recording sites on status — a 4xx means the caller was rejected as designed (expected control flow), not a server fault:

- Shared `isExpectedClientError(status)` classifier (400–499).
- `recordServerFnError` (fn middleware): skips `recordException`/`ERROR` status for 4xx, and stamps the re-thrown `Error` with **non-enumerable** `httpStatus`/`httpMessage` so it stays classifiable downstream **without** leaking into the client-bound JSON message.
- `recordRequestError` (request middleware): skips recording for 4xx; records `>=500` and non-HTTP (treated as 500) exactly as before.

4xx still carry `http.status_code` on the span, so they remain queryable in APM — they're only excluded from Error Tracking.

### Coverage / scope
This also clears sibling 4xx noise (e.g. `Too big/Too small: expected string…` and `Name cannot be empty` `ValidationError`s, `You are not the recipient…`, `…sign up is not enabled`) while **keeping** genuine faults like `Repository query failed: column "source" does not exist` (a real 500), `ECONNRESET` (infra) and Framer upstream failures.

Out of scope: `handler /…` spans (Better Auth / Nitro route handlers) and `client.error` spans (browser RUM) are produced by different instrumentation, so their 4xx are not affected by this change — possible follow-up.

## Tests
`apps/web/src/start.test.ts` (new) covers both helpers: 401/404 not recorded, 5xx/unknown recorded, the re-thrown error stays `isHttpError`-classifiable without leaking `httpStatus` into its JSON message, and the **end-to-end** path (server-fn 401 → re-thrown → request middleware also leaves it unrecorded). Verified the tests fail without the gate (both directions) and pass with it.

- `pnpm --filter web test` — 43 suites / 494 pass
- `pnpm --filter web typecheck` (tsgo) clean; `biome check` clean

## Verification after deploy
Occurrences of issue `d8e806a8…` (and the related 4xx issues above) should drop to zero. Real 5xx issues continue to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)