### PR TITLE
docs(deployment): custom domain self-hosting guide; drop dead LAT_BETTER_AUTH_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,8 +142,6 @@ LAT_MASTER_ENCRYPTION_KEY=75d697b90c1e46c13bd7f7343ab2b9a9e430cdcda05d47f055e152
 # Better Auth
 # Generate a unique value for production (openssl rand -hex 32)
 LAT_BETTER_AUTH_SECRET=bd84f86b2cc1011da17d68e5a808f873d30383bc3717c4e770629e4f3b55b7da
-# Change to "https://api.your-domain" for production
-LAT_BETTER_AUTH_URL=http://localhost:3001
 
 # Cloudflare Turnstile (optional - bot protection)
 # LAT_TURNSTILE_SECRET_KEY=0x...

--- a/charts/latitude/templates/configmap.yaml
+++ b/charts/latitude/templates/configmap.yaml
@@ -11,7 +11,6 @@ data:
   LAT_WEB_URL: {{ required "Set config.webUrl (e.g. https://latitude.example.com)" .Values.config.webUrl | quote }}
   LAT_API_URL: {{ required "Set config.apiUrl (e.g. https://api.latitude.example.com)" .Values.config.apiUrl | quote }}
   LAT_INGEST_URL: {{ required "Set config.ingestUrl (e.g. https://ingest.latitude.example.com)" .Values.config.ingestUrl | quote }}
-  LAT_BETTER_AUTH_URL: {{ .Values.config.apiUrl | quote }}
   LAT_TRUSTED_ORIGINS: {{ .Values.config.webUrl | quote }}
   LAT_CORS_ALLOWED_ORIGINS: {{ .Values.config.webUrl | quote }}
 

--- a/docs/deployment/cluster.mdx
+++ b/docs/deployment/cluster.mdx
@@ -179,6 +179,36 @@ ingress:
 
 Keep the `config.*Url` values on `https://` — they feed the `LAT_*_URL` and CORS/trusted-origin settings.
 
