### PR TITLE
fix(web): show settings in sample project sidebar

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -174,7 +174,7 @@ function ProjectLayout() {
 
   if (project.settings.isSample) {
     return (
-      <div className="flex h-screen flex-col overflow-hidden bg-primary">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden bg-primary">
         <SampleProjectStrip />
         <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-t-2xl bg-background">
           <ProjectSidebar project={project} projectSlug={projectSlug} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Settings entry in the project sidebar footer was clipped on sample projects, so it looked like the tab was missing.

## Root cause

Sample projects use a dedicated layout with the blue informational strip at the top. That wrapper used `h-screen` even though it renders inside the authenticated shell, which already reserves height for the top nav. The sidebar ended up taller than its container, and the footer (Changelog, Sandbox toggle, Settings) was pushed below the visible area.

Regular projects already use `h-full`, so Settings was only broken on sample projects.

## Fix

Change the sample project wrapper to `h-full min-h-0` so it fits the available height and the sidebar footer stays visible.

## Testing

- `pnpm --filter web typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f93a285-554d-45ae-9f7e-79f5f290e6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f93a285-554d-45ae-9f7e-79f5f290e6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

