### PR TITLE
feat(web): add "add to dataset" action to trace and session details

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-trace-to-dataset-action.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-trace-to-dataset-action.tsx
@@ -1,0 +1,31 @@
+import { Button, Icon } from "@repo/ui"
+import { DatabaseIcon } from "lucide-react"
+import { useState } from "react"
+import { AddToDatasetModal } from "./add-to-dataset-modal.tsx"
+
+export function AddTraceToDatasetAction({
+  projectId,
+  traceId,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)} type="button">
+        <Icon icon={DatabaseIcon} />
+        Add to dataset
+      </Button>
+      <AddToDatasetModal
+        open={open}
+        onOpenChange={setOpen}
+        projectId={projectId}
+        selection={{ mode: "selected", rowIds: [traceId] }}
+        selectedCount={1}
+        onSuccess={() => setOpen(false)}
+      />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -9,6 +9,7 @@ import { useSessionDetail } from "../../../../../domains/sessions/sessions.colle
 import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { SignalLifecycleActions } from "../signals/-components/signal-lifecycle-actions.tsx"
+import { AddTraceToDatasetAction } from "./add-trace-to-dataset-action.tsx"
 import { isSessionTab, SessionSlot, type SessionTabId } from "./session-detail-drawer/session-slot.tsx"
 import { SignalSlot } from "./session-detail-drawer/signal-slot.tsx"
 import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
@@ -98,7 +99,8 @@ export function SessionDetailDrawer({
   // the issue slot under a sandbox scope, even from a deep-linked `?signalId=`
   // (its `SignalLifecycleActions` registers command-palette commands, and the
   // sandbox tree has no provider).
-  const signalsEnabled = !use(TraceScopeContext)
+  const isSandbox = !!use(TraceScopeContext)
+  const signalsEnabled = !isSandbox
   const detailKind: DetailSlotKind | null =
     traceId.length > 0 ? "trace" : signalId.length > 0 && signalsEnabled ? "issue" : null
   const showDetail = detailKind !== null && !isSessionMissing
@@ -153,18 +155,25 @@ export function SessionDetailDrawer({
       }
       actions={
         showDetail ? (
-          <Tooltip
-            asChild
-            side="bottom"
-            trigger={
-              <Button variant="default-soft" onClick={backToSession} type="button">
-                <Icon icon={ChevronLeftIcon} />
-                View session
-              </Button>
-            }
-          >
-            View session <HotkeyBadge hotkey="Escape" />
-          </Tooltip>
+          <>
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <Button variant="default-soft" onClick={backToSession} type="button">
+                  <Icon icon={ChevronLeftIcon} />
+                  View session
+                </Button>
+              }
+            >
+              View session <HotkeyBadge hotkey="Escape" />
+            </Tooltip>
+            {detailKind === "trace" && !isSandbox && traceId ? (
+              <AddTraceToDatasetAction projectId={projectId} traceId={traceId} />
+            ) : null}
+          </>
+        ) : !isSandbox && session?.latestTraceId ? (
+          <AddTraceToDatasetAction projectId={projectId} traceId={session.latestTraceId} />
         ) : undefined
       }
       rightActions={

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -32,6 +32,7 @@ import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx
 import { useTraceDetail } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { AddTraceToDatasetAction } from "./add-trace-to-dataset-action.tsx"
 import { isGlobalAnnotation } from "./annotations/hooks/use-annotation-navigation.ts"
 import { useConversationAnnotationFocus } from "./annotations/hooks/use-conversation-annotation-focus.ts"
 import { TraceAnnotationsList } from "./annotations/trace-annotations-list.tsx"
@@ -514,6 +515,7 @@ function TraceDetailDrawerShell({
     readonly closeLabel?: ReactNode
     readonly drawerStoreKey?: string
   }) {
+  const isSandbox = !!use(TraceScopeContext)
   return (
     <DetailDrawer
       storeKey={drawerStoreKey}
@@ -527,6 +529,7 @@ function TraceDetailDrawerShell({
       }
       actions={
         <>
+          {!isSandbox && <AddTraceToDatasetAction projectId={projectId} traceId={traceId} />}
           <Tooltip
             asChild
             side="bottom"


### PR DESCRIPTION
## What

Adds an **Add to dataset** action to the trace and session detail drawers, so a single trace can be added to a dataset without going back to the traces table and bulk-selecting. Closes [LAT-696](https://linear.app/latitude/issue/LAT-696/add-dataset-actions-to-trace-and-session-details).

Three entry points:
- **Trace detail drawer** — action in the header for the open trace.
- **Session detail (session view)** — action for the session's latest trace.
- **Session detail (trace view)** — action beside "View session" for the open trace.

## How

This is mostly wiring — the backend, the `AddToDatasetModal`, and `addTracesToDatasetFunction` already power the bulk "Add to Dataset" flow on the traces table. A new thin `AddTraceToDatasetAction` component opens that modal with a single-trace selection (`{ mode: "selected", rowIds: [traceId] }`, `selectedCount: 1`), styled as a neutral `outline` button to match the existing bulk action.

The action is **gated out of the sandbox scope** (`TraceScopeContext`), consistent with how signals/annotations are gated — adding a sandbox-org trace to a live-org dataset would be a tenancy mismatch.

## Test plan

- [x] `pnpm --filter @app/web typecheck`
- [x] `biome check` on changed files
- [x] Manual: open a trace from the traces table → "Add to dataset" → pick existing / create new → row lands in the dataset
- [x] Manual: open a session → "Add to dataset" adds the latest trace; open a trace within the session → action adds that trace
- [x] Manual: sandbox traces route → action is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)