### PR TITLE
feat(web): replace Annotations tab with Scores tab in trace/session drawers

### DIFF
--- a/apps/web/src/domains/annotations/annotations.collection.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.ts
@@ -178,6 +178,7 @@ export function useCreateAnnotation() {
     mutationFn: (input: CreateAnnotationInput) => createAnnotation({ data: input }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+      void queryClient.invalidateQueries({ queryKey: ["scores"] })
     },
   })
 }
@@ -189,6 +190,7 @@ export function useUpdateAnnotation() {
     mutationFn: (input: UpdateAnnotationInput) => updateAnnotation({ data: input }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+      void queryClient.invalidateQueries({ queryKey: ["scores"] })
     },
   })
 }
@@ -200,6 +202,7 @@ export function useDeleteAnnotation() {
     mutationFn: (input: DeleteAnnotationInput) => deleteAnnotation({ data: input }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+      void queryClient.invalidateQueries({ queryKey: ["scores"] })
     },
   })
 }
@@ -245,6 +248,7 @@ export function useApproveSystemAnnotation() {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+      void queryClient.invalidateQueries({ queryKey: ["scores"] })
     },
   })
 }
@@ -284,6 +288,7 @@ export function useRejectSystemAnnotation() {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+      void queryClient.invalidateQueries({ queryKey: ["scores"] })
     },
   })
 }

--- a/apps/web/src/domains/scores/scores.collection.ts
+++ b/apps/web/src/domains/scores/scores.collection.ts
@@ -1,0 +1,74 @@
+import { useQuery } from "@tanstack/react-query"
+import { listScoresBySession, listScoresByTrace } from "./scores.functions.ts"
+
+const DEFAULT_TRACE_DRAFT_MODE = "include" as const
+
+const scoresByTraceQueryKey = (
+  projectId: string,
+  traceId: string,
+  limit?: number,
+  offset?: number,
+  draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
+) => ["scores", "trace", projectId, traceId, limit, offset, draftMode] as const
+
+const scoresBySessionQueryKey = (
+  projectId: string,
+  traceIds: readonly string[],
+  limit?: number,
+  offset?: number,
+  draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
+) => ["scores", "session", projectId, [...traceIds].sort(), limit, offset, draftMode] as const
+
+export function useScoresByTrace({
+  projectId,
+  traceId,
+  limit,
+  offset,
+  draftMode,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly limit?: number
+  readonly offset?: number
+  readonly draftMode?: "exclude" | "include" | "only"
+  readonly enabled?: boolean
+}) {
+  const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
+
+  return useQuery({
+    queryKey: scoresByTraceQueryKey(projectId, traceId, limit, offset, effectiveDraftMode),
+    queryFn: () =>
+      listScoresByTrace({
+        data: { projectId, traceId, limit, offset, draftMode: effectiveDraftMode },
+      }),
+    enabled: enabled && projectId.length > 0 && traceId.length > 0,
+  })
+}
+
+export function useScoresBySession({
+  projectId,
+  traceIds,
+  limit,
+  offset,
+  draftMode,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly traceIds: readonly string[]
+  readonly limit?: number
+  readonly offset?: number
+  readonly draftMode?: "exclude" | "include" | "only"
+  readonly enabled?: boolean
+}) {
+  const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
+
+  return useQuery({
+    queryKey: scoresBySessionQueryKey(projectId, traceIds, limit, offset, effectiveDraftMode),
+    queryFn: () =>
+      listScoresBySession({
+        data: { projectId, traceIds: [...traceIds], limit, offset, draftMode: effectiveDraftMode },
+      }),
+    enabled: enabled && projectId.length > 0 && traceIds.length > 0,
+  })
+}

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -1,5 +1,11 @@
-import { listScoresByTraceIdsUseCase, listTraceScoresUseCase, type Score, scoreDraftModeSchema } from "@domain/scores"
-import { ProjectId } from "@domain/shared"
+import {
+  listScoresByTraceIdsUseCase,
+  listTraceScoresUseCase,
+  type Score,
+  type ScoreListPage,
+  type ScoreSourceType,
+  scoreDraftModeSchema,
+} from "@domain/scores"
 import { ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -8,40 +14,59 @@ import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getPostgresClient } from "../../server/clients.ts"
 
