### PR TITLE
fix: speed up signals list loading

### DIFF
--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -331,7 +331,7 @@ type ListSignalsRequest = z.infer<typeof listSignalsInputSchema>
 
 const runSignalsList = async (
   data: ListSignalsRequest,
-  options: { readonly includeAnalytics: boolean },
+  options: { readonly includeAnalytics: boolean; readonly includeItems?: boolean },
 ): Promise<SignalsListResultRecord> => {
   const { organizationId, userId } = await requireSession()
   const orgId = OrganizationId(organizationId)
@@ -384,6 +384,7 @@ const runSignalsList = async (
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
         ...(data.offset !== undefined ? { offset: data.offset } : {}),
         includeAnalytics: options.includeAnalytics,
+        ...(options.includeItems !== undefined ? { includeItems: options.includeItems } : {}),
         ...(data.lifecycleGroup ? { lifecycleGroup: data.lifecycleGroup } : {}),
         ...(data.assigneeIds?.length ? { assigneeIds: data.assigneeIds } : {}),
         ...(data.sort ? { sort: data.sort } : {}),
@@ -418,7 +419,10 @@ export const listSignals = createServerFn({ method: "GET" })
 
 export const getSignalsAnalytics = createServerFn({ method: "GET" })
   .inputValidator(listSignalsInputSchema)
-  .handler(async ({ data }): Promise<SignalsListResultRecord> => runSignalsList(data, { includeAnalytics: true }))
+  .handler(
+    async ({ data }): Promise<SignalsListResultRecord> =>
+      runSignalsList(data, { includeAnalytics: true, includeItems: false }),
+  )
 
 export const getSignalRowMetrics = createServerFn({ method: "GET" })
   .inputValidator(signalRowMetricsInputSchema)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -71,6 +71,10 @@ import { TracesView } from "./traces-view.tsx"
 
 export type ExplorerMode = "traces" | "sessions"
 
+/** Default Sessions time window when none is set — keeps listing, counts, and
+ * metrics scoped to what the time filter shows (matches the Signals page). */
+const DEFAULT_SESSION_RANGE_SECONDS = 30 * 24 * 60 * 60
+
 export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string }) {
   const routeProject = useRouteProject()
   const { data: project } = useProjectsCollection(
@@ -195,6 +199,21 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const traceIdsRef = useRef<string[]>([])
 
   const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
+  // In Sessions mode, default the time range to the last month when the user
+  // hasn't set one, so listing, counts, metrics, and the time dropdown all stay
+  // scoped to the same visible window (matches the Signals page). Traces mode
+  // keeps the raw filter set untouched.
+  const sessionFilters = useMemo(() => {
+    if (!isSessions || filters.startTime) return filters
+    // Match how the time dropdown stores a "Last month" preset: an open-ended
+    // `gte` (no `lte`), so the dropdown shows "Last month" instead of a custom
+    // absolute range, and the data still scopes to the last 30 days.
+    const fromMs = Date.now() - DEFAULT_SESSION_RANGE_SECONDS * 1000
+    return {
+      ...filters,
+      startTime: [{ op: "gte" as const, value: new Date(fromMs).toISOString() }],
+    }
+  }, [filters, isSessions])
   // The Sessions surface's hooks (useSessionsInfiniteScroll / useSessionsCount)
   // apply `withSessionDefaults` internally to hide orphan-fragment sessions
   // by default. The trace-side surfaces here (count, export, add-to-dataset)
@@ -217,8 +236,8 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   })
   const hasActiveFilters = Object.keys(filters).length > 0
   const hasSelectedSavedSearch = savedSearchSlug.length > 0
