### PR TITLE
fix: retry transient connection resets in ClickHouse client

### DIFF
--- a/packages/domain/shared/src/errors.test.ts
+++ b/packages/domain/shared/src/errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   BadRequestError,
   ConflictError,
+  causesIncludeConnectionReset,
   NotFoundError,
   PermissionError,
   RepositoryError,
@@ -94,6 +95,40 @@ describe("dynamic httpMessage", () => {
     const err = new PermissionError({ message: "Forbidden", organizationId: "org1" })
     expect(err.httpStatus).toBe(403)
     expect(err.httpMessage).toBe("Forbidden")
+  })
+})
+
+describe("causesIncludeConnectionReset", () => {
+  it("detects an ECONNRESET code at the top level", () => {
+    expect(causesIncludeConnectionReset(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }))).toBe(true)
+  })
+
+  it("detects EPIPE", () => {
+    expect(causesIncludeConnectionReset(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }))).toBe(true)
+  })
+
+  it("detects a socket hang up by message", () => {
+    expect(causesIncludeConnectionReset(new Error("socket hang up"))).toBe(true)
+  })
+
+  it("walks nested cause chains, e.g. a wrapped RepositoryError", () => {
+    const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+    const wrapped = new RepositoryError({ cause: reset, operation: "query" })
+    const outer = new RepositoryError({ cause: wrapped, operation: "findByTraceId" })
+    expect(causesIncludeConnectionReset(outer)).toBe(true)
+  })
+
+  it("returns false for unrelated errors", () => {
+    expect(causesIncludeConnectionReset(new Error("Code: 159. DB::Exception: Timeout exceeded"))).toBe(false)
+    expect(causesIncludeConnectionReset(Object.assign(new Error("nope"), { code: "ENOENT" }))).toBe(false)
+    expect(causesIncludeConnectionReset(null)).toBe(false)
+  })
+
+  it("terminates on circular cause chains", () => {
+    const a: { message: string; cause?: unknown } = { message: "a" }
+    const b: { message: string; cause?: unknown } = { message: "b", cause: a }
+    a.cause = b
+    expect(causesIncludeConnectionReset(a)).toBe(false)
   })
 })
 

--- a/packages/domain/shared/src/errors.ts
+++ b/packages/domain/shared/src/errors.ts
@@ -265,6 +265,29 @@ export const findPostgresUniqueViolationConstraint = (error: unknown): string | 
   return null
 }
 
+/**
+ * Walks `error` and nested `cause` chains for a transient TCP connection reset —
+ * `ECONNRESET` / `EPIPE` / a "socket hang up". These surface when a pooled
+ * keep-alive socket is reused in the narrow window after the server (or an
+ * intervening load balancer) has already closed it: the request never reaches
+ * the server, so the operation is safe to retry.
+ */
+export const causesIncludeConnectionReset = (error: unknown): boolean => {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current)
+    if (isRecord(current)) {
+      if (current.code === "ECONNRESET" || current.code === "EPIPE") return true
+      if (typeof current.message === "string" && current.message.includes("socket hang up")) return true
+    }
+    current = isRecord(current) ? current.cause : undefined
+  }
+
+  return false
+}
+
 export const isNotFoundError = (error: unknown): error is NotFoundError => error instanceof NotFoundError
 
 export const isConflictError = (error: unknown): error is ConflictError => error instanceof ConflictError

