### PR TITLE
feat(telemetry): add Python Latitude tracer helper

### DIFF
--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Latitude.get_tracer(scope, context=None)` returns a tracer from the provider Latitude is exporting
+  from, prefixing scopes with `so.latitude.instrumentation.` when needed. Pass the optional context
+  to stamp spans with the same Latitude context accepted by `capture()` (`user_id`, `session_id`,
+  `tags`, `metadata`, and `project`).
+
 ## [3.5.0] - 2026-06-29
 
 ### Added

--- a/packages/telemetry/python/README.md
+++ b/packages/telemetry/python/README.md
@@ -205,9 +205,28 @@ class Latitude:
         ...
 
     provider: TracerProvider
+    def get_tracer(self, scope: str, context: ContextOptions | None = None) -> Tracer: ...
     def flush(self) -> None: ...
     def shutdown(self) -> None: ...
 ```
+
+Use `get_tracer()` when a framework accepts an OpenTelemetry tracer directly:
+
+```python
+tracer = latitude.get_tracer(
+    "my-agent-framework",
+    {
+        "user_id": "user_123",
+        "session_id": "session_456",
+        "tags": ["support"],
+        "metadata": {"queue": "priority"},
+        "project": "support-agent",
+    },
+)
+```
+
+The scope is exported under `so.latitude.instrumentation.*`, and the optional context stamps every
+span started by that tracer with the same Latitude attributes accepted by `capture()`.
 
 `init_latitude()` remains available as a backwards-compatible wrapper that returns `{"provider", "flush", "shutdown"}`.
 

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -15,12 +15,13 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter
-from opentelemetry.trace import NoOpTracerProvider, ProxyTracerProvider
+from opentelemetry.trace import NoOpTracerProvider, ProxyTracerProvider, Tracer
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from latitude_telemetry.sdk._deprecation import warn_project_slug_deprecated
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
-from latitude_telemetry.sdk.types import InstrumentationsInput, SmartFilterOptions
+from latitude_telemetry.sdk.tracer import get_latitude_tracer
+from latitude_telemetry.sdk.types import ContextOptions, InstrumentationsInput, SmartFilterOptions
 from latitude_telemetry.telemetry.latitude_span_processor import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
 from latitude_telemetry.telemetry.redact_span_processor import RedactSpanProcessorOptions
 
@@ -176,6 +177,9 @@ class Latitude:
             return
 
         self._latitude_processor.shutdown()
+
+    def get_tracer(self, scope: str, context: ContextOptions | None = None) -> Tracer:
+        return get_latitude_tracer(self.provider, scope, context)
 
     def _register_shutdown_handlers(self) -> None:
         global _shutdown_handlers_registered

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/tracer.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/tracer.py
@@ -1,0 +1,120 @@
+import json
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from typing import Any, cast
+
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, Span, SpanKind, Tracer
+from opentelemetry.util.types import Attributes, AttributeValue
+
+from latitude_telemetry.constants import ATTRIBUTES, SCOPE_LATITUDE
+from latitude_telemetry.sdk._deprecation import warn_project_slug_deprecated
+from latitude_telemetry.sdk.types import ContextOptions
+
+
+def _scope_name(scope: str) -> str:
+    return scope if scope == SCOPE_LATITUDE or scope.startswith(f"{SCOPE_LATITUDE}.") else f"{SCOPE_LATITUDE}.{scope}"
+
+
+LatitudeAttributes = dict[str, AttributeValue]
+
+
+def latitude_attributes_from_context(options: ContextOptions) -> LatitudeAttributes:
+    attributes: LatitudeAttributes = {}
+    project = options.get("project")
+    if project is None and "project_slug" in options:
+        warn_project_slug_deprecated("capture")
+        project = options.get("project_slug")
+
+    tags = options.get("tags")
+    metadata = options.get("metadata")
+    session_id = options.get("session_id")
+    user_id = options.get("user_id")
+    user_email = options.get("user_email")
+    if tags:
+        attributes[ATTRIBUTES.tags] = json.dumps(tags)
+    if metadata:
+        attributes[ATTRIBUTES.metadata] = json.dumps(metadata)
+    if session_id:
+        attributes[ATTRIBUTES.session_id] = session_id
+    if user_id:
+        attributes[ATTRIBUTES.user_id] = user_id
+    if user_email:
+        attributes[ATTRIBUTES.user_email] = user_email
+    if project:
+        attributes[ATTRIBUTES.project] = project
+
+    return attributes
+
+
+class _LatitudeTracer:
+    def __init__(self, tracer: Tracer, attributes: LatitudeAttributes):
+        self._tracer = tracer
+        self._attributes = attributes
+
+    def start_span(
+        self,
+        name: str,
+        context: Context | None = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Attributes | None = None,
+        links: Sequence[Link] | None = None,
+        start_time: int | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+    ) -> Span:
+        span = self._tracer.start_span(
+            name,
+            context=context,
+            kind=kind,
+            attributes=attributes,
+            links=links,
+            start_time=start_time,
+            record_exception=record_exception,
+            set_status_on_exception=set_status_on_exception,
+        )
+        span.set_attributes(self._attributes)
+        return span
+
+    @contextmanager
+    def start_as_current_span(
+        self,
+        name: str,
+        context: Context | None = None,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Attributes | None = None,
+        links: Sequence[Link] | None = None,
+        start_time: int | None = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+        end_on_exit: bool = True,
+    ) -> Generator[Span, None, None]:
+        with self._tracer.start_as_current_span(
+            name,
+            context=context,
+            kind=kind,
+            attributes=attributes,
+            links=links,
+            start_time=start_time,
+            record_exception=record_exception,
+            set_status_on_exception=set_status_on_exception,
+            end_on_exit=end_on_exit,
+        ) as span:
+            span.set_attributes(self._attributes)
+            yield span
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._tracer, name)
+
+
+def with_latitude_attributes(tracer: Tracer, attributes: LatitudeAttributes) -> Tracer:
+    if not attributes:
+        return tracer
+    return cast(Tracer, _LatitudeTracer(tracer, attributes))
+
+
+def get_latitude_tracer(provider: Any, scope: str, context: ContextOptions | None = None) -> Tracer:
+    tracer = provider.get_tracer(_scope_name(scope))
+    if context is None:
+        return tracer
+    return with_latitude_attributes(tracer, latitude_attributes_from_context(context))

