### PR TITLE
fix(ingest): normalize hyphenated UUID trace IDs at ingest time

### DIFF
--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -235,3 +235,73 @@ describe("transformOtlpToSpans per-span project resolution", () => {
     expect(spans[1]?.projectId).toBe("proj-default")
   })
 })
+
+describe("transformOtlpToSpans trace ID normalization", () => {
+  const ctx = {
+    ...baseContext,
+    defaultProjectId: "proj-default",
+    projectIdBySlug: new Map<string, string>(),
+  }
+
+  it("strips hyphens from a UUID-format trace ID", () => {
+    const { spans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: "0af76519-16cd-43dd-8448-eb211c80319c",
+                    spanId: "n1",
+                    name: "n1",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    )
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.traceId).toBe("0af7651916cd43dd8448eb211c80319c")
+  })
+
+  it("leaves a valid 32-char hex trace ID unchanged", () => {
+    const { spans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "n2",
+                    name: "n2",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    )
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.traceId).toBe("0af7651916cd43dd8448eb211c80319c")
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -173,7 +173,7 @@ function transformSpan({
     sessionId: SessionId(resolved.sessionId),
     userId: ExternalUserId(resolved.userId),
     userEmail: resolved.userEmail,
-    traceId: TraceId(span.traceId),
+    traceId: TraceId(span.traceId.replace(/-/g, "")),
     spanId: SpanId(span.spanId),
     parentSpanId: span.parentSpanId ?? "",
     apiKeyId: context.apiKeyId,


### PR DESCRIPTION
## Summary

- In `packages/domain/spans/src/otlp/transform.ts`, strip hyphens from the incoming `span.traceId` before wrapping it in `TraceId()`: `span.traceId.replace(/-/g, "")`
- One-line change at the single point where OTel span trace IDs enter the system

## Root cause

Per the W3C Trace Context spec and OTel specification, a trace ID is exactly **32 lowercase hex characters with no separators**. Some customer SDKs send trace IDs in UUID format (`8e3479ca-2854-49a2-b753-bc2482da9a59`, 36 chars), which is non-compliant but common in practice.

The ingest pipeline previously stored trace IDs verbatim — `TraceId()` is a type cast with no runtime validation. The 36-char UUID would be written to ClickHouse's `FixedString(32)` columns which silently accepted the write in some paths but then rejected parameterized query lookups with **"Too large value for FixedString(32)"** (17 occurrences in production, last seen Jun 23).

## Fix

Normalize at the single entry point in the OTel transform: strip hyphens before assigning the trace ID. Both compliant (32-char hex) and non-compliant (36-char UUID) inputs produce the correct 32-char hex output. Already-valid inputs are unchanged (no hyphens to strip).

## Validation

- Biome: clean
- Single-character change in a pure data transform — no schema, migration, or behavior change for compliant inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWkUKw7bQj7JXkN1q2Upu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWkUKw7bQj7JXkN1q2Upu4)_