### PR TITLE
fix(sandbox): rename Traces→Sessions, make score filters work, contain render errors

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,6 @@
 import { ssoClient } from "@better-auth/sso/client"
-import { createAuthClient } from "better-auth/client"
 import { magicLinkClient, organizationClient } from "better-auth/client/plugins"
+import { createAuthClient } from "better-auth/react"
 import { AUTH_BASE_PATH } from "./auth-config.ts"
 
 // No `baseURL`: Better Auth's client resolves `window.location.origin` in the

--- a/apps/web/src/lib/client-error-reporting.tsx
+++ b/apps/web/src/lib/client-error-reporting.tsx
@@ -1,7 +1,8 @@
 import { createLogger, recordSpanExceptionForDatadog, SpanStatusCode, trace } from "@repo/observability"
-import { Button, CopyableText, Text, useMountEffect } from "@repo/ui"
+import { Button, CopyableText, cn, Text, useMountEffect } from "@repo/ui"
+import { CatchBoundary, useRouterState } from "@tanstack/react-router"
 import { createServerFn } from "@tanstack/react-start"
-import { useMemo } from "react"
+import { type ReactNode, useMemo } from "react"
 import { z } from "zod"
 
 const logger = createLogger("client-error")
@@ -44,10 +45,12 @@ export function ErrorFallback({
   error,
   componentStack,
   reset,
+  variant,
 }: {
   error: Error
   componentStack?: string | null
   reset: () => void
+  variant: "fullscreen" | "contained"
 }) {
   const errorId = useMemo(() => generateErrorId(), [])
 
@@ -63,7 +66,12 @@ export function ErrorFallback({
   })
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center gap-4">
+    <div
+      className={cn("flex flex-col items-center justify-center gap-4 p-8", {
+        "min-h-screen": variant === "fullscreen",
+        "h-full min-h-0": variant === "contained",
+      })}
+    >
       <Text.H3>Something went wrong</Text.H3>
       <Text.H5 color="foregroundMuted">
         If this error persists, please contact support and reference this error ID:
@@ -73,5 +81,23 @@ export function ErrorFallback({
       </div>
       <Button onClick={reset}>Try again</Button>
     </div>
+  )
+}
+
+/**
+ * Scopes render errors to a content region: the fallback renders in place of
+ * `children` while the surrounding shell (sidebar, nav) stays interactive,
+ * instead of the error bubbling to the root boundary and replacing the whole
+ * app. Resets automatically on navigation (the pathname is the reset key).
+ */
+export function ContentErrorBoundary({ children }: { children: ReactNode }) {
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
+  return (
+    <CatchBoundary
+      getResetKey={() => pathname}
+      errorComponent={({ error, reset }) => <ErrorFallback error={error} reset={reset} variant="contained" />}
+    >
+      {children}
+    </CatchBoundary>
   )
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,7 +21,7 @@ const AgentationToolbar = import.meta.env.DEV
 
 export const Route = createRootRoute({
   errorComponent: ({ error, info, reset }) => (
-    <ErrorFallback error={error} componentStack={info?.componentStack ?? null} reset={reset} />
+    <ErrorFallback error={error} componentStack={info?.componentStack ?? null} reset={reset} variant="fullscreen" />
   ),
   loader: async () => {
     const theme = await getThemePreference()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -13,6 +13,7 @@ import { useProjectsCollection } from "../../../domains/projects/projects.collec
 import { type ProjectRecord, rememberLastProjectSlug, toRecord } from "../../../domains/projects/projects.functions.ts"
 import { getLatestWrappedReportForProject } from "../../../domains/wrapped/wrapped.functions.ts"
 import { AppSidebar, NavItem } from "../../../layouts/AppSidebar/index.tsx"
+import { ContentErrorBoundary } from "../../../lib/client-error-reporting.tsx"
 import { requireSession } from "../../../server/auth.ts"
 import { getPostgresClient } from "../../../server/clients.ts"
 import { ChangelogSidebarEntry } from "../-components/changelog/changelog-sidebar-entry.tsx"
@@ -179,7 +180,9 @@ function ProjectLayout() {
         <div className="relative flex min-h-0 flex-1 overflow-hidden rounded-t-2xl bg-background">
           <ProjectSidebar project={project} projectSlug={projectSlug} />
           <main className="flex-1 min-w-0 overflow-y-auto">
-            <Outlet />
+            <ContentErrorBoundary>
+              <Outlet />
+            </ContentErrorBoundary>
           </main>
         </div>
       </div>
@@ -190,7 +193,9 @@ function ProjectLayout() {
     <div className="flex h-full">
       <ProjectSidebar project={project} projectSlug={projectSlug} />
       <main className="flex-1 min-w-0 overflow-y-auto">
-        <Outlet />
+        <ContentErrorBoundary>
+          <Outlet />
+        </ContentErrorBoundary>
       </main>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -22,8 +22,8 @@ import type { DistinctColumn } from "../../../../../components/filters-builder/t
 import { useMembersCollection } from "../../../../../domains/members/members.collection.ts"
 import { useTopicFilterOptions } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { authClient } from "../../../../../lib/auth-client.ts"
 import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
-import { useAuthenticatedUser } from "../../../-route-data.ts"
 
 export type { FilterMode }
 
@@ -486,17 +486,21 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
     [setField],
   )
 
-  const me = useAuthenticatedUser()
+  // Read the current user from the auth client (not the `/_authenticated` route
+  // loader) so the score filters work in the sandbox shell too, where a dev can
+  // create scores via the API. `meId` is undefined until the session resolves.
+  const { data: session } = authClient.useSession()
+  const meId = session?.user.id
   const { data: members } = useMembersCollection()
   const annotatorItems = useMemo<readonly StaticFilterItem[]>(() => {
     const active = (members ?? []).filter((m) => m.status === "active" && m.userId)
     const others = active
-      .filter((m) => m.userId !== me.id)
+      .filter((m) => m.userId !== meId)
       .map((m) => ({ value: m.userId as string, label: m.name?.trim() || m.email }))
       .sort((a, b) => a.label.localeCompare(b.label))
-    // Current user pinned on top as "Your scores", regardless of member-list ordering.
-    return [{ value: me.id, label: "Your scores" }, ...others]
-  }, [members, me.id])
+    // Current user pinned on top as "Your scores" once the session resolves.
+    return meId ? [{ value: meId, label: "Your scores" }, ...others] : others
+  }, [members, meId])
 
   const setAnnotatedBy = useCallback(
     (values: string[]) => {
@@ -635,7 +639,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
           )
         })}
 
-        <CollapsibleSection label="Annotated by" defaultOpen={getInValues(filters, ANNOTATOR_FIELD).length > 0}>
+        <CollapsibleSection label="Scored by" defaultOpen={getInValues(filters, ANNOTATOR_FIELD).length > 0}>
           <MultiSelectFilter
             mode={mode}
             projectId={projectId}
@@ -647,12 +651,12 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
           />
         </CollapsibleSection>
 
-        <CollapsibleSection label="Has annotations" defaultOpen={getHasAnnotationsOn(filters)}>
+        <CollapsibleSection label="Has scores" defaultOpen={getHasAnnotationsOn(filters)}>
           <div className="flex items-center justify-between gap-2">
             <Text.H7 color="foregroundMuted">
               {getHasAnnotationsOn(filters)
-                ? "Showing only items with a human annotation."
-                : "Off — annotations don't filter results."}
+                ? "Showing only items with a human score."
+                : "Off — scores don't filter results."}
             </Text.H7>
             <Switch
               checked={getHasAnnotationsOn(filters)}

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-shell.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-shell.tsx
@@ -8,6 +8,7 @@ import { useProjectsCollection } from "../../../../domains/projects/projects.col
 import { useSandboxLifecycleMutations } from "../../../../domains/sandbox/sandbox.collection.ts"
 import { useSandboxProjects } from "../../../../domains/sandbox/sandbox-projects.collection.ts"
 import { AppSidebar, NavItem } from "../../../../layouts/AppSidebar/index.tsx"
+import { ContentErrorBoundary } from "../../../../lib/client-error-reporting.tsx"
 import { toUserMessage } from "../../../../lib/errors.ts"
 import { SandboxConfigModal } from "./sandbox-config-modal.tsx"
 import { SandboxNavHeader } from "./sandbox-nav-header.tsx"
@@ -188,7 +189,9 @@ export function SandboxShell() {
             )}
           </AppSidebar>
           <main className="min-w-0 flex-1 overflow-y-auto">
