### PR TITLE
feat(telemetry): add CI publish for hermes telemetry pip package

### DIFF
--- a/.github/workflows/publish-hermes-telemetry.yml
+++ b/.github/workflows/publish-hermes-telemetry.yml
@@ -1,0 +1,120 @@
+name: Publish Hermes Telemetry
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to publish from
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to publish from
+        required: false
+        type: string
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'latitude-dev/latitude-llm' }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Get current version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(grep -m1 '^version' packages/telemetry/hermes/pyproject.toml | sed -E 's/version *= *"([^"]+)"/\1/')
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version on PyPI
+        id: check_version
+        run: |
+          CURRENT_VERSION="${{ steps.get_version.outputs.version }}"
+          if curl -s "https://pypi.org/pypi/latitude-telemetry-hermes/$CURRENT_VERSION/json" | grep -q '"version"'; then
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Python
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          cd packages/telemetry/hermes
+          uv venv
+          uv sync --all-extras --all-groups
+
+      - name: Run tests
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          cd packages/telemetry/hermes
+          uv run pytest tests/ -x
+
+      - name: Build package
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          cd packages/telemetry/hermes
+          uv build
+
+      - name: Extract changelog
+        if: steps.check_version.outputs.should_publish == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          CHANGELOG="packages/telemetry/hermes/CHANGELOG.md"
+          if [ ! -f "$CHANGELOG" ]; then
+            echo "Missing changelog: ${CHANGELOG}"
+            exit 1
+          fi
+
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) { found=1; next } }
+            found { print }
+          ' "$CHANGELOG" > release_notes.md
+
+          if [ ! -s release_notes.md ]; then
+            echo "Missing changelog entry for version ${VERSION} in ${CHANGELOG}"
+            exit 1
+          fi
+
+          {
+            echo "body<<EOF"
+            cat release_notes.md
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Publish to PyPI
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          cd packages/telemetry/hermes
+          uv publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: hermes-telemetry-${{ steps.get_version.outputs.version }}
+          name: Hermes Telemetry v${{ steps.get_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
+          target_commitish: ${{ inputs.ref || github.sha }}
+          draft: false
+          prerelease: ${{ contains(steps.get_version.outputs.version, 'a') || contains(steps.get_version.outputs.version, 'b') || contains(steps.get_version.outputs.version, 'rc') }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -75,6 +75,14 @@ jobs:
       ref: ${{ github.sha }}
     secrets: inherit
 
+  publish-hermes-telemetry:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-hermes-telemetry.yml
+    with:
+      ref: ${{ github.sha }}
+    secrets: inherit
+
   publish-python-sdk:
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ workflow-test-output.txt
 # Better auth schema reference. Used to track schema drift between our custom
 # schema and better auth's default schema.
 packages/platform/db-postgres/better-auth.schema.reference.ts
+__pycache__/

--- a/docs/telemetry/hermes.md
+++ b/docs/telemetry/hermes.md
@@ -28,6 +28,14 @@ LATITUDE_API_KEY=lat_xxx
 LATITUDE_PROJECT=your-project-slug
 ```
 
+<Note>
+  The plugin sends to Latitude Cloud (`https://ingest.latitude.so`) by default. If you
+  run a **self-hosted or local** Latitude, also set `LATITUDE_BASE_URL` to your ingest
+  **origin only** — for example `http://localhost:3002` on a local dev stack — with no
+  `/v1/traces` suffix (the plugin appends it). The API key and project slug must belong
+  to that same instance.
+</Note>
+
 ## Verify
 
 Run Hermes and send a message to your agent, then open your Latitude project and go to **Traces**. The new trace should appear within a few seconds.
@@ -79,7 +87,7 @@ All configuration is read from environment variables (set them in your shell or 
 |-----|---------|-------------|
 | `LATITUDE_API_KEY` | — | API key (required) |
 | `LATITUDE_PROJECT` / `LATITUDE_PROJECT_SLUG` | — | Project slug (required) |
-| `LATITUDE_BASE_URL` | `https://ingest.latitude.so` | Ingest endpoint |
+| `LATITUDE_BASE_URL` | `https://ingest.latitude.so` | Ingest origin (no path; the plugin appends `/v1/traces`). Set to your own ingest for self-hosted/local, e.g. `http://localhost:3002` |
 | `LATITUDE_HERMES_TELEMETRY_ENABLED` / `LATITUDE_TELEMETRY_ENABLED` | `true` | Master switch |
 | `LATITUDE_HERMES_NO_CONTENT` / `LATITUDE_NO_CONTENT` | `false` | Export structure/timing only |
 | `LATITUDE_DEBUG` | `false` | Verbose logging |

--- a/packages/telemetry/hermes/CHANGELOG.md
+++ b/packages/telemetry/hermes/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the Latitude Hermes telemetry plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0]
+
+### Added
+
+- Initial release of `latitude-telemetry-hermes`, a Hermes Agent plugin that streams sessions to Latitude as OTLP traces.

--- a/packages/telemetry/hermes/README.md
+++ b/packages/telemetry/hermes/README.md
@@ -30,6 +30,12 @@ export LATITUDE_PROJECT=my-project
 That's it — every session is now streamed to Latitude as OTLP traces. To export
 structure and timing without prompt/response/tool content, set `LATITUDE_NO_CONTENT=true`.
 
+> **Self-hosted / local Latitude?** The plugin defaults to Latitude Cloud
+> (`https://ingest.latitude.so`). Point it at your own ingest by setting
+> `LATITUDE_BASE_URL` to the ingest **origin only** — e.g. `http://localhost:3002`
+> for a local dev stack — without the `/v1/traces` suffix (the plugin appends it).
+> Your `LATITUDE_API_KEY` and `LATITUDE_PROJECT` must come from that same instance.
+
 ## How it works
 
 Hermes loads pip-installed plugins via the `hermes_agent.plugins` entry point and calls
@@ -61,7 +67,7 @@ All configuration is read from environment variables:
 |-----|---------|-------------|
 | `LATITUDE_API_KEY` | — | API key (required) |
 | `LATITUDE_PROJECT` / `LATITUDE_PROJECT_SLUG` | — | Project slug (required) |
-| `LATITUDE_BASE_URL` | `https://ingest.latitude.so` | Ingest endpoint |
+| `LATITUDE_BASE_URL` | `https://ingest.latitude.so` | Ingest origin (no path; the plugin appends `/v1/traces`). Set to your own ingest for self-hosted/local, e.g. `http://localhost:3002` |
 | `LATITUDE_HERMES_TELEMETRY_ENABLED` / `LATITUDE_TELEMETRY_ENABLED` | `true` | Master switch |
 | `LATITUDE_HERMES_NO_CONTENT` / `LATITUDE_NO_CONTENT` | `false` | Export structure/timing only (no prompts, responses, or tool I/O) |
 | `LATITUDE_DEBUG` | `false` | Verbose logging |

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
@@ -51,7 +51,7 @@ _SSL_CONTEXT = _ssl_context()
 
 logger = logging.getLogger(__name__)
 
-SCOPE_NAME = "@latitude-data/hermes-telemetry"
+SCOPE_NAME = "latitude-telemetry-hermes"
 PKG_VERSION = "0.1.0"
 
 # Bound on live trace state, so turns that never reach a clean finish


### PR DESCRIPTION
## What

Adds a PyPI publish pipeline for the `latitude-telemetry-hermes` Hermes plugin (added in #3658 but with no release path yet), modeled on the existing reusable `publish-python-telemetry.yml` workflow.

- **New `publish-hermes-telemetry.yml`** (`workflow_call` + `workflow_dispatch`): detects the version from `pyproject.toml`, skips if it's already on PyPI, runs tests, builds, publishes via `PYPI_TOKEN`, and cuts a GitHub release tagged `hermes-telemetry-<version>`.
- **Wired into `publish-packages.yml`** as a `publish-hermes-telemetry` job alongside the other Python telemetry packages (runs on push to `development`).
- **Added `packages/telemetry/hermes/CHANGELOG.md`** — the publish workflow fails without a matching `## [version]` entry. Seeded with `[0.1.0]`.
- **Aligned `SCOPE_NAME`** with the published package name `latitude-telemetry-hermes` (was `@latitude-data/hermes-telemetry`).
- **Docs:** documented that self-hosted/local users must set `LATITUDE_BASE_URL` to their ingest **origin** (the default targets Latitude Cloud), in both the package README and `docs/telemetry/hermes.md`.

## Verification

- `uv run pytest tests/` → 7 passed
- `uv run ruff check .` → clean
- `uv build` → builds `latitude_telemetry_hermes-0.1.0` sdist + wheel
- Version detection + changelog-extraction `awk` validated locally against `[0.1.0]`
- Both workflow YAML files parse

## Notes

- `uv.lock` is intentionally not tracked (matching the original package commit; the workflow uses `uv sync` + `uv build`).
- There's still no PR-time lint/test CI for hermes (mirroring `python-telemetry-ci.yml`) — left out as it's outside the publish scope; happy to add in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)