### PR TITLE
fix(web): accept unknown OAuth error codes in Slack integration routes

### DIFF
--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -15,7 +15,7 @@ import { resolveDefaultProjectSlug } from "../../domains/projects/projects.funct
 const searchSchema = z.object({
   next: z.literal("integrations").optional(),
   installed: z.literal("ok").optional(),
-  error: z.enum(["workspace_taken", "oauth_failed"]).optional(),
+  error: z.string().optional(),
 })
 
 export const Route = createFileRoute("/_authenticated/")({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -60,7 +60,7 @@ export function OnboardingFlow({
   readonly slackEnvConfigured: boolean
   readonly initialStep?: OnboardingStep
   readonly flashInstalled?: "ok"
-  readonly flashError?: "workspace_taken" | "oauth_failed"
+  readonly flashError?: string
   readonly onOpenProjectTraces: (projectId: string) => Promise<void>
 }) {
   const { toast } = useToast()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/onboarding.tsx
@@ -9,7 +9,7 @@ import { useRouteProject } from "./-route-data.ts"
 const searchSchema = z.object({
   step: z.enum(ONBOARDING_STEPS).optional(),
   installed: z.literal("ok").optional(),
-  error: z.enum(["workspace_taken", "oauth_failed"]).optional(),
+  error: z.string().optional(),
 })
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/onboarding")({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations.tsx
@@ -18,7 +18,7 @@ import { SLACK_INTEGRATION_QUERY_KEY, SlackRouteRow } from "./-components/slack-
 
 const searchSchema = z.object({
   installed: z.literal("ok").optional(),
-  error: z.enum(["workspace_taken", "oauth_failed"]).optional(),
+  error: z.string().optional(),
 })
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/integrations")({


### PR DESCRIPTION
## Summary

- Widened `error` search-param schema from `z.enum(["workspace_taken", "oauth_failed"])` to `z.string()` in three authenticated routes that handle Slack OAuth flash messages
- Widened the `OnboardingFlow` component `flashError` prop type from a literal union to `string` to match

## Root cause

Slack sends its own error codes (e.g. `client_disabled` when a workspace admin has disabled the Slack app) back to our OAuth callback. Our callback forwards those codes through the redirect chain to the final landing page. Three route `validateSearch` schemas used a strict `z.enum` that only accepted `"workspace_taken"` and `"oauth_failed"` — any other string caused TanStack Router's Zod validation to throw before the route could mount, breaking the page for the user.

Affected routes:
- `/_authenticated/index.tsx` — receives `/?error=client_disabled` after Slack denies
- `/_authenticated/projects/$projectSlug/settings/integrations.tsx`
- `/_authenticated/projects/$projectSlug/onboarding.tsx`

**Datadog issue:** `d0c30f9e-6862-11f1-9725-da7ad0900005`
8 occurrences in the last 7 days (latest Jun 24, 2026).

## Fix

Changed all three route schemas to `error: z.string().optional()`, matching the pattern already used in `login.tsx`. Unknown error codes fall through the existing `if/else` chain silently — the user sees no toast for unrecognised codes, which is safe (the page still loads).

## Validation

- Existing unit tests for the Slack OAuth callback (`-callback.test.ts`) continue to pass — `buildPostInstallRedirect` and `isWorkspaceConflict` behaviour is unchanged.
- The fix is additive (accepting more values, not fewer), so no regression risk to the `workspace_taken`/`oauth_failed` toast paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCLo6VNnGX5U34PYr8epRE)_