-            <Outlet />
+            <ContentErrorBoundary>
+              <Outlet />
+            </ContentErrorBoundary>
           </main>
         </div>
       </div>

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-shell.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/-components/sandbox-shell.tsx
@@ -1,7 +1,7 @@
 import { Button, CopyableText, cn, Icon, Text, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { getRouteApi, Link, Outlet, useParams, useRouter, useRouterState } from "@tanstack/react-router"
-import { ArrowLeftRight, TextAlignStartIcon } from "lucide-react"
+import { ArrowLeftRight, MessagesSquareIcon } from "lucide-react"
 import { useState } from "react"
 import { SandboxToggle } from "../../../../components/sandbox-toggle.tsx"
 import { useProjectsCollection } from "../../../../domains/projects/projects.collection.ts"
@@ -143,8 +143,8 @@ export function SandboxShell() {
     }
   }
 
-  const tracesTo = projectSlug ? `/sandbox/${sandboxOrgId}/projects/${projectSlug}` : `/sandbox/${sandboxOrgId}`
-  const tracesActive = pathname.startsWith(`/sandbox/${sandboxOrgId}/projects/`)
+  const sessionsTo = projectSlug ? `/sandbox/${sandboxOrgId}/projects/${projectSlug}` : `/sandbox/${sandboxOrgId}`
+  const sessionsActive = pathname.startsWith(`/sandbox/${sandboxOrgId}/projects/`)
 
   return (
     <div className={cn("flex h-screen flex-col overflow-hidden", isArchived ? "bg-muted-foreground" : "bg-primary")}>
@@ -179,10 +179,10 @@ export function SandboxShell() {
           >
             {({ collapsed }) => (
               <NavItem
-                icon={TextAlignStartIcon}
-                label="Traces"
-                to={tracesTo}
-                active={tracesActive}
+                icon={MessagesSquareIcon}
+                label="Sessions"
+                to={sessionsTo}
+                active={sessionsActive}
                 collapsed={collapsed}
               />
             )}

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -206,7 +206,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
   if (projectsLoading) {
     return (
       <Layout>
-        <Layout.Header title="Traces" />
+        <Layout.Header title="Sessions" />
       </Layout>
     )
   }
@@ -236,7 +236,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
 
   return (
     <Layout>
-      <Layout.Header title={project?.name ?? "Traces"} />
+      <Layout.Header title={project?.name ?? "Sessions"} />
       <Layout.Actions>
         <Layout.ActionsRow>
           <Layout.ActionRowItem>


### PR DESCRIPTION
## What

Several fixes to the sandbox (`/sandbox`) surface, mirroring live and fixing a crash.

### 1. Rename sandbox section Traces → Sessions
Mirrors the live UI. Sidebar nav item and project header now read **Sessions** (with `MessagesSquareIcon`, matching the live `sessions` section). The Sessions/Traces dual-tabs *inside* the view are unchanged — live keeps that same tab.

### 2. Fix: Filters crashed the whole app in sandbox
Opening **Filters** in a sandbox project threw and took down the entire app (root error boundary → full-screen "Something went wrong").

Root cause: `FiltersSidebar` read the current user via `useAuthenticatedUser()`, which is `getRouteApi("/_authenticated").useLoaderData()`. Sandbox routes live under `/sandbox/*`, never under `/_authenticated`, so that loader data isn't in the match tree → throw.

Devs can create scores via the **API** inside a sandbox, so the score filters must work there too (not be hidden). Fix: read the current user from the route-independent **`authClient.useSession()`** instead — `lib/auth-client.ts` now uses `better-auth/react` so `useSession()` is a real React hook. `useMembersCollection()` already works in both shells. `meId` is `undefined` until the session resolves, handled gracefully.

### 3. Rename annotation filters → scores
"Annotated by" → **"Scored by"**, "Has annotations" → **"Has scores"** (+ helper copy), matching the annotations→scores rename.

### 4. Contain render errors instead of nuking the app
Previously the only error boundary was the root route's `errorComponent`, so any render error replaced the whole app. Added a reusable **`ContentErrorBoundary`** (TanStack `CatchBoundary`) around the project content `<Outlet/>` in both the **live** and **sandbox** shells. A render error now shows a **contained** fallback in the content area while the sidebar/nav stay alive; it auto-resets on navigation. Reuses the existing Datadog error reporting (`ErrorFallback`, now with a required `variant`).

## Verification
`pnpm --filter @app/web typecheck` and `biome check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)