### PR TITLE
fix(web): externalize quickjs-emscripten so its WASM resolves at runtime

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -45,12 +45,7 @@ const temporalExternal: (string | RegExp)[] = [
   "long",
 ]
 
-// quickjs-emscripten's default variant (@jitl/quickjs-wasmfile-release-sync)
-// loads its WASM binary as a sibling file via `new URL("emscripten-module.wasm",
-// import.meta.url)`. Bundling the glue into `_ssr/` moves import.meta.url away
-// from the .wasm, so getQuickJS() aborts with ENOENT at runtime. Keep the whole
-// quickjs tree external so the module (and its sibling .wasm) resolves from
-// node_modules — mirrors the apps/workers tsdown `neverBundle` entry.
+// quickjs-emscripten's glue loads its .wasm via `new URL(…, import.meta.url)`, so it must stay external to resolve from node_modules, not the bundled `_ssr/` chunk.
 const quickjsExternal: (string | RegExp)[] = [/^quickjs-emscripten(-core)?$/, /^@jitl\/quickjs-/]
 
 // @effect/opentelemetry ships a WebSdk.js entry that imports from

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -45,6 +45,14 @@ const temporalExternal: (string | RegExp)[] = [
   "long",
 ]
 
+// quickjs-emscripten's default variant (@jitl/quickjs-wasmfile-release-sync)
+// loads its WASM binary as a sibling file via `new URL("emscripten-module.wasm",
+// import.meta.url)`. Bundling the glue into `_ssr/` moves import.meta.url away
+// from the .wasm, so getQuickJS() aborts with ENOENT at runtime. Keep the whole
+// quickjs tree external so the module (and its sibling .wasm) resolves from
+// node_modules — mirrors the apps/workers tsdown `neverBundle` entry.
+const quickjsExternal: (string | RegExp)[] = [/^quickjs-emscripten(-core)?$/, /^@jitl\/quickjs-/]
+
 // @effect/opentelemetry ships a WebSdk.js entry that imports from
 // @opentelemetry/sdk-trace-web (an optional peer, browser-only). The SSR
 // bundle never reaches the web SDK path, but Rolldown's resolver scans it.
@@ -55,6 +63,7 @@ const temporalExternal: (string | RegExp)[] = [
 // both the Vite SSR pass and the Nitro production bundle.
 const ssrExternal: (string | RegExp)[] = [
   ...temporalExternal,
+  ...quickjsExternal,
   "@opentelemetry/sdk-trace-web",
   "@resvg/resvg-js",
 ]
@@ -87,6 +96,10 @@ export default defineConfig({
       "long",
       "@opentelemetry/sdk-trace-web",
       "@resvg/resvg-js",
+      "quickjs-emscripten",
+      "quickjs-emscripten-core",
+      "@jitl/quickjs-ffi-types",
+      "@jitl/quickjs-wasmfile-release-sync",
     ],
   },
   optimizeDeps: {


### PR DESCRIPTION
## what

Externalizes the `quickjs-emscripten` package tree from the `apps/web` server bundle (Nitro/Rolldown SSR external + Vite `ssr.external`), so the QuickJS glue and its `.wasm` binary resolve from `node_modules` at runtime instead of being bundled into `.output/server`.

## why

The signals builder UI (#3773) is the first code to pull the QuickJS sandbox into the web SSR bundle: `createSignal` and `updateSignalEvaluation` provide `QuickJsScriptRuntimeLive`, which pre-warms the sandbox by calling `getQuickJS()` at layer construction.

`getQuickJS()` uses `@jitl/quickjs-wasmfile-release-sync`, whose emscripten glue loads its binary as a sibling file:

```js
new URL("emscripten-module.wasm", import.meta.url)
```

In a `vite dev` server this resolves against `node_modules` and works. In the production build the glue gets bundled into a `_ssr/` chunk, so at runtime `import.meta.url` points into `_ssr/` and it looks for `_ssr/emscripten-module.wasm` — which the bundler never emits. `getQuickJS()` then aborts:

```
QuickJS WASM initialization failed: Aborted(Error: ENOENT: no such file or directory,
  open '/app/apps/web/.output/server/_ssr/emscripten-module.wasm')
```

The failure is handled (not a crash), but it breaks creating and editing a signal's evaluation from the builder on any deployed build (surfaced on staging via Datadog; production would hit it identically once this branch releases). Signal *preview* was unaffected — it runs in the `signals-preview` worker, where `apps/workers` already keeps `quickjs-emscripten` external via tsdown `neverBundle`. This change applies the same treatment to `web`.

## verification

Clean `pnpm --filter @app/web build`: the `signals.functions` server chunk now emits `import { getQuickJS } from "quickjs-emscripten"` as a bare external import, with no bundled glue and no `_ssr/emscripten-module.wasm` reference. Typecheck passes. Runtime behavior (creating a signal on a built image) still needs a manual check on a deploy.

Refs Datadog issue `6922d304-7552-11f1-94ac-da7ad0900005`.