-const toRecord = (score: Score) => ({
+export interface ScoreRecord {
+  readonly id: string
+  readonly organizationId: string
+  readonly projectId: string
+  readonly sessionId: string | null
+  readonly traceId: string | null
+  readonly spanId: string | null
+  readonly source: ScoreSourceType
+  readonly sourceId: string
+  readonly simulationId: string | null
+  readonly signalId: string | null
+  readonly value: number
+  readonly passed: boolean
+  readonly feedback: string
+  readonly metadata: { readonly [key: string]: {} }
+  readonly error: string | null
+  readonly errored: boolean
+  readonly duration: number
+  readonly tokens: number
+  readonly cost: number
+  readonly draftedAt: string | null
+  readonly annotatorId: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+const toRecord = (score: Score): ScoreRecord => ({
   id: score.id as string,
-  organizationId: score.organizationId,
-  projectId: score.projectId,
-  sessionId: score.sessionId,
-  traceId: score.traceId,
-  spanId: score.spanId,
+  organizationId: score.organizationId as string,
+  projectId: score.projectId as string,
+  sessionId: score.sessionId ? (score.sessionId as string) : null,
+  traceId: score.traceId ? (score.traceId as string) : null,
+  spanId: score.spanId ? (score.spanId as string) : null,
   source: score.sourceType,
   sourceId: score.sourceId,
-  simulationId: score.simulationId,
-  signalId: score.signalId,
+  simulationId: score.simulationId ? (score.simulationId as string) : null,
+  signalId: score.signalId ? (score.signalId as string) : null,
   value: score.value,
   passed: score.passed,
   feedback: score.feedback,
-  metadata: score.metadata,
+  metadata: score.metadata as { [key: string]: {} },
   error: score.error,
   errored: score.errored,
   duration: score.duration,
   tokens: score.tokens,
   cost: score.cost,
   draftedAt: score.draftedAt ? score.draftedAt.toISOString() : null,
-  annotatorId: score.annotatorId,
+  annotatorId: score.annotatorId ? (score.annotatorId as string) : null,
   createdAt: score.createdAt.toISOString(),
   updatedAt: score.updatedAt.toISOString(),
 })
 
-export type ScoreRecord = ReturnType<typeof toRecord>
-
-const toListResult = (page: {
-  readonly items: readonly Score[]
-  readonly hasMore: boolean
-  readonly limit: number
-  readonly offset: number
-}) => ({
+const toListResult = (page: ScoreListPage) => ({
   items: page.items.map(toRecord),
   hasMore: page.hasMore,
   limit: page.limit,

--- a/apps/web/src/domains/scores/scores.functions.ts
+++ b/apps/web/src/domains/scores/scores.functions.ts
@@ -1,0 +1,114 @@
+import { listScoresByTraceIdsUseCase, listTraceScoresUseCase, type Score, scoreDraftModeSchema } from "@domain/scores"
+import { ProjectId } from "@domain/shared"
+import { ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getPostgresClient } from "../../server/clients.ts"
+
+const toRecord = (score: Score) => ({
+  id: score.id as string,
+  organizationId: score.organizationId,
+  projectId: score.projectId,
+  sessionId: score.sessionId,
+  traceId: score.traceId,
+  spanId: score.spanId,
+  source: score.sourceType,
+  sourceId: score.sourceId,
+  simulationId: score.simulationId,
+  signalId: score.signalId,
+  value: score.value,
+  passed: score.passed,
+  feedback: score.feedback,
+  metadata: score.metadata,
+  error: score.error,
+  errored: score.errored,
+  duration: score.duration,
+  tokens: score.tokens,
+  cost: score.cost,
+  draftedAt: score.draftedAt ? score.draftedAt.toISOString() : null,
+  annotatorId: score.annotatorId,
+  createdAt: score.createdAt.toISOString(),
+  updatedAt: score.updatedAt.toISOString(),
+})
+
+export type ScoreRecord = ReturnType<typeof toRecord>
+
+const toListResult = (page: {
+  readonly items: readonly Score[]
+  readonly hasMore: boolean
+  readonly limit: number
+  readonly offset: number
+}) => ({
+  items: page.items.map(toRecord),
+  hasMore: page.hasMore,
+  limit: page.limit,
+  offset: page.offset,
+})
+
+type ScoreListResult = ReturnType<typeof toListResult>
+
+export const listScoresByTrace = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceId: z.string(),
+      limit: z.number().optional(),
+      offset: z.number().optional(),
+      draftMode: scoreDraftModeSchema.optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<ScoreListResult> => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const result = await Effect.runPromise(
+      listTraceScoresUseCase({
+        projectId: data.projectId,
+        traceId: data.traceId,
+        limit: data.limit,
+        offset: data.offset,
+        draftMode: data.draftMode ?? "include",
+      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+    )
+
+    return toListResult(result)
+  })
+
+/**
+ * Every score across a set of traces (session panel Scores tab). Scopes by
+ * `trace_id IN (...)` rather than `session_id` so orphan sessions still surface
+ * their scores.
+ */
+export const listScoresBySession = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceIds: z.array(z.string().length(32)).max(500),
+      limit: z.number().optional(),
+      offset: z.number().optional(),
+      draftMode: scoreDraftModeSchema.optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<ScoreListResult> => {
+    if (data.traceIds.length === 0) {
+      return { items: [], hasMore: false, limit: data.limit ?? 50, offset: data.offset ?? 0 }
+    }
+
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const result = await Effect.runPromise(
+      listScoresByTraceIdsUseCase({
+        projectId: data.projectId,
+        traceIds: data.traceIds,
+        limit: data.limit,
+        offset: data.offset,
+        draftMode: data.draftMode ?? "include",
+      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+    )
+
+    return toListResult(result)
+  })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -191,8 +191,8 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     validate: (v): v is SortDirection | "" => v === "asc" || v === "desc" || v === "",
   })
   const [traceDetailTab] = useParamState("detailTab", "trace", {
-    validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
-      v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
+    validate: (v): v is "trace" | "conversation" | "spans" | "scores" | "annotations" =>
+      v === "trace" || v === "conversation" || v === "spans" || v === "scores" || v === "annotations",
   })
 
   // Ref to the ordered list of trace IDs from the currently loaded table page

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-card.tsx
@@ -1,0 +1,118 @@
+import type { ScoreSourceType } from "@domain/scores"
+import { Badge, Icon, Text, Tooltip } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { Link, useParams } from "@tanstack/react-router"
+import { AlertCircleIcon, ShieldAlertIcon, ThumbsDownIcon, ThumbsUpIcon } from "lucide-react"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+import { useSignal } from "../../../../../../domains/signals/signals.collection.ts"
+
+const SOURCE_LABELS: Record<ScoreSourceType, string> = {
+  annotation: "Annotation",
+  custom: "Custom",
+  evaluation: "Evaluation",
+}
+
+interface ScoreCardProps {
+  readonly score: ScoreRecord
+  readonly projectId: string
+}
+
+export function ReadOnlyScoreCard({ score, projectId }: ScoreCardProps) {
+  const { projectSlug } = useParams({ strict: false })
+  const { data: linkedSignal } = useSignal({
+    projectId,
+    signalId: score.signalId ?? "",
+    enabled: score.signalId !== null,
+  })
+
+  const linkedSignalName = linkedSignal?.name ?? null
+  const linkedSignalDescription = linkedSignal?.description?.trim()
+  const sourceLabel = SOURCE_LABELS[score.source]
+  const feedback = score.feedback?.trim()
+
+  return (
+    <div data-score-card-id={score.id} tabIndex={-1} className="flex flex-col gap-1 m-1 p-1 rounded-lg outline-none">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" size="small">
+          {sourceLabel}
+        </Badge>
+        <Text.H6 color="foregroundMuted" className="truncate">
+          {score.sourceId}
+        </Text.H6>
+        <Text.H6 color="foregroundMuted">{relativeTime(new Date(score.createdAt))}</Text.H6>
+        <div className="ml-auto flex items-center gap-x-1">
+          {score.errored ? (
+            <Tooltip
+              asChild
+              trigger={
+                <div className="flex h-8 w-8 items-center justify-center">
+                  <Icon icon={AlertCircleIcon} size="xs" color="destructiveMutedForeground" />
+                </div>
+              }
+            >
+              {score.error ?? "Score generation failed"}
+            </Tooltip>
+          ) : (
+            <div className="flex h-8 w-8 items-center justify-center">
+              <Icon
+                icon={score.passed ? ThumbsUpIcon : ThumbsDownIcon}
+                size="xs"
+                color={score.passed ? "successMutedForeground" : "destructiveMutedForeground"}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <Text.H6 color="foregroundMuted">Value: {Math.round(score.value * 100)}%</Text.H6>
+
+      {feedback ? <Text.H5 className="whitespace-pre-wrap">{feedback}</Text.H5> : null}
+
+      {linkedSignalName ? (
+        <div className="flex items-center gap-2 pt-1">
+          {(() => {
+            const isNavigable = Boolean(projectSlug && score.signalId)
+            const badge = (
+              <Badge
+                variant="outline"
+                size="small"
+                ellipsis
+                {...(isNavigable ? { className: "cursor-pointer hover:bg-muted" } : {})}
+                iconProps={{
+                  icon: ShieldAlertIcon,
+                  color: "foregroundMuted",
+                  placement: "start",
+                  className: "stroke-[2.5]",
+                }}
+              >
+                {linkedSignalName}
+              </Badge>
+            )
+            const trigger =
+              projectSlug && score.signalId ? (
+                <Link
+                  data-no-navigate
+                  to="/projects/$projectSlug/signals/$signalId"
+                  params={{ projectSlug, signalId: score.signalId }}
+                  aria-label={`Open signal ${linkedSignalName}`}
+                  onClick={(event) => event.stopPropagation()}
+                  className="inline-flex min-w-0"
+                >
+                  {badge}
+                </Link>
+              ) : (
+                badge
+              )
+            return linkedSignalDescription ? (
+              <Tooltip asChild trigger={trigger}>
+                <span className="block max-w-xs whitespace-pre-wrap text-left">{linkedSignalDescription}</span>
+              </Tooltip>
+            ) : (
+              trigger
+            )
+          })()}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-list.tsx
@@ -8,9 +8,11 @@ import type { AnnotationSaveData } from "../annotations/annotation-list.tsx"
 import { isGlobalAnnotation } from "../annotations/hooks/use-annotation-navigation.ts"
 import { ReadOnlyScoreCard } from "./score-card.tsx"
 
-function isAnnotationScore(score: ScoreRecord): score is AnnotationRecord {
+function isAnnotationScore(score: ScoreRecord): boolean {
   return score.source === "annotation"
 }
+
+const asAnnotationRecord = (score: ScoreRecord): AnnotationRecord => score as unknown as AnnotationRecord
 
 /**
  * Presentational scores surface shared by the trace drawer and session panel:
@@ -79,7 +81,7 @@ export function ScoreList({
           <div className="flex flex-col gap-2 pt-4">
             {sortedScores.map((score) => {
               const isSelected = selectedScoreId === score.id
-              const annotation = isAnnotationScore(score) ? score : null
+              const annotation = isAnnotationScore(score) ? asAnnotationRecord(score) : null
               const isGlobal = annotation ? isGlobalAnnotation(annotation) : false
               const clickable = annotation !== null && !isGlobal && onScoreClick !== undefined
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/score-list.tsx
@@ -1,0 +1,121 @@
+import { cn, Skeleton, Text } from "@repo/ui"
+import { type KeyboardEvent, type MouseEvent, type ReactNode, useCallback } from "react"
+import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+import { AnnotationCard } from "../annotations/annotation-card.tsx"
+import { AnnotationInput } from "../annotations/annotation-input.tsx"
+import type { AnnotationSaveData } from "../annotations/annotation-list.tsx"
+import { isGlobalAnnotation } from "../annotations/hooks/use-annotation-navigation.ts"
+import { ReadOnlyScoreCard } from "./score-card.tsx"
+
+function isAnnotationScore(score: ScoreRecord): score is AnnotationRecord {
+  return score.source === "annotation"
+}
+
+/**
+ * Presentational scores surface shared by the trace drawer and session panel:
+ * annotation create form + newest-first list of every score source.
+ */
+export function ScoreList({
+  projectId,
+  scores,
+  isLoading,
+  isError,
+  intro,
+  showCreateForm = true,
+  createPending = false,
+  onCreate,
+  updatePending = false,
+  onUpdate,
+  onScoreClick,
+  selectedScoreId,
+  renderItemAccessory,
+}: {
+  readonly projectId: string
+  readonly scores: readonly ScoreRecord[]
+  readonly isLoading: boolean
+  readonly isError: boolean
+  readonly intro?: ReactNode
+  readonly showCreateForm?: boolean
+  readonly createPending?: boolean
+  readonly onCreate: (data: AnnotationSaveData) => void
+  readonly updatePending?: boolean
+  readonly onUpdate: (score: AnnotationRecord, data: AnnotationSaveData) => void
+  readonly onScoreClick?: (score: ScoreRecord) => void
+  readonly selectedScoreId?: string | undefined
+  readonly renderItemAccessory?: (score: ScoreRecord) => ReactNode
+}) {
+  const sortedScores = [...scores].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+
+  const onClickScoreCard = useCallback(
+    ({ score, clickable }: { score: ScoreRecord; clickable: boolean }) =>
+      (event: MouseEvent | KeyboardEvent) => {
+        if (!clickable) return
+        const target = event.target
+        if (target instanceof Element && target.closest("[data-no-navigate]")) return
+        if ("key" in event && event.key !== "Enter" && event.key !== " ") return
+        onScoreClick?.(score)
+      },
+    [onScoreClick],
+  )
+
+  return (
+    <div className="flex flex-col flex-1 overflow-y-auto p-6 gap-6">
+      {intro}
+
+      <div className="flex flex-col gap-4">
+        {showCreateForm ? <AnnotationInput projectId={projectId} isLoading={createPending} onSave={onCreate} /> : null}
+
+        {isLoading ? (
+          <div className="flex flex-col gap-4 pt-4">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : isError ? (
+          <Text.H6 color="foregroundMuted" className="pt-4">
+            Could not load scores.
+          </Text.H6>
+        ) : sortedScores.length > 0 ? (
+          <div className="flex flex-col gap-2 pt-4">
+            {sortedScores.map((score) => {
+              const isSelected = selectedScoreId === score.id
+              const annotation = isAnnotationScore(score) ? score : null
+              const isGlobal = annotation ? isGlobalAnnotation(annotation) : false
+              const clickable = annotation !== null && !isGlobal && onScoreClick !== undefined
+
+              return (
+                /* biome-ignore lint/a11y/noStaticElementInteractions: only interactive for navigable annotations */
+                <div
+                  key={`${score.id}:${score.draftedAt !== null ? "draft" : "pub"}`}
+                  data-annotation-navigation={clickable ? "true" : undefined}
+                  className={cn(
+                    "rounded-lg",
+                    clickable ? "cursor-pointer hover:bg-secondary" : undefined,
+                    isSelected && "bg-secondary ring-2 ring-primary/50 ring-offset-2",
+                  )}
+                  onClick={onClickScoreCard({ score, clickable })}
+                  onKeyDown={onClickScoreCard({ score, clickable })}
+                  role={clickable ? "button" : undefined}
+                  tabIndex={clickable ? 0 : undefined}
+                >
+                  {renderItemAccessory?.(score)}
+                  {annotation ? (
+                    <AnnotationCard
+                      annotation={annotation}
+                      projectId={projectId}
+                      isGlobal={isGlobal}
+                      isUpdateLoading={updatePending}
+                      onUpdate={(data) => onUpdate(annotation, data)}
+                    />
+                  ) : (
+                    <ReadOnlyScoreCard score={score} projectId={projectId} />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/trace-scores-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/scores/trace-scores-list.tsx
@@ -1,0 +1,79 @@
+import { Text } from "@repo/ui"
+import {
+  useCreateAnnotation,
+  useUpdateAnnotation,
+} from "../../../../../../domains/annotations/annotations.collection.ts"
+import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
+import { useScoresByTrace } from "../../../../../../domains/scores/scores.collection.ts"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+import { ScoreList } from "./score-list.tsx"
+
+export function TraceScoresList({
+  projectId,
+  traceId,
+  selectedScoreId,
+  onScoreClick,
+  hideIntro = false,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly selectedScoreId?: string | undefined
+  readonly onScoreClick?: ((score: ScoreRecord) => void) | undefined
+  readonly hideIntro?: boolean | undefined
+}) {
+  const {
+    data: scoresData,
+    isLoading,
+    isError,
+  } = useScoresByTrace({
+    projectId,
+    traceId,
+    draftMode: "include",
+  })
+  const createMutation = useCreateAnnotation()
+  const updateMutation = useUpdateAnnotation()
+
+  return (
+    <ScoreList
+      projectId={projectId}
+      scores={scoresData?.items ?? []}
+      isLoading={isLoading}
+      isError={isError}
+      intro={
+        hideIntro ? undefined : (
+          <div className="flex flex-col">
+            <Text.H5M>Scores</Text.H5M>
+            <Text.H5 color="foregroundMuted">
+              Evaluations, annotations, and custom scores attached to this trace
+            </Text.H5>
+          </div>
+        )
+      }
+      createPending={createMutation.isPending}
+      onCreate={(data) =>
+        createMutation.mutate({
+          projectId,
+          traceId,
+          value: data.passed ? 1 : 0,
+          passed: data.passed,
+          feedback: data.comment.trim(),
+          ...(data.signalId ? { signalId: data.signalId } : {}),
+        })
+      }
+      updatePending={updateMutation.isPending}
+      onUpdate={(annotation: AnnotationRecord, data) =>
+        updateMutation.mutate({
+          scoreId: annotation.id,
+          projectId,
+          traceId,
+          value: data.passed ? 1 : 0,
+          passed: data.passed,
+          feedback: data.comment.trim(),
+          signalId: data.signalId ?? undefined,
+        })
+      }
+      {...(onScoreClick ? { onScoreClick } : {})}
+      {...(selectedScoreId !== undefined ? { selectedScoreId } : {})}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -9,7 +9,12 @@ import { useSessionDetail } from "../../../../../domains/sessions/sessions.colle
 import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { SignalLifecycleActions } from "../signals/-components/signal-lifecycle-actions.tsx"
-import { isSessionTab, SessionSlot, type SessionTabId } from "./session-detail-drawer/session-slot.tsx"
+import {
+  isSessionTab,
+  normalizeSessionTab,
+  SessionSlot,
+  type SessionTabId,
+} from "./session-detail-drawer/session-slot.tsx"
 import { SignalSlot } from "./session-detail-drawer/signal-slot.tsx"
 import { type DetailSlotKind, SlotTransition } from "./session-detail-drawer/slot-transition.tsx"
 import { isTraceDetailTab, type TraceDetailTabId, TraceSlot } from "./session-detail-drawer/trace-slot.tsx"
@@ -54,9 +59,10 @@ export function SessionDetailDrawer({
   // conversation tab's search-match autoscroll/highlight has something to scroll to.
   const defaultSessionTab =
     defaultTab ?? ((searchQuery?.length ?? q.length) > 0 || focusMomentKind ? "conversation" : "session")
-  const [activeTab, setActiveTab] = useParamState("sessionTab", defaultSessionTab, {
+  const [rawActiveTab, setActiveTab] = useParamState("sessionTab", defaultSessionTab, {
     validate: isSessionTab,
   })
+  const activeTab = normalizeSessionTab(rawActiveTab)
   // Owned by `TraceSlot` once it mounts, but written here when sliding into a
   // trace so the slot lands on the requested tab (Signals → "trace",
   // Annotations → "conversation"). Kept distinct from `sessionTab` so the two

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
@@ -5,7 +5,6 @@ import {
 } from "../../../../../../domains/annotations/annotations.collection.ts"
 import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
 import { useScoresBySession } from "../../../../../../domains/scores/scores.collection.ts"
-import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
 import { ScoreList } from "../scores/score-list.tsx"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/scores-tab.tsx
@@ -1,21 +1,20 @@
 import { Text } from "@repo/ui"
 import {
-  useAnnotationsBySession,
   useCreateAnnotation,
   useUpdateAnnotation,
 } from "../../../../../../domains/annotations/annotations.collection.ts"
-import { AnnotationList } from "../annotations/annotation-list.tsx"
+import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
+import { useScoresBySession } from "../../../../../../domains/scores/scores.collection.ts"
+import type { ScoreRecord } from "../../../../../../domains/scores/scores.functions.ts"
+import { ScoreList } from "../scores/score-list.tsx"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 
 /**
- * Session-wide annotations — the same surface as the trace drawer's
- * `TraceAnnotationsList`, reusing `AnnotationList`. Annotations attach to a
- * trace, so the create form targets the session's *latest* trace (its current
- * conversation); editing targets each annotation's own trace. A "Trace N" label
- * marks which trace each annotation belongs to, and a click routes to the
- * Conversation tab (latest trace) or slides into an older trace's slot.
+ * Session-wide scores — every score source across the session's traces.
+ * Annotation create still targets the latest trace; editing targets each
+ * annotation's own trace.
  */
-export function AnnotationsTab({
+export function ScoresTab({
   projectId,
   traceIds,
   latestTraceId,
@@ -27,19 +26,17 @@ export function AnnotationsTab({
   readonly traceIds: readonly string[]
   readonly latestTraceId: string
   readonly traceNumberById: ReadonlyMap<string, number>
-  /** Inline annotation on the latest trace → switch to the Conversation tab. */
   readonly onOpenInConversation: (annotationId: string) => void
-  /** Inline annotation on an older trace → slide into its trace slot, focused on it. */
   readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
 }) {
-  const { data, isLoading, isError } = useAnnotationsBySession({ projectId, traceIds })
+  const { data, isLoading, isError } = useScoresBySession({ projectId, traceIds })
   const createMutation = useCreateAnnotation()
   const updateMutation = useUpdateAnnotation()
 
   return (
-    <AnnotationList
+    <ScoreList
       projectId={projectId}
-      annotations={data?.items ?? []}
+      scores={data?.items ?? []}
       isLoading={isLoading}
       isError={isError}
       showCreateForm={latestTraceId.length > 0}
@@ -56,7 +53,7 @@ export function AnnotationsTab({
         })
       }}
       updatePending={updateMutation.isPending}
-      onUpdate={(annotation, annotationData) => {
+      onUpdate={(annotation: AnnotationRecord, annotationData) => {
         const traceId = annotation.traceId ?? ""
         if (!traceId) return
         updateMutation.mutate({
@@ -69,14 +66,15 @@ export function AnnotationsTab({
           signalId: annotationData.signalId ?? undefined,
         })
       }}
-      onAnnotationClick={(annotation) => {
-        const traceId = annotation.traceId ?? ""
+      onScoreClick={(score) => {
+        if (score.source !== "annotation") return
+        const traceId = score.traceId ?? ""
         if (!traceId) return
-        if (traceId === latestTraceId) onOpenInConversation(annotation.id)
-        else onOpenTrace(traceId, { focusAnnotationId: annotation.id })
+        if (traceId === latestTraceId) onOpenInConversation(score.id)
+        else onOpenTrace(traceId, { focusAnnotationId: score.id })
       }}
-      renderItemAccessory={(annotation) => {
-        const traceNumber = traceNumberById.get(annotation.traceId ?? "")
+      renderItemAccessory={(score) => {
+        const traceNumber = traceNumberById.get(score.traceId ?? "")
         return traceNumber !== undefined ? (
           <Text.H6 color="foregroundMuted" className="px-3 pt-1">
             Trace {traceNumber}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -3,9 +3,9 @@ import type { FilterSet } from "@domain/shared"
 import { CopyableText, Icon, ProviderIcon, Status, type TabOption, Tabs, Text, Tooltip } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { GroupIcon, ListTreeIcon, MessageSquareIcon, MessagesSquareIcon, ShieldAlertIcon } from "lucide-react"
+import { GaugeIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon, ShieldAlertIcon } from "lucide-react"
 import { use, useEffect, useMemo, useState } from "react"
-import { useAnnotationsBySession } from "../../../../../../domains/annotations/annotations.collection.ts"
+import { useScoresBySession } from "../../../../../../domains/scores/scores.collection.ts"
 import { deriveSessionStatus, useSessionSignals } from "../../../../../../domains/sessions/sessions.collection.ts"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { TraceScopeContext } from "../../../../../../domains/traces/trace-scope.tsx"
@@ -15,22 +15,24 @@ import { AddTraceToDatasetAction } from "../add-trace-to-dataset-action.tsx"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
 import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import { SpansTab } from "../trace-detail-drawer/tabs/spans-tab.tsx"
-import { AnnotationsTab } from "./annotations-tab.tsx"
 import { ConversationTab } from "./conversation-tab.tsx"
 import { MetadataTab } from "./metadata-tab.tsx"
+import { ScoresTab } from "./scores-tab.tsx"
 import { SessionStatusPill } from "./session-status-pill.tsx"
 import { SignalsTab } from "./signals-tab.tsx"
 
-export type SessionTabId = "session" | "conversation" | "spans" | "annotations" | "issues"
+export type SessionTabId = "session" | "conversation" | "spans" | "scores" | "issues"
 
 export function isSessionTab(value: string): value is SessionTabId {
+  if (value === "annotations") return true
   return (
-    value === "session" ||
-    value === "conversation" ||
-    value === "spans" ||
-    value === "annotations" ||
-    value === "issues"
+    value === "session" || value === "conversation" || value === "spans" || value === "scores" || value === "issues"
   )
+}
+
+export function normalizeSessionTab(value: string): SessionTabId {
+  if (value === "annotations") return "scores"
+  return isSessionTab(value) ? value : "session"
 }
 
 const tabCountPillClass =
@@ -82,16 +84,16 @@ export function SessionSlot({
   // Annotations and issues are analysis/feedback features the sandbox doesn't
   // produce — both off under a sandbox scope: hide the tabs and skip the fetches.
   const isSandbox = !!use(TraceScopeContext)
-  const annotationsEnabled = !isSandbox
+  const scoresEnabled = !isSandbox
   const signalsEnabled = !isSandbox
   // A single-trace session can surface its spans inline
   const singleTrace = traces.length === 1 ? traces[0] : undefined
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   const { openWithErrors, openWithModel } = useSpanFilters()
-  const requestedTab: SessionTabId = activeTab === "spans" && !singleTrace ? "session" : activeTab
+  const requestedTab: SessionTabId = activeTab === "spans" && !singleTrace ? "session" : normalizeSessionTab(activeTab)
   // A deep-linked tab for a feature that's off (sandbox) falls back to Session.
   const effectiveActiveTab: SessionTabId =
-    (requestedTab === "annotations" && !annotationsEnabled) || (requestedTab === "issues" && !signalsEnabled)
+    (requestedTab === "scores" && !scoresEnabled) || (requestedTab === "issues" && !signalsEnabled)
       ? "session"
       : requestedTab
   const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<SessionTabId>>(() => new Set([effectiveActiveTab]))
@@ -128,13 +130,13 @@ export function SessionSlot({
 
   // Badge counts. Both queries are shared (same key) with the tab panes, so
   // mounting a tab doesn't refetch.
-  const { data: annotationsData } = useAnnotationsBySession({
+  const { data: scoresData } = useScoresBySession({
     projectId,
     traceIds,
-    enabled: annotationsEnabled,
+    enabled: scoresEnabled,
   })
   const { data: issues } = useSessionSignals({ projectId, traceIds, enabled: signalsEnabled })
-  const annotationCount = annotationsData?.items.length ?? 0
+  const scoreCount = scoresData?.items.length ?? 0
   const signalCount = issues?.length ?? 0
 
   const traceNumberById = useMemo(() => {
@@ -169,12 +171,12 @@ export function SessionSlot({
         suffix: countSuffix(singleTrace.spanCount),
       })
     }
-    if (annotationsEnabled) {
+    if (scoresEnabled) {
       all.push({
-        id: "annotations",
-        label: "Annotations",
-        icon: <Icon icon={MessageSquareIcon} size="sm" />,
-        suffix: countSuffix(annotationCount),
+        id: "scores",
+        label: "Scores",
+        icon: <Icon icon={GaugeIcon} size="sm" />,
+        suffix: countSuffix(scoreCount),
       })
     }
     if (signalsEnabled) {
@@ -186,7 +188,7 @@ export function SessionSlot({
       })
     }
     return all
-  }, [annotationsEnabled, signalsEnabled, annotationCount, signalCount, singleTrace])
+  }, [scoresEnabled, signalsEnabled, scoreCount, signalCount, singleTrace])
 
   // H/L cycle the session tabs (wrapping), matching the trace drawer. Disabled
   // while a trace/issue slot is shown so they don't collide with the trace slot.
@@ -323,9 +325,9 @@ export function SessionSlot({
             />
           </div>
         )}
-        {annotationsEnabled && visitedTabs.has("annotations") && (
-          <div className={effectiveActiveTab === "annotations" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-            <AnnotationsTab
+        {scoresEnabled && visitedTabs.has("scores") && (
+          <div className={effectiveActiveTab === "scores" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+            <ScoresTab
               projectId={projectId}
               traceIds={traceIds}
               latestTraceId={latestTraceId}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -15,18 +15,12 @@ import {
 } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  GroupIcon,
-  ListTreeIcon,
-  MessageSquareIcon,
-  MessagesSquareIcon,
-} from "lucide-react"
+import { ArrowDownIcon, ArrowUpIcon, GaugeIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon } from "lucide-react"
 import { type ReactNode, use, useCallback, useEffect, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
-import { useAnnotationsByTrace } from "../../../../../domains/annotations/annotations.collection.ts"
 import type { AnnotationRecord } from "../../../../../domains/annotations/annotations.functions.ts"
+import { useScoresByTrace } from "../../../../../domains/scores/scores.collection.ts"
+import type { ScoreRecord } from "../../../../../domains/scores/scores.functions.ts"
 import { useSpansByTraceCollection } from "../../../../../domains/spans/spans.collection.ts"
 import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx"
 import { useTraceDetail } from "../../../../../domains/traces/traces.collection.ts"
@@ -35,18 +29,24 @@ import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { AddTraceToDatasetAction } from "./add-trace-to-dataset-action.tsx"
 import { isGlobalAnnotation } from "./annotations/hooks/use-annotation-navigation.ts"
 import { useConversationAnnotationFocus } from "./annotations/hooks/use-conversation-annotation-focus.ts"
-import { TraceAnnotationsList } from "./annotations/trace-annotations-list.tsx"
 import { useTraceTimeline } from "./conversation-timeline/use-trace-timeline.ts"
+import { TraceScoresList } from "./scores/trace-scores-list.tsx"
 import { ConversationTab } from "./trace-detail-drawer/tabs/conversation-tab.tsx"
 import { useSpanFilters } from "./trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import { SpansTab } from "./trace-detail-drawer/tabs/spans-tab.tsx"
 import { TraceTab } from "./trace-detail-drawer/tabs/trace-tab.tsx"
 import { TraceCommandPaletteContributor } from "./trace-detail-drawer/trace-command-palette-contributor.tsx"
 
-export type TraceDetailTabId = "trace" | "conversation" | "spans" | "annotations"
+export type TraceDetailTabId = "trace" | "conversation" | "spans" | "scores"
 
 export function isTraceDetailTab(value: string): value is TraceDetailTabId {
-  return value === "trace" || value === "conversation" || value === "spans" || value === "annotations"
+  if (value === "annotations") return true
+  return value === "trace" || value === "conversation" || value === "spans" || value === "scores"
+}
+
+export function normalizeTraceDetailTab(value: string): TraceDetailTabId {
+  if (value === "annotations") return "scores"
+  return isTraceDetailTab(value) ? value : "trace"
 }
 
 type TabId = TraceDetailTabId
@@ -68,34 +68,34 @@ const TABS: TabOption<TabId>[] = [
     icon: <Icon icon={ListTreeIcon} size="sm" />,
   },
   {
-    id: "annotations",
-    label: "Annotations",
-    icon: <Icon icon={MessageSquareIcon} size="sm" />,
+    id: "scores",
+    label: "Scores",
+    icon: <Icon icon={GaugeIcon} size="sm" />,
   },
 ]
 
 const tabCountPillClass =
   "inline-flex min-h-5 min-w-[1.125rem] shrink-0 items-center justify-center rounded-full bg-muted px-1.5 text-[0.6875rem] font-medium leading-none text-muted-foreground"
 
-function getAnnotationTabSuffix({
-  annotationsByTraceError,
-  annotationsByTraceLoading,
-  annotationCount,
+function getScoresTabSuffix({
+  scoresByTraceError,
+  scoresByTraceLoading,
+  scoreCount,
 }: {
-  readonly annotationsByTraceError: boolean
-  readonly annotationsByTraceLoading: boolean
-  readonly annotationCount: number
+  readonly scoresByTraceError: boolean
+  readonly scoresByTraceLoading: boolean
+  readonly scoreCount: number
 }): ReactNode {
-  if (annotationsByTraceError) {
+  if (scoresByTraceError) {
     return <span className={tabCountPillClass}>–</span>
   }
-  if (annotationsByTraceLoading) {
+  if (scoresByTraceLoading) {
     return null
   }
-  if (annotationCount === 0) {
+  if (scoreCount === 0) {
     return null
   }
-  return <span className={cn(tabCountPillClass, "tabular-nums")}>{annotationCount}</span>
+  return <span className={cn(tabCountPillClass, "tabular-nums")}>{scoreCount}</span>
 }
 
 function getSpansTabSuffix(spanCount: number | undefined): ReactNode {
@@ -153,9 +153,10 @@ function TraceDetailDrawerWithUrlTabs(props: Omit<TraceDetailDrawerProps, "urlSy
   // Default to Conversation when arriving from an active search so the
   // search-match autoscroll/highlight lands on a hit instead of the trace tab.
   const defaultTab = (props.searchQuery?.length ?? 0) > 0 ? "conversation" : "trace"
-  const [activeTab, setActiveTab] = useParamState("detailTab", defaultTab, {
+  const [rawActiveTab, setActiveTab] = useParamState("detailTab", defaultTab, {
     validate: isTraceDetailTab,
   })
+  const activeTab = normalizeTraceDetailTab(rawActiveTab)
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   return (
     <TraceDetailDrawerShell
@@ -175,7 +176,7 @@ function TraceDetailDrawerWithUrlTabs(props: Omit<TraceDetailDrawerProps, "urlSy
 
 function TraceDetailDrawerWithLocalTabs(props: Omit<TraceDetailDrawerProps, "urlSyncedTabs">) {
   const { initialTab, initialSpanId, closeLabel, drawerStoreKey, ...rest } = props
-  const [activeTab, setActiveTab] = useState<TabId>(initialTab ?? "trace")
+  const [activeTab, setActiveTab] = useState<TabId>(normalizeTraceDetailTab(initialTab ?? "trace"))
   const [selectedSpanId, setSelectedSpanId] = useState(initialSpanId ?? "")
   return (
     <TraceDetailDrawerShell
@@ -234,31 +235,31 @@ export function TraceDetailBody({
   searchQuery,
 }: TraceDetailBodyProps) {
   const isSandbox = !!use(TraceScopeContext)
-  const annotationsEnabled = !isSandbox
+  const scoresEnabled = !isSandbox
   const commandPaletteEnabled = !isSandbox
   const { data: traceDetail, isLoading: isDetailLoading } = useTraceDetail({
     projectId,
     traceId,
   })
   const {
-    data: annotationsByTraceData,
-    isLoading: annotationsByTraceLoading,
-    isError: annotationsByTraceError,
-  } = useAnnotationsByTrace({
+    data: scoresByTraceData,
+    isLoading: scoresByTraceLoading,
+    isError: scoresByTraceError,
+  } = useScoresByTrace({
     projectId,
     traceId,
     draftMode: "include",
-    enabled: annotationsEnabled,
+    enabled: scoresEnabled,
   })
-  const annotationCount = annotationsByTraceData?.items?.length ?? 0
-  const annotationTabSuffix = useMemo(
+  const scoreCount = scoresByTraceData?.items?.length ?? 0
+  const scoresTabSuffix = useMemo(
     () =>
-      getAnnotationTabSuffix({
-        annotationsByTraceError,
-        annotationsByTraceLoading,
-        annotationCount,
+      getScoresTabSuffix({
+        scoresByTraceError,
+        scoresByTraceLoading,
+        scoreCount,
       }),
-    [annotationsByTraceError, annotationsByTraceLoading, annotationCount],
+    [scoresByTraceError, scoresByTraceLoading, scoreCount],
   )
   const isRecordLoading = !trace && !traceDetail
   const traceRecord: TraceRecord | undefined = traceDetail ?? trace
@@ -273,12 +274,12 @@ export function TraceDetailBody({
   const spansTabSuffix = useMemo(() => getSpansTabSuffix(traceRecord?.spanCount), [traceRecord?.spanCount])
   const tabsWithCounts = useMemo<TabOption<TabId>[]>(
     () =>
-      TABS.filter((tab) => annotationsEnabled || tab.id !== "annotations").map((tab) => {
-        if (tab.id === "annotations") return { ...tab, suffix: annotationTabSuffix }
+      TABS.filter((tab) => scoresEnabled || tab.id !== "scores").map((tab) => {
+        if (tab.id === "scores") return { ...tab, suffix: scoresTabSuffix }
         if (tab.id === "spans") return { ...tab, suffix: spansTabSuffix }
         return tab
       }),
-    [annotationsEnabled, annotationTabSuffix, spansTabSuffix],
+    [scoresEnabled, scoresTabSuffix, spansTabSuffix],
   )
   const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(() => new Set([activeTab]))
   const { openWithErrors, openWithModel } = useSpanFilters()
@@ -298,7 +299,7 @@ export function TraceDetailBody({
     traceRecord,
     traceDetail,
     spans,
-    annotationsEnabled,
+    annotationsEnabled: scoresEnabled,
   })
 
   // H/L cycle the trace tabs (J/K are reserved for prev/next trace and, on the
@@ -329,14 +330,16 @@ export function TraceDetailBody({
     focusAnnotationId,
     isConversationActive: activeTab === "conversation",
     onActivateConversation: () => handleSetActiveTab("conversation"),
-    annotationsEnabled,
+    annotationsEnabled: scoresEnabled,
   })
 
   useEffect(() => {
     setVisitedTabs((prev) => new Set([...prev, activeTab]))
   }, [activeTab])
 
-  function handleAnnotationClick(annotation: AnnotationRecord) {
+  function handleScoreClick(score: ScoreRecord) {
+    if (score.source !== "annotation") return
+    const annotation = score as AnnotationRecord
     if (isGlobalAnnotation(annotation)) return
     scrollToAnnotation(annotation)
   }
@@ -452,7 +455,7 @@ export function TraceDetailBody({
             navigateToSpan={navigateToSpan}
             projectId={projectId}
             isActive={activeTab === "conversation"}
-            annotationsEnabled={annotationsEnabled}
+            annotationsEnabled={scoresEnabled}
             scrollContainerRef={scrollContainerRef}
             textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
             timeline={timeline}
@@ -477,19 +480,14 @@ export function TraceDetailBody({
           />
         )}
       </div>
-      {annotationsEnabled ? (
+      {scoresEnabled ? (
         <div
           className={cn("flex flex-col flex-1 overflow-hidden", {
-            hidden: activeTab !== "annotations",
+            hidden: activeTab !== "scores",
           })}
         >
-          {visitedTabs.has("annotations") && (
-            <TraceAnnotationsList
-              projectId={projectId}
-              traceId={traceId}
-              hideAnnotationIntro
-              onAnnotationClick={handleAnnotationClick}
-            />
+          {visitedTabs.has("scores") && (
+            <TraceScoresList projectId={projectId} traceId={traceId} hideIntro onScoreClick={handleScoreClick} />
           )}
         </div>
       ) : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/trace-command-palette-contributor.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/trace-command-palette-contributor.tsx
@@ -1,6 +1,6 @@
 import { useToast } from "@repo/ui"
 import { useNavigate } from "@tanstack/react-router"
-import { CopyIcon, LayersIcon, ListTreeIcon, MessageSquareIcon, MessagesSquareIcon } from "lucide-react"
+import { CopyIcon, GaugeIcon, LayersIcon, ListTreeIcon, MessagesSquareIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useRegisterCommands } from "../../../../../../components/command-palette/command-palette-provider.tsx"
 import { useCurrentProject } from "../../../../../../components/command-palette/commands/use-current-project.ts"
@@ -53,13 +53,13 @@ export function TraceCommandPaletteContributor({
         perform: () => onGoToTab("spans"),
       },
       {
-        id: `trace:${traceId}:annotations`,
-        title: "View annotations",
-        icon: MessageSquareIcon,
+        id: `trace:${traceId}:scores`,
+        title: "View scores",
+        icon: GaugeIcon,
         section: "context",
         group: "Trace",
-        keywords: "annotations notes scores",
-        perform: () => onGoToTab("annotations"),
+        keywords: "scores annotations evaluations custom",
+        perform: () => onGoToTab("scores"),
       },
     ]
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -110,7 +110,7 @@ export function TracesView({
   const handleAnnotationClick = useCallback(
     (trace: TraceRecord) => {
       onActiveTraceChange(trace.traceId)
-      setTraceDetailTab("annotations")
+      setTraceDetailTab("scores")
     },
     [onActiveTraceChange, setTraceDetailTab],
   )

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -96,8 +96,8 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
     direction: sortDirection,
   }
   const [detailTab] = useParamState("detailTab", "trace", {
-    validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
-      v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
+    validate: (v): v is "trace" | "conversation" | "spans" | "scores" | "annotations" =>
+      v === "trace" || v === "conversation" || v === "spans" || v === "scores" || v === "annotations",
   })
 
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)

--- a/packages/domain/scores/src/index.ts
+++ b/packages/domain/scores/src/index.ts
@@ -92,6 +92,15 @@ export {
   listSourceScoresUseCase,
 } from "./use-cases/list-scores.ts"
 export {
+  type ListScoresByTraceIdsInput,
+  type ListTraceScoresError,
+  type ListTraceScoresInput,
+  listScoresByTraceIdsInputSchema,
+  listScoresByTraceIdsUseCase,
+  listTraceScoresInputSchema,
+  listTraceScoresUseCase,
+} from "./use-cases/list-trace-scores.ts"
+export {
   type SyncScoreAnalyticsInput,
   syncScoreAnalyticsUseCase,
 } from "./use-cases/save-score-analytics.ts"

--- a/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
@@ -1,0 +1,108 @@
+import { createFakeScoreRepository } from "@domain/scores/testing"
+import { ProjectId, ScoreId, TraceId } from "@domain/shared"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { scoreSchema } from "../entities/score.ts"
+import { ScoreRepository } from "../ports/score-repository.ts"
+import { listScoresByTraceIdsUseCase, listTraceScoresUseCase } from "./list-trace-scores.ts"
+
+const projectId = ProjectId("p".repeat(24))
+const traceId = TraceId("t".repeat(32))
+const otherTraceId = TraceId("u".repeat(32))
+
+const makeScore = (overrides: Record<string, unknown> = {}) =>
+  scoreSchema.parse({
+    id: ScoreId("s".repeat(24)),
+    organizationId: "o".repeat(24),
+    projectId,
+    sessionId: null,
+    traceId,
+    spanId: null,
+    simulationId: null,
+    signalId: null,
+    sourceType: "custom",
+    sourceId: "api-pipeline",
+    value: 0.2,
+    passed: false,
+    feedback: "Wrong answer",
+    metadata: {},
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: null,
+    annotatorId: null,
+    createdAt: new Date("2026-03-31T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-31T00:00:00.000Z"),
+    ...overrides,
+  })
+
+const listScoresForTraces = (scores: Map<string, ReturnType<typeof makeScore>>, traceIds: readonly TraceId[]) => {
+  const traceIdSet = new Set(traceIds.map(String))
+  const items = [...scores.values()].filter(
+    (score) => score.projectId === projectId && score.traceId !== null && traceIdSet.has(String(score.traceId)),
+  )
+  return { items, hasMore: false, limit: 50, offset: 0 }
+}
+
+describe("listTraceScoresUseCase", () => {
+  it("returns every score source for a trace", async () => {
+    const custom = makeScore({ id: ScoreId("a".repeat(24)), sourceType: "custom", sourceId: "api" })
+    const evaluation = makeScore({
+      id: ScoreId("b".repeat(24)),
+      sourceType: "evaluation",
+      sourceId: "e".repeat(24),
+      metadata: { evaluationHash: "hash" },
+      passed: true,
+    })
+    const annotation = makeScore({
+      id: ScoreId("c".repeat(24)),
+      sourceType: "annotation",
+      sourceId: "UI",
+      metadata: { rawFeedback: "note" },
+    })
+
+    const { repository, scores } = createFakeScoreRepository({
+      listByTraceId: ({ traceId: requestedTraceId }) => Effect.succeed(listScoresForTraces(scores, [requestedTraceId])),
+    })
+    scores.set(custom.id, custom)
+    scores.set(evaluation.id, evaluation)
+    scores.set(annotation.id, annotation)
+
+    const page = await Effect.runPromise(
+      listTraceScoresUseCase({ projectId, traceId }).pipe(Effect.provideService(ScoreRepository, repository)),
+    )
+
+    expect(page.items).toHaveLength(3)
+    expect(page.items.map((score) => score.sourceType).sort()).toEqual(["annotation", "custom", "evaluation"])
+  })
+})
+
+describe("listScoresByTraceIdsUseCase", () => {
+  it("returns scores across multiple traces without filtering by source", async () => {
+    const onFirstTrace = makeScore({ id: ScoreId("a".repeat(24)), traceId })
+    const onSecondTrace = makeScore({
+      id: ScoreId("b".repeat(24)),
+      traceId: otherTraceId,
+      sourceType: "evaluation",
+      sourceId: "e".repeat(24),
+      metadata: { evaluationHash: "hash" },
+      passed: true,
+    })
+
+    const { repository, scores } = createFakeScoreRepository({
+      listByTraceIds: ({ traceIds }) => Effect.succeed(listScoresForTraces(scores, traceIds)),
+    })
+    scores.set(onFirstTrace.id, onFirstTrace)
+    scores.set(onSecondTrace.id, onSecondTrace)
+
+    const page = await Effect.runPromise(
+      listScoresByTraceIdsUseCase({ projectId, traceIds: [traceId, otherTraceId] }).pipe(
+        Effect.provideService(ScoreRepository, repository),
+      ),
+    )
+
+    expect(page.items).toHaveLength(2)
+  })
+})

--- a/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.test.ts
@@ -1,11 +1,13 @@
 import { createFakeScoreRepository } from "@domain/scores/testing"
-import { ProjectId, ScoreId, TraceId } from "@domain/shared"
+import { OrganizationId, ProjectId, ScoreId, SqlClient, TraceId } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import { scoreSchema } from "../entities/score.ts"
 import { ScoreRepository } from "../ports/score-repository.ts"
 import { listScoresByTraceIdsUseCase, listTraceScoresUseCase } from "./list-trace-scores.ts"
 
+const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
 const traceId = TraceId("t".repeat(32))
 const otherTraceId = TraceId("u".repeat(32))
@@ -13,7 +15,7 @@ const otherTraceId = TraceId("u".repeat(32))
 const makeScore = (overrides: Record<string, unknown> = {}) =>
   scoreSchema.parse({
     id: ScoreId("s".repeat(24)),
-    organizationId: "o".repeat(24),
+    organizationId: organizationId as string,
     projectId,
     sessionId: null,
     traceId,
@@ -46,6 +48,14 @@ const listScoresForTraces = (scores: Map<string, ReturnType<typeof makeScore>>, 
   return { items, hasMore: false, limit: 50, offset: 0 }
 }
 
+const provideTestServices =
+  (repository: ReturnType<typeof createFakeScoreRepository>["repository"]) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(ScoreRepository, repository),
+      Effect.provideService(SqlClient, createFakeSqlClient({ organizationId })),
+    )
+
 describe("listTraceScoresUseCase", () => {
   it("returns every score source for a trace", async () => {
     const custom = makeScore({ id: ScoreId("a".repeat(24)), sourceType: "custom", sourceId: "api" })
@@ -71,7 +81,7 @@ describe("listTraceScoresUseCase", () => {
     scores.set(annotation.id, annotation)
 
     const page = await Effect.runPromise(
-      listTraceScoresUseCase({ projectId, traceId }).pipe(Effect.provideService(ScoreRepository, repository)),
+      listTraceScoresUseCase({ projectId, traceId }).pipe(provideTestServices(repository)),
     )
 
     expect(page.items).toHaveLength(3)
@@ -99,7 +109,7 @@ describe("listScoresByTraceIdsUseCase", () => {
 
     const page = await Effect.runPromise(
       listScoresByTraceIdsUseCase({ projectId, traceIds: [traceId, otherTraceId] }).pipe(
-        Effect.provideService(ScoreRepository, repository),
+        provideTestServices(repository),
       ),
     )
 

--- a/packages/domain/scores/src/use-cases/list-trace-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-trace-scores.ts
@@ -1,0 +1,93 @@
+import { BadRequestError, cuidSchema, ProjectId, type RepositoryError, TraceId, traceIdSchema } from "@domain/shared"
+import { Effect } from "effect"
+import { z } from "zod"
+import { ScoreRepository, scoreDraftModeSchema } from "../ports/score-repository.ts"
+import { baseListScoresInputSchema } from "./list-scores.ts"
+
+const formatValidationError = (error: z.ZodError): string => error.issues.map((issue) => issue.message).join(", ")
+
+const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, message: string) =>
+  Effect.try({
+    try: () => schema.parse(input),
+    catch: (error: unknown) =>
+      new BadRequestError({
+        message: error instanceof z.ZodError ? formatValidationError(error) : message,
+      }),
+  })
+
+/** List every published score type for a trace (conversation in the trace drawer). */
+export const listTraceScoresInputSchema = z.object({
+  projectId: cuidSchema.transform(ProjectId),
+  traceId: traceIdSchema.transform(TraceId),
+  limit: baseListScoresInputSchema.shape.limit,
+  offset: baseListScoresInputSchema.shape.offset,
+  draftMode: scoreDraftModeSchema.default("include"),
+})
+export type ListTraceScoresInput = z.input<typeof listTraceScoresInputSchema>
+
+export const listScoresByTraceIdsInputSchema = z.object({
+  projectId: cuidSchema.transform(ProjectId),
+  traceIds: z.array(traceIdSchema.transform(TraceId)).max(500),
+  limit: baseListScoresInputSchema.shape.limit,
+  offset: baseListScoresInputSchema.shape.offset,
+  draftMode: scoreDraftModeSchema.default("include"),
+})
+export type ListScoresByTraceIdsInput = z.input<typeof listScoresByTraceIdsInputSchema>
+
+export type ListTraceScoresError = RepositoryError | BadRequestError
+
+export const listTraceScoresUseCase = Effect.fn("scores.listTraceScores")(function* (input: ListTraceScoresInput) {
+  const parsed = yield* parseOrBadRequest(listTraceScoresInputSchema, input, "Invalid list trace scores input")
+  yield* Effect.annotateCurrentSpan("score.projectId", parsed.projectId)
+  yield* Effect.annotateCurrentSpan("score.traceId", parsed.traceId)
+
+  const scoreRepository = yield* ScoreRepository
+
+  return yield* scoreRepository.listByTraceId({
+    projectId: parsed.projectId,
+    traceId: parsed.traceId,
+    options: {
+      limit: parsed.limit,
+      offset: parsed.offset,
+      draftMode: parsed.draftMode,
+    },
+  })
+})
+
+/**
+ * Every score across a set of traces (session panel Scores tab). Scopes by
+ * `trace_id IN (...)` rather than `session_id` so orphan sessions still surface
+ * their scores.
+ */
+export const listScoresByTraceIdsUseCase = Effect.fn("scores.listScoresByTraceIds")(function* (
+  input: ListScoresByTraceIdsInput,
+) {
+  const parsed = yield* parseOrBadRequest(
+    listScoresByTraceIdsInputSchema,
+    input,
+    "Invalid list scores by trace ids input",
+  )
+  yield* Effect.annotateCurrentSpan("score.projectId", parsed.projectId)
+  yield* Effect.annotateCurrentSpan("score.traceCount", parsed.traceIds.length)
+
+  if (parsed.traceIds.length === 0) {
+    return {
+      items: [],
+      hasMore: false,
+      limit: parsed.limit,
+      offset: parsed.offset,
+    }
+  }
+
+  const scoreRepository = yield* ScoreRepository
+
+  return yield* scoreRepository.listByTraceIds({
+    projectId: parsed.projectId,
+    traceIds: parsed.traceIds,
+    options: {
+      limit: parsed.limit,
+      offset: parsed.offset,
+      draftMode: parsed.draftMode,
+    },
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3692 by replacing the Annotations tab in trace and session detail drawers with a **Scores** tab that lists every score source (`annotation`, `custom`, `evaluation`).

- Adds `listTraceScores` / `listScoresBySession` domain + web server functions (no `source` filter)
- Annotation scores keep full create/edit UX via existing `AnnotationCard`
- Custom/evaluation scores render as read-only cards with source badge, verdict, feedback, and linked signal
- Legacy URL params `detailTab=annotations` / `sessionTab=annotations` normalize to `scores`

## Test plan

- [ ] Open a trace with API-ingested custom/evaluation scores and confirm they appear under Scores
- [ ] Create/edit an annotation from the Scores tab and verify it still works
- [ ] Open a multi-trace session and confirm scores from all traces are listed with trace labels
- [ ] Verify clicking an annotation score still navigates to the conversation anchor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-873dc96f-e266-4600-a9dd-7b2f77dc5f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-873dc96f-e266-4600-a9dd-7b2f77dc5f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

