### PR TITLE
fix(telemetry): tighten Python tracer helper compatibility

### DIFF
--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-29
+
 ### Added
 
 - `Latitude.get_tracer(scope, context=None)` returns a tracer from the provider Latitude is exporting

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.5.0"
+version = "3.6.0"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/_deprecation.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/_deprecation.py
@@ -25,7 +25,11 @@ def warn_project_slug_deprecated(site: str) -> None:
     if _project_slug_deprecation_warned:
         return
     _project_slug_deprecation_warned = True
-    option = "`project_slug`" if site == "constructor" else "`project_slug` on capture()"
+    option = {
+        "constructor": "`project_slug`",
+        "capture": "`project_slug` on capture()",
+        "get_tracer": "`project_slug` on get_tracer()",
+    }.get(site, f"`project_slug` on {site}")
     logger.warning(
         "[Latitude] %s is deprecated and will be removed in a future release — rename it to "
         "`project`. Both work for now; when both are passed, `project` wins.",

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/tracer.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/tracer.py
@@ -1,10 +1,10 @@
 import json
-from collections.abc import Generator, Sequence
-from contextlib import contextmanager
-from typing import Any, cast
+from collections.abc import Iterator, Sequence
+from typing import Any
 
 from opentelemetry.context import Context
 from opentelemetry.trace import Link, Span, SpanKind, Tracer
+from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.util.types import Attributes, AttributeValue
 
 from latitude_telemetry.constants import ATTRIBUTES, SCOPE_LATITUDE
@@ -23,7 +23,7 @@ def latitude_attributes_from_context(options: ContextOptions) -> LatitudeAttribu
     attributes: LatitudeAttributes = {}
     project = options.get("project")
     if project is None and "project_slug" in options:
-        warn_project_slug_deprecated("capture")
+        warn_project_slug_deprecated("get_tracer")
         project = options.get("project_slug")
 
     tags = options.get("tags")
@@ -47,7 +47,7 @@ def latitude_attributes_from_context(options: ContextOptions) -> LatitudeAttribu
     return attributes
 
 
-class _LatitudeTracer:
+class _LatitudeTracer(Tracer):
     def __init__(self, tracer: Tracer, attributes: LatitudeAttributes):
         self._tracer = tracer
         self._attributes = attributes
@@ -76,7 +76,7 @@ class _LatitudeTracer:
         span.set_attributes(self._attributes)
         return span
 
-    @contextmanager
+    @_agnosticcontextmanager
     def start_as_current_span(
         self,
         name: str,
@@ -88,7 +88,7 @@ class _LatitudeTracer:
         record_exception: bool = True,
         set_status_on_exception: bool = True,
         end_on_exit: bool = True,
-    ) -> Generator[Span, None, None]:
+    ) -> Iterator[Span]:
         with self._tracer.start_as_current_span(
             name,
             context=context,
@@ -110,7 +110,7 @@ class _LatitudeTracer:
 def with_latitude_attributes(tracer: Tracer, attributes: LatitudeAttributes) -> Tracer:
     if not attributes:
         return tracer
-    return cast(Tracer, _LatitudeTracer(tracer, attributes))
+    return _LatitudeTracer(tracer, attributes)
 
 
 def get_latitude_tracer(provider: Any, scope: str, context: ContextOptions | None = None) -> Tracer:

--- a/packages/telemetry/python/tests/telemetry/span_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_test.py
@@ -9,6 +9,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import Tracer
 
 from latitude_telemetry import Latitude, init_latitude
 from latitude_telemetry.constants import ATTRIBUTES, SCOPE_LATITUDE
@@ -65,6 +66,8 @@ class TestTracerAccess:
         )
 
         tracer = lat.get_tracer("cloudflare-think")
+        assert isinstance(tracer, Tracer)
+
         with tracer.start_as_current_span("ai-call"):
             pass
 
@@ -252,4 +255,21 @@ class TestProjectArgRename:
             )
 
         assert not any("deprecated" in r.message for r in caplog.records)
+        lat.shutdown()
+
+    def test_get_tracer_project_slug_logs_get_tracer_deprecation(self, caplog):
+        with (
+            patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"),
+            caplog.at_level(logging.WARNING, logger="latitude_telemetry.sdk._deprecation"),
+        ):
+            lat = Latitude(
+                api_key="test-api-key",
+                project="my-project",
+                disable_batch=True,
+                tracer_provider=TracerProvider(),
+            )
+            lat.get_tracer("test", {"project_slug": "legacy-slug"})
+
+        assert any("`project_slug` on get_tracer() is deprecated" in r.message for r in caplog.records)
+        assert not any("`project_slug` on capture() is deprecated" in r.message for r in caplog.records)
         lat.shutdown()

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1246,7 +1246,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "openinference-instrumentation-crewai" },


### PR DESCRIPTION
Addresses two review findings on the Python `Latitude.get_tracer()` helper:

- `_LatitudeTracer` now subclasses OpenTelemetry `Tracer`, so frameworks that validate `isinstance(tracer, Tracer)` accept the wrapped tracer.
- `project_slug` passed through `get_tracer(..., context)` now logs a deprecation warning that names `get_tracer()` instead of `capture()`.

Validation:
- `mise exec -- uv run ruff check src/latitude_telemetry/sdk/tracer.py src/latitude_telemetry/sdk/_deprecation.py tests/telemetry/span_test.py`
- `mise exec -- uv run pyright src/latitude_telemetry/sdk/tracer.py src/latitude_telemetry/sdk/_deprecation.py`
- `mise exec -- uv run pytest -q tests/telemetry/span_test.py`