### PR TITLE
fix(web): normalize hyphenated UUIDs at trace ID input boundaries

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -31,6 +31,8 @@ import {
   getWorkflowStarter,
 } from "../../server/clients.ts"
 
+const normalizeTraceId = z.string().transform((s) => s.replace(/-/g, ""))
+
 const toRecord = (score: AnnotationScore) => ({
   id: score.id as string,
   organizationId: score.organizationId,
@@ -90,7 +92,7 @@ export const createAnnotation = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceId: z.string().length(32),
+      traceId: normalizeTraceId,
       spanId: z.string().optional(),
       sessionId: z.string().optional(),
       queueId: z.string().optional(),
@@ -143,7 +145,7 @@ export const updateAnnotation = createServerFn({ method: "POST" })
     z.object({
       scoreId: z.string(),
       projectId: z.string(),
-      traceId: z.string().length(32),
+      traceId: normalizeTraceId,
       queueId: z.string().optional(),
       value: z.number(),
       passed: z.boolean(),
@@ -205,7 +207,7 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       limit: z.number().optional(),
       offset: z.number().optional(),
       draftMode: scoreDraftModeSchema.optional(),
@@ -238,7 +240,7 @@ export const listAnnotationsBySession = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string().length(32)).max(500),
+      traceIds: z.array(normalizeTraceId).max(500),
       limit: z.number().optional(),
       offset: z.number().optional(),
       draftMode: scoreDraftModeSchema.optional(),
@@ -275,7 +277,7 @@ export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
       projectId: z.string(),
-      traceIds: z.array(z.string().length(32)).max(500),
+      traceIds: z.array(normalizeTraceId).max(500),
       draftMode: scoreDraftModeSchema.optional(),
     }),
   )

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -14,6 +14,8 @@ const dateTimeParamSchema = z
   .datetime()
   .transform((value) => new Date(value))
 
+const normalizeTraceId = z.string().transform((s) => s.replace(/-/g, ""))
+
 export interface SpanRecord {
   readonly organizationId: string
   readonly projectId: string
@@ -148,7 +150,7 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       startTimeFrom: dateTimeParamSchema.optional(),
       startTimeTo: dateTimeParamSchema.optional(),
     }),
@@ -226,7 +228,7 @@ export const listConversationMessageSpans = createServerFn({ method: "GET" })
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       startTime: dateTimeParamSchema,
     }),
   )
@@ -279,7 +281,7 @@ export const getSpanDetail = createServerFn({ method: "GET" })
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       spanId: z.string(),
       startTimeFrom: dateTimeParamSchema.optional(),
       startTimeTo: dateTimeParamSchema.optional(),

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -164,10 +164,12 @@ export interface TraceConversationChunkRecord {
   readonly payloadBytes: number
 }
 
+const normalizeTraceId = z.string().transform((s) => s.replace(/-/g, ""))
+
 const traceListCursorSchema = z.object({
   sortValue: z.string(),
   secondaryValue: z.string().optional(),
-  traceId: z.string(),
+  traceId: normalizeTraceId,
 })
 
 interface TraceListResult {
@@ -353,7 +355,7 @@ export const getTraceSearchHighlights = createServerFn({ method: "GET" })
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       searchQuery: z.string().max(500),
     }),
   )
@@ -437,7 +439,7 @@ export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
   })
 
 export const getTraceDetail = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: z.string() }))
+  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: normalizeTraceId }))
   .handler(async ({ data }) => {
     const orgId = await resolveOrgScope(data)
 
@@ -467,7 +469,7 @@ export const getTraceConversationChunk = createServerFn({ method: "GET" })
     z.object({
       sandboxOrgId: z.string().optional(),
       projectId: z.string(),
-      traceId: z.string(),
+      traceId: normalizeTraceId,
       offset: z.number().int().nonnegative().optional(),
       limit: z.number().int().positive().max(100).optional(),
     }),


### PR DESCRIPTION
## Summary

- Adds a `normalizeTraceId` transform (`z.string().transform(s => s.replace(/-/g, ""))`) at every web server function that accepts a trace ID as input
- Covers `traces.functions.ts` (4 endpoints), `annotations.functions.ts` (5 endpoints), and `spans.functions.ts` (3 endpoints)
- Also fixes the previous `z.string().length(32)` validators in `createAnnotation` / `updateAnnotation` / `listAnnotationsBySession` / `listAnnotationCountsByTraceIds` which were rejecting valid 36-char hyphenated UUIDs with a Zod "Too big" error

## Root cause

ClickHouse `FixedString(32)` expects exactly 32 bytes. OTel trace IDs are 32-char hex strings, but some callers pass standard UUID format with hyphens (36 chars). This caused two distinct production errors:

- **"Too large value for FixedString(32)"** (17 occurrences, last seen Jun 23) — 36-char UUID reached ClickHouse directly via `TraceId(data.traceId)` cast in the handler
- **"Too big: <=32 characters"** (16 occurrences, last seen Jun 23) — 36-char UUID failed `z.string().length(32)` Zod validation before reaching ClickHouse at all

Both errors hit the same underlying mismatch: the web layer accepted `z.string()` or `z.string().length(32)` without stripping hyphens first.

## Fix

Normalize at the boundary — strip hyphens so a standard UUID (`8e3479ca-2854-49a2-b753-bc2482da9a59`) becomes the canonical 32-char hex (`8e3479ca285449a2b753bc2482da9a59`) before any downstream use. Both 32-char hex and 36-char UUID inputs pass through cleanly; anything else still fails at ClickHouse with a clear error.

## Validation

- Biome: clean (`Checked 3 files. No fixes applied.`)
- TypeScript: no errors from changed files (`pnpm --filter web typecheck` — pre-existing unrelated `@latitude-data/telemetry` errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWkUKw7bQj7JXkN1q2Upu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWkUKw7bQj7JXkN1q2Upu4)_