### PR TITLE
fix: allow API deploys when version deploy is disabled

### DIFF
--- a/apps/web/src/actions/commits/publishDraftCommitAction.ts
+++ b/apps/web/src/actions/commits/publishDraftCommitAction.ts
@@ -2,6 +2,9 @@
 
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { updateAndMergeCommit } from '@latitude-data/core/services/commits/updateAndMerge'
+import { isFeatureEnabledByName } from '@latitude-data/core/services/workspaceFeatures/isFeatureEnabledByName'
+import { DISABLE_VERSION_DEPLOY_FLAG } from '@latitude-data/core/services/workspaceFeatures/flags'
+import { UnprocessableEntityError } from '@latitude-data/constants/errors'
 import { z } from 'zod'
 
 import { withProject, withProjectSchema } from '../procedures'
@@ -17,6 +20,19 @@ export const publishDraftCommitAction = withProject
   .action(async ({ parsedInput, ctx }) => {
     const { workspace } = ctx
     const { id: commitId, title, description } = parsedInput
+
+    // Deploying from Latitude's own UI can be disabled per workspace (e.g. for
+    // customers that deploy through their own version control). This only gates
+    // the in-app action: deploys via the public API are intentionally allowed.
+    const deployDisabled = await isFeatureEnabledByName(
+      workspace.id,
+      DISABLE_VERSION_DEPLOY_FLAG,
+    ).then((r) => r.unwrap())
+    if (deployDisabled) {
+      throw new UnprocessableEntityError(
+        'Deploying versions has been disabled for this workspace by your Latitude administrator.',
+      )
+    }
 
     const commitScope = new CommitsRepository(ctx.workspace.id)
     const commit = await commitScope

--- a/packages/core/src/services/commits/updateAndMerge.test.ts
+++ b/packages/core/src/services/commits/updateAndMerge.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import { findHeadCommit } from '../../data-access/commits'
 import { updateAndMergeCommit } from './updateAndMerge'
-import { createFeature } from '../features/create'
-import { toggleWorkspaceFeature } from '../workspaceFeatures/toggle'
-import { DISABLE_VERSION_DEPLOY_FLAG } from '../workspaceFeatures/flags'
 
 describe('updateAndMergeCommit', () => {
   it('updates and merges a draft commit', async (ctx) => {
@@ -55,43 +52,6 @@ describe('updateAndMergeCommit', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error!.message).toBe('Cannot modify a merged commit')
-  })
-
-  it('fails loudly when version deploy is disabled for the workspace', async (ctx) => {
-    const { project, workspace, user, providers } =
-      await ctx.factories.createProject()
-    const { commit: draft } = await ctx.factories.createDraft({ project, user })
-
-    await ctx.factories.createDocumentVersion({
-      workspace,
-      user,
-      commit: draft,
-      path: 'foo',
-      content: ctx.factories.helpers.createPrompt({ provider: providers[0]! }),
-    })
-
-    const feature = await createFeature({
-      name: DISABLE_VERSION_DEPLOY_FLAG,
-    }).then((r) => r.unwrap())
-    await toggleWorkspaceFeature(workspace.id, feature.id, true).then((r) =>
-      r.unwrap(),
-    )
-
-    const result = await updateAndMergeCommit({
-      workspace,
-      commit: draft,
-      data: { title: 'Updated Title' },
-    })
-
-    expect(result.ok).toBe(false)
-    expect(result.error!.message).toContain(
-      'Deploying versions is disabled for this workspace',
-    )
-
-    const headCommit = await findHeadCommit({ projectId: project.id }).then(
-      (r) => r.value,
-    )
-    expect(headCommit?.id).not.toBe(draft.id)
   })
 
   it('merges without updates if no data is provided', async (ctx) => {

--- a/packages/core/src/services/commits/updateAndMerge.ts
+++ b/packages/core/src/services/commits/updateAndMerge.ts
@@ -1,13 +1,10 @@
 import { type Commit } from '../../schema/models/types/Commit'
 import { type Workspace } from '../../schema/models/types/Workspace'
-import { Result, TypedResult } from '../../lib/Result'
+import { TypedResult } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
-import { UnprocessableEntityError } from '../../lib/errors'
 import { mergeCommit } from './merge'
 import { updateCommit } from './update'
 import { assertCanEditCommit } from '../../lib/assertCanEditCommit'
-import { isFeatureEnabledByName } from '../workspaceFeatures/isFeatureEnabledByName'
-import { DISABLE_VERSION_DEPLOY_FLAG } from '../workspaceFeatures/flags'
 
 export async function updateAndMergeCommit(
   {
@@ -26,20 +23,6 @@ export async function updateAndMergeCommit(
 ): Promise<TypedResult<Commit, Error>> {
   const assertResult = await assertCanEditCommit(commit)
   if (assertResult.error) return assertResult
-
-  const deployDisabled = await isFeatureEnabledByName(
-    workspace.id,
-    DISABLE_VERSION_DEPLOY_FLAG,
-  ).then((r) => r.unwrap())
-  if (deployDisabled) {
-    const message =
-      'Deploying versions is disabled for this workspace. Contact your Latitude administrator if you need to publish changes.'
-    return Result.error(
-      new UnprocessableEntityError(message, {
-        [commit.id]: [message],
-      }),
-    )
-  }
 
   if (Object.keys(data).length > 0) {
     const updateResult = await updateCommit(


### PR DESCRIPTION
## Problem

A client reported that enabling the `disable-version-deploy` feature flag (added in #3707) blocked **all** version deploys — not just the in-app "Deploy version" button, but also programmatic deploys through the public API (their GitHub Actions).

The guard was placed in `updateAndMergeCommit`, which is shared by **both** entrypoints:
- the in-app server action (`publishDraftCommitAction`)
- the public API publish handler (`apps/gateway/.../publish/publishCommit.handler.ts`)

So the flag blocked the API too, which was not intended.

## Fix

Move the guard out of the shared service and into the **web action only**:

- `updateAndMergeCommit` — guard removed; it's the shared primitive again.
- `publishDraftCommitAction` — checks `disable-version-deploy` and throws `UnprocessableEntityError` when enabled. This is the in-app backend path.
- API publish handler — unchanged, so programmatic deploys keep working.

The UI behavior from #3707 is untouched: when the flag is on, the "Deploy version" buttons remain disabled with an explanatory tooltip.

Net effect when the flag is enabled for a workspace:
| Path | Before | After |
| --- | --- | --- |
| In-app UI button | blocked (disabled) | blocked (disabled) |
| In-app backend (action) | blocked | blocked |
| Public API | blocked ❌ | **allowed** ✅ |

## Tests / checks

- Removed the now-misplaced service-level guard test from `updateAndMerge.test.ts`; suite back to green (3/3).
- `pnpm tc` passes across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)