### PR TITLE
fix(taxonomy): make retries idempotent and preserve observation ids

### DIFF
--- a/apps/workflows/src/activities/demo-project-snapshot.ts
+++ b/apps/workflows/src/activities/demo-project-snapshot.ts
@@ -128,7 +128,7 @@ const sha256 = (parts: readonly string[]): string => createHash("sha256").update
 
 const mapObservationId = (sourceId: unknown, scope: SeedScope): unknown =>
   typeof sourceId === "string"
-    ? sha256(["snapshot:taxonomy-observation", scope.projectId, sourceId]).slice(0, 32)
+    ? sha256(["snapshot:taxonomy-observation", scope.projectId, sourceId]).slice(0, 24)
     : sourceId
 
 /**

--- a/packages/domain/taxonomy/src/entities/observation.ts
+++ b/packages/domain/taxonomy/src/entities/observation.ts
@@ -30,7 +30,7 @@ export const TaxonomyObservationAssignmentMethod = {
 export const taxonomyMomentObservationSchema = z.object({
   organizationId: cuidSchema,
   projectId: cuidSchema,
-  observationId: cuidSchema,
+  observationId: z.string().min(1),
   sessionId: sessionIdSchema,
   analysisHash: z.string().length(64),
   momentId: z.string().min(1),

--- a/packages/domain/taxonomy/src/entities/observation.ts
+++ b/packages/domain/taxonomy/src/entities/observation.ts
@@ -30,7 +30,7 @@ export const TaxonomyObservationAssignmentMethod = {
 export const taxonomyMomentObservationSchema = z.object({
   organizationId: cuidSchema,
   projectId: cuidSchema,
-  observationId: z.string().min(1),
+  observationId: cuidSchema,
   sessionId: sessionIdSchema,
   analysisHash: z.string().length(64),
   momentId: z.string().min(1),

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -49,6 +49,29 @@ const makeObservation = (overrides: Partial<TaxonomyMomentObservation> = {}): Ta
   ...overrides,
 })
 
+const toClickHouseDateTime = (date: Date) => date.toISOString().replace("Z", "")
+
+const makeObservationRow = (observation: TaxonomyMomentObservation) => ({
+  organization_id: observation.organizationId as string,
+  project_id: observation.projectId as string,
+  observation_id: observation.observationId,
+  session_id: observation.sessionId as string,
+  analysis_hash: observation.analysisHash,
+  moment_id: observation.momentId,
+  projection_method: observation.projectionMethod,
+  projection_hash: observation.projectionHash,
+  projection_metadata: JSON.stringify(observation.projectionMetadata),
+  embedding: [...observation.embedding],
+  assigned_cluster_id: observation.assignedClusterId ?? "",
+  assignment_confidence: observation.assignmentConfidence,
+  assignment_method: observation.assignmentMethod,
+  reassignment_run_id: observation.reassignmentRunId ?? "",
+  start_time: toClickHouseDateTime(observation.startTime),
+  end_time: toClickHouseDateTime(observation.endTime),
+  retention_days: observation.retentionDays,
+  indexed_at: toClickHouseDateTime(observation.indexedAt),
+})
+
 const runWithRepository = <A, E>(effect: Effect.Effect<A, E, TaxonomyObservationRepository | ChSqlClient>) =>
   Effect.runPromise(effect.pipe(withClickHouse(TaxonomyObservationRepositoryLive, ch.client, organizationId)))
 
@@ -72,6 +95,59 @@ describe("TaxonomyObservationRepositoryLive", () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]?.momentId).toBe("moment-1")
     expect(rows[0]?.projectionMetadata).toEqual({ turnIndexes: [0, 2] })
+  })
+
+  it("ignores malformed legacy observation ids", async () => {
+    const legacyProjectId = ProjectId("l".repeat(24))
+    const legacySessionId = SessionId("legacy-session")
+    const valid = makeObservation({
+      observationId: "v".repeat(24),
+      projectId: legacyProjectId,
+      sessionId: legacySessionId,
+      assignedClusterId: clusterId,
+      assignmentMethod: "centroid_online",
+      assignmentConfidence: 0.8,
+    })
+    const legacy = makeObservation({
+      observationId: "f".repeat(32),
+      projectId: legacyProjectId,
+      sessionId: legacySessionId,
+      momentId: "legacy-moment",
+    })
+
+    await ch.client.insert({
+      table: "taxonomy_observations",
+      values: [makeObservationRow(legacy)],
+      format: "JSONEachRow",
+    })
+
+    const result = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        yield* repo.upsert(valid)
+        const rows = yield* repo.listBySession({
+          organizationId,
+          projectId: legacyProjectId,
+          sessionId: legacySessionId,
+        })
+        const sample = yield* repo.listForClusteringSample({
+          organizationId,
+          projectId: legacyProjectId,
+          since: new Date("2026-05-23T00:00:00.000Z"),
+          limit: 10,
+        })
+        const counts = yield* repo.getCounts({
+          organizationId,
+          projectId: legacyProjectId,
+          since: new Date("2026-05-23T00:00:00.000Z"),
+        })
+        return { rows, sample, counts }
+      }),
+    )
+
+    expect(result.rows.map((row) => row.observationId)).toEqual([valid.observationId])
+    expect(result.sample.map((row) => row.observationId)).toEqual([valid.observationId])
+    expect(result.counts).toEqual({ total: 1, assigned: 1, noise: 0 })
   })
 
   it("keeps noise and counts project-scoped", async () => {

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -75,11 +75,14 @@ const selectColumns = `
   indexed_at
 `
 
+const validObservationIdClause = "length(observation_id) = 24"
+
 const latestProjectWindow = `
   SELECT ${selectColumns}
   FROM taxonomy_observations FINAL
   WHERE organization_id = {organizationId:String}
     AND project_id = {projectId:String}
+    AND ${validObservationIdClause}
   ORDER BY start_time DESC, observation_id ASC
   LIMIT {windowLimit:UInt32}
 `
@@ -236,6 +239,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                           FROM taxonomy_observations FINAL
                           WHERE organization_id = {organizationId:String}
                             AND project_id = {projectId:String}
+                            AND ${validObservationIdClause}
                             AND observation_id IN {observationIds:Array(String)}`,
                   query_params: {
                     organizationId: organizationId as string,
@@ -266,6 +270,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         FROM taxonomy_observations
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
                           AND observation_id IN {observationIds:Array(String)}`,
                 query_params: {
                   organizationId: organizationId as string,
@@ -333,6 +338,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         FROM taxonomy_observations FINAL
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
                           AND length(embedding) > 0
                           AND start_time >= {since:DateTime64(9, 'UTC')}
                           AND observation_id IN (
@@ -347,6 +353,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                               FROM taxonomy_observations FINAL
                               WHERE organization_id = {organizationId:String}
                                 AND project_id = {projectId:String}
+                                AND ${validObservationIdClause}
                                 AND length(embedding) > 0
                                 AND start_time >= {since:DateTime64(9, 'UTC')}
                             )
@@ -383,6 +390,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         FROM taxonomy_observations FINAL
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
                           AND length(embedding) > 0
                           AND start_time >= {since:DateTime64(9, 'UTC')}
                           AND observation_id IN (
@@ -397,6 +405,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                               FROM taxonomy_observations FINAL
                               WHERE organization_id = {organizationId:String}
                                 AND project_id = {projectId:String}
+                                AND ${validObservationIdClause}
                                 AND length(embedding) > 0
                                 AND start_time >= {since:DateTime64(9, 'UTC')}
                             )
@@ -502,6 +511,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
                           AND session_id = {sessionId:String}
+                          AND ${validObservationIdClause}
                           ${hashClause}
                         ORDER BY start_time ASC, observation_id ASC`,
                 query_params: {
@@ -531,6 +541,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         FROM taxonomy_observations FINAL
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
                           AND start_time >= {since:DateTime64(9, 'UTC')}`,
                 query_params: {
                   organizationId: organizationId as string,

--- a/packages/platform/db-postgres/src/repositories/taxonomy-lineage-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-lineage-repository.ts
@@ -46,7 +46,10 @@ export const TaxonomyLineageRepositoryLive = Layer.effect(
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const insertRows = rows.map(toInsertRow)
           yield* sqlClient.query((db, organizationId) =>
-            db.insert(taxonomyClusterLineage).values(insertRows.map((row) => ({ ...row, organizationId }))),
+            db
+              .insert(taxonomyClusterLineage)
+              .values(insertRows.map((row) => ({ ...row, organizationId })))
+              .onConflictDoNothing({ target: taxonomyClusterLineage.id }),
           )
         }),
 


### PR DESCRIPTION
## Summary

Fixes two active taxonomy/conversation-intelligence production errors.

### Lineage retries are idempotent

The taxonomy gardening workflow can retry after lineage rows have already been inserted. When the retry replays the insert with the same lineage primary keys, Postgres raised `taxonomy_cluster_lineage_pkey` duplicate key errors.

This PR changes lineage append writes to `onConflictDoNothing` on `taxonomy_cluster_lineage.id`, so replaying an already-inserted lineage batch is safe.

Datadog issue: https://app.datadoghq.eu/error-tracking/issue/0d61dada-6ef2-11f1-8861-da7ad0900005

### Taxonomy observation IDs stay cuid-shaped

`taxonomyMomentObservationSchema.observationId` remains `cuidSchema` (`24` chars). The earlier relaxation to `z.string().min(1)` was not valid: taxonomy observations should use the same 24-char ID shape as the analyzer writes.

Production ClickHouse had `133,720` `taxonomy_observations` rows with 32-char `observation_id` values. Those came from demo project snapshot imports: `mapObservationId` was remapping imported taxonomy observations with `sha256(...).slice(0, 32)`. This PR changes new snapshot imports to write 24-char IDs instead.

Existing malformed production rows are filtered out by taxonomy observation repository reads before Zod parsing. That keeps the domain schema strict while avoiding crashes from already-imported 32-char rows until we decide whether/how to clean them up.

Datadog issues:
- https://app.datadoghq.eu/error-tracking/issue/b24cc8fe-7125-11f1-9132-da7ad0900005
- https://app.datadoghq.eu/error-tracking/issue/b250b392-7125-11f1-9132-da7ad0900005

## Validation

- Queried V2 production ClickHouse via MCP to confirm the invalid IDs were exactly 32-char rows and matched demo snapshot-style data.
- `pnpm exec biome check --fix packages/domain/taxonomy/src/entities/observation.ts packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts apps/workflows/src/activities/demo-project-snapshot.ts`
- `pnpm --filter @platform/db-clickhouse exec vitest run src/repositories/taxonomy-observation-repository.test.ts`

## Follow-up

Existing 32-char `taxonomy_observations` rows are ignored for now. We should decide separately whether to delete or rewrite them.