### PR TITLE
docs(agents): note Docker 29 containerd-snapshotter requirement for cloud VMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,4 +71,4 @@ For services, ports, health checks, Docker Compose, dev servers, and Mailpit aut
 - **mise activation**: Use `eval "$(mise env)"` (not `mise activate bash`) before running scripts that call `node`/`pnpm` in child shells. `mise activate` only hooks the current shell's prompt; child `bash` invocations won't inherit the PATH.
 - `pnpm build` must complete before `pnpm db:up` — migration scripts depend on compiled platform packages.
 - The `pnpm install` output may warn about unapproved build scripts (`@swc/core`, `sharp`, etc.). These are non-blocking — pre-built binaries are used.
-- The Docker daemon in cloud VMs needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles this.
+- The Docker daemon in cloud VMs needs the `fuse-overlayfs` storage driver and `iptables-legacy`; on Docker 29+ you must also set `features.containerd-snapshotter=false` in `/etc/docker/daemon.json` or `fuse-overlayfs` is ignored. This daemon config plus `docker` group membership for the run user are baked into the VM snapshot (not the update script); `cloud-start.sh` only starts the already-configured daemon.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Sets up and verifies the Cursor Cloud development environment for this repo, and records one durable, non-obvious gotcha discovered during setup.

The only code change is a one-line clarification in `AGENTS.md` (symlinked to `CLAUDE.md`): on Docker 29+ the daemon needs `features.containerd-snapshotter=false` in `/etc/docker/daemon.json` or the `fuse-overlayfs` storage driver is silently ignored. It also clarifies that the daemon config + `docker` group membership are baked into the VM snapshot (not the update script), and that `cloud-start.sh` only starts the already-configured daemon.

No application code was modified — the repo's existing `.cursor/environment.json` + `scripts/cloud-install.sh` + `scripts/cloud-start.sh` flow was used as-is.

## Related issue (if applicable)

Closes #

## How was this tested?

Brought the full stack up from a fresh VM and exercised the product end-to-end:

- Installed system deps (Docker 29 w/ fuse-overlayfs + iptables-legacy, mise + Node 25), then ran `scripts/cloud-install.sh` (deps + telemetry/sdk build), `pnpm build`, and `scripts/cloud-start.sh` (Docker infra + Postgres/ClickHouse migrations + seeds).
- All 7 infra containers healthy; all 5 dev apps healthy: web `http://localhost:3000` (200), api `:3001/health` (200), ingest `:3002/health` (200), workers `:9090/health` (200), workflows `:9091/health` (200).
- Hello-world: completed the passwordless magic-link login (`owner@acme.com` → Mailpit → "Continue to Latitude") and navigated the authenticated dashboard showing seeded data (1.6K sessions, 115 signals, 11 users, 43-span trace waterfall).

[latitude_magic_link_login_and_dashboard.mp4](https://cursor.com/agents/bc-f667b659-fd98-4cf8-9216-ac91295dbc65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flatitude_magic_link_login_and_dashboard.mp4)

[Authenticated Sessions dashboard with seeded data](https://cursor.com/agents/bc-f667b659-fd98-4cf8-9216-ac91295dbc65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_26838.webp)
[Trace span waterfall detail](https://cursor.com/agents/bc-f667b659-fd98-4cf8-9216-ac91295dbc65/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftour_a0ec8.webp)

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f667b659-fd98-4cf8-9216-ac91295dbc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f667b659-fd98-4cf8-9216-ac91295dbc65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

