### PR TITLE
fix(web): restrict prompt editing when Prompt Management is off

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/layout.tsx
@@ -35,6 +35,7 @@ export default async function CommitLayout({
   let session: SessionData
   let project: Project
   let commit: Commit | undefined
+  let headCommit: Commit | undefined
   let isHead = false
   const { projectId, commitUuid } = await params
   try {
@@ -47,7 +48,7 @@ export default async function CommitLayout({
       workspaceId: workspace.id,
     })
 
-    const headCommit = await getHeadCommitCached({
+    headCommit = await getHeadCommitCached({
       workspace,
       projectId: project.id,
     })
@@ -72,6 +73,14 @@ export default async function CommitLayout({
   }
 
   const productAccess = computeProductAccess(session.workspace)
+
+  if (!productAccess.promptManagement && headCommit && !isHead) {
+    return redirect(
+      ROUTES.projects
+        .detail({ id: project.id })
+        .commits.detail({ uuid: HEAD_COMMIT }).issues.root,
+    )
+  }
 
   return (
     <ProjectProvider project={project}>

--- a/apps/web/src/components/Sidebar/Files/DocumentHeader/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/DocumentHeader/index.tsx
@@ -35,11 +35,13 @@ export default function DocumentHeader({
   selected,
   node,
   currentEvaluationUuid,
+  promptManagement,
 }: {
   open: boolean
   selected: boolean
   node: Node
   currentEvaluationUuid: ParamValue
+  promptManagement: boolean
 }) {
   const { commit, isHead } = useCurrentCommit()
   const { project } = useCurrentProject()
@@ -129,6 +131,8 @@ export default function DocumentHeader({
     [documentUuid, commit.id],
   )
   const actions = useMemo<MenuOption[]>(() => {
+    if (!promptManagement) return []
+
     return [
       {
         label: 'Rename file',
@@ -176,6 +180,7 @@ export default function DocumentHeader({
     project.id,
     isHead,
     commit.uuid,
+    promptManagement,
   ])
   const icon = useMemo<IconName>(() => {
     const docName = node.name
@@ -193,8 +198,10 @@ export default function DocumentHeader({
       name={node.name}
       isEditing={isEditing}
       setIsEditing={setIsEditing}
-      isMainDocument={mainDocumentUuid === documentUuid}
-      setMainDocument={setMainDocument}
+      isMainDocument={
+        promptManagement ? mainDocumentUuid === documentUuid : undefined
+      }
+      setMainDocument={promptManagement ? setMainDocument : undefined}
       hasChildren={false}
       actions={actions}
       selected={selected}

--- a/apps/web/src/components/Sidebar/Files/FileNode.tsx
+++ b/apps/web/src/components/Sidebar/Files/FileNode.tsx
@@ -17,12 +17,14 @@ export type FileNodeProps = {
   nodeId: string
   currentUuid: string | undefined
   currentEvaluationUuid: ParamValue
+  promptManagement: boolean
 }
 
 export const FileNode = memo(function FileNode({
   nodeId,
   currentUuid,
   currentEvaluationUuid,
+  promptManagement,
 }: FileNodeProps) {
   const node = useTreeNode(nodeId)
   const open = !!useOpenPaths((state) => state.openPaths[node?.path ?? ''])
@@ -51,6 +53,7 @@ export const FileNode = memo(function FileNode({
         hasChildren={hasChildren}
         onToggleOpen={onToggleOpen}
         currentEvaluationUuid={currentEvaluationUuid}
+        promptManagement={promptManagement}
       />
 
       {node.isFile ? null : (
@@ -59,13 +62,17 @@ export const FileNode = memo(function FileNode({
             hidden: !open,
           })}
         >
-          <TempFolderChildren parentPath={node.path} />
+          <TempFolderChildren
+            parentPath={node.path}
+            promptManagement={promptManagement}
+          />
           {node.children.map((childId) => (
             <li key={childId} className='cursor-pointer'>
               <FileNode
                 nodeId={childId}
                 currentUuid={currentUuid}
                 currentEvaluationUuid={currentEvaluationUuid}
+                promptManagement={promptManagement}
               />
             </li>
           ))}
@@ -82,6 +89,7 @@ function NodeHeader({
   node,
   hasChildren,
   currentEvaluationUuid,
+  promptManagement,
 }: {
   selected: boolean
   open: boolean
@@ -89,6 +97,7 @@ function NodeHeader({
   hasChildren: boolean
   onToggleOpen: () => void
   currentEvaluationUuid: ParamValue
+  promptManagement: boolean
 }) {
   if (node.isFile) {
     return (
@@ -97,6 +106,7 @@ function NodeHeader({
         selected={selected}
         node={node}
         currentEvaluationUuid={currentEvaluationUuid}
+        promptManagement={promptManagement}
       />
     )
   }
@@ -107,11 +117,18 @@ function NodeHeader({
       open={open}
       hasChildren={hasChildren}
       onToggleOpen={onToggleOpen}
+      promptManagement={promptManagement}
     />
   )
 }
 
-export function TempFolderChildren({ parentPath }: { parentPath: string }) {
+export function TempFolderChildren({
+  parentPath,
+  promptManagement,
+}: {
+  parentPath: string
+  promptManagement: boolean
+}) {
   const selector = useCallback(
     (state: { tmpFolders: Record<string, TempNode[]> }) =>
       state.tmpFolders[parentPath] ?? [],
@@ -121,15 +138,17 @@ export function TempFolderChildren({ parentPath }: { parentPath: string }) {
 
   return tempNodes.map((node) => (
     <li key={node.id} className='cursor-pointer'>
-      <TempFolderTreeNode node={node} />
+      <TempFolderTreeNode node={node} promptManagement={promptManagement} />
     </li>
   ))
 }
 
 const TempFolderTreeNode = memo(function TempFolderTreeNode({
   node,
+  promptManagement,
 }: {
   node: TempNode
+  promptManagement: boolean
 }) {
   const openPaths = useOpenPaths((state) => state.openPaths)
   const togglePath = useOpenPaths((state) => state.togglePath)
@@ -149,6 +168,7 @@ const TempFolderTreeNode = memo(function TempFolderTreeNode({
         open={open}
         hasChildren={hasChildren}
         onToggleOpen={onToggleOpen}
+        promptManagement={promptManagement}
       />
       <ul
         className={cn('flex flex-col', {
@@ -157,7 +177,10 @@ const TempFolderTreeNode = memo(function TempFolderTreeNode({
       >
         {node.children.map((childNode) => (
           <li key={childNode.id} className='cursor-pointer'>
-            <TempFolderTreeNode node={childNode} />
+            <TempFolderTreeNode
+              node={childNode}
+              promptManagement={promptManagement}
+            />
           </li>
         ))}
       </ul>

--- a/apps/web/src/components/Sidebar/Files/FolderHeader/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/FolderHeader/index.tsx
@@ -14,11 +14,13 @@ export default function FolderHeader({
   open,
   hasChildren,
   onToggleOpen,
+  promptManagement,
 }: {
   node: Node | TempNode
   open: boolean
   hasChildren: boolean
   onToggleOpen?: () => void
+  promptManagement: boolean
 }) {
   const { commit } = useCurrentCommit()
   const { project } = useCurrentProject()
@@ -106,6 +108,8 @@ export default function FolderHeader({
   )
   const isEditing = isEditingState
   const actions = useMemo<MenuOption[]>(() => {
+    if (!promptManagement) return []
+
     return [
       {
         label: 'Rename folder',
@@ -162,6 +166,7 @@ export default function FolderHeader({
     deleteTmpFolder,
     setIsEditing,
     onAddNode,
+    promptManagement,
   ])
 
   return (

--- a/apps/web/src/components/Sidebar/Files/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/index.tsx
@@ -33,13 +33,17 @@ export function FilesTree({
           documents={documents}
         />
         <ul className={cn('flex flex-col pt-1 pb-8')}>
-          <TempFolderChildren parentPath='' />
+          <TempFolderChildren
+            parentPath=''
+            promptManagement={promptManagement}
+          />
           {topLevelNodeIds.map((nodeId) => (
             <li key={nodeId} className='cursor-pointer'>
               <FileNode
                 nodeId={nodeId}
                 currentUuid={currentUuid}
                 currentEvaluationUuid={currentEvaluationUuid}
+                promptManagement={promptManagement}
               />
             </li>
           ))}


### PR DESCRIPTION
## Problem

When the **Prompt Management** product feature is turned off, the workspace is in observability-only mode — documents exist purely as auto-created containers for incoming traces (created/merged during span ingestion in `captureReferences.ts`, which is intentional). However, users could still **add/delete/rename prompts** in production, which was not intended.

Two leaks caused this:

1. **File-tree per-node menus were not gated by the feature flag.** The top toolbar buttons (`TreeToolbar`) correctly hid "New file/New folder" when the flag was off, but the per-node context menus (`DocumentHeader`/`FolderHeader`) gated rename/delete/new and the "set as main prompt" star only on `isMerged` — so they appeared on any draft commit.
2. **Draft (non-live) version URLs were directly reachable**, exposing the whole editing surface even with the flag off.

## Fix

- **Hide editing affordances on the file tree** — thread the existing `promptManagement` prop from `FilesTree` → `FileNode`/`NodeHeader`/temp nodes → `DocumentHeader` & `FolderHeader`. When the flag is off, the action lists return `[]` (so `NodeHeaderWrapper` renders no menu) and the "set as main prompt" star is hidden (`isMainDocument`/`setMainDocument` pass `undefined`, so `MainPromptIcon` returns `null`).
- **Redirect non-live versions to live** — in `CommitLayout`, when `promptManagement` is off and the requested commit is not the live `HEAD`, redirect to the live version's issues page (the canonical landing for observability-only mode). Targets the literal `HEAD_COMMIT` so there's no redirect loop, and only when a head commit exists (so projects with no merged version don't bounce to a 404).

When Prompt Management is **on**, behavior is completely unchanged.

## Scope / notes

- Trace-ingestion auto-creation of documents is intentionally left as-is — that's the intended observability behavior.
- This is a UI-level fix. The server-side write paths (web actions, gateway endpoints, core services) still don't enforce the flag; true server-side enforcement would be a separate, more invasive change and can follow up if desired.

## Testing

- `pnpm tc` (apps/web) passes.
- Manual: with a workspace's `promptManagerEnabled = false`, opening a draft commit URL bounces to `…/versions/live/issues`, and file/folder right-click menus no longer show rename/delete/new or the main-prompt star.

🤖 Generated with [Claude Code](https://claude.com/claude-code)