### PR TITLE
Optimize onboarding | Add support chat help

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/changelog/changelog-banner.tsx
+++ b/apps/web/src/routes/_authenticated/-components/changelog/changelog-banner.tsx
@@ -51,7 +51,7 @@ export function ChangelogBanner({ title, description, coverUrl, onCollapse, clas
       <div className="absolute top-2 right-2 z-20">
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           size="icon"
           className="h-8 w-8 shrink-0"
           onClick={onCollapse}

--- a/apps/web/src/routes/_authenticated/-route-data.ts
+++ b/apps/web/src/routes/_authenticated/-route-data.ts
@@ -14,6 +14,13 @@ export function useAuthenticatedUser() {
   return authenticatedRoute.useLoaderData({ select: (data) => data.user })
 }
 
+/** True when Intercom identity verification credentials are configured. */
+export function useSupportEnabled() {
+  return authenticatedRoute.useLoaderData({
+    select: (data) => data.supportIdentity !== null,
+  })
+}
+
 /** Reads the active organization id from the parent route's cached loader data. */
 export function useAuthenticatedOrganizationId() {
   return authenticatedRoute.useLoaderData({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
@@ -1,8 +1,7 @@
-// import { showNewMessage } from "@intercom/messenger-js-sdk"
-import { Alert, Icon, Skeleton, Text, useToast } from "@repo/ui"
-import { Check, Headset } from "lucide-react"
-import { useSupportEnabled } from "../../../../../-route-data.ts" 
 import { showNewMessage } from "@intercom/messenger-js-sdk"
+import { Alert, Button, Icon, Skeleton, Text, useToast } from "@repo/ui"
+import { Check, Headset, RefreshCcw } from "lucide-react"
+import { useSupportEnabled } from "../../../../../-route-data.ts"
 
 const TOTAL_ROWS = 4
 
@@ -28,6 +27,13 @@ export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }
           <SkeletonTraceRow key={i} />
         ))}
       </div>
+
+      {!traceReceived ? (
+        <Button variant="muted" size="sm" className="w-fit" onClick={() => window.location.reload()}>
+          <Icon icon={RefreshCcw} size="sm" />
+          Refresh
+        </Button>
+      ) : null}
     </div>
   )
 }