--- a/packages/platform/db-clickhouse/src/ch-sql-client.test.ts
+++ b/packages/platform/db-clickhouse/src/ch-sql-client.test.ts
@@ -1,0 +1,69 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import { ChSqlClient, type ChSqlClientShape, OrganizationId, RepositoryError } from "@domain/shared"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { ChSqlClientLive } from "./ch-sql-client.ts"
+
+const fakeClient = {} as ClickHouseClient
+const organizationId = OrganizationId("org-1")
+
+const econnreset = () => Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+
+const runQuery = <T>(fn: (client: ClickHouseClient, organizationId: OrganizationId) => Promise<T>) =>
+  Effect.gen(function* () {
+    const client = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+    return yield* client.query(fn)
+  }).pipe(Effect.provide(ChSqlClientLive(fakeClient, organizationId)))
+
+describe("ChSqlClientLive query retry", () => {
+  it("retries a connection reset and eventually succeeds", async () => {
+    let attempts = 0
+    const result = await Effect.runPromise(
+      runQuery(async () => {
+        attempts += 1
+        if (attempts < 3) throw econnreset()
+        return "ok"
+      }),
+    )
+
+    expect(result).toBe("ok")
+    expect(attempts).toBe(3)
+  })
+
+  it("gives up after exhausting retries on persistent resets", async () => {
+    let attempts = 0
+    const exit = await Effect.runPromiseExit(
+      runQuery(async () => {
+        attempts += 1
+        throw econnreset()
+      }),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    expect(attempts).toBe(3)
+  })
+
+  it("does not retry non-reset errors", async () => {
+    let attempts = 0
+    const exit = await Effect.runPromiseExit(
+      runQuery(async () => {
+        attempts += 1
+        throw new Error("Code: 159. DB::Exception: Timeout exceeded")
+      }),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    expect(attempts).toBe(1)
+  })
+
+  it("surfaces a RepositoryError to callers", async () => {
+    const error = await Effect.runPromise(
+      runQuery(async () => {
+        throw new Error("boom")
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(RepositoryError)
+    expect(error.operation).toBe("query")
+  })
+})

--- a/packages/platform/db-clickhouse/src/ch-sql-client.ts
+++ b/packages/platform/db-clickhouse/src/ch-sql-client.ts
@@ -1,6 +1,20 @@
 import type { ClickHouseClient } from "@clickhouse/client"
-import { ChSqlClient, type ChSqlClientShape, type OrganizationId, toRepositoryError } from "@domain/shared"
-import { Effect, Layer } from "effect"
+import {
+  ChSqlClient,
+  type ChSqlClientShape,
+  causesIncludeConnectionReset,
+  type OrganizationId,
+  type RepositoryError,
+  toRepositoryError,
+} from "@domain/shared"
+import { Effect, Layer, Schedule } from "effect"
+
+// Keep-alive sockets are pooled and reused, but the server (or an intervening
+// load balancer) closes idle ones on its own timeout. Reusing a socket in the
+// race window after it was closed surfaces as `ECONNRESET` before the request
+// reaches the server — transient and safe to retry. Two quick retries clear it
+// without masking real outages; the small delay lets the stale socket be evicted.
+const CONNECTION_RESET_RETRY_SCHEDULE = Schedule.addDelay(Schedule.recurs(2), () => Effect.succeed("50 millis"))
 
 export const ChSqlClientLive = (client: ClickHouseClient, organizationId: OrganizationId) =>
   Layer.succeed(ChSqlClient, {
@@ -10,5 +24,10 @@ export const ChSqlClientLive = (client: ClickHouseClient, organizationId: Organi
       Effect.tryPromise({
         try: () => fn(client, organizationId),
         catch: (error) => toRepositoryError(error, "query"),
-      }),
+      }).pipe(
+        Effect.retry({
+          while: (error: RepositoryError) => causesIncludeConnectionReset(error),
+          schedule: CONNECTION_RESET_RETRY_SCHEDULE,
+        }),
+      ),
   } satisfies ChSqlClientShape<ClickHouseClient>)

--- a/packages/platform/db-clickhouse/src/client.ts
+++ b/packages/platform/db-clickhouse/src/client.ts
@@ -15,6 +15,14 @@ type CreateClickhouseClientError = MissingEnvValueError | InvalidEnvValueError
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 /** Default max open connections (sockets per host). */
 const DEFAULT_MAX_OPEN_CONNECTIONS = 10
+/**
+ * Discard a pooled keep-alive socket after this long idle. Must stay below the
+ * server's (and any load balancer's) keep-alive timeout so the client never
+ * reuses a socket the peer is about to close — that race surfaces as
+ * `ECONNRESET`. ClickHouse's default `keep_alive_timeout` is 3s; 2.5s leaves a
+ * safety margin. Retries in `ch-sql-client` cover the residual race.
+ */
+const KEEP_ALIVE_IDLE_SOCKET_TTL_MS = 2_500
 
 export const createClickhouseClientEffect = (
   config: ClickhouseConfig = {},
@@ -31,10 +39,7 @@ export const createClickhouseClientEffect = (
         username: resolvedConfig.username,
         password: resolvedConfig.password,
         database: resolvedConfig.database,
-        // Keep-alive enabled so the HTTP agent reuses sockets, but stale
-        // sockets are discarded automatically by Node's HTTP agent when the
-        // server closes the connection (e.g. after a restart).
-        keep_alive: { enabled: true },
+        keep_alive: { enabled: true, idle_socket_ttl: KEEP_ALIVE_IDLE_SOCKET_TTL_MS },
         request_timeout: DEFAULT_REQUEST_TIMEOUT_MS,
         max_open_connections: DEFAULT_MAX_OPEN_CONNECTIONS,
       }


### PR DESCRIPTION
## What does this PR do?

Adds automatic retry logic for transient TCP connection resets when querying ClickHouse. When a pooled keep-alive socket is reused in the narrow window after the server (or load balancer) has closed it, the request fails with `ECONNRESET`, `EPIPE`, or "socket hang up" before reaching the server — making it safe to retry.

The fix:
1. **Detects connection reset errors** via a new `causesIncludeConnectionReset()` utility that walks error cause chains for `ECONNRESET`, `EPIPE`, or "socket hang up" messages
2. **Configures socket TTL** in the ClickHouse client to discard idle sockets before the server's keep-alive timeout (2.5s vs ClickHouse's 3s default), reducing the race window
3. **Retries up to 2 times** with a 50ms delay between attempts in `ChSqlClientLive`, allowing stale sockets to be evicted without masking real outages

## Related issue (if applicable)

Closes #

## How was this tested?

- Added comprehensive unit tests in `ch-sql-client.test.ts` covering:
  - Successful retry after transient resets
  - Exhaustion of retries on persistent failures
  - Non-reset errors are not retried
  - Errors are wrapped as `RepositoryError`
- Added unit tests for `causesIncludeConnectionReset()` in `errors.test.ts` covering:
  - Detection of `ECONNRESET` and `EPIPE` codes
  - Detection of "socket hang up" by message
  - Walking nested cause chains (e.g., wrapped `RepositoryError`)
  - Circular cause chain termination
  - False negatives for unrelated errors

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

https://claude.ai/code/session_01MQF7jm5UEWmTRgAe4rFgn4