+## Custom domain
+
+Latitude exposes three public surfaces — the **web** UI, the **API** (which also hosts the **MCP server**), and **ingest** (OTLP traces). You set them through `config.webUrl`, `config.apiUrl`, and `config.ingestUrl`; the [Ingress](#tls-and-reverse-proxy) derives its three hosts from those same values, and the chart wires the rest of the URL contract for you — `LAT_TRUSTED_ORIGINS` and `LAT_CORS_ALLOWED_ORIGINS` are derived from `config.webUrl`.
+
+So a standard three-host setup needs nothing beyond getting those three URLs right and pointing DNS at the Ingress:
+
+```yaml
+config:
+  webUrl: https://app.your-domain.com
+  apiUrl: https://api.your-domain.com
+  ingestUrl: https://ingest.your-domain.com
+```
+
+Each must be the real, externally-resolvable `https://` URL (scheme included): the chart feeds them into the in-cluster `LAT_*_URL`, CORS, and trusted-origin settings and routes the matching Ingress host to each Service. The `LAT_*_PORT` values stay cluster-internal — the Ingress maps your hostnames to them, so you leave them unchanged. Add the certificates as shown under [TLS and reverse proxy](#tls-and-reverse-proxy).
+
+If you serve the web UI from more than one origin (e.g. a vanity host alongside the canonical one), override the allowlists explicitly through `config.extraEnv`:
+
+```yaml
+config:
+  extraEnv:
+    - name: LAT_TRUSTED_ORIGINS
+      value: https://app.your-domain.com,https://latitude.your-domain.com
+    - name: LAT_CORS_ALLOWED_ORIGINS
+      value: https://app.your-domain.com,https://latitude.your-domain.com
+```
+
+<Note>
+  **MCP clients** connect to `${apiUrl}/v1/mcp` but sign in via OAuth against the **web** origin, so both `config.apiUrl` and `config.webUrl` must be correct and externally reachable (Ingress + TLS).
+</Note>
+
 ## Bring your own infrastructure
 
 Every bundled dependency is an independent toggle: set `<dep>.enabled: false` and fill its `external:` block, and the chart wires the right `LAT_*` configuration at your existing or managed instance instead of deploying the bundle.

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -129,7 +129,6 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | --- | --- |
 | `NODE_ENV` | Controls under what environment the code runs. Set to `production`. |
 | `LAT_WEB_URL`, `LAT_API_URL`, `LAT_INGEST_URL` | Public URLs where users and clients reach each service. |
-| `LAT_BETTER_AUTH_URL` | Auth base URL — your API origin. |
 | `LAT_TRUSTED_ORIGINS`, `LAT_CORS_ALLOWED_ORIGINS` | Comma-separated list of origins allowed to call the API. |
 | `LAT_WEB_PORT`, `LAT_API_PORT`, `LAT_INGEST_PORT` | Host bind ports (default `3000` / `3001` / `3002`). |
 | `LAT_WORKERS_HEALTH_PORT`, `LAT_WORKFLOWS_HEALTH_PORT` | Health-check ports for the background workers (default `9090` / `9091`). |

--- a/docs/deployment/single-host.mdx
+++ b/docs/deployment/single-host.mdx
@@ -138,6 +138,37 @@ Every service exposes an HTTP health endpoint, wired as the container healthchec
 
 `docker-stack.yml` publishes `web` (3000), `api` (3001), and `ingest` (3002) on the host over plain HTTP. For anything internet-facing, put a TLS-terminating reverse proxy (Caddy, nginx, Traefik) in front, route your domain(s) to those ports, and set the `LAT_*_URL` / `*_ORIGINS` values to the public `https://` URLs.
 
+## Custom domain
+
+Latitude exposes three public surfaces, each typically on its own hostname behind your [reverse proxy](#tls-and-reverse-proxy): the **web** UI, the **API** (which also hosts the **MCP server**), and **ingest** (OTLP traces). `.env.example` ships these pointing at `localhost`; for a real domain you must update the public URLs **and** the origin allowlists, so that browsers, the API, and MCP clients all agree on where each service lives.
+
+In `.env.production`:
+
+```bash
+# Public URLs — what users, SDKs, and MCP clients connect to
+# (https, terminated by your reverse proxy)
+LAT_WEB_URL=https://app.your-domain.com
+LAT_API_URL=https://api.your-domain.com
+LAT_INGEST_URL=https://ingest.your-domain.com
+
+# Origin allowlists — must contain your web origin, or browser calls to the API
+# are rejected and sign-in fails. Comma-separate to allow several origins.
+LAT_TRUSTED_ORIGINS=https://app.your-domain.com
+LAT_CORS_ALLOWED_ORIGINS=https://app.your-domain.com
+```
+
+Then restart so the services pick up the new values:
+
+```bash
+docker compose --env-file .env.production -f docker-stack.yml up -d
+```
+
+The hostnames are yours to pick — three subdomains (above), three separate domains, or one domain with path routing — as long as each `LAT_*_URL` exactly matches (scheme included) the URL your reverse proxy serves, and the proxy forwards each host to the matching service port. Leave the `LAT_*_PORT` values as their defaults (`3000` / `3001` / `3002`): they're the ports each service listens on internally, not part of the public hostname.
+
+<Note>
+  **MCP clients** connect to `${LAT_API_URL}/v1/mcp` but sign in via OAuth against the **web** origin, so both `LAT_WEB_URL` and `LAT_API_URL` must be correct.
+</Note>
+
 ## Bring your own infrastructure
 
 Each infra service in `docker-stack.yml` is a clearly-marked, independently removable block. To use an existing or managed datastore, comment out its block and point the matching `LAT_*` value at your instance:

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -461,7 +461,6 @@ function createTaskDefinition(
           { name: "LAT_INGEST_URL", value: ingestUrl },
           { name: "LAT_LATITUDE_TELEMETRY_INGEST_URL", value: ingestUrl },
           { name: "LAT_LATITUDE_API_URL", value: apiUrl },
-          { name: "LAT_BETTER_AUTH_URL", value: apiUrl },
           { name: "LAT_TRUSTED_ORIGINS", value: trustedOrigins },
           { name: "LAT_CORS_ALLOWED_ORIGINS", value: webUrl },
           ...(config.name === "production" ? [{ name: "VITE_LAT_GTM_CONTAINER_ID", value: "GTM-5NWGV24H" }] : []),

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -97,7 +97,7 @@ export interface StripePlanConfig {
 }
 
 export const createBetterAuth = (config: BetterAuthConfig) => {
-  const baseUrl = config.baseUrl ?? Effect.runSync(parseEnv("LAT_BETTER_AUTH_URL", "string", "http://localhost:3000"))
+  const baseUrl = config.baseUrl ?? Effect.runSync(parseEnv("LAT_WEB_URL", "string", "http://localhost:3000"))
   const basePath = config.basePath ?? "/auth"
   const secret = config.secret ?? Effect.runSync(parseEnv("LAT_BETTER_AUTH_SECRET", "string"))
 


### PR DESCRIPTION
## Why

A self-hoster (custom domain, Docker) got MCP OAuth to succeed but the client then couldn't connect, and our docs had no guidance on the URLs/origins a custom domain needs. While writing that guidance, `LAT_BETTER_AUTH_URL` turned out to be dead config that was also documented/set pointing at the **API** origin — which is exactly what produced the confusing advice.

## What

**Docs — new "Custom domain" section** in both [`single-host`](docs/deployment/single-host.mdx) and [`cluster`](docs/deployment/cluster.mdx):
- The public URLs (`LAT_WEB_URL` / `LAT_API_URL` / `LAT_INGEST_URL`) and origin allowlists (`LAT_TRUSTED_ORIGINS` / `LAT_CORS_ALLOWED_ORIGINS`) a real domain needs, and a note that `LAT_*_PORT` are internal listen ports left at their defaults.
- An MCP/OAuth `<Note>` explaining the failure mode: the API publishes `/.well-known/oauth-protected-resource` with `resource = LAT_API_URL` and `authorization_servers = [LAT_WEB_URL]`, so if either is still a `localhost` value, **OAuth succeeds but the client can't connect** (the resource URL it's handed is unreachable).

**Remove `LAT_BETTER_AUTH_URL` everywhere** — it's read by no running service:
- The web app constructs Better Auth with `baseUrl: LAT_WEB_URL` (mounted at `/api/auth`); the browser auth client uses `window.location.origin`; the API validates OAuth tokens straight from the shared `oauthAccessTokens` table. The `LAT_BETTER_AUTH_URL` fallback in `createBetterAuth` was never reached.
- It was also set/documented as the **API** origin (`.env.example`, `configuration.mdx`, Helm configmap, ECS task def), which is semantically backwards.
- Removed from `.env.example`, `configuration.mdx`, `charts/latitude/templates/configmap.yaml`, and `infra/lib/ecs.ts`.
- `createBetterAuth` keeps `baseUrl` optional but now falls back to `LAT_WEB_URL` (the correct origin) instead of `LAT_BETTER_AUTH_URL`.

## ⚠️ Pulumi follow-up (infra reviewer)

`infra/lib/ecs.ts` no longer emits the `LAT_BETTER_AUTH_URL` task-definition env var. This needs a **`pulumi up`** to roll out, which will show `LAT_BETTER_AUTH_URL` being **removed** from the app task definitions in `pulumi preview`. It is a **functional no-op** (no service ever read the var), but the apply should be done deliberately as part of merging this — please run/own the `pulumi up`.

## Testing

- `pnpm --filter @platform/db-postgres typecheck` ✅
- `pnpm --filter @app/web typecheck` ✅
- `pnpm --filter latitude-infra typecheck` ✅
- `create-better-auth.test.ts` — 8/8 ✅
- Repo-wide grep: zero `LAT_BETTER_AUTH_URL` references remain in tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)