### PR TITLE
fix(clickhouse): strip UUID dashes before FixedString(32) query params

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/session-intelligence-repositories.ts
+++ b/packages/platform/db-clickhouse/src/repositories/session-intelligence-repositories.ts
@@ -318,7 +318,11 @@ export const SessionSemanticMomentRepositoryLive = Layer.effect(
                           AND project_id = {projectId:String}
                           AND trace_id = {traceId:FixedString(32)}
                         ORDER BY first_message_index ASC, moment_id ASC`,
-                query_params: { organizationId: organizationId as string, projectId: projectId as string, traceId },
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  traceId: (traceId as string).replace(/-/g, ""),
+                },
                 format: "JSONEachRow",
               })
               return ((await result.json()) as SemanticMomentRow[]).map(toDomainSemanticMoment)

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -374,7 +374,7 @@ export const SpanRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                traceId,
+                traceId: (traceId as string).replace(/-/g, ""),
                 ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
                 ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
               },
@@ -702,7 +702,7 @@ export const SpanRepositoryLive = Layer.effect(
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
-                  traceId,
+                  traceId: (traceId as string).replace(/-/g, ""),
                   spanId,
                   ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
                   ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
@@ -753,7 +753,7 @@ export const SpanRepositoryLive = Layer.effect(
                   projectId: projectId as string,
                   startTimeFrom: toClickhouseDateTime(startTimeFrom),
                   startTimeTo: toClickhouseDateTime(startTimeTo),
-                  traceId,
+                  traceId: (traceId as string).replace(/-/g, ""),
                 },
                 format: "JSONEachRow",
               })

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -940,7 +940,7 @@ export const TraceRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                traceId,
+                traceId: (traceId as string).replace(/-/g, ""),
                 ...filterParams,
               },
               format: "JSONEachRow",
@@ -976,7 +976,7 @@ export const TraceRepositoryLive = Layer.effect(
         const queryParams: Record<string, unknown> = {
           organizationId: organizationId as string,
           projectId: projectId as string,
-          traceId,
+          traceId: (traceId as string).replace(/-/g, ""),
         }
 
         const matchExpressions = resolvedSets.map(({ filterId, filters }, index) => {
@@ -1448,7 +1448,7 @@ export const TraceRepositoryLive = Layer.effect(
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
-                  traceId,
+                  traceId: (traceId as string).replace(/-/g, ""),
                 },
                 format: "JSONEachRow",
               })
@@ -1482,7 +1482,7 @@ export const TraceRepositoryLive = Layer.effect(
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
-                  traceId,
+                  traceId: (traceId as string).replace(/-/g, ""),
                 },
                 format: "JSONEachRow",
               })
@@ -1538,7 +1538,7 @@ export const TraceRepositoryLive = Layer.effect(
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
-                  traceId,
+                  traceId: (traceId as string).replace(/-/g, ""),
                   offset,
                   limit,
                 },

--- a/packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-search-repository.ts
@@ -114,7 +114,7 @@ export const TraceSearchRepositoryLive = Layer.effect(
             query_params: {
               organizationId: organizationId as string,
               projectId: projectId as string,
-              traceId,
+              traceId: (traceId as string).replace(/-/g, ""),
               chunkIndex,
               contentHash,
             },
@@ -149,7 +149,7 @@ export const TraceSearchRepositoryLive = Layer.effect(
             query_params: {
               organizationId: args.organizationId as string,
               projectId: args.projectId as string,
-              traceId: args.traceId,
+              traceId: (args.traceId as string).replace(/-/g, ""),
               queryEmbedding: [...args.queryEmbedding],
             },
             format: "JSONEachRow",
@@ -223,7 +223,7 @@ export const TraceSearchRepositoryLive = Layer.effect(
             query_params: {
               organizationId: args.organizationId as string,
               projectId: args.projectId as string,
-              traceId: args.traceId,
+              traceId: (args.traceId as string).replace(/-/g, ""),
               embeddingModel: resolveSharedEmbeddingModel(),
               queryEmbedding: [...args.queryEmbedding],
               ...BOILERPLATE_FILTER_PARAMS,


### PR DESCRIPTION
## Datadog issue addressed

**[1087a10c — RepositoryError: Too large value for FixedString(32)](https://app.datadoghq.eu/error-tracking/issue/1087a10c-63f0-11f1-b545-da7ad0900005)**
Service: `web` | 17 occurrences (Jun 9–23)

Error signature:
```
Too large value for FixedString(32): value 5c47cc32-3f11-4448-bc7e-8c8f32855823
cannot be parsed as FixedString(32) for query parameter 'traceId'
```

## Root cause

ClickHouse stores `trace_id` as `FixedString(32)` — a 32-character hex string with no dashes. Standard UUIDs arriving from Postgres or HTTP requests use the dashed format (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, 36 chars). Passing a dashed UUID directly to a `{traceId:FixedString(32)}` query parameter causes ClickHouse to reject it with the "too large value" error.

The same fix pattern already exists in the ingestion path at `packages/domain/spans/src/otlp/transform.ts:176`:
```typescript
traceId: TraceId(span.traceId.replace(/-/g, ""))
```

But the read-path repositories missed this normalisation entirely.

## Fix

Apply `.replace(/-/g, "")` to `traceId` in `query_params` at all 12 affected call sites across four ClickHouse repository files:

| File | Functions fixed |
|---|---|
| `trace-repository.ts` | `matchesFiltersByTraceId`, `listMatchingFilterIdsByTraceId`, `findByTraceId`, `findMetadataByTraceId`, `findConversationChunk` |
| `trace-search-repository.ts` | `hasEmbeddingWithHash`, `findLegacySemanticHighlightForTrace`, `findSharedSemanticHighlightForTrace` |
| `span-repository.ts` | `findByTraceId`, `findDetailBySpanId`, `findMessagesByTraceId` |
| `session-intelligence-repositories.ts` | `SessionSemanticMomentRepository.listByTrace` |

No interface changes — callers pass `TraceId` branded strings as before; the normalisation happens inside the repository just before the ClickHouse call.

## Verification

After deploy, occurrences of issue [`1087a10c`](https://app.datadoghq.eu/error-tracking/issue/1087a10c-63f0-11f1-b545-da7ad0900005) should remain at zero. The error already stopped firing on June 23 (likely after the callers changed), but the underlying vulnerability remained; this closes the gap so re-introduction of dashed UUIDs at any call site is handled correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TtcaVuuv4fCFkTJDRv8n3

---
_Generated by [Claude Code](https://claude.ai/code/session_018TtcaVuuv4fCFkTJDRv8n3)_