--- a/packages/telemetry/python/tests/telemetry/span_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_test.py
@@ -1,5 +1,6 @@
 """Tests for tracer access via Latitude bootstrap."""
 
+import json
 import logging
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from latitude_telemetry import Latitude, init_latitude
+from latitude_telemetry.constants import ATTRIBUTES, SCOPE_LATITUDE
 from latitude_telemetry.sdk._deprecation import reset_project_slug_deprecation_warning_for_testing
 
 
@@ -51,6 +53,66 @@ class TestTracerAccess:
         with tracer.start_as_current_span("test-span") as span:
             assert span is not None
             span.set_attribute("test.key", "test-value")
+
+    def test_get_tracer_prefixes_latitude_scope(self):
+        latitude_exporter = InMemorySpanExporter()
+        lat = Latitude(
+            api_key="test-api-key",
+            project="test-project",
+            disable_batch=True,
+            tracer_provider=TracerProvider(),
+            exporter=latitude_exporter,
+        )
+
+        tracer = lat.get_tracer("cloudflare-think")
+        with tracer.start_as_current_span("ai-call"):
+            pass
+
+        lat.flush()
+
+        spans = latitude_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].instrumentation_scope.name == f"{SCOPE_LATITUDE}.cloudflare-think"
+
+        lat.shutdown()
+
+    def test_get_tracer_stamps_latitude_context_on_spans(self):
+        latitude_exporter = InMemorySpanExporter()
+        lat = Latitude(
+            api_key="test-api-key",
+            project="test-project",
+            disable_batch=True,
+            tracer_provider=TracerProvider(),
+            exporter=latitude_exporter,
+        )
+
+        tracer = lat.get_tracer(
+            "cloudflare-think",
+            {
+                "user_id": "user-1",
+                "session_id": "session-1",
+                "tags": ["think", "tool"],
+                "metadata": {"turn": 1},
+                "project": "project-override",
+            },
+        )
+        span = tracer.start_span("ai-call")
+        span.end()
+        with tracer.start_as_current_span("active-ai-call"):
+            pass
+        lat.flush()
+
+        spans = {span.name: span for span in latitude_exporter.get_finished_spans()}
+        assert set(spans) == {"ai-call", "active-ai-call"}
+        for finished_span in spans.values():
+            attrs = finished_span.attributes
+            assert attrs[ATTRIBUTES.user_id] == "user-1"
+            assert attrs[ATTRIBUTES.session_id] == "session-1"
+            assert json.loads(attrs[ATTRIBUTES.tags]) == ["think", "tool"]
+            assert json.loads(attrs[ATTRIBUTES.metadata]) == {"turn": 1}
+            assert attrs[ATTRIBUTES.project] == "project-override"
+
+        lat.shutdown()
 
     def test_init_latitude_keeps_dict_compatibility(self):
         """Test that init_latitude keeps the previous dict return shape."""


### PR DESCRIPTION
Adds the Python SDK equivalent of the TypeScript `Latitude#getTracer(...)` API as `Latitude.get_tracer(scope, context=None)`. The helper returns a tracer from the provider Latitude exports from, prefixes custom scopes under `so.latitude.instrumentation`, and can stamp spans with the same per-request Latitude context used by `capture()`.

This fills the Python parity gap noticed after #3738. The new changelog entry is under `Unreleased` because `python-telemetry-3.5.0` is already tagged on development.

Validation:
- `mise exec -- uv run ruff check src/latitude_telemetry/sdk/tracer.py src/latitude_telemetry/sdk/init.py tests/telemetry/span_test.py`
- `mise exec -- uv run pyright src/latitude_telemetry/sdk/tracer.py src/latitude_telemetry/sdk/init.py`
- `mise exec -- uv run pytest -q tests/telemetry/span_test.py`