### PR TITLE
feat(evaluations): run evaluations against a session runtime context

### DIFF
--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -11,6 +11,8 @@ import {
 import {
   type ClickHouseClient,
   ScoreAnalyticsRepositoryLive,
+  SessionRepositoryLive,
+  SpanRepositoryLive,
   TraceRepositoryLive,
   withClickHouse,
 } from "@platform/db-clickhouse"
@@ -161,7 +163,7 @@ export const createLiveEvaluationsWorker = ({
       Effect.provide(RedisBillingSpendReservationLive(rdClient)),
       Effect.provide(RedisDetectorHealthTrackerLive(rdClient)),
       withClickHouse(
-        Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive),
+        Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive, SessionRepositoryLive, SpanRepositoryLive),
         chClient,
         OrganizationId(payload.organizationId),
       ),

--- a/packages/domain/evaluations/src/codegen/compile-settings-to-script.test.ts
+++ b/packages/domain/evaluations/src/codegen/compile-settings-to-script.test.ts
@@ -25,4 +25,11 @@ describe("compileSettingsToScript", () => {
     const interpolations = script.match(/\$\{[^}]+\}/g) ?? []
     expect(interpolations).toEqual([EVALUATION_CONVERSATION_PLACEHOLDER])
   })
+
+  it("interpolates session.conversation, not the legacy bare conversation global", () => {
+    expect(EVALUATION_CONVERSATION_PLACEHOLDER).toBe("${session.conversation}")
+    const script = compileSettingsToScript({ kind: "judge", criteria: "x" })
+    expect(script).toContain("${session.conversation}")
+    expect(script).not.toContain("${conversation}")
+  })
 })

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -174,12 +174,10 @@ export {
 export {
   type ExecuteLiveEvaluationError,
   executeLiveEvaluationUseCase,
-  type LiveEvaluationConversationInput,
   type LiveEvaluationExecutionInput,
   type LiveEvaluationExecutionResult,
   type LiveEvaluationResultPayload,
   type LiveEvaluationSignalContext,
-  liveEvaluationConversationInputSchema,
   liveEvaluationExecutionInputSchema,
   liveEvaluationExecutionResultSchema,
   liveEvaluationResultPayloadSchema,

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -141,6 +141,7 @@ export {
   toEvaluationExecutionResult,
   wrapPromptAsEvaluationScript,
 } from "./runtime/evaluation-execution.ts"
+export { loadScriptSessionContext } from "./runtime/load-session-context.ts"
 export { executeEvaluationScriptSandboxed } from "./runtime/sandbox-execution.ts"
 export { collectAlignmentExamplesUseCase } from "./use-cases/alignment/collect-alignment-examples.ts"
 export { evaluateBaselineDraftUseCase } from "./use-cases/alignment/evaluate-baseline-draft.ts"

--- a/packages/domain/evaluations/src/live-execution.test.ts
+++ b/packages/domain/evaluations/src/live-execution.test.ts
@@ -1,5 +1,5 @@
 import { createFakeAI } from "@domain/ai/testing"
-import { ScriptRuntimeError } from "@domain/sandbox"
+import { minimalScriptSession, ScriptRuntimeError } from "@domain/sandbox"
 import { createFakeScriptRuntime } from "@domain/sandbox/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -13,16 +13,10 @@ import {
 
 const evaluationId = "eeeeeeeeeeeeeeeeeeeeeeee"
 
-const allMessages = [
-  {
-    role: "user",
-    parts: [{ type: "text", content: "Please summarize the deployment checklist." }],
-  },
-  {
-    role: "assistant",
-    parts: [{ type: "text", content: "Verify migrations, rollback steps, and dashboards after deploy." }],
-  },
-] as const
+const session = minimalScriptSession([
+  { role: "user", content: "Please summarize the deployment checklist." },
+  { role: "assistant", content: "Verify migrations, rollback steps, and dashboards after deploy." },
+])
 
 const validScript = wrapPromptAsEvaluationScript(
   [
@@ -38,11 +32,7 @@ const validScript = wrapPromptAsEvaluationScript(
 const validInput = liveEvaluationExecutionInputSchema.parse({
   evaluationId,
   script: validScript,
-  issue: {
-    name: "Deployment checklist omission",
-    description: "The assistant fails to mention key deployment steps.",
-  },
-  conversation: allMessages,
+  session,
 })
 
 describe("executeLiveEvaluationUseCase", () => {
@@ -52,17 +42,14 @@ describe("executeLiveEvaluationUseCase", () => {
     expect(
       liveEvaluationExecutionInputSchema.safeParse({
         ...validInput,
-        issue: {
-          name: "",
-          description: validInput.issue.description,
-        },
+        script: "",
       }).success,
     ).toBe(false)
 
     expect(
       liveEvaluationExecutionInputSchema.safeParse({
         ...validInput,
-        conversation: ["not-a-message"],
+        session: "not-a-session",
       }).success,
     ).toBe(false)
   })
@@ -132,8 +119,7 @@ describe("executeLiveEvaluationUseCase", () => {
     )
     expect(fakeRuntime.calls.compile).toHaveLength(1)
     expect(fakeRuntime.calls.run).toHaveLength(1)
-    expect(fakeRuntime.calls.run[0]?.context.conversation[0]?.role).toBe("user")
-    expect(fakeRuntime.calls.run[0]?.context.issue?.name).toBe("Deployment checklist omission")
+    expect(fakeRuntime.calls.run[0]?.context.session.conversation[0]?.role).toBe("user")
     expect(aiCalls.generate).toHaveLength(0)
   })
 

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.ts
@@ -26,7 +26,7 @@ if (result.passed) {
   return Failed(0, result.feedback)
 }`
 
-export const EVALUATION_CONVERSATION_PLACEHOLDER = ["${", "conversation}"].join("")
+export const EVALUATION_CONVERSATION_PLACEHOLDER = ["${", "session.conversation}"].join("")
 
 export interface EvaluationConversationMessage {
   readonly role: string

--- a/packages/domain/evaluations/src/runtime/load-session-context.test.ts
+++ b/packages/domain/evaluations/src/runtime/load-session-context.test.ts
@@ -1,0 +1,155 @@
+import { ChSqlClient, ExternalUserId, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import { SessionRepository, type SessionToolSpan, type Span, SpanRepository, type TraceDetail } from "@domain/spans"
+import { createFakeSessionRepository, createFakeSpanRepository, stubListSpan } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { loadScriptSessionContext } from "./load-session-context.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const traceA = TraceId("a".repeat(32))
+const traceB = TraceId("b".repeat(32))
+const sessionId = SessionId("session-1")
+
+const span = (overrides: Partial<Span> & Pick<Span, "traceId" | "spanId">): Span => ({
+  ...stubListSpan({
+    organizationId,
+    projectId,
+    traceId: overrides.traceId,
+    sessionId,
+    spanId: overrides.spanId,
+    operation: "chat",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:00.500Z"),
+  }),
+  ...overrides,
+})
+
+const traceDetail: TraceDetail = {
+  organizationId,
+  projectId,
+  traceId: traceA,
+  spanCount: 3,
+  errorCount: 1,
+  startTime: new Date("2026-01-01T00:00:00.000Z"),
+  endTime: new Date("2026-01-01T00:00:01.000Z"),
+  durationNs: 1_000_000_000,
+  timeToFirstTokenNs: 0,
+  tokensInput: 120,
+  tokensOutput: 80,
+  tokensCacheRead: 0,
+  tokensCacheCreate: 0,
+  tokensReasoning: 0,
+  tokensTotal: 200,
+  costInputMicrocents: 50,
+  costOutputMicrocents: 25,
+  costTotalMicrocents: 75,
+  sessionId,
+  userId: ExternalUserId("user"),
+  userEmail: "",
+  simulationId: "",
+  tags: [],
+  metadata: {},
+  models: ["gpt-4o-mini"],
+  providers: ["openai"],
+  serviceNames: ["web"],
+  rootSpanId: SpanId("r".repeat(16)),
+  rootSpanName: "root",
+  systemInstructions: [],
+  inputMessages: [],
+  outputMessages: [],
+  allMessages: [
+    { role: "user", parts: [{ type: "text", content: "summarize the deploy" }] },
+    { role: "assistant", parts: [{ type: "text", content: "migrations, rollback, dashboards" }] },
+  ],
+}
+
+const longInput = "x".repeat(5_000)
+
+const runLoader = (input: { spans: readonly Span[]; toolSpans: readonly SessionToolSpan[] }) => {
+  const { repository: sessionRepository } = createFakeSessionRepository()
+  const { repository: spanRepository } = createFakeSpanRepository({
+    listBySessionId: () => Effect.succeed(input.spans),
+    listToolSpansBySessionId: () => Effect.succeed(input.toolSpans),
+  })
+  return Effect.runPromise(
+    loadScriptSessionContext({ organizationId, projectId, traceDetail }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(SessionRepository, sessionRepository),
+          Layer.succeed(SpanRepository, spanRepository),
+          Layer.succeed(ChSqlClient, {} as never),
+        ),
+      ),
+    ),
+  )
+}
+
+describe("loadScriptSessionContext", () => {
+  it("builds the deduped conversation from the trace when the session aggregate is absent", async () => {
+    const session = await runLoader({ spans: [], toolSpans: [] })
+    expect(session.conversation).toEqual([
+      { role: "user", content: "summarize the deploy" },
+      { role: "assistant", content: "migrations, rollback, dashboards" },
+    ])
+  })
+
+  it("groups spans into per-trace rollups (metrics, models, providers, finish reasons, status)", async () => {
+    const session = await runLoader({
+      spans: [
+        span({
+          traceId: traceA,
+          spanId: SpanId("a1".padEnd(16, "0")),
+          name: "root",
+          model: "gpt-4o",
+          provider: "openai",
+          finishReasons: ["stop"],
+          tokensInput: 10,
+          tokensOutput: 5,
+          costTotalMicrocents: 7,
+        }),
+        span({
+          traceId: traceA,
+          spanId: SpanId("a2".padEnd(16, "0")),
+          parentSpanId: "a1".padEnd(16, "0"),
+          model: "gpt-4o",
+          finishReasons: ["length"],
+          tokensInput: 3,
+          tokensOutput: 0,
+        }),
+        span({ traceId: traceB, spanId: SpanId("b1".padEnd(16, "0")), statusCode: "error", errorType: "Timeout" }),
+      ],
+      toolSpans: [],
+    })
+
+    expect(session.traces).toHaveLength(2)
+    const a = session.traces.find((t) => t.id === traceA)
+    expect(a?.models).toEqual(["gpt-4o"])
+    expect(a?.providers).toEqual(["openai"])
+    expect(a?.finishReasons).toEqual(["stop", "length"])
+    expect(a?.status).toBe("ok")
+    expect(a?.spanCount).toBe(2)
+    expect(a?.tokens.input).toBe(13)
+
+    const b = session.traces.find((t) => t.id === traceB)
+    expect(b?.status).toBe("error")
+    expect(b?.errorCount).toBe(1)
+  })
+
+  it("projects tool spans per trace and truncates their I/O", async () => {
+    const session = await runLoader({
+      spans: [span({ traceId: traceA, spanId: SpanId("a1".padEnd(16, "0")) })],
+      toolSpans: [
+        { traceId: traceA, name: "search", input: longInput, output: "ok", error: false, durationNs: 42 },
+        { traceId: traceA, name: "delete", input: "{}", output: "boom", error: true, durationNs: 7 },
+      ],
+    })
+
+    const tools = session.traces.find((t) => t.id === traceA)?.tools ?? []
+    expect(tools).toHaveLength(2)
+    expect(tools[0]?.name).toBe("search")
+    expect(tools[0]?.input.length).toBeLessThan(longInput.length)
+    expect(tools[0]?.input.endsWith("…")).toBe(true)
+    expect(tools[1]).toMatchObject({ name: "delete", error: true, duration: 7 })
+  })
+})

--- a/packages/domain/evaluations/src/runtime/load-session-context.test.ts
+++ b/packages/domain/evaluations/src/runtime/load-session-context.test.ts
@@ -1,5 +1,12 @@
 import { ChSqlClient, ExternalUserId, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
-import { SessionRepository, type SessionToolSpan, type Span, SpanRepository, type TraceDetail } from "@domain/spans"
+import {
+  type SessionDetail,
+  SessionRepository,
+  type SessionToolSpan,
+  type Span,
+  SpanRepository,
+  type TraceDetail,
+} from "@domain/spans"
 import { createFakeSessionRepository, createFakeSpanRepository, stubListSpan } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -66,8 +73,52 @@ const traceDetail: TraceDetail = {
 
 const longInput = "x".repeat(5_000)
 
-const runLoader = (input: { spans: readonly Span[]; toolSpans: readonly SessionToolSpan[] }) => {
-  const { repository: sessionRepository } = createFakeSessionRepository()
+const sessionDetail: SessionDetail = {
+  organizationId,
+  projectId,
+  sessionId,
+  traceCount: 2,
+  traceIds: [traceA as string],
+  spanCount: 5,
+  errorCount: 0,
+  startTime: new Date("2026-01-01T00:00:00.000Z"),
+  endTime: new Date("2026-01-01T00:00:02.000Z"),
+  lastActivityTime: new Date("2026-01-01T00:00:02.000Z"),
+  durationNs: 2_000_000_000,
+  timeToFirstTokenNs: 100,
+  tokensInput: 200,
+  tokensOutput: 100,
+  tokensCacheRead: 0,
+  tokensCacheCreate: 0,
+  tokensReasoning: 0,
+  tokensTotal: 300,
+  costInputMicrocents: 600,
+  costOutputMicrocents: 399,
+  costTotalMicrocents: 999,
+  userId: ExternalUserId("rollup-user"),
+  userEmail: "",
+  simulationId: "",
+  tags: ["rollup"],
+  metadata: { src: "rollup" },
+  models: ["gpt-4o"],
+  providers: ["openai"],
+  serviceNames: ["web"],
+  rootSpanId: "",
+  rootSpanName: "root",
+  systemInstructions: [],
+  inputMessages: [],
+  lastInputMessages: [{ role: "user", parts: [{ type: "text", content: "rollup question" }] }],
+  outputMessages: [{ role: "assistant", parts: [{ type: "text", content: "rollup answer" }] }],
+}
+
+const runLoader = (input: {
+  spans: readonly Span[]
+  toolSpans: readonly SessionToolSpan[]
+  sessionDetail?: SessionDetail
+}) => {
+  const { repository: sessionRepository } = createFakeSessionRepository(
+    input.sessionDetail ? { findBySessionId: () => Effect.succeed(input.sessionDetail as SessionDetail) } : undefined,
+  )
   const { repository: spanRepository } = createFakeSpanRepository({
     listBySessionId: () => Effect.succeed(input.spans),
     listToolSpansBySessionId: () => Effect.succeed(input.toolSpans),
@@ -92,6 +143,43 @@ describe("loadScriptSessionContext", () => {
       { role: "user", content: "summarize the deploy" },
       { role: "assistant", content: "migrations, rollback, dashboards" },
     ])
+  })
+
+  it("builds conversation and aggregates from the session rollup when present", async () => {
+    const session = await runLoader({
+      sessionDetail,
+      spans: [span({ traceId: traceA, spanId: SpanId("a1".padEnd(16, "0")) })],
+      toolSpans: [],
+    })
+    // conversation comes from the rollup reconstruction (system + lastInput + outputs), not the trace
+    expect(session.conversation).toEqual([
+      { role: "user", content: "rollup question" },
+      { role: "assistant", content: "rollup answer" },
+    ])
+    // session-level aggregates come from the rollup, not the trace fallback (traceCount 1 / cost 75 / tokens 200)
+    expect(session.id).toBe("session-1")
+    expect(session.traceCount).toBe(2)
+    expect(session.cost.total).toBe(999)
+    expect(session.tokens.total).toBe(300)
+    expect(session.tags).toEqual(["rollup"])
+    // per-trace rollups are still assembled from the session's spans
+    expect(session.traces).toHaveLength(1)
+  })
+
+  it("falls back to the earliest span for per-trace duration when no root span is present", async () => {
+    const session = await runLoader({
+      spans: [
+        span({
+          traceId: traceA,
+          spanId: SpanId("a1".padEnd(16, "0")),
+          parentSpanId: "p".repeat(16), // no span with parentSpanId === "" → root falls back to group[0]
+          startTime: new Date("2026-01-01T00:00:00.000Z"),
+          endTime: new Date("2026-01-01T00:00:00.250Z"),
+        }),
+      ],
+      toolSpans: [],
+    })
+    expect(session.traces[0]?.duration).toBe(250_000_000)
   })
 
   it("groups spans into per-trace rollups (metrics, models, providers, finish reasons, status)", async () => {

--- a/packages/domain/evaluations/src/runtime/load-session-context.ts
+++ b/packages/domain/evaluations/src/runtime/load-session-context.ts
@@ -1,0 +1,202 @@
+import type {
+  ScriptCostBreakdown,
+  ScriptSessionContext,
+  ScriptTokenBreakdown,
+  ScriptToolContext,
+  ScriptTraceContext,
+} from "@domain/sandbox"
+import { type ChSqlClient, type OrganizationId, type ProjectId, type RepositoryError, SessionId } from "@domain/shared"
+import {
+  type SessionDetail,
+  SessionRepository,
+  type SessionToolSpan,
+  type Span,
+  SpanRepository,
+  type TraceDetail,
+} from "@domain/spans"
+import { Effect } from "effect"
+import { type EvaluationConversationMessage, toEvaluationConversationMessages } from "./evaluation-execution.ts"
+
+const TOOL_IO_MAX_CHARS = 4_000
+
+const truncate = (value: string): string =>
+  value.length > TOOL_IO_MAX_CHARS ? `${value.slice(0, TOOL_IO_MAX_CHARS)}…` : value
+
+const distinct = (values: readonly string[]): string[] => [...new Set(values.filter((value) => value !== ""))]
+
+const sessionDuration = (start: Date, end: Date): number => (end.getTime() - start.getTime()) * 1_000_000
+
+/**
+ * Deduped, session-wide readable transcript: opening system instructions + the last responsive trace's
+ * input + outputs (mirrors `analyze-session`'s reconstruction, avoiding the per-span input-accumulation
+ * blowup). This is the single message store the script reads as `session.conversation`.
+ */
+const reconstructConversation = (session: SessionDetail): readonly EvaluationConversationMessage[] => {
+  const systemMessage =
+    Array.isArray(session.systemInstructions) && session.systemInstructions.length > 0
+      ? [{ role: "system", parts: session.systemInstructions }]
+      : []
+  const messages = [...systemMessage, ...session.lastInputMessages, ...session.outputMessages]
+  return toEvaluationConversationMessages(messages as Parameters<typeof toEvaluationConversationMessages>[0])
+}
+
+const buildTools = (toolSpans: readonly SessionToolSpan[]): Map<string, ScriptToolContext[]> => {
+  const byTrace = new Map<string, ScriptToolContext[]>()
+  for (const tool of toolSpans) {
+    const tools = byTrace.get(tool.traceId) ?? []
+    tools.push({
+      name: tool.name,
+      input: truncate(tool.input),
+      output: truncate(tool.output),
+      error: tool.error,
+      duration: tool.durationNs,
+    })
+    byTrace.set(tool.traceId, tools)
+  }
+  return byTrace
+}
+
+const buildTraces = (spans: readonly Span[], toolSpans: readonly SessionToolSpan[]): ScriptTraceContext[] => {
+  const toolsByTrace = buildTools(toolSpans)
+  const byTrace = new Map<string, Span[]>()
+  for (const span of spans) {
+    const group = byTrace.get(span.traceId) ?? []
+    group.push(span)
+    byTrace.set(span.traceId, group)
+  }
+
+  return [...byTrace.entries()].map(([traceId, group]) => {
+    const root = group.find((span) => span.parentSpanId === "") ?? group[0]
+    const cost: ScriptCostBreakdown = {
+      input: group.reduce((sum, s) => sum + s.costInputMicrocents, 0),
+      output: group.reduce((sum, s) => sum + s.costOutputMicrocents, 0),
+      total: group.reduce((sum, s) => sum + s.costTotalMicrocents, 0),
+    }
+    const tokens: ScriptTokenBreakdown = {
+      input: group.reduce((sum, s) => sum + s.tokensInput, 0),
+      output: group.reduce((sum, s) => sum + s.tokensOutput, 0),
+      cacheRead: group.reduce((sum, s) => sum + s.tokensCacheRead, 0),
+      cacheCreate: group.reduce((sum, s) => sum + s.tokensCacheCreate, 0),
+      reasoning: group.reduce((sum, s) => sum + s.tokensReasoning, 0),
+      total: group.reduce((sum, s) => sum + s.tokensInput + s.tokensOutput, 0),
+    }
+    return {
+      id: traceId,
+      name: root?.name ?? "",
+      status: group.some((s) => s.statusCode === "error") ? "error" : "ok",
+      errorCount: group.filter((s) => s.statusCode === "error").length,
+      spanCount: group.length,
+      duration: root ? sessionDuration(root.startTime, root.endTime) : 0,
+      timeToFirstToken: root?.timeToFirstTokenNs ?? 0,
+      cost,
+      tokens,
+      models: distinct(group.map((s) => s.model)),
+      providers: distinct(group.map((s) => s.provider)),
+      finishReasons: distinct(group.flatMap((s) => [...s.finishReasons])),
+      tools: toolsByTrace.get(traceId) ?? [],
+    } satisfies ScriptTraceContext
+  })
+}
+
+const fromSessionDetail = (
+  id: string,
+  session: SessionDetail,
+  conversation: readonly EvaluationConversationMessage[],
+  traces: readonly ScriptTraceContext[],
+): ScriptSessionContext => ({
+  id,
+  traceCount: session.traceCount,
+  spanCount: session.spanCount,
+  errorCount: session.errorCount,
+  duration: session.durationNs,
+  timeToFirstToken: session.timeToFirstTokenNs,
+  cost: {
+    input: session.costInputMicrocents,
+    output: session.costOutputMicrocents,
+    total: session.costTotalMicrocents,
+  },
+  tokens: {
+    input: session.tokensInput,
+    output: session.tokensOutput,
+    total: session.tokensTotal,
+    cacheRead: session.tokensCacheRead,
+    cacheCreate: session.tokensCacheCreate,
+    reasoning: session.tokensReasoning,
+  },
+  startTime: session.startTime.toISOString(),
+  endTime: session.endTime.toISOString(),
+  userId: session.userId,
+  tags: [...session.tags],
+  metadata: { ...session.metadata },
+  conversation,
+  traces,
+})
+
+/** Fallback when the session aggregate is absent (orphan single-trace sessions): build from the trace. */
+const fromTraceDetail = (
+  id: string,
+  trace: TraceDetail,
+  conversation: readonly EvaluationConversationMessage[],
+  traces: readonly ScriptTraceContext[],
+): ScriptSessionContext => ({
+  id,
+  traceCount: 1,
+  spanCount: trace.spanCount,
+  errorCount: trace.errorCount,
+  duration: trace.durationNs,
+  timeToFirstToken: trace.timeToFirstTokenNs,
+  cost: {
+    input: trace.costInputMicrocents,
+    output: trace.costOutputMicrocents,
+    total: trace.costTotalMicrocents,
+  },
+  tokens: {
+    input: trace.tokensInput,
+    output: trace.tokensOutput,
+    total: trace.tokensTotal,
+    cacheRead: trace.tokensCacheRead,
+    cacheCreate: trace.tokensCacheCreate,
+    reasoning: trace.tokensReasoning,
+  },
+  startTime: trace.startTime.toISOString(),
+  endTime: trace.endTime.toISOString(),
+  userId: trace.userId,
+  tags: [...trace.tags],
+  metadata: { ...trace.metadata },
+  conversation,
+  traces,
+})
+
+/**
+ * Assembles the `ScriptSessionContext` an evaluation script runs against, from the triggering trace's
+ * session. Reads the deduped conversation + aggregates from the session rollup, per-trace metrics from
+ * the session's spans, and tool I/O from a focused tool-span read. Orphan sessions (no rollup row) fall
+ * back to the single trace.
+ */
+export const loadScriptSessionContext = (input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly traceDetail: TraceDetail
+}): Effect.Effect<ScriptSessionContext, RepositoryError, SessionRepository | SpanRepository | ChSqlClient> =>
+  Effect.gen(function* () {
+    const sessionId = SessionId(input.traceDetail.sessionId || input.traceDetail.traceId)
+    const scope = { organizationId: input.organizationId, projectId: input.projectId, sessionId }
+
+    const sessionRepository = yield* SessionRepository
+    const spanRepository = yield* SpanRepository
+
+    const sessionDetail = yield* sessionRepository
+      .findBySessionId(scope)
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    const spans = yield* spanRepository.listBySessionId(scope)
+    const toolSpans = yield* spanRepository.listToolSpansBySessionId(scope)
+
+    const traces = buildTraces(spans, toolSpans)
+    const conversation = sessionDetail
+      ? reconstructConversation(sessionDetail)
+      : toEvaluationConversationMessages(input.traceDetail.allMessages)
+
+    return sessionDetail
+      ? fromSessionDetail(sessionId, sessionDetail, conversation, traces)
+      : fromTraceDetail(sessionId, input.traceDetail, conversation, traces)
+  }).pipe(Effect.withSpan("evaluations.loadScriptSessionContext"))

--- a/packages/domain/evaluations/src/runtime/load-session-context.ts
+++ b/packages/domain/evaluations/src/runtime/load-session-context.ts
@@ -24,7 +24,8 @@ const truncate = (value: string): string =>
 
 const distinct = (values: readonly string[]): string[] => [...new Set(values.filter((value) => value !== ""))]
 
-const sessionDuration = (start: Date, end: Date): number => (end.getTime() - start.getTime()) * 1_000_000
+const MS_TO_NS = 1_000_000
+const rootDurationNs = (start: Date, end: Date): number => (end.getTime() - start.getTime()) * MS_TO_NS
 
 /**
  * Deduped, session-wide readable transcript: opening system instructions + the last responsive trace's
@@ -78,7 +79,12 @@ const buildTraces = (spans: readonly Span[], toolSpans: readonly SessionToolSpan
       cacheRead: group.reduce((sum, s) => sum + s.tokensCacheRead, 0),
       cacheCreate: group.reduce((sum, s) => sum + s.tokensCacheCreate, 0),
       reasoning: group.reduce((sum, s) => sum + s.tokensReasoning, 0),
-      total: group.reduce((sum, s) => sum + s.tokensInput + s.tokensOutput, 0),
+      // total = sum of all components so the per-trace breakdown is self-consistent and matches the
+      // session rollup's `tokensTotal` semantics (not just input + output).
+      total: group.reduce(
+        (sum, s) => sum + s.tokensInput + s.tokensOutput + s.tokensCacheRead + s.tokensCacheCreate + s.tokensReasoning,
+        0,
+      ),
     }
     return {
       id: traceId,
@@ -86,7 +92,7 @@ const buildTraces = (spans: readonly Span[], toolSpans: readonly SessionToolSpan
       status: group.some((s) => s.statusCode === "error") ? "error" : "ok",
       errorCount: group.filter((s) => s.statusCode === "error").length,
       spanCount: group.length,
-      duration: root ? sessionDuration(root.startTime, root.endTime) : 0,
+      duration: root ? rootDurationNs(root.startTime, root.endTime) : 0,
       timeToFirstToken: root?.timeToFirstTokenNs ?? 0,
       cost,
       tokens,
@@ -185,11 +191,15 @@ export const loadScriptSessionContext = (input: {
     const sessionRepository = yield* SessionRepository
     const spanRepository = yield* SpanRepository
 
-    const sessionDetail = yield* sessionRepository
-      .findBySessionId(scope)
-      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-    const spans = yield* spanRepository.listBySessionId(scope)
-    const toolSpans = yield* spanRepository.listToolSpansBySessionId(scope)
+    // The three reads are independent; run them concurrently to keep the per-eval load cost down.
+    const [sessionDetail, spans, toolSpans] = yield* Effect.all(
+      [
+        sessionRepository.findBySessionId(scope).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null))),
+        spanRepository.listBySessionId(scope),
+        spanRepository.listToolSpansBySessionId(scope),
+      ],
+      { concurrency: "unbounded" },
+    )
 
     const traces = buildTraces(spans, toolSpans)
     const conversation = sessionDetail

--- a/packages/domain/evaluations/src/runtime/sandbox-execution.ts
+++ b/packages/domain/evaluations/src/runtime/sandbox-execution.ts
@@ -1,13 +1,17 @@
 import { AI, AICredentialError, AIError, type GenerateTelemetryCapture, resolveGenerationConfig } from "@domain/ai"
-import { buildSchemaFromDescriptor, type HostLlmFunction, isScoreMatch, ScriptRuntime } from "@domain/sandbox"
+import {
+  buildSchemaFromDescriptor,
+  type HostLlmFunction,
+  isScoreMatch,
+  ScriptRuntime,
+  type ScriptSessionContext,
+} from "@domain/sandbox"
 import { Effect } from "effect"
 import { EvaluationExecutionError } from "../errors.ts"
 import {
   EVALUATION_DEFAULT_SCRIPT_RUNTIME_MODEL,
   EVALUATION_SCRIPT_RUNTIME_SYSTEM_PROMPT,
-  type EvaluationConversationMessage,
   type EvaluationScriptExecution,
-  type EvaluationSignalContext,
   estimateEvaluationScriptCostMicrocents,
 } from "./evaluation-execution.ts"
 
@@ -25,11 +29,10 @@ const toExecutionError = (error: { readonly message: string; readonly cause?: un
 export const executeEvaluationScriptSandboxed = Effect.fn("evaluations.executeEvaluationScriptSandboxed")(
   function* (input: {
     readonly script: string
-    readonly conversation: readonly EvaluationConversationMessage[]
-    readonly issue: EvaluationSignalContext
+    readonly session: ScriptSessionContext
     readonly telemetry?: GenerateTelemetryCapture
   }) {
-    yield* Effect.annotateCurrentSpan("evaluation.conversationMessageCount", input.conversation.length)
+    yield* Effect.annotateCurrentSpan("evaluation.conversationMessageCount", input.session.conversation.length)
 
     const runtime = yield* ScriptRuntime
     const ai = yield* AI
@@ -63,7 +66,7 @@ export const executeEvaluationScriptSandboxed = Effect.fn("evaluations.executeEv
     const runResult = yield* runtime
       .run({
         script: compiled,
-        context: { conversation: input.conversation, issue: input.issue },
+        context: { session: input.session },
         llm,
       })
       .pipe(

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
@@ -1,3 +1,4 @@
+import { minimalScriptSession } from "@domain/sandbox"
 import { Effect } from "effect"
 import type {
   BaselineEvaluationExampleResult,
@@ -27,11 +28,7 @@ export const evaluateDraftAgainstExamplesUseCase = Effect.fn("evaluations.evalua
     for (const example of examples) {
       const execution = yield* executeEvaluationScriptSandboxed({
         script: input.script,
-        conversation: example.conversation,
-        issue: {
-          name: input.signalName,
-          description: input.signalDescription,
-        },
+        session: minimalScriptSession(example.conversation),
         telemetry: buildEvaluationAlignmentJudgeTelemetryCapture({
           scope: input.judgeTelemetry,
           traceId: String(example.traceId),

--- a/packages/domain/evaluations/src/use-cases/live/execute-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/execute-live-evaluation.ts
@@ -1,6 +1,5 @@
 import type { AI, AICredentialError, AIError, GenerateTelemetryCapture } from "@domain/ai"
-import type { ScriptRuntime } from "@domain/sandbox"
-import { type TraceDetail, traceDetailSchema } from "@domain/spans"
+import type { ScriptRuntime, ScriptSessionContext } from "@domain/sandbox"
 import { Effect } from "effect"
 import { z } from "zod"
 import { evaluationSchema } from "../../entities/evaluation.ts"
@@ -12,7 +11,6 @@ import {
   evaluationExecutionResultPayloadSchema,
   evaluationExecutionResultSchema,
   evaluationSignalContextSchema,
-  toEvaluationConversationMessages,
   toEvaluationExecutionResult,
 } from "../../runtime/evaluation-execution.ts"
 import { executeEvaluationScriptSandboxed } from "../../runtime/sandbox-execution.ts"
@@ -21,9 +19,6 @@ export type ExecuteLiveEvaluationError = AIError | AICredentialError | LiveEvalu
 
 export const liveEvaluationSignalContextSchema = evaluationSignalContextSchema
 export type LiveEvaluationSignalContext = EvaluationSignalContext
-
-export const liveEvaluationConversationInputSchema = traceDetailSchema.shape.allMessages
-export type LiveEvaluationConversationInput = TraceDetail["allMessages"]
 
 export const liveEvaluationResultPayloadSchema = evaluationExecutionResultPayloadSchema
 export type LiveEvaluationResultPayload = EvaluationExecutionResultPayload
@@ -37,8 +32,7 @@ const liveEvaluationExecutionTelemetrySchema = z.object({
 export const liveEvaluationExecutionInputSchema = z.object({
   evaluationId: evaluationSchema.shape.id,
   script: evaluationSchema.shape.script,
-  issue: liveEvaluationSignalContextSchema,
-  conversation: liveEvaluationConversationInputSchema,
+  session: z.custom<ScriptSessionContext>((value) => value !== null && typeof value === "object"),
   telemetry: liveEvaluationExecutionTelemetrySchema.optional(),
 })
 export type LiveEvaluationExecutionInput = z.infer<typeof liveEvaluationExecutionInputSchema>
@@ -62,13 +56,11 @@ export const executeLiveEvaluationUseCase = (input: LiveEvaluationExecutionInput
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
 
-    const conversation = toEvaluationConversationMessages(input.conversation)
     const telemetry = toGenerateTelemetryCapture(input.telemetry)
 
     const execution = yield* executeEvaluationScriptSandboxed({
       script: input.script,
-      conversation,
-      issue: input.issue,
+      session: input.session,
       ...(telemetry ? { telemetry } : {}),
     }).pipe(
       Effect.catchTag("EvaluationExecutionError", (error) =>

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -36,8 +36,8 @@ import {
   TraceId,
 } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
-import { type TraceDetail, TraceRepository } from "@domain/spans"
-import { createFakeTraceRepository } from "@domain/spans/testing"
+import { SessionRepository, SpanRepository, type TraceDetail, TraceRepository } from "@domain/spans"
+import { createFakeSessionRepository, createFakeSpanRepository, createFakeTraceRepository } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import {
@@ -260,7 +260,9 @@ function createUseCaseLayer(input: {
   | OutboxEventWriter
   | ScoreRepository
   | ScriptRuntime
+  | SessionRepository
   | SettingsReader
+  | SpanRepository
   | SqlClient
   | StripeSubscriptionLookup
   | TraceRepository,
@@ -269,6 +271,8 @@ function createUseCaseLayer(input: {
 > {
   return Layer.mergeAll(
     Layer.succeed(TraceRepository, input.traceRepository),
+    Layer.succeed(SessionRepository, createFakeSessionRepository().repository),
+    Layer.succeed(SpanRepository, createFakeSpanRepository().repository),
     Layer.succeed(EvaluationRepository, input.evaluationRepository),
     input.scoreWriteLayer ?? createScoreWriteLayer({ scoreRepository: input.scoreRepository }),
     Layer.succeed(

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -29,13 +29,14 @@ import {
   type SqlClient,
   TraceId,
 } from "@domain/shared"
-import { type TraceDetail, TraceRepository } from "@domain/spans"
+import { type SessionRepository, type SpanRepository, type TraceDetail, TraceRepository } from "@domain/spans"
 import { Cause, Effect, Exit } from "effect"
 import type { Evaluation } from "../../entities/evaluation.ts"
 import { getLiveEvaluationEligibility } from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 import { EvaluationSignalRepository } from "../../ports/evaluation-signal-repository.ts"
 import { buildEvaluationJudgeLiveTelemetryCapture } from "../../runtime/ai-telemetry.ts"
+import { loadScriptSessionContext } from "../../runtime/load-session-context.ts"
 import {
   executeLiveEvaluationUseCase,
   type LiveEvaluationExecutionResult,
@@ -239,12 +240,17 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
       } satisfies RunLiveEvaluationResult
     }
 
+    const session = yield* loadScriptSessionContext({
+      organizationId: OrganizationId(input.organizationId),
+      projectId,
+      traceDetail,
+    })
+
     const executionStartedAt = performance.now()
     const execution = yield* executeLiveEvaluationUseCase({
       evaluationId: evaluation.id,
       script: evaluation.script,
-      issue: signalContext,
-      conversation: traceDetail.allMessages,
+      session,
       telemetry: buildEvaluationJudgeLiveTelemetryCapture({
         organizationId: input.organizationId,
         projectId: input.projectId,
@@ -410,7 +416,9 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
     | ScoreAnalyticsRepository
     | ScoreRepository
     | ScriptRuntime
+    | SessionRepository
     | SettingsReader
+    | SpanRepository
     | SqlClient
     | StripeSubscriptionLookup
     | TraceRepository

--- a/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
+++ b/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
@@ -1,4 +1,5 @@
 import type { OptimizationCandidate, OptimizationTrajectory } from "@domain/optimizations"
+import { minimalScriptSession } from "@domain/sandbox"
 import { Effect } from "effect"
 import type { HydratedEvaluationAlignmentExample } from "../../alignment/types.ts"
 import {
@@ -19,11 +20,7 @@ export const evaluateOptimizationCandidate = Effect.fn("evaluations.evaluateOpti
 
   const execution = yield* executeEvaluationScriptSandboxed({
     script: input.candidate.text,
-    conversation: input.example.conversation,
-    issue: {
-      name: input.signalName,
-      description: input.signalDescription,
-    },
+    session: minimalScriptSession(input.example.conversation),
     telemetry: buildEvaluationOptimizationJudgeTelemetryCapture({
       scope: input.judgeTelemetry,
       candidateHash: input.candidate.hash,

--- a/packages/domain/sandbox/src/index.ts
+++ b/packages/domain/sandbox/src/index.ts
@@ -57,3 +57,4 @@ export {
   type SchemaDescriptor,
   schemaDescriptorSchema,
 } from "./schema-descriptor.ts"
+export { minimalScriptSession } from "./script-session.ts"

--- a/packages/domain/sandbox/src/index.ts
+++ b/packages/domain/sandbox/src/index.ts
@@ -41,11 +41,15 @@ export {
   type HostLlmFunction,
   type HostLlmResult,
   type ScriptConversationMessage,
+  type ScriptCostBreakdown,
   type ScriptRunContext,
   type ScriptRunInput,
   ScriptRuntime,
   type ScriptRuntimeShape,
-  type ScriptSubjectContext,
+  type ScriptSessionContext,
+  type ScriptTokenBreakdown,
+  type ScriptToolContext,
+  type ScriptTraceContext,
 } from "./ports/script-runtime.ts"
 export {
   type BaseSchemaDescriptor,

--- a/packages/domain/sandbox/src/ports/script-runtime.ts
+++ b/packages/domain/sandbox/src/ports/script-runtime.ts
@@ -10,16 +10,73 @@ export interface ScriptConversationMessage {
   readonly content: string
 }
 
-/** `{ name, description }` context of the owning entity (`issue` / `signal` globals). */
-export interface ScriptSubjectContext {
+export interface ScriptCostBreakdown {
+  readonly input: number
+  readonly output: number
+  readonly total: number
+}
+
+export interface ScriptTokenBreakdown {
+  readonly input: number
+  readonly output: number
+  readonly total: number
+  readonly cacheRead: number
+  readonly cacheCreate: number
+  readonly reasoning: number
+}
+
+/** A tool span (`operation = execute_tool`) projected for the script; `input`/`output` are truncated. */
+export interface ScriptToolContext {
   readonly name: string
-  readonly description: string
+  readonly input: string
+  readonly output: string
+  readonly error: boolean
+  readonly duration: number
+}
+
+export interface ScriptTraceContext {
+  readonly id: string
+  readonly name: string
+  readonly status: string
+  readonly errorCount: number
+  readonly spanCount: number
+  readonly duration: number
+  readonly timeToFirstToken: number
+  readonly cost: ScriptCostBreakdown
+  readonly tokens: ScriptTokenBreakdown
+  readonly models: readonly string[]
+  readonly providers: readonly string[]
+  readonly finishReasons: readonly string[]
+  readonly tools: readonly ScriptToolContext[]
+}
+
+/**
+ * The single runtime context bound into every evaluation script as the `session` global. Built from a
+ * trace's session (`@domain/spans`). `conversation` is the lossy, deduped, session-wide transcript (its
+ * `toString()` renders `[role] content` lines) used by `llm()`; per-trace rollups plus the `tools`
+ * projection carry the structured metrics + tool data deterministic conditions read. There is no raw
+ * per-span array. Base units: ns, microcents, token counts.
+ */
+export interface ScriptSessionContext {
+  readonly id: string
+  readonly traceCount: number
+  readonly spanCount: number
+  readonly errorCount: number
+  readonly duration: number
+  readonly timeToFirstToken: number
+  readonly cost: ScriptCostBreakdown
+  readonly tokens: ScriptTokenBreakdown
+  readonly startTime: string
+  readonly endTime: string
+  readonly userId: string
+  readonly tags: readonly string[]
+  readonly metadata: Readonly<Record<string, string>>
+  readonly conversation: readonly ScriptConversationMessage[]
+  readonly traces: readonly ScriptTraceContext[]
 }
 
 export interface ScriptRunContext {
-  readonly conversation: readonly ScriptConversationMessage[]
-  readonly issue?: ScriptSubjectContext
-  readonly signal?: ScriptSubjectContext
+  readonly session: ScriptSessionContext
 }
 
 /** Schema-less generation is out of contract: every `llm()` call declares its output shape. */

--- a/packages/domain/sandbox/src/script-session.ts
+++ b/packages/domain/sandbox/src/script-session.ts
@@ -1,0 +1,29 @@
+import type { ScriptConversationMessage, ScriptSessionContext } from "./ports/script-runtime.ts"
+
+const ZERO_COST = { input: 0, output: 0, total: 0 } as const
+const ZERO_TOKENS = { input: 0, output: 0, total: 0, cacheRead: 0, cacheCreate: 0, reasoning: 0 } as const
+
+/**
+ * A `ScriptSessionContext` carrying only a conversation — zeroed aggregates, no traces. Used where the
+ * full session is unavailable or irrelevant: alignment/optimization runs (judge scripts read only
+ * `session.conversation`) and tests.
+ */
+export const minimalScriptSession = (
+  conversation: readonly ScriptConversationMessage[] = [],
+): ScriptSessionContext => ({
+  id: "",
+  traceCount: 0,
+  spanCount: 0,
+  errorCount: 0,
+  duration: 0,
+  timeToFirstToken: 0,
+  cost: ZERO_COST,
+  tokens: ZERO_TOKENS,
+  startTime: "",
+  endTime: "",
+  userId: "",
+  tags: [],
+  metadata: {},
+  conversation,
+  traces: [],
+})

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -75,6 +75,7 @@ export type {
 } from "./ports/session-repository.ts"
 export { emptySessionMetrics, SessionRepository } from "./ports/session-repository.ts"
 export type {
+  SessionToolSpan,
   SpanIngestedAtWindow,
   SpanIngestionCursor,
   SpanListOptions,

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -107,6 +107,7 @@ export type {
 } from "./ports/session-repository.ts"
 export { emptySessionMetrics, SessionRepository } from "./ports/session-repository.ts"
 export type {
+  SessionToolSpan,
   SpanIngestedAtWindow,
   SpanIngestionCursor,
   SpanListOptions,

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -27,6 +27,19 @@ export interface SpanMessagesData {
 }
 
 /**
+ * A tool span (`operation = execute_tool`) projected for the evaluation `session` context. `input` /
+ * `output` are the raw tool I/O strings (the caller truncates). Returned by `listToolSpansBySessionId`.
+ */
+export interface SessionToolSpan {
+  readonly traceId: TraceId
+  readonly name: string
+  readonly input: string
+  readonly output: string
+  readonly error: boolean
+  readonly durationNs: number
+}
+
+/**
  * Compound watermark for ingestion-ordered window reads. `ingested_at` is
  * stamped once per ingest request batch, so many spans share an identical
  * millisecond — `spanId` breaks ties so a limit-truncated read can resume
@@ -95,6 +108,17 @@ export interface SpanRepositoryShape {
     readonly startTimeFrom: Date
     readonly startTimeTo: Date
   }): Effect.Effect<readonly SpanMessagesData[], RepositoryError, ChSqlClient>
+
+  /**
+   * The session's tool spans (`operation = execute_tool`), projected to name + I/O + error + duration.
+   * Powers the `session.traces[].tools` evaluation context; membership mirrors `sessions_mv`
+   * (see listBySessionId). The light `Span` projection omits tool I/O, hence this focused read.
+   */
+  listToolSpansBySessionId(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly sessionId: SessionId
+  }): Effect.Effect<readonly SessionToolSpan[], RepositoryError, ChSqlClient>
 
   /**
    * Same projection as findMessagesForTrace but across every trace in a

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -15,6 +15,7 @@ export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape
     },
     listByTraceId: () => Effect.succeed([]),
     listBySessionId: () => Effect.succeed([]),
+    listToolSpansBySessionId: () => Effect.succeed([]),
     listByProjectId: () => Effect.succeed([]),
     findBySpanId: () => Effect.fail(new NotFoundError({ entity: "Span", id: "" })),
     findMessagesForTrace: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -550,6 +550,124 @@ describe("SpanRepository", () => {
     })
   })
 
+  describe("listToolSpansBySessionId", () => {
+    const SESSION_ID = SessionId("tool-session")
+    const TRACE_A = TraceId("11111111111111111111111111111111")
+    const TRACE_B = TraceId("22222222222222222222222222222222")
+    const ORPHAN_TRACE = TraceId("33333333333333333333333333333333")
+
+    const insertToolFixture = () =>
+      runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          // trace A: the same tool span re-ingested — newest ingested_at (output "NEW") must win
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa111111111111",
+            operation: "execute_tool",
+            tool_name: "search",
+            tool_input: '{"q":"x"}',
+            tool_output: "OLD",
+            status_code: 1,
+            start_time: "2026-03-01 00:00:00.000000000",
+            end_time: "2026-03-01 00:00:00.500000000",
+            ingested_at: "2026-03-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa111111111111",
+            operation: "execute_tool",
+            tool_name: "search",
+            tool_input: '{"q":"x"}',
+            tool_output: "NEW",
+            status_code: 1,
+            start_time: "2026-03-01 00:00:00.000000000",
+            end_time: "2026-03-01 00:00:00.500000000",
+            ingested_at: "2026-03-01 00:00:01.000",
+          }),
+          // trace A: a non-tool span — excluded (operation != execute_tool)
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_A,
+            span_id: "aaaa222222222222",
+            operation: "chat",
+            start_time: "2026-03-01 00:00:02.000000000",
+            end_time: "2026-03-01 00:00:03.000000000",
+            ingested_at: "2026-03-01 00:00:02.000",
+          }),
+          // trace B: a failing tool span (status error)
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_B,
+            span_id: "bbbb111111111111",
+            operation: "execute_tool",
+            tool_name: "delete",
+            tool_input: "{}",
+            tool_output: "boom",
+            status_code: 2,
+            error_type: "ToolError",
+            start_time: "2026-03-01 00:01:00.000000000",
+            end_time: "2026-03-01 00:01:00.100000000",
+            ingested_at: "2026-03-01 00:01:00.000",
+          }),
+          // tool span in a different session — excluded
+          makeSpanRow({
+            session_id: "session-other",
+            trace_id: TraceId("44444444444444444444444444444444"),
+            span_id: "cccc111111111111",
+            operation: "execute_tool",
+            tool_name: "leak",
+            start_time: "2026-03-01 00:02:00.000000000",
+            end_time: "2026-03-01 00:02:01.000000000",
+            ingested_at: "2026-03-01 00:02:00.000",
+          }),
+          // orphan single-trace session (empty session_id), keyed by trace id
+          makeSpanRow({
+            session_id: "",
+            trace_id: ORPHAN_TRACE,
+            span_id: "dddd111111111111",
+            operation: "execute_tool",
+            tool_name: "orphan_tool",
+            start_time: "2026-03-01 00:03:00.000000000",
+            end_time: "2026-03-01 00:03:00.250000000",
+            ingested_at: "2026-03-01 00:03:00.000",
+          }),
+        ]),
+      )
+
+    it("returns the session's execute_tool spans, deduped, ordered by start time, with mapped I/O and error", async () => {
+      await insertToolFixture()
+      const tools = await runCh(
+        repo.listToolSpansBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: SESSION_ID }),
+      )
+
+      expect(tools.map((t) => t.name)).toEqual(["search", "delete"])
+      expect(tools[0]).toMatchObject({
+        traceId: TRACE_A,
+        name: "search",
+        input: '{"q":"x"}',
+        output: "NEW",
+        error: false,
+      })
+      expect(tools[0]?.durationNs).toBeGreaterThan(0)
+      expect(tools[1]).toMatchObject({ traceId: TRACE_B, name: "delete", error: true })
+    })
+
+    it("matches orphan single-trace sessions keyed by trace id", async () => {
+      await insertToolFixture()
+      const tools = await runCh(
+        repo.listToolSpansBySessionId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          sessionId: SessionId(ORPHAN_TRACE as string),
+        }),
+      )
+
+      expect(tools.map((t) => t.name)).toEqual(["orphan_tool"])
+    })
+  })
+
   describe("findBySpanId", () => {
     it("scopes by project and returns the latest ingested row without FINAL", async () => {
       await runCh(

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -13,7 +13,15 @@ import {
   toRepositoryError,
   TraceId as toTraceId,
 } from "@domain/shared"
-import type { Span, SpanDetail, SpanKind, SpanMessagesData, SpanStatusCode, ToolDefinition } from "@domain/spans"
+import type {
+  SessionToolSpan,
+  Span,
+  SpanDetail,
+  SpanKind,
+  SpanMessagesData,
+  SpanStatusCode,
+  ToolDefinition,
+} from "@domain/spans"
 import { SpanRepository, type SpanRepositoryShape } from "@domain/spans"
 import { normalizeCHString, parseCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
@@ -154,6 +162,25 @@ type SpanDetailRow = SpanListRow & {
   tool_input: string
   tool_output: string
 }
+
+interface SessionToolSpanRow {
+  trace_id: string
+  tool_name: string
+  tool_input: string
+  tool_output: string
+  status_code: number
+  error_type: string
+  duration_ns: string
+}
+
+const toSessionToolSpan = (row: SessionToolSpanRow): SessionToolSpan => ({
+  traceId: toTraceId(normalizeCHString(row.trace_id)),
+  name: normalizeCHString(row.tool_name),
+  input: row.tool_input,
+  output: row.tool_output,
+  error: (INT_TO_STATUS_CODE[row.status_code] ?? "unset") === "error" || normalizeCHString(row.error_type) !== "",
+  durationNs: Number(row.duration_ns),
+})
 
 const toBaseFields = (row: SpanListRow) => ({
   organizationId: toOrganizationId(normalizeCHString(row.organization_id)),
@@ -484,6 +511,44 @@ export const SpanRepositoryLive = Layer.effect(
           )
       })
 
+    const listToolSpansBySessionId: SpanRepositoryShape["listToolSpansBySessionId"] = ({
+      organizationId,
+      projectId,
+      sessionId,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              // Session membership mirrors sessions_mv (see listBySessionId); only execute_tool spans.
+              query: `SELECT trace_id, tool_name, tool_input, tool_output, status_code, error_type, duration_ns
+                    FROM (
+                      SELECT span_id, trace_id, tool_name, tool_input, tool_output, status_code, error_type, duration_ns, start_time, ingested_at
+                      FROM spans
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
+                        AND operation = 'execute_tool'
+                      ORDER BY span_id, ingested_at DESC
+                      LIMIT 1 BY span_id
+                    )
+                    ORDER BY start_time ASC`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                sessionId: sessionId as string,
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<SessionToolSpanRow>()
+          })
+          .pipe(
+            Effect.map((rows) => rows.map(toSessionToolSpan)),
+            Effect.mapError((error) => toRepositoryError(error, "listToolSpansBySessionId")),
+          )
+      })
+
     const listByIngestedAtWindow: SpanRepositoryShape["listByIngestedAtWindow"] = ({
       organizationId,
       projectId,
@@ -599,6 +664,8 @@ export const SpanRepositoryLive = Layer.effect(
       listByTraceId,
 
       listBySessionId,
+
+      listToolSpansBySessionId,
 
       listByProjectId,
 

--- a/packages/platform/op-gepa/src/prompts/proposer.test.ts
+++ b/packages/platform/op-gepa/src/prompts/proposer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { GEPA_PROPOSER_SYSTEM_PROMPT } from "./proposer.ts"
+
+describe("GEPA_PROPOSER_SYSTEM_PROMPT", () => {
+  it("constrains the only interpolation placeholder to session.conversation", () => {
+    expect(GEPA_PROPOSER_SYSTEM_PROMPT).toContain("${session.conversation}")
+    // The legacy bare-conversation global must not creep back into the proposer contract.
+    expect(GEPA_PROPOSER_SYSTEM_PROMPT).not.toContain("${conversation}")
+  })
+
+  it("keeps the judge locked to the single llm() wrapper", () => {
+    expect(GEPA_PROPOSER_SYSTEM_PROMPT).toContain("one llm() call")
+  })
+})

--- a/packages/platform/op-gepa/src/prompts/proposer.ts
+++ b/packages/platform/op-gepa/src/prompts/proposer.ts
@@ -39,7 +39,7 @@ Rules for the script:
 - Preserve the current MVP script wrapper exactly: one llm() call that returns { passed: boolean, feedback: string }, followed by the existing Passed/Failed return logic
 - Only change the prompt text inside the llm() template literal
 - The prompt must instruct the judge to set passed to true when the target behavior is present and false when it is absent
-- The only allowed interpolation placeholder inside the prompt text is \${conversation} — it will be replaced at runtime with the formatted conversation
+- The only allowed interpolation placeholder inside the prompt text is \${session.conversation} — it will be replaced at runtime with the formatted conversation
 - Do not use backticks inside the prompt text
 - Keep the prompt text focused on detecting the target issue in the conversation
 - Learn from failures and false positives in the trajectories — especially use the human annotation context to understand why false positives are actually correct behavior

--- a/packages/platform/sandbox-quickjs/src/adversarial.test.ts
+++ b/packages/platform/sandbox-quickjs/src/adversarial.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SCRIPT_MEMORY_BYTES,
   DEFAULT_SCRIPT_STACK_SIZE_BYTES,
+  minimalScriptSession,
   type ScriptRunError,
   type ScriptRunInput,
   type ScriptRunLimits,
@@ -26,7 +27,7 @@ const limits = (overrides?: Partial<ScriptRunLimits>): ScriptRunLimits => ({
 const runError = async (source: string, input?: Partial<ScriptRunInput>): Promise<ScriptRunError> => {
   const script = await Effect.runPromise(runtime.compile({ source }))
   const exit = await Effect.runPromiseExit(
-    runtime.run({ script, context: { conversation: [] }, limits: limits(), ...input }),
+    runtime.run({ script, context: { session: minimalScriptSession() }, limits: limits(), ...input }),
   )
   if (Exit.isSuccess(exit)) throw new Error(`expected run to fail, got ${JSON.stringify(exit.value)}`)
   const error = Cause.findErrorOption(exit.cause)
@@ -86,7 +87,9 @@ describe("isolation boundary", () => {
         `,
       }),
     )
-    const result = await Effect.runPromise(runtime.run({ script, context: { conversation: [] }, limits: limits() }))
+    const result = await Effect.runPromise(
+      runtime.run({ script, context: { session: minimalScriptSession() }, limits: limits() }),
+    )
     expect(result.feedback ?? "").toBe("")
     expect(result.value).toBe(1)
   })
@@ -101,7 +104,7 @@ describe("isolation boundary", () => {
       runtime.compile({ source: "Object.prototype.polluted = 'yes'; return Score(({}).polluted === 'yes' ? 1 : 0)" }),
     )
     const pollutingResult = await Effect.runPromise(
-      runtime.run({ script: polluting, context: { conversation: [] }, limits: limits() }),
+      runtime.run({ script: polluting, context: { session: minimalScriptSession() }, limits: limits() }),
     )
     expect(pollutingResult.value).toBe(1)
 
@@ -109,7 +112,7 @@ describe("isolation boundary", () => {
       runtime.compile({ source: "return Score(({}).polluted === undefined ? 1 : 0)" }),
     )
     const probeResult = await Effect.runPromise(
-      runtime.run({ script: probe, context: { conversation: [] }, limits: limits() }),
+      runtime.run({ script: probe, context: { session: minimalScriptSession() }, limits: limits() }),
     )
     expect(probeResult.value).toBe(1)
 
@@ -131,7 +134,7 @@ describe("isolation boundary", () => {
             `,
           }),
         ),
-        context: { conversation: [] },
+        context: { session: minimalScriptSession() },
         limits: limits(),
       }),
     )
@@ -141,12 +144,12 @@ describe("isolation boundary", () => {
   it("keeps hostile conversation content inert", async () => {
     const script = await Effect.runPromise(
       // biome-ignore lint/suspicious/noTemplateCurlyInString: the placeholder must interpolate inside the sandbox, not here
-      runtime.compile({ source: "return Score(1, `${conversation}`.slice(0, 64))" }),
+      runtime.compile({ source: "return Score(1, `${session.conversation}`.slice(0, 64))" }),
     )
     const result = await Effect.runPromise(
       runtime.run({
         script,
-        context: { conversation: [{ role: "user", content: "`); globalThis.escaped = true; (`" }] },
+        context: { session: minimalScriptSession([{ role: "user", content: "`); globalThis.escaped = true; (`" }]) },
         limits: limits(),
       }),
     )

--- a/packages/platform/sandbox-quickjs/src/prelude.ts
+++ b/packages/platform/sandbox-quickjs/src/prelude.ts
@@ -89,14 +89,21 @@ export const SANDBOX_PRELUDE = `;(() => {
     }
   }
 
+  const deepFreeze = (value) => {
+    if (value && typeof value === "object" && !Object.isFrozen(value)) {
+      Object.freeze(value)
+      for (const key of Object.keys(value)) deepFreeze(value[key])
+    }
+    return value
+  }
+
   const session = (bootstrap && bootstrap.session) || { conversation: [], traces: [] }
   const conversation = session.conversation || []
   Object.defineProperty(conversation, "toString", {
     value: () => conversation.map((message) => "[" + message.role + "] " + message.content).join("\\n"),
   })
-  for (const message of conversation) Object.freeze(message)
-  Object.freeze(conversation)
   session.conversation = conversation
-  globalThis.session = Object.freeze(session)
+  // Deep-freeze the whole payload so a script cannot mutate the session (traces, tools, metrics) it reads.
+  globalThis.session = deepFreeze(session)
 })()
 `

--- a/packages/platform/sandbox-quickjs/src/prelude.ts
+++ b/packages/platform/sandbox-quickjs/src/prelude.ts
@@ -5,13 +5,13 @@
  *
  * - `__hostLlm(call)`   — async host bridge behind `llm()` (only for llm-capability runs)
  * - `__hostParse(v, d)` — sync host bridge behind `parse()` (real Zod runs host-side)
- * - `__contextData`     — `{ conversation, issue?, signal? }` plain data
+ * - `__contextData`     — `{ session }` plain data (the only runtime context)
  *
  * The `z` builders produce serializable schema descriptors (see
  * `@domain/sandbox` `schema-descriptor.ts`), not real Zod schemas: schemas
  * only exist to cross the boundary into `llm()` and `parse()`, both performed
- * by the host. `conversation` stringifies as `[role] content` lines so stored
- * judge templates interpolating `${conversation}` keep their exact prompt.
+ * by the host. `session.conversation` stringifies as `[role] content` lines so
+ * judge templates interpolating `${session.conversation}` keep their exact prompt.
  */
 export const SANDBOX_PRELUDE = `;(() => {
   "use strict"
@@ -89,14 +89,14 @@ export const SANDBOX_PRELUDE = `;(() => {
     }
   }
 
-  const conversation = (bootstrap && bootstrap.conversation) || []
+  const session = (bootstrap && bootstrap.session) || { conversation: [], traces: [] }
+  const conversation = session.conversation || []
   Object.defineProperty(conversation, "toString", {
     value: () => conversation.map((message) => "[" + message.role + "] " + message.content).join("\\n"),
   })
   for (const message of conversation) Object.freeze(message)
   Object.freeze(conversation)
-  globalThis.conversation = conversation
-  if (bootstrap && bootstrap.issue) globalThis.issue = Object.freeze(bootstrap.issue)
-  if (bootstrap && bootstrap.signal) globalThis.signal = Object.freeze(bootstrap.signal)
+  session.conversation = conversation
+  globalThis.session = Object.freeze(session)
 })()
 `

--- a/packages/platform/sandbox-quickjs/src/runtime.test.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_SCRIPT_STACK_SIZE_BYTES,
   type HostLlmCall,
   type HostLlmFunction,
+  minimalScriptSession,
   type RunResult,
   type ScriptRunError,
   type ScriptRunInput,
@@ -33,7 +34,7 @@ const compileAndRun = async (
   const script = await compile(source)
   return run({
     script,
-    context: { conversation: [{ role: "user", content: "hello" }] },
+    context: { session: minimalScriptSession([{ role: "user", content: "hello" }]) },
     ...(options?.llm ? { llm: options.llm } : {}),
     ...(options?.limits ? { limits: options.limits } : {}),
   })
@@ -98,30 +99,32 @@ describe("run: the score contract", () => {
 
   it("rejects out-of-range or non-numeric scores as runtime errors", async () => {
     const script = await compile("return Score(2)")
-    const error = await runError({ script, context: { conversation: [] } })
+    const error = await runError({ script, context: { session: minimalScriptSession() } })
     expect(error._tag).toBe("ScriptRuntimeError")
 
     const nan = await compile("return Score('high')")
-    expect((await runError({ script: nan, context: { conversation: [] } }))._tag).toBe("ScriptRuntimeError")
+    expect((await runError({ script: nan, context: { session: minimalScriptSession() } }))._tag).toBe(
+      "ScriptRuntimeError",
+    )
   })
 
   it("rejects runs that do not return a Score", async () => {
     const script = await compile("return { value: 1 }")
-    const error = await runError({ script, context: { conversation: [] } })
+    const error = await runError({ script, context: { session: minimalScriptSession() } })
     expect(error._tag).toBe("ScriptRuntimeError")
     expect(error.message).toContain("must return Score")
   })
 
   it("surfaces script throws as ScriptRuntimeError", async () => {
     const script = await compile("throw new Error('detector blew up')")
-    const error = await runError({ script, context: { conversation: [] } })
+    const error = await runError({ script, context: { session: minimalScriptSession() } })
     expect(error._tag).toBe("ScriptRuntimeError")
     expect(error.message).toContain("detector blew up")
   })
 
   it("pure runs are deterministic functions of (definition, trace)", async () => {
-    const script = await compile("return Score(conversation[0].content.includes('hello') ? 1 : 0)")
-    const context = { conversation: [{ role: "user", content: "hello there" }] }
+    const script = await compile("return Score(session.conversation[0].content.includes('hello') ? 1 : 0)")
+    const context = { session: minimalScriptSession([{ role: "user", content: "hello there" }]) }
     const first = await run({ script, context })
     const second = await run({ script, context })
     expect(second.value).toBe(first.value)
@@ -130,33 +133,30 @@ describe("run: the score contract", () => {
 })
 
 describe("run: host-controlled globals", () => {
-  it("exposes conversation as a read-only view that stringifies as prompt lines", async () => {
+  it("exposes session.conversation as a read-only view that stringifies as prompt lines", async () => {
     const script = await compile(`
-      const text = \`\${conversation}\`
-      const frozen = Object.isFrozen(conversation) && Object.isFrozen(conversation[0])
+      const text = \`\${session.conversation}\`
+      const frozen = Object.isFrozen(session.conversation) && Object.isFrozen(session.conversation[0])
       return Score(text === "[user] hi\\n[assistant] yo" && frozen ? 1 : 0)
     `)
     const result = await run({
       script,
       context: {
-        conversation: [
+        session: minimalScriptSession([
           { role: "user", content: "hi" },
           { role: "assistant", content: "yo" },
-        ],
+        ]),
       },
     })
     expect(result.value).toBe(1)
   })
 
-  it("exposes the owning entity as issue/signal context", async () => {
+  it("exposes session and not the legacy conversation/issue/signal globals", async () => {
     const script = await compile(
-      "return Score(issue.name === 'n' && issue.description === 'd' ? 1 : 0, typeof signal === 'undefined' ? 'no signal' : 'signal leaked')",
+      "return Score(typeof session === 'object' && typeof conversation === 'undefined' && typeof issue === 'undefined' && typeof signal === 'undefined' ? 1 : 0)",
     )
-    const result = await run({
-      script,
-      context: { conversation: [], issue: { name: "n", description: "d" } },
-    })
-    expect(result).toMatchObject({ value: 1, feedback: "no signal" })
+    const result = await run({ script, context: { session: minimalScriptSession() } })
+    expect(result.value).toBe(1)
   })
 
   it("validates values host-side through parse()", async () => {
@@ -174,7 +174,7 @@ describe("run: host-controlled globals", () => {
         return Score(1, String(error.message).slice(0, 32))
       }
     `)
-    const result = await run({ script: bad, context: { conversation: [] } })
+    const result = await run({ script: bad, context: { session: minimalScriptSession() } })
     expect(result.value).toBe(1)
     expect(result.feedback).toContain("validation failed")
   })
@@ -195,7 +195,7 @@ describe("run: host-controlled globals", () => {
     expect(zodV4.value).toBe(1)
 
     const script = await compile('require("node:fs"); return Score(0)')
-    const error = await runError({ script, context: { conversation: [] } })
+    const error = await runError({ script, context: { session: minimalScriptSession() } })
     expect(error._tag).toBe("ScriptRuntimeError")
     expect(error.message).toContain('require() is unavailable in the sandbox for module "node:fs"')
   })
@@ -203,7 +203,7 @@ describe("run: host-controlled globals", () => {
 
 describe("run: llm host calls", () => {
   const judgeScript = `const result = await llm(
-  \`Judge:\n\${conversation}\`,
+  \`Judge:\n\${session.conversation}\`,
   { schema: z.object({ passed: z.boolean(), feedback: z.string() }) }
 )
 
@@ -268,7 +268,7 @@ if (result.passed) {
     expect(script.capabilities).toEqual([])
     const result = await run({
       script,
-      context: { conversation: [] },
+      context: { session: minimalScriptSession() },
       llm: async () => ({ object: {}, tokens: 0, duration: 0, cost: 0 }),
     })
     expect(result.value).toBe(1)
@@ -278,7 +278,7 @@ if (result.passed) {
     const script = await compile(judgeScript)
     const error = await runError({
       script,
-      context: { conversation: [] },
+      context: { session: minimalScriptSession() },
       llm: async () => {
         throw new Error("upstream timeout")
       },
@@ -308,7 +308,7 @@ if (result.passed) {
 
   it("fails fast when an llm-capability script runs without a host implementation", async () => {
     const script = await compile("await llm('x'); return Score(1)")
-    const error = await runError({ script, context: { conversation: [] }, limits: tightLimits() })
+    const error = await runError({ script, context: { session: minimalScriptSession() }, limits: tightLimits() })
     expect(error._tag).toBe("ScriptRuntimeError")
     expect(error.message).toContain("without a host llm implementation")
   })
@@ -318,7 +318,7 @@ if (result.passed) {
     const script = await compile("const r = await llm('x', { schema: { kind: 'exploit' } }); return Score(1)")
     const error = await runError({
       script,
-      context: { conversation: [] },
+      context: { session: minimalScriptSession() },
       llm: async (call) => {
         calls.push(call)
         return { object: {}, tokens: 0, duration: 0, cost: 0 }
@@ -331,7 +331,7 @@ if (result.passed) {
 
   it("does not let scripts masquerade their own throws as transient host failures", async () => {
     const script = await compile("const e = new Error('fake'); e.name = 'HostCallError'; throw e")
-    const error = await runError({ script, context: { conversation: [] } })
+    const error = await runError({ script, context: { session: minimalScriptSession() } })
     expect(error._tag).toBe("ScriptRuntimeError")
   })
 
@@ -344,7 +344,7 @@ if (result.passed) {
 
     for (const source of ["await llm('x'); return Score(1)", "await llm('x', {}); return Score(1)"]) {
       const script = await compile(source)
-      const error = await runError({ script, context: { conversation: [] }, llm, limits: tightLimits() })
+      const error = await runError({ script, context: { session: minimalScriptSession() }, llm, limits: tightLimits() })
       expect(error._tag).toBe("ScriptRuntimeError")
       expect(error.message).toContain("llm() requires a schema")
     }

--- a/packages/platform/sandbox-quickjs/src/runtime.test.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.test.ts
@@ -8,6 +8,7 @@ import {
   type ScriptRunError,
   type ScriptRunInput,
   type ScriptRunLimits,
+  type ScriptSessionContext,
 } from "@domain/sandbox"
 import { Cause, Effect, Exit } from "effect"
 import { describe, expect, it } from "vitest"
@@ -157,6 +158,61 @@ describe("run: host-controlled globals", () => {
     )
     const result = await run({ script, context: { session: minimalScriptSession() } })
     expect(result.value).toBe(1)
+  })
+
+  it("serializes the full session payload (metrics, per-trace rollups, tools) into the script", async () => {
+    const session: ScriptSessionContext = {
+      id: "session-1",
+      traceCount: 1,
+      spanCount: 2,
+      errorCount: 1,
+      duration: 1_500,
+      timeToFirstToken: 50,
+      cost: { input: 1, output: 2, total: 3 },
+      tokens: { input: 10, output: 20, total: 30, cacheRead: 0, cacheCreate: 0, reasoning: 0 },
+      startTime: "2026-01-01T00:00:00.000Z",
+      endTime: "2026-01-01T00:00:01.500Z",
+      userId: "user-1",
+      tags: ["checkout"],
+      metadata: { env: "prod" },
+      conversation: [{ role: "assistant", content: "done" }],
+      traces: [
+        {
+          id: "trace-1",
+          name: "root",
+          status: "error",
+          errorCount: 1,
+          spanCount: 2,
+          duration: 1_500,
+          timeToFirstToken: 50,
+          cost: { input: 1, output: 2, total: 3 },
+          tokens: { input: 10, output: 20, total: 30, cacheRead: 0, cacheCreate: 0, reasoning: 0 },
+          models: ["gpt-4o"],
+          providers: ["openai"],
+          finishReasons: ["length"],
+          tools: [{ name: "search", input: "{q:1}", output: "[]", error: true, duration: 42 }],
+        },
+      ],
+    }
+    const script = await compile(`
+      const t = session.traces[0]
+      const tool = t.tools[0]
+      const ok =
+        session.errorCount === 1 &&
+        session.tags[0] === "checkout" &&
+        session.metadata.env === "prod" &&
+        t.status === "error" &&
+        t.cost.total === 3 &&
+        t.tokens.input === 10 &&
+        t.models[0] === "gpt-4o" &&
+        t.finishReasons[0] === "length" &&
+        tool.name === "search" &&
+        tool.error === true &&
+        tool.duration === 42
+      return Score(ok ? 1 : 0, JSON.stringify({ tools: t.tools.length, model: t.models[0] }))
+    `)
+    const result = await run({ script, context: { session } })
+    expect(result).toMatchObject({ value: 1, feedback: '{"tools":1,"model":"gpt-4o"}' })
   })
 
   it("validates values host-side through parse()", async () => {

--- a/packages/platform/sandbox-quickjs/src/runtime.test.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.test.ts
@@ -208,7 +208,13 @@ describe("run: host-controlled globals", () => {
         t.finishReasons[0] === "length" &&
         tool.name === "search" &&
         tool.error === true &&
-        tool.duration === 42
+        tool.duration === 42 &&
+        // the whole payload is deep-frozen — traces, their arrays, and tools are immutable
+        Object.isFrozen(session.traces) &&
+        Object.isFrozen(t) &&
+        Object.isFrozen(t.models) &&
+        Object.isFrozen(t.tools) &&
+        Object.isFrozen(tool)
       return Score(ok ? 1 : 0, JSON.stringify({ tools: t.tools.length, model: t.models[0] }))
     `)
     const result = await run({ script, context: { session } })

--- a/packages/platform/sandbox-quickjs/src/runtime.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.ts
@@ -279,11 +279,7 @@ export const createQuickJsScriptRuntime = (): ScriptRuntimeShape => {
       }
       installHostParse(context)
 
-      const contextData = jsonToHandle(context, {
-        conversation: input.context.conversation,
-        ...(input.context.issue !== undefined ? { issue: input.context.issue } : {}),
-        ...(input.context.signal !== undefined ? { signal: input.context.signal } : {}),
-      })
+      const contextData = jsonToHandle(context, { session: input.context.session })
       context.setProp(context.global, "__contextData", contextData)
       contextData.dispose()
 

--- a/specs/signals.md
+++ b/specs/signals.md
@@ -661,3 +661,18 @@ Settings-defined deterministic conditions that compile to a script over the `ses
 - [ ] **P7-d** Flagger consolidation: where a flagger overlaps a semantic signal (e.g. `frustration`), make the semantic evaluation canonical and retire the overlapping flagger; non-overlapping flaggers keep feeding system-created signals via discovery.
 
 **Exit gate:** an evaluation script can call `similarity()`; moments run as semantic evaluations through the matching pipeline; overlapping flaggers retired, others unchanged.
+
+### Phase 8 — GEPA optimizes arbitrary evaluation scripts `[FUTURE]`
+
+**Deps:** PR4b (the `rule` codegen + the rich `session` payload). Not part of the MVP.
+
+Today GEPA is locked to the **LLM-as-judge wrapper**: it only rewrites the prompt text inside the single `llm()` call, and the only interpolation it may use is `${session.conversation}` (`GEPA_PROPOSER_SYSTEM_PROMPT` in `packages/platform/op-gepa/src/prompts/proposer.ts`; the `TODO(eval-sandbox)` there marks this constraint). So generation/optimization can improve *judge wording* but cannot author or tune deterministic checks, nor reason over the rest of the `session` payload (metrics, tools, finishReasons).
+
+**Ships:** GEPA generates and optimizes the *entire* `script` — deterministic `rule` scripts, judge scripts, and hybrids that read the full `session` object — not just the judge prompt.
+
+- [ ] **P8-a** Relax the proposer contract: allow emitting/rewriting the whole script body (not only the `llm()` prompt text). Teach the proposer the `session` payload surface (conversation + per-trace metrics/models/providers/finishReasons/tools) and the sandbox host API (`Passed()`/`Failed()`/`Score()`, `llm()`, `similarity()`).
+- [ ] **P8-b** Compile + validate every candidate (`validateEvaluationScriptCompiles`) and score it through the sandbox against the alignment set as today; reject non-compiling candidates so a malformed rewrite can never win.
+- [ ] **P8-c** Capability-aware optimization: detect each candidate's capability (pure / llm / embedding) from the script and account cost/lane per candidate; keep the optimizer within the sandbox contract (script-size and allowed-globals guardrails).
+- [ ] **P8-d** Decide the search space for non-judge scripts (e.g. seed from the `settings` `rule` codegen vs. free-form) and how alignment scoring applies to deterministic candidates (which never call `llm()`).
+
+**Exit gate:** GEPA can produce and improve deterministic, judge, and hybrid scripts that read the `session` payload, each validated by compile + alignment scoring — not just judge-prompt rewrites.

--- a/specs/signals.md
+++ b/specs/signals.md
@@ -91,13 +91,13 @@ Constraints:
 
 **A signal's membership detector is an `evaluations` row**, linked 1:1 via `evaluations.signal_id` — exactly one active evaluation per signal. **An evaluation is always a script** that runs in the shared QuickJS sandbox (`specs/sandbox-runtime.md`); there is no detector taxonomy and no second engine. Its shape is defined once in [Data model → Shared contracts](#shared-contracts-domainshared-domainscores).
 
-- **One engine, three ways to author the same script.** Every evaluation produces one `script` artifact, and that is exactly what executes: write it from a declarative **`settings`** object (compiled **deterministically** by a settings→script compiler **built in Phase 2/PR3** — no such codegen pre-exists; the option shapes are defined as the builder grows), generate and align it with **GEPA** (`optimize-evaluation`), or hand-write a **raw** script (advanced). `settings` is optional (NULL for a raw or GEPA-generated script); `script` is always present.
+- **One engine, three ways to author the same script.** Every evaluation produces one `script` artifact, and that is exactly what executes: write it from a declarative **`settings`** object (compiled **deterministically** by the settings→script compiler `compileSettingsToScript`, built in PR3 — the `judge` shape shipped then, the `rule`/condition shapes in PR4b), generate and align it with **GEPA** (`optimize-evaluation`), or hand-write a **raw** script (advanced). `settings` is optional (NULL for a raw or GEPA-generated script); `script` is always present. Every compiled script runs against the mandatory `session` runtime object ([Shared contract — the `session` runtime object](#shared-contract--the-session-runtime-object-domainsandbox-pr4a)).
 - **A judge is just a script that calls `llm()`.** "LLM-as-judge" is not a distinct type — it is the common case of a generated script whose body calls `llm()` (`const result = await llm(\`…\`, { schema }); return result.passed ? Passed() : Failed()`), running on the sandbox behind the `evaluation-sandbox-runtime` flag exactly as today. The `optimize-evaluation` workflow and alignment state (`alignment`/`aligned_at`) apply to these judge scripts; both arise when a user authors a judge directly (criteria → generated/aligned script) and via the discovery → tracking path ([Discovery](#discovery-and-tracking)), and are NULL for scripts that never call `llm()`.
 - **The script returns a score and optional reasoning; the host derives the verdict.** Each run yields `value` (a normalized score ∈ [0,1], for sort/confidence/display) and optional `feedback`; the host derives the run's verdict by thresholding `value` (`isScoreMatch` against `DEFAULT_SCRIPT_SCORE_THRESHOLD` = 0.5). Membership is recorded as `signal_id`, not `passed` (see [Score](#score--the-membership-ledger)); the writer stamps the evaluation's signal when the behavior is *present* (`passed = true`). Definition edits (script or settings) apply **forward only** — a definition-changed marker appears on charts, and existing scores are never re-evaluated.
 - **Type is a property of the `settings`, not the script.** A script can mix `llm()`, deterministic checks, and (later) semantic similarity, so an arbitrary script has no single type. The type lives in the **`settings`** of templated evaluations and drives the builder form; raw and GEPA-generated scripts are simply custom. "How many evaluations use `llm()` / semantic / code" is a separate, **multi-valued capability** question — answered by inspecting what the script does, not by a single type label (post-MVP analytics).
 - **Every score is stored the same way.** There is no per-type or per-capability storage split: every evaluation's scores go to Postgres (canonical) and ClickHouse (analytics), exactly like annotations (see [Score](#score--the-membership-ledger)).
 
-> **Semantic similarity is a future capability, not an MVP type.** Today's conversation-intelligence anchor matching is *not* yet expressed as an evaluation. A future phase adds it — most likely as a `similarity()`/`embedding()` host function the script can call (with a possible native batch-runner optimization), its exact shape deferred until then (see [Tasks → Phase 7](#phase-7--semantic-similarity-evaluations-future)). Until then, every evaluation is a sandbox script as above.
+> **Semantic similarity is an on-demand host function (PR4b), not a separate engine.** A `rule` condition can call a `similarity(a, b)` host function that embeds both strings at eval time and returns their cosine — usable directly from the builder. This is on-demand (per-run embeddings, metered like `llm()`), so it works on the TraceEnd path with no embeddings-lane change. The **native batch-runner optimization** (one pass over a trace's chunk embeddings against all anchor sets) and folding the existing conversation-intelligence anchor matching (moments) + overlapping flaggers into signal evaluations remain [Phase 7](#phase-7--semantic-similarity-evaluations-future). Every evaluation is still a sandbox script reading the `session` object.
 
 ### Score — the membership ledger
 
@@ -155,12 +155,12 @@ So a system-created signal's life is **annotation-fed (no evaluation) → option
 Today's write-time machinery is evaluation-oriented (`EvaluationTrigger`: filter / turn / debounce / sampling decides when an evaluation runs). This generalizes into a single **signal matching pipeline** that runs every active signal's evaluation against incoming traces — every evaluation is a script, so there is one runner.
 
 - the **filters pre-gate** is shared (one pass per trace over all active signals' `filters`); out-of-gate traces never reach the evaluation.
-- the **sandbox runner** executes the evaluation's `script` in the shared sandboxed JS (QuickJS) runtime — the single execution path for every evaluation (judge scripts call `llm()`; deterministic scripts don't).
+- the **sandbox runner** executes the evaluation's `script` in the shared sandboxed JS (QuickJS) runtime — the single execution path for every evaluation (judge scripts call `llm()`; deterministic scripts don't). The script runs against the mandatory `session` runtime object (PR4a), assembled at eval time from all traces of the trigger trace's session ([Shared contract — the `session` runtime object](#shared-contract--the-session-runtime-object-domainsandbox-pr4a)).
 - evaluation-specific options (`sampling`, `turn`, `debounce`) are settings on the evaluation row, not pipeline concepts.
 
 A run writes a score (matched or not) with `signal_id`, `source_type = 'evaluation'`, `source_id` = the evaluation id, persisted to Postgres + ClickHouse like any score (see [Score](#score--the-membership-ledger)). Signals with no evaluation are not in this pipeline — their membership comes only from annotations.
 
-*(A future phase adds semantic-similarity detection — likely a `similarity()`/`embedding()` host function the script calls, possibly with a native batch-runner optimization for that case; see [Tasks → Phase 7](#phase-7--semantic-similarity-evaluations-future).)*
+*(Semantic-similarity detection is an on-demand `similarity()` host function the script calls (PR4b); the native batch-runner optimization for the pure-similarity case stays [Phase 7](#phase-7--semantic-similarity-evaluations-future).)*
 
 ## Main flows
 
@@ -260,15 +260,36 @@ export const SIGNAL_ORIGINS = ["user", "system"] as const
 //   - storage is uniform: every score → Postgres (canonical) + ClickHouse (analytics); no store-routing.
 
 // `settings` is the OPTIONAL declarative config a user edits in the builder; it compiles to `script`
-// (deterministic codegen for rule-like options, or GEPA generation for a judge) and is NULL when the
-// script is hand-written (advanced). Concrete shapes are defined as the builder grows — kept open
-// here; the judge case is the first:
+// (deterministic codegen for `rule` options, or the single-sourced judge template for a `judge`) and is
+// NULL when the script is hand-written (advanced). The judge kind shipped in PR3; the `rule` kind +
+// conditions ship in PR4b. The runtime contract every compiled script reads is the `session` object
+// (PR4a) — see "Shared contract — the `session` runtime object" below.
 export type EvaluationSettings =
-  | { kind: "judge"; criteria: string }   // → a script that calls llm(), generated + aligned via optimize-evaluation
-  // future kinds that compile to a script: deterministic rule comparators; semantic similarity (Phase 7)
+  | { kind: "judge"; criteria: string }   // PR3 — a script that calls llm(`${session.conversation}` …), generated + aligned via optimize-evaluation
+  | {                                       // PR4b — deterministic conditions compiled to a pure script over `session`
+      kind: "rule"
+      match: "all" | "any"                 // AND / OR across the conditions
+      conditions: Condition[]
+    }
 
-// (Semantic-similarity anchors — positive/contrast/margin/roles — are deferred to Phase 7, where the
-//  semantic detector is added as a host function the script can call.)
+// Condition kinds (PR4b). Content conditions read session.conversation by role; metric reads session/
+// per-trace aggregates; tool/finish read session.traces[].{tools,finishReasons}; semantic uses the
+// on-demand similarity() host fn (cosine of two embedded strings).
+type MessageScope = "last_assistant" | "any_assistant" | "any_user" | "any_tool" | "conversation"
+type Condition =
+  | { type: "text_match"; scope: MessageScope; operator: "contains" | "not_contains" | "matches_regex" | "not_matches_regex"; value: string; caseSensitive?: boolean }
+  | { type: "empty_output" }
+  | { type: "output_length"; unit: "chars" | "words"; operator: "gt" | "gte" | "lt" | "lte"; value: number }
+  | { type: "json_output"; expectation: "valid" | "invalid" }
+  | { type: "metric"; field: "duration" | "cost" | "tokensTotal" | "tokensInput" | "tokensOutput" | "errorCount" | "traceCount" | "spanCount"; aggregation: "session" | "anyTrace" | "allTraces"; operator: "gt" | "gte" | "lt" | "lte"; value: number }
+  | { type: "tool_used"; toolName: string }
+  | { type: "tool_failed"; toolName?: string }
+  | { type: "tool_call_count"; operator: "gt" | "gte" | "lt" | "lte"; value: number }
+  | { type: "error" }
+  | { type: "finish_reason"; value: "length" | "content_filter" | "error" | "stop" | "tool_call" }
+  | { type: "semantic_similarity"; scope: MessageScope; anchor: string; threshold: number }
+
+// The native batch-runner optimization for pure-similarity and moments/flagger consolidation stay Phase 7.
 
 // CHANGED (@domain/scores): renames SCORE_SOURCES `source`→`source_type` and splits annotation→flagger/user.
 // `evaluation` is KEPT (a signal's detector is an evaluation), so existing evaluation-sourced scores need
@@ -292,6 +313,31 @@ export type ScoreSourceType = (typeof SCORE_SOURCE_TYPES)[number]
 //   AlertMetricThreshold  = absolute(value) | multiplier(factor, baseline) | expected(sensitivity)   // + direction above|below
 //   threshold / escalating conditions carry { metric, threshold, direction?, window? }
 ```
+
+### Shared contract — the `session` runtime object (`@domain/sandbox`, PR4a)
+
+Every evaluation script runs against a **single mandatory `session` global** (there is no `conversation`/`issue`/`signal` global). It is assembled at eval time from all traces of the trigger trace's session and bound into the QuickJS sandbox. Messages live in exactly one place (`session.conversation`, deduped); there is no raw per-span array — tool spans are projected to a focused `tools` list and the rest is rolled up per trace. Base units: ns, microcents, token counts.
+
+```ts
+interface ScriptSessionContext {
+  id: string
+  traceCount: number; spanCount: number; errorCount: number
+  duration: number; timeToFirstToken: number            // ns
+  cost: { input: number; output: number; total: number } // microcents
+  tokens: { input: number; output: number; total: number; cacheRead: number; cacheCreate: number; reasoning: number }
+  startTime: string; endTime: string; userId: string
+  tags: string[]; metadata: Record<string, string>
+  conversation: { role: string; content: string }[]      // deduped, session-wide; toString() → "[role] content" lines (used by llm())
+  traces: {
+    id: string; name: string; status: string; errorCount: number; spanCount: number
+    duration: number; timeToFirstToken: number; cost: {…}; tokens: {…}
+    models: string[]; providers: string[]; finishReasons: string[]
+    tools: { name: string; input: string; output: string; error: boolean; duration: number }[]   // all tool spans; input/output truncated
+  }[]
+}
+```
+
+A judge reads `session.conversation` (its `toString()` is interpolated as `${session.conversation}` in the generated prompt); rule conditions read the structured fields. `alignment`/optimization wrap a single example's conversation via `minimalScriptSession(conversation)`.
 
 ### Postgres: `signals` (evolves `issues` in place — keep the rows)
 
@@ -414,7 +460,7 @@ Definition (evaluation + filters), signal trend, escalation incidents, mute stat
 
 ### Creating a signal
 
-One builder, three entry points (Signals list, "Create signal from this search", annotation flow), one rule: **never let users define membership blind** — the builder always shows a live preview via the sandbox dry-run harness against sample traces. The builder edits a declarative `settings` form (or, for advanced users, a raw `script`); either way it produces the evaluation's `script`, generating a judge that calls `llm()` via `optimize-evaluation` when that's the chosen form.
+One builder (PR4c), three entry points (Signals list, "Create signal from this search", annotation flow), one rule: **never let users define membership blind** — the builder always shows a live preview (`previewEvaluationUseCase`: compile + run against recent sample sessions, no persist). It edits a declarative `settings` form via three tabs — **Rules** (deterministic conditions over the `session` object, incl. `semantic_similarity`), **Judge** (`criteria` → a script that calls `llm(\`${session.conversation}\` …)`), and **Advanced** (raw `script`) — plus a `filters` scope editor (which writes through to `evaluation.trigger.filter`). Editing a settings-defined signal recompiles its detector (archive active + create new); raw-script and `origin=system` signals are not settings-editable.
 
 ### Monitoring
 
@@ -453,7 +499,7 @@ Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/s
 5. **Evaluations write every run** (present and absent), mirroring how judges persist pass and fail today; occurrences are the rows carrying `signal_id`. **All scores are stored the same way** — Postgres-canonical + ClickHouse mirror, no per-type or per-capability split. → [Score](#score--the-membership-ledger)
 6. **Users cannot create evaluation-less signals** — only `system`-origin signals may have no evaluation, which removes the pure-filter write-amplification footgun; `filters` is only an evaluation pre-gate; plain filter tracking stays saved searches + monitors. → [Signal](#signal)
 7. **Mute stays on the signal row** for the MVP; escalation is represented by source-keyed incidents, not by a default monitor. → [Signal](#signal)
-8. **Script evaluations are the MVP detector; the judge is a generated script that calls `llm()`.** Both arise from the builder (settings → script, or raw script) and from the discovery → tracking path. **There is no tunable threshold**: the script returns `Passed`/`Failed`, so the cutoff is written into the script; `value` is only confidence/sort. **Semantic similarity is a future capability** ([Phase 7](#phase-7--semantic-similarity-evaluations-future)) — likely a `similarity()`/`embedding()` host function the script can call (with a possible native batch-runner optimization), shape deferred. **Custom-source scores** (`/scores` accepting `signal_id`) are POST-MVP.
+8. **Script evaluations are the MVP detector; the judge is a generated script that calls `llm()`.** Both arise from the builder (settings → script, or raw script) and from the discovery → tracking path. **There is no tunable threshold**: the script returns `Passed`/`Failed`, so the cutoff is written into the script; `value` is only confidence/sort. **Semantic similarity** ships in PR4b as an on-demand `similarity(a, b)` host function (per-run embeddings) usable from a `rule` condition; the native batch-runner optimization stays [Phase 7](#phase-7--semantic-similarity-optimization--momentsflagger-consolidation-future). **Custom-source scores** (`/scores` accepting `signal_id`) are POST-MVP.
 9. **No per-project signal cap.** Evaluation matching cost and score write volume are bounded by the shared selection pre-gate (sampling / turn / filter) and the single `signals:match` pipeline, not by an arbitrary count limit.
 10. **A signal's behavior is present when `passed = true`.** Membership is `signal_id`; the writer stamps it when an evaluation's verdict is present (`passed = true`), and the generated-judge convention (baseline prompt + GEPA proposer) sets `passed = true` when the behavior is present. `passed` is host-derived per run, so the convention lives in the runtime sites (writer, discovery eligibility, alignment scoring) and the judge prompt — no stored flag, no `scores` migration. → [Evaluation](#evaluation-the-detector) / [Score](#score--the-membership-ledger) / [Phase 2 PR2](#phase-2--evaluation-substrate--script-evaluations-mvp)
 
@@ -477,14 +523,14 @@ Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/s
 > 2. **In-place PG `RENAME` causes brief downtime** (migrations run as a one-shot task before a rolling service deploy, so old tasks query the renamed table for the rollover window). This is **accepted** — no long-term issues. ClickHouse, being append-only, EXPANDs (ADD `signal_id`, keep `issue_id`) instead.
 > 3. **KEEP wire-level tokens** (rename surrounding code, keep the string + a TODO): BullMQ queue/topic `"issues"` + ops + dedupe-key prefixes, Temporal workflow type names, Redis lock keys (`org:*:issues:*`, `issue:${id}`), export `kind:"issues"`, the `issue.*` alert kinds + source type `'issue'` (these are *retired*, not renamed, in later phases), and the CH `issue_id` column. Renaming them needs a coordinated drain, not a rename, and buys nothing user-visible.
 
-- [ ] **P1-a** PG **in-place RENAME** migration (hand-written via `pg:generate:custom` — Drizzle has no `RENAME COLUMN` precedent and interactive rename detection is unavailable in CI): `ALTER TABLE issues RENAME TO signals`; `scores`/`evaluations` `RENAME COLUMN issue_id → signal_id`; `ALTER INDEX … RENAME`; `ALTER POLICY issues_organization_policy → signals_organization_policy`. Plus the **outbox value migration** for correction (1): `UPDATE outbox_events SET event_name = 'Signal…' WHERE event_name = 'Issue…' AND published = false` (×6) and `aggregate_type 'issue'→'signal'`. Verify `snapshot.json` + data-preservation on a copy.
-- [ ] **P1-b** CH **EXPAND** (`pnpm --filter @platform/db-clickhouse ch:create`, append-only): `ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT ''`; `ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != ''`; rebuild the `scores_hourly_buckets` MV keyed on `signal_id` (DROP VIEW→DROP TABLE→CREATE→full re-aggregate backfill); `score-fields.ts` adds `score.signalId`; `score-analytics-repository.ts` reads `if(signal_id != '', signal_id, issue_id)` during the async mutation. **Keep `issue_id` until Phase 9.**
-- [ ] **P1-c** Domain rename `@domain/issues`→`@domain/signals`: folder + package name + tsconfig path alias + all imports; `Issue*`→`Signal*` types/ports/use-cases; `IssueId` brand → `SignalId` (`@domain/shared/id.ts`); `Score.issueId`→`signalId` (`@domain/scores`); also rename `EvaluationIssueRepository` in `@domain/evaluations`. **Events:** rename `EventPayloads` keys + literals + handler-map keys + payload types together, **and** add the `EVENT_NAME_ALIASES` shim at the dispatcher (`apps/workers/src/workers/domain-events.ts`) per correction (1). **Keep alert-kind strings `issue.*`** (persisted; *retired* later) — only relabel `ALERT_INCIDENT_KIND_LABEL`.
-- [ ] **P1-d** Platform: `@platform/db-postgres` `issue-repository`→`signal-repository`, schema `issues.ts`→`signals.ts`, mappers, seeds, export `IssueRepositoryLive`→`SignalRepositoryLive`. Plus the rest of the importers (workers, workflows, `@domain/{notifications,monitors,integrations,email}`, web server-fns) — flip import path + symbol; KEEP wire-token strings.
-- [ ] **P1-e** API: `apps/api/src/routes/issues.ts`→`signals.ts`; parameterize the Fern-group + op-id factory so one definition set mounts at `/projects/:projectSlug/signals` (group `signals`, op-ids `listSignals…`) **and** `/projects/:projectSlug/issues` (group `issues`, op-ids `listIssues…`, `deprecated:true`, TODO to remove). `pnpm generate:sdk` (emits openapi/mcp + Fern TS+Python) → both `client.signals.*` and deprecated `client.issues.*` generate.
-- [ ] **P1-f** Web: signals routes/pages/`-components` (`issues/`→`signals/`, `$issueId`→`$signalId`, `issue-*`→`signal-*`), `domains/issues`→`signals`, `useIssue*`/`getIssue*`→`useSignal*`/`getSignal*`; `ProjectSidebar` nav; `/issues/...`→`/signals/...` redirect (sibling layout route) + legacy `?issueId=` `beforeLoad` redirect kept. **Keep search-param key strings** (`issuesSearch` etc.) so redirect-preserved bookmarks resolve.
-- [ ] **P1-g** Copy: notification templates + `ALERT_INCIDENT_KIND_LABEL` Issue→Signal wording (email/Slack/in-app); keep variable names (`issueUrl`/`issueId`) and saved-search branches.
-- [ ] **P1-h** Docs: `dev-docs/issues.md`→`dev-docs/signals.md` (record corrections 1–3); fix references in `monitors.md`/`scores.md`/`reliability.md`/`notifications.md`/`evaluations.md`; `specs/issue-details-page.md`; AGENTS.md skill glossary; **public Mintlify `docs/` pages + redirects**.
+- [x] **P1-a** PG **in-place RENAME** migration (hand-written via `pg:generate:custom` — Drizzle has no `RENAME COLUMN` precedent and interactive rename detection is unavailable in CI): `ALTER TABLE issues RENAME TO signals`; `scores`/`evaluations` `RENAME COLUMN issue_id → signal_id`; `ALTER INDEX … RENAME`; `ALTER POLICY issues_organization_policy → signals_organization_policy`. Plus the **outbox value migration** for correction (1): `UPDATE outbox_events SET event_name = 'Signal…' WHERE event_name = 'Issue…' AND published = false` (×6) and `aggregate_type 'issue'→'signal'`. Verify `snapshot.json` + data-preservation on a copy.
+- [x] **P1-b** CH **EXPAND** (`pnpm --filter @platform/db-clickhouse ch:create`, append-only): `ALTER TABLE scores ADD COLUMN signal_id FixedString(24) DEFAULT ''`; `ALTER TABLE scores UPDATE signal_id = issue_id WHERE issue_id != ''`; rebuild the `scores_hourly_buckets` MV keyed on `signal_id` (DROP VIEW→DROP TABLE→CREATE→full re-aggregate backfill); `score-fields.ts` adds `score.signalId`; `score-analytics-repository.ts` reads `if(signal_id != '', signal_id, issue_id)` during the async mutation. **Keep `issue_id` until Phase 9.**
+- [x] **P1-c** Domain rename `@domain/issues`→`@domain/signals`: folder + package name + tsconfig path alias + all imports; `Issue*`→`Signal*` types/ports/use-cases; `IssueId` brand → `SignalId` (`@domain/shared/id.ts`); `Score.issueId`→`signalId` (`@domain/scores`); also rename `EvaluationIssueRepository` in `@domain/evaluations`. **Events:** rename `EventPayloads` keys + literals + handler-map keys + payload types together, **and** add the `EVENT_NAME_ALIASES` shim at the dispatcher (`apps/workers/src/workers/domain-events.ts`) per correction (1). **Keep alert-kind strings `issue.*`** (persisted; *retired* later) — only relabel `ALERT_INCIDENT_KIND_LABEL`.
+- [x] **P1-d** Platform: `@platform/db-postgres` `issue-repository`→`signal-repository`, schema `issues.ts`→`signals.ts`, mappers, seeds, export `IssueRepositoryLive`→`SignalRepositoryLive`. Plus the rest of the importers (workers, workflows, `@domain/{notifications,monitors,integrations,email}`, web server-fns) — flip import path + symbol; KEEP wire-token strings.
+- [x] **P1-e** API: `apps/api/src/routes/issues.ts`→`signals.ts`; parameterize the Fern-group + op-id factory so one definition set mounts at `/projects/:projectSlug/signals` (group `signals`, op-ids `listSignals…`) **and** `/projects/:projectSlug/issues` (group `issues`, op-ids `listIssues…`, `deprecated:true`, TODO to remove). `pnpm generate:sdk` (emits openapi/mcp + Fern TS+Python) → both `client.signals.*` and deprecated `client.issues.*` generate.
+- [x] **P1-f** Web: signals routes/pages/`-components` (`issues/`→`signals/`, `$issueId`→`$signalId`, `issue-*`→`signal-*`), `domains/issues`→`signals`, `useIssue*`/`getIssue*`→`useSignal*`/`getSignal*`; `ProjectSidebar` nav; `/issues/...`→`/signals/...` redirect (sibling layout route) + legacy `?issueId=` `beforeLoad` redirect kept. **Keep search-param key strings** (`issuesSearch` etc.) so redirect-preserved bookmarks resolve.
+- [x] **P1-g** Copy: notification templates + `ALERT_INCIDENT_KIND_LABEL` Issue→Signal wording (email/Slack/in-app); keep variable names (`issueUrl`/`issueId`) and saved-search branches.
+- [x] **P1-h** Docs: `dev-docs/issues.md`→`dev-docs/signals.md` (record corrections 1–3); fix references in `monitors.md`/`scores.md`/`reliability.md`/`notifications.md`/`evaluations.md`; `specs/issue-details-page.md`; AGENTS.md skill glossary; **public Mintlify `docs/` pages + redirects**.
 
 **Exit gate:** full suite green; `/issues` URLs + `?issueId=` deep links redirect; both `client.issues.*` (deprecated) and `client.signals.*` SDK groups resolve; an emitted score still routes through the renamed dispatch (incl. a legacy `IssueCreated`-named outbox row via the alias) and opens an `alert_incidents` row; PG migration data-preserving; `grep -rl "@domain/issues"` empty. Brief rollover downtime is the only behavioral diff.
 
@@ -492,7 +538,7 @@ Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/s
 
 ### Phase 2 — Evaluation substrate + script evaluations `[MVP]`
 
-> **Delivered as four self-contained PRs (big-bang cutover, no feature flag).** The original flag-gated, additive framing was superseded during implementation. **PR1 — engine cutover** (membership = `signal_id`, `signals:match`, `source_type` rename, sandbox `value` contract) is **shipped**. **PR2 — present-verdict convention** (a signal's behavior is present ⇒ `passed = true`) is **next**. **PR3 — user-created signals** (CRUD API + MCP + codegen + backfill) and **PR4 — builder UI** follow. Phase 5 (unify judge execution onto the matching pipeline) is **folded into PR1**.
+> **Delivered as self-contained PRs (big-bang cutover, no feature flag).** **PR1 — engine cutover** (membership = `signal_id`, `signals:match`, `source_type` rename, sandbox `value` contract), **PR2 — present-verdict convention** (present ⇒ `passed = true`, #3661), and **PR3 — user-created signals over the API + MCP** (#3690) are **shipped**. The remaining builder work expanded into three PRs: **PR4a — session runtime context** (evaluations run against a rich `session` object), **PR4b — conditions contract + codegen** (settings-defined deterministic conditions, incl. on-demand semantic similarity), and **PR4c — builder UI**. Phase 5 (unify judge execution onto the matching pipeline) is **folded into PR1**.
 
 **Deps:** P1.
 
@@ -509,33 +555,54 @@ Signals are exposed as a public REST surface under `/v1/projects/{projectSlug}/s
 - [x] **Read-side membership**: per-signal occurrence/trace reads use "`signal_id` present"; the `scores_signal_discovery_work_idx` predicate gates `passed = false` for discovery candidates.
 - [x] **Data convention**: existing `evaluation` + `annotation` scores follow present ⇒ `passed = false`; the `scores_hourly_buckets` MV counts `signal_id`-bearing scores (no `passed` filter).
 
-#### PR2 — Present-verdict convention (`passed = true` = present) `[~] in progress`
+#### PR2 — Present-verdict convention (`passed = true` = present) `[x] complete (#3661)`
 
 PR1 shipped one present-verdict convention: behavior *present* ⇒ `passed = false`. This PR flips it to the intuitive **present ⇒ `passed = true`** across every site that reads or emits the verdict. Membership stays `signal_id`; the writer stamps it when `passed = true`. There is **no `scores` migration and no schema change** — `passed` is host-derived per run, so the convention is only how the writer, discovery, and alignment read it and how generated judges are phrased.
 
-- [ ] **Writer** (`run-live-evaluation`): stamp `signal_id` when `present = passed === true`. Absent runs still write a score with `signal_id` null.
-- [ ] **Discovery eligibility** (`check-eligibility` on the score → `discover-signal` path): an **evaluation** score is a discovery candidate only when present (`passed = true`); an absent run (`passed = false`, `signal_id` null) is skipped so `resolveLinkedSignalId` cannot assign it. The **annotation** branch is unchanged (negative = `passed = false` seeds discovery; clustering discovery is the annotation path).
-- [ ] **Alignment scoring** (`evaluate-draft-against-examples`, `evaluate-optimization-candidate`): `predictedPositive = passed === true`.
-- [ ] **Present-verdict instruction**: the convention text lives in `baseline-prompt.ts` — "set `passed = true` when the behavior is present" (generation-only; sole caller `generate-baseline-draft`). The **GEPA proposer** (`packages/platform/op-gepa/src/prompts/proposer.ts`) carries an explicit polarity rule in `GEPA_PROPOSER_SYSTEM_PROMPT` ("instruct the judge to set `passed = true` when the behavior is present, `false` when absent") so its prompt rewrites stay on the convention.
-- [ ] **ClickHouse sync**: an evaluation run is immutable on arrival and syncs regardless of verdict (`isImmutableScore`), so absent runs (`passed = false`, no `signal_id`) remain denominators.
-- [ ] **No changes** to occurrence reads, the `scores_hourly_buckets` MV, or annotation/`custom` write paths — membership is `signal_id`, independent of the verdict convention.
+- [x] **Writer** (`run-live-evaluation`): stamp `signal_id` when `present = passed === true`. Absent runs still write a score with `signal_id` null.
+- [x] **Discovery eligibility** (`check-eligibility` on the score → `discover-signal` path): an **evaluation** score is a discovery candidate only when present (`passed = true`); an absent run (`passed = false`, `signal_id` null) is skipped so `resolveLinkedSignalId` cannot assign it. The **annotation** branch is unchanged (negative = `passed = false` seeds discovery; clustering discovery is the annotation path).
+- [x] **Alignment scoring** (`evaluate-draft-against-examples`, `evaluate-optimization-candidate`): `predictedPositive = passed === true`.
+- [x] **Present-verdict instruction**: the convention text lives in `baseline-prompt.ts` — "set `passed = true` when the behavior is present" (generation-only; sole caller `generate-baseline-draft`). The **GEPA proposer** (`packages/platform/op-gepa/src/prompts/proposer.ts`) carries an explicit polarity rule in `GEPA_PROPOSER_SYSTEM_PROMPT` ("instruct the judge to set `passed = true` when the behavior is present, `false` when absent") so its prompt rewrites stay on the convention.
+- [x] **ClickHouse sync**: an evaluation run is immutable on arrival and syncs regardless of verdict (`isImmutableScore`), so absent runs (`passed = false`, no `signal_id`) remain denominators.
+- [x] **No changes** to occurrence reads, the `scores_hourly_buckets` MV, or annotation/`custom` write paths — membership is `signal_id`, independent of the verdict convention.
 
 **Exit gate (PR2):** an evaluation assigns `signal_id` on `passed = true` and leaves it null on `passed = false`; occurrence counts (by `signal_id`) are unaffected; annotations and their sentiment are unchanged; no `scores` migration or schema change ran.
 
-#### PR3 — User-created signals (API + MCP + backfill) `[ ] pending`
+#### PR3 — User-created signals (API + MCP) `[x] complete (#3690)`
 
-- [ ] Contracts: `SIGNAL_ORIGINS`, `EvaluationSettings` zod (`@domain/shared`).
-- [ ] Additive PG migration: `signals` — `origin` (backfill `'system'`), `filters`, `deleted_at`, nullable `centroid`/`clustered_at`, partial-unique slug; `evaluations` — `settings`, nullable `alignment`/`aligned_at`, dedupe-then-active-detector partial-unique index `(signal_id) WHERE deleted_at IS NULL AND archived_at IS NULL` + lookup btree. Make `toCentroidEmbedding` + the API evaluation response mapper null-safe; handle the un-renamed `issues_centroid_embedding_consistency_check` constraint (survived Phase 1's rename, untracked by Drizzle).
-- [ ] **Settings → script codegen** (`@domain/sandbox`, **net-new**): the original "consume the existing sandbox-runtime *SignalRule* codegen" claim is **refuted** — no such codegen exists yet; PR2 **builds** `compileSettingsToScript` + compile-on-save validation (`ScriptCompileError` → 422), single-sourcing the judge template so capability detection (`llm(`) and parity hold.
-- [ ] **`evaluations.script_hash`** column, filled for all evaluations — the writer reads it for the score's `metadata.evaluationHash` instead of the now-nullable `alignment.evaluationHash` (moved here from PR1: only needed once `alignment` becomes nullable).
-- [ ] `createSignal`/`updateSignal`/`deleteSignal` use-cases + API routes (monitors template) + MCP/SDK regen; reject evaluation-less `origin=user`. `deleteSignal` = PG **soft-delete** + archive the linked evaluation (auto write-stop via the active-detector scan); **no CH cleanup** — deleted-signal scores are excluded read-side via PG lifecycle. **No per-project signal cap.** Signal escalation is handled by source-keyed incidents, not default monitors.
-- [ ] `signals:backfill` worker + `backfillSignalScoresUseCase`: deterministic scripts only (judges collect forward); sandbox traces excluded; `windowStartIso` resolved once; idempotent per `(evaluation, trace)`.
+- [x] Contracts: `SIGNAL_ORIGINS`, `EvaluationSettings` zod (`@domain/shared`) — judge-only at this point; the `rule`/condition kinds land in PR4b.
+- [x] Additive PG migration: `signals` — `origin` (backfill `'system'`), `filters`, `deleted_at`, nullable `centroid`/`clustered_at`, partial-unique slug; `evaluations` — `settings`, nullable `alignment`/`aligned_at`, dedupe-then-active-detector partial-unique index `(signal_id) WHERE deleted_at IS NULL AND archived_at IS NULL` + lookup btree. Make `toCentroidEmbedding` + the API evaluation response mapper null-safe; handle the un-renamed `issues_centroid_embedding_consistency_check` constraint (survived Phase 1's rename, untracked by Drizzle).
+- [x] **Settings → script codegen** (`@domain/evaluations/src/codegen/compile-settings-to-script.ts`, **net-new** — note: landed in `@domain/evaluations`, not `@domain/sandbox`): `compileSettingsToScript` + `validateEvaluationScriptCompiles` (compile-on-save, `ScriptCompileError` → 422), single-sourcing the judge template (`wrapPromptAsEvaluationScript` + `generateJudgePromptText`) so capability detection (`llm(`) and parity hold. Generated scripts use the present-verdict convention (`Passed()` when the behavior is present). (PR4b extends the `switch` with the `rule` kind.)
+- [x] **`evaluations.script_hash`** column, filled for all evaluations — the writer reads it for the score's `metadata.evaluationHash` instead of the now-nullable `alignment.evaluationHash` (only needed once `alignment` becomes nullable).
+- [x] `createSignal`/`updateSignal`/`deleteSignal` use-cases + API routes (monitors template) + MCP/SDK regen; reject evaluation-less `origin=user`. `deleteSignal` = PG **soft-delete** + archive the linked evaluation (auto write-stop via the active-detector scan); **no CH cleanup** — deleted-signal scores are excluded read-side via PG lifecycle. **No per-project signal cap.** Signal escalation is handled by source-keyed incidents, not default monitors. (Note: `updateSignal` edits name/description/`filters` only — editing the evaluation's `settings` is added in PR4c.)
+- [x] ~~`signals:backfill`~~ **Dropped — collect forward only.** A backfill worker was built then removed (`da4d75130`); new signals score forward via the normal `signals:match` → `live-evaluations:execute` pipeline (no historical backfill). `createSignal` enqueues nothing.
 
-#### PR4 — Builder UI `[ ] pending`
+#### PR4a — Session runtime context `[~] in progress`
 
-- [ ] `apps/web` create-signal modal: name/description + `filters` editor + raw-script editor (judge form is Phase 3) + a **live dry-run preview** (compile + run a script against sample traces, **no persist**). Entry points: "New signal" (signals list), "Create signal from this search" (saved-search surface).
+Every evaluation now runs against a single mandatory **`session`** object (replacing the old `conversation`/`issue`/`signal` globals), so conditions can read metrics, tools, status, and content — not just text. **Triggering stays on TraceEnd / per-trace membership** (no pipeline/dedupe/analytics change); the `session` is assembled at eval time from all traces of the trigger trace's session. (Assumes no prod evaluations on the old context → no script migration; a follow-up may move triggering to session-settle — see [Phase 7](#phase-7--semantic-similarity-evaluations-future) neighborhood / future tasks.)
 
-**Exit gate (PR3/PR4):** users create/manage script & judge signals via API/MCP/UI; new in-scope traces produce evaluation scores visible on the signal page; backfill works.
+- [ ] **Runtime contract** (`@domain/sandbox` `ports/script-runtime.ts`): `ScriptRunContext = { session: ScriptSessionContext }` — define `ScriptSessionContext`/`ScriptTraceContext`/`ScriptToolContext` (+ cost/token breakdowns); drop `conversation`/`issue`/`signal` and `ScriptSubjectContext`. `session.conversation` is the deduped, session-wide `{role,content}[]` (with `toString()`); per-trace `models`/`providers`/`finishReasons` + a `tools:[{name,input,output,error,duration}]` projection — no raw per-span array; tool I/O truncated.
+- [ ] **QuickJS binding** (`@platform/sandbox-quickjs`): `runtime.ts` serializes only `session` into `__contextData`; `prelude.ts` binds the frozen `session` global and attaches `toString()` to `session.conversation`. Remove the old globals.
+- [ ] **Session loader** (`@domain/evaluations` `runtime/load-session-context.ts`): aggregates + deduped conversation from `SessionRepository.findBySessionId` (system + `lastInputMessages` + `outputMessages`); per-trace rollups + tool name/error/duration from `SpanRepository.listBySessionId`; tool input/output from a focused tool-span detail read (light `Span` omits them). Reuse `formatGenAIMessage`/`toEvaluationConversationMessages`. Export `minimalScriptSession(conversation)` for the alignment paths.
+- [ ] **Thread `session`**: `sandbox-execution.ts` (`context:{ session }`), `execute-live-evaluation.ts` (input carries `session`), `run-live-evaluation.ts` (assemble + pass; add `SessionRepository`/`SpanRepository` reqs + the `apps/workers` layer).
+- [ ] **Judge generation + GEPA → `session.conversation`**: `EVALUATION_CONVERSATION_PLACEHOLDER` + `wrapPromptAsEvaluationScript` + `generateJudgePromptText`; GEPA `GEPA_PROPOSER_SYSTEM_PROMPT` allowed placeholder becomes `${session.conversation}`.
+- [ ] **Alignment/optimization**: `evaluate-draft-against-examples` + `evaluate-optimization-candidate` pass `minimalScriptSession(example.conversation)`.
+
+#### PR4b — Conditions contract + codegen `[ ] pending`
+
+Settings-defined deterministic conditions that compile to a script over the `session` object.
+
+- [ ] **Contract** (`@domain/shared/evaluation-settings.ts`): add the `rule` kind — `{ kind:"rule", match:"all"|"any", conditions: Condition[] }` — with conditions `text_match` (role-scoped contains/regex), `empty_output`, `output_length`, `json_output`, `metric` (session/anyTrace/allTraces over duration/cost/tokens/errorCount/…), `tool_used`/`tool_failed`/`tool_call_count`, `error`, `finish_reason`, and `semantic_similarity` (scope + anchor + threshold).
+- [ ] **Codegen** (`compile-settings-to-script.ts`): `case "rule"` → a pure (non-`llm`) script = JSON condition literal + a fixed **async** interpreter over `session` returning `Passed()`/`Failed()`; user values go in the data literal, never code positions (regex via `new RegExp`).
+- [ ] **On-demand `similarity(a, b)`** host fn (`@platform/sandbox-quickjs`): embeds both strings via an embeddings model, returns cosine ∈ [0,1], metered like `llm()`; add `similarity(`/`embedding(` to capability detection (non-pure lane). The **native batch-runner** optimization + moments/flagger consolidation stay [Phase 7](#phase-7--semantic-similarity-evaluations-future).
+
+#### PR4c — Builder UI `[ ] pending`
+
+- [ ] **Backend for web**: `previewEvaluationUseCase` (compile + run against recent sample sessions, **no persist**); `updateSignalEvaluationUseCase` (user-origin, `settings IS NOT NULL` only — archive active + create new in one tx); **filters-gate fix** — propagate the signal's `filters` into `evaluation.trigger.filter` (today `createSignal` leaves it `{}`, so signal filters don't actually gate). Web `createServerFn` handlers + `signals.collection.ts` hooks (no REST/SDK regen — UI leads).
+- [ ] **UI** (`apps/web`): create/edit signal builder modal with `Rules` / `Judge` / `Advanced` tabs + a conditions editor + `filters` (scope) editor + a **live preview** (deterministic live; judge/semantic on-demand). Entry points: "New signal" (signals list), "Create signal from this search" (saved-search surface), and **Edit** on the signal detail page (replace the "Editing its settings is coming soon" note for `origin=user` & `settings≠null`); delete action.
+- [ ] **Cleanup**: drop the dead `QueuePublisher` layer on `createSignal` and fix the stale backfill prose in `apps/api/src/routes/signals.ts`.
+
+**Exit gate (PR4a–c):** evaluations run against the `session` object; users create/edit rule, judge & raw-script signals from the UI with a live preview; settings edits recompile the detector; new in-scope traces produce evaluation scores visible on the signal page.
 
 ### Phase 3 — User-created LLM-as-judge signals `[MVP]`
 
@@ -582,14 +649,14 @@ PR1 shipped one present-verdict convention: behavior *present* ⇒ `passed = fal
 
 **Exit gate:** monitor and signal incidents use the final source taxonomy; the old alert-kind axis is absent from the shipped monitor/signal UI and notification producer.
 
-### Phase 7 — Semantic similarity evaluations `[FUTURE]`
+### Phase 7 — Semantic similarity optimization + moments/flagger consolidation `[FUTURE]`
 
-**Deps:** P2 (+ the sandbox runtime). Not part of the MVP — sequenced after the script substrate is proven; this is where we "worry about improving the script to include semantic similarity".
-**Ships:** semantic similarity as a capability an evaluation script can use, then folds the existing conversation-intelligence anchor matching (moments) and overlapping flaggers into signal evaluations.
-**Open design (resolve before building):** how semantic executes — most likely a `similarity()`/`embedding()` **host function the script calls** (mirroring the `llm()` host bridge, `installHostLlm` in `@platform/sandbox-quickjs`), with a possible **native batch-runner optimization** for the pure-similarity case (one pass over a trace's chunk embeddings against all anchor sets, instead of a per-trace isolate). Needs a coordinated `specs/sandbox-runtime.md` edit — a new capability beyond `{pure, llm}` and an **embeddings-ready execution lane** (a `similarity()`-calling script needs chunk embeddings that exist only on the later `trace_search_embeddings` hop, not at trace-end) — plus a precedence rule for a script that calls both `similarity()` and `llm()`.
+**Deps:** PR4b (the on-demand `similarity()` host function). Not part of the MVP.
+**Ships:** a **native batch-runner optimization** for pure-similarity evaluations, then folds the existing conversation-intelligence anchor matching (moments) and overlapping flaggers into signal evaluations.
+**Open design (resolve before building):** the on-demand `similarity(a, b)` host fn (PR4b) embeds per run, which is fine at low volume but costs an embedding call per evaluation. The optimization is a **native batch-runner** for the pure-similarity case (one pass over a trace's chunk embeddings against all anchor sets, instead of a per-run isolate + per-run embedding). That needs an **embeddings-ready execution lane** (chunk embeddings exist only on the later `trace_search_embeddings` hop, not at trace-end) — a coordinated `specs/sandbox-runtime.md` edit and a precedence rule for a script that calls both `similarity()` and `llm()`.
 
-- [ ] **P7-a** Add the `similarity()`/`embedding()` sandbox host function + its capability and embeddings-ready execution lane (coordinated `sandbox-runtime.md` edit); surface the globals in the builder/MCP authoring.
-- [ ] **P7-b** Decide + (if warranted) implement the native batch-runner optimization for pure-similarity evaluations.
+- [x] **P7-a** ~~Add the `similarity()`/`embedding()` sandbox host function~~ — **shipped in PR4b** as the on-demand `similarity(a, b)` host bridge (per-run embeddings, metered like `llm()`).
+- [ ] **P7-b** Decide + (if warranted) implement the native batch-runner optimization for pure-similarity evaluations (the embeddings-ready lane).
 - [ ] **P7-c** Moments → signal evaluations: express the 8 `MOMENT_KINDS` as `origin=system` semantic evaluations (anchors + their static gates), so moment labeling runs through the one matching pipeline.
 - [ ] **P7-d** Flagger consolidation: where a flagger overlaps a semantic signal (e.g. `frustration`), make the semantic evaluation canonical and retire the overlapping flagger; non-overlapping flaggers keep feeding system-created signals via discovery.
 


### PR DESCRIPTION
## summary

Evaluation scripts now run against a single `session` object instead of the lossy `conversation` context. It lets later PRs add deterministic conditions over metrics, tools, and status, and gives LLM judges the full session transcript — while keeping the existing per-trace TraceEnd pipeline and membership model unchanged.

This is **PR4a** of the signals Phase 2 builder work (`specs/signals.md`). PR4b (settings-defined conditions + codegen) and PR4c (builder UI) follow.

## the `session` object

A script's sole runtime global is now `session` (the old `conversation` / `issue` / `signal` globals are gone), assembled at evaluation time from the triggering trace's session. Base units: ns (`duration` / `timeToFirstToken`), microcents (`cost`), token counts. Schema:

```json
{
  "id": "string",
  "traceCount": "number",
  "spanCount": "number",
  "errorCount": "number",
  "duration": "number",
  "timeToFirstToken": "number",
  "cost": { "input": "number", "output": "number", "total": "number" },
  "tokens": {
    "input": "number",
    "output": "number",
    "total": "number",
    "cacheRead": "number",
    "cacheCreate": "number",
    "reasoning": "number"
  },
  "startTime": "string",
  "endTime": "string",
  "userId": "string",
  "tags": ["string"],
  "metadata": { "[key]": "string" },
  "conversation": [{ "role": "string", "content": "string" }],
  "traces": [
    {
      "id": "string",
      "name": "string",
      "status": "string",
      "errorCount": "number",
      "spanCount": "number",
      "duration": "number",
      "timeToFirstToken": "number",
      "cost": { "input": "number", "output": "number", "total": "number" },
      "tokens": {
        "input": "number",
        "output": "number",
        "total": "number",
        "cacheRead": "number",
        "cacheCreate": "number",
        "reasoning": "number"
      },
      "models": ["string"],
      "providers": ["string"],
      "finishReasons": ["string"],
      "tools": [
        {
          "name": "string",
          "input": "string",
          "output": "string",
          "error": "boolean",
          "duration": "number"
        }
      ]
    }
  ]
}
```

`session.conversation` is the deduped, session-wide transcript (its `toString()` renders `[role] content` lines) — the single message store judges interpolate as `${session.conversation}`. There is no raw per-span array: spans are rolled up per trace and tool spans are projected, so the object stays small even for long sessions.

## assembly

`loadScriptSessionContext` (`@domain/evaluations`) builds the object:

- conversation + aggregates from `SessionRepository.findBySessionId` (the deduped system + last-input + outputs reconstruction, same one conversation-intelligence uses). Orphan sessions with no rollup row fall back to the triggering trace.
- per-trace rollups from `SpanRepository.listBySessionId`.
- tool I/O from a new focused `SpanRepository.listToolSpansBySessionId` read — the light `Span` projection omits `tool_input`/`tool_output`, so this returns `execute_tool` spans with their I/O, error, and duration.

`run-live-evaluation` assembles the session and passes it to the executor; the alignment and optimization paths wrap a single example's conversation via `minimalScriptSession` (judges read only `session.conversation`).

## judge generation

The baseline and settings judge templates and the GEPA proposer now target `${session.conversation}`, so generated and optimized judges read the new global.

## scope and decisions

- **Triggering is unchanged.** Evaluations still run per trace at TraceEnd and membership stays keyed to the trace; the session is loaded at eval time from the trace's session. Moving to true session-settle triggering is a deferred follow-up.
- **No script migration.** This assumes no production evaluations on the old `conversation` global — existing stored scripts that reference it would break, and new generation uses `session.conversation`.
- Includes a spec refresh (`specs/signals.md`): Phase 1 / PR2 / PR3 marked complete, and the remaining builder work split into PR4a / PR4b / PR4c.

## testing

- Full workspace typecheck passes.
- Unit tests cover the sandbox binding (`session.conversation` view, legacy globals gone), the loader assembly (conversation fallback, per-trace rollups, tool projection + truncation), and the updated live / alignment execution paths.
- The new `listToolSpansBySessionId` ClickHouse query is exercised in CI (chdb).


