### PR TITLE
Add CodeDeploy blue/green deployments for ALB-backed ECS services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -264,6 +264,11 @@ jobs:
           fi
           echo "Migrations completed successfully"
 
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.staging-build.outputs.git_commit_sha }}
+
       - name: Deploy all services
         env:
           CLUSTER: latitude-staging-cluster
@@ -272,174 +277,10 @@ jobs:
           REGISTRY: ${{ needs.staging-build.outputs.registry }}
         run: |
           set -euo pipefail
-          poll_service_rollout() {
-            local SERVICE="$1"
-            local SERVICE_ARN="$2"
-            local MAX_ATTEMPTS=60
-            local SLEEP_SECONDS=10
-            local attempt=1
-            local last_event=""
-
-            while [ "${attempt}" -le "${MAX_ATTEMPTS}" ]; do
-              local service_json
-              service_json=$(aws ecs describe-services \
-                --cluster "${CLUSTER}" \
-                --services "${SERVICE_ARN}" \
-                --output json)
-
-              local progress_line
-              progress_line=$(echo "${service_json}" | jq -r '
-                .services[0] as $service |
-                [
-                  "desired=\($service.desiredCount // 0)",
-                  "running=\($service.runningCount // 0)",
-                  "pending=\($service.pendingCount // 0)",
-                  "deployments=" + ((
-                    $service.deployments // []
-                  ) | map("\(.status // "unknown")/\(.rolloutState // "n/a")@\(.taskDefinition | split("/")[-1])") | join(", "))
-                ] | join(" | ")
-              ')
-              echo "[${SERVICE}] Poll ${attempt}/${MAX_ATTEMPTS}: ${progress_line}"
-
-              local newest_event
-              newest_event=$(echo "${service_json}" | jq -r '
-                .services[0].events[0]? |
-                "\(.createdAt // "n/a")|\(.message // "")"
-              ')
-              if [ -n "${newest_event}" ] && [ "${newest_event}" != "null|null" ] && [ "${newest_event}" != "${last_event}" ]; then
-                echo "${service_json}" | jq -r --arg service "${SERVICE}" '
-                  .services[0].events[0:3][]? |
-                  "[" + $service + "] Event: " + (.message // "")
-                '
-                last_event="${newest_event}"
-              fi
-
-              local is_stable
-              is_stable=$(echo "${service_json}" | jq -r '
-                .services[0] as $service |
-                ($service.deployments | length == 1) and
-                (($service.deployments[0].rolloutState // "") == "COMPLETED") and
-                (($service.runningCount // 0) == ($service.desiredCount // 0)) and
-                (($service.pendingCount // 0) == 0)
-              ')
-
-              if [ "${is_stable}" = "true" ]; then
-                echo "[${SERVICE}] Service stabilized successfully"
-                return 0
-              fi
-
-              if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
-                sleep "${SLEEP_SECONDS}"
-              fi
-              attempt=$((attempt + 1))
-            done
-
-            echo "[${SERVICE}] Timed out waiting for service to stabilize"
-            return 1
-          }
-
-          dump_service_debug() {
-            local SERVICE="$1"
-            local SERVICE_ARN="$2"
-
-            echo "[${SERVICE}] Final ECS service snapshot:"
-            aws ecs describe-services \
-              --cluster "${CLUSTER}" \
-              --services "${SERVICE_ARN}" \
-              --output json | jq -r --arg service "${SERVICE}" '
-                .services[0] as $service |
-                "[" + $service + "] desired=\($service.desiredCount // 0) running=\($service.runningCount // 0) pending=\($service.pendingCount // 0)",
-                (
-                  $service.deployments[]? |
-                  "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") taskDef=\(.taskDefinition | split("/")[-1]) running=\(.runningCount // 0) pending=\(.pendingCount // 0) created=\(.createdAt // "n/a") updated=\(.updatedAt // "n/a")"
-                ),
-                (
-                  $service.events[0:10][]? |
-                  "[" + $service + "] event: \(.createdAt // "n/a") \(.message // "")"
-                )
-              '
-
-            local stopped_tasks
-            stopped_tasks=$(aws ecs list-tasks \
-              --cluster "${CLUSTER}" \
-              --service-name "latitude-${ENV_NAME}-${SERVICE}" \
-              --desired-status STOPPED \
-              --output json | jq -r '.taskArns[:5] | join(" ")')
-
-            if [ -n "${stopped_tasks}" ]; then
-              echo "[${SERVICE}] Recent stopped tasks:"
-              aws ecs describe-tasks \
-                --cluster "${CLUSTER}" \
-                --tasks ${stopped_tasks} \
-                --output json | jq -r --arg service "${SERVICE}" '
-                  .tasks[]? as $task |
-                  "[" + $service + "] task=" + ($task.taskArn | split("/")[-1]) +
-                  " lastStatus=" + ($task.lastStatus // "unknown") +
-                  " stopCode=" + ($task.stopCode // "n/a") +
-                  " stoppedReason=" + ($task.stoppedReason // "n/a"),
-                  (
-                    $task.containers[]? |
-                    "[" + $service + "]   container=" + (.name // "unknown") +
-                    " exitCode=" + ((.exitCode // "n/a") | tostring) +
-                    " reason=" + (.reason // "n/a")
-                  )
-                '
-            else
-              echo "[${SERVICE}] No stopped tasks found for debugging"
-            fi
-          }
-
-          deploy_service() {
-            local SERVICE="$1"
-            set -euo pipefail
-            echo "::group::Deploy ${SERVICE}"
-            FAMILY="latitude-${ENV_NAME}-${SERVICE}"
-            IMAGE="${REGISTRY}/latitude-${ENV_NAME}-${SERVICE}:${IMAGE_TAG}"
-            SERVICE_ARN=$(aws ecs list-services \
-              --cluster "${CLUSTER}" \
-              --query "serviceArns[?contains(@, 'latitude-${ENV_NAME}-${SERVICE}')]" \
-              --output text)
-            echo "[${SERVICE}] Using service ARN ${SERVICE_ARN}"
-            aws ecs register-task-definition \
-              --family "${FAMILY}" \
-              --cli-input-json "$(aws ecs describe-task-definition \
-                --task-definition "${FAMILY}" \
-                --query 'taskDefinition' \
-                --output json | jq \
-                  --arg image "${IMAGE}" \
-                  --arg name "${SERVICE}" '
-                  .containerDefinitions |= map(if .name == $name then .image = $image else . end) |
-                  del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
-                ')" > /dev/null
-            local update_response
-            update_response=$(aws ecs update-service \
-              --cluster "${CLUSTER}" \
-              --service "${SERVICE_ARN}" \
-              --task-definition "${FAMILY}")
-            echo "${update_response}" | jq -r --arg service "${SERVICE}" '
-              .service as $serviceData |
-              "[" + $service + "] Updated service to taskDef=" + ($serviceData.taskDefinition | split("/")[-1]),
-              (
-                $serviceData.deployments[]? |
-                "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") running=\(.runningCount // 0) pending=\(.pendingCount // 0)"
-              )
-            '
-
-            if ! poll_service_rollout "${SERVICE}" "${SERVICE_ARN}"; then
-              dump_service_debug "${SERVICE}" "${SERVICE_ARN}"
-              echo "::endgroup::"
-              return 1
-            fi
-            echo "::endgroup::"
-          }
-          export -f deploy_service
-          export -f poll_service_rollout
-          export -f dump_service_debug
-          export CLUSTER ENV_NAME IMAGE_TAG REGISTRY
-
+          chmod +x scripts/deploy-ecs-service.sh
           pids=()
           for SERVICE in web api ingest workers workflows; do
-            ( deploy_service "${SERVICE}" ) &
+            ( ./scripts/deploy-ecs-service.sh "${SERVICE}" ) &
             pids+=($!)
           done
           ec=0
@@ -637,6 +478,11 @@ jobs:
           fi
           echo "Migrations completed successfully"
 
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.production-build.outputs.git_commit_sha }}
+
       - name: Deploy all services
         env:
           CLUSTER: latitude-production-cluster
@@ -645,174 +491,10 @@ jobs:
           REGISTRY: ${{ needs.production-build.outputs.registry }}
         run: |
           set -euo pipefail
-          poll_service_rollout() {
-            local SERVICE="$1"
-            local SERVICE_ARN="$2"
-            local MAX_ATTEMPTS=60
-            local SLEEP_SECONDS=10
-            local attempt=1
-            local last_event=""
-
-            while [ "${attempt}" -le "${MAX_ATTEMPTS}" ]; do
-              local service_json
-              service_json=$(aws ecs describe-services \
-                --cluster "${CLUSTER}" \
-                --services "${SERVICE_ARN}" \
-                --output json)
-
-              local progress_line
-              progress_line=$(echo "${service_json}" | jq -r '
-                .services[0] as $service |
-                [
-                  "desired=\($service.desiredCount // 0)",
-                  "running=\($service.runningCount // 0)",
-                  "pending=\($service.pendingCount // 0)",
-                  "deployments=" + ((
-                    $service.deployments // []
-                  ) | map("\(.status // "unknown")/\(.rolloutState // "n/a")@\(.taskDefinition | split("/")[-1])") | join(", "))
-                ] | join(" | ")
-              ')
-              echo "[${SERVICE}] Poll ${attempt}/${MAX_ATTEMPTS}: ${progress_line}"
-
-              local newest_event
-              newest_event=$(echo "${service_json}" | jq -r '
-                .services[0].events[0]? |
-                "\(.createdAt // "n/a")|\(.message // "")"
-              ')
-              if [ -n "${newest_event}" ] && [ "${newest_event}" != "null|null" ] && [ "${newest_event}" != "${last_event}" ]; then
-                echo "${service_json}" | jq -r --arg service "${SERVICE}" '
-                  .services[0].events[0:3][]? |
-                  "[" + $service + "] Event: " + (.message // "")
-                '
-                last_event="${newest_event}"
-              fi
-
-              local is_stable
-              is_stable=$(echo "${service_json}" | jq -r '
-                .services[0] as $service |
-                ($service.deployments | length == 1) and
-                (($service.deployments[0].rolloutState // "") == "COMPLETED") and
-                (($service.runningCount // 0) == ($service.desiredCount // 0)) and
-                (($service.pendingCount // 0) == 0)
-              ')
-
-              if [ "${is_stable}" = "true" ]; then
-                echo "[${SERVICE}] Service stabilized successfully"
-                return 0
-              fi
-
-              if [ "${attempt}" -lt "${MAX_ATTEMPTS}" ]; then
-                sleep "${SLEEP_SECONDS}"
-              fi
-              attempt=$((attempt + 1))
-            done
-
-            echo "[${SERVICE}] Timed out waiting for service to stabilize"
-            return 1
-          }
-
-          dump_service_debug() {
-            local SERVICE="$1"
-            local SERVICE_ARN="$2"
-
-            echo "[${SERVICE}] Final ECS service snapshot:"
-            aws ecs describe-services \
-              --cluster "${CLUSTER}" \
-              --services "${SERVICE_ARN}" \
-              --output json | jq -r --arg service "${SERVICE}" '
-                .services[0] as $service |
-                "[" + $service + "] desired=\($service.desiredCount // 0) running=\($service.runningCount // 0) pending=\($service.pendingCount // 0)",
-                (
-                  $service.deployments[]? |
-                  "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") taskDef=\(.taskDefinition | split("/")[-1]) running=\(.runningCount // 0) pending=\(.pendingCount // 0) created=\(.createdAt // "n/a") updated=\(.updatedAt // "n/a")"
-                ),
-                (
-                  $service.events[0:10][]? |
-                  "[" + $service + "] event: \(.createdAt // "n/a") \(.message // "")"
-                )
-              '
-
-            local stopped_tasks
-            stopped_tasks=$(aws ecs list-tasks \
-              --cluster "${CLUSTER}" \
-              --service-name "latitude-${ENV_NAME}-${SERVICE}" \
-              --desired-status STOPPED \
-              --output json | jq -r '.taskArns[:5] | join(" ")')
-
-            if [ -n "${stopped_tasks}" ]; then
-              echo "[${SERVICE}] Recent stopped tasks:"
-              aws ecs describe-tasks \
-                --cluster "${CLUSTER}" \
-                --tasks ${stopped_tasks} \
-                --output json | jq -r --arg service "${SERVICE}" '
-                  .tasks[]? as $task |
-                  "[" + $service + "] task=" + ($task.taskArn | split("/")[-1]) +
-                  " lastStatus=" + ($task.lastStatus // "unknown") +
-                  " stopCode=" + ($task.stopCode // "n/a") +
-                  " stoppedReason=" + ($task.stoppedReason // "n/a"),
-                  (
-                    $task.containers[]? |
-                    "[" + $service + "]   container=" + (.name // "unknown") +
-                    " exitCode=" + ((.exitCode // "n/a") | tostring) +
-                    " reason=" + (.reason // "n/a")
-                  )
-                '
-            else
-              echo "[${SERVICE}] No stopped tasks found for debugging"
-            fi
-          }
-
-          deploy_service() {
-            local SERVICE="$1"
-            set -euo pipefail
-            echo "::group::Deploy ${SERVICE}"
-            FAMILY="latitude-${ENV_NAME}-${SERVICE}"
-            IMAGE="${REGISTRY}/latitude-${ENV_NAME}-${SERVICE}:${IMAGE_TAG}"
-            SERVICE_ARN=$(aws ecs list-services \
-              --cluster "${CLUSTER}" \
-              --query "serviceArns[?contains(@, 'latitude-${ENV_NAME}-${SERVICE}')]" \
-              --output text)
-            echo "[${SERVICE}] Using service ARN ${SERVICE_ARN}"
-            aws ecs register-task-definition \
-              --family "${FAMILY}" \
-              --cli-input-json "$(aws ecs describe-task-definition \
-                --task-definition "${FAMILY}" \
-                --query 'taskDefinition' \
-                --output json | jq \
-                  --arg image "${IMAGE}" \
-                  --arg name "${SERVICE}" '
-                  .containerDefinitions |= map(if .name == $name then .image = $image else . end) |
-                  del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
-                ')" > /dev/null
-            local update_response
-            update_response=$(aws ecs update-service \
-              --cluster "${CLUSTER}" \
-              --service "${SERVICE_ARN}" \
-              --task-definition "${FAMILY}")
-            echo "${update_response}" | jq -r --arg service "${SERVICE}" '
-              .service as $serviceData |
-              "[" + $service + "] Updated service to taskDef=" + ($serviceData.taskDefinition | split("/")[-1]),
-              (
-                $serviceData.deployments[]? |
-                "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") running=\(.runningCount // 0) pending=\(.pendingCount // 0)"
-              )
-            '
-
-            if ! poll_service_rollout "${SERVICE}" "${SERVICE_ARN}"; then
-              dump_service_debug "${SERVICE}" "${SERVICE_ARN}"
-              echo "::endgroup::"
-              return 1
-            fi
-            echo "::endgroup::"
-          }
-          export -f deploy_service
-          export -f poll_service_rollout
-          export -f dump_service_debug
-          export CLUSTER ENV_NAME IMAGE_TAG REGISTRY
-
+          chmod +x scripts/deploy-ecs-service.sh
           pids=()
           for SERVICE in web api ingest workers workflows; do
-            ( deploy_service "${SERVICE}" ) &
+            ( ./scripts/deploy-ecs-service.sh "${SERVICE}" ) &
             pids+=($!)
           done
           ec=0

--- a/infra/README.md
+++ b/infra/README.md
@@ -97,7 +97,8 @@ infra/
     ├── vpc.ts               # VPC, subnets, NAT
     ├── vpc-endpoints.ts     # S3 + Secrets Manager VPC endpoints
     ├── security-groups.ts   # Security group factories
-    ├── alb.ts               # ALB + listeners + target groups
+    ├── alb.ts               # ALB + listeners + blue/green target groups
+    ├── codedeploy.ts        # CodeDeploy app + deployment groups
     ├── ecs.ts               # ECS cluster + services + migrations task
     ├── rds.ts               # RDS (standard) / Aurora Serverless v2
     ├── redis.ts             # ElastiCache / MemoryDB
@@ -108,6 +109,21 @@ infra/
     ├── github-actions.ts    # OIDC provider + deploy role
     └── observability.ts     # CloudWatch dashboards + alarms
 ```
+
+## Deployments
+
+ALB-fronted services (`web`, `api`, `ingest`, `workers`) use **AWS CodeDeploy blue/green** deployments. Each service has paired blue and green target groups; CodeDeploy shifts production traffic to the green group only after new tasks pass health checks, then drains the blue tasks after a short wait. `workflows` has no ALB and keeps ECS rolling deployments.
+
+Pulumi provisions:
+
+- Green target groups alongside existing blue groups (`lat-{prod|stg}-{service}-grn`)
+- ECS services with `deploymentController: CODE_DEPLOY` for ALB-backed services
+- `healthCheckGracePeriodSeconds: 120` so tasks can warm up before ALB health checks count
+- A CodeDeploy application (`latitude-{env}-codedeploy`) and per-service deployment groups
+
+GitHub Actions (`scripts/deploy-ecs-service.sh`) registers a new task definition revision, then calls `aws deploy create-deployment` with an AppSpec for CodeDeploy-managed services. `workflows` still uses `ecs update-service`.
+
+**Rollout order:** apply the Pulumi changes first (`pulumi up`) so green target groups, CodeDeploy resources, and the `CODE_DEPLOY` controller exist before the updated deploy workflow runs. The first CodeDeploy deployment after migration may replace ECS service wiring; plan a maintenance window if needed.
 
 ## CI/CD
 
@@ -145,7 +161,7 @@ To deploy to production:
    - Run all checks in parallel
    - Build and push container images to GHCR
    - Execute database migrations via ECS task
-   - Deploy services to ECS Fargate with zero-downtime rolling updates
+   - Deploy ALB-fronted services via CodeDeploy blue/green; deploy `workflows` via ECS rolling update
 
 5. **Verify deployment**: Check service health via their endpoints:
    - `https://console.latitude.so/api/health`

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -2,6 +2,7 @@ import * as pulumi from "@pulumi/pulumi"
 import { defaults, type EnvironmentConfig, productionConfig, stagingConfig } from "./config.ts"
 import { createAlb } from "./lib/alb.ts"
 import { createBastion } from "./lib/bastion.ts"
+import { createCodeDeploy } from "./lib/codedeploy.ts"
 import { createDatadogSynthetics } from "./lib/datadog-synthetics.ts"
 import { createCertificate, createDnsRecords, createHostedZone, createTryLatitudeDnsRecords } from "./lib/dns.ts"
 import { createEcs } from "./lib/ecs.ts"
@@ -119,10 +120,10 @@ const ecs = createEcs(
   s3.bucket,
   imageTag,
   {
-    web: alb.targetGroups.web.arn,
-    api: alb.targetGroups.api.arn,
-    ingest: alb.targetGroups.ingest.arn,
-    bullBoard: alb.targetGroups.bullBoard.arn,
+    web: alb.targetGroups.web.blue.arn,
+    api: alb.targetGroups.api.blue.arn,
+    ingest: alb.targetGroups.ingest.blue.arn,
+    bullBoard: alb.targetGroups.bullBoard.blue.arn,
   },
   {
     address: temporalCloudAddress,
@@ -136,6 +137,10 @@ const datadogSynthetics = environment === "production" && enableDatadogSynthetic
       datadogSite,
       slackAlertHandle: datadogSlackAlertHandle,
     })
+  : undefined
+
+const codeDeploy = alb.httpsListener
+  ? createCodeDeploy(name, envConfig, ecs.cluster, ecs.services, alb, alb.httpsListener.arn)
   : undefined
 
 const githubActions = createGithubActionsOidc(name, environment, githubOwner, githubRepo)
@@ -161,6 +166,15 @@ export const outputs = {
 
   ecsClusterName: ecs.cluster.name,
   ecsServiceNames: Object.fromEntries(Object.entries(ecs.services).map(([k, v]) => [k, v.name])),
+
+  ...(codeDeploy
+    ? {
+        codeDeployApplicationName: codeDeploy.application.name,
+        codeDeployDeploymentGroupNames: Object.fromEntries(
+          Object.entries(codeDeploy.deploymentGroups).map(([service, group]) => [service, group.deploymentGroupName]),
+        ),
+      }
+    : {}),
 
   certificateArn: certificate.certificate.arn,
 

--- a/infra/lib/alb.ts
+++ b/infra/lib/alb.ts
@@ -5,9 +5,14 @@ import type { Ec2SecurityGroup, Ec2Subnet, LbListener, LbLoadBalancer, LbTargetG
 
 const STATUS_PAGE_URL = "https://status.latitude.so/"
 
+export interface TargetGroupPair {
+  blue: LbTargetGroup
+  green: LbTargetGroup
+}
+
 export interface AlbOutput {
   alb: LbLoadBalancer
-  targetGroups: Record<string, LbTargetGroup>
+  targetGroups: Record<string, TargetGroupPair>
   httpListener: LbListener
   httpsListener?: LbListener
 }
@@ -33,7 +38,7 @@ export function createAlb(
     },
   })
 
-  const targetGroups: Record<string, LbTargetGroup> = {}
+  const targetGroups: Record<string, TargetGroupPair> = {}
 
   // bull-board routes to the workers service, so we map "bullBoard" -> "workers" for
   // the service config lookup.
@@ -45,34 +50,56 @@ export function createAlb(
     const healthCheckPath = serviceConfig?.healthCheckPath ?? "/health"
 
     const shortEnv = config.name === "production" ? "prod" : "stg"
-    const tgName = `lat-${shortEnv}-${domainKey}-tg`
+    const blueName = `lat-${shortEnv}-${domainKey}-tg`
+    const greenName = `lat-${shortEnv}-${domainKey}-grn`
 
-    targetGroups[domainKey] = new aws.lb.TargetGroup(
+    const targetGroupArgs = {
+      port: 8080,
+      protocol: "HTTP" as const,
+      targetType: "ip" as const,
+      vpcId: publicSubnets[0].vpcId,
+      healthCheck: {
+        enabled: true,
+        healthyThreshold: 2,
+        interval: 30,
+        matcher: "200",
+        path: healthCheckPath,
+        port: "traffic-port",
+        protocol: "HTTP" as const,
+        timeout: 5,
+        unhealthyThreshold: 3,
+      },
+    }
+
+    const blue = new aws.lb.TargetGroup(
       `${name}-${domainKey}-tg`,
       {
-        name: tgName,
-        port: 8080,
-        protocol: "HTTP",
-        targetType: "ip",
-        vpcId: publicSubnets[0].vpcId,
-        healthCheck: {
-          enabled: true,
-          healthyThreshold: 2,
-          interval: 30,
-          matcher: "200",
-          path: healthCheckPath,
-          port: "traffic-port",
-          protocol: "HTTP",
-          timeout: 5,
-          unhealthyThreshold: 3,
-        },
+        ...targetGroupArgs,
+        name: blueName,
         tags: {
           Name: `${name}-${domainKey}-tg`,
           Environment: config.name,
+          DeploymentColor: "blue",
         },
       },
       { deleteBeforeReplace: false },
     )
+
+    const green = new aws.lb.TargetGroup(
+      `${name}-${domainKey}-tg-green`,
+      {
+        ...targetGroupArgs,
+        name: greenName,
+        tags: {
+          Name: `${name}-${domainKey}-tg-green`,
+          Environment: config.name,
+          DeploymentColor: "green",
+        },
+      },
+      { deleteBeforeReplace: false },
+    )
+
+    targetGroups[domainKey] = { blue, green }
   }
 
   const httpListener = new aws.lb.Listener(`${name}-http`, {
@@ -93,7 +120,7 @@ export function createAlb(
       : [
           {
             type: "forward",
-            targetGroupArn: targetGroups.web.arn,
+            targetGroupArn: targetGroups.web.blue.arn,
           },
         ],
   })
@@ -104,20 +131,20 @@ export function createAlb(
     const createServiceActions = (targetGroup: LbTargetGroup) =>
       enableMaintenanceRedirect ? createStatusPageRedirectActions() : createForwardActions(targetGroup)
 
-    const defaultActions = createServiceActions(targetGroups.web)
+    const defaultActions = createServiceActions(targetGroups.web.blue)
 
     const rules = [
       {
         hostname: config.domains.api,
-        actions: createServiceActions(targetGroups.api),
+        actions: createServiceActions(targetGroups.api.blue),
       },
       {
         hostname: config.domains.ingest,
-        actions: createServiceActions(targetGroups.ingest),
+        actions: createServiceActions(targetGroups.ingest.blue),
       },
       {
         hostname: config.domains.bullBoard,
-        actions: createServiceActions(targetGroups.bullBoard),
+        actions: createServiceActions(targetGroups.bullBoard.blue),
       },
     ]
 
@@ -150,10 +177,10 @@ export function createAlb(
 
     if (enableMaintenanceRedirect) {
       const associationRules = [
-        { ruleName: "web-target-group-association", targetGroup: targetGroups.web },
-        { ruleName: "api-target-group-association", targetGroup: targetGroups.api },
-        { ruleName: "ingest-target-group-association", targetGroup: targetGroups.ingest },
-        { ruleName: "bull-board-target-group-association", targetGroup: targetGroups.bullBoard },
+        { ruleName: "web-target-group-association", targetGroup: targetGroups.web.blue },
+        { ruleName: "api-target-group-association", targetGroup: targetGroups.api.blue },
+        { ruleName: "ingest-target-group-association", targetGroup: targetGroups.ingest.blue },
+        { ruleName: "bull-board-target-group-association", targetGroup: targetGroups.bullBoard.blue },
       ]
 
       for (let i = 0; i < associationRules.length; i++) {

--- a/infra/lib/codedeploy.ts
+++ b/infra/lib/codedeploy.ts
@@ -1,0 +1,128 @@
+import * as aws from "@pulumi/aws"
+import type { Output } from "@pulumi/pulumi"
+import type { EnvironmentConfig, ServiceConfig } from "../config.ts"
+import type { AlbOutput } from "./alb.ts"
+import type { EcsCluster, EcsService, IamRole } from "./types.ts"
+
+const ALB_FRONTED_DOMAIN_KEYS = ["web", "api", "ingest", "bullBoard"] as const
+type AlbFrontedDomainKey = (typeof ALB_FRONTED_DOMAIN_KEYS)[number]
+
+const DOMAIN_KEY_TO_SERVICE: Record<AlbFrontedDomainKey, ServiceConfig["name"]> = {
+  web: "web",
+  api: "api",
+  ingest: "ingest",
+  bullBoard: "workers",
+}
+
+export interface CodeDeployOutput {
+  application: aws.codedeploy.Application
+  serviceRole: IamRole
+  deploymentGroups: Record<string, aws.codedeploy.DeploymentGroup>
+}
+
+export function createCodeDeploy(
+  name: string,
+  config: EnvironmentConfig,
+  cluster: EcsCluster,
+  services: Record<string, EcsService>,
+  alb: AlbOutput,
+  httpsListenerArn: Output<string>,
+): CodeDeployOutput {
+  const application = new aws.codedeploy.Application(`${name}-codedeploy`, {
+    computePlatform: "ECS",
+    tags: {
+      Name: `${name}-codedeploy`,
+      Environment: config.name,
+    },
+  })
+
+  const serviceRole = new aws.iam.Role(`${name}-codedeploy-role`, {
+    assumeRolePolicy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "sts:AssumeRole",
+          Effect: "Allow",
+          Principal: {
+            Service: "codedeploy.amazonaws.com",
+          },
+        },
+      ],
+    }),
+    tags: {
+      Name: `${name}-codedeploy-role`,
+      Environment: config.name,
+    },
+  })
+
+  new aws.iam.RolePolicyAttachment(`${name}-codedeploy-ecs-policy`, {
+    role: serviceRole.name,
+    policyArn: "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS",
+  })
+
+  const deploymentGroups: Record<string, aws.codedeploy.DeploymentGroup> = {}
+
+  for (const domainKey of ALB_FRONTED_DOMAIN_KEYS) {
+    const serviceName = DOMAIN_KEY_TO_SERVICE[domainKey]
+    const ecsService = services[serviceName]
+    const targetGroupPair = alb.targetGroups[domainKey]
+
+    deploymentGroups[serviceName] = new aws.codedeploy.DeploymentGroup(
+      `${name}-${serviceName}-codedeploy-dg`,
+      {
+        appName: application.name,
+        deploymentGroupName: `${name}-${serviceName}`,
+        serviceRoleArn: serviceRole.arn,
+        deploymentConfigName: "CodeDeployDefault.ECSAllAtOnce",
+        deploymentStyle: {
+          deploymentType: "BLUE_GREEN",
+          deploymentOption: "WITH_TRAFFIC_CONTROL",
+        },
+        autoRollbackConfiguration: {
+          enabled: true,
+          events: ["DEPLOYMENT_FAILURE"],
+        },
+        blueGreenDeploymentConfig: {
+          deploymentReadyOption: {
+            actionOnTimeout: "CONTINUE_DEPLOYMENT",
+            waitTimeInMinutes: 0,
+          },
+          terminateBlueInstancesOnDeploymentSuccess: {
+            action: "TERMINATE",
+            terminationWaitTimeInMinutes: 5,
+          },
+        },
+        ecsService: {
+          clusterName: cluster.name,
+          serviceName: ecsService.name,
+        },
+        loadBalancerInfo: {
+          targetGroupPairInfo: {
+            prodTrafficRoute: {
+              listenerArns: [httpsListenerArn],
+            },
+            targetGroups: [
+              { name: targetGroupPair.blue.name },
+              { name: targetGroupPair.green.name },
+            ],
+          },
+        },
+        tags: {
+          Name: `${name}-${serviceName}-codedeploy-dg`,
+          Environment: config.name,
+          Service: serviceName,
+        },
+      },
+    )
+  }
+
+  return {
+    application,
+    serviceRole,
+    deploymentGroups,
+  }
+}
+
+export function isCodeDeployService(serviceName: string): boolean {
+  return (Object.values(DOMAIN_KEY_TO_SERVICE) as string[]).includes(serviceName)
+}

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -3,6 +3,7 @@ import type { Output } from "@pulumi/pulumi"
 import * as pulumi from "@pulumi/pulumi"
 import type { EnvironmentConfig, ServiceConfig } from "../config.ts"
 import type { SecretRef } from "./secrets.ts"
+import { isCodeDeployService } from "./codedeploy.ts"
 import type {
   CloudwatchLogGroup,
   Ec2SecurityGroup,
@@ -200,6 +201,9 @@ export function createEcs(
     )
     taskDefinitions[serviceConfig.name] = taskDef
 
+    const usesCodeDeploy = isCodeDeployService(serviceConfig.name)
+    const hasLoadBalancer = serviceConfig.port !== undefined
+
     const ecsService = new aws.ecs.Service(
       `${name}-${serviceConfig.name}`,
       {
@@ -207,12 +211,13 @@ export function createEcs(
         taskDefinition: taskDef.arn,
         desiredCount: serviceConfig.desiredCount,
         launchType: "FARGATE",
+        healthCheckGracePeriodSeconds: hasLoadBalancer ? 120 : undefined,
         networkConfiguration: {
           subnets: privateSubnets.map((s) => s.id),
           securityGroups: [securityGroup.id],
           assignPublicIp: false,
         },
-        loadBalancers: serviceConfig.port
+        loadBalancers: hasLoadBalancer
           ? Object.entries(albTargetGroupArns)
               .filter(([key]) => {
                 if (serviceConfig.name === "workers") return key === "bullBoard"
@@ -225,7 +230,7 @@ export function createEcs(
               }))
           : undefined,
         deploymentController: {
-          type: "ECS",
+          type: usesCodeDeploy ? "CODE_DEPLOY" : "ECS",
         },
         tags: {
           Name: `${name}-${serviceConfig.name}`,

--- a/infra/lib/github-actions.ts
+++ b/infra/lib/github-actions.ts
@@ -37,6 +37,20 @@ function createDeployPolicy(environment: string): aws.iam.RolePolicyArgs["policy
         Action: ["iam:PassRole"],
         Resource: `arn:aws:iam::*:role/latitude-${environment}-*`,
       },
+      {
+        Sid: "CodeDeployOperations",
+        Effect: "Allow",
+        Action: [
+          "codedeploy:CreateDeployment",
+          "codedeploy:GetDeployment",
+          "codedeploy:GetDeploymentConfig",
+          "codedeploy:GetDeploymentGroup",
+          "codedeploy:ListDeployments",
+          "codedeploy:RegisterApplicationRevision",
+          "codedeploy:GetApplicationRevision",
+        ],
+        Resource: "*",
+      },
     ],
   }
 }

--- a/scripts/deploy-ecs-service.sh
+++ b/scripts/deploy-ecs-service.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="${1:?service name required}"
+CLUSTER="${CLUSTER:?CLUSTER is required}"
+ENV_NAME="${ENV_NAME:?ENV_NAME is required}"
+IMAGE_TAG="${IMAGE_TAG:?IMAGE_TAG is required}"
+REGISTRY="${REGISTRY:?REGISTRY is required}"
+
+CODE_DEPLOY_SERVICES=(web api ingest workers)
+
+poll_service_rollout() {
+  local service_arn="$1"
+  local max_attempts=60
+  local sleep_seconds=10
+  local attempt=1
+  local last_event=""
+
+  while [ "${attempt}" -le "${max_attempts}" ]; do
+    local service_json
+    service_json=$(aws ecs describe-services \
+      --cluster "${CLUSTER}" \
+      --services "${service_arn}" \
+      --output json)
+
+    local progress_line
+    progress_line=$(echo "${service_json}" | jq -r '
+      .services[0] as $service |
+      [
+        "desired=\($service.desiredCount // 0)",
+        "running=\($service.runningCount // 0)",
+        "pending=\($service.pendingCount // 0)",
+        "deployments=" + ((
+          $service.deployments // []
+        ) | map("\(.status // "unknown")/\(.rolloutState // "n/a")@\(.taskDefinition | split("/")[-1])") | join(", "))
+      ] | join(" | ")
+    ')
+    echo "[${SERVICE}] Poll ${attempt}/${max_attempts}: ${progress_line}"
+
+    local newest_event
+    newest_event=$(echo "${service_json}" | jq -r '
+      .services[0].events[0]? |
+      "\(.createdAt // "n/a")|\(.message // "")"
+    ')
+    if [ -n "${newest_event}" ] && [ "${newest_event}" != "null|null" ] && [ "${newest_event}" != "${last_event}" ]; then
+      echo "${service_json}" | jq -r --arg service "${SERVICE}" '
+        .services[0].events[0:3][]? |
+        "[" + $service + "] Event: " + (.message // "")
+      '
+      last_event="${newest_event}"
+    fi
+
+    local is_stable
+    is_stable=$(echo "${service_json}" | jq -r '
+      .services[0] as $service |
+      ($service.deployments | length == 1) and
+      (($service.deployments[0].rolloutState // "") == "COMPLETED") and
+      (($service.runningCount // 0) == ($service.desiredCount // 0)) and
+      (($service.pendingCount // 0) == 0)
+    ')
+
+    if [ "${is_stable}" = "true" ]; then
+      echo "[${SERVICE}] Service stabilized successfully"
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${max_attempts}" ]; then
+      sleep "${sleep_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "[${SERVICE}] Timed out waiting for service to stabilize"
+  return 1
+}
+
+poll_codedeploy_deployment() {
+  local deployment_id="$1"
+  local max_attempts=90
+  local sleep_seconds=10
+  local attempt=1
+
+  while [ "${attempt}" -le "${max_attempts}" ]; do
+    local deployment_json
+    deployment_json=$(aws deploy get-deployment \
+      --deployment-id "${deployment_id}" \
+      --output json)
+
+    local status
+    status=$(echo "${deployment_json}" | jq -r '.deploymentInfo.status // "unknown"')
+    local overview
+    overview=$(echo "${deployment_json}" | jq -r '
+      .deploymentInfo as $deployment |
+      [
+        "status=\($deployment.status // "unknown")",
+        "ready=\($deployment.deploymentOverview.Ready // 0)",
+        "pending=\($deployment.deploymentOverview.Pending // 0)",
+        "inProgress=\($deployment.deploymentOverview.InProgress // 0)",
+        "failed=\($deployment.deploymentOverview.Failed // 0)"
+      ] | join(" | ")
+    ')
+    echo "[${SERVICE}] CodeDeploy poll ${attempt}/${max_attempts}: ${overview}"
+
+    case "${status}" in
+      Succeeded)
+        echo "[${SERVICE}] CodeDeploy deployment succeeded"
+        return 0
+        ;;
+      Failed|Stopped)
+        echo "[${SERVICE}] CodeDeploy deployment ${status}"
+        echo "${deployment_json}" | jq -r --arg service "${SERVICE}" '
+          .deploymentInfo.errorInformation? |
+          "[" + $service + "] error code=" + (.code // "n/a") + " message=" + (.message // "n/a")
+        '
+        return 1
+        ;;
+    esac
+
+    if [ "${attempt}" -lt "${max_attempts}" ]; then
+      sleep "${sleep_seconds}"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "[${SERVICE}] Timed out waiting for CodeDeploy deployment"
+  return 1
+}
+
+dump_service_debug() {
+  local service_arn="$1"
+
+  echo "[${SERVICE}] Final ECS service snapshot:"
+  aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${service_arn}" \
+    --output json | jq -r --arg service "${SERVICE}" '
+      .services[0] as $service |
+      "[" + $service + "] desired=\($service.desiredCount // 0) running=\($service.runningCount // 0) pending=\($service.pendingCount // 0)",
+      (
+        $service.deployments[]? |
+        "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") taskDef=\(.taskDefinition | split("/")[-1]) running=\(.runningCount // 0) pending=\(.pendingCount // 0) created=\(.createdAt // "n/a") updated=\(.updatedAt // "n/a")"
+      ),
+      (
+        $service.events[0:10][]? |
+        "[" + $service + "] event: \(.createdAt // "n/a") \(.message // "")"
+      )
+    '
+
+  local stopped_tasks
+  stopped_tasks=$(aws ecs list-tasks \
+    --cluster "${CLUSTER}" \
+    --service-name "latitude-${ENV_NAME}-${SERVICE}" \
+    --desired-status STOPPED \
+    --output json | jq -r '.taskArns[:5] | join(" ")')
+
+  if [ -n "${stopped_tasks}" ]; then
+    echo "[${SERVICE}] Recent stopped tasks:"
+    aws ecs describe-tasks \
+      --cluster "${CLUSTER}" \
+      --tasks ${stopped_tasks} \
+      --output json | jq -r --arg service "${SERVICE}" '
+        .tasks[]? as $task |
+        "[" + $service + "] task=" + ($task.taskArn | split("/")[-1]) +
+        " lastStatus=" + ($task.lastStatus // "unknown") +
+        " stopCode=" + ($task.stopCode // "n/a") +
+        " stoppedReason=" + ($task.stoppedReason // "n/a"),
+        (
+          $task.containers[]? |
+          "[" + $service + "]   container=" + (.name // "unknown") +
+          " exitCode=" + ((.exitCode // "n/a") | tostring) +
+          " reason=" + (.reason // "n/a")
+        )
+      '
+  else
+    echo "[${SERVICE}] No stopped tasks found for debugging"
+  fi
+}
+
+uses_codedeploy() {
+  local candidate
+  for candidate in "${CODE_DEPLOY_SERVICES[@]}"; do
+    if [ "${candidate}" = "${SERVICE}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+echo "::group::Deploy ${SERVICE}"
+family="latitude-${ENV_NAME}-${SERVICE}"
+image="${REGISTRY}/latitude-${ENV_NAME}-${SERVICE}:${IMAGE_TAG}"
+service_arn=$(aws ecs list-services \
+  --cluster "${CLUSTER}" \
+  --query "serviceArns[?contains(@, 'latitude-${ENV_NAME}-${SERVICE}')]" \
+  --output text)
+echo "[${SERVICE}] Using service ARN ${service_arn}"
+
+aws ecs register-task-definition \
+  --family "${family}" \
+  --cli-input-json "$(aws ecs describe-task-definition \
+    --task-definition "${family}" \
+    --query 'taskDefinition' \
+    --output json | jq \
+      --arg image "${image}" \
+      --arg name "${SERVICE}" '
+      .containerDefinitions |= map(if .name == $name then .image = $image else . end) |
+      del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
+    ')" > /dev/null
+
+if uses_codedeploy; then
+  task_def_arn=$(aws ecs describe-task-definition \
+    --task-definition "${family}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text)
+
+  appspec_content=$(jq -c -n \
+    --arg taskDef "${task_def_arn}" \
+    --arg containerName "${SERVICE}" \
+    --argjson containerPort 8080 \
+    '{
+      version: "0.0",
+      Resources: [{
+        TargetService: {
+          Type: "AWS::ECS::Service",
+          Properties: {
+            TaskDefinition: $taskDef,
+            LoadBalancerInfo: {
+              ContainerName: $containerName,
+              ContainerPort: $containerPort
+            }
+          }
+        }
+      }]
+    }')
+
+  revision_file=$(mktemp)
+  jq -n --arg content "${appspec_content}" \
+    '{revisionType: "AppSpecContent", appSpecContent: {content: $content}}' > "${revision_file}"
+
+  deployment_id=$(aws deploy create-deployment \
+    --application-name "latitude-${ENV_NAME}-codedeploy" \
+    --deployment-group-name "latitude-${ENV_NAME}-${SERVICE}" \
+    --revision "file://${revision_file}" \
+    --query 'deploymentId' \
+    --output text)
+  rm -f "${revision_file}"
+
+  echo "[${SERVICE}] Started CodeDeploy deployment ${deployment_id} with taskDef=${task_def_arn##*/}"
+
+  if ! poll_codedeploy_deployment "${deployment_id}"; then
+    dump_service_debug "${service_arn}"
+    echo "::endgroup::"
+    exit 1
+  fi
+else
+  update_response=$(aws ecs update-service \
+    --cluster "${CLUSTER}" \
+    --service "${service_arn}" \
+    --task-definition "${family}")
+  echo "${update_response}" | jq -r --arg service "${SERVICE}" '
+    .service as $serviceData |
+    "[" + $service + "] Updated service to taskDef=" + ($serviceData.taskDefinition | split("/")[-1]),
+    (
+      $serviceData.deployments[]? |
+      "[" + $service + "] deployment status=\(.status // "unknown") rollout=\(.rolloutState // "n/a") running=\(.runningCount // 0) pending=\(.pendingCount // 0)"
+    )
+  '
+
+  if ! poll_service_rollout "${service_arn}"; then
+    dump_service_debug "${service_arn}"
+    echo "::endgroup::"
+    exit 1
+  fi
+fi
+
+echo "::endgroup::"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Production web downtime on 2026-06-30 was caused by simultaneous ECS task replacement leaving zero healthy ALB targets during the swap. This PR moves ALB-fronted services to AWS CodeDeploy blue/green so new tasks must pass health checks on a green target group before traffic shifts.

## What changes

**Pulumi (`infra/`)**
- Each ALB-fronted domain (`web`, `api`, `ingest`, `bullBoard`/`workers`) gets paired blue and green target groups. Listeners keep routing to blue initially.
- New `codedeploy.ts` provisions a CodeDeploy ECS application, IAM service role, and per-service deployment groups with `CodeDeployDefault.ECSAllAtOnce`, auto-rollback on failure, and a 5-minute blue termination wait.
- ALB-backed ECS services switch to `deploymentController: CODE_DEPLOY` and `healthCheckGracePeriodSeconds: 120`. `workflows` stays on ECS rolling (no ALB).
- GitHub Actions deploy role gains CodeDeploy API permissions; `iam:PassRole` for `latitude-{env}-*` is preserved.

**CI (`scripts/deploy-ecs-service.sh`, `deploy.yml`)**
- `web`, `api`, `ingest`, `workers`: register task definition → `aws deploy create-deployment` with AppSpec → poll CodeDeploy status.
- `workflows`: unchanged ECS `update-service` rolling deploy.
- Deploy logic extracted to `scripts/deploy-ecs-service.sh` so staging and production share one path.

## Rollout order

1. Merge and `pulumi up` staging, then production — creates green target groups, CodeDeploy resources, and switches ECS services to the `CODE_DEPLOY` controller.
2. Merge this PR (or deploy workflow changes) so subsequent image deploys use CodeDeploy.

The first Pulumi apply after merge may replace ECS service wiring. Plan a short maintenance window if you want to avoid any risk during controller migration.

## Testing

- `pnpm --filter latitude-infra typecheck`
- Deploy workflow changes are not exercised until Pulumi is applied in each environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019aafdc-c77d-413f-be5a-1d28ca2a2d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019aafdc-c77d-413f-be5a-1d28ca2a2d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