-  const timeFrom = getTimeFilterValue(filters, "gte")
-  const timeTo = getTimeFilterValue(filters, "lte")
+  const timeFrom = getTimeFilterValue(sessionFilters, "gte")
+  const timeTo = getTimeFilterValue(sessionFilters, "lte")
   const sessionsMonitorTarget = useMemo<MonitorTarget>(
     () => ({
       kind: "session",
@@ -639,7 +658,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
         <TraceAggregationsPanel
           projectId={currentProject.id}
           projectSlug={currentProject.slug}
-          filters={filters}
+          filters={sessionFilters}
           mode={activeTab}
           onTimeRangeSelect={onTimeRangeSelect}
         />
@@ -648,7 +667,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       {isSessions ? (
         <SessionsView
           projectId={currentProject.id}
-          filters={filters}
+          filters={sessionFilters}
           filtersOpen={filtersOpen}
           activeSessionId={activeSessionId || undefined}
           activeTraceId={activeTraceId || undefined}

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -431,7 +431,7 @@ describe("listSignalsUseCase", () => {
     expect(result.offset).toBe(0)
   })
 
-  it("lists signals that have no occurrences yet in the default view", async () => {
+  it("excludes signals with no activity in the selected window from the listing", async () => {
     const now = new Date("2026-04-10T00:00:00.000Z")
     const activeSignal = makeSignal({
       id: SignalId("aaaaaaaaaaaaaaaaaaaaaaaa"),
@@ -440,7 +440,8 @@ describe("listSignalsUseCase", () => {
       clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
     })
     // A freshly created user signal with no scores yet: no window metric and no
-    // full-history occurrence aggregate.
+    // full-history occurrence aggregate. It must not appear in the listing
+    // because it has no activity within the selected window.
     const freshSignal = makeSignal({
       id: SignalId("ffffffffffffffffffffffff"),
       origin: "user",
@@ -488,14 +489,12 @@ describe("listSignalsUseCase", () => {
       ),
     )
 
-    expect(result.totalCount).toBe(2)
-    const occurrencesById = new Map(result.items.map((issue) => [issue.id, issue.occurrences]))
-    expect(occurrencesById.get(freshSignal.id)).toBe(0)
-    expect(occurrencesById.get(activeSignal.id)).toBe(5)
-    const fresh = result.items.find((issue) => issue.id === freshSignal.id)
-    expect(fresh?.firstSeenAt).toEqual(freshSignal.createdAt)
-    expect(fresh?.lastSeenAt).toEqual(freshSignal.createdAt)
-    expect(fresh?.affectedSessionsPercent).toBe(0)
+    expect(result.totalCount).toBe(1)
+    expect(result.items.map((issue) => issue.id)).toEqual([activeSignal.id])
+    expect(result.items[0]?.occurrences).toBe(5)
+    // The project still has signals overall, so the empty-window state stays
+    // distinct from an empty project.
+    expect(result.hasAnySignals).toBe(true)
   })
 
   it("keeps analytics independent from the lifecycle tab and hydrates only visible signal ids", async () => {

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -1354,6 +1354,69 @@ describe("listSignalsUseCase", () => {
       expect(histogramCalls).toBe(0)
     })
 
+    it("can compute analytics without loading page item enrichments", async () => {
+      const { repository: signalRepository } = createFakeSignalRepository(mixedPrioritySeed.map((entry) => entry.issue))
+      const { repository: evaluationRepository, listBySignalIdsCalls } = createEvaluationRepository()
+      let aggregateCalls = 0
+      let tagsCalls = 0
+      let trendCalls = 0
+      let histogramCalls = 0
+      const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
+        listSignalWindowMetrics: () =>
+          Effect.succeed(mixedPrioritySeed.map((entry) => makeWindowMetric({ signalId: SignalId(entry.issue.id) }))),
+        aggregateBySignals: () =>
+          Effect.sync(() => {
+            aggregateCalls += 1
+            return []
+          }),
+        aggregateTagsBySignals: () =>
+          Effect.sync(() => {
+            tagsCalls += 1
+            return []
+          }),
+        trendBySignals: () =>
+          Effect.sync(() => {
+            trendCalls += 1
+            return []
+          }),
+        histogramBySignals: () =>
+          Effect.sync(() => {
+            histogramCalls += 1
+            return []
+          }),
+      })
+
+      const result = await Effect.runPromise(
+        listSignalsUseCase({
+          organizationId,
+          projectId,
+          now,
+          includeAnalytics: true,
+          includeItems: false,
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(SignalRepository, signalRepository),
+              Layer.succeed(EvaluationRepository, evaluationRepository),
+              Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+              Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+              Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+              provideSessionRepository,
+            ),
+          ),
+        ),
+      )
+
+      expect(result.items).toEqual([])
+      expect(result.totalCount).toBe(mixedPrioritySeed.length)
+      expect(result.priorityCounts).toEqual({ urgent: 1, high: 1, medium: 1, low: 1, none: 1 })
+      expect(histogramCalls).toBe(1)
+      expect(listBySignalIdsCalls).toEqual([])
+      expect(aggregateCalls).toBe(0)
+      expect(tagsCalls).toBe(0)
+      expect(trendCalls).toBe(0)
+    })
+
     const userA = "1".repeat(24)
     const userB = "2".repeat(24)
     const assignedToA = makeSignal({ id: SignalId("a".repeat(24)), assigneeId: userA, priority: "high" })

--- a/packages/domain/signals/src/use-cases/list-signals.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.ts
@@ -85,6 +85,7 @@ const listSignalsInputSchema = z.object({
   limit: z.number().int().min(1).max(100).default(50),
   offset: z.number().int().min(0).default(0),
   includeAnalytics: z.boolean().default(true),
+  includeItems: z.boolean().default(true),
   now: z.date().optional(),
 })
 
@@ -534,9 +535,14 @@ export const listSignalsUseCase = (
     // shows up immediately. Window metrics still drive occurrence stats and are synthesized
     // to zero for signals without any. Search and explicit-id listings keep their own
     // candidate selection.
-    const isDefaultListing = parsed.signalIds === undefined && parsed.search === undefined
+    const shouldLoadEverySignal =
+      parsed.includeAnalytics &&
+      parsed.signalIds === undefined &&
+      parsed.search === undefined &&
+      parsed.textSearchQuery === undefined &&
+      selectedTimeRange === undefined
     const allActiveSignals: SignalWithLifecycle[] = []
-    if (isDefaultListing) {
+    if (shouldLoadEverySignal) {
       for (let page = 0; page < MAX_ALL_SIGNALS_PAGES; page += 1) {
         const signalPage = yield* signalRepository.list({
           projectId: parsed.projectId,
@@ -550,7 +556,7 @@ export const listSignalsUseCase = (
 
     let hasAnySignals = parsed.signalIds !== undefined
     if (!parsed.signalIds) {
-      hasAnySignals = isDefaultListing
+      hasAnySignals = shouldLoadEverySignal
         ? allActiveSignals.length > 0
         : (yield* signalRepository.list({ projectId: parsed.projectId, limit: 1, offset: 0 })).items.length > 0
 
@@ -735,7 +741,7 @@ export const listSignalsUseCase = (
       ? searchCandidates
           .map((candidate) => candidate.signalId)
           .filter((signalId) => windowMetricsBySignalId.has(signalId))
-      : isDefaultListing
+      : shouldLoadEverySignal
         ? allActiveSignalIds
         : windowMetrics.map((metric) => metric.signalId)
     // When the caller passed an explicit `signalIds` filter, include those
@@ -796,10 +802,10 @@ export const listSignalsUseCase = (
     )
     const forceIncludeSignalIds = parsed.signalIds
       ? new Set<string>(parsed.signalIds)
-      : isDefaultListing
+      : shouldLoadEverySignal
         ? new Set<string>(allActiveSignalIds)
         : null
-    const canonicalSignals = isDefaultListing
+    const canonicalSignals = shouldLoadEverySignal
       ? allActiveSignals
       : yield* signalRepository
           .findByIds({
@@ -860,7 +866,7 @@ export const listSignalsUseCase = (
     const priorityCounts = toPriorityCounts(tableCandidates)
 
     const occurrencesSum = tableCandidates.reduce((sum, candidate) => sum + candidate.windowMetric.occurrences, 0)
-    const pageCandidates = tableCandidates.slice(parsed.offset, parsed.offset + parsed.limit)
+    const pageCandidates = parsed.includeItems ? tableCandidates.slice(parsed.offset, parsed.offset + parsed.limit) : []
     const pageSignalIds = pageCandidates.map((candidate) => candidate.issue.id)
     const trendTimeRange = resolveTrendTimeRange({
       timeRange: parsed.timeRange,

--- a/packages/domain/signals/src/use-cases/list-signals.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.ts
@@ -512,10 +512,6 @@ const toAnalyticsCounts = (candidates: readonly AnalyticsCandidate[]): SignalLis
   seenOccurrences: candidates.reduce((sum, candidate) => sum + candidate.windowMetric.occurrences, 0),
 })
 
-/** Page size + max pages when loading every active signal for the default listing. */
-const ALL_SIGNALS_PAGE_SIZE = 500
-const MAX_ALL_SIGNALS_PAGES = 40
-
 export const listSignalsUseCase = (
   input: ListSignalsInput,
 ): Effect.Effect<
@@ -530,35 +526,10 @@ export const listSignalsUseCase = (
     const now = parsed.now ?? new Date()
     const selectedTimeRange = toScoreAnalyticsTimeRange(parsed.timeRange)
 
-    // The default listing (no search, no explicit ids) surfaces EVERY active signal in
-    // the project — including ones with no occurrences yet — so a freshly created signal
-    // shows up immediately. Window metrics still drive occurrence stats and are synthesized
-    // to zero for signals without any. Search and explicit-id listings keep their own
-    // candidate selection.
-    const shouldLoadEverySignal =
-      parsed.includeAnalytics &&
-      parsed.signalIds === undefined &&
-      parsed.search === undefined &&
-      parsed.textSearchQuery === undefined &&
-      selectedTimeRange === undefined
-    const allActiveSignals: SignalWithLifecycle[] = []
-    if (shouldLoadEverySignal) {
-      for (let page = 0; page < MAX_ALL_SIGNALS_PAGES; page += 1) {
-        const signalPage = yield* signalRepository.list({
-          projectId: parsed.projectId,
-          limit: ALL_SIGNALS_PAGE_SIZE,
-          offset: page * ALL_SIGNALS_PAGE_SIZE,
-        })
-        allActiveSignals.push(...signalPage.items)
-        if (!signalPage.hasMore) break
-      }
-    }
-
     let hasAnySignals = parsed.signalIds !== undefined
     if (!parsed.signalIds) {
-      hasAnySignals = shouldLoadEverySignal
-        ? allActiveSignals.length > 0
-        : (yield* signalRepository.list({ projectId: parsed.projectId, limit: 1, offset: 0 })).items.length > 0
+      hasAnySignals =
+        (yield* signalRepository.list({ projectId: parsed.projectId, limit: 1, offset: 0 })).items.length > 0
 
       if (!hasAnySignals) {
         const histogramTimeRange = resolveHistogramTimeRange({
@@ -736,14 +707,11 @@ export const listSignalsUseCase = (
     const [windowMetrics, searchCandidates] = yield* Effect.all([windowMetricsEffect, searchCandidatesEffect])
 
     const windowMetricsBySignalId = new Map(windowMetrics.map((metric) => [metric.signalId, metric] as const))
-    const allActiveSignalIds = allActiveSignals.map((issue) => issue.id)
     const baseCandidateIds = parsed.search
       ? searchCandidates
           .map((candidate) => candidate.signalId)
           .filter((signalId) => windowMetricsBySignalId.has(signalId))
-      : shouldLoadEverySignal
-        ? allActiveSignalIds
-        : windowMetrics.map((metric) => metric.signalId)
+      : windowMetrics.map((metric) => metric.signalId)
     // When the caller passed an explicit `signalIds` filter, include those
     // issues in the candidate set even if they had no activity in the
     // window — they get synthesized zero `windowMetric` rows below so the
@@ -800,19 +768,13 @@ export const listSignalsUseCase = (
     const searchScoresBySignalId = new Map(
       searchCandidates.map((candidate) => [candidate.signalId, candidate.score] as const),
     )
-    const forceIncludeSignalIds = parsed.signalIds
-      ? new Set<string>(parsed.signalIds)
-      : shouldLoadEverySignal
-        ? new Set<string>(allActiveSignalIds)
-        : null
-    const canonicalSignals = shouldLoadEverySignal
-      ? allActiveSignals
-      : yield* signalRepository
-          .findByIds({
-            projectId: parsed.projectId,
-            signalIds: candidateSignalIds,
-          })
-          .pipe(Effect.withSpan("issues.listSignals.findByIds"))
+    const forceIncludeSignalIds = parsed.signalIds ? new Set<string>(parsed.signalIds) : null
+    const canonicalSignals = yield* signalRepository
+      .findByIds({
+        projectId: parsed.projectId,
+        signalIds: candidateSignalIds,
+      })
+      .pipe(Effect.withSpan("issues.listSignals.findByIds"))
 
     const matchedSignalIds = canonicalSignals.map((issue) => issue.id)
 


### PR DESCRIPTION
## What changed

Speeds up the Signals page server reads by avoiding the expensive "load every signal in the project" pass for table-page reads, and by letting the analytics request skip page item enrichment it does not render.

Datadog showed `listSignals` taking 4–18s and `getSignalsAnalytics` taking up to ~9s in production. The slow traces spent most of their time inside `issues.listSignals` before the instrumented ClickHouse spans; the ClickHouse child spans were sub-250ms. The uninstrumented work mapped to the default-listing path loading every signal from Postgres in 500-row pages before the table-row query or analytics response.

## Behavior preserved

The table data path still uses `signalRepository.listTableRows`, so filtering and ordering by Signals table columns remain server-side and unchanged. Per-row aggregate values are still loaded separately through `getSignalRowMetrics`, preserving occurrences, affected sessions %, and row trend behavior.

For the analytics-only request, the use case still computes the filtered candidate set, counts, priority counts, assignee counts, occurrence sum, and histogram, but it no longer runs page-only enrichments (`listBySignalIds`, trend, tags, occurrence detail) or returns page items.

## Validation

- `pnpm --filter @domain/signals test -- src/use-cases/list-signals.test.ts`
- `pnpm --filter @domain/signals typecheck`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @domain/signals check`
- `pnpm --filter @app/web check` (passes with one pre-existing optional-chain warning in `alignment-stats-modal.tsx`)
