### PR TITLE
fix(web): align behaviors and moments naming in filters and detail view

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -642,10 +642,10 @@ function BehaviourSessionsTable({
       },
       {
         key: "signals",
-        header: "Detected signals",
+        header: "Moments",
         width: 220,
         render: (session) =>
-          session.momentKinds.length > 0 ? session.momentKinds.join(", ").replaceAll("_", " ") : "no detected signals",
+          session.momentKinds.length > 0 ? session.momentKinds.join(", ").replaceAll("_", " ") : "-",
       },
       {
         key: "sessionId",
@@ -762,9 +762,9 @@ function DetectedSignalsChart({
 
   return (
     <div className="flex h-full flex-col rounded-lg bg-secondary">
-      <ChartPanelHeader title="Detected signals" />
+      <ChartPanelHeader title="Moments" />
       <div className="flex flex-1 items-center justify-center px-2 pb-2">
-        <svg className="size-24 shrink-0" viewBox="0 0 160 160" role="img" aria-label="Detected signal distribution">
+        <svg className="size-24 shrink-0" viewBox="0 0 160 160" role="img" aria-label="Moment distribution">
           <circle cx="80" cy="80" r="78" className="fill-muted" />
           {slices.map((slice) => (
             <Tooltip

--- a/packages/domain/shared/src/trace-filter-fields.ts
+++ b/packages/domain/shared/src/trace-filter-fields.ts
@@ -52,7 +52,7 @@ export const TRACE_FILTER_FIELDS = [
   },
   { field: "tags", type: "multiSelect", label: "Tags" },
   { field: "moments", type: "multiSelect", label: "Moments", sessionOnly: true },
-  { field: "topics", type: "multiSelect", label: "Topics", sessionOnly: true },
+  { field: "topics", type: "multiSelect", label: "Behaviors", sessionOnly: true },
   { field: "models", type: "multiSelect", label: "Models" },
   { field: "providers", type: "multiSelect", label: "Providers" },
   { field: "serviceNames", type: "multiSelect", label: "Services" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames two user-facing labels that were inconsistent with the Behaviors page:

- Sessions filter **Topics** → **Behaviors** (matches the Behaviors nav and page)
- Behavior detail sessions table/chart **Detected signals** → **Moments** (matches the Moments column on the main Behaviors table)

## Why

The sessions filter and behavior detail view used legacy taxonomy wording ("Topics", "Detected signals") while the Behaviors page already uses "Behaviors" and "Moments". This made the same concepts appear under different names depending on where you were in the product.

## Changes

- `TRACE_FILTER_FIELDS`: `topics` multi-select label is now "Behaviors"
- Behavior detail sessions table: column header and empty state use "Moments"
- Behavior detail moment distribution chart: title and aria-label use "Moments"

## Testing

- `pnpm --filter @domain/shared typecheck`
- `pnpm --filter web typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-168dd7d0-7bfa-4cc4-a5f6-fcb5c0eff54a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-168dd7d0-7bfa-4cc4-a5f6-fcb5c0eff54a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

