### PR TITLE
feat(web): export Behaviours and Signal sessions to datasets (#3685)

### DIFF
--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -1,3 +1,4 @@
+import { MOMENT_KINDS } from "@domain/conversation-intelligence"
 import type { Dataset, DatasetRow } from "@domain/datasets"
 import {
   addTracesToDataset,
@@ -12,6 +13,7 @@ import {
   insertRows,
   listDatasets,
   listRows,
+  MAX_TRACES_PER_DATASET_IMPORT,
   parseDatasetCsv,
   prepareDatasetExportUseCase,
   searchDatasets,
@@ -31,17 +33,25 @@ import {
   putInDisk,
   SignalId,
   sortDirectionSchema,
+  TaxonomyClusterId,
   TraceId,
   UnauthorizedError,
 } from "@domain/shared"
+import { listClusterSessionTraceIdsUseCase } from "@domain/taxonomy"
 import { AIEmbedLive, withAi } from "@platform/ai"
 import {
   DatasetRowRepositoryLive,
   ScoreAnalyticsRepositoryLive,
+  TaxonomyClusterIntelligenceRepositoryLive,
   TraceRepositoryLive,
   withClickHouse,
 } from "@platform/db-clickhouse"
-import { DatasetRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
+import {
+  DatasetRepositoryLive,
+  OutboxEventWriterLive,
+  TaxonomyClusterRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
@@ -763,3 +773,150 @@ export const createDatasetFromTracesFunction = createServerFn({
       }
     },
   )
+
+const clusterSourceSchema = z.object({
+  clusterId: z.string(),
+  filter: z.enum(["all", ...MOMENT_KINDS]).optional(),
+  momentRange: z
+    .object({
+      metric: z.enum(["frequency", "escalation", "resolution", "churnRisk", "wins"]),
+      fromTurn: z.number().int().min(0),
+      toTurn: z.number().int().min(0),
+    })
+    .optional(),
+  timeFromIso: z.string().optional(),
+  timeToIso: z.string().optional(),
+})
+
+export type ClusterSource = z.infer<typeof clusterSourceSchema>
+type ClusterSourceInput = ClusterSource
+
+// Resolve a behaviour selection to explicit trace ids. "selected" uses the
+// checked rows verbatim (the table already holds their trace ids); "all" /
+// "allExcept" resolve the cluster (its subtree) to one trace id per session
+// honouring the drawer's active filters, capped one above the import limit so
+// the domain surfaces TooManyTracesError when the selection is too large.
+function resolveClusterTraceIds(
+  orgId: OrganizationId,
+  projectId: ProjectId,
+  cluster: ClusterSourceInput,
+  selection: z.infer<typeof rowSelectionSchema>,
+) {
+  return Effect.gen(function* () {
+    if (selection.mode === "selected") return selection.rowIds.map(TraceId)
+    const all = yield* listClusterSessionTraceIdsUseCase({
+      organizationId: orgId,
+      projectId,
+      clusterId: TaxonomyClusterId(cluster.clusterId),
+      ...(cluster.filter ? { filter: cluster.filter } : {}),
+      ...(cluster.momentRange ? { momentRange: cluster.momentRange } : {}),
+      ...(cluster.timeFromIso ? { startTimeFrom: new Date(cluster.timeFromIso) } : {}),
+      ...(cluster.timeToIso ? { startTimeTo: new Date(cluster.timeToIso) } : {}),
+      limit: MAX_TRACES_PER_DATASET_IMPORT + 1,
+    })
+    if (selection.mode === "all") return all
+    const excluded = new Set<string>(selection.rowIds)
+    return all.filter((id) => !excluded.has(id as string))
+  })
+}
+
+export const addClusterSessionsToDatasetFunction = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      datasetId: z.string(),
+      cluster: clusterSourceSchema,
+      selection: rowSelectionSchema,
+    }),
+  )
+  .handler(async ({ data }): Promise<{ versionId: string; version: number; rowCount: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const chClient = getClickhouseClient()
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const traceIds = yield* resolveClusterTraceIds(orgId, projectId, data.cluster, data.selection)
+        return yield* addTracesToDataset({
+          projectId,
+          datasetId: DatasetId(data.datasetId),
+          source: { kind: "project" },
+          selection: { mode: "selected", traceIds },
+        })
+      }).pipe(
+        withPostgres(Layer.mergeAll(DatasetRepositoryLive, TaxonomyClusterRepositoryLive), getPostgresClient(), orgId),
+        withClickHouse(
+          Layer.mergeAll(
+            DatasetRowRepositoryLive,
+            TraceRepositoryLive,
+            ScoreAnalyticsRepositoryLive,
+            TaxonomyClusterIntelligenceRepositoryLive,
+          ),
+          chClient,
+          orgId,
+        ),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
+    )
+
+    return {
+      versionId: result.versionId as string,
+      version: result.version,
+      rowCount: result.rowIds.length,
+    }
+  })
+
+export const createDatasetFromClusterSessionsFunction = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      name: z.string().min(1),
+      cluster: clusterSourceSchema,
+      selection: rowSelectionSchema,
+    }),
+  )
+  .handler(async ({ data }): Promise<{ datasetId: string; versionId: string; version: number; rowCount: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const chClient = getClickhouseClient()
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const traceIds = yield* resolveClusterTraceIds(orgId, projectId, data.cluster, data.selection)
+        return yield* createDatasetFromTraces({
+          projectId,
+          name: data.name,
+          source: { kind: "project" },
+          selection: { mode: "selected", traceIds },
+        })
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive, TaxonomyClusterRepositoryLive),
+          getPostgresClient(),
+          orgId,
+        ),
+        withClickHouse(
+          Layer.mergeAll(
+            DatasetRowRepositoryLive,
+            TraceRepositoryLive,
+            ScoreAnalyticsRepositoryLive,
+            TaxonomyClusterIntelligenceRepositoryLive,
+          ),
+          chClient,
+          orgId,
+        ),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
+    )
+
+    return {
+      datasetId: result.datasetId as string,
+      versionId: result.versionId as string,
+      version: result.version,
+      rowCount: result.rowIds.length,
+    }
+  })

--- a/apps/web/src/domains/signals/signals.collection.ts
+++ b/apps/web/src/domains/signals/signals.collection.ts
@@ -18,6 +18,7 @@ import type {
   UpdateSignalTriageRecord,
 } from "./signals.functions.ts"
 import {
+  countSignalSessions,
   getRelatedSignals,
   getSignal,
   getSignalDetail,
@@ -447,6 +448,24 @@ export function useUpdateSignalTriage(projectId: string, signalId: string) {
       }),
     onSuccess: () => invalidateSignalQueries(projectId, signalId),
   })
+}
+
+export function useSignalSessionsCount({
+  projectId,
+  signalId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly signalId: string
+  readonly enabled?: boolean
+}) {
+  const { data } = useQuery({
+    queryKey: getSignalSessionsCountQueryKey(projectId, signalId),
+    queryFn: () => countSignalSessions({ data: { projectId, signalId } }),
+    staleTime: ISSUES_QUERY_STALE_TIME_MS,
+    enabled: enabled && projectId.length > 0 && signalId.length > 0,
+  })
+  return data ?? 0
 }
 
 export function useSignalSessionsInfiniteScroll({

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -827,6 +827,24 @@ export const listSignalSessions = createServerFn({ method: "GET" })
     return toSignalSessionPageRecord(result)
   })
 
+export const countSignalSessions = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), signalId: z.string() }))
+  .handler(async ({ data }): Promise<number> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+        return yield* scoreAnalyticsRepository.countSessionsBySignal({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          signalId: SignalId(data.signalId),
+        })
+      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId)),
+    )
+  })
+
 export const getSignalImpact = createServerFn({ method: "GET" })
   .inputValidator(signalImpactInputSchema)
   .handler(async ({ data }): Promise<SignalImpactRecord> => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
@@ -1,41 +1,30 @@
 import { MAX_TRACES_PER_DATASET_IMPORT } from "@domain/datasets/constants"
-import type { FilterSet } from "@domain/shared"
-import { Alert, Button, CloseTrigger, Input, Modal, Select, type SelectOption, Text, useToast } from "@repo/ui"
+import { Alert, Button, CloseTrigger, Icon, Input, Modal, Select, type SelectOption, Text, useToast } from "@repo/ui"
 import { useNavigate } from "@tanstack/react-router"
 import { Plus } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { useDatasetsList } from "../../../../../domains/datasets/datasets.collection.ts"
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
-import {
-  addTracesToDatasetFunction,
-  createDatasetFromTracesFunction,
-} from "../../../../../domains/datasets/datasets.functions.ts"
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
-import type { BulkSelection } from "../../../../../lib/hooks/useSelectableRows.ts"
 
+/**
+ * Generic "add the current selection to a dataset" modal. It owns only the
+ * dataset picker / create-new UI and the success plumbing (toast, cache
+ * invalidation, navigation); the caller supplies how its selection turns into
+ * rows via {@link onAddToExisting} / {@link onCreateNew}, so new row sources
+ * (traces, issue traces, cluster sessions, …) need no changes here.
+ */
 interface AddToDatasetModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   projectId: string
-  /**
-   * When set, "all" / "allExcept" selections resolve only against traces linked
-   * to this issue (via score analytics). Omit on the project-wide traces page.
-   */
-  signalId?: string
-  /**
-   * Saved-search query that scopes "all" / "allExcept" selections. Ignored when
-   * `signalId` is set. Omit outside the search page.
-   */
-  searchQuery?: string
-  /**
-   * Active table filters that scope "all" / "allExcept" selections to the
-   * same set the user sees. Ignored when `signalId` is set. Omit when no
-   * filters are active.
-   */
-  filters?: FilterSet
-  selection: BulkSelection<string>
+  /** Noun shown in the modal copy (e.g. "trace", "session"). */
+  itemLabel: string
   selectedCount: number
+  description?: string
+  onAddToExisting: (datasetId: string) => Promise<{ version: number; rowCount: number }>
+  onCreateNew: (name: string) => Promise<{ datasetId: string; version: number; rowCount: number }>
   onSuccess: () => void
 }
 
