### PR TITLE
docs: Add documentation links to empty states and settings

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -1,6 +1,6 @@
-import { Text } from "@repo/ui"
+import { Button, Icon, Text } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
-import { Loader2Icon, TagsIcon } from "lucide-react"
+import { ExternalLinkIcon, Loader2Icon, TagsIcon } from "lucide-react"
 import { useMemo } from "react"
 import { type BehaviourSegment, useProjectBehaviours } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import type {
@@ -156,6 +156,14 @@ function BehavioursPageContent() {
                   : "Live taxonomy behaviors will appear here after sessions have been clustered."}
               </Text.H5>
             </div>
+            {isDemoProject ? null : (
+              <a href="https://docs.latitude.so/search/behaviours" target="_blank" rel="noopener noreferrer">
+                <Button>
+                  <Icon size="sm" icon={ExternalLinkIcon} />
+                  Read the docs
+                </Button>
+              </a>
+            )}
           </div>
         </Layout.Content>
       </Layout>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
@@ -1,5 +1,5 @@
 import { Button, DatabaseAddIcon, Icon, Text } from "@repo/ui"
-import { DatabaseIcon } from "lucide-react"
+import { DatabaseIcon, ExternalLinkIcon } from "lucide-react"
 
 export function DatasetsEmptyState({
   onCreate,
@@ -21,10 +21,18 @@ export function DatasetsEmptyState({
             started.
           </Text.H5>
         </div>
-        <Button onClick={onCreate} disabled={creating} isLoading={creating}>
-          <Icon size="sm" icon={DatabaseAddIcon} />
-          Dataset
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button onClick={onCreate} disabled={creating} isLoading={creating}>
+            <Icon size="sm" icon={DatabaseAddIcon} />
+            Dataset
+          </Button>
+          <a href="https://docs.latitude.so/evaluations/overview" target="_blank" rel="noopener noreferrer">
+            <Button variant="outline">
+              <Icon size="sm" icon={ExternalLinkIcon} />
+              Read the docs
+            </Button>
+          </a>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destinations-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destinations-section.tsx
@@ -41,6 +41,7 @@ export function DestinationsSection({
             icon: Plus,
             onClick: () => setCreating(true),
           }}
+          docsHref="https://docs.latitude.so/more/data-destinations/overview"
         />
       ) : (
         <>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-empty-state.tsx
@@ -17,7 +17,7 @@ export function ToolsEmptyState({ isLoading = false }: { readonly isLoading?: bo
           </Text.H5>
         </div>
         {!isLoading ? (
-          <a href="https://docs.latitude.so" target="_blank" rel="noopener noreferrer">
+          <a href="https://docs.latitude.so/observability/tools" target="_blank" rel="noopener noreferrer">
             <Button>
               <Icon size="sm" icon={ExternalLinkIcon} />
               Read the docs


### PR DESCRIPTION
## What does this PR do?

Adds contextual documentation links to three empty state and settings components to help users discover relevant docs:

- **Datasets empty state**: Added a "Read the docs" button linking to the evaluations overview documentation, displayed alongside the "Create Dataset" button
- **Tools empty state**: Updated the documentation link from the generic docs homepage to the specific tools/observability documentation page
- **Destinations section**: Added a `docsHref` prop pointing to the data destinations overview documentation

These changes improve discoverability of product documentation at key user touchpoints where users are first encountering features.

## Related issue (if applicable)

Closes #

## How was this tested?

Visual inspection of the component changes. The modifications are UI-only additions of documentation links with no behavioral changes to existing functionality.

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

https://claude.ai/code/session_01MUdv7qJqdj48qNh6mRyfzu