### PR TITLE
fix: coerce legacy sourceType 'issue' → 'signal' to stop active production errors

### DIFF
--- a/apps/web/src/domains/alerts/alerts.functions.test.ts
+++ b/apps/web/src/domains/alerts/alerts.functions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { listProjectAlertIncidentsInRangeInputSchema } from "./alerts.functions.ts"
+
+const BASE_INPUT = {
+  projectId: "proj_123",
+  fromIso: "2026-01-01T00:00:00Z",
+  toIso: "2026-01-02T00:00:00Z",
+}
+
+describe("listProjectAlertIncidentsInRangeInputSchema", () => {
+  it("accepts sourceType 'signal'", () => {
+    const result = listProjectAlertIncidentsInRangeInputSchema.safeParse({
+      ...BASE_INPUT,
+      sourceType: "signal",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.sourceType).toBe("signal")
+  })
+
+  it("accepts sourceType 'monitor'", () => {
+    const result = listProjectAlertIncidentsInRangeInputSchema.safeParse({
+      ...BASE_INPUT,
+      sourceType: "monitor",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.sourceType).toBe("monitor")
+  })
+
+  it("maps legacy sourceType 'issue' to 'signal'", () => {
+    const result = listProjectAlertIncidentsInRangeInputSchema.safeParse({
+      ...BASE_INPUT,
+      sourceType: "issue",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.sourceType).toBe("signal")
+  })
+
+  it("accepts omitted sourceType", () => {
+    const result = listProjectAlertIncidentsInRangeInputSchema.safeParse(BASE_INPUT)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.sourceType).toBeUndefined()
+  })
+
+  it("rejects unknown sourceType values", () => {
+    const result = listProjectAlertIncidentsInRangeInputSchema.safeParse({
+      ...BASE_INPUT,
+      sourceType: "session",
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/alerts/alerts.functions.ts
+++ b/apps/web/src/domains/alerts/alerts.functions.ts
@@ -23,11 +23,11 @@ import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getPostgresClient } from "../../server/clients.ts"
 
-const listProjectAlertIncidentsInRangeInputSchema = z.object({
+export const listProjectAlertIncidentsInRangeInputSchema = z.object({
   projectId: z.string(),
   fromIso: z.iso.datetime(),
   toIso: z.iso.datetime(),
-  sourceType: incidentSourceTypeSchema.optional(),
+  sourceType: z.preprocess((v) => (v === "issue" ? "signal" : v), incidentSourceTypeSchema).optional(),
   sourceId: z.string().min(1).optional(),
 })
 

--- a/apps/web/src/domains/alerts/alerts.functions.ts
+++ b/apps/web/src/domains/alerts/alerts.functions.ts
@@ -27,6 +27,7 @@ export const listProjectAlertIncidentsInRangeInputSchema = z.object({
   projectId: z.string(),
   fromIso: z.iso.datetime(),
   toIso: z.iso.datetime(),
+  // TODO: remove once old browser bundles (pre-June-2026 issues→signals rename) are fully cycled out
   sourceType: z.preprocess((v) => (v === "issue" ? "signal" : v), incidentSourceTypeSchema).optional(),
   sourceId: z.string().min(1).optional(),
 })

--- a/knip.json
+++ b/knip.json
@@ -162,7 +162,11 @@
   },
   "ignoreBinaries": [
     "tmuxinator",
-    "pulumi"
+    "pulumi",
+    "tsx",
+    "tsdown",
+    "mcp-inspector",
+    "email"
   ],
   "ignoreDependencies": [
     "@pulumi/awsx",
@@ -171,7 +175,11 @@
     "@pulumi/datadog",
     "@pulumi/random",
     "fern-api",
-    "chdb"
+    "chdb",
+    "tsx",
+    "zod",
+    "@modelcontextprotocol/inspector",
+    "react-email"
   ],
   "tags": [
     "-knipignore"


### PR DESCRIPTION
## Summary

- **22 production errors in the last 2 days** (`listProjectAlertIncidentsInRange` server function): old browser-cached JS bundles from before the June 2026 issues→signals terminology rename still send `sourceType: "issue"` to the server. The Zod schema was tightened to only accept `"monitor" | "signal"`, rejecting the legacy value.
- Fix: add a `z.preprocess` coercion on the `sourceType` field that maps `"issue"` → `"signal"` before Zod validates it — preserves the `IncidentSourceType` output type, correct DB filter behaviour.
- Export the input schema and add a test file covering the backward-compat coercion and normal values.
- Fix pre-existing knip false positives: `tsx`/`tsdown`/`mcp-inspector`/`email` are used as binaries in npm scripts (not library imports), and `zod`/`@modelcontextprotocol/inspector`/`react-email` were incorrectly flagged as unused dependencies — all added to `ignoreBinaries`/`ignoreDependencies` in `knip.json`.

## Root cause

The `listProjectAlertIncidentsInRangeInputSchema` used `incidentSourceTypeSchema.optional()` which is `z.enum(["monitor", "signal"]).optional()`. After the database rename migration (June 17, 2026), `"issue"` was no longer a valid value — but browser-cached JS bundles built before that change still sent `sourceType: "issue"` on each request. No code path maps `"issue"` to `"signal"` at the server boundary, so every request from an old bundle threw a Zod validation error.

The fix is a one-line backward-compat transform at the input boundary. Old bundles mapping `"issue"` will now correctly query for signal-type incidents.

## Test plan

- [x] Unit tests: `alerts.functions.test.ts` — covers `"issue"` → `"signal"` coercion, `"signal"` and `"monitor"` pass-through, undefined omission, and rejection of unknown values
- [x] All 5 new tests pass (`vitest run`)
- [x] `pnpm --filter @app/web typecheck` — clean
- [x] `pnpm knip` — clean (pre-existing false positives fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXAZukN61dj4zEFUGtugpc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXAZukN61dj4zEFUGtugpc)_