### PR TITLE
fix(sandbox): expose conversation as top-level global alias for session.conversation

### DIFF
--- a/packages/platform/sandbox-quickjs/src/prelude.ts
+++ b/packages/platform/sandbox-quickjs/src/prelude.ts
@@ -105,5 +105,7 @@ export const SANDBOX_PRELUDE = `;(() => {
   session.conversation = conversation
   // Deep-freeze the whole payload so a script cannot mutate the session (traces, tools, metrics) it reads.
   globalThis.session = deepFreeze(session)
+  // Alias for backwards-compatibility: scripts written before session scoping can reference conversation directly.
+  globalThis.conversation = session.conversation
 })()
 `

--- a/packages/platform/sandbox-quickjs/src/runtime.test.ts
+++ b/packages/platform/sandbox-quickjs/src/runtime.test.ts
@@ -152,9 +152,27 @@ describe("run: host-controlled globals", () => {
     expect(result.value).toBe(1)
   })
 
-  it("exposes session and not the legacy conversation/issue/signal globals", async () => {
+  it("exposes conversation as a top-level alias for session.conversation", async () => {
+    const script = await compile(`
+      const text = \`\${conversation}\`
+      const isSameRef = conversation === session.conversation
+      return Score(text === "[user] hi\\n[assistant] yo" && isSameRef ? 1 : 0)
+    `)
+    const result = await run({
+      script,
+      context: {
+        session: minimalScriptSession([
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "yo" },
+        ]),
+      },
+    })
+    expect(result.value).toBe(1)
+  })
+
+  it("exposes session and not the legacy issue/signal globals", async () => {
     const script = await compile(
-      "return Score(typeof session === 'object' && typeof conversation === 'undefined' && typeof issue === 'undefined' && typeof signal === 'undefined' ? 1 : 0)",
+      "return Score(typeof session === 'object' && typeof issue === 'undefined' && typeof signal === 'undefined' ? 1 : 0)",
     )
     const result = await run({ script, context: { session: minimalScriptSession() } })
     expect(result.value).toBe(1)


### PR DESCRIPTION
## What does this PR do?

Fixes a `ReferenceError: 'conversation' is not defined` error thrown by evaluation scripts that reference `conversation` as a bare global rather than `session.conversation`.

**Root cause:** PR #3734 (`feat(evaluations): run evaluations against a session runtime context`) introduced the `session` runtime context. The QuickJS prelude creates a local `const conversation = session.conversation` (with a custom `toString()`), assigns it back to `session.conversation`, and deep-freezes the session — but it never writes the local variable to `globalThis`. Scripts written before the session scoping refactor used the bare `conversation` name and started throwing `ReferenceError` after that deploy.

**Fix:** After `globalThis.session = deepFreeze(session)`, add `globalThis.conversation = session.conversation` so both identifiers resolve to the same frozen array.

This is fully backwards-compatible — `conversation` and `session.conversation` are the same reference, already frozen.

**Production impact:** 110 `EvaluationExecutionError` occurrences over 7 days (55 each on `evaluations.executeEvaluationScriptSandboxed` and `evaluations.executeLiveEvaluation`), all on the current deploy (SHA `f5022c37`, task version 154).

## Related issue (if applicable)

Closes #

## How was this tested?

- Updated the existing `"exposes session and not the legacy conversation/issue/signal globals"` test to reflect the new behavior (bare `conversation` is now defined).
- Added a new test `"exposes conversation as a top-level alias for session.conversation"` that verifies both the string rendering and reference equality with `session.conversation`.
- All 37 tests pass (`pnpm --filter @platform/sandbox-quickjs test`).
- Typecheck passes (`pnpm --filter @platform/sandbox-quickjs typecheck`).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_0194CzHCFSvE94vPSQ1eyNtC)_