### PR TITLE
fix(sandbox-quickjs): eager WASM init to prevent silent ScriptCompileError on load failure

### DIFF
--- a/packages/platform/sandbox-quickjs/src/runtime.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.ts
@@ -388,4 +388,16 @@ export const createQuickJsScriptRuntime = (): ScriptRuntimeShape => {
   }
 }
 
-export const QuickJsScriptRuntimeLive = Layer.succeed(ScriptRuntime, createQuickJsScriptRuntime())
+// Pre-warm the WASM module at layer construction so a load failure
+// surfaces as a worker startup defect rather than a ScriptCompileError.
+export const QuickJsScriptRuntimeLive = Layer.effect(
+  ScriptRuntime,
+  Effect.tryPromise({
+    try: async () => {
+      await getQuickJS()
+      return createQuickJsScriptRuntime()
+    },
+    catch: (error) =>
+      new Error(`QuickJS WASM initialization failed: ${error instanceof Error ? error.message : String(error)}`),
+  }).pipe(Effect.orDie),
+)


### PR DESCRIPTION
## What does this PR do?

Fixes a production error where `getQuickJS()` WASM initialization failures on an ECS instance were silently swallowed and re-emitted as `EvaluationExecutionError: require is not a function` on every evaluation compile call until the container was replaced.

**Root cause:** `QuickJsScriptRuntimeLive` was built with `Layer.succeed`, which calls `createQuickJsScriptRuntime()` synchronously at module load time but defers `getQuickJS()` to the first `compile()` call. When `getQuickJS()` fails, `quickjs-emscripten` caches the rejected promise — so the same failure is replayed on every subsequent call. The `compile()` catch handler wraps any non-`ScriptCompileError` as a `ScriptCompileError`, producing 21 consecutive `EvaluationExecutionError: require is not a function` errors from a single ECS instance over 32 minutes before the container was replaced.

**Fix:** Switch `QuickJsScriptRuntimeLive` from `Layer.succeed` (lazy) to `Layer.effect` (async, eager). `getQuickJS()` is now awaited once at layer construction time before the runtime shape is returned. On success the WASM singleton is warm for all later `compile`/`run` calls (no performance impact — `getQuickJS()` returns the cached resolved promise). On failure, `Effect.orDie` causes the activity to die immediately at startup with a clear message (`QuickJS WASM initialization failed: …`), letting Temporal retry the activity and ECS replace the container rather than masking the infrastructure error as an evaluation failure.

The change is a single export at the bottom of `packages/platform/sandbox-quickjs/src/runtime.ts`. `createQuickJsScriptRuntime()` is unchanged (tests call it directly and still pass).

## Related issue (if applicable)

Closes #

## How was this tested?

- All 35 existing unit tests in `@platform/sandbox-quickjs` pass (`pnpm --filter @platform/sandbox-quickjs test`)
- `pnpm --filter @platform/sandbox-quickjs typecheck` passes
- Pre-existing typecheck errors in `@domain/evaluations` and `@app/workflows` (unrelated `@latitude-data/telemetry` module) were confirmed present on `development` before this change
- Datadog Error Tracking: 21 occurrences of `EvaluationExecutionError: require is not a function`, all from a single ECS instance (`ip-10-1-51-205.eu-central-1.compute.internal`), all within 32 minutes of the `feat(signals)` deploy (67fb9449, 2026-06-26) — zero new occurrences after the instance was replaced

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKswgcgRRqHRePFssk5fx)_