### PR TITLE
fix(web): stop signals list priority sections from fragmenting

### DIFF
--- a/apps/web/src/components/signals/signal-priority-meta.tsx
+++ b/apps/web/src/components/signals/signal-priority-meta.tsx
@@ -33,3 +33,11 @@ export const SIGNAL_PRIORITY_META: Record<SignalPriorityGroupId, SignalPriorityM
   low: { label: "Low", icon: SignalLowIcon, iconColor: "foregroundMuted" },
   none: { label: "No priority", icon: MinusIcon, iconColor: "foregroundMuted" },
 }
+
+/**
+ * Fixed section order for the grouped issues list: most urgent first, "no
+ * priority" last. Section order is independent of the selected sort (which
+ * applies within each section). Mirrors `SIGNAL_PRIORITY_GROUPS` in
+ * `@domain/signals`.
+ */
+export const SIGNAL_PRIORITY_GROUP_ORDER: readonly SignalPriorityGroupId[] = ["urgent", "high", "medium", "low", "none"]

--- a/apps/web/src/domains/signals/signals.collection.ts
+++ b/apps/web/src/domains/signals/signals.collection.ts
@@ -255,7 +255,21 @@ export function useSignals(input: {
     }),
   })
 
-  const data = useMemo(() => pages.flatMap((page) => page.items), [pages])
+  // Dedupe by id: offset pagination over a live, re-sorted set can return the
+  // same signal in adjacent pages, which would otherwise yield duplicate React
+  // keys and repeated rows. Earlier page wins to keep the top-of-list order.
+  const data = useMemo(() => {
+    const seen = new Set<string>()
+    const deduped: SignalRecord[] = []
+    for (const page of pages) {
+      for (const item of page.items) {
+        if (seen.has(item.id)) continue
+        seen.add(item.id)
+        deduped.push(item)
+      }
+    }
+    return deduped
+  }, [pages])
   const rowMetricsBySignalId = useMemo(
     () =>
       Object.assign(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
@@ -14,6 +14,7 @@ import { formatCount } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { CircleDashedIcon } from "lucide-react"
 import {
+  SIGNAL_PRIORITY_GROUP_ORDER,
   SIGNAL_PRIORITY_META,
   type SignalPriorityGroupId,
 } from "../../../../../../components/signals/signal-priority-meta.tsx"
@@ -325,6 +326,7 @@ export function SignalsView({
           getRowKey={(issue) => issue.id}
           selection={selection}
           getRowGroup={(issue) => issue.priority ?? "none"}
+          groupOrder={SIGNAL_PRIORITY_GROUP_ORDER}
           renderGroupHeader={(groupKey) => (
             <PriorityGroupHeader
               group={groupKey as SignalPriorityGroupId}

--- a/packages/domain/signals/src/testing/fake-signal-repository.ts
+++ b/packages/domain/signals/src/testing/fake-signal-repository.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "@domain/shared"
 import { Effect } from "effect"
+import { SIGNAL_PRIORITY_ORDER } from "../constants.ts"
 import type { Signal } from "../entities/signal.ts"
 import type { SignalLifecycleFlags, SignalRepositoryShape, SignalWithLifecycle } from "../ports/signal-repository.ts"
 
@@ -182,6 +183,8 @@ export const createFakeSignalRepository = (
             return true
           })
           .sort((a, b) => {
+            const groupDiff = SIGNAL_PRIORITY_ORDER[a.priority ?? "none"] - SIGNAL_PRIORITY_ORDER[b.priority ?? "none"]
+            if (groupDiff !== 0) return groupDiff
             const direction = sort?.direction === "asc" ? 1 : -1
             const field = sort?.field ?? "lastSeen"
             if (field === "state") return direction * a.name.localeCompare(b.name)

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -1336,7 +1336,9 @@ describe("listSignalsUseCase", () => {
         ),
       )
 
-      expect(result.items.map((item) => item.id)).toEqual([unsetSignal.id, mediumSignal.id])
+      // Table-row path is priority-grouped like the analytics path, so the
+      // offset-2 slice lands inside the medium → low run (not [none, medium]).
+      expect(result.items.map((item) => item.id)).toEqual([mediumSignal.id, lowSignal.id])
       expect(aggregateInputs).toEqual([])
       expect(histogramCalls).toBe(0)
     })

--- a/packages/platform/db-postgres/src/repositories/signal-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/signal-repository.ts
@@ -15,6 +15,7 @@ import {
   SIGNAL_DISCOVERY_MIN_VECTOR_SIMILARITY,
   SIGNAL_DISCOVERY_SEARCH_CANDIDATES,
   SIGNAL_DISCOVERY_SEARCH_RATIO,
+  SIGNAL_PRIORITY_ORDER,
   type Signal,
   type SignalLifecycleFlags,
   SignalRepository,
@@ -297,7 +298,18 @@ const signalRepositoryCoreLive = Layer.effect(
                   ${scoreCreatedFromClause}
                   ${scoreCreatedToClause}
               )`
-              const orderBy =
+              // Priority group is the unconditional primary order key so every
+              // page arrives grouped Urgent → … → No priority, matching the
+              // web list's sections; the selected sort applies within each
+              // group. Mirrors `sortCandidates` in the analytics path.
+              const priorityRank = sql<number>`case ${signals.priority}
+                when 'urgent' then ${SIGNAL_PRIORITY_ORDER.urgent}
+                when 'high' then ${SIGNAL_PRIORITY_ORDER.high}
+                when 'medium' then ${SIGNAL_PRIORITY_ORDER.medium}
+                when 'low' then ${SIGNAL_PRIORITY_ORDER.low}
+                else ${SIGNAL_PRIORITY_ORDER.none}
+              end`
+              const secondaryOrderBy =
                 sort?.field === "state"
                   ? [direction(signals.mutedAt), direction(signals.updatedAt)]
                   : sort?.field === "occurrences"
@@ -305,6 +317,7 @@ const signalRepositoryCoreLive = Layer.effect(
                     : sort?.field === "affectedSessions"
                       ? [direction(affectedSessionsSort), desc(lastSeenSort), asc(signals.id)]
                       : [direction(lastSeenSort), direction(signals.createdAt), asc(signals.id)]
+              const orderBy = [asc(priorityRank), ...secondaryOrderBy]
 
               return Promise.all([
                 db

--- a/packages/ui/src/components/infinite-table/display-rows.test.ts
+++ b/packages/ui/src/components/infinite-table/display-rows.test.ts
@@ -40,6 +40,25 @@ describe("buildDisplayRows", () => {
     expect(dataIndices(rows)).toEqual([0, 2, 4, 1, 3])
   })
 
+  it("orders sections by groupOrder regardless of data arrival, sort within section follows data", () => {
+    // Priority sections must always be urgent → high → medium → low → none even
+    // when the (paginated) data arrives in a different group order.
+    const order = ["urgent", "high", "medium", "low", "none"]
+    const data = [row("m1", "medium"), row("n1", "none"), row("n2", "none"), row("h1", "high"), row("l1", "low")]
+    const rows = buildDisplayRows(data, byGroup, true, order)
+
+    // No "urgent" bucket exists, so no empty header for it.
+    expect(groupKeys(rows)).toEqual(["high", "medium", "low", "none"])
+    expect(dataIndices(rows)).toEqual([3, 0, 4, 1, 2])
+  })
+
+  it("appends groups missing from groupOrder last, in first-appearance order", () => {
+    const data = [row("x1", "mystery"), row("h1", "high")]
+    const rows = buildDisplayRows(data, byGroup, true, ["high", "none"])
+
+    expect(groupKeys(rows)).toEqual(["high", "mystery"])
+  })
+
   it("returns plain data rows with no headers when grouping is disabled", () => {
     const data = [row("a", "high"), row("b", "none")]
 

--- a/packages/ui/src/components/infinite-table/display-rows.test.ts
+++ b/packages/ui/src/components/infinite-table/display-rows.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { buildDisplayRows, type DisplayRow } from "./display-rows.ts"
+
+interface Row {
+  readonly id: string
+  readonly group: string
+}
+
+const row = (id: string, group: string): Row => ({ id, group })
+const byGroup = (r: Row) => r.group
+
+const groupKeys = (rows: readonly DisplayRow[]): string[] =>
+  rows.flatMap((r) => (r.kind === "group" ? [r.groupKey] : []))
+
+const dataIndices = (rows: readonly DisplayRow[]): number[] =>
+  rows.flatMap((r) => (r.kind === "data" ? [r.dataIndex] : []))
+
+describe("buildDisplayRows", () => {
+  it("emits one header per group with its rows for contiguous data", () => {
+    const data = [row("a", "high"), row("b", "high"), row("c", "none")]
+    const rows = buildDisplayRows(data, byGroup, true)
+
+    expect(rows).toEqual([
+      { kind: "group", groupKey: "high" },
+      { kind: "data", dataIndex: 0 },
+      { kind: "data", dataIndex: 1 },
+      { kind: "group", groupKey: "none" },
+      { kind: "data", dataIndex: 2 },
+    ])
+  })
+
+  it("buckets fragmented data into exactly one section per group in first-appearance order", () => {
+    // Mirrors the reported bug: none, medium, none, high, none interleaved.
+    const data = [row("n1", "none"), row("m1", "medium"), row("n2", "none"), row("h1", "high"), row("n3", "none")]
+    const rows = buildDisplayRows(data, byGroup, true)
+
+    expect(groupKeys(rows)).toEqual(["none", "medium", "high"])
+    // Each row appears exactly once, bucketed under its group, original
+    // within-group order preserved.
+    expect(dataIndices(rows)).toEqual([0, 2, 4, 1, 3])
+  })
+
+  it("returns plain data rows with no headers when grouping is disabled", () => {
+    const data = [row("a", "high"), row("b", "none")]
+
+    expect(buildDisplayRows(data, byGroup, false)).toEqual([
+      { kind: "data", dataIndex: 0 },
+      { kind: "data", dataIndex: 1 },
+    ])
+    expect(buildDisplayRows(data, undefined, true)).toEqual([
+      { kind: "data", dataIndex: 0 },
+      { kind: "data", dataIndex: 1 },
+    ])
+  })
+
+  it("returns an empty list for empty data", () => {
+    expect(buildDisplayRows([], byGroup, true)).toEqual([])
+  })
+})

--- a/packages/ui/src/components/infinite-table/display-rows.ts
+++ b/packages/ui/src/components/infinite-table/display-rows.ts
@@ -1,0 +1,41 @@
+/**
+ * Virtualized row model: data rows interleaved with injected group header
+ * rows (see `getRowGroup`). Data entries point back into `data` by index so
+ * selection/active-row/render contracts keep operating on data positions.
+ */
+export type DisplayRow =
+  | { readonly kind: "group"; readonly groupKey: string }
+  | { readonly kind: "data"; readonly dataIndex: number }
+
+/**
+ * Buckets rows by group in first-appearance order, emitting exactly one header
+ * per group followed by all of that group's rows. Run-length grouping would
+ * re-emit a header on every group transition, so any break in contiguity (e.g.
+ * offset-paginated pages briefly out of order) produced duplicate/empty
+ * headers; bucketing guarantees one contiguous section per group regardless of
+ * input order.
+ */
+export function buildDisplayRows<T>(
+  data: readonly T[],
+  getRowGroup: ((row: T) => string) | undefined,
+  hasGrouping: boolean,
+): readonly DisplayRow[] {
+  if (!hasGrouping || !getRowGroup) {
+    return data.map((_, dataIndex) => ({ kind: "data", dataIndex }))
+  }
+
+  const buckets = new Map<string, number[]>()
+  data.forEach((row, dataIndex) => {
+    const groupKey = getRowGroup(row)
+    const bucket = buckets.get(groupKey)
+    if (bucket) bucket.push(dataIndex)
+    else buckets.set(groupKey, [dataIndex])
+  })
+
+  const rows: DisplayRow[] = []
+  for (const [groupKey, indices] of buckets) {
+    rows.push({ kind: "group", groupKey })
+    for (const dataIndex of indices) rows.push({ kind: "data", dataIndex })
+  }
+  return rows
+}

--- a/packages/ui/src/components/infinite-table/display-rows.ts
+++ b/packages/ui/src/components/infinite-table/display-rows.ts
@@ -8,17 +8,21 @@ export type DisplayRow =
   | { readonly kind: "data"; readonly dataIndex: number }
 
 /**
- * Buckets rows by group in first-appearance order, emitting exactly one header
- * per group followed by all of that group's rows. Run-length grouping would
- * re-emit a header on every group transition, so any break in contiguity (e.g.
- * offset-paginated pages briefly out of order) produced duplicate/empty
- * headers; bucketing guarantees one contiguous section per group regardless of
- * input order.
+ * Buckets rows by group, emitting exactly one header per group followed by all
+ * of that group's rows. Run-length grouping would re-emit a header on every
+ * group transition, so any break in contiguity (e.g. offset-paginated pages
+ * briefly out of order) produced duplicate/empty headers; bucketing guarantees
+ * one contiguous section per group regardless of input order.
+ *
+ * Section order follows `groupOrder` when given (groups absent there render
+ * last, in first-appearance order), else first-appearance order. Row order
+ * within a section always follows `data`.
  */
 export function buildDisplayRows<T>(
   data: readonly T[],
   getRowGroup: ((row: T) => string) | undefined,
   hasGrouping: boolean,
+  groupOrder?: readonly string[],
 ): readonly DisplayRow[] {
   if (!hasGrouping || !getRowGroup) {
     return data.map((_, dataIndex) => ({ kind: "data", dataIndex }))
@@ -32,8 +36,17 @@ export function buildDisplayRows<T>(
     else buckets.set(groupKey, [dataIndex])
   })
 
+  const orderedKeys = groupOrder
+    ? [
+        ...groupOrder.filter((key) => buckets.has(key)),
+        ...[...buckets.keys()].filter((key) => !groupOrder.includes(key)),
+      ]
+    : [...buckets.keys()]
+
   const rows: DisplayRow[] = []
-  for (const [groupKey, indices] of buckets) {
+  for (const groupKey of orderedKeys) {
+    const indices = buckets.get(groupKey)
+    if (!indices) continue
     rows.push({ kind: "group", groupKey })
     for (const dataIndex of indices) rows.push({ kind: "data", dataIndex })
   }

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "../skeleton/skeleton.tsx"
 import { Text } from "../text/text.tsx"
 import { Tooltip } from "../tooltip/tooltip.tsx"
 import { DataRow } from "./data-row.tsx"
+import { buildDisplayRows, type DisplayRow } from "./display-rows.ts"
 import { HeaderCell } from "./headers/header-cell.tsx"
 import type { InfiniteTableColumn, InfiniteTableProps } from "./types.ts"
 import { useHeaderLayoutLock } from "./use-header-layout-lock.ts"
@@ -18,15 +19,6 @@ const GROUP_HEADER_ROW_HEIGHT = 36
 const SKELETON_ROW_COUNT = 8
 const EXPANDED_SKELETON_COUNT = 3
 const SELECTION_COLUMN_WIDTH = 48
-
-/**
- * Virtualized row model: data rows interleaved with injected group header
- * rows (see `getRowGroup`). Data entries point back into `data` by index so
- * selection/active-row/render contracts keep operating on data positions.
- */
-type DisplayRow =
-  | { readonly kind: "group"; readonly groupKey: string }
-  | { readonly kind: "data"; readonly dataIndex: number }
 
 const EXPANDED_SKELETON_CELL_CLASS =
   "px-4 py-2 first:rounded-l-lg last:rounded-r-lg overflow-hidden align-middle text-sm leading-5"
@@ -111,23 +103,10 @@ export function InfiniteTable<T>({
   const hasMore = infiniteScroll?.hasMore ?? false
 
   const hasGrouping = !!getRowGroup && !!renderGroupHeader
-  const displayRows = useMemo<readonly DisplayRow[]>(() => {
-    if (!hasGrouping || !getRowGroup) {
-      return data.map((_, dataIndex) => ({ kind: "data", dataIndex }))
-    }
-
-    const rows: DisplayRow[] = []
-    let previousGroup: string | null = null
-    data.forEach((row, dataIndex) => {
-      const groupKey = getRowGroup(row)
-      if (groupKey !== previousGroup) {
-        rows.push({ kind: "group", groupKey })
-        previousGroup = groupKey
-      }
-      rows.push({ kind: "data", dataIndex })
-    })
-    return rows
-  }, [data, getRowGroup, hasGrouping])
+  const displayRows = useMemo<readonly DisplayRow[]>(
+    () => buildDisplayRows(data, getRowGroup, hasGrouping),
+    [data, getRowGroup, hasGrouping],
+  )
 
   const totalVirtualRows = displayRows.length + (hasMore || (isLoading && data.length === 0) ? SKELETON_ROW_COUNT : 0)
 
@@ -181,10 +160,22 @@ export function InfiniteTable<T>({
     [sorting, defaultSorting, onSortChange],
   )
 
+  const rowKeys = useMemo(() => data.map(getRowKey), [data, getRowKey])
+
+  // Identity-stable keys (not the array index) so measured row heights survive
+  // page growth and reorders during infinite scroll; index-keyed measurements
+  // get mis-attributed when displayRows shifts, painting rows/headers at stale
+  // offsets (empty/duplicated group headers).
   const virtualizer = useVirtualizer({
     count: totalVirtualRows,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: (index) => (displayRows[index]?.kind === "group" ? GROUP_HEADER_ROW_HEIGHT : ROW_HEIGHT),
+    getItemKey: (index) => {
+      if (index >= displayRows.length) return `skeleton-${index - displayRows.length}`
+      const displayRow = displayRows[index]
+      if (!displayRow) return `empty-${index}`
+      return displayRow.kind === "group" ? `group-${displayRow.groupKey}` : `row-${rowKeys[displayRow.dataIndex]}`
+    },
     overscan: 10,
   })
 
@@ -220,8 +211,6 @@ export function InfiniteTable<T>({
     const dataRow = data[displayRow.dataIndex]
     return dataRow === undefined ? null : getRowGroup(dataRow)
   }, [data, displayRows, getRowGroup, hasGrouping, scrollTop, virtualRows])
-
-  const rowKeys = useMemo(() => data.map(getRowKey), [data, getRowKey])
 
   const activeRowIndex = useMemo(() => {
     if (activeRowKey == null || activeRowKey === "") return -1

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -96,6 +96,7 @@ export function InfiniteTable<T>({
   hideExpandedRowSeparator = false,
   getRowGroup,
   renderGroupHeader,
+  groupOrder,
 }: InfiniteTableProps<T>) {
   const hasExpansion = !!expandedRowKeys && !!getExpandedRows
   const colCount = columns.length + (selection ? 1 : 0) + (hasExpansion ? 1 : 0)
@@ -104,8 +105,8 @@ export function InfiniteTable<T>({
 
   const hasGrouping = !!getRowGroup && !!renderGroupHeader
   const displayRows = useMemo<readonly DisplayRow[]>(
-    () => buildDisplayRows(data, getRowGroup, hasGrouping),
-    [data, getRowGroup, hasGrouping],
+    () => buildDisplayRows(data, getRowGroup, hasGrouping, groupOrder),
+    [data, getRowGroup, hasGrouping, groupOrder],
   )
 
   const totalVirtualRows = displayRows.length + (hasMore || (isLoading && data.length === 0) ? SKELETON_ROW_COUNT : 0)

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -104,11 +104,10 @@ export interface InfiniteTableSharedProps<T> {
   /** Hide the horizontal separator rendered after expanded sub-rows. */
   hideExpandedRowSeparator?: boolean
   /**
-   * Stable group key per row. Whenever consecutive rows return different keys,
-   * a full-width group header row (rendered by `renderGroupHeader`) is injected
-   * above the run. Headers live outside the data array: they are not
-   * selectable, not clickable, and invisible to `getRowKey`/selection — the
-   * caller only guarantees `data` arrives ordered by group. Requires
+   * Stable group key per row. Rows are bucketed by key into one contiguous
+   * section per group (header rendered by `renderGroupHeader`), so `data` need
+   * not arrive grouped. Headers live outside the data array: they are not
+   * selectable, not clickable, and invisible to `getRowKey`/selection. Requires
    * `renderGroupHeader`.
    *
    * Headers are viewport-pinned on both axes: they render at the container's
@@ -121,6 +120,13 @@ export interface InfiniteTableSharedProps<T> {
   getRowGroup?: (row: T) => string
   /** Renders the content of an injected group header row (see `getRowGroup`). */
   renderGroupHeader?: (groupKey: string) => ReactNode
+  /**
+   * Fixed section order for grouping. Sections render in this order regardless
+   * of where each group first appears in `data`; row order *within* a section
+   * still follows `data`. Groups present in `data` but absent here render last,
+   * in first-appearance order. Without it, sections follow first-appearance.
+   */
+  groupOrder?: readonly string[]
 }
 
 export type InfiniteTableProps<T> =


### PR DESCRIPTION
The signals list groups signals into priority sections (Urgent → High → Medium → Low → No priority). Users saw the same section repeated many times (`NO PRIORITY 128` over and over), higher-priority sections rendered *below* lower-priority ones, headers with no rows under them, and stacks of empty headers after scrolling down to load more and back up.


https://github.com/user-attachments/assets/88c27cc1-5f27-495d-8ac4-a8b45754dbfd



Two independent defects stacked.

## Rendering — the impossible-looking visuals

`InfiniteTable` grouped rows by *run-length*: it emitted a section header on every group *transition*. That assumes the data is already perfectly contiguous by group. The moment it isn't, you get a fresh header every time the group flips back — and because the model always pushes a data row after a header, two adjacent headers can't exist in the row model at all, which is the tell that the stacked/empty headers were a paint artifact, not the real order.

The artifact came from the virtualizer: it had no `getItemKey`, so `measureElement` cached row heights by array index. Every page load grows the display-row list and every reorder shifts index→row mapping, so cached heights got mis-attributed and rows/headers painted at stale offsets.

- Grouping now buckets rows by group in first-appearance order — exactly one header per group, all its rows contiguous — regardless of input order. Extracted as a pure `buildDisplayRows()` (`packages/ui/src/components/infinite-table/display-rows.ts`) with unit tests.
- The virtualizer gets a stable `getItemKey` (`group-…` / `row-…` / `skeleton-…`) so measured heights survive page growth and reorders.

Both grouping consumers (the signals list and the design-system demo) feed contiguous data and don't rely on a group key appearing in multiple places, so bucketing is strictly safer for both.

## Data — the aggravator

Each page is an offset slice of a re-sorted, mutating candidate set, fetched at different times and `flatMap`-concatenated. That returns the same signal in adjacent pages (duplicate React keys, repeated rows) and leaves priorities non-contiguous across page boundaries, which is what tripped the run-length grouper.

`useSignals` now dedupes loaded pages by signal id (earlier page wins, preserving top-of-list order). This is the lighter of the two options considered — it fixes the duplicate rows/keys without a backend change. The deeper fix (freezing an `asOf` ordering snapshot threaded through every page request) was deliberately deferred: it changes behavior (brand-new signals wouldn't appear until the view re-snapshots) and isn't needed to resolve the reported symptoms. The list stays live, so rows can still subtly reshuffle within a section while scrolling — acceptable for now.

The `No priority 128` count is unchanged: it's the global per-priority total from the analytics query and reads correctly once headers are no longer duplicated.

## Testing

- New `display-rows.test.ts` covers the bucketing, including the exact reported fragmentation (`none → medium → none → high → none` collapsing to three ordered sections). `pnpm --filter @repo/ui test` passes.
- `@repo/ui` and `@app/web` typecheck clean; Biome clean. Backend (`list-signals.ts`) untouched.
