### PR TITLE
fix(signals): rename affectedTracesPercent → affectedSessionsPercent (API + SDKs) and populate seed session_id

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -7671,7 +7671,7 @@
     {
       "name": "listSignals",
       "title": "List project signals",
-      "description": "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.",
+      "description": "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -7869,11 +7869,11 @@
                   "maximum": 9007199254740991,
                   "description": "Number of occurrences in the time window."
                 },
-                "affectedTracesPercent": {
+                "affectedSessionsPercent": {
                   "type": "number",
                   "minimum": 0,
                   "maximum": 1,
-                  "description": "Fraction of project traces affected by this signal in the time window, in `[0, 1]`."
+                  "description": "Fraction of project sessions affected by this signal in the time window, in `[0, 1]`."
                 }
               },
               "required": [
@@ -7893,7 +7893,7 @@
                 "firstSeenAt",
                 "lastSeenAt",
                 "occurrences",
-                "affectedTracesPercent"
+                "affectedSessionsPercent"
               ],
               "additionalProperties": false
             },
@@ -8727,7 +8727,7 @@
     {
       "name": "getSignal",
       "title": "Get project signal",
-      "description": "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
+      "description": "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -8880,11 +8880,11 @@
             "maximum": 9007199254740991,
             "description": "Lifetime occurrence count."
           },
-          "affectedTracesPercent": {
+          "affectedSessionsPercent": {
             "type": "number",
             "minimum": 0,
             "maximum": 1,
-            "description": "Lifetime fraction of project traces affected by this signal, in `[0, 1]`."
+            "description": "Lifetime fraction of project sessions affected by this signal, in `[0, 1]`."
           },
           "evaluations": {
             "type": "array",
@@ -9116,7 +9116,7 @@
           "firstSeenAt",
           "lastSeenAt",
           "occurrences",
-          "affectedTracesPercent",
+          "affectedSessionsPercent",
           "evaluations",
           "monitoringState"
         ],

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4096,11 +4096,11 @@
             "minimum": 0,
             "description": "Number of occurrences in the time window."
           },
-          "affectedTracesPercent": {
+          "affectedSessionsPercent": {
             "type": "number",
             "minimum": 0,
             "maximum": 1,
-            "description": "Fraction of project traces affected by this signal in the time window, in `[0, 1]`."
+            "description": "Fraction of project sessions affected by this signal in the time window, in `[0, 1]`."
           }
         },
         "required": [
@@ -4120,7 +4120,7 @@
           "firstSeenAt",
           "lastSeenAt",
           "occurrences",
-          "affectedTracesPercent"
+          "affectedSessionsPercent"
         ]
       },
       "SignalTrendBucket": {
@@ -4821,11 +4821,11 @@
             "minimum": 0,
             "description": "Lifetime occurrence count."
           },
