### PR TITLE
fix(web): expand span tree when no span is selected

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -53,12 +53,12 @@ export function SpansTab({
   }, [selectedSpanId, spans?.length])
 
   function handleSelectSpan(spanId: string) {
-    if (spanId === selectedSpanId) {
+    if (spanId === "" || spanId === selectedSpanId) {
       onSelectSpan("")
       setIsMinimized(false)
-    } else {
-      onSelectSpan(spanId)
+      return
     }
+    onSelectSpan(spanId)
   }
 
   function handleCloseDetail() {
@@ -118,7 +118,7 @@ export function SpansTab({
         spans={filteredSpans}
         selectedSpanId={selectedSpanId}
         onSelectSpan={handleSelectSpan}
-        isMinimized={isMinimized}
+        isMinimized={isMinimized && selectedSpanId !== ""}
         onToggleMinimized={handleToggleMinimized}
         isActive={isActive}
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -114,7 +114,10 @@ export function SpanTree({
     // biome-ignore lint/a11y/noStaticElementInteractions: passive mouse tracking for waterfall cursor
     <div
       ref={containerRef}
-      className={cn("relative flex flex-col overflow-hidden", isMinimized ? "shrink-0" : "flex-1")}
+      className={cn(
+        "relative flex flex-col overflow-hidden",
+        isMinimized ? "shrink-0 border-b border-border" : "flex-1",
+      )}
       style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3648

## Summary

The span tree on trace and session detail panels kept a 192px `max-height` scroll container after deselecting a span, leaving a large blank area below a clipped tree.

## Root cause

`isMinimized` was set to `true` when a span was selected, but deselecting via **Escape** or **filter changes** cleared `selectedSpanId` without resetting `isMinimized`. The tree stayed in minimized layout even though the span detail panel was hidden.

## Fix

- Treat the tree as minimized only when `isMinimized && selectedSpanId !== ""`, so an empty selection always expands the tree to fill available space.
- Consolidate deselect handling in `handleSelectSpan` so clearing the selection (including via Escape) also resets `isMinimized`.
- Add a bottom border on the minimized tree container so the scroll boundary is visually obvious when a span is selected and the tree is collapsed.

## Testing

- `pnpm --filter @app/web typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0BD28XC1SS/p1782386916927699?thread_ts=1782386916.927699&cid=C0BD28XC1SS)

<div><a href="https://cursor.com/agents/bc-d884a752-b7d1-5f20-9afd-223f7f343366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d884a752-b7d1-5f20-9afd-223f7f343366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