@@ -57,13 +63,15 @@ export function TelemetryHelpAlert() {
       }
       description={
         <>
-          <button
+          <Button
             type="button"
-            className="font-semibold underline underline-offset-2 hover:opacity-80"
+            variant="link"
+            size="default"
+            className="inline-flex h-auto min-h-0 w-auto p-0 font-semibold underline underline-offset-2"
             onClick={openSupportChat}
           >
             Click here
-          </button>{" "}
+          </Button>{" "}
           and we'll come back to you to help you install Latitude in your project
         </>
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
@@ -29,7 +29,7 @@ export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }
       </div>
 
       {!traceReceived ? (
-        <Button variant="muted" size="sm" className="w-fit" onClick={() => window.location.reload()}>
+        <Button variant="outline" size="sm" className="w-fit" onClick={() => window.location.reload()}>
           <Icon icon={RefreshCcw} size="sm" />
           Refresh
         </Button>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
@@ -1,7 +1,11 @@
-import { Alert, Icon, Skeleton, Text } from "@repo/ui"
+import { showNewMessage } from "@intercom/messenger-js-sdk"
+import { Alert, Icon, Skeleton, Text, useToast } from "@repo/ui"
 import { Check, Headset } from "lucide-react"
+import { useSupportEnabled } from "../../../../../-route-data.ts"
 
 const TOTAL_ROWS = 4
+
+const ONBOARDING_SETUP_HELP_MESSAGE = "Hi, I need help with setting up Latitude in my project ASAP!"
 
 export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }) {
   const skeletonCount = traceReceived ? TOTAL_ROWS - 1 : TOTAL_ROWS
@@ -28,6 +32,17 @@ export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }
 }
 
 export function TelemetryHelpAlert() {
+  const supportEnabled = useSupportEnabled()
+  const { toast } = useToast()
+
+  const openSupportChat = () => {
+    if (!supportEnabled) {
+      toast({ variant: "destructive", description: "Support chat isn't available in this environment." })
+      return
+    }
+    showNewMessage(ONBOARDING_SETUP_HELP_MESSAGE)
+  }
+
   return (
     <Alert
       showIcon={false}
@@ -41,7 +56,11 @@ export function TelemetryHelpAlert() {
       }
       description={
         <>
-          <button type="button" className="font-semibold underline underline-offset-2 hover:opacity-80">
+          <button
+            type="button"
+            className="font-semibold underline underline-offset-2 hover:opacity-80"
+            onClick={openSupportChat}
+          >
             Click here
           </button>{" "}
           and we'll come back to you to help you install Latitude in your project

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
@@ -1,5 +1,5 @@
-import { Skeleton, Text } from "@repo/ui"
-import { Check } from "lucide-react"
+import { Alert, Icon, Skeleton, Text } from "@repo/ui"
+import { Check, Headset } from "lucide-react"
 
 const TOTAL_ROWS = 4
 
@@ -7,7 +7,7 @@ export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }
   const skeletonCount = traceReceived ? TOTAL_ROWS - 1 : TOTAL_ROWS
 
   return (
-    <div className="flex h-fit w-full max-w-[440px] flex-col gap-4 self-center">
+    <div className="flex w-full flex-col gap-4">
       <div className="flex flex-col gap-1">
         <Text.H5M>{traceReceived ? "Your first trace just arrived" : "Waiting for your first trace…"}</Text.H5M>
         <Text.H6 color="foregroundMuted">
@@ -24,6 +24,30 @@ export function TraceTail({ traceReceived }: { readonly traceReceived: boolean }
         ))}
       </div>
     </div>
+  )
+}
+
+export function TelemetryHelpAlert() {
+  return (
+    <Alert
+      showIcon={false}
+      spacing="xsmall"
+      className="rounded-lg shadow-none"
+      title={
+        <span className="flex items-center gap-2">
+          <Icon icon={Headset} size="sm" color="accentForeground" weight="L" />
+          Need help with setting up?
+        </span>
+      }
+      description={
+        <>
+          <button type="button" className="font-semibold underline underline-offset-2 hover:opacity-80">
+            Click here
+          </button>{" "}
+          and we'll come back to you to help you install Latitude in your project
+        </>
+      }
+    />
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/mocks/trace-tail.tsx
@@ -1,7 +1,8 @@
-import { showNewMessage } from "@intercom/messenger-js-sdk"
+// import { showNewMessage } from "@intercom/messenger-js-sdk"
 import { Alert, Icon, Skeleton, Text, useToast } from "@repo/ui"
 import { Check, Headset } from "lucide-react"
-import { useSupportEnabled } from "../../../../../-route-data.ts"
+import { useSupportEnabled } from "../../../../../-route-data.ts" 
+import { showNewMessage } from "@intercom/messenger-js-sdk"
 
 const TOTAL_ROWS = 4
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
@@ -1,12 +1,12 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
 import {
+  Badge,
   CodeBlock,
   CopyButton,
   OpentelemetryIcon,
   ProviderIcon,
   PythonIcon,
   Tabs,
-  TagBadge,
   Text,
   TypescriptIcon,
 } from "@repo/ui"
@@ -445,7 +445,7 @@ export function TelemetryInstructions({ projectSlug }: { readonly projectSlug: s
         <div className="flex flex-col gap-2">
           <span className="inline-flex items-center gap-1.5">
             <Text.H5M>Prompt</Text.H5M>
-            <TagBadge tag="Recommended" variant="accent" />
+            <Badge variant="accent">Recommended</Badge>
           </span>
           <Text.H5 color="foregroundMuted">
             Paste this into the chat with your coding agent — Cursor, Claude Code, Codex, or any other — to set up

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-instructions.tsx
@@ -6,6 +6,7 @@ import {
   ProviderIcon,
   PythonIcon,
   Tabs,
+  TagBadge,
   Text,
   TypescriptIcon,
 } from "@repo/ui"
@@ -442,7 +443,10 @@ export function TelemetryInstructions({ projectSlug }: { readonly projectSlug: s
 
       {telemetrySetupMode === "coding-agent" ? (
         <div className="flex flex-col gap-2">
-          <Text.H5M>Prompt</Text.H5M>
+          <span className="inline-flex items-center gap-1.5">
+            <Text.H5M>Prompt</Text.H5M>
+            <TagBadge tag="Recommended" variant="accent" />
+          </span>
           <Text.H5 color="foregroundMuted">
             Paste this into the chat with your coding agent — Cursor, Claude Code, Codex, or any other — to set up
             Latitude telemetry in your project.

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
@@ -1,6 +1,6 @@
 import { Button, Text } from "@repo/ui"
 import { lazy, Suspense } from "react"
-import { TraceTail } from "../mocks/trace-tail.tsx"
+import { TraceTail, TelemetryHelpAlert } from "../mocks/trace-tail.tsx"
 import { TelemetryInstructions } from "./telemetry-instructions.tsx"
 
 const OnboardingWaitingLottie = lazy(() => import("../../onboarding-waiting-lottie.tsx"))
@@ -54,5 +54,16 @@ export function Left({
 }
 
 export function Right({ traceReceived }: { readonly traceReceived: boolean }) {
-  return <TraceTail traceReceived={traceReceived} />
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col self-stretch">
+      <div className="mx-auto flex w-full max-w-[448px] flex-1 flex-col justify-center">
+        <TraceTail traceReceived={traceReceived} />
+      </div>
+      {!traceReceived ? (
+        <div className="mx-auto w-full max-w-[448px] shrink-0 -mb-10 lg:-mb-16">
+          <TelemetryHelpAlert />
+        </div>
+      ) : null}
+    </div>
+  )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/steps/telemetry-step.tsx
@@ -1,6 +1,6 @@
 import { Button, Text } from "@repo/ui"
 import { lazy, Suspense } from "react"
-import { TraceTail, TelemetryHelpAlert } from "../mocks/trace-tail.tsx"
+import { TelemetryHelpAlert, TraceTail } from "../mocks/trace-tail.tsx"
 import { TelemetryInstructions } from "./telemetry-instructions.tsx"
 
 const OnboardingWaitingLottie = lazy(() => import("../../onboarding-waiting-lottie.tsx"))

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -337,8 +337,14 @@ export function Tabs<T extends string>({
             ) : (
               <>
                 {option.icon}
-                <Text.H5 color={isActive ? "foreground" : "foregroundMuted"}>{option.label}</Text.H5>
-                {option.suffix}
+                {option.suffix ? (
+                  <span className="inline-flex items-baseline gap-1">
+                    <Text.H5 color={isActive ? "foreground" : "foregroundMuted"}>{option.label}</Text.H5>
+                    {option.suffix}
+                  </span>
+                ) : (
+                  <Text.H5 color={isActive ? "foreground" : "foregroundMuted"}>{option.label}</Text.H5>
+                )}
               </>
             )}
           </button>

--- a/packages/ui/src/components/tag-badge/tag-badge.tsx
+++ b/packages/ui/src/components/tag-badge/tag-badge.tsx
@@ -2,16 +2,13 @@ import { memo } from "react"
 import { useHashColor } from "../../hooks/use-hash-color.ts"
 import { cn } from "../../utils/cn.ts"
 
-export type TagBadgeVariant = "hash" | "accent"
-
 export interface TagBadgeProps {
   readonly tag: string
-  readonly variant?: TagBadgeVariant
 }
 
 const tagBadgeClassName = "inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium"
 
-function HashTagBadge({ tag }: { readonly tag: string }) {
+export const TagBadge = memo(function TagBadge({ tag }: TagBadgeProps) {
   const { style, className } = useHashColor(tag)
 
   return (
@@ -19,14 +16,6 @@ function HashTagBadge({ tag }: { readonly tag: string }) {
       {tag}
     </span>
   )
-}
-
-export const TagBadge = memo(function TagBadge({ tag, variant = "hash" }: TagBadgeProps) {
-  if (variant === "accent") {
-    return <span className={cn(tagBadgeClassName, "bg-accent text-accent-foreground")}>{tag}</span>
-  }
-
-  return <HashTagBadge tag={tag} />
 })
 
 export interface TagBadgeListProps {

--- a/packages/ui/src/components/tag-badge/tag-badge.tsx
+++ b/packages/ui/src/components/tag-badge/tag-badge.tsx
@@ -2,21 +2,31 @@ import { memo } from "react"
 import { useHashColor } from "../../hooks/use-hash-color.ts"
 import { cn } from "../../utils/cn.ts"
 
+export type TagBadgeVariant = "hash" | "accent"
+
 export interface TagBadgeProps {
   readonly tag: string
+  readonly variant?: TagBadgeVariant
 }
 
-export const TagBadge = memo(function TagBadge({ tag }: TagBadgeProps) {
+const tagBadgeClassName = "inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium"
+
+function HashTagBadge({ tag }: { readonly tag: string }) {
   const { style, className } = useHashColor(tag)
 
   return (
-    <span
-      className={cn("inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium", className)}
-      style={style}
-    >
+    <span className={cn(tagBadgeClassName, className)} style={style}>
       {tag}
     </span>
   )
+}
+
+export const TagBadge = memo(function TagBadge({ tag, variant = "hash" }: TagBadgeProps) {
+  if (variant === "accent") {
+    return <span className={cn(tagBadgeClassName, "bg-accent text-accent-foreground")}>{tag}</span>
+  }
+
+  return <HashTagBadge tag={tag} />
 })
 
 export interface TagBadgeListProps {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -292,7 +292,6 @@ export {
   TagBadgeList,
   type TagBadgeListProps,
   type TagBadgeProps,
-  type TagBadgeVariant,
 } from "./components/tag-badge/tag-badge.tsx"
 export {
   TagList,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -292,6 +292,7 @@ export {
   TagBadgeList,
   type TagBadgeListProps,
   type TagBadgeProps,
+  type TagBadgeVariant,
 } from "./components/tag-badge/tag-badge.tsx"
 export {
   TagList,


### PR DESCRIPTION
**Changes**
- Adds a "Need help with setting up?"  in the telemetry onboarding step. Clicking it opens Intercom chat (`showNewMessage`) with a pre-filled message.

**Proposed future changes**
- Add a guidance video(-s) explaining how to set up / debug Latitude in the project to start seeing traces in the UI to lower confusion.