-          "affectedTracesPercent": {
+          "affectedSessionsPercent": {
             "type": "number",
             "minimum": 0,
             "maximum": 1,
-            "description": "Lifetime fraction of project traces affected by this signal, in `[0, 1]`."
+            "description": "Lifetime fraction of project sessions affected by this signal, in `[0, 1]`."
           },
           "evaluations": {
             "type": "array",
@@ -4855,7 +4855,7 @@
           "firstSeenAt",
           "lastSeenAt",
           "occurrences",
-          "affectedTracesPercent",
+          "affectedSessionsPercent",
           "evaluations",
           "monitoringState"
         ]
@@ -11656,7 +11656,7 @@
         "x-fern-sdk-group-name": "signals",
         "x-fern-sdk-method-name": "list",
         "summary": "List project signals",
-        "description": "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.",
+        "description": "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.",
         "security": [
           {
             "ApiKeyAuth": []
@@ -12039,7 +12039,7 @@
         "x-fern-sdk-group-name": "signals",
         "x-fern-sdk-method-name": "get",
         "summary": "Get project signal",
-        "description": "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
+        "description": "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
         "security": [
           {
             "ApiKeyAuth": []

--- a/apps/api/src/openapi/entities/signal.ts
+++ b/apps/api/src/openapi/entities/signal.ts
@@ -77,11 +77,11 @@ const signalListFields = {
   firstSeenAt: z.string().describe("ISO-8601 timestamp of the earliest occurrence in the time window."),
   lastSeenAt: z.string().describe("ISO-8601 timestamp of the latest occurrence in the time window."),
   occurrences: z.number().int().nonnegative().describe("Number of occurrences in the time window."),
-  affectedTracesPercent: z
+  affectedSessionsPercent: z
     .number()
     .min(0)
     .max(1)
-    .describe("Fraction of project traces affected by this signal in the time window, in `[0, 1]`."),
+    .describe("Fraction of project sessions affected by this signal in the time window, in `[0, 1]`."),
 } as const
 
 // Detail-endpoint fields: full-history versions of every list stat plus
@@ -98,11 +98,11 @@ const signalDetailFields = {
     .nullable()
     .describe("ISO-8601 timestamp of the latest occurrence over the signal's lifetime, or `null` if none yet."),
   occurrences: z.number().int().nonnegative().describe("Lifetime occurrence count."),
-  affectedTracesPercent: z
+  affectedSessionsPercent: z
     .number()
     .min(0)
     .max(1)
-    .describe("Lifetime fraction of project traces affected by this signal, in `[0, 1]`."),
+    .describe("Lifetime fraction of project sessions affected by this signal, in `[0, 1]`."),
   evaluations: z
     .array(EvaluationSchema)
     .describe("Active evaluations monitoring the signal. Archived and deleted evaluations are excluded."),
@@ -132,7 +132,7 @@ export const toSignalResponse = (item: SignalListItem, organizationId: string) =
   firstSeenAt: item.firstSeenAt.toISOString(),
   lastSeenAt: item.lastSeenAt.toISOString(),
   occurrences: item.occurrences,
-  affectedTracesPercent: item.affectedSessionsPercent,
+  affectedSessionsPercent: item.affectedSessionsPercent,
   trend: item.trend.map((bucket) => ({ bucket: bucket.bucket, count: bucket.count })),
   tags: [...item.tags],
 })
@@ -152,7 +152,7 @@ export const toSignalDetailResponse = (details: SignalDetails, organizationId: s
   firstSeenAt: details.firstSeenAt ? details.firstSeenAt.toISOString() : null,
   lastSeenAt: details.lastSeenAt ? details.lastSeenAt.toISOString() : null,
   occurrences: details.occurrences,
-  affectedTracesPercent: details.affectedTracesPercent,
+  affectedSessionsPercent: details.affectedSessionsPercent,
   tags: [...details.tags],
   trend: details.trend.map((bucket) => ({ bucket: bucket.bucket, count: bucket.count })),
   evaluations: details.evaluations.map(toEvaluationResponse),

--- a/apps/api/src/routes/signals.ts
+++ b/apps/api/src/routes/signals.ts
@@ -287,7 +287,7 @@ const listSignals = signalEndpoint({
     ...signalsFernGroup("list"),
     summary: "List project signals",
     description:
-      "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.",
+      "Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.",
     security: PROTECTED_SECURITY,
     request: { params: ProjectParamsSchema, query: ListSignalsQuerySchema },
     responses: openApiResponses({ status: 200, schema: PaginatedSignalsSchema, description: "Page of signals" }),
@@ -434,7 +434,7 @@ const getSignal = signalEndpoint({
     ...signalsFernGroup("get"),
     summary: "Get project signal",
     description:
-      "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
+      "Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.",
     security: PROTECTED_SECURITY,
     request: { params: SignalSlugParamsSchema },
     responses: openApiResponses({ status: 200, schema: SignalDetailSchema, description: "Signal" }),
@@ -463,7 +463,7 @@ const getSignal = signalEndpoint({
           organizationId,
         ),
         withClickHouse(
-          Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive),
+          Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive),
           c.var.clickhouse,
           organizationId,
         ),

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -26,6 +26,7 @@ import {
   fillBuckets,
   getEscalationOccurrenceThreshold,
   getRelatedSignalsUseCase,
+  getSignalImpactUseCase,
   type ListSignalsResult,
   listSignalsUseCase,
   type OrgSignalSearchItem,
@@ -43,7 +44,7 @@ import {
   TAG_AGGREGATION_FALLBACK_DAYS,
   updateSignalTriageUseCase,
 } from "@domain/signals"
-import { SessionRepository, TraceRepository } from "@domain/spans"
+import { SessionRepository } from "@domain/spans"
 import { AIEmbedLive, withAi } from "@platform/ai"
 import {
   ScoreAnalyticsRepositoryLive,
@@ -213,6 +214,8 @@ export interface SignalImpactRecord {
   readonly tokens: number
   readonly totalProjectTraces: number
   readonly affectedTracesPercent: number
+  readonly totalProjectSessions: number
+  readonly affectedSessionsPercent: number
 }
 
 const updateSignalTriageInputSchema = z.object({
@@ -851,30 +854,12 @@ export const getSignalImpact = createServerFn({ method: "GET" })
     const signalId = SignalId(data.signalId)
 
     return Effect.runPromise(
-      Effect.gen(function* () {
-        const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
-        const traceRepository = yield* TraceRepository
-
-        const [impact, totalProjectTraces] = yield* Effect.all([
-          scoreAnalyticsRepository.aggregateImpactBySignal({ organizationId: orgId, projectId, signalId }),
-          traceRepository.countByProjectId({ organizationId: orgId, projectId }),
-        ])
-
-        const affectedTracesPercent =
-          totalProjectTraces === 0 ? 0 : Math.min(impact.affectedTraces / totalProjectTraces, 1)
-
-        return {
-          occurrences: impact.occurrences,
-          affectedTraces: impact.affectedTraces,
-          affectedSessions: impact.affectedSessions,
-          affectedUsers: impact.affectedUsers,
-          costMicrocents: impact.costMicrocents,
-          tokens: impact.tokens,
-          totalProjectTraces,
-          affectedTracesPercent,
-        } satisfies SignalImpactRecord
-      }).pipe(
-        withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive), chClient, orgId),
+      getSignalImpactUseCase({ organizationId: orgId, projectId, signalId }).pipe(
+        withClickHouse(
+          Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive, SessionRepositoryLive),
+          chClient,
+          orgId,
+        ),
         withTracing,
       ),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalId/-components/signal-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalId/-components/signal-summary.tsx
@@ -100,6 +100,26 @@ export function SignalSummary({ projectId, signalId }: { readonly projectId: str
             </>
           )}
 
+          <Tile label="Affected sessions">
+            {impactLoading ? (
+              <Skeleton className="h-5 w-16" />
+            ) : impact ? (
+              <Tooltip
+                asChild
+                trigger={
+                  <div className="flex cursor-default flex-row items-baseline gap-1">
+                    <Text.H5 color="foreground">{formatCount(impact.affectedSessions)}</Text.H5>
+                    <Text.H6 color="foregroundMuted">· {formatPercent(impact.affectedSessionsPercent)}</Text.H6>
+                  </div>
+                }
+              >
+                {formatPercent(impact.affectedSessionsPercent)} of all project sessions are affected by this signal.
+              </Tooltip>
+            ) : (
+              <Text.H5 color="foreground">-</Text.H5>
+            )}
+          </Tile>
+
           <Tile label="Affected traces">
             {impactLoading ? (
               <Skeleton className="h-5 w-16" />
@@ -118,14 +138,6 @@ export function SignalSummary({ projectId, signalId }: { readonly projectId: str
               </Tooltip>
             ) : (
               <Text.H5 color="foreground">-</Text.H5>
-            )}
-          </Tile>
-
-          <Tile label="Affected sessions">
-            {impactLoading ? (
-              <Skeleton className="h-5 w-16" />
-            ) : (
-              <Text.H5 color="foreground">{impact ? formatCount(impact.affectedSessions) : "-"}</Text.H5>
             )}
           </Tile>
 

--- a/apps/workers/src/workers/billing.test.ts
+++ b/apps/workers/src/workers/billing.test.ts
@@ -54,6 +54,16 @@ const provideAtomicReservation = Effect.provideService(
   createFakeBillingSpendReservation("atomic").reservation,
 )
 
+// `billing_usage_events` is range-partitioned by `billing_period_start`, and the
+// migration only provisions partitions for `[now - 2 months, now + 3 months]`. A
+// fixed calendar date eventually falls outside that window as the clock advances
+// (insert then fails with "no partition of relation found for row"), so anchor
+// test periods to the current UTC month. Evaluated at module load, before any
+// `vi.useFakeTimers()`, so it uses the real clock the migration also saw.
+const NOW = new Date()
+const BILLING_PERIOD_START = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth(), 1))
+const BILLING_PERIOD_END = new Date(Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() + 1, 1))
+
 describe("billing runtime integration", () => {
   it("prefers a manual override over an active Stripe subscription", async () => {
     vi.useFakeTimers()
@@ -189,8 +199,8 @@ describe("billing runtime integration", () => {
       stripeCustomerId: "cus_retry",
       stripeSubscriptionId: "sub_retry",
       status: "active",
-      periodStart: new Date("2026-04-01T00:00:00.000Z"),
-      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: BILLING_PERIOD_START,
+      periodEnd: BILLING_PERIOD_END,
     })
 
     const run = async (action: "live-eval-scan" | "eval-generation", idempotencyKey: string) => {
@@ -244,8 +254,8 @@ describe("billing runtime integration", () => {
     const context = {
       planSlug: "free" as const,
       planSource: "free-fallback" as const,
-      periodStart: new Date("2026-04-01T00:00:00.000Z"),
-      periodEnd: new Date("2026-05-01T00:00:00.000Z"),
+      periodStart: BILLING_PERIOD_START,
+      periodEnd: BILLING_PERIOD_END,
       includedCredits: PLAN_CONFIGS.free.includedCredits,
       overageAllowed: false,
     }
@@ -346,8 +356,8 @@ describe("billing runtime integration", () => {
   it("records trace usage batches idempotently across queue retries", async () => {
     const organizationId = generateId()
     const projectId = generateId()
-    const periodStart = new Date("2026-04-01T00:00:00.000Z")
-    const periodEnd = new Date("2026-05-01T00:00:00.000Z")
+    const periodStart = BILLING_PERIOD_START
+    const periodEnd = BILLING_PERIOD_END
 
     await pg.db.insert(organizations).values({
       id: organizationId,
@@ -418,8 +428,8 @@ describe("billing runtime integration", () => {
       traceIds: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"],
       planSlug: "free" as const,
       planSource: "free-fallback" as const,
-      periodStart: new Date("2026-04-01T00:00:00.000Z").toISOString(),
-      periodEnd: new Date("2026-05-01T00:00:00.000Z").toISOString(),
+      periodStart: BILLING_PERIOD_START.toISOString(),
+      periodEnd: BILLING_PERIOD_END.toISOString(),
       includedCredits: PLAN_CONFIGS.free.includedCredits,
       overageAllowed: false,
       isSandbox: true,
@@ -443,8 +453,8 @@ describe("billing runtime integration", () => {
     const organizationId = generateId()
     const firstProjectId = generateId()
     const secondProjectId = generateId()
-    const periodStart = new Date("2026-04-01T00:00:00.000Z")
-    const periodEnd = new Date("2026-05-01T00:00:00.000Z")
+    const periodStart = BILLING_PERIOD_START
+    const periodEnd = BILLING_PERIOD_END
 
     await pg.db.insert(organizations).values({
       id: organizationId,

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -69,6 +69,8 @@ export interface SessionScoreRollup {
 export interface SignalOccurrenceAggregate {
   readonly signalId: SignalId
   readonly totalOccurrences: number
+  /** Distinct non-empty `session_id`s the issue's occurrences belong to, over its lifetime. */
+  readonly affectedSessions: number
   readonly recentOccurrences: number // last 1 day
   readonly baselineAvgOccurrences: number // average daily occurrences in previous 7-day baseline
   readonly firstSeenAt: Date

--- a/packages/domain/signals/src/browser.ts
+++ b/packages/domain/signals/src/browser.ts
@@ -198,6 +198,12 @@ export {
   type SignalDetails,
 } from "./use-cases/get-signal-details.ts"
 export {
+  type GetSignalImpactError,
+  type GetSignalImpactInput,
+  getSignalImpactUseCase,
+  type SignalImpact,
+} from "./use-cases/get-signal-impact.ts"
+export {
   type GetSignalTrendError,
   type GetSignalTrendInput,
   type GetSignalTrendResult,

--- a/packages/domain/signals/src/use-cases/get-signal-details.ts
+++ b/packages/domain/signals/src/use-cases/get-signal-details.ts
@@ -16,7 +16,7 @@ import type {
   SignalId,
   SqlClient,
 } from "@domain/shared"
-import { TraceRepository } from "@domain/spans"
+import { SessionRepository } from "@domain/spans"
 import { Effect } from "effect"
 import type { SignalState } from "../entities/signal.ts"
 import { deriveSignalLifecycleStates } from "../helpers.ts"
@@ -41,8 +41,8 @@ export interface SignalDetails {
   readonly lastSeenAt: Date | null
   /** Lifetime occurrence count. */
   readonly occurrences: number
-  /** Fraction of project traces affected by this issue over its lifetime, in `[0, 1]`. */
-  readonly affectedTracesPercent: number
+  /** Fraction of project sessions affected by this issue over its lifetime, in `[0, 1]`. */
+  readonly affectedSessionsPercent: number
   /** Tags seen on the issue's occurrences over its lifetime. */
   readonly tags: readonly string[]
   /** Last 14 days of daily occurrence buckets, UTC-aligned. */
@@ -58,7 +58,7 @@ export type GetSignalDetailsError = NotFoundError | RepositoryError
 /**
  * Loads the full-detail view of one issue: lifecycle states, lifetime
  * occurrence stats (`occurrences`, `firstSeenAt`, `lastSeenAt`,
- * `affectedTracesPercent`, `tags`), a 14-day trend, the active evaluations
+ * `affectedSessionsPercent`, `tags`), a 14-day trend, the active evaluations
  * monitoring it, and the real-time `alignmentState` derived from running
  * Temporal workflows.
  *
@@ -76,7 +76,7 @@ export const getSignalDetailsUseCase = (
   | SignalRepository
   | ScoreAnalyticsRepository
   | SqlClient
-  | TraceRepository
+  | SessionRepository
   | WorkflowQuerier
 > =>
   Effect.gen(function* () {
@@ -87,11 +87,11 @@ export const getSignalDetailsUseCase = (
     const signalRepository = yield* SignalRepository
     const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
     const evaluationRepository = yield* EvaluationRepository
-    const traceRepository = yield* TraceRepository
+    const sessionRepository = yield* SessionRepository
 
     const issue = yield* signalRepository.findById(input.signalId)
 
-    const [occurrenceAggregates, trend, evaluationsPage, totalTraces] = yield* Effect.all([
+    const [occurrenceAggregates, trend, evaluationsPage, sessionCount] = yield* Effect.all([
       scoreAnalyticsRepository.aggregateBySignals({
         organizationId: input.organizationId,
         projectId: input.projectId,
@@ -109,7 +109,7 @@ export const getSignalDetailsUseCase = (
         signalId: input.signalId,
         options: { lifecycle: "active" },
       }),
-      traceRepository.countByProjectId({
+      sessionRepository.countByProjectId({
         organizationId: input.organizationId,
         projectId: input.projectId,
       }),
@@ -131,7 +131,9 @@ export const getSignalDetailsUseCase = (
     })
 
     const occurrences = aggregate?.totalOccurrences ?? 0
-    const affectedTracesPercent = totalTraces === 0 ? 0 : Math.min(occurrences / totalTraces, 1)
+    const affectedSessions = aggregate?.affectedSessions ?? 0
+    const totalSessions = sessionCount.totalCount
+    const affectedSessionsPercent = totalSessions === 0 ? 0 : Math.min(affectedSessions / totalSessions, 1)
     const tags = tagsAggregates[0]?.tags ?? []
     const activeEvaluations = evaluationsPage.items.filter(isActiveEvaluation)
 
@@ -147,7 +149,7 @@ export const getSignalDetailsUseCase = (
       firstSeenAt: aggregate?.firstSeenAt ?? null,
       lastSeenAt: aggregate?.lastSeenAt ?? null,
       occurrences,
-      affectedTracesPercent,
+      affectedSessionsPercent,
       tags,
       trend,
       evaluations: activeEvaluations,

--- a/packages/domain/signals/src/use-cases/get-signal-impact.ts
+++ b/packages/domain/signals/src/use-cases/get-signal-impact.ts
@@ -1,0 +1,74 @@
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError, SignalId } from "@domain/shared"
+import { SessionRepository, TraceRepository } from "@domain/spans"
+import { Effect } from "effect"
+
+export interface GetSignalImpactInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly signalId: SignalId
+}
+
+/**
+ * Lifetime impact rollup for one issue: raw counts (`scores`), the project-wide
+ * denominators, and the two affected-share fractions. Sessions are the
+ * product's primary unit, so `affectedSessionsPercent` is the headline metric;
+ * `affectedTracesPercent` is the trace-level baseline the Patterns view compares
+ * against. Both fractions are clamped to `[0, 1]`.
+ */
+export interface SignalImpact {
+  readonly occurrences: number
+  readonly affectedTraces: number
+  readonly affectedSessions: number
+  readonly affectedUsers: number
+  readonly costMicrocents: number
+  readonly tokens: number
+  readonly totalProjectTraces: number
+  readonly affectedTracesPercent: number
+  readonly totalProjectSessions: number
+  readonly affectedSessionsPercent: number
+}
+
+export type GetSignalImpactError = RepositoryError
+
+export const getSignalImpactUseCase = (
+  input: GetSignalImpactInput,
+): Effect.Effect<
+  SignalImpact,
+  GetSignalImpactError,
+  ChSqlClient | ScoreAnalyticsRepository | TraceRepository | SessionRepository
+> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", String(input.projectId))
+    yield* Effect.annotateCurrentSpan("signalId", String(input.signalId))
+
+    const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+    const traceRepository = yield* TraceRepository
+    const sessionRepository = yield* SessionRepository
+
+    const [impact, totalProjectTraces, projectSessions] = yield* Effect.all([
+      scoreAnalyticsRepository.aggregateImpactBySignal({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        signalId: input.signalId,
+      }),
+      traceRepository.countByProjectId({ organizationId: input.organizationId, projectId: input.projectId }),
+      sessionRepository.countByProjectId({ organizationId: input.organizationId, projectId: input.projectId }),
+    ])
+
+    const totalProjectSessions = projectSessions.totalCount
+
+    return {
+      occurrences: impact.occurrences,
+      affectedTraces: impact.affectedTraces,
+      affectedSessions: impact.affectedSessions,
+      affectedUsers: impact.affectedUsers,
+      costMicrocents: impact.costMicrocents,
+      tokens: impact.tokens,
+      totalProjectTraces,
+      affectedTracesPercent: totalProjectTraces === 0 ? 0 : Math.min(impact.affectedTraces / totalProjectTraces, 1),
+      totalProjectSessions,
+      affectedSessionsPercent:
+        totalProjectSessions === 0 ? 0 : Math.min(impact.affectedSessions / totalProjectSessions, 1),
+    } satisfies SignalImpact
+  }).pipe(Effect.withSpan("issues.getSignalImpact"))

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -73,6 +73,7 @@ const makeWindowMetric = (overrides: Partial<SignalWindowMetric> = {}): SignalWi
 const makeOccurrence = (overrides: Partial<SignalOccurrenceAggregate> = {}): SignalOccurrenceAggregate => ({
   signalId: SignalId("i".repeat(24)),
   totalOccurrences: 10,
+  affectedSessions: 5,
   recentOccurrences: 2,
   baselineAvgOccurrences: 1,
   firstSeenAt: new Date("2026-03-01T00:00:00.000Z"),

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -543,8 +543,32 @@ describe("ScoreAnalyticsRepository", () => {
       const aggA = aggs.find((a) => (a.signalId as string) === signalA)
       expect(aggA).toBeDefined()
       expect(aggA?.totalOccurrences).toBe(3)
+      // Fixture rows carry no session_id, so distinct affected sessions is 0.
+      expect(aggA?.affectedSessions).toBe(0)
       expect(aggA?.firstSeenAt.toISOString()).toBe("2026-03-10T10:00:00.000Z")
       expect(aggA?.lastSeenAt.toISOString()).toBe("2026-03-25T10:00:00.000Z")
+    })
+
+    it("counts distinct non-empty session ids as affectedSessions", async () => {
+      const signalC = "issue_cccccccccccccccccc"
+      await fixture.insertScores([
+        makeScoreRow({ signal_id: signalC, session_id: "session_c1", created_at: "2026-03-25 10:00:00.000" }),
+        makeScoreRow({ signal_id: signalC, session_id: "session_c1", created_at: "2026-03-24 10:00:00.000" }),
+        makeScoreRow({ signal_id: signalC, session_id: "session_c2", created_at: "2026-03-23 10:00:00.000" }),
+        makeScoreRow({ signal_id: signalC, session_id: "", created_at: "2026-03-22 10:00:00.000" }),
+      ])
+
+      const aggs = await fixture.runCh(
+        fixture.repo.aggregateBySignals({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          signalIds: [SignalId(signalC)],
+        }),
+      )
+
+      const aggC = aggs.find((a) => (a.signalId as string) === signalC)
+      expect(aggC?.totalOccurrences).toBe(4)
+      expect(aggC?.affectedSessions).toBe(2)
     })
 
     it("returns empty for no issue ids", async () => {

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -184,6 +184,7 @@ type SessionRollupRow = {
 type SignalOccurrenceRow = {
   signal_id: string
   total_occurrences: string
+  affected_sessions: string
   recent_occurrences: string
   baseline_avg_occurrences: string
   first_seen_at: string
@@ -351,6 +352,7 @@ const toSessionRollup = (row: SessionRollupRow): SessionScoreRollup => ({
 const toSignalOccurrence = (row: SignalOccurrenceRow): SignalOccurrenceAggregate => ({
   signalId: toSignalId(normalizeCHString(row.signal_id)),
   totalOccurrences: Number(row.total_occurrences),
+  affectedSessions: Number(row.affected_sessions),
   recentOccurrences: Number(row.recent_occurrences),
   baselineAvgOccurrences: Number(row.baseline_avg_occurrences),
   firstSeenAt: parseCHDate(row.first_seen_at),
@@ -1012,6 +1014,7 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                 query: `SELECT
                         signal_id,
                         count()                                                AS total_occurrences,
+                        uniqExactIf(session_id, session_id != '')              AS affected_sessions,
                         countIf(created_at >= now() - INTERVAL 1 DAY)          AS recent_occurrences,
                         -- average daily occurrences over the previous 7-day baseline (days 1-8 ago)
                         countIf(

--- a/packages/platform/db-clickhouse/src/seeds/scores/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/scores/index.ts
@@ -67,12 +67,15 @@ function buildTau2SignalAnalyticsRows(scope: SeedScope, maxTrajectories = TAU2_S
 
     return Array.from({ length: occurrenceCount }, (_, occurrenceIndex) => {
       const trajectoryIndex = candidateIndexes[(signalIndex + occurrenceIndex) % candidateIndexes.length] ?? 0
+      const traceId = scope.traceHex("tau2-trajectory", trajectoryIndex)
       return {
         id: ScoreId(scope.cuid(`score:tau2-issue:${signalIndex}:${occurrenceIndex}`)),
         organization_id: orgId,
         project_id: projectId,
-        session_id: "",
-        trace_id: scope.traceHex("tau2-trajectory", trajectoryIndex),
+        // Matches the session the trajectory's spans roll up to (sessions_mv keys
+        // session-less spans by trace_id), so the affected-sessions metric counts them.
+        session_id: traceId,
+        trace_id: traceId,
         span_id: scope.spanHex("tau2-trajectory-root", trajectoryIndex),
         source: "custom",
         source_id: "tau2-seed-classifier",
@@ -102,7 +105,7 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       id: ScoreId(scope.cuid("score:passed")),
       organization_id: orgId,
       project_id: projectId,
-      session_id: "",
+      session_id: scope.traceHex("lifecycle", 2),
       trace_id: scope.traceHex("lifecycle", 2),
       span_id: scope.spanHex("lifecycle", 2),
       source: "evaluation",
@@ -121,7 +124,7 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       id: ScoreId(scope.cuid("score:errored")),
       organization_id: orgId,
       project_id: projectId,
-      session_id: "",
+      session_id: scope.traceHex("lifecycle", 3),
       trace_id: scope.traceHex("lifecycle", 3),
       span_id: scope.spanHex("lifecycle", 3),
       source: "evaluation",
@@ -140,7 +143,7 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       id: ScoreId(scope.cuid("score:api-reviewed")),
       organization_id: orgId,
       project_id: projectId,
-      session_id: "",
+      session_id: scope.traceHex("lifecycle", 3),
       trace_id: scope.traceHex("lifecycle", 3),
       span_id: "",
       source: "annotation",
@@ -159,7 +162,7 @@ export function buildLifecycleAnalyticsRows(scope: SeedScope) {
       id: ScoreId(scope.cuid("score:pending")),
       organization_id: orgId,
       project_id: projectId,
-      session_id: "",
+      session_id: scope.traceHex("lifecycle", 4),
       trace_id: scope.traceHex("lifecycle", 4),
       span_id: "",
       source: "custom",

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -108,7 +108,7 @@ function createTau2LlmSpan(opts: {
   return {
     organization_id: opts.scope.organizationId,
     project_id: opts.scope.projectId,
-    session_id: "",
+    session_id: opts.traceId,
     user_id: opts.user?.id ?? "",
     user_email: opts.user?.email ?? "",
     trace_id: opts.traceId,
@@ -183,7 +183,7 @@ function createTau2ToolSpan(opts: {
   return {
     organization_id: opts.scope.organizationId,
     project_id: opts.scope.projectId,
-    session_id: "",
+    session_id: opts.traceId,
     user_id: opts.user?.id ?? "",
     user_email: opts.user?.email ?? "",
     trace_id: opts.traceId,
@@ -266,7 +266,7 @@ function createCompatibilityChatSpan(opts: {
   return {
     organization_id: opts.scope.organizationId,
     project_id: opts.scope.projectId,
-    session_id: "",
+    session_id: traceId,
     user_id: opts.user?.id ?? "",
     user_email: opts.user?.email ?? "",
     trace_id: traceId,
@@ -640,7 +640,7 @@ export function buildTau2TrajectorySpans(scope: SeedScope, maxTrajectories = TAU
     const root: SpanRow = {
       organization_id: scope.organizationId,
       project_id: scope.projectId,
-      session_id: "",
+      session_id: traceId,
       user_id: user?.id ?? "",
       user_email: user?.email ?? "",
       trace_id: traceId,

--- a/packages/sdk/python/CHANGELOG.md
+++ b/packages/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.0] - 2026-06-30
+
+### Changed
+
+- Renamed `affected_traces_percent` → `affected_sessions_percent` on the `Signal` (list) and `SignalDetail` (detail) response models (JSON alias `affectedSessionsPercent`). The value is the fraction of project sessions affected by the signal, in `[0, 1]` (sessions are the platform's primary unit); the previous name mislabeled a sessions-based ratio as traces. Update any code reading `signal.affected_traces_percent` to `signal.affected_sessions_percent`.
+
 ## [6.5.0] - 2026-06-29
 
 ### Added

--- a/packages/sdk/python/pyproject.toml
+++ b/packages/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-sdk"
-version = "6.5.0"
+version = "6.6.0"
 description = "Official Python SDK for the Latitude API"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/sdk/python/src/latitude_sdk/signals/client.py
+++ b/packages/sdk/python/src/latitude_sdk/signals/client.py
@@ -58,7 +58,7 @@ class SignalsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PaginatedSignals:
         """
-        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.
+        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.
 
         Parameters
         ----------
@@ -215,7 +215,7 @@ class SignalsClient:
         self, project_slug: str, signal_slug: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> SignalDetail:
         """
-        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
+        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
 
         Parameters
         ----------
@@ -751,7 +751,7 @@ class AsyncSignalsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PaginatedSignals:
         """
-        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.
+        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.
 
         Parameters
         ----------
@@ -923,7 +923,7 @@ class AsyncSignalsClient:
         self, project_slug: str, signal_slug: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> SignalDetail:
         """
-        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
+        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
 
         Parameters
         ----------

--- a/packages/sdk/python/src/latitude_sdk/signals/raw_client.py
+++ b/packages/sdk/python/src/latitude_sdk/signals/raw_client.py
@@ -57,7 +57,7 @@ class RawSignalsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[PaginatedSignals]:
         """
-        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.
+        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.
 
         Parameters
         ----------
@@ -275,7 +275,7 @@ class RawSignalsClient:
         self, project_slug: str, signal_slug: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> HttpResponse[SignalDetail]:
         """
-        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
+        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
 
         Parameters
         ----------
@@ -1150,7 +1150,7 @@ class AsyncRawSignalsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[PaginatedSignals]:
         """
-        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.
+        Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.
 
         Parameters
         ----------
@@ -1368,7 +1368,7 @@ class AsyncRawSignalsClient:
         self, project_slug: str, signal_slug: str, *, request_options: typing.Optional[RequestOptions] = None
     ) -> AsyncHttpResponse[SignalDetail]:
         """
-        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
+        Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
 
         Parameters
         ----------

--- a/packages/sdk/python/src/latitude_sdk/types/signal.py
+++ b/packages/sdk/python/src/latitude_sdk/types/signal.py
@@ -94,11 +94,11 @@ class Signal(UniversalBaseModel):
     Number of occurrences in the time window.
     """
 
-    affected_traces_percent: typing_extensions.Annotated[float, FieldMetadata(alias="affectedTracesPercent")] = (
+    affected_sessions_percent: typing_extensions.Annotated[float, FieldMetadata(alias="affectedSessionsPercent")] = (
         pydantic.Field()
     )
     """
-    Fraction of project traces affected by this signal in the time window, in `[0, 1]`.
+    Fraction of project sessions affected by this signal in the time window, in `[0, 1]`.
     """
 
     model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)

--- a/packages/sdk/python/src/latitude_sdk/types/signal_detail.py
+++ b/packages/sdk/python/src/latitude_sdk/types/signal_detail.py
@@ -100,11 +100,11 @@ class SignalDetail(UniversalBaseModel):
     Lifetime occurrence count.
     """
 
-    affected_traces_percent: typing_extensions.Annotated[float, FieldMetadata(alias="affectedTracesPercent")] = (
+    affected_sessions_percent: typing_extensions.Annotated[float, FieldMetadata(alias="affectedSessionsPercent")] = (
         pydantic.Field()
     )
     """
-    Lifetime fraction of project traces affected by this signal, in `[0, 1]`.
+    Lifetime fraction of project sessions affected by this signal, in `[0, 1]`.
     """
 
     evaluations: typing.List[Evaluation] = pydantic.Field()

--- a/packages/sdk/typescript/CHANGELOG.md
+++ b/packages/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.0] - 2026-06-30
+
+### Changed
+
+- Renamed `affectedTracesPercent` → `affectedSessionsPercent` on the `Signal` (list) and `SignalDetail` (detail) response types. The value is the fraction of project sessions affected by the signal, in `[0, 1]` (sessions are the platform's primary unit); the previous name mislabeled a sessions-based ratio as traces. Update any code reading `signal.affectedTracesPercent` to `signal.affectedSessionsPercent`.
+
 ## [6.5.0] - 2026-06-29
 
 ### Added

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Official TypeScript SDK for the Latitude API",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/sdk/typescript/src/api/resources/signals/client/Client.ts
+++ b/packages/sdk/typescript/src/api/resources/signals/client/Client.ts
@@ -23,7 +23,7 @@ export class SignalsClient {
     }
 
     /**
-     * Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `trend`, and `tags`.
+     * Returns a cursor-paginated page of signals in the project. Each item includes lifecycle `states` plus time-window stats: `firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `trend`, and `tags`.
      *
      * @param {string} projectSlug - Project slug (human-readable identifier)
      * @param {LatitudeApi.SignalsListRequest} request
@@ -234,7 +234,7 @@ export class SignalsClient {
     }
 
     /**
-     * Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedTracesPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
+     * Returns the full-history detail view of one signal: lifecycle `states`, lifetime activity stats (`firstSeenAt`, `lastSeenAt`, `occurrences`, `affectedSessionsPercent`, `tags`), a 14-day occurrence `trend`, the active `evaluations` monitoring it, and the current `monitoringState`.
      *
      * @param {string} projectSlug - Project slug (human-readable identifier)
      * @param {string} signalSlug - Signal slug.

--- a/packages/sdk/typescript/src/api/types/Signal.ts
+++ b/packages/sdk/typescript/src/api/types/Signal.ts
@@ -35,8 +35,8 @@ export interface Signal {
     lastSeenAt: string;
     /** Number of occurrences in the time window. */
     occurrences: number;
-    /** Fraction of project traces affected by this signal in the time window, in `[0, 1]`. */
-    affectedTracesPercent: number;
+    /** Fraction of project sessions affected by this signal in the time window, in `[0, 1]`. */
+    affectedSessionsPercent: number;
 }
 
 export namespace Signal {

--- a/packages/sdk/typescript/src/api/types/SignalDetail.ts
+++ b/packages/sdk/typescript/src/api/types/SignalDetail.ts
@@ -35,8 +35,8 @@ export interface SignalDetail {
     lastSeenAt?: string | undefined;
     /** Lifetime occurrence count. */
     occurrences: number;
-    /** Lifetime fraction of project traces affected by this signal, in `[0, 1]`. */
-    affectedTracesPercent: number;
+    /** Lifetime fraction of project sessions affected by this signal, in `[0, 1]`. */
+    affectedSessionsPercent: number;
     /** Active evaluations monitoring the signal. Archived and deleted evaluations are excluded. */
     evaluations: LatitudeApi.Evaluation[];
     monitoringState: LatitudeApi.SignalMonitoringState;


### PR DESCRIPTION
## What does this PR do?

Fixes the signals impact metric that read `affectedTracesPercent: 0` for every signal while dogfooding the Latitude MCP on the seeded default project (Acme Inc. / Support Agent, tau2-bench).

The product is **session-centric** — the sessions/traces view is titled "sessions" and defaults to sessions, and behaviours + search operate on sessions — so the impact metric is **sessions-based**. The bug was the field's **name and seed data**, not its semantics.

### Bug A — honest, aligned naming (was a public-surface mislabel)
- The list mapped the API field `affectedTracesPercent` from the domain's affected-**sessions** value, and the detail computed `occurrences / totalTraces`: the name said "traces", the data was sessions/occurrences, and list ≠ detail.
- **Rename the public field `affectedTracesPercent` → `affectedSessionsPercent`** (fraction in `[0,1]`) across the list + detail responses, `openapi.json` / `mcp.json`, and the generated **TS + Python SDKs** (regenerated via Fern).
- **Align the detail path** on the same metric — it now computes `affected sessions / total project sessions` (was `occurrences / total traces`), so list and detail agree.

### Bug B — populate `session_id` in the demo seed (root cause of the 0)
- The seeded scores **and** the tau2-trajectory / lifecycle **spans** carried an empty `session_id`. `sessions_mv` masks this for session *counts* via `coalesce(nullIf(session_id,''), toString(trace_id))`, but the signals numerator `uniqExactIf(session_id, session_id != '')` has no such fallback → it read 0.
- **Populate `session_id`** with the trace's own id (exactly the key the MV already derives) on both the scores and their spans, so the metric is meaningful and spans/scores/sessions agree. **Session-table cardinality is unchanged** (the key was already `trace_id` via the fallback); this also makes span-level session metrics like `listTools` non-zero.

### Supporting change
- ClickHouse `aggregateBySignals` now also returns distinct `affected_sessions` (lifetime) for the detail metric, surfaced on `SignalOccurrenceAggregate`.

## Where review should focus
- **Naming**: `affectedSessionsPercent` is a fraction `[0,1]` despite the `…Percent` suffix — kept the suffix to match the existing convention and the web detail tile; the description documents the range. Public rename touches openapi/mcp/SDKs (all regenerated).
- **Detail semantics change**: the API detail's impact % moves from occurrences/traces to affected-sessions/sessions to align with the list. The **web** signal-detail page now also leads with affected **sessions** (count + % of project sessions); the affected-traces tile stays as a secondary metric since it's the baseline the Patterns section compares against.
- **Seed approach**: `session_id = trace_id`. It's the canonical session key the MV already produces for session-less traces, so it changes the column from empty→populated without shifting session counts. Reasonable, or do you want real per-conversation session ids?
- **Note**: `getSignalDetailsUseCase` has no unit test (pre-existing gap); the sessions arithmetic mirrors the tested list path, and the new `affected_sessions` CH query is covered.

## History
Supersedes this PR's earlier approach (making the field genuinely trace-based) — reverted in favor of sessions to match the session-centric product.

## How was this tested?
- `pnpm --filter @domain/scores --filter @domain/signals --filter @platform/db-clickhouse --filter @app/api --filter @app/web typecheck` — all pass
- `pnpm --filter @domain/signals test` — 81 pass
- `pnpm --filter @platform/db-clickhouse test -- score-analytics-repository.test.ts` — 49 pass (added distinct-`session_id` coverage for `aggregateBySignals`)
- `pnpm openapi:emit && pnpm mcp:emit` — field renamed in both manifests
- `pnpm generate:sdk` — TS + Python SDKs regenerated (rename-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## QA plan

Manual verification to run against a local stack. The seed change only lands after a **reseed** (the seeders are idempotent and skip when their sentinel rows already exist). `andres@` will walk this with assistant help — check each box.

### 0. Apply the change locally
- [x] On this branch: `pnpm build` (platform packages must be compiled before seeding)
- [x] Reseed ClickHouse (truncates data tables, then re-seeds with the fix): `pnpm --filter @platform/db-clickhouse ch:seed:reset`
  - If Postgres signals aren't seeded yet, run the full path instead: `pnpm db:reset && pnpm db:up && pnpm seed`
- [x] Start the API: `pnpm --filter @app/api dev` (and the web app if doing the UI checks)

Target data: org **Acme Inc.**, project **Support Agent** (slug `default-project`), seeded with tau2-bench trajectories.

### 1. Seed-level (ClickHouse) — `session_id` is populated
Open a CH shell: `pnpm --filter @platform/db-clickhouse ch:connect`
- [x] **Scores now carry `session_id`** (was `''` before):
  ```sql
  SELECT count() AS total, countIf(session_id != '') AS with_session
  FROM scores WHERE signal_id != '';
  ```
  Expect `with_session == total` (no empty session_id on signal-linked scores).
- [x] **Scored spans carry `session_id`** (tau2 trajectories + lifecycle):
  ```sql
  SELECT countIf(session_id != '') AS with_session, count() AS total
  FROM spans WHERE service_name LIKE 'tau2-%';
  ```
  Expect `with_session > 0` (previously 0).
- [x] **A signal has non-zero affected sessions** (numerator is no longer 0):
  ```sql
  SELECT signal_id, count() AS occ, uniqExactIf(session_id, session_id != '') AS affected_sessions
  FROM scores WHERE signal_id != '' GROUP BY signal_id ORDER BY occ DESC LIMIT 5;
  ```
  Expect `affected_sessions > 0` for every row.

### 2. API / MCP — `affectedSessionsPercent` is present and non-zero
The local API listens on **`http://localhost:3001`**. Auth is `Authorization: Bearer <token>` with the seeded **Default API Key**: `lat_seed_default_api_key_token`. Project slug is `default-project`.

```bash
# Reusable env
export LAT_API=http://localhost:3001
export LAT_TOKEN=lat_seed_default_api_key_token
```

- [x] **`listSignals`** — every item has `affectedSessionsPercent` in `[0,1]`, **> 0** for active signals, and **no** `affectedTracesPercent` key:
  ```bash
  curl -s -H "Authorization: Bearer $LAT_TOKEN" \
    "$LAT_API/v1/projects/default-project/signals?fromIso=2026-06-01T00:00:00.000Z&toIso=2026-07-01T00:00:00.000Z" \
    | jq '.items[] | {slug, occurrences, affectedSessionsPercent, hasTracesField: has("affectedTracesPercent")}'
  ```
  Expect `affectedSessionsPercent > 0` on active signals and `hasTracesField: false` for all.
- [x] **`getSignal`** (detail) — grab the first slug from the list and fetch its detail; `affectedSessionsPercent` present, in `[0,1]`, **> 0**:
  ```bash
  SLUG=$(curl -s -H "Authorization: Bearer $LAT_TOKEN" \
    "$LAT_API/v1/projects/default-project/signals" | jq -r '.items[0].slug')
  curl -s -H "Authorization: Bearer $LAT_TOKEN" \
    "$LAT_API/v1/projects/default-project/signals/$SLUG" \
    | jq '{slug, occurrences, affectedSessionsPercent, hasTracesField: has("affectedTracesPercent")}'
  ```
- [x] **List ↔ detail consistency**: both report the same *kind* of metric (fraction of project sessions). The detail value is lifetime, the list value is windowed — they need not be numerically equal, but neither should be 0 when the signal has scored sessions.
- [x] **MCP transport** (how the bug was originally found): point an MCP client at `http://localhost:3001/v1/mcp` (HTTP transport) with header `Authorization: Bearer lat_seed_default_api_key_token`, or run the inspector `pnpm --filter @app/api mcp:inspect`. Call the `listSignals` tool with `{ "projectSlug": "default-project" }` and the `getSignal` tool with `{ "projectSlug": "default-project", "signalSlug": "<slug>" }`; confirm `affectedSessionsPercent` is returned and non-zero, with no `affectedTracesPercent`.

### 3. Public-surface artifacts — rename propagated
- [x] `apps/api/openapi.json` and `apps/api/mcp.json` contain `affectedSessionsPercent` and **no** `affectedTracesPercent` (signals schemas only):
  ```bash
  grep -c affectedSessionsPercent apps/api/openapi.json apps/api/mcp.json   # > 0
  grep -c affectedTracesPercent  apps/api/openapi.json apps/api/mcp.json    # 0
  ```
- [x] TS + Python SDK types use `affectedSessionsPercent` (`packages/sdk/typescript/src/api/types/Signal.ts`, `SignalDetail.ts`; `packages/sdk/python/.../types/signal.py`, `signal_detail.py`).
- [x] No drift: `pnpm openapi:emit && pnpm mcp:emit && git diff --exit-code apps/api/openapi.json apps/api/mcp.json`.

### 4. Web (UI) — unchanged behavior holds
- [x] Signals **list** (`/projects/default-project/signals`): the "Affected sessions" column shows non-zero percentages after reseed.
- [x] Signal **detail** page leads with the "Affected sessions" tile (count + % of project sessions, non-zero after reseed); the "Affected traces" tile follows as a secondary metric (still the Patterns baseline).

### 5. Regression — session counts didn't shift
- [x] Session-table cardinality is unchanged by the seed change (we set `session_id = trace_id`, the key `sessions_mv` already derived for session-less spans):
  ```sql
  SELECT uniqExact(session_id) FROM sessions;
  ```
  Sanity-check this is in the same ballpark as before the change (no large jump/drop).

### Automated checks (already green on this branch; re-run if anything above fails)
- [x] `pnpm --filter @domain/scores --filter @domain/signals --filter @platform/db-clickhouse --filter @app/api --filter @app/web typecheck`
- [x] `pnpm --filter @domain/signals test`
- [x] `pnpm --filter @platform/db-clickhouse test -- score-analytics-repository.test.ts`


---

## SDK release

Both SDKs are bumped **6.5.0 → 6.6.0** (minor) with changelog entries for the field rename:
- `@latitude-data/sdk` (TypeScript): `Signal.affectedTracesPercent` → `affectedSessionsPercent` (and on `SignalDetail`).
- `latitude-sdk` (Python): `affected_traces_percent` → `affected_sessions_percent`.

SDK sources were regenerated from `apps/api/openapi.json` via `pnpm generate:sdk` (Fern, TS + Python). `fern/generators.yml` owns everything under each SDK's `src/`; the version/changelog in the hand-written package shell were bumped manually.