@@ -43,11 +32,11 @@ export function AddToDatasetModal({
   open,
   onOpenChange,
   projectId,
-  signalId,
-  searchQuery,
-  filters,
-  selection,
+  itemLabel,
   selectedCount,
+  description,
+  onAddToExisting,
+  onCreateNew,
   onSuccess,
 }: AddToDatasetModalProps) {
   const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
@@ -73,22 +62,15 @@ export function AddToDatasetModal({
     setSelectedDatasetId(null)
   }, [])
 
+  const itemLabelTitle = `${itemLabel.charAt(0).toUpperCase()}${itemLabel.slice(1)}s`
+
   const handleSubmit = useCallback(async () => {
     if (selectedCount === 0) return
     setSubmitting(true)
     try {
       if (creatingNew) {
         if (!newDatasetName.trim()) return
-        const result = await createDatasetFromTracesFunction({
-          data: {
-            projectId,
-            name: newDatasetName.trim(),
-            selection,
-            ...(signalId ? { signalId } : {}),
-            ...(searchQuery ? { searchQuery } : {}),
-            ...(filters ? { filters } : {}),
-          },
-        })
+        const result = await onCreateNew(newDatasetName.trim())
         toast({
           title: "Dataset created",
           description: `"${newDatasetName.trim()}" created with ${result.rowCount} row${result.rowCount === 1 ? "" : "s"}.`,
@@ -102,18 +84,9 @@ export function AddToDatasetModal({
         })
       } else {
         if (!selectedDatasetId) return
-        const result = await addTracesToDatasetFunction({
-          data: {
-            projectId,
-            datasetId: selectedDatasetId,
-            selection,
-            ...(signalId ? { signalId } : {}),
-            ...(searchQuery ? { searchQuery } : {}),
-            ...(filters ? { filters } : {}),
-          },
-        })
+        const result = await onAddToExisting(selectedDatasetId)
         toast({
-          title: "Traces added to dataset",
+          title: `${itemLabelTitle} added to dataset`,
           description: `${result.rowCount} row${result.rowCount === 1 ? "" : "s"} added (version ${result.version}).`,
         })
         getQueryClient().invalidateQueries({ queryKey: ["datasets", projectId] })
@@ -136,10 +109,9 @@ export function AddToDatasetModal({
     selectedDatasetId,
     newDatasetName,
     projectId,
-    signalId,
-    searchQuery,
-    filters,
-    selection,
+    itemLabelTitle,
+    onAddToExisting,
+    onCreateNew,
     selectedCount,
     toast,
     navigate,
@@ -158,14 +130,14 @@ export function AddToDatasetModal({
     <Modal
       open={open}
       onOpenChange={onOpenChange}
-      title="Add traces to dataset"
-      description={`${selectedCount} trace${selectedCount === 1 ? "" : "s"} selected`}
+      title={`Add ${itemLabel}s to dataset`}
+      description={description ?? `${selectedCount} ${itemLabel}${selectedCount === 1 ? "" : "s"} selected`}
       dismissible
       footer={
         <div className="flex flex-row items-center gap-2">
           <CloseTrigger />
           <Button onClick={handleSubmit} disabled={!canSubmit} isLoading={submitting}>
-            {!submitting && <Plus className="h-4 w-4" />}
+            {!submitting && <Icon icon={Plus} size="sm" />}
             {creatingNew ? "Create & add" : "Add to dataset"}
           </Button>
         </div>
@@ -176,7 +148,7 @@ export function AddToDatasetModal({
           <Alert
             variant="destructive"
             title="Selection too large"
-            description={`You selected ${selectedCount} traces, but the maximum allowed is ${MAX_TRACES_PER_DATASET_IMPORT.toLocaleString()}. Please narrow your selection.`}
+            description={`You selected ${selectedCount} ${itemLabel}s, but the maximum allowed is ${MAX_TRACES_PER_DATASET_IMPORT.toLocaleString()}. Please narrow your selection.`}
           />
         )}
         {creatingNew ? (
@@ -206,7 +178,7 @@ export function AddToDatasetModal({
             side="bottom"
             footerAction={{
               label: "Create new dataset",
-              icon: <Plus className="h-4 w-4" />,
+              icon: <Icon icon={Plus} size="sm" />,
               onClick: handleCreateNew,
             }}
           />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-trace-to-dataset-action.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-trace-to-dataset-action.tsx
@@ -1,29 +1,39 @@
 import { Button, Icon } from "@repo/ui"
 import { DatabaseIcon } from "lucide-react"
 import { useState } from "react"
+import {
+  addTracesToDatasetFunction,
+  createDatasetFromTracesFunction,
+} from "../../../../../domains/datasets/datasets.functions.ts"
 import { AddToDatasetModal } from "./add-to-dataset-modal.tsx"
 
 export function AddTraceToDatasetAction({
   projectId,
   traceId,
+  description,
 }: {
   readonly projectId: string
   readonly traceId: string
+  readonly description?: string
 }) {
   const [open, setOpen] = useState(false)
+  const selection = { mode: "selected" as const, rowIds: [traceId] }
 
   return (
     <>
-      <Button variant="outline" onClick={() => setOpen(true)} type="button">
-        <Icon icon={DatabaseIcon} />
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)} type="button">
+        <Icon icon={DatabaseIcon} size="sm" />
         Add to dataset
       </Button>
       <AddToDatasetModal
         open={open}
         onOpenChange={setOpen}
         projectId={projectId}
-        selection={{ mode: "selected", rowIds: [traceId] }}
+        itemLabel="trace"
         selectedCount={1}
+        {...(description ? { description } : {})}
+        onAddToExisting={(datasetId) => addTracesToDatasetFunction({ data: { projectId, datasetId, selection } })}
+        onCreateNew={(name) => createDatasetFromTracesFunction({ data: { projectId, name, selection } })}
         onSuccess={() => setOpen(false)}
       />
     </>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -17,6 +17,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRegisterCommands } from "../../../../../components/command-palette/command-palette-provider.tsx"
 import type { PaletteCommand } from "../../../../../components/command-palette/types.ts"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
+import {
+  addTracesToDatasetFunction,
+  createDatasetFromTracesFunction,
+} from "../../../../../domains/datasets/datasets.functions.ts"
 import { useMonitors } from "../../../../../domains/monitors/monitors.collection.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { useSavedSearchBySlug } from "../../../../../domains/saved-searches/saved-searches.collection.ts"
@@ -715,11 +719,31 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
             open={addToDatasetOpen}
             onOpenChange={setAddToDatasetOpen}
             projectId={currentProject.id}
-            selection={bulkSelection}
+            itemLabel="trace"
             selectedCount={selectedCount}
+            onAddToExisting={(datasetId) =>
+              addTracesToDatasetFunction({
+                data: {
+                  projectId: currentProject.id,
+                  datasetId,
+                  selection: bulkSelection,
+                  filters: effectiveFilters,
+                  ...(hasSearchQuery ? { searchQuery: query } : {}),
+                },
+              })
+            }
+            onCreateNew={(name) =>
+              createDatasetFromTracesFunction({
+                data: {
+                  projectId: currentProject.id,
+                  name,
+                  selection: bulkSelection,
+                  filters: effectiveFilters,
+                  ...(hasSearchQuery ? { searchQuery: query } : {}),
+                },
+              })
+            }
             onSuccess={clearSelections}
-            filters={effectiveFilters}
-            {...(hasSearchQuery ? { searchQuery: query } : {})}
           />
         </>
       )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -9,7 +9,6 @@ import { useSessionDetail } from "../../../../../domains/sessions/sessions.colle
 import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { SignalLifecycleActions } from "../signals/-components/signal-lifecycle-actions.tsx"
-import { AddTraceToDatasetAction } from "./add-trace-to-dataset-action.tsx"
 import { isSessionTab, SessionSlot, type SessionTabId } from "./session-detail-drawer/session-slot.tsx"
 import { SignalSlot } from "./session-detail-drawer/signal-slot.tsx"
 import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
@@ -155,25 +154,18 @@ export function SessionDetailDrawer({
       }
       actions={
         showDetail ? (
-          <>
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <Button variant="default-soft" onClick={backToSession} type="button">
-                  <Icon icon={ChevronLeftIcon} />
-                  View session
-                </Button>
-              }
-            >
-              View session <HotkeyBadge hotkey="Escape" />
-            </Tooltip>
-            {detailKind === "trace" && !isSandbox && traceId ? (
-              <AddTraceToDatasetAction projectId={projectId} traceId={traceId} />
-            ) : null}
-          </>
-        ) : !isSandbox && session?.latestTraceId ? (
-          <AddTraceToDatasetAction projectId={projectId} traceId={session.latestTraceId} />
+          <Tooltip
+            asChild
+            side="bottom"
+            trigger={
+              <Button variant="default-soft" onClick={backToSession} type="button">
+                <Icon icon={ChevronLeftIcon} />
+                View session
+              </Button>
+            }
+          >
+            View session <HotkeyBadge hotkey="Escape" />
+          </Tooltip>
         ) : undefined
       }
       rightActions={

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -11,6 +11,7 @@ import type { SessionDetailRecord } from "../../../../../../domains/sessions/ses
 import { TraceScopeContext } from "../../../../../../domains/traces/trace-scope.tsx"
 import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
+import { AddTraceToDatasetAction } from "../add-trace-to-dataset-action.tsx"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import { SpansTab } from "../trace-detail-drawer/tabs/spans-tab.tsx"
@@ -213,6 +214,9 @@ export function SessionSlot({
 
   const title = session.rootSpanName || session.sessionId.slice(0, 12)
   const status = deriveSessionStatus(session.endTime)
+  // Prefer the latest output trace; fall back to any trace so sessions whose
+  // spans have no output messages (latestTraceId === "") can still be added.
+  const datasetTraceId = latestTraceId || session.traceIds[0]
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -262,6 +266,15 @@ export function SessionSlot({
                   label={`${formatCount(session.errorCount)} ${session.errorCount === 1 ? "error" : "errors"}`}
                 />
               )
+            ) : null}
+            {!isSandbox && datasetTraceId ? (
+              <div className="ml-auto shrink-0">
+                <AddTraceToDatasetAction
+                  projectId={projectId}
+                  traceId={datasetTraceId}
+                  description={`Adding ${latestTraceId ? "the latest" : "a"} trace of this session · ${datasetTraceId.slice(0, 7)}`}
+                />
+              </div>
             ) : null}
           </div>
           <CopyableText

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -407,6 +407,11 @@ export function TraceDetailBody({
                 />
               </button>
             ) : null}
+            {!isSandbox ? (
+              <div className="ml-auto shrink-0">
+                <AddTraceToDatasetAction projectId={projectId} traceId={traceId} />
+              </div>
+            ) : null}
           </div>
           <CopyableText value={traceId} displayValue={traceId.slice(0, 7)} size="sm" tooltip="Copy trace ID" />
         </div>
@@ -515,7 +520,6 @@ function TraceDetailDrawerShell({
     readonly closeLabel?: ReactNode
     readonly drawerStoreKey?: string
   }) {
-  const isSandbox = !!use(TraceScopeContext)
   return (
     <DetailDrawer
       storeKey={drawerStoreKey}
@@ -529,7 +533,6 @@ function TraceDetailDrawerShell({
       }
       actions={
         <>
-          {!isSandbox && <AddTraceToDatasetAction projectId={projectId} traceId={traceId} />}
           <Tooltip
             asChild
             side="bottom"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   InfiniteTable,
   type InfiniteTableColumn,
+  type InfiniteTableSelection,
   Skeleton,
   Slider,
   Tabs,
@@ -22,6 +23,7 @@ import {
   ArrowUpIcon,
   BrainIcon,
   ChevronRightIcon,
+  DatabaseIcon,
   FlameIcon,
   MinusIcon,
   SparklesIcon,
@@ -29,6 +31,11 @@ import {
   XIcon,
 } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react"
+import {
+  addClusterSessionsToDatasetFunction,
+  type ClusterSource,
+  createDatasetFromClusterSessionsFunction,
+} from "../../../../../../domains/datasets/datasets.functions.ts"
 import {
   type BehaviourSegment,
   useBehaviourSessions,
@@ -46,6 +53,12 @@ import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
+import {
+  EMPTY_SELECTION,
+  type SelectionState,
+  useSelectableRows,
+} from "../../../../../../lib/hooks/useSelectableRows.ts"
+import { AddToDatasetModal } from "../../-components/add-to-dataset-modal.tsx"
 import { SessionDetailDrawer } from "../../-components/session-detail-drawer.tsx"
 import { BehavioursTrajectoryChart } from "./behaviours-trajectory-chart.tsx"
 
@@ -263,6 +276,8 @@ export function BehaviourDetailDrawer({
   const [sessionOverlayId, setSessionOverlayId] = useState<string | null>(null)
   const [sessionOverlayMomentId, setSessionOverlayMomentId] = useState<string | null>(null)
   const [sessionPanelEntered, setSessionPanelEntered] = useState(false)
+  const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
+  const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
   const { data: intelligence } = useClusterProfile(projectId, cluster.id, timeRange)
   const {
     data: behaviourSessionsData,
@@ -273,6 +288,35 @@ export function BehaviourDetailDrawer({
   } = useBehaviourSessions(projectId, cluster.id, sessionFilter, timeRange, momentRange)
   const behaviourSessions = behaviourSessionsData?.pages.flatMap((page) => page.sessions) ?? []
   const behaviourSessionHistogram = behaviourSessionsData?.pages[0]?.histogram ?? []
+  // A session row's identity is its (first) trace id — the unit a dataset row is
+  // built from. Selecting rows therefore selects trace ids directly.
+  const sessionRowKey = useCallback((session: BehaviourSessionRecord) => session.traceId || session.sessionId, [])
+  const sessionRowKeys = useMemo(() => behaviourSessions.map(sessionRowKey), [behaviourSessions, sessionRowKey])
+  // The histogram is computed over the full filtered set (no pagination), so its
+  // total is the count "Select all" stands for, not just the loaded page.
+  const totalSessionCount = useMemo(
+    () => behaviourSessionHistogram.reduce((sum, bucket) => sum + bucket.count, 0),
+    [behaviourSessionHistogram],
+  )
+  const sessionSelection = useSelectableRows<string>({
+    rowIds: sessionRowKeys,
+    totalRowCount: totalSessionCount,
+    controlledState: selectionState,
+    onStateChange: setSelectionState,
+  })
+  const clusterSource = useMemo<ClusterSource>(
+    () => ({
+      clusterId: cluster.id,
+      ...(sessionFilter !== "all" ? { filter: sessionFilter } : {}),
+      ...(momentRange
+        ? { momentRange: { metric: momentRange.metric, fromTurn: momentRange.fromTurn, toTurn: momentRange.toTurn } }
+        : {}),
+      ...(timeRange?.fromIso ? { timeFromIso: timeRange.fromIso } : {}),
+      ...(timeRange?.toIso ? { timeToIso: timeRange.toIso } : {}),
+    }),
+    [cluster.id, sessionFilter, momentRange, timeRange],
+  )
+  const datasetSelection = sessionSelection.bulkSelection
   const detectedSignals = intelligence?.topMoments ?? []
   const activeMomentKinds = momentRange
     ? momentKindsForTrajectoryMetric(momentRange.metric)
@@ -306,6 +350,12 @@ export function BehaviourDetailDrawer({
     setSessionOverlayId(null)
     setSessionPanelEntered(false)
   }, [momentRange])
+
+  // The selection stands for a specific filtered set; drop it whenever that set
+  // changes so a stale "select all" can't carry into a different filter.
+  useEffect(() => {
+    setSelectionState(EMPTY_SELECTION)
+  }, [cluster.id, sessionFilter, momentRange, timeRange])
 
   const openSessionOverlay = (session: BehaviourSessionRecord) => {
     setSessionOverlayId(session.sessionId)
@@ -361,8 +411,8 @@ export function BehaviourDetailDrawer({
                     />
                     {showDetectedSignalsChart ? <DetectedSignalsChart signals={detectedSignals} /> : null}
                   </div>
-                  {sessionFilterOptions.length > 0 ? (
-                    <div className="flex flex-wrap gap-2">
+                  {sessionFilterOptions.length > 0 || hasSessionFilters ? (
+                    <div className="flex flex-wrap items-center gap-2">
                       {sessionFilterOptions.map((option) => (
                         <MetricButton
                           key={option.id}
@@ -376,11 +426,6 @@ export function BehaviourDetailDrawer({
                           }}
                         />
                       ))}
-                    </div>
-                  ) : null}
-                  <div className="flex flex-col gap-2 pt-4">
-                    <div className="flex items-center justify-between gap-2">
-                      <Text.H5>Associated sessions</Text.H5>
                       {hasSessionFilters ? (
                         <Button
                           variant="ghost"
@@ -395,6 +440,9 @@ export function BehaviourDetailDrawer({
                         </Button>
                       ) : null}
                     </div>
+                  ) : null}
+                  <div className="flex flex-col gap-2 pt-4">
+                    <Text.H5>Associated sessions</Text.H5>
                     {momentRange ? (
                       <TurnRangeSlider
                         range={momentRange}
@@ -409,12 +457,25 @@ export function BehaviourDetailDrawer({
                           ? "All sessions for this behavior"
                           : `Sessions matching ${sessionFilter.replaceAll("_", " ")}`}
                     </Text.H6>
+                    {sessionSelection.selectedCount > 0 ? (
+                      <div className="flex items-center gap-2">
+                        <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                          <Icon icon={DatabaseIcon} size="xs" />
+                          Add to dataset ({sessionSelection.selectedCount.toLocaleString()})
+                        </Button>
+                      </div>
+                    ) : null}
                     {behaviourSessionsLoading ? (
                       <Skeleton className="h-16 rounded-xl" />
                     ) : behaviourSessions.length ? (
                       <BehaviourSessionsTable
                         sessions={behaviourSessions}
-                        activeSessionId={sessionOverlayId ?? undefined}
+                        activeRowKey={
+                          behaviourSessions.find((session) => session.sessionId === sessionOverlayId)?.traceId ||
+                          (sessionOverlayId ?? undefined)
+                        }
+                        getRowKey={sessionRowKey}
+                        selection={sessionSelection}
                         onSessionClick={openSessionOverlay}
                         hasMore={hasNextBehaviourSessionsPage === true}
                         isLoadingMore={isFetchingNextBehaviourSessionsPage}
@@ -432,6 +493,26 @@ export function BehaviourDetailDrawer({
           </div>
         </div>
       </DetailDrawer>
+      {datasetSelection ? (
+        <AddToDatasetModal
+          open={addToDatasetOpen}
+          onOpenChange={setAddToDatasetOpen}
+          projectId={projectId}
+          itemLabel="session"
+          selectedCount={sessionSelection.selectedCount}
+          onAddToExisting={(datasetId) =>
+            addClusterSessionsToDatasetFunction({
+              data: { projectId, datasetId, cluster: clusterSource, selection: datasetSelection },
+            })
+          }
+          onCreateNew={(name) =>
+            createDatasetFromClusterSessionsFunction({
+              data: { projectId, name, cluster: clusterSource, selection: datasetSelection },
+            })
+          }
+          onSuccess={sessionSelection.clearSelections}
+        />
+      ) : null}
       {sessionOverlayId !== null ? (
         <>
           <button
@@ -524,14 +605,18 @@ function TurnRangeSlider({
 
 function BehaviourSessionsTable({
   sessions,
-  activeSessionId,
+  activeRowKey,
+  getRowKey,
+  selection,
   onSessionClick,
   hasMore,
   isLoadingMore,
   onLoadMore,
 }: {
   readonly sessions: readonly BehaviourSessionRecord[]
-  readonly activeSessionId: string | undefined
+  readonly activeRowKey: string | undefined
+  readonly getRowKey: (session: BehaviourSessionRecord) => string
+  readonly selection: InfiniteTableSelection
   readonly onSessionClick: (session: BehaviourSessionRecord) => void
   readonly hasMore: boolean
   readonly isLoadingMore: boolean
@@ -577,11 +662,12 @@ function BehaviourSessionsTable({
       <InfiniteTable
         data={sessions}
         columns={columns}
-        getRowKey={(session) => session.sessionId}
+        getRowKey={getRowKey}
+        selection={selection}
         onRowClick={onSessionClick}
         getRowAriaLabel={(session) => `Open session ${session.sessionId} in the session panel`}
         rowInteractionRole="button"
-        {...(activeSessionId ? { activeRowKey: activeSessionId } : {})}
+        {...(activeRowKey ? { activeRowKey } : {})}
         scrollAreaLayout="intrinsic"
         className="max-h-[min(28rem,50vh)]"
         infiniteScroll={{ hasMore, isLoadingMore, onLoadMore }}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-detail-drawer.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   CopyableText,
   DetailSection,
   Icon,
@@ -12,15 +13,27 @@ import {
   Tooltip,
 } from "@repo/ui"
 import { formatCount, formatDuration, relativeTime } from "@repo/utils"
-import { ArrowDownRightIcon, CheckIcon, TextAlignStartIcon } from "lucide-react"
-import { type ReactNode, useMemo, useState } from "react"
+import { ArrowDownRightIcon, CheckIcon, DatabaseIcon, TextAlignStartIcon } from "lucide-react"
+import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
+import {
+  addTracesToDatasetFunction,
+  createDatasetFromTracesFunction,
+} from "../../../../../../domains/datasets/datasets.functions.ts"
 import type { SessionRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import {
   useSignalDetail,
+  useSignalSessionsCount,
   useSignalSessionsInfiniteScroll,
 } from "../../../../../../domains/signals/signals.collection.ts"
+import {
+  type BulkSelection,
+  EMPTY_SELECTION,
+  type SelectionState,
+  useSelectableRows,
+} from "../../../../../../lib/hooks/useSelectableRows.ts"
+import { AddToDatasetModal } from "../../-components/add-to-dataset-modal.tsx"
 import { SessionDetailDrawer } from "../../-components/session-detail-drawer.tsx"
 import { SignalDrawerEvaluations } from "./signal-drawer-evaluations.tsx"
 import { formatSeenAgeParts, formatSignalAgeAgoLabel } from "./signal-formatters.ts"
@@ -148,8 +161,36 @@ export function SignalDetailBody({
     signalId,
     enabled: issue !== null,
   })
+  const totalSessionCount = useSignalSessionsCount({ projectId, signalId, enabled: issue !== null })
   const [sessionSheetSessionId, setSessionSheetSessionId] = useState<string | null>(null)
   const [sessionSheetOpen, setSessionSheetOpen] = useState(false)
+  const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
+  const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
+
+  useEffect(() => {
+    setSelectionState(EMPTY_SELECTION)
+  }, [signalId])
+
+  const sessionIds = useMemo(() => sessions.map((session) => session.sessionId), [sessions])
+  const sessionSelection = useSelectableRows<string>({
+    rowIds: sessionIds,
+    totalRowCount: totalSessionCount,
+    controlledState: selectionState,
+    onStateChange: setSelectionState,
+  })
+  // A signal session selection becomes the trace ids of its sessions: "selected"
+  // / "allExcept" expand each loaded session to all its trace ids; "all" defers
+  // to the signal scope so the server resolves every trace linked to the signal.
+  const datasetSelection = useMemo<BulkSelection<string> | null>(() => {
+    const selection = sessionSelection.bulkSelection
+    if (!selection) return null
+    if (selection.mode === "all") return selection
+    const tracesBySession = new Map<string, readonly string[]>(
+      sessions.map((session) => [session.sessionId, session.traceIds]),
+    )
+    const traceIds = selection.rowIds.flatMap((id) => [...(tracesBySession.get(id) ?? [])])
+    return { mode: selection.mode, rowIds: traceIds }
+  }, [sessionSelection.bulkSelection, sessions])
 
   // Window the incident query to the same range that the trend chart paints. Bucket keys are
   // ISO timestamps now (12h-aligned), and `trendBucketSeconds` tells us the cell width so we can
@@ -410,11 +451,20 @@ export function SignalDetailBody({
             className="gap-1"
             contentClassName="pl-0 pt-0 max-h-none overflow-hidden flex flex-col"
           >
+            {sessionSelection.selectedCount > 0 ? (
+              <div className="flex items-center gap-2 pb-2">
+                <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                  <Icon icon={DatabaseIcon} size="xs" />
+                  Add to dataset ({sessionSelection.selectedCount.toLocaleString()})
+                </Button>
+              </div>
+            ) : null}
             <InfiniteTable
               data={sessions}
               isLoading={sessionsLoading}
               columns={sessionColumns}
               getRowKey={(session) => session.sessionId}
+              selection={sessionSelection}
               onRowClick={(session) => openSessionSheet(session.sessionId)}
               getRowAriaLabel={(session) => `Open session ${session.sessionId}`}
               infiniteScroll={infiniteScroll}
@@ -444,6 +494,23 @@ export function SignalDetailBody({
           />
         ) : null}
       </Sheet>
+
+      {datasetSelection ? (
+        <AddToDatasetModal
+          open={addToDatasetOpen}
+          onOpenChange={setAddToDatasetOpen}
+          projectId={projectId}
+          itemLabel="session"
+          selectedCount={sessionSelection.selectedCount}
+          onAddToExisting={(datasetId) =>
+            addTracesToDatasetFunction({ data: { projectId, datasetId, signalId, selection: datasetSelection } })
+          }
+          onCreateNew={(name) =>
+            createDatasetFromTracesFunction({ data: { projectId, name, signalId, selection: datasetSelection } })
+          }
+          onSuccess={sessionSelection.clearSelections}
+        />
+      ) : null}
     </>
   )
 }

--- a/apps/workers/src/workers/taxonomy.ts
+++ b/apps/workers/src/workers/taxonomy.ts
@@ -12,7 +12,7 @@ import {
 import type { RedisClient } from "@platform/cache-redis"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { TaxonomyObservationRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
-import type { PostgresClient } from "@platform/db-postgres"
+import { listGardenableProjectRefs, type PostgresClient } from "@platform/db-postgres"
 import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 
@@ -81,12 +81,7 @@ const deterministicProjectDelayMs = (input: {
 
 const listActiveProjects = (adminPostgresClient: PostgresClient) =>
   Effect.tryPromise({
-    try: async () => {
-      const result = await adminPostgresClient.pool.query<ActiveProjectRow>(
-        `SELECT organization_id, id AS project_id FROM latitude.projects WHERE deleted_at IS NULL`,
-      )
-      return result.rows
-    },
+    try: () => listGardenableProjectRefs(adminPostgresClient),
     catch: (cause) => cause,
   })
 

--- a/apps/workflows/src/activities/demo-project-snapshot.test.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.test.ts
@@ -1,7 +1,8 @@
-import { seedTraceHex } from "@domain/shared/seeding"
+import { cuidSchema } from "@domain/shared"
+import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID, seedTraceHex } from "@domain/shared/seeding"
 import { demoSeedTraceSlots } from "@platform/db-clickhouse/seeding"
 import { describe, expect, it } from "vitest"
-import { buildTraceIdRemap } from "./demo-project-snapshot.ts"
+import { buildTraceIdRemap, mapClickHouseRow, mapObservationId } from "./demo-project-snapshot.ts"
 
 const SOURCE_PROJECT_ID = "yvl1e78evmwfs2mosyjb08rc"
 const TARGET_PROJECT_ID = "an3s1qhl5twcq2nbkajayw1u"
@@ -26,5 +27,116 @@ describe("buildTraceIdRemap", () => {
 
   it("is empty when source and target projects are the same", () => {
     expect(buildTraceIdRemap(SOURCE_PROJECT_ID, SOURCE_PROJECT_ID).size).toEqual(0)
+  })
+})
+
+describe("mapObservationId", () => {
+  const scope = createSeedScope({
+    organizationId: SEED_ORG_ID,
+    projectId: SEED_PROJECT_ID,
+    timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
+    queueAssigneeUserIds: [],
+    apiKeyId: SEED_API_KEY_ID,
+  })
+
+  // Regression: a 32-char id fails `taxonomyMomentObservationSchema.observationId`
+  // (an exact-24 cuid), so every gardening read of an imported demo observation threw.
+  it("produces a cuid-width (24-char) id the observation schema accepts", () => {
+    const mapped = mapObservationId("a".repeat(64), scope)
+    expect(typeof mapped).toBe("string")
+    expect((mapped as string).length).toBe(24)
+    expect(() => cuidSchema.parse(mapped)).not.toThrow()
+  })
+
+  it("is deterministic and distinct per source id", () => {
+    expect(mapObservationId("obs-1", scope)).toEqual(mapObservationId("obs-1", scope))
+    expect(mapObservationId("obs-1", scope)).not.toEqual(mapObservationId("obs-2", scope))
+  })
+
+  it("passes non-string values through untouched", () => {
+    expect(mapObservationId(undefined, scope)).toBeUndefined()
+    expect(mapObservationId(42, scope)).toBe(42)
+  })
+})
+
+describe("mapClickHouseRow observation timestamps", () => {
+  const baseInput = {
+    scope: createSeedScope({
+      organizationId: SEED_ORG_ID,
+      projectId: SEED_PROJECT_ID,
+      timelineAnchor: new Date("2026-06-26T12:00:00.000Z"),
+      queueAssigneeUserIds: [],
+      apiKeyId: SEED_API_KEY_ID,
+    }),
+    deltaMs: 0,
+    mapClusterId: (id: string) => id,
+    mapRunId: (id: string) => id,
+    traceIdRemap: new Map<string, string>(),
+  }
+
+  // Snapshot observations carry a bunched, source-build timestamp; the session's
+  // analysis row carries the real (spread) session time.
+  const OBS_TIME = "2026-06-26 09:30:00.000000000"
+  const SESSION_START = "2026-06-13 04:15:00.000000000"
+  const SESSION_END = "2026-06-13 04:20:00.000000000"
+  const obsRow = () => ({
+    session_id: "s1",
+    analysis_hash: "h1",
+    observation_id: "obs-1",
+    assigned_cluster_id: "c1",
+    reassignment_run_id: "",
+    start_time: OBS_TIME,
+    end_time: OBS_TIME,
+    indexed_at: OBS_TIME,
+  })
+
+  it("re-stamps observation start/end from the matching session's analysis time", () => {
+    const withOverride = mapClickHouseRow("taxonomy_observations", obsRow(), {
+      ...baseInput,
+      sessionTimes: new Map([["s1\0h1", { start_time: SESSION_START, end_time: SESSION_END }]]),
+    })
+    const asSession = mapClickHouseRow(
+      "taxonomy_observations",
+      { ...obsRow(), start_time: SESSION_START, end_time: SESSION_END },
+      baseInput,
+    )
+    const noOverride = mapClickHouseRow("taxonomy_observations", obsRow(), baseInput)
+
+    // The override yields exactly the session's (spread, past) times…
+    expect(withOverride.start_time).toBe(asSession.start_time)
+    expect(withOverride.end_time).toBe(asSession.end_time)
+    // …not the observation's own bunched value.
+    expect(withOverride.start_time).not.toBe(noOverride.start_time)
+    // Pinned dates (deltaMs=0 preserves the date) — fully wall-clock independent:
+    // the override carries the session day, the fallback the observation day.
+    expect(String(withOverride.start_time)).toMatch(/^2026-06-13/)
+    expect(String(noOverride.start_time)).toMatch(/^2026-06-26/)
+  })
+
+  it("falls back to the observation's own time when no session matches", () => {
+    const noMatch = mapClickHouseRow("taxonomy_observations", obsRow(), {
+      ...baseInput,
+      sessionTimes: new Map([["other\0h", { start_time: SESSION_START, end_time: SESSION_END }]]),
+    })
+    const noOverride = mapClickHouseRow("taxonomy_observations", obsRow(), baseInput)
+    expect(noMatch.start_time).toBe(noOverride.start_time)
+  })
+
+  it("never re-stamps non-observation tables (analyses keep their own times)", () => {
+    const analysisRow = {
+      session_id: "s1",
+      analysis_hash: "h1",
+      trace_ids: ["t1"],
+      analysis_status: "analyzed",
+      start_time: SESSION_START,
+      end_time: SESSION_END,
+      indexed_at: SESSION_START,
+    }
+    const mapped = mapClickHouseRow("session_analyses", analysisRow, {
+      ...baseInput,
+      sessionTimes: new Map([["s1\0h1", { start_time: OBS_TIME, end_time: OBS_TIME }]]),
+    })
+    const baseline = mapClickHouseRow("session_analyses", analysisRow, baseInput)
+    expect(mapped.start_time).toBe(baseline.start_time)
   })
 })

--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -126,9 +126,12 @@ const stableId = (prefix: string, sourceId: string, scope: SeedScope): string =>
 
 const sha256 = (parts: readonly string[]): string => createHash("sha256").update(parts.join("\0")).digest("hex")
 
-const mapObservationId = (sourceId: unknown, scope: SeedScope): unknown =>
+// Observation ids are cuid-width (exactly 24 chars per `taxonomyMomentObservationSchema`);
+// the live analysis pipeline truncates its hash to 24, so the snapshot remap must too —
+// a 32-char id fails validation on every gardening read (`listAllByCluster`).
+export const mapObservationId = (sourceId: unknown, scope: SeedScope): unknown =>
   typeof sourceId === "string"
-    ? sha256(["snapshot:taxonomy-observation", scope.projectId, sourceId]).slice(0, 32)
+    ? sha256(["snapshot:taxonomy-observation", scope.projectId, sourceId]).slice(0, 24)
     : sourceId
 
 /**
@@ -149,7 +152,7 @@ export const buildTraceIdRemap = (sourceProjectId: string, targetProjectId: stri
   return remap
 }
 
-const mapClickHouseRow = (
+export const mapClickHouseRow = (
   table: ClickHouseTable,
   row: SnapshotRow,
   input: {
@@ -158,9 +161,17 @@ const mapClickHouseRow = (
     readonly mapClusterId: (id: string) => string
     readonly mapRunId: (id: string) => string
     readonly traceIdRemap: ReadonlyMap<string, string>
+    readonly sessionTimes?: ReadonlyMap<string, { readonly start_time: unknown; readonly end_time: unknown }>
   },
 ): SnapshotRow => {
   const mapped: SnapshotRow = { ...row, organization_id: input.scope.organizationId, project_id: input.scope.projectId }
+  if (table === "taxonomy_observations" && input.sessionTimes) {
+    const sessionTime = input.sessionTimes.get(`${String(row.session_id)}\0${String(row.analysis_hash)}`)
+    if (sessionTime) {
+      mapped.start_time = sessionTime.start_time
+      mapped.end_time = sessionTime.end_time
+    }
+  }
   for (const column of timestampColumnsByTable[table])
     mapped[column] = formatClickHouseTimestamp(mapped[column], input.deltaMs)
 
@@ -228,6 +239,7 @@ const importClickHouseTable = async (
     readonly mapClusterId: (id: string) => string
     readonly mapRunId: (id: string) => string
     readonly traceIdRemap: ReadonlyMap<string, string>
+    readonly sessionTimes?: ReadonlyMap<string, { readonly start_time: unknown; readonly end_time: unknown }>
     readonly keep?: (row: SnapshotRow) => boolean
     readonly afterKeep?: (row: SnapshotRow) => void
   },
@@ -514,6 +526,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
   const analysisKey = (row: SnapshotRow) => `${String(row.session_id)}\0${String(row.analysis_hash)}`
   const momentKey = (row: SnapshotRow) =>
     `${String(row.session_id)}\0${String(row.analysis_hash)}\0${String(row.moment_id)}`
+  const sessionTimes = new Map<string, { readonly start_time: unknown; readonly end_time: unknown }>()
 
   await importClickHouseTable(input.clickhouseClient, "trace_search_documents", {
     scope: input.scope,
@@ -546,7 +559,10 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     mapRunId,
     traceIdRemap,
     keep: (row) => Array.isArray(row.trace_ids) && row.trace_ids.some((traceId) => traceIds.has(String(traceId))),
-    afterKeep: (row) => analysisKeys.add(analysisKey(row)),
+    afterKeep: (row) => {
+      analysisKeys.add(analysisKey(row))
+      sessionTimes.set(analysisKey(row), { start_time: row.start_time, end_time: row.end_time })
+    },
   })
   await importClickHouseTable(input.clickhouseClient, "session_semantic_moments", {
     scope: input.scope,
@@ -571,6 +587,7 @@ export const importDemoProjectDerivedSnapshot = async (input: {
     mapClusterId,
     mapRunId,
     traceIdRemap,
+    sessionTimes,
     // Behaviours read sessions from here; keep only observations whose session
     // is a seeded single-trace session (`session_id` is the trace id), so every
     // behaviour's "associated session" resolves to a real seeded trace.

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -109,6 +109,8 @@ export { taxonomyClusterLockKey, withTaxonomyClusterLock } from "./locks.ts"
 export {
   type ClusterAnalysisAggregate,
   type ClusterRepresentativeExample,
+  type ClusterSessionMomentRange,
+  type ClusterSessionTraceIdsInput,
   TaxonomyClusterIntelligenceRepository,
   type TaxonomyClusterIntelligenceRepositoryShape,
 } from "./ports/taxonomy-cluster-intelligence-repository.ts"
@@ -195,6 +197,10 @@ export {
   type GetClusterDetailsResult,
   getClusterDetailsUseCase,
 } from "./use-cases/get-details.ts"
+export {
+  type ListClusterSessionTraceIdsInput,
+  listClusterSessionTraceIdsUseCase,
+} from "./use-cases/list-cluster-session-trace-ids.ts"
 export {
   type ListTaxonomyClustersInput,
   listClustersUseCase,

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-intelligence-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-intelligence-repository.ts
@@ -1,5 +1,36 @@
-import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError, TaxonomyClusterId } from "@domain/shared"
+import type {
+  ChSqlClient,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+  TaxonomyClusterId,
+  TraceId,
+} from "@domain/shared"
 import { Context, type Effect } from "effect"
+
+/**
+ * Moment-turn range filter for the cluster session list. `metric` selects which
+ * moment kinds count (frequency = any, escalation, resolution, churnRisk,
+ * wins); `fromTurn`/`toTurn` bound the conversation turn at which the moment
+ * appears. Mirrors the Behaviours drawer's turn-range slider.
+ */
+export interface ClusterSessionMomentRange {
+  readonly metric: string
+  readonly fromTurn: number
+  readonly toTurn: number
+}
+
+export interface ClusterSessionTraceIdsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly clusterIds: readonly TaxonomyClusterId[]
+  /** "all" or a single moment kind the session must contain. */
+  readonly filter: string
+  readonly momentRange?: ClusterSessionMomentRange
+  readonly startTimeFrom?: Date
+  readonly startTimeTo?: Date
+  readonly limit: number
+}
 
 export interface ClusterAnalysisAggregate {
   readonly sourceObservationCount: number
@@ -33,6 +64,15 @@ export interface TaxonomyClusterIntelligenceRepositoryShape {
     readonly sourceWindowEnd: Date
     readonly limit: number
   }): Effect.Effect<readonly ClusterRepresentativeExample[], RepositoryError, ChSqlClient>
+  /**
+   * One trace id per session assigned to the cluster subtree, scoped by the
+   * same moment-kind / turn-range / time filters the Behaviours drawer exposes.
+   * Picks each session's first trace (the trace the Behaviours table links to).
+   * Used to feed cluster sessions into a dataset.
+   */
+  listSessionTraceIds(
+    input: ClusterSessionTraceIdsInput,
+  ): Effect.Effect<readonly TraceId[], RepositoryError, ChSqlClient>
 }
 
 export class TaxonomyClusterIntelligenceRepository extends Context.Service<

--- a/packages/domain/taxonomy/src/use-cases/list-cluster-session-trace-ids.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-cluster-session-trace-ids.ts
@@ -1,0 +1,42 @@
+import type { OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { Effect } from "effect"
+import type { ClusterSessionMomentRange } from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import { TaxonomyClusterIntelligenceRepository } from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
+
+export interface ListClusterSessionTraceIdsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly clusterId: TaxonomyClusterId
+  /** "all" or a single moment kind the session must contain. */
+  readonly filter?: string
+  readonly momentRange?: ClusterSessionMomentRange
+  readonly startTimeFrom?: Date
+  readonly startTimeTo?: Date
+  readonly limit: number
+}
+
+/**
+ * Resolves a cluster (its whole subtree) to one trace id per assigned session,
+ * honouring the Behaviours drawer's moment-kind / turn-range / time filters.
+ * Shared by the manual "Add to dataset" export and the auto-feed pipeline.
+ */
+export const listClusterSessionTraceIdsUseCase = (input: ListClusterSessionTraceIdsInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("taxonomy.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("taxonomy.clusterId", input.clusterId)
+    const clusters = yield* TaxonomyClusterRepository
+    const intelligence = yield* TaxonomyClusterIntelligenceRepository
+    // A tree node represents its whole subtree: sessions are assigned to leaves.
+    const clusterIds = yield* clusters.listSubtreeIds({ projectId: input.projectId, clusterId: input.clusterId })
+    return yield* intelligence.listSessionTraceIds({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      clusterIds,
+      filter: input.filter ?? "all",
+      ...(input.momentRange ? { momentRange: input.momentRange } : {}),
+      ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
+      ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
+      limit: input.limit,
+    })
+  }).pipe(Effect.withSpan("taxonomy.listClusterSessionTraceIds"))

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.test.ts
@@ -1,0 +1,181 @@
+import { type ChSqlClient, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { TaxonomyClusterIntelligenceRepository } from "@domain/taxonomy"
+import { setupTestClickHouse } from "@platform/testkit"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { withClickHouse } from "../with-clickhouse.ts"
+import { TaxonomyClusterIntelligenceRepositoryLive } from "./taxonomy-cluster-intelligence-repository.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const clusterId = TaxonomyClusterId("c".repeat(24))
+const analysisHash = "a".repeat(64)
+const ts = "2026-05-24 12:00:00.000000000"
+
+const traceIdFor = (n: number) => `${n}`.padStart(32, "t")
+
+const insertObservation = (sessionId: string, times: { startTime?: string; endTime?: string } = {}) =>
+  ch.client.insert({
+    table: "taxonomy_observations",
+    values: [
+      {
+        organization_id: organizationId as string,
+        project_id: projectId as string,
+        observation_id: `obs-${sessionId}`,
+        session_id: sessionId,
+        analysis_hash: analysisHash,
+        moment_id: `moment-${sessionId}`,
+        projection_method: "session_user_intent_embedding",
+        projection_hash: "d".repeat(64),
+        projection_metadata: JSON.stringify({ summary: `summary ${sessionId}` }),
+        embedding: [1, 0, 0],
+        assigned_cluster_id: clusterId as string,
+        assignment_confidence: 1,
+        assignment_method: "gardening_reassign",
+        start_time: times.startTime ?? ts,
+        end_time: times.endTime ?? ts,
+      },
+    ],
+    format: "JSONEachRow",
+  })
+
+const insertAnalysis = (sessionId: string, traceIds: string[]) =>
+  ch.client.insert({
+    table: "session_analyses",
+    values: [
+      {
+        organization_id: organizationId as string,
+        project_id: projectId as string,
+        session_id: sessionId,
+        start_time: ts,
+        end_time: ts,
+        trace_ids: traceIds,
+        analysis_hash: analysisHash,
+        analysis_status: "analyzed",
+      },
+    ],
+    format: "JSONEachRow",
+  })
+
+const insertMomentLabel = (sessionId: string, kind: string, firstMessageIndex: number) =>
+  ch.client.insert({
+    table: "session_moment_labels",
+    values: [
+      {
+        organization_id: organizationId as string,
+        project_id: projectId as string,
+        session_id: sessionId,
+        analysis_hash: analysisHash,
+        label_id: `label-${sessionId}-${kind}`,
+        moment_id: `moment-${sessionId}`,
+        kind,
+        actor: "assistant",
+        first_message_index: firstMessageIndex,
+        last_message_index: firstMessageIndex,
+        evidence: "",
+      },
+    ],
+    format: "JSONEachRow",
+  })
+
+const ch = setupTestClickHouse()
+
+const run = <A, E>(effect: Effect.Effect<A, E, TaxonomyClusterIntelligenceRepository | ChSqlClient>) =>
+  Effect.runPromise(effect.pipe(withClickHouse(TaxonomyClusterIntelligenceRepositoryLive, ch.client, organizationId)))
+
+const listTraceIds = (input: { filter: string; momentRange?: { metric: string; fromTurn: number; toTurn: number } }) =>
+  run(
+    Effect.gen(function* () {
+      const repo = yield* TaxonomyClusterIntelligenceRepository
+      return yield* repo.listSessionTraceIds({
+        organizationId,
+        projectId,
+        clusterIds: [clusterId],
+        filter: input.filter,
+        ...(input.momentRange ? { momentRange: input.momentRange } : {}),
+        limit: 100,
+      })
+    }),
+  )
+
+const runList = (overrides: {
+  clusterIds?: readonly TaxonomyClusterId[]
+  filter?: string
+  startTimeFrom?: Date
+  startTimeTo?: Date
+  limit?: number
+}) =>
+  run(
+    Effect.gen(function* () {
+      const repo = yield* TaxonomyClusterIntelligenceRepository
+      return yield* repo.listSessionTraceIds({
+        organizationId,
+        projectId,
+        clusterIds: overrides.clusterIds ?? [clusterId],
+        filter: overrides.filter ?? "all",
+        ...(overrides.startTimeFrom ? { startTimeFrom: overrides.startTimeFrom } : {}),
+        ...(overrides.startTimeTo ? { startTimeTo: overrides.startTimeTo } : {}),
+        limit: overrides.limit ?? 100,
+      })
+    }),
+  )
+
+describe("TaxonomyClusterIntelligenceRepository.listSessionTraceIds", () => {
+  it("returns one trace id per session and filters by moment kind / turn range", async () => {
+    await insertObservation("escalated")
+    await insertAnalysis("escalated", [traceIdFor(1)])
+    await insertMomentLabel("escalated", "escalation", 3)
+
+    await insertObservation("resolved")
+    await insertAnalysis("resolved", [traceIdFor(2)])
+    await insertMomentLabel("resolved", "resolution", 1)
+
+    expect([...(await listTraceIds({ filter: "all" }))].sort()).toEqual([traceIdFor(1), traceIdFor(2)].sort())
+    expect(await listTraceIds({ filter: "escalation" })).toEqual([traceIdFor(1)])
+    expect(await listTraceIds({ filter: "resolution" })).toEqual([traceIdFor(2)])
+
+    // Turn range narrows to escalation moments within the window only.
+    expect(
+      await listTraceIds({ filter: "all", momentRange: { metric: "escalation", fromTurn: 0, toTurn: 5 } }),
+    ).toEqual([traceIdFor(1)])
+    expect(
+      await listTraceIds({ filter: "all", momentRange: { metric: "escalation", fromTurn: 10, toTurn: 20 } }),
+    ).toEqual([])
+  })
+
+  it("skips sessions whose analysis carries no trace id", async () => {
+    await insertObservation("no-trace")
+    await insertAnalysis("no-trace", [])
+    await insertMomentLabel("no-trace", "escalation", 1)
+
+    expect(await listTraceIds({ filter: "all" })).toEqual([])
+  })
+
+  it("caps results at the limit, newest-first by end time", async () => {
+    await insertObservation("older", { endTime: "2026-05-24 10:00:00.000000000" })
+    await insertAnalysis("older", [traceIdFor(1)])
+    await insertObservation("newer", { endTime: "2026-05-24 14:00:00.000000000" })
+    await insertAnalysis("newer", [traceIdFor(2)])
+
+    // limit caps the set; the web layer passes MAX+1 to detect overflow.
+    expect(await runList({ limit: 1 })).toEqual([traceIdFor(2)])
+    expect(await runList({ limit: 100 })).toEqual([traceIdFor(2), traceIdFor(1)])
+  })
+
+  it("filters by the start-time window", async () => {
+    await insertObservation("early", { startTime: "2026-05-10 12:00:00.000000000" })
+    await insertAnalysis("early", [traceIdFor(1)])
+    await insertObservation("late", { startTime: "2026-05-24 12:00:00.000000000" })
+    await insertAnalysis("late", [traceIdFor(2)])
+
+    expect(await runList({ startTimeFrom: new Date("2026-05-20T00:00:00.000Z") })).toEqual([traceIdFor(2)])
+    expect(await runList({ startTimeTo: new Date("2026-05-20T00:00:00.000Z") })).toEqual([traceIdFor(1)])
+  })
+
+  it("returns [] for an empty cluster id list without querying", async () => {
+    await insertObservation("any")
+    await insertAnalysis("any", [traceIdFor(1)])
+
+    expect(await runList({ clusterIds: [] })).toEqual([])
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.ts
@@ -1,5 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client"
-import { ChSqlClient, type ChSqlClientShape, toRepositoryError } from "@domain/shared"
+import { ChSqlClient, type ChSqlClientShape, TraceId, toRepositoryError } from "@domain/shared"
 import {
   type ClusterAnalysisAggregate,
   type ClusterRepresentativeExample,
@@ -8,6 +8,77 @@ import {
 import { Effect, Layer } from "effect"
 
 const toClickhouseDateTime = (date: Date): string => date.toISOString().replace("Z", "")
+
+const behaviourSessionFilterSql = `
+  ({filter:String} = 'all'
+    OR ({filter:String} = 'resolution' AND has(momentKinds, 'resolution'))
+    OR ({filter:String} = 'abandonment' AND has(momentKinds, 'abandonment'))
+    OR ({filter:String} NOT IN ('all', 'resolution', 'abandonment') AND has(momentKinds, {filter:String})))
+`
+
+const behaviourMetricMomentSql = `
+  (({momentMetric:String} = 'frequency' AND m.kind != '')
+    OR ({momentMetric:String} = 'escalation' AND m.kind = 'escalation')
+    OR ({momentMetric:String} = 'resolution' AND m.kind = 'resolution')
+    OR ({momentMetric:String} = 'churnRisk' AND m.kind IN ('abandonment', 'user_frustration'))
+    OR ({momentMetric:String} = 'wins' AND m.kind IN ('resolution', 'user_satisfaction')))
+`
+
+const behaviourMomentRangeSql = `
+  ${behaviourMetricMomentSql}
+  AND m.first_message_index >= {turnFrom:UInt16}
+  AND m.first_message_index <= {turnTo:UInt16}
+`
+
+// Observations are pinned to each session's CURRENT analysis: superseded
+// analysis generations are never deleted, so an unscoped read unions every
+// re-analysis and `any(analysis_hash)` could pick a stale hash, breaking the
+// trace link and silently dropping every moment label.
+const behaviourClusterSessionsCte = (timeFromClause: string, timeToClause: string, hasMomentRange: boolean) => `
+  WITH latest_analyses AS (
+    SELECT organization_id, project_id, session_id, analysis_hash, trace_ids
+    FROM session_analyses FINAL
+    WHERE organization_id = {organizationId:String}
+      AND project_id = {projectId:String}
+  ),
+  cluster_sessions AS (
+    SELECT
+      o.organization_id AS organization_id,
+      o.project_id AS project_id,
+      o.session_id AS session_id,
+      any(a.analysis_hash) AS analysisHash,
+      arrayElement(any(a.trace_ids), 1) AS traceId,
+      min(o.start_time) AS startTime,
+      max(o.end_time) AS endTime
+    FROM taxonomy_observations AS o FINAL
+    INNER JOIN latest_analyses AS a
+      ON o.organization_id = a.organization_id
+     AND o.project_id = a.project_id
+     AND o.session_id = a.session_id
+     AND o.analysis_hash = a.analysis_hash
+    WHERE o.organization_id = {organizationId:String}
+      AND o.project_id = {projectId:String}
+      AND o.assigned_cluster_id IN {clusterIds:Array(String)}
+      ${timeFromClause}
+      ${timeToClause}
+    GROUP BY o.organization_id, o.project_id, o.session_id
+  ),
+  enriched_sessions AS (
+    SELECT
+      cs.session_id AS sessionId,
+      any(cs.traceId) AS traceId,
+      any(cs.endTime) AS endTime,
+      ${hasMomentRange ? `countIf(${behaviourMomentRangeSql})` : "toUInt64(0)"} AS selectedMomentCount,
+      groupUniqArrayIf(m.kind, m.kind != '') AS momentKinds
+    FROM cluster_sessions AS cs
+    LEFT JOIN session_moment_labels AS m FINAL
+      ON cs.organization_id = m.organization_id
+     AND cs.project_id = m.project_id
+     AND cs.session_id = m.session_id
+     AND cs.analysisHash = m.analysis_hash
+    GROUP BY cs.session_id
+  )
+`
 
 type DistributionRow = {
   readonly key: string
@@ -167,6 +238,55 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyClusterIntelligenceRepository.listRepresentativeExamples"),
+              ),
+            )
+        }),
+      listSessionTraceIds: ({
+        organizationId,
+        projectId,
+        clusterIds,
+        filter,
+        momentRange,
+        startTimeFrom,
+        startTimeTo,
+        limit,
+      }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          if (clusterIds.length === 0) return []
+          const timeFromClause = startTimeFrom ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
+          const timeToClause = startTimeTo ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
+          const momentRangeClause = momentRange ? "AND selectedMomentCount > 0" : ""
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, Boolean(momentRange))}
+                        SELECT traceId
+                        FROM enriched_sessions
+                        WHERE traceId != ''
+                          AND ${behaviourSessionFilterSql}
+                          ${momentRangeClause}
+                        ORDER BY endTime DESC
+                        LIMIT {limit:UInt32}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  clusterIds: clusterIds as readonly string[],
+                  filter,
+                  limit,
+                  ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
+                  ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
+                  ...(momentRange
+                    ? { momentMetric: momentRange.metric, turnFrom: momentRange.fromTurn, turnTo: momentRange.toTurn }
+                    : {}),
+                },
+                format: "JSONEachRow",
+              })
+              return ((await result.json()) as { readonly traceId: string }[]).map((row) => TraceId(row.traceId))
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyClusterIntelligenceRepository.listSessionTraceIds"),
               ),
             )
         }),

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.test.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.test.ts
@@ -1,0 +1,35 @@
+import { createSeedScope, SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared/seeding"
+import { describe, expect, it } from "vitest"
+import { buildTau2TrajectorySpans } from "./fixed-traces.ts"
+
+const scope = createSeedScope({
+  organizationId: SEED_ORG_ID,
+  projectId: SEED_PROJECT_ID,
+  timelineAnchor: new Date("2026-06-16T12:00:00.000Z"),
+  queueAssigneeUserIds: [],
+  apiKeyId: SEED_API_KEY_ID,
+})
+
+describe("buildTau2TrajectorySpans message serialization", () => {
+  // The trace/session rollups select messages with `input_messages != ''`, so
+  // an empty list must serialize to "" (not "[]"). A leading assistant greeting
+  // has no input; if it stored "[]" it would win the earliest-span tie and
+  // blank out the whole trace's Input.
+  it("never serializes empty message lists as '[]'", () => {
+    const spans = buildTau2TrajectorySpans(scope, 50)
+    expect(spans.length).toBeGreaterThan(0)
+    for (const span of spans) {
+      expect(span.input_messages).not.toBe("[]")
+      expect(span.output_messages).not.toBe("[]")
+    }
+  })
+
+  it("stores '' (not '[]') for the leading greeting span with no prior input", () => {
+    const spans = buildTau2TrajectorySpans(scope, 50)
+    const emptyInputChatSpans = spans.filter(
+      (span) => span.operation === "chat" && span.input_messages === "" && span.output_messages !== "",
+    )
+    // Every tau2 trajectory opens with an assistant greeting (no input).
+    expect(emptyInputChatSpans.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -76,6 +76,14 @@ function estimateTau2Tokens(messages: readonly Tau2Message[]): number {
   return Math.max(12, Math.ceil(JSON.stringify(messages).length / 4))
 }
 
+// Empty message lists must serialize to "" (not "[]") to match the real span
+// writer's contract: the traces/sessions rollups select messages with
+// `input_messages != ''`, so a "[]" leading-greeting span would otherwise win
+// the earliest-span tie and blank out the whole trace's Input.
+function serializeMessages(messages: readonly Tau2Message[]): string {
+  return messages.length > 0 ? JSON.stringify(messages) : ""
+}
+
 function createTau2LlmSpan(opts: {
   scope: SeedScope
   traceId: string
@@ -135,8 +143,8 @@ function createTau2LlmSpan(opts: {
     is_streaming: hasToolCall ? 0 : 1,
     response_id: `seed-${opts.spanId}`,
     finish_reasons: [hasToolCall ? "tool_calls" : "stop"],
-    input_messages: JSON.stringify(opts.inputMessages),
-    output_messages: JSON.stringify([opts.outputMessage]),
+    input_messages: serializeMessages(opts.inputMessages),
+    output_messages: serializeMessages([opts.outputMessage]),
     system_instructions: JSON.stringify([{ type: "text", content: opts.systemInstruction }]),
     tool_definitions: JSON.stringify(
       opts.toolDefinitions.map((name) => ({ name, description: TAU2_TOOL_DESCRIPTIONS[name] ?? `${name} tool` })),
@@ -585,7 +593,7 @@ function buildLargeConversationSpans(scope: SeedScope): SpanRow[] {
   return LARGE_CONVERSATION_SPECS.map((spec) => createLargeConversationChatSpan({ scope, spec }))
 }
 
-function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length): SpanRow[] {
+export function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_TRAJECTORIES.length): SpanRow[] {
   const spans: SpanRow[] = []
 
   TAU2_SEED_TRAJECTORIES.slice(0, maxTrajectories).forEach((trajectory, trajectoryIndex) => {
@@ -758,8 +766,8 @@ function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU2_SEED_
     root.cost_input_microcents = rootInputTokens * 25
     root.cost_output_microcents = rootOutputTokens * 100
     root.cost_total_microcents = root.cost_input_microcents + root.cost_output_microcents
-    root.input_messages = JSON.stringify(rootInputMessages)
-    root.output_messages = JSON.stringify(rootOutputMessages)
+    root.input_messages = serializeMessages(rootInputMessages)
+    root.output_messages = serializeMessages(rootOutputMessages)
     root.end_time = formatClickHouseTimestamp(new Date(cursor.getTime() + 50))
   })
 

--- a/packages/platform/db-clickhouse/src/seeds/spans/span-builders.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/span-builders.ts
@@ -337,8 +337,10 @@ export function makeLlmSpan({
   span.cost_is_estimated = 1
   span.response_id = randomResponseId(modelConfig.provider)
   span.finish_reasons = [finishReason]
-  span.input_messages = JSON.stringify(inputMessages)
-  span.output_messages = JSON.stringify(outputMessages)
+  // Empty lists serialize to "" (not "[]") to match the real span writer: the
+  // trace/session rollups select messages with `input_messages != ''`.
+  span.input_messages = inputMessages.length > 0 ? JSON.stringify(inputMessages) : ""
+  span.output_messages = outputMessages.length > 0 ? JSON.stringify(outputMessages) : ""
   span.system_instructions = systemInstructions ? JSON.stringify([{ type: "text", content: systemInstructions }]) : ""
   span.tool_definitions = toolDefinitions ? JSON.stringify(toolDefinitions.map(toolToDefinition)) : ""
   span.scope_name = modelConfig.scopeName

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -45,6 +45,7 @@ export { EvaluationAlignmentExamplesRepositoryLive } from "./repositories/evalua
 export { EvaluationRepositoryLive } from "./repositories/evaluation-repository.ts"
 export { FeatureFlagRepositoryLive } from "./repositories/feature-flag-repository.ts"
 export { FlaggerRepositoryLive } from "./repositories/flagger-repository.ts"
+export { type GardenableProjectRef, listGardenableProjectRefs } from "./repositories/gardenable-projects.ts"
 export { IncidentMonitorReaderLive } from "./repositories/incident-monitor-reader.ts"
 export { InvitationRepositoryLive } from "./repositories/invitation-repository.ts"
 export { MembershipRepositoryLive } from "./repositories/membership-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/gardenable-projects.test.ts
+++ b/packages/platform/db-postgres/src/repositories/gardenable-projects.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { projects } from "../schema/projects.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { listGardenableProjectRefs } from "./gardenable-projects.ts"
+
+const pg = setupTestPostgres()
+
+const makeId = (prefix: string): string => prefix.padEnd(24, "x").slice(0, 24)
+
+const ORG = makeId("org-garden")
+const REAL = makeId("proj-real")
+const DEMO = makeId("proj-demo")
+const DELETED = makeId("proj-deleted")
+const NO_SETTINGS = makeId("proj-nosettings")
+const NOT_SAMPLE = makeId("proj-notsample")
+
+describe("listGardenableProjectRefs", () => {
+  beforeAll(async () => {
+    const now = new Date("2026-06-01T12:00:00.000Z")
+    await pg.db.insert(projects).values([
+      { id: REAL, organizationId: ORG, name: "Real", slug: "real", createdAt: now, updatedAt: now },
+      {
+        id: DEMO,
+        organizationId: ORG,
+        name: "Sample project",
+        slug: "sample",
+        settings: { isSample: true },
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: DELETED,
+        organizationId: ORG,
+        name: "Deleted",
+        slug: "deleted",
+        deletedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: NO_SETTINGS,
+        organizationId: ORG,
+        name: "No settings",
+        slug: "no-settings",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: NOT_SAMPLE,
+        organizationId: ORG,
+        name: "Not sample",
+        slug: "not-sample",
+        settings: { isSample: false },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+  })
+
+  it("excludes demo (isSample) and soft-deleted projects, keeps everything else", async () => {
+    const ids = (await listGardenableProjectRefs(pg.adminPostgresClient)).map((row) => row.project_id)
+
+    // Real projects are gardened — including those with null settings or isSample:false.
+    expect(ids).toContain(REAL)
+    expect(ids).toContain(NO_SETTINGS)
+    expect(ids).toContain(NOT_SAMPLE)
+    // Demo projects and soft-deleted projects are never gardened.
+    expect(ids).not.toContain(DEMO)
+    expect(ids).not.toContain(DELETED)
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/gardenable-projects.ts
+++ b/packages/platform/db-postgres/src/repositories/gardenable-projects.ts
@@ -1,0 +1,25 @@
+import { and, isNull, sql } from "drizzle-orm"
+import type { PostgresClient } from "../client.ts"
+import { projects } from "../schema/projects.ts"
+
+export interface GardenableProjectRef {
+  readonly organization_id: string
+  readonly project_id: string
+}
+
+/**
+ * Cross-org list of projects the taxonomy gardening sweep should consider:
+ * not soft-deleted and not demo ("sample") projects. Demo projects are seeded
+ * once from a curated snapshot; gardening them would re-cluster on the recent
+ * lookback subset and drift the curated behaviours, so they're excluded.
+ *
+ * ⚠️ Runs without an `organization_id` filter — pass the admin (RLS-bypass)
+ * client so it sees every organization's projects.
+ */
+export const listGardenableProjectRefs = async (adminClient: PostgresClient): Promise<GardenableProjectRef[]> =>
+  adminClient.db
+    .select({ organization_id: projects.organizationId, project_id: projects.id })
+    .from(projects)
+    .where(
+      and(isNull(projects.deletedAt), sql`coalesce((${projects.settings} ->> 'isSample')::boolean, false) = false`),
+    )


### PR DESCRIPTION
## Why

Closes the loop from discovery → actionable data. You could find a recurring pattern (a Behaviours cluster / Moment, or a Signal) but had no way to turn those sessions into a Dataset for evals/training. Fixes #3685, and recovers the signal export that regressed during the Issues→Signals rename.

While QA'ing the export against the sample project, three pre-existing **demo-provisioning** bugs surfaced (all demo-only — see "Do real projects hit this?"). They're fixed here too.

## What

### Behaviours cluster → dataset
- **Shared domain resolver** `listClusterSessionTraceIds` (use-case + `TaxonomyClusterIntelligenceRepository.listSessionTraceIds`) maps a cluster subtree to one trace id per session, honouring the drawer's moment-kind / turn-range / time filters.
- New web server fns add to / create a dataset from cluster sessions, reusing the **unchanged** domain `addTracesToDataset` (dedup, 1000-row cap, versioning).
- **Batch selection** in the cluster drawer (mirrors Signals): select-all across the behaviour or pick individual rows. "Clear filters" moved next to the moment-filter chips.

### Signals → dataset (recovered)
- The Issues→Signals rename dropped the add-to-dataset action from the detail drawer. Restored it on the signal's **sessions** table with batch selection: "all" resolves every trace linked to the signal; selected/allExcept expand the chosen sessions to their traces.
- Added `countSignalSessions` server fn + `useSignalSessionsCount` hook for accurate select-all counts.
- `AddToDatasetModal` is now source-agnostic: the caller supplies `onAddToExisting` / `onCreateNew`, and the copy noun is configurable (trace/session).

### Add-to-dataset UI placement
- Moved the **"Add to dataset"** button to the right of the title (right-aligned) and made it smaller, in both the session panel and the traces panel.
- Adding a **session** still adds its latest trace, but the modal now states which one ("Adding the latest trace of this session · `xxxxxxx`"). Falls back to the session's first trace when no output-bearing trace exists (so sessions with no output messages still show the button).

## Demo-data fixes (found during QA — unrelated to the feature)

All three are in the demo **snapshot provisioning** path (`apps/workflows/src/activities/demo-project-snapshot.ts`, demo seed), introduced when demo seeding moved to importing a derived snapshot. They affect **demo/sample projects only**.

**1. Blank trace Input.** The tau2 demo seed serialized empty message lists as `"[]"` instead of `""`. The trace/session rollups select messages with `input_messages != ''`, so a leading assistant-greeting span (empty history) could win the earliest-span tie and blank out a trace's Input ("No input messages"). Now serializes empty lists as `""`, matching the real span writer.

**2. Gardening crash on demo observations.** The snapshot import remapped `observation_id` to a **32-char** hash, but `taxonomyMomentObservationSchema.observationId` is an exact-**24** cuid. Every gardening read (`listAllByCluster` → `toDomainObservation`) threw `expected string to have <=24 characters`, so gardening kept failing on demo projects. Now truncates to 24 (matching the live pipeline's `hash(...).slice(0, 24)`).

**3. Moments intermittently not displaying + one-bar "Session activity" histogram — root cause.**

The demo project is seeded by importing a derived snapshot. The import remaps every timestamp by a **whole-day** delta — `deltaMs = utcDay(targetAnchor) − utcDay(sourceAnchor)` — which **preserves each row's source time-of-day**. For most tables that's fine. But the snapshot's `taxonomy_observations` rows all carry a single *source-build* time-of-day, **not** the real session time (unlike `session_analyses`, which keep the true, spread session times). So after the whole-day shift, every demo observation lands:

- **on the provisioning day** (all the same day → the "Session activity" histogram collapses to one bar), and
- **at the source time-of-day**, which can be later than the current wall clock when you view it → the observation is dated **in the future**.

The behaviours "Detected signals" / Conversation-intelligence query selects observations with `start_time < now()`, so future-dated observations are excluded → empty signals panel / "moments don't display." The Associated-sessions list has no upper bound, so sessions still render — the confusing "sessions show but no detected signals" state.

This is **time-of-day dependent**, which is why onboarding mostly looked fine: it only appears for a demo **provisioned the same day** and **viewed before** that time-of-day window passes. Viewed later in the day, or for any demo provisioned on a previous day (observations firmly in the past), moments display normally. Observed directly with no code change, just the clock: a demo's observations were in the future at `now()=09:16` (empty signals); the same project at `now()=10:35` reported `in_future = 0` and the signals rendered.

**Fix:** during snapshot import, re-stamp `taxonomy_observations.start_time/end_time` from the matching session's analysis row (which the snapshot already carries with correct, spread session times) before the day-shift. Observations then land spread and in the past — deterministically correct regardless of view time. Fixes both the one-bar histogram and the missing signals.

**Also: demo projects are now excluded from gardening.** Demo ("sample") projects are seeded once from a curated snapshot; gardening them would re-cluster on the recent 7-day lookback subset and drift the curated behaviours. The sweep now skips projects with `settings.isSample = true`.

> Note: these demo fixes apply to **newly provisioned** demos. Existing demo projects must be re-created to pick them up.

### Do real projects hit this?

No. Real observations are written by the live pipeline (`analyze-session.ts`) with `startTime = session.startTime` — the actual, past session time, which is always `< now()` and never excluded; real sessions also spread over real time, so no one-bar histogram. The only analog is upstream **customer clock skew** (an app sending future-dated spans), which is rare, transient, and self-heals as `now()` advances — not a product bug and unrelated to the snapshot path.

## Tests
- `taxonomy-cluster-intelligence-repository.test.ts` — `listSessionTraceIds`: moment-kind/turn-range filtering, empty-trace skipping, **limit + newest-first ordering**, **start-time window**, **empty cluster ids**.
- `gardenable-projects.test.ts` — the gardening sweep query excludes `isSample` demos and soft-deleted projects, keeps everything else.
- `demo-project-snapshot.test.ts` — `mapObservationId` is exactly 24 chars (schema-valid); `mapClickHouseRow` re-stamps observation start/end from the session time (and ignores it for other tables).
- `fixed-traces.test.ts` — seed never emits `"[]"`; greeting span stores `""`.
- Typecheck + Biome clean across touched packages.

## QA notes
- Behaviours drawer: filter by a moment kind → select all → add to dataset / create new; verify row count and dedup on re-run.
- Signal detail: select sessions (and select-all) → add to dataset.
- Demo fixes need a **fresh demo project** (re-run onboarding / "Create Demo Project") to verify; existing demos won't update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
