### PR TITLE
fix(api): strip internal project settings from listProjects MCP output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API
+
+- Fixed `listProjects` MCP output validation by stripping internal-only project `settings` fields (`isSample`, `onboardingType`, `onboardingCompleted`, `sampling`) from API responses (ref: #3703).
+
 ## v0.3.20 - 2026-06-26
 
 ### Signals and evaluations

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -108,6 +108,38 @@ describe("Projects Routes Integration", () => {
     expect(body.items.find((p) => p.id === live.id)).toBeUndefined()
   })
 
+  it<ApiTestContext>("GET /v1/projects strips internal-only settings fields from the response", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Internal Settings")
+
+    await database.db
+      .update(projects)
+      .set({
+        settings: {
+          keepMonitoring: false,
+          isSample: true,
+          onboardingType: "prod-traces",
+          onboardingCompleted: true,
+        },
+      })
+      .where(eq(projects.id, project.id))
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as PaginatedProjects
+    const listed = body.items.find((row) => row.id === project.id)
+    expect(listed).toBeDefined()
+    expect(listed?.settings).toEqual({ keepMonitoring: false })
+  })
+
   it<ApiTestContext>("PATCH /v1/projects/:projectSlug updates settings and keeps the slug stable on rename", async ({
     app,
     database,

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -180,7 +180,7 @@ const toResponse = (project: Project) => ({
   organizationId: project.organizationId as string,
   name: project.name,
   slug: project.slug,
-  settings: ProjectSettingsSchema.nullable().parse(project.settings),
+  settings: ProjectSettingsSchema.nullable().safeParse(project.settings).data ?? null,
   firstTraceAt: project.firstTraceAt ? project.firstTraceAt.toISOString() : null,
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
   lastEditedAt: project.lastEditedAt.toISOString(),

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -180,7 +180,7 @@ const toResponse = (project: Project) => ({
   organizationId: project.organizationId as string,
   name: project.name,
   slug: project.slug,
-  settings: project.settings,
+  settings: ProjectSettingsSchema.nullable().parse(project.settings),
   firstTraceAt: project.firstTraceAt ? project.firstTraceAt.toISOString() : null,
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
   lastEditedAt: project.lastEditedAt.toISOString(),

--- a/packages/sdk/python/CHANGELOG.md
+++ b/packages/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.1] - 2026-06-26
+
+### Fixed
+
+- Project list/get/create/update responses now strip internal-only `settings` fields (`is_sample`, `onboarding_type`, `onboarding_completed`, `sampling`) that could leak from Postgres and break MCP `listProjects` output validation.
+
 ## [6.2.0] - 2026-06-26
 
 ### Added

--- a/packages/sdk/python/pyproject.toml
+++ b/packages/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-sdk"
-version = "6.2.0"
+version = "6.2.1"
 description = "Official Python SDK for the Latitude API"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/sdk/typescript/CHANGELOG.md
+++ b/packages/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.1] - 2026-06-26
+
+### Fixed
+
+- Project list/get/create/update responses now strip internal-only `settings` fields (`isSample`, `onboardingType`, `onboardingCompleted`, `sampling`) that could leak from Postgres and break MCP `listProjects` output validation.
+
 ## [6.2.0] - 2026-06-26
 
 ### Added

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Official TypeScript SDK for the Latitude API",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`latitude_listProjects` fails MCP output validation when any project in the org has internal-only settings fields in Postgres (e.g. `isSample`, `onboardingType`, `onboardingCompleted`, `sampling`). The MCP output schema for `settings` only allows `keepMonitoring`, `notifications`, and `escalation`, with `additionalProperties: false`.

`toResponse` was returning `project.settings` verbatim from the database, so sample/onboarding projects triggered schema errors like:

```
data/items/N/settings must NOT have additional properties
```

## Fix

Parse `settings` through `ProjectSettingsSchema.nullable().safeParse(...)` in `toResponse`, so only API-documented fields are returned (malformed DB values fall back to `null` instead of throwing). This applies to all project endpoints (`listProjects`, `getProject`, `createProject`, `updateProject`) since they share the same mapper.

## SDK release

- Bumped `@latitude-data/sdk` and `latitude-sdk` to **6.2.1**
- Updated SDK changelogs and root `CHANGELOG.md`
- Regenerated OpenAPI/MCP manifests and Fern SDKs (`pnpm generate:sdk`) — no schema diff, so generated SDK sources are unchanged

## Testing

- Added integration test asserting internal fields are stripped from `GET /v1/projects` responses.
- `@app/api` typecheck passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cbc45ff-117a-4cf5-8b46-d3049e5670b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cbc45ff-117a-4cf5-8b46-d3049e5670b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

