### PR TITLE
feat(telemetry): document Cloudflare Code Mode observability support

### DIFF
--- a/.agents/skills/explain-diff/SKILL.md
+++ b/.agents/skills/explain-diff/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: explain-diff-html
+description: Use when the user asks for a rich explanation of a code change, diff, branch, or PR. Produces HTML output.
+---
+
+# Explain Diff
+
+Please make me a rich, interactive explanation of the specified code change.
+
+It should have these sections:
+
+- Background: Explain the existing system relevant to this change. (You should broadly explore surrounding code for this.) We don't know how much the reader already knows, so include a deep background for beginners (note that it can be skipped if the reader is already familiar), and then a more narrow background directly relevant to the change.
+- Intuition: Explain the core intuition for the code change. The focus here is to explain the essence, not the full details. Use concrete examples with toy data. Use figures and diagrams liberally.
+- Code: Do a high-level walkthrough of the changes to the code. Group/order the changes in an understandable way.
+- Quiz: Come up with five questions that test the reader's knowledge of this PR. This should be medium difficulty, difficult enough that you actually need to understand the substance of the PR to answer them, but not gotchas. The goal is to help the reader make sure that they've actually understood. These should be presented as interactive multiple-choice questions, and when the user clicks, it tells them whether they were correct and gives feedback.
+
+Format:
+
+- Output a single self-contained HTML file which includes CSS and JavaScript. Make the whole thing one long page with section headers and a table of contents. Don't use tabs for the top-level structure. Basic responsive styling so you can view it on a phone is nice too. Put the file in a global place on my computer outside of the code repo, and make sure the filename always starts with today's date in `YYYY-MM-DD-` format, because it helps keep the files time-sorted and out of version control. For example: /tmp/2026-01-12-explanation-<slug>.html
+- Please write with the clarity and flow of Martin Kleppmann, making it engaging and written in classic style. Transitions between sections should be smooth.
+- Some tips on diagrams. Ideally, you should pick a small number of diagram families that can be reused throughout the explanation to explain various cases. Some useful kinds of diagrams:
+  - A very simplified version of the UI that the user sees in the app, to explain UI changes.
+  - A system diagram showing data flow or communication between components. Make sure to include example data here!
+- Don't use ASCII diagrams. Always use simple HTML designs for your diagrams, HTML lists for lists of things, etc.
+  - For code blocks, always use `<pre>` tags. If you use a custom styled div instead, it **must** have
+    `white-space: pre-wrap` in its CSS, or the browser will collapse all newlines into a single line.
+    Before saving the file, scan each code block in the HTML source and confirm its CSS includes
+    `white-space: pre` or `pre-wrap`.
+- Use callouts for key concepts or definitions, important edge cases, etc.

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -258,3 +258,32 @@ export function useConversationSpanMaps({
       enabled && projectId.length > 0 && traceId.length > 0 && startTime !== undefined && allMessages !== undefined,
   })
 }
+
+export function useConversationMessageSpans({
+  projectId,
+  traceId,
+  startTime,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly startTime: string | undefined
+  readonly enabled?: boolean
+}) {
+  const scope = use(TraceScopeContext)
+  return useQuery({
+    queryKey: ["conversationMessageSpans", scope?.sandboxOrgId, projectId, traceId],
+    queryFn: async () => {
+      return listConversationMessageSpans({
+        data: {
+          ...(scope ? { sandboxOrgId: scope.sandboxOrgId } : {}),
+          projectId,
+          traceId,
+          startTime: startTime ?? "",
+        },
+      })
+    },
+    enabled: enabled && projectId.length > 0 && traceId.length > 0 && startTime !== undefined,
+    staleTime: 30_000,
+  })
+}

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -43,9 +43,10 @@ export interface SpanRecord {
   readonly attrBool?: Readonly<Record<string, boolean>>
 }
 
+// The Run tab reconstructs the agent→sub-agent graph from natural keys: functionId
+// (node role), run_id (the cross-trace sub-agent edge), and parent_tool_call_id
+// (disambiguates the delegating tool span). Turn/phase are derived, not read.
 const CODEMODE_TIMELINE_ATTR_STRING_KEYS = [
-  "latitude.codemode.phase",
-  "latitude.codemode.turn_id",
   "latitude.agent_tool.parent_tool_call_id",
   "latitude.agent_tool.run_id",
   "ai.telemetry.functionId",

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -39,6 +39,42 @@ export interface SpanRecord {
   readonly startTime: string
   readonly endTime: string
   readonly ingestedAt: string
+  readonly attrString?: Readonly<Record<string, string>>
+  readonly attrBool?: Readonly<Record<string, boolean>>
+}
+
+const CODEMODE_TIMELINE_ATTR_STRING_KEYS = [
+  "latitude.codemode.phase",
+  "latitude.codemode.turn_id",
+  "latitude.agent_tool.parent_tool_call_id",
+  "latitude.agent_tool.run_id",
+  "ai.telemetry.functionId",
+] as const
+
+const pickCodemodeTimelineAttrs = (span: Span): Pick<SpanRecord, "attrString" | "attrBool"> => {
+  const attrString: Record<string, string> = {}
+  for (const key of CODEMODE_TIMELINE_ATTR_STRING_KEYS) {
+    const value = span.attrString[key]
+    if (value !== undefined) attrString[key] = value
+  }
+  const attrBool: Record<string, boolean> = {}
+  const innerTool = span.attrBool["latitude.codemode.inner_tool"]
+  if (innerTool !== undefined) attrBool["latitude.codemode.inner_tool"] = innerTool
+  return {
+    ...(Object.keys(attrString).length > 0 ? { attrString } : {}),
+    ...(Object.keys(attrBool).length > 0 ? { attrBool } : {}),
+  }
+}
+
+const SPAN_TREE_TOOL_NAME_ATTRS = ["ai.toolCall.name", "gen_ai.tool.name"] as const
+
+const pickSpanTreeToolAttrs = (span: Span): Pick<SpanRecord, "attrString"> => {
+  const attrString: Record<string, string> = {}
+  for (const key of SPAN_TREE_TOOL_NAME_ATTRS) {
+    const value = span.attrString[key]
+    if (value !== undefined) attrString[key] = value
+  }
+  return Object.keys(attrString).length > 0 ? { attrString } : {}
 }
 
 export interface SpanDetailRecord extends SpanRecord {
@@ -103,6 +139,7 @@ const serializeSpan = (span: Span): SpanRecord => ({
   startTime: span.startTime.toISOString(),
   endTime: span.endTime.toISOString(),
   ingestedAt: span.ingestedAt.toISOString(),
+  ...pickSpanTreeToolAttrs(span),
 })
 
 const serializeSpanDetail = (span: SpanDetail): SpanDetailRecord => ({
@@ -194,7 +231,7 @@ export const listSpansBySession = createServerFn({ method: "GET" })
         })
       }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
-    return spans.map(serializeSpan)
+    return spans.map((span) => ({ ...serializeSpan(span), ...pickCodemodeTimelineAttrs(span) }))
   })
 
 export interface SpanMessagesRecord {
@@ -203,6 +240,7 @@ export interface SpanMessagesRecord {
   readonly toolCallId: string
   readonly toolName: string
   readonly toolInput: string
+  readonly toolOutput: string
   readonly inputMessages: readonly object[]
   readonly outputMessages: readonly object[]
 }
@@ -213,6 +251,7 @@ const serializeSpanMessages = (span: SpanMessagesData): SpanMessagesRecord => ({
   toolCallId: span.toolCallId,
   toolName: span.toolName,
   toolInput: span.toolInput,
+  toolOutput: span.toolOutput,
   inputMessages: span.inputMessages,
   outputMessages: span.outputMessages,
 })

--- a/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.test.ts
+++ b/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildCodemodeRunTimeline,
+  type CodemodeRunNode,
   type CodemodeTimelineMessageInput,
   type CodemodeTimelineSpanInput,
   type CodemodeTimelineTraceInput,
@@ -45,33 +46,41 @@ const session = {
   sessionId: "sess-qa",
   startTime: iso(0),
   endTime: iso(30_000),
-  traceIds: ["plan", "exec", "sub", "sum"],
+  traceIds: ["plan", "delegate", "sub", "format", "sum"],
 }
 
-// A qa-a8624440-shaped codemode turn: plan → codemode execution (with two inner
-// tools) → sub-agent → summarize, one user message, spans carrying the Phase 0
-// `latitude.codemode.*` attributes.
-function codemodeFixture(): {
+const kinds = (nodes: readonly CodemodeRunNode[]) => nodes.map((n) => n.kind)
+const labels = (nodes: readonly CodemodeRunNode[]) => nodes.map((n) => n.label)
+
+// A realistic codemode orchestration turn. Unlike an idealized single trace, real
+// ingest splits each execution context into its OWN root trace with NO cross-trace
+// parentSpanId: the plan trace holds the `ai.toolCall codemode` node; each sandbox
+// inner tool is a separate root trace (`inner_tool`); the sub-agent is a separate
+// trace linked only by `run_id`; the summary is a separate trace.
+function realCodemodeTurn(): {
   traces: CodemodeTimelineTraceInput[]
   spans: CodemodeTimelineSpanInput[]
   messages: CodemodeTimelineMessageInput[]
 } {
+  const RUN = "run-Yfwe"
   const traces = [
-    trace({ traceId: "sum", startTime: iso(26_000), endTime: iso(29_200), rootSpanName: "ai.streamText" }),
     trace({ traceId: "plan", startTime: iso(0), endTime: iso(18_300), rootSpanName: "ai.generateText" }),
-    trace({ traceId: "exec", startTime: iso(18_300), endTime: iso(22_600), rootSpanName: "ai.toolCall codemode" }),
+    trace({ traceId: "delegate", startTime: iso(2_500), endTime: iso(16_800), rootSpanName: "ai.toolCall" }),
     trace({
       traceId: "sub",
-      startTime: iso(19_000),
-      endTime: iso(22_100),
+      startTime: iso(3_000),
+      endTime: iso(16_000),
       rootSpanName: "ai.streamText",
       metadata: { role: "weather-research-subagent" },
     }),
+    trace({ traceId: "format", startTime: iso(16_500), endTime: iso(16_600), rootSpanName: "ai.toolCall" }),
+    trace({ traceId: "sum", startTime: iso(26_000), endTime: iso(29_200), rootSpanName: "ai.streamText" }),
   ]
 
   const spans = [
+    // plan trace: generateText (plan) → doGenerate (noise) → codemode execute span
     span({
-      spanId: "plan-gen",
+      spanId: "plan-root",
       traceId: "plan",
       name: "ai.generateText",
       operation: "invoke_agent",
@@ -80,47 +89,85 @@ function codemodeFixture(): {
       attrString: { "ai.telemetry.functionId": "codemode-plan" },
     }),
     span({
-      spanId: "exec-codemode",
-      traceId: "exec",
-      name: "ai.toolCall codemode",
-      operation: "execute_tool",
-      toolName: "codemode",
-      startTime: iso(18_300),
-      endTime: iso(22_600),
+      spanId: "plan-chat",
+      traceId: "plan",
+      parentSpanId: "plan-root",
+      name: "ai.generateText.doGenerate",
+      operation: "chat",
+      startTime: iso(100),
+      endTime: iso(2_000),
     }),
     span({
-      spanId: "inner-delegate",
-      traceId: "exec",
-      parentSpanId: "exec-codemode",
+      spanId: "code-exec",
+      traceId: "plan",
+      parentSpanId: "plan-root",
+      name: "ai.toolCall",
+      operation: "execute_tool",
+      toolName: "codemode",
+      startTime: iso(2_000),
+      endTime: iso(17_000),
+    }),
+    // delegate: separate root trace, inner sandbox tool, carries run_id (spawned the sub-agent)
+    span({
+      spanId: "delegate-root",
+      traceId: "delegate",
       name: "ai.toolCall delegateWeatherResearch",
       operation: "execute_tool",
       toolName: "delegateWeatherResearch",
-      startTime: iso(18_400),
-      endTime: iso(22_700),
+      startTime: iso(2_500),
+      endTime: iso(16_800),
       attrBool: { "latitude.codemode.inner_tool": true },
+      attrString: {
+        "latitude.agent_tool.run_id": RUN,
+        "latitude.agent_tool.parent_tool_call_id": "codemode-inner-delegateWeatherResearch-a7f1",
+      },
     }),
+    // sub-agent: separate root trace, linked ONLY by run_id; wrapper span is collapsed
     span({
-      spanId: "inner-format",
-      traceId: "exec",
-      parentSpanId: "exec-codemode",
-      name: "ai.toolCall formatTravelBrief",
-      operation: "execute_tool",
-      toolName: "formatTravelBrief",
-      startTime: iso(22_500),
-      endTime: iso(22_500),
-      attrBool: { "latitude.codemode.inner_tool": true },
-    }),
-    span({
-      spanId: "sub-gen",
+      spanId: "sub-root",
       traceId: "sub",
       name: "ai.streamText",
       operation: "invoke_agent",
-      startTime: iso(19_000),
-      endTime: iso(22_100),
-      attrString: { "ai.telemetry.functionId": "research-subagent-turn" },
+      startTime: iso(3_000),
+      endTime: iso(16_000),
+      attrString: { "ai.telemetry.functionId": "research-subagent-turn", "latitude.agent_tool.run_id": RUN },
     }),
     span({
-      spanId: "sum-gen",
+      spanId: "sub-wrapper",
+      traceId: "sub",
+      parentSpanId: "sub-root",
+      name: "ai.toolCall",
+      operation: "execute_tool",
+      startTime: iso(3_200),
+      endTime: iso(4_000),
+      attrString: { "latitude.agent_tool.run_id": RUN },
+    }),
+    span({
+      spanId: "sub-tool",
+      traceId: "sub",
+      parentSpanId: "sub-wrapper",
+      name: "ai.toolCall getWeatherDetail",
+      operation: "execute_tool",
+      toolName: "getWeatherDetail",
+      startTime: iso(3_300),
+      endTime: iso(3_800),
+      attrBool: { "latitude.codemode.inner_tool": true },
+      attrString: { "latitude.agent_tool.run_id": RUN },
+    }),
+    // format: separate root trace, inner sandbox tool (no sub-agent)
+    span({
+      spanId: "format-root",
+      traceId: "format",
+      name: "ai.toolCall formatTravelBrief",
+      operation: "execute_tool",
+      toolName: "formatTravelBrief",
+      startTime: iso(16_500),
+      endTime: iso(16_600),
+      attrBool: { "latitude.codemode.inner_tool": true },
+    }),
+    // summary: separate root trace
+    span({
+      spanId: "sum-root",
       traceId: "sum",
       name: "ai.streamText",
       operation: "invoke_agent",
@@ -140,133 +187,103 @@ function codemodeFixture(): {
 }
 
 describe("buildCodemodeRunTimeline", () => {
-  it("builds one turn with plan → execute (inner tools) → sub-agent → summarize in chronological order", () => {
-    const { traces, spans, messages } = codemodeFixture()
+  it("stitches disconnected traces into one graph via run_id + inner_tool containment", () => {
+    const { traces, spans, messages } = realCodemodeTurn()
     const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
 
     expect(timeline.turns).toHaveLength(1)
     const turn = timeline.turns[0]!
-    expect(turn.turnIndex).toBe(0)
     expect(turn.label).toBe("Compare Barcelona vs Paris for a weekend trip")
 
-    expect(turn.nodes.map((n) => n.kind)).toEqual(["plan", "execute", "subagent", "summarize"])
+    // Top level: plan and summarize (summary joins the same turn — not a turn entry).
+    expect(kinds(turn.nodes)).toEqual(["plan", "summarize"])
 
     const plan = turn.nodes[0]!
-    expect(plan.confidence).toBe("high")
-    expect(plan.label).toBe("Plan")
-    expect(plan.spanId).toBeNull()
-    expect(plan.traceId).toBe("plan")
-    expect(plan.durationMs).toBe(18_300)
+    expect(kinds(plan.children)).toEqual(["execute"])
 
-    const execute = turn.nodes[1]!
+    const execute = plan.children[0]!
     expect(execute.label).toBe("Codemode execution")
-    expect(execute.children.map((c) => c.label)).toEqual(["delegateWeatherResearch", "formatTravelBrief"])
-    expect(execute.children.map((c) => c.kind)).toEqual(["innerTool", "innerTool"])
-    // formatTravelBrief has a zero-length window
-    expect(execute.children[1]!.durationMs).toBe(0)
-    expect(execute.children[0]!.spanId).toBe("inner-delegate")
+    // Inner-tool traces attach under the code node by time containment, in start order.
+    expect(labels(execute.children)).toEqual(["delegateWeatherResearch", "formatTravelBrief"])
+    expect(kinds(execute.children)).toEqual(["innerTool", "innerTool"])
 
-    const subagent = turn.nodes[2]!
+    // Sub-agent nests under the delegate tool (run_id edge), and its wrapper span collapses.
+    const delegate = execute.children[0]!
+    expect(kinds(delegate.children)).toEqual(["subagent"])
+    const subagent = delegate.children[0]!
     expect(subagent.label).toBe("Sub-agent · weather-research-subagent")
-
-    expect(turn.nodes[3]!.label).toBe("Summarize")
+    expect(labels(subagent.children)).toEqual(["getWeatherDetail"])
   })
 
-  it("marks failed spans/traces with isError", () => {
-    const { traces, spans, messages } = codemodeFixture()
-    const failingSpans = spans.map((s) => (s.spanId === "inner-delegate" ? { ...s, statusCode: "error" } : s))
-    const failingTraces = traces.map((t) => (t.traceId === "exec" ? { ...t, errorCount: 1 } : t))
-    const timeline = buildCodemodeRunTimeline({ session, traces: failingTraces, spans: failingSpans, messages })
-
-    const execute = timeline.turns[0]!.nodes.find((n) => n.kind === "execute")!
-    expect(execute.isError).toBe(true)
-    expect(execute.children.find((c) => c.spanId === "inner-delegate")!.isError).toBe(true)
+  it("navigates every node to its own span", () => {
+    const { traces, spans, messages } = realCodemodeTurn()
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
+    const execute = timeline.turns[0]!.nodes[0]!.children[0]!
+    expect(execute.spanId).toBe("code-exec")
+    expect(execute.traceId).toBe("plan")
+    const delegate = execute.children[0]!
+    expect(delegate.spanId).toBe("delegate-root")
+    expect(delegate.traceId).toBe("delegate")
   })
 
-  it("groups by latitude.codemode.turn_id when present (authoritative over time windows)", () => {
-    const spans: CodemodeTimelineSpanInput[] = [
+  it("propagates span errors onto the matching node", () => {
+    const { traces, spans, messages } = realCodemodeTurn()
+    const failing = spans.map((s) => (s.spanId === "delegate-root" ? { ...s, statusCode: "error" } : s))
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans: failing, messages })
+    const delegate = timeline.turns[0]!.nodes[0]!.children[0]!.children[0]!
+    expect(delegate.spanId).toBe("delegate-root")
+    expect(delegate.isError).toBe(true)
+  })
+
+  it("splits turns at each main-agent entry (greeting turn + orchestration turn)", () => {
+    // Reproduces the original bug: a simple 'codemode-turn' reply followed by an
+    // orchestration (plan+summary) must render as TWO turns, not one.
+    const traces = [
+      trace({ traceId: "greet", startTime: iso(0), endTime: iso(900), rootSpanName: "ai.streamText" }),
+      trace({ traceId: "plan", startTime: iso(5_000), endTime: iso(8_000), rootSpanName: "ai.generateText" }),
+      trace({ traceId: "sum", startTime: iso(9_000), endTime: iso(11_000), rootSpanName: "ai.streamText" }),
+    ]
+    const spans = [
       span({
-        spanId: "p1",
-        traceId: "t1",
-        name: "ai.generateText",
+        spanId: "greet-root",
+        traceId: "greet",
+        name: "ai.streamText",
         operation: "invoke_agent",
         startTime: iso(0),
-        endTime: iso(5_000),
-        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
+        endTime: iso(900),
+        attrString: { "ai.telemetry.functionId": "codemode-turn" },
       }),
       span({
-        spanId: "p2",
-        traceId: "t2",
+        spanId: "plan-root",
+        traceId: "plan",
         name: "ai.generateText",
         operation: "invoke_agent",
-        startTime: iso(6_000),
-        endTime: iso(9_000),
-        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:1" },
+        startTime: iso(5_000),
+        endTime: iso(8_000),
+        attrString: { "ai.telemetry.functionId": "codemode-plan" },
+      }),
+      span({
+        spanId: "sum-root",
+        traceId: "sum",
+        name: "ai.streamText",
+        operation: "invoke_agent",
+        startTime: iso(9_000),
+        endTime: iso(11_000),
+        attrString: { "ai.telemetry.functionId": "codemode-summary" },
       }),
     ]
-    const traces = [
-      trace({ traceId: "t1", startTime: iso(0), endTime: iso(5_000), rootSpanName: "ai.generateText" }),
-      trace({ traceId: "t2", startTime: iso(6_000), endTime: iso(9_000), rootSpanName: "ai.generateText" }),
-    ]
-    const messages = [userMessage("first question"), userMessage("second question")]
+    const messages = [userMessage("how u doing"), userMessage("help me plan my summer trip")]
 
     const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
 
     expect(timeline.turns).toHaveLength(2)
-    expect(timeline.turns[0]!.turnId).toBe("sess:0")
-    expect(timeline.turns[0]!.label).toBe("first question")
-    expect(timeline.turns[1]!.turnId).toBe("sess:1")
-    expect(timeline.turns[1]!.label).toBe("second question")
+    expect(timeline.turns[0]!.label).toBe("how u doing")
+    expect(kinds(timeline.turns[0]!.nodes)).toEqual(["agent"])
+    expect(timeline.turns[1]!.label).toBe("help me plan my summer trip")
+    expect(kinds(timeline.turns[1]!.nodes)).toEqual(["plan", "summarize"])
   })
 
-  it("splits by plan boundaries when turn_id is identical but the session has multiple user messages", () => {
-    const spans: CodemodeTimelineSpanInput[] = [
-      span({
-        spanId: "p1",
-        traceId: "t1",
-        name: "ai.generateText",
-        operation: "invoke_agent",
-        startTime: iso(0),
-        endTime: iso(5_000),
-        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
-      }),
-      span({
-        spanId: "p2",
-        traceId: "t2",
-        name: "ai.generateText",
-        operation: "invoke_agent",
-        startTime: iso(20_000),
-        endTime: iso(25_000),
-        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
-      }),
-    ]
-    const traces = [
-      trace({ traceId: "t1", startTime: iso(0), endTime: iso(5_000), rootSpanName: "ai.generateText" }),
-      trace({ traceId: "t2", startTime: iso(20_000), endTime: iso(25_000), rootSpanName: "ai.generateText" }),
-    ]
-    const messages = [userMessage("first question"), userMessage("second question")]
-
-    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
-
-    expect(timeline.turns).toHaveLength(2)
-    expect(timeline.turns[0]!.label).toBe("first question")
-    expect(timeline.turns[1]!.label).toBe("second question")
-  })
-
-  it("classifies ai.toolCall codemode as execute even when phase=plan is inherited from the turn tracer", () => {
-    const { traces, spans, messages } = codemodeFixture()
-    const spansWithInheritedPlan = spans.map((s) =>
-      s.spanId === "exec-codemode"
-        ? { ...s, attrString: { ...(s.attrString ?? {}), "latitude.codemode.phase": "plan" } }
-        : s,
-    )
-    const timeline = buildCodemodeRunTimeline({ session, traces, spans: spansWithInheritedPlan, messages })
-    const kinds = timeline.turns[0]!.nodes.map((n) => n.kind)
-    expect(kinds).toEqual(["plan", "execute", "subagent", "summarize"])
-  })
-
-  it("degrades to name/operation heuristics with low confidence when no codemode attributes exist (legacy data)", () => {
-    // No attrString/attrBool — mirrors the current session span collection (SpanRecord has no attributes).
+  it("degrades to name/operation heuristics when no codemode attributes exist (legacy data)", () => {
     const traces = [
       trace({ traceId: "plan", startTime: iso(0), endTime: iso(10_000), rootSpanName: "ai.generateText" }),
       trace({ traceId: "exec", startTime: iso(10_000), endTime: iso(14_000), rootSpanName: "ai.toolCall codemode" }),
@@ -315,50 +332,12 @@ describe("buildCodemodeRunTimeline", () => {
 
     expect(timeline.turns).toHaveLength(1)
     const turn = timeline.turns[0]!
-    expect(turn.nodes.map((n) => n.kind)).toEqual(["plan", "execute", "summarize"])
+    expect(kinds(turn.nodes)).toEqual(["plan", "execute", "summarize"])
     // execute detection from operation + toolName is high confidence even without attributes
     expect(turn.nodes.find((n) => n.kind === "execute")!.confidence).toBe("high")
     // plan/summarize inferred from name only → low confidence
     expect(turn.nodes.find((n) => n.kind === "plan")!.confidence).toBe("low")
-    // inner tool nested under execute via parent tool-call fallback
-    expect(turn.nodes.find((n) => n.kind === "execute")!.children.map((c) => c.label)).toEqual(["lookupCity"])
-  })
-
-  it("does not label codemode-turn streamText traces as codemode execution", () => {
-    const traces = [
-      trace({
-        traceId: "agent-turn",
-        startTime: iso(0),
-        endTime: iso(900),
-        rootSpanName: "ai.streamText",
-      }),
-    ]
-    const spans = [
-      span({
-        spanId: "root",
-        traceId: "agent-turn",
-        name: "ai.streamText",
-        operation: "invoke_agent",
-        startTime: iso(0),
-        endTime: iso(900),
-        attrString: { "ai.telemetry.functionId": "codemode-turn" },
-      }),
-      span({
-        spanId: "stream",
-        traceId: "agent-turn",
-        parentSpanId: "root",
-        name: "ai.streamText.doStream",
-        operation: "chat",
-        startTime: iso(0),
-        endTime: iso(900),
-        attrString: { "ai.telemetry.functionId": "codemode-turn" },
-      }),
-    ]
-    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [userMessage("hello")] })
-    const node = timeline.turns[0]!.nodes[0]!
-    expect(node.kind).toBe("agent")
-    expect(node.label).toBe("Agent response")
-    expect(node.confidence).toBe("high")
+    expect(labels(turn.nodes.find((n) => n.kind === "execute")!.children)).toEqual(["lookupCity"])
   })
 
   it("labels a single inner-tool trace by tool name instead of unlabeled", () => {
@@ -389,45 +368,38 @@ describe("buildCodemodeRunTimeline", () => {
     expect(node.spanId).toBe("inner-format")
   })
 
-  it("nests inner-tool spans under sub-agent traces", () => {
+  it("does not label a codemode-turn streamText trace as codemode execution", () => {
     const traces = [
-      trace({
-        traceId: "sub",
-        startTime: iso(19_000),
-        endTime: iso(22_100),
-        rootSpanName: "ai.streamText",
-        metadata: { role: "weather-research-subagent" },
-      }),
+      trace({ traceId: "agent-turn", startTime: iso(0), endTime: iso(900), rootSpanName: "ai.streamText" }),
     ]
     const spans = [
       span({
-        spanId: "sub-root",
-        traceId: "sub",
+        spanId: "root",
+        traceId: "agent-turn",
         name: "ai.streamText",
         operation: "invoke_agent",
-        startTime: iso(19_000),
-        endTime: iso(22_100),
-        attrString: { "ai.telemetry.functionId": "research-subagent-turn" },
+        startTime: iso(0),
+        endTime: iso(900),
+        attrString: { "ai.telemetry.functionId": "codemode-turn" },
       }),
       span({
-        spanId: "sub-tool",
-        traceId: "sub",
-        parentSpanId: "sub-root",
-        name: "ai.toolCall getWeatherDetail",
-        operation: "execute_tool",
-        toolName: "getWeatherDetail",
-        startTime: iso(19_500),
-        endTime: iso(20_000),
-        attrBool: { "latitude.codemode.inner_tool": true },
+        spanId: "stream",
+        traceId: "agent-turn",
+        parentSpanId: "root",
+        name: "ai.streamText.doStream",
+        operation: "chat",
+        startTime: iso(0),
+        endTime: iso(900),
       }),
     ]
     const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [userMessage("hello")] })
     const node = timeline.turns[0]!.nodes[0]!
-    expect(node.kind).toBe("subagent")
-    expect(node.children.map((child) => child.label)).toEqual(["getWeatherDetail"])
+    expect(node.kind).toBe("agent")
+    expect(node.label).toBe("Agent response")
+    expect(node.confidence).toBe("high")
   })
 
-  it("falls back to a single turn keyed by session id when there is no turn metadata or timestamps", () => {
+  it("falls back to a single turn labelled by index when there is no user message", () => {
     const traces = [trace({ traceId: "exec", rootSpanName: "ai.toolCall codemode", endTime: iso(1_000) })]
     const spans = [
       span({

--- a/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.test.ts
+++ b/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.test.ts
@@ -1,0 +1,447 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildCodemodeRunTimeline,
+  type CodemodeTimelineMessageInput,
+  type CodemodeTimelineSpanInput,
+  type CodemodeTimelineTraceInput,
+} from "./build-codemode-run-timeline.ts"
+
+const T0 = Date.parse("2026-07-02T10:00:00.000Z")
+const iso = (offsetMs: number) => new Date(T0 + offsetMs).toISOString()
+
+function span(
+  overrides: Partial<CodemodeTimelineSpanInput> & Pick<CodemodeTimelineSpanInput, "spanId" | "traceId">,
+): CodemodeTimelineSpanInput {
+  return {
+    parentSpanId: "",
+    name: "",
+    operation: "",
+    toolName: "",
+    startTime: iso(0),
+    endTime: iso(0),
+    statusCode: "ok",
+    ...overrides,
+  }
+}
+
+function trace(
+  overrides: Partial<CodemodeTimelineTraceInput> & Pick<CodemodeTimelineTraceInput, "traceId">,
+): CodemodeTimelineTraceInput {
+  return {
+    startTime: iso(0),
+    endTime: iso(0),
+    rootSpanName: "",
+    errorCount: 0,
+    ...overrides,
+  }
+}
+
+const userMessage = (content: string): CodemodeTimelineMessageInput => ({
+  role: "user",
+  parts: [{ type: "text", content }],
+})
+
+const session = {
+  sessionId: "sess-qa",
+  startTime: iso(0),
+  endTime: iso(30_000),
+  traceIds: ["plan", "exec", "sub", "sum"],
+}
+
+// A qa-a8624440-shaped codemode turn: plan → codemode execution (with two inner
+// tools) → sub-agent → summarize, one user message, spans carrying the Phase 0
+// `latitude.codemode.*` attributes.
+function codemodeFixture(): {
+  traces: CodemodeTimelineTraceInput[]
+  spans: CodemodeTimelineSpanInput[]
+  messages: CodemodeTimelineMessageInput[]
+} {
+  const traces = [
+    trace({ traceId: "sum", startTime: iso(26_000), endTime: iso(29_200), rootSpanName: "ai.streamText" }),
+    trace({ traceId: "plan", startTime: iso(0), endTime: iso(18_300), rootSpanName: "ai.generateText" }),
+    trace({ traceId: "exec", startTime: iso(18_300), endTime: iso(22_600), rootSpanName: "ai.toolCall codemode" }),
+    trace({
+      traceId: "sub",
+      startTime: iso(19_000),
+      endTime: iso(22_100),
+      rootSpanName: "ai.streamText",
+      metadata: { role: "weather-research-subagent" },
+    }),
+  ]
+
+  const spans = [
+    span({
+      spanId: "plan-gen",
+      traceId: "plan",
+      name: "ai.generateText",
+      operation: "invoke_agent",
+      startTime: iso(0),
+      endTime: iso(18_300),
+      attrString: { "ai.telemetry.functionId": "codemode-plan" },
+    }),
+    span({
+      spanId: "exec-codemode",
+      traceId: "exec",
+      name: "ai.toolCall codemode",
+      operation: "execute_tool",
+      toolName: "codemode",
+      startTime: iso(18_300),
+      endTime: iso(22_600),
+    }),
+    span({
+      spanId: "inner-delegate",
+      traceId: "exec",
+      parentSpanId: "exec-codemode",
+      name: "ai.toolCall delegateWeatherResearch",
+      operation: "execute_tool",
+      toolName: "delegateWeatherResearch",
+      startTime: iso(18_400),
+      endTime: iso(22_700),
+      attrBool: { "latitude.codemode.inner_tool": true },
+    }),
+    span({
+      spanId: "inner-format",
+      traceId: "exec",
+      parentSpanId: "exec-codemode",
+      name: "ai.toolCall formatTravelBrief",
+      operation: "execute_tool",
+      toolName: "formatTravelBrief",
+      startTime: iso(22_500),
+      endTime: iso(22_500),
+      attrBool: { "latitude.codemode.inner_tool": true },
+    }),
+    span({
+      spanId: "sub-gen",
+      traceId: "sub",
+      name: "ai.streamText",
+      operation: "invoke_agent",
+      startTime: iso(19_000),
+      endTime: iso(22_100),
+      attrString: { "ai.telemetry.functionId": "research-subagent-turn" },
+    }),
+    span({
+      spanId: "sum-gen",
+      traceId: "sum",
+      name: "ai.streamText",
+      operation: "invoke_agent",
+      startTime: iso(26_000),
+      endTime: iso(29_200),
+      attrString: { "ai.telemetry.functionId": "codemode-summary" },
+    }),
+  ]
+
+  const messages: CodemodeTimelineMessageInput[] = [
+    { role: "system", parts: [{ type: "text", content: "You are helpful." }] },
+    userMessage("Compare Barcelona vs Paris for a weekend trip"),
+    { role: "assistant", parts: [{ type: "text", content: "Barcelona edges it out." }] },
+  ]
+
+  return { traces, spans, messages }
+}
+
+describe("buildCodemodeRunTimeline", () => {
+  it("builds one turn with plan → execute (inner tools) → sub-agent → summarize in chronological order", () => {
+    const { traces, spans, messages } = codemodeFixture()
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
+
+    expect(timeline.turns).toHaveLength(1)
+    const turn = timeline.turns[0]!
+    expect(turn.turnIndex).toBe(0)
+    expect(turn.label).toBe("Compare Barcelona vs Paris for a weekend trip")
+
+    expect(turn.nodes.map((n) => n.kind)).toEqual(["plan", "execute", "subagent", "summarize"])
+
+    const plan = turn.nodes[0]!
+    expect(plan.confidence).toBe("high")
+    expect(plan.label).toBe("Plan")
+    expect(plan.spanId).toBeNull()
+    expect(plan.traceId).toBe("plan")
+    expect(plan.durationMs).toBe(18_300)
+
+    const execute = turn.nodes[1]!
+    expect(execute.label).toBe("Codemode execution")
+    expect(execute.children.map((c) => c.label)).toEqual(["delegateWeatherResearch", "formatTravelBrief"])
+    expect(execute.children.map((c) => c.kind)).toEqual(["innerTool", "innerTool"])
+    // formatTravelBrief has a zero-length window
+    expect(execute.children[1]!.durationMs).toBe(0)
+    expect(execute.children[0]!.spanId).toBe("inner-delegate")
+
+    const subagent = turn.nodes[2]!
+    expect(subagent.label).toBe("Sub-agent · weather-research-subagent")
+
+    expect(turn.nodes[3]!.label).toBe("Summarize")
+  })
+
+  it("marks failed spans/traces with isError", () => {
+    const { traces, spans, messages } = codemodeFixture()
+    const failingSpans = spans.map((s) => (s.spanId === "inner-delegate" ? { ...s, statusCode: "error" } : s))
+    const failingTraces = traces.map((t) => (t.traceId === "exec" ? { ...t, errorCount: 1 } : t))
+    const timeline = buildCodemodeRunTimeline({ session, traces: failingTraces, spans: failingSpans, messages })
+
+    const execute = timeline.turns[0]!.nodes.find((n) => n.kind === "execute")!
+    expect(execute.isError).toBe(true)
+    expect(execute.children.find((c) => c.spanId === "inner-delegate")!.isError).toBe(true)
+  })
+
+  it("groups by latitude.codemode.turn_id when present (authoritative over time windows)", () => {
+    const spans: CodemodeTimelineSpanInput[] = [
+      span({
+        spanId: "p1",
+        traceId: "t1",
+        name: "ai.generateText",
+        operation: "invoke_agent",
+        startTime: iso(0),
+        endTime: iso(5_000),
+        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
+      }),
+      span({
+        spanId: "p2",
+        traceId: "t2",
+        name: "ai.generateText",
+        operation: "invoke_agent",
+        startTime: iso(6_000),
+        endTime: iso(9_000),
+        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:1" },
+      }),
+    ]
+    const traces = [
+      trace({ traceId: "t1", startTime: iso(0), endTime: iso(5_000), rootSpanName: "ai.generateText" }),
+      trace({ traceId: "t2", startTime: iso(6_000), endTime: iso(9_000), rootSpanName: "ai.generateText" }),
+    ]
+    const messages = [userMessage("first question"), userMessage("second question")]
+
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
+
+    expect(timeline.turns).toHaveLength(2)
+    expect(timeline.turns[0]!.turnId).toBe("sess:0")
+    expect(timeline.turns[0]!.label).toBe("first question")
+    expect(timeline.turns[1]!.turnId).toBe("sess:1")
+    expect(timeline.turns[1]!.label).toBe("second question")
+  })
+
+  it("splits by plan boundaries when turn_id is identical but the session has multiple user messages", () => {
+    const spans: CodemodeTimelineSpanInput[] = [
+      span({
+        spanId: "p1",
+        traceId: "t1",
+        name: "ai.generateText",
+        operation: "invoke_agent",
+        startTime: iso(0),
+        endTime: iso(5_000),
+        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
+      }),
+      span({
+        spanId: "p2",
+        traceId: "t2",
+        name: "ai.generateText",
+        operation: "invoke_agent",
+        startTime: iso(20_000),
+        endTime: iso(25_000),
+        attrString: { "ai.telemetry.functionId": "codemode-plan", "latitude.codemode.turn_id": "sess:0" },
+      }),
+    ]
+    const traces = [
+      trace({ traceId: "t1", startTime: iso(0), endTime: iso(5_000), rootSpanName: "ai.generateText" }),
+      trace({ traceId: "t2", startTime: iso(20_000), endTime: iso(25_000), rootSpanName: "ai.generateText" }),
+    ]
+    const messages = [userMessage("first question"), userMessage("second question")]
+
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
+
+    expect(timeline.turns).toHaveLength(2)
+    expect(timeline.turns[0]!.label).toBe("first question")
+    expect(timeline.turns[1]!.label).toBe("second question")
+  })
+
+  it("classifies ai.toolCall codemode as execute even when phase=plan is inherited from the turn tracer", () => {
+    const { traces, spans, messages } = codemodeFixture()
+    const spansWithInheritedPlan = spans.map((s) =>
+      s.spanId === "exec-codemode"
+        ? { ...s, attrString: { ...(s.attrString ?? {}), "latitude.codemode.phase": "plan" } }
+        : s,
+    )
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans: spansWithInheritedPlan, messages })
+    const kinds = timeline.turns[0]!.nodes.map((n) => n.kind)
+    expect(kinds).toEqual(["plan", "execute", "subagent", "summarize"])
+  })
+
+  it("degrades to name/operation heuristics with low confidence when no codemode attributes exist (legacy data)", () => {
+    // No attrString/attrBool — mirrors the current session span collection (SpanRecord has no attributes).
+    const traces = [
+      trace({ traceId: "plan", startTime: iso(0), endTime: iso(10_000), rootSpanName: "ai.generateText" }),
+      trace({ traceId: "exec", startTime: iso(10_000), endTime: iso(14_000), rootSpanName: "ai.toolCall codemode" }),
+      trace({ traceId: "sum", startTime: iso(14_000), endTime: iso(18_000), rootSpanName: "ai.streamText" }),
+    ]
+    const spans = [
+      span({
+        spanId: "s-plan",
+        traceId: "plan",
+        name: "ai.generateText",
+        operation: "invoke_agent",
+        startTime: iso(0),
+        endTime: iso(10_000),
+      }),
+      span({
+        spanId: "s-exec",
+        traceId: "exec",
+        name: "ai.toolCall codemode",
+        operation: "execute_tool",
+        toolName: "codemode",
+        startTime: iso(10_000),
+        endTime: iso(14_000),
+      }),
+      span({
+        spanId: "s-inner",
+        traceId: "exec",
+        parentSpanId: "s-exec",
+        name: "ai.toolCall lookupCity",
+        operation: "execute_tool",
+        toolName: "lookupCity",
+        startTime: iso(10_500),
+        endTime: iso(11_000),
+      }),
+      span({
+        spanId: "s-sum",
+        traceId: "sum",
+        name: "ai.streamText",
+        operation: "invoke_agent",
+        startTime: iso(14_000),
+        endTime: iso(18_000),
+      }),
+    ]
+    const messages = [userMessage("hello there")]
+
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages })
+
+    expect(timeline.turns).toHaveLength(1)
+    const turn = timeline.turns[0]!
+    expect(turn.nodes.map((n) => n.kind)).toEqual(["plan", "execute", "summarize"])
+    // execute detection from operation + toolName is high confidence even without attributes
+    expect(turn.nodes.find((n) => n.kind === "execute")!.confidence).toBe("high")
+    // plan/summarize inferred from name only → low confidence
+    expect(turn.nodes.find((n) => n.kind === "plan")!.confidence).toBe("low")
+    // inner tool nested under execute via parent tool-call fallback
+    expect(turn.nodes.find((n) => n.kind === "execute")!.children.map((c) => c.label)).toEqual(["lookupCity"])
+  })
+
+  it("does not label codemode-turn streamText traces as codemode execution", () => {
+    const traces = [
+      trace({
+        traceId: "agent-turn",
+        startTime: iso(0),
+        endTime: iso(900),
+        rootSpanName: "ai.streamText",
+      }),
+    ]
+    const spans = [
+      span({
+        spanId: "root",
+        traceId: "agent-turn",
+        name: "ai.streamText",
+        operation: "invoke_agent",
+        startTime: iso(0),
+        endTime: iso(900),
+        attrString: { "ai.telemetry.functionId": "codemode-turn" },
+      }),
+      span({
+        spanId: "stream",
+        traceId: "agent-turn",
+        parentSpanId: "root",
+        name: "ai.streamText.doStream",
+        operation: "chat",
+        startTime: iso(0),
+        endTime: iso(900),
+        attrString: { "ai.telemetry.functionId": "codemode-turn" },
+      }),
+    ]
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [userMessage("hello")] })
+    const node = timeline.turns[0]!.nodes[0]!
+    expect(node.kind).toBe("agent")
+    expect(node.label).toBe("Agent response")
+    expect(node.confidence).toBe("high")
+  })
+
+  it("labels a single inner-tool trace by tool name instead of unlabeled", () => {
+    const traces = [
+      trace({
+        traceId: "inner-only",
+        startTime: iso(10_000),
+        endTime: iso(10_001),
+        rootSpanName: "ai.toolCall formatTravelBrief",
+      }),
+    ]
+    const spans = [
+      span({
+        spanId: "inner-format",
+        traceId: "inner-only",
+        name: "ai.toolCall formatTravelBrief",
+        operation: "execute_tool",
+        toolName: "formatTravelBrief",
+        startTime: iso(10_000),
+        endTime: iso(10_001),
+        attrBool: { "latitude.codemode.inner_tool": true },
+      }),
+    ]
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [userMessage("hello")] })
+    const node = timeline.turns[0]!.nodes[0]!
+    expect(node.kind).toBe("innerTool")
+    expect(node.label).toBe("formatTravelBrief")
+    expect(node.spanId).toBe("inner-format")
+  })
+
+  it("nests inner-tool spans under sub-agent traces", () => {
+    const traces = [
+      trace({
+        traceId: "sub",
+        startTime: iso(19_000),
+        endTime: iso(22_100),
+        rootSpanName: "ai.streamText",
+        metadata: { role: "weather-research-subagent" },
+      }),
+    ]
+    const spans = [
+      span({
+        spanId: "sub-root",
+        traceId: "sub",
+        name: "ai.streamText",
+        operation: "invoke_agent",
+        startTime: iso(19_000),
+        endTime: iso(22_100),
+        attrString: { "ai.telemetry.functionId": "research-subagent-turn" },
+      }),
+      span({
+        spanId: "sub-tool",
+        traceId: "sub",
+        parentSpanId: "sub-root",
+        name: "ai.toolCall getWeatherDetail",
+        operation: "execute_tool",
+        toolName: "getWeatherDetail",
+        startTime: iso(19_500),
+        endTime: iso(20_000),
+        attrBool: { "latitude.codemode.inner_tool": true },
+      }),
+    ]
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [userMessage("hello")] })
+    const node = timeline.turns[0]!.nodes[0]!
+    expect(node.kind).toBe("subagent")
+    expect(node.children.map((child) => child.label)).toEqual(["getWeatherDetail"])
+  })
+
+  it("falls back to a single turn keyed by session id when there is no turn metadata or timestamps", () => {
+    const traces = [trace({ traceId: "exec", rootSpanName: "ai.toolCall codemode", endTime: iso(1_000) })]
+    const spans = [
+      span({
+        spanId: "x",
+        traceId: "exec",
+        name: "ai.toolCall codemode",
+        operation: "execute_tool",
+        toolName: "codemode",
+        endTime: iso(1_000),
+      }),
+    ]
+    const timeline = buildCodemodeRunTimeline({ session, traces, spans, messages: [] })
+    expect(timeline.turns).toHaveLength(1)
+    expect(timeline.turns[0]!.turnId).toBe("sess-qa:0")
+    expect(timeline.turns[0]!.label).toBe("Turn 1")
+  })
+})

--- a/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.ts
+++ b/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.ts
@@ -1,0 +1,524 @@
+// Pure, dependency-free construction of the session-drawer "Run" tree for
+// codemode orchestrations. Input shapes are structural subsets of the app's
+// `SpanRecord` / `TraceRecord` / `SessionDetailRecord` / `GenAIMessage` so the
+// UI can pass those records directly, while tests can supply richer fixtures
+// (including the `latitude.codemode.*` span attributes that the session-level
+// span collection does not yet serialize — see the module doc note below).
+//
+// Phase detection follows spec D6 priority: (1) `latitude.codemode.phase`
+// attribute, (2) `ai.telemetry.functionId` attribute, (3) operation + name
+// heuristics for legacy data. When no signal reaches high confidence a node is
+// emitted as "unlabeled" so legacy sessions still render top-to-bottom.
+
+export const CODEMODE_ATTR = {
+  phase: "latitude.codemode.phase",
+  innerTool: "latitude.codemode.inner_tool",
+  turnId: "latitude.codemode.turn_id",
+  parentToolCallId: "latitude.agent_tool.parent_tool_call_id",
+  runId: "latitude.agent_tool.run_id",
+  functionId: "ai.telemetry.functionId",
+} as const
+
+const FUNCTION_ID_PHASE: Readonly<Record<string, CodemodeRunNodeKind>> = {
+  "codemode-plan": "plan",
+  "codemode-summary": "summarize",
+  "research-subagent-turn": "subagent",
+}
+
+const USER_LABEL_MAX_CHARS = 80
+
+export type CodemodeRunNodeKind = "plan" | "execute" | "innerTool" | "subagent" | "summarize" | "agent" | "unlabeled"
+
+export type CodemodeRunConfidence = "high" | "low"
+
+export interface CodemodeTimelineSpanInput {
+  readonly spanId: string
+  readonly parentSpanId: string
+  readonly traceId: string
+  readonly name: string
+  readonly operation: string
+  readonly toolName: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly statusCode: string
+  readonly statusMessage?: string
+  readonly attrString?: Readonly<Record<string, string>>
+  readonly attrBool?: Readonly<Record<string, boolean>>
+}
+
+export interface CodemodeTimelineTraceInput {
+  readonly traceId: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly rootSpanName: string
+  readonly errorCount: number
+  readonly metadata?: Readonly<Record<string, string>>
+}
+
+export interface CodemodeTimelineMessageInput {
+  readonly role: string
+  readonly parts?: readonly unknown[]
+  /** Optional wall-clock time; absent for `GenAIMessage`, present in fixtures that exercise the window fallback. */
+  readonly atMs?: number
+}
+
+export interface CodemodeTimelineSessionInput {
+  readonly sessionId: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly traceIds: readonly string[]
+}
+
+export interface CodemodeRunNode {
+  /** Stable identity: the span id when the node is a span, otherwise the trace id. */
+  readonly id: string
+  readonly kind: CodemodeRunNodeKind
+  readonly label: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly durationMs: number
+  readonly isError: boolean
+  readonly confidence: CodemodeRunConfidence
+  readonly traceId: string
+  /** Set when the node maps to a specific span (span-detail navigation); null for whole-trace rows. */
+  readonly spanId: string | null
+  readonly children: readonly CodemodeRunNode[]
+  /** Short signal explaining why this step got its kind (shown muted in the Run tab). */
+  readonly hint: string | null
+}
+
+export interface CodemodeRunTurn {
+  readonly turnId: string
+  readonly turnIndex: number
+  readonly label: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly nodes: readonly CodemodeRunNode[]
+}
+
+export interface CodemodeRunTimeline {
+  readonly turns: readonly CodemodeRunTurn[]
+}
+
+export interface BuildCodemodeRunTimelineInput {
+  readonly session: CodemodeTimelineSessionInput
+  readonly traces: readonly CodemodeTimelineTraceInput[]
+  readonly spans: readonly CodemodeTimelineSpanInput[]
+  readonly messages: readonly CodemodeTimelineMessageInput[]
+}
+
+interface NormalizedSpan {
+  readonly spanId: string
+  readonly parentSpanId: string
+  readonly traceId: string
+  readonly name: string
+  readonly operation: string
+  readonly toolName: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly isError: boolean
+  readonly phaseAttr: string | undefined
+  readonly functionId: string | undefined
+  readonly turnId: string | undefined
+  readonly isInnerTool: boolean
+  readonly isSubagent: boolean
+}
+
+interface NormalizedTrace {
+  readonly traceId: string
+  readonly startMs: number
+  readonly endMs: number
+  readonly rootSpanName: string
+  readonly isError: boolean
+  readonly metadata: Readonly<Record<string, string>>
+  readonly spans: readonly NormalizedSpan[]
+  readonly turnId: string | undefined
+}
+
+const toMs = (iso: string): number => {
+  const ms = Date.parse(iso)
+  return Number.isFinite(ms) ? ms : 0
+}
+
+const attrBool = (span: CodemodeTimelineSpanInput, key: string): boolean =>
+  span.attrBool?.[key] === true || span.attrString?.[key] === "true"
+
+function normalizeSpan(span: CodemodeTimelineSpanInput): NormalizedSpan {
+  const phaseAttr = span.attrString?.[CODEMODE_ATTR.phase]
+  const functionId = span.attrString?.[CODEMODE_ATTR.functionId]
+  const turnId = span.attrString?.[CODEMODE_ATTR.turnId]
+  const isInnerTool = attrBool(span, CODEMODE_ATTR.innerTool)
+  const isSubagent =
+    functionId === "research-subagent-turn" ||
+    phaseAttr === "subagent" ||
+    span.attrString?.[CODEMODE_ATTR.runId] !== undefined ||
+    span.attrString?.[CODEMODE_ATTR.parentToolCallId] !== undefined
+  return {
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId,
+    traceId: span.traceId,
+    name: span.name,
+    operation: span.operation,
+    toolName: span.toolName,
+    startMs: toMs(span.startTime),
+    endMs: toMs(span.endTime),
+    isError: span.statusCode === "error",
+    phaseAttr,
+    functionId,
+    turnId,
+    isInnerTool,
+    isSubagent,
+  }
+}
+
+const isCodemodeExecuteSpan = (span: NormalizedSpan): boolean =>
+  span.operation === "execute_tool" && (span.toolName === "codemode" || / codemode$/i.test(span.name))
+
+const isToolCallSpan = (span: NormalizedSpan): boolean => span.operation === "execute_tool"
+
+/** Phase from an individual span using D6 priorities 1→2→3. Returns undefined when nothing matches. */
+function spanPhase(span: NormalizedSpan): { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } | undefined {
+  if (isCodemodeExecuteSpan(span)) return { kind: "execute", confidence: "high" }
+  if (span.phaseAttr === "plan" || span.phaseAttr === "execute" || span.phaseAttr === "summarize") {
+    return { kind: span.phaseAttr, confidence: "high" }
+  }
+  if (span.functionId === "codemode-turn") {
+    if (isCodemodeExecuteSpan(span)) return { kind: "execute", confidence: "high" }
+    return undefined
+  }
+  if (span.functionId && FUNCTION_ID_PHASE[span.functionId]) {
+    return { kind: FUNCTION_ID_PHASE[span.functionId] as CodemodeRunNodeKind, confidence: "high" }
+  }
+  if (span.isSubagent) return { kind: "subagent", confidence: "high" }
+  if (span.isInnerTool && isToolCallSpan(span)) return { kind: "innerTool", confidence: "high" }
+  if (/generateText/i.test(span.name)) return { kind: "plan", confidence: "low" }
+  if (/streamText/i.test(span.name) && span.functionId === "codemode-summary") {
+    return { kind: "summarize", confidence: "high" }
+  }
+  if (/streamText/i.test(span.name)) return { kind: "summarize", confidence: "low" }
+  return undefined
+}
+
+function pickTurnId(spans: readonly NormalizedSpan[]): string | undefined {
+  for (const span of spans) {
+    if (span.turnId) return span.turnId
+  }
+  return undefined
+}
+
+function normalizeTrace(trace: CodemodeTimelineTraceInput, spans: readonly NormalizedSpan[]): NormalizedTrace {
+  return {
+    traceId: trace.traceId,
+    startMs: toMs(trace.startTime),
+    endMs: toMs(trace.endTime),
+    rootSpanName: trace.rootSpanName,
+    isError: trace.errorCount > 0 || spans.some((s) => s.isError),
+    metadata: trace.metadata ?? {},
+    spans,
+    turnId: trace.metadata?.[CODEMODE_ATTR.turnId] ?? pickTurnId(spans),
+  }
+}
+
+const SUBAGENT_METADATA_HINT = /subagent|sub-agent/i
+
+function standaloneInnerToolSpan(trace: NormalizedTrace): NormalizedSpan | undefined {
+  const toolSpans = trace.spans.filter((span) => isToolCallSpan(span) && !isCodemodeExecuteSpan(span))
+  if (toolSpans.length !== 1) return undefined
+  const only = toolSpans[0]
+  if (!only?.isInnerTool) return undefined
+  const nonToolSpans = trace.spans.filter((span) => !isToolCallSpan(span))
+  if (
+    nonToolSpans.some((span) => {
+      const phase = spanPhase(span)
+      return (
+        phase?.kind === "subagent" || phase?.kind === "plan" || phase?.kind === "summarize" || phase?.kind === "execute"
+      )
+    })
+  ) {
+    return undefined
+  }
+  return only
+}
+
+function toolChildSpans(trace: NormalizedTrace, kind: CodemodeRunNodeKind): NormalizedSpan[] {
+  if (kind === "execute") return innerToolSpans(trace)
+  if (kind === "subagent") {
+    return trace.spans.filter((span) => isToolCallSpan(span) && span.isInnerTool).sort((a, b) => a.startMs - b.startMs)
+  }
+  return []
+}
+
+function spanToChildNode(span: NormalizedSpan): CodemodeRunNode {
+  return {
+    id: span.spanId,
+    kind: "innerTool",
+    label: innerToolLabel(span),
+    startMs: span.startMs,
+    endMs: span.endMs,
+    durationMs: Math.max(0, span.endMs - span.startMs),
+    isError: span.isError,
+    confidence: "high",
+    traceId: span.traceId,
+    spanId: span.spanId,
+    children: [],
+    hint: "inner sandbox tool",
+  }
+}
+function tracePhase(trace: NormalizedTrace): { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } {
+  let fallback: { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } | undefined
+  for (const span of trace.spans) {
+    const detected = spanPhase(span)
+    if (!detected) continue
+    if (detected.confidence === "high") return detected
+    fallback = fallback ?? detected
+  }
+
+  const metaRole = trace.metadata.role ?? ""
+  if (SUBAGENT_METADATA_HINT.test(metaRole)) return { kind: "subagent", confidence: "high" }
+
+  if (
+    trace.spans.length > 0 &&
+    trace.spans.every((span) => span.functionId === "codemode-turn") &&
+    trace.spans.every((span) => /streamText/i.test(span.name) || span.operation === "chat")
+  ) {
+    return { kind: "agent", confidence: "high" }
+  }
+
+  const rootName = trace.rootSpanName
+  if (/ codemode$/i.test(rootName) || /toolCall codemode/i.test(rootName)) {
+    return { kind: "execute", confidence: "low" }
+  }
+  if (/generateText/i.test(rootName)) return { kind: "plan", confidence: "low" }
+  if (/streamText/i.test(rootName) && trace.spans.some((span) => span.functionId === "codemode-summary")) {
+    return { kind: "summarize", confidence: "high" }
+  }
+  if (/streamText/i.test(rootName)) return { kind: "summarize", confidence: "low" }
+
+  const loneInnerTool = standaloneInnerToolSpan(trace)
+  if (loneInnerTool) return { kind: "innerTool", confidence: "high" }
+
+  return fallback ?? { kind: "unlabeled", confidence: "low" }
+}
+
+/** Inner-tool spans of the execute trace: explicit `inner_tool` flag, else tool-call spans that aren't the codemode call itself. */
+function innerToolSpans(trace: NormalizedTrace): NormalizedSpan[] {
+  const explicit = trace.spans.filter((s) => s.isInnerTool)
+  if (explicit.length > 0) return explicit.slice().sort((a, b) => a.startMs - b.startMs)
+  return trace.spans.filter((s) => isToolCallSpan(s) && !isCodemodeExecuteSpan(s)).sort((a, b) => a.startMs - b.startMs)
+}
+
+function innerToolLabel(span: NormalizedSpan): string {
+  if (span.toolName) return span.toolName
+  return span.name.replace(/^ai\.toolCall\s+/i, "") || span.name
+}
+
+function phaseLabel(kind: CodemodeRunNodeKind, trace: NormalizedTrace): string {
+  switch (kind) {
+    case "plan":
+      return "Plan"
+    case "execute":
+      return "Codemode execution"
+    case "summarize":
+      return "Summarize"
+    case "agent":
+      return "Agent response"
+    case "innerTool": {
+      const toolSpan = standaloneInnerToolSpan(trace) ?? trace.spans.find((span) => span.isInnerTool)
+      return toolSpan ? innerToolLabel(toolSpan) : trace.rootSpanName || "Tool"
+    }
+    case "subagent": {
+      const role = trace.metadata.role
+      return role ? `Sub-agent · ${role}` : "Sub-agent"
+    }
+    default:
+      return trace.rootSpanName || "Unlabeled phase"
+  }
+}
+
+function phaseHint(kind: CodemodeRunNodeKind, trace: NormalizedTrace): string | null {
+  switch (kind) {
+    case "plan":
+      return trace.spans.some((span) => span.functionId === "codemode-plan")
+        ? "generateText · codemode-plan"
+        : "generateText"
+    case "agent":
+      return "streamText · codemode-turn (main agent, not sandbox)"
+    case "execute":
+      return "execute_tool · codemode"
+    case "summarize":
+      return trace.spans.some((span) => span.functionId === "codemode-summary")
+        ? "streamText · codemode-summary"
+        : "streamText"
+    case "subagent":
+      return trace.metadata.role ? `sub-agent · ${trace.metadata.role}` : "research-subagent-turn"
+    case "innerTool":
+      return "inner sandbox tool"
+    default:
+      return null
+  }
+}
+
+function buildTraceNode(trace: NormalizedTrace): CodemodeRunNode {
+  const loneInnerTool = standaloneInnerToolSpan(trace)
+  if (loneInnerTool) {
+    return {
+      ...spanToChildNode(loneInnerTool),
+      kind: "innerTool",
+      label: innerToolLabel(loneInnerTool),
+    }
+  }
+
+  const { kind, confidence } = tracePhase(trace)
+  const children: CodemodeRunNode[] = toolChildSpans(trace, kind).map(spanToChildNode)
+
+  const primarySpan =
+    kind === "innerTool" ? (trace.spans.find((span) => span.isInnerTool && isToolCallSpan(span)) ?? null) : null
+
+  return {
+    id: primarySpan?.spanId ?? trace.traceId,
+    kind,
+    label: phaseLabel(kind, trace),
+    startMs: trace.startMs,
+    endMs: trace.endMs,
+    durationMs: Math.max(0, trace.endMs - trace.startMs),
+    isError: trace.isError,
+    confidence,
+    traceId: trace.traceId,
+    spanId: primarySpan?.spanId ?? null,
+    children,
+    hint: phaseHint(kind, trace),
+  }
+}
+
+function messageText(message: CodemodeTimelineMessageInput): string {
+  let text = ""
+  for (const part of message.parts ?? []) {
+    if (part && typeof part === "object" && (part as { type?: string }).type === "text") {
+      const content = (part as { content?: unknown }).content
+      if (typeof content === "string") text += `${content} `
+    }
+  }
+  return text.replace(/\s+/g, " ").trim()
+}
+
+function turnLabel(userMessages: readonly CodemodeTimelineMessageInput[], turnIndex: number): string {
+  const message = userMessages[turnIndex]
+  const text = message ? messageText(message) : ""
+  if (!text) return `Turn ${turnIndex + 1}`
+  return text.length > USER_LABEL_MAX_CHARS ? `${text.slice(0, USER_LABEL_MAX_CHARS)}…` : text
+}
+
+function assignByTurnId(traces: readonly NormalizedTrace[]): Map<string, NormalizedTrace[]> {
+  const byTurn = new Map<string, NormalizedTrace[]>()
+  // Order turn ids by the earliest trace that carries them so turn indices read chronologically.
+  const turnOrder = new Map<string, number>()
+  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
+  for (const trace of sorted) {
+    const turnId = trace.turnId ?? "unassigned"
+    if (!turnOrder.has(turnId)) turnOrder.set(turnId, turnOrder.size)
+    const bucket = byTurn.get(turnId)
+    if (bucket) bucket.push(trace)
+    else byTurn.set(turnId, [trace])
+  }
+  return byTurn
+}
+
+/** Fallback turn count/boundaries when no `turn_id`: split the chronological run at each Plan phase. */
+function assignByPlanBoundary(traces: readonly NormalizedTrace[]): NormalizedTrace[][] {
+  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
+  const groups: NormalizedTrace[][] = []
+  for (const trace of sorted) {
+    const kind = tracePhase(trace).kind
+    if (groups.length === 0 || kind === "plan") {
+      groups.push([trace])
+    } else {
+      const last = groups[groups.length - 1]
+      if (last) last.push(trace)
+    }
+  }
+  return groups.length > 0 ? groups : [[]]
+}
+
+/** Window fallback (spec §"Turn grouping"): assign traces to turns by user-message timestamps. */
+function assignByMessageWindow(
+  traces: readonly NormalizedTrace[],
+  userMessages: readonly CodemodeTimelineMessageInput[],
+  sessionEndMs: number,
+): NormalizedTrace[][] {
+  const windows = userMessages.map((message, index) => ({
+    startMs: message.atMs ?? Number.NEGATIVE_INFINITY,
+    endMs: userMessages[index + 1]?.atMs ?? sessionEndMs,
+  }))
+  const groups: NormalizedTrace[][] = windows.map(() => [])
+  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
+  for (const trace of sorted) {
+    let turnIndex = 0
+    for (let i = 0; i < windows.length; i++) {
+      const window = windows[i]
+      if (window && trace.startMs >= window.startMs && trace.startMs < window.endMs) {
+        turnIndex = i
+        break
+      }
+      if (window && trace.startMs >= window.endMs) turnIndex = Math.min(i + 1, windows.length - 1)
+    }
+    groups[turnIndex]?.push(trace)
+  }
+  return groups
+}
+
+function buildTurn(
+  turnId: string,
+  turnIndex: number,
+  traces: readonly NormalizedTrace[],
+  userMessages: readonly CodemodeTimelineMessageInput[],
+): CodemodeRunTurn {
+  const nodes = traces
+    .slice()
+    .sort((a, b) => a.startMs - b.startMs)
+    .map(buildTraceNode)
+  const startMs = nodes.reduce((min, node) => Math.min(min, node.startMs), Number.POSITIVE_INFINITY)
+  const endMs = nodes.reduce((max, node) => Math.max(max, node.endMs), 0)
+  return {
+    turnId,
+    turnIndex,
+    label: turnLabel(userMessages, turnIndex),
+    startMs: Number.isFinite(startMs) ? startMs : 0,
+    endMs,
+    nodes,
+  }
+}
+
+export function buildCodemodeRunTimeline(input: BuildCodemodeRunTimelineInput): CodemodeRunTimeline {
+  const normalizedSpans = input.spans.map(normalizeSpan)
+  const spansByTrace = new Map<string, NormalizedSpan[]>()
+  for (const span of normalizedSpans) {
+    const bucket = spansByTrace.get(span.traceId)
+    if (bucket) bucket.push(span)
+    else spansByTrace.set(span.traceId, [span])
+  }
+
+  const traces = input.traces.map((trace) => normalizeTrace(trace, spansByTrace.get(trace.traceId) ?? []))
+  const userMessages = input.messages.filter((message) => message.role === "user")
+  const sessionEndMs = toMs(input.session.endTime)
+
+  const distinctTurnIds = new Set(
+    traces.map((trace) => trace.turnId).filter((turnId): turnId is string => turnId !== undefined),
+  )
+  const canGroupByTurnId = distinctTurnIds.size > 1 || (distinctTurnIds.size === 1 && userMessages.length <= 1)
+
+  let turns: CodemodeRunTurn[]
+  if (canGroupByTurnId && distinctTurnIds.size > 0) {
+    const byTurn = assignByTurnId(traces)
+    turns = [...byTurn.entries()].map(([turnId, group], index) => buildTurn(turnId, index, group, userMessages))
+  } else {
+    const hasTimestamps = userMessages.some((message) => message.atMs !== undefined)
+    const groups =
+      hasTimestamps && userMessages.length > 0
+        ? assignByMessageWindow(traces, userMessages, sessionEndMs)
+        : assignByPlanBoundary(traces)
+    turns = groups.map((group, index) => buildTurn(`${input.session.sessionId}:${index}`, index, group, userMessages))
+  }
+
+  turns.sort((a, b) => a.startMs - b.startMs || a.turnIndex - b.turnIndex)
+  return { turns: turns.map((turn, index) => ({ ...turn, turnIndex: index })) }
+}

--- a/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.ts
+++ b/apps/web/src/lib/codemode-run-timeline/build-codemode-run-timeline.ts
@@ -1,31 +1,43 @@
-// Pure, dependency-free construction of the session-drawer "Run" tree for
-// codemode orchestrations. Input shapes are structural subsets of the app's
-// `SpanRecord` / `TraceRecord` / `SessionDetailRecord` / `GenAIMessage` so the
-// UI can pass those records directly, while tests can supply richer fixtures
-// (including the `latitude.codemode.*` span attributes that the session-level
-// span collection does not yet serialize — see the module doc note below).
+// Pure, dependency-free construction of the session-drawer "Run" tree.
 //
-// Phase detection follows spec D6 priority: (1) `latitude.codemode.phase`
-// attribute, (2) `ai.telemetry.functionId` attribute, (3) operation + name
-// heuristics for legacy data. When no signal reaches high confidence a node is
-// emitted as "unlabeled" so legacy sessions still render top-to-bottom.
+// First principles: a session's traces are disconnected islands — OTel context
+// does NOT propagate across the sandbox / Durable-Object / isolate boundaries,
+// so `parentSpanId` links never cross a trace. The agent→sub-agent dependency
+// graph therefore is NOT in the waterfall; it has to be reconstructed from the
+// natural keys that already exist on the spans (no bespoke per-span telemetry
+// required beyond the sub-agent link):
+//
+//   • `ai.telemetry.functionId`        — native AI SDK; the node's role.
+//   • `latitude.agent_tool.run_id`     — the ONE irreducible cross-boundary edge:
+//                                        a delegate tool-call span and every span
+//                                        of the sub-agent trace it spawned share it.
+//   • `latitude.codemode.inner_tool`   — sandbox tool spans (attach under the code node).
+//   • operation + tool name            — code node (`execute_tool` + `codemode`).
+//
+// The engine is generic: any agent→sub-agent workload renders with the same
+// forest + run_id edge. Codemode is just the special case that inserts a
+// "code execution" node between an agent and its (sandbox) tools.
 
-export const CODEMODE_ATTR = {
-  phase: "latitude.codemode.phase",
+const CODEMODE_ATTR = {
   innerTool: "latitude.codemode.inner_tool",
-  turnId: "latitude.codemode.turn_id",
   parentToolCallId: "latitude.agent_tool.parent_tool_call_id",
   runId: "latitude.agent_tool.run_id",
   functionId: "ai.telemetry.functionId",
 } as const
 
-const FUNCTION_ID_PHASE: Readonly<Record<string, CodemodeRunNodeKind>> = {
+const FUNCTION_ID_KIND: Readonly<Record<string, CodemodeRunNodeKind>> = {
   "codemode-plan": "plan",
   "codemode-summary": "summarize",
+  "codemode-turn": "agent",
   "research-subagent-turn": "subagent",
 }
 
+/** functionIds that start a new turn (a main-agent entry for one user message). */
+const TURN_ENTRY_KINDS: ReadonlySet<CodemodeRunNodeKind> = new Set(["agent", "plan"])
+
 const USER_LABEL_MAX_CHARS = 80
+/** Slack allowed when matching an inner-tool trace into a code node's time window. */
+const CONTAINMENT_TOLERANCE_MS = 50
 
 export type CodemodeRunNodeKind = "plan" | "execute" | "innerTool" | "subagent" | "summarize" | "agent" | "unlabeled"
 
@@ -58,11 +70,9 @@ export interface CodemodeTimelineTraceInput {
 export interface CodemodeTimelineMessageInput {
   readonly role: string
   readonly parts?: readonly unknown[]
-  /** Optional wall-clock time; absent for `GenAIMessage`, present in fixtures that exercise the window fallback. */
-  readonly atMs?: number
 }
 
-export interface CodemodeTimelineSessionInput {
+interface CodemodeTimelineSessionInput {
   readonly sessionId: string
   readonly startTime: string
   readonly endTime: string
@@ -70,7 +80,7 @@ export interface CodemodeTimelineSessionInput {
 }
 
 export interface CodemodeRunNode {
-  /** Stable identity: the span id when the node is a span, otherwise the trace id. */
+  /** Stable identity: the span id the node maps to. */
   readonly id: string
   readonly kind: CodemodeRunNodeKind
   readonly label: string
@@ -80,14 +90,14 @@ export interface CodemodeRunNode {
   readonly isError: boolean
   readonly confidence: CodemodeRunConfidence
   readonly traceId: string
-  /** Set when the node maps to a specific span (span-detail navigation); null for whole-trace rows. */
-  readonly spanId: string | null
+  /** The span this node navigates to (always set — nodes are span-backed). */
+  readonly spanId: string
   readonly children: readonly CodemodeRunNode[]
   /** Short signal explaining why this step got its kind (shown muted in the Run tab). */
   readonly hint: string | null
 }
 
-export interface CodemodeRunTurn {
+interface CodemodeRunTurn {
   readonly turnId: string
   readonly turnIndex: number
   readonly label: string
@@ -96,11 +106,11 @@ export interface CodemodeRunTurn {
   readonly nodes: readonly CodemodeRunNode[]
 }
 
-export interface CodemodeRunTimeline {
+interface CodemodeRunTimeline {
   readonly turns: readonly CodemodeRunTurn[]
 }
 
-export interface BuildCodemodeRunTimelineInput {
+interface BuildCodemodeRunTimelineInput {
   readonly session: CodemodeTimelineSessionInput
   readonly traces: readonly CodemodeTimelineTraceInput[]
   readonly spans: readonly CodemodeTimelineSpanInput[]
@@ -117,22 +127,10 @@ interface NormalizedSpan {
   readonly startMs: number
   readonly endMs: number
   readonly isError: boolean
-  readonly phaseAttr: string | undefined
   readonly functionId: string | undefined
-  readonly turnId: string | undefined
+  readonly runId: string | undefined
+  readonly parentToolCallId: string | undefined
   readonly isInnerTool: boolean
-  readonly isSubagent: boolean
-}
-
-interface NormalizedTrace {
-  readonly traceId: string
-  readonly startMs: number
-  readonly endMs: number
-  readonly rootSpanName: string
-  readonly isError: boolean
-  readonly metadata: Readonly<Record<string, string>>
-  readonly spans: readonly NormalizedSpan[]
-  readonly turnId: string | undefined
 }
 
 const toMs = (iso: string): number => {
@@ -144,15 +142,6 @@ const attrBool = (span: CodemodeTimelineSpanInput, key: string): boolean =>
   span.attrBool?.[key] === true || span.attrString?.[key] === "true"
 
 function normalizeSpan(span: CodemodeTimelineSpanInput): NormalizedSpan {
-  const phaseAttr = span.attrString?.[CODEMODE_ATTR.phase]
-  const functionId = span.attrString?.[CODEMODE_ATTR.functionId]
-  const turnId = span.attrString?.[CODEMODE_ATTR.turnId]
-  const isInnerTool = attrBool(span, CODEMODE_ATTR.innerTool)
-  const isSubagent =
-    functionId === "research-subagent-turn" ||
-    phaseAttr === "subagent" ||
-    span.attrString?.[CODEMODE_ATTR.runId] !== undefined ||
-    span.attrString?.[CODEMODE_ATTR.parentToolCallId] !== undefined
   return {
     spanId: span.spanId,
     parentSpanId: span.parentSpanId,
@@ -163,156 +152,59 @@ function normalizeSpan(span: CodemodeTimelineSpanInput): NormalizedSpan {
     startMs: toMs(span.startTime),
     endMs: toMs(span.endTime),
     isError: span.statusCode === "error",
-    phaseAttr,
-    functionId,
-    turnId,
-    isInnerTool,
-    isSubagent,
+    functionId: span.attrString?.[CODEMODE_ATTR.functionId],
+    runId: span.attrString?.[CODEMODE_ATTR.runId],
+    parentToolCallId: span.attrString?.[CODEMODE_ATTR.parentToolCallId],
+    isInnerTool: attrBool(span, CODEMODE_ATTR.innerTool),
   }
 }
 
-const isCodemodeExecuteSpan = (span: NormalizedSpan): boolean =>
-  span.operation === "execute_tool" && (span.toolName === "codemode" || / codemode$/i.test(span.name))
+const isToolSpan = (span: NormalizedSpan): boolean => span.operation === "execute_tool"
 
-const isToolCallSpan = (span: NormalizedSpan): boolean => span.operation === "execute_tool"
+const isCodeExecuteSpan = (span: NormalizedSpan): boolean =>
+  isToolSpan(span) && (span.toolName === "codemode" || / codemode$/i.test(span.name))
 
-/** Phase from an individual span using D6 priorities 1→2→3. Returns undefined when nothing matches. */
-function spanPhase(span: NormalizedSpan): { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } | undefined {
-  if (isCodemodeExecuteSpan(span)) return { kind: "execute", confidence: "high" }
-  if (span.phaseAttr === "plan" || span.phaseAttr === "execute" || span.phaseAttr === "summarize") {
-    return { kind: span.phaseAttr, confidence: "high" }
-  }
-  if (span.functionId === "codemode-turn") {
-    if (isCodemodeExecuteSpan(span)) return { kind: "execute", confidence: "high" }
-    return undefined
-  }
-  if (span.functionId && FUNCTION_ID_PHASE[span.functionId]) {
-    return { kind: FUNCTION_ID_PHASE[span.functionId] as CodemodeRunNodeKind, confidence: "high" }
-  }
-  if (span.isSubagent) return { kind: "subagent", confidence: "high" }
-  if (span.isInnerTool && isToolCallSpan(span)) return { kind: "innerTool", confidence: "high" }
-  if (/generateText/i.test(span.name)) return { kind: "plan", confidence: "low" }
-  if (/streamText/i.test(span.name) && span.functionId === "codemode-summary") {
-    return { kind: "summarize", confidence: "high" }
-  }
-  if (/streamText/i.test(span.name)) return { kind: "summarize", confidence: "low" }
-  return undefined
+/** A bare AI-SDK `ai.toolCall` wrapper (no concrete tool) — structural noise we collapse through. */
+const isToolWrapperSpan = (span: NormalizedSpan): boolean =>
+  isToolSpan(span) && span.toolName === "" && /^ai\.toolCall$/i.test(span.name.trim())
+
+const isAgentSpan = (span: NormalizedSpan): boolean => span.operation === "invoke_agent"
+
+/** Kept nodes are the meaningful steps: agent turns, the code node, and concrete tool calls. */
+function isMeaningful(span: NormalizedSpan): boolean {
+  if (isAgentSpan(span)) return true
+  if (isCodeExecuteSpan(span)) return true
+  if (isToolSpan(span) && !isToolWrapperSpan(span)) return true
+  return false
 }
 
-function pickTurnId(spans: readonly NormalizedSpan[]): string | undefined {
-  for (const span of spans) {
-    if (span.turnId) return span.turnId
-  }
-  return undefined
-}
-
-function normalizeTrace(trace: CodemodeTimelineTraceInput, spans: readonly NormalizedSpan[]): NormalizedTrace {
-  return {
-    traceId: trace.traceId,
-    startMs: toMs(trace.startTime),
-    endMs: toMs(trace.endTime),
-    rootSpanName: trace.rootSpanName,
-    isError: trace.errorCount > 0 || spans.some((s) => s.isError),
-    metadata: trace.metadata ?? {},
-    spans,
-    turnId: trace.metadata?.[CODEMODE_ATTR.turnId] ?? pickTurnId(spans),
-  }
-}
-
-const SUBAGENT_METADATA_HINT = /subagent|sub-agent/i
-
-function standaloneInnerToolSpan(trace: NormalizedTrace): NormalizedSpan | undefined {
-  const toolSpans = trace.spans.filter((span) => isToolCallSpan(span) && !isCodemodeExecuteSpan(span))
-  if (toolSpans.length !== 1) return undefined
-  const only = toolSpans[0]
-  if (!only?.isInnerTool) return undefined
-  const nonToolSpans = trace.spans.filter((span) => !isToolCallSpan(span))
-  if (
-    nonToolSpans.some((span) => {
-      const phase = spanPhase(span)
-      return (
-        phase?.kind === "subagent" || phase?.kind === "plan" || phase?.kind === "summarize" || phase?.kind === "execute"
-      )
-    })
-  ) {
-    return undefined
-  }
-  return only
-}
-
-function toolChildSpans(trace: NormalizedTrace, kind: CodemodeRunNodeKind): NormalizedSpan[] {
-  if (kind === "execute") return innerToolSpans(trace)
-  if (kind === "subagent") {
-    return trace.spans.filter((span) => isToolCallSpan(span) && span.isInnerTool).sort((a, b) => a.startMs - b.startMs)
-  }
-  return []
-}
-
-function spanToChildNode(span: NormalizedSpan): CodemodeRunNode {
-  return {
-    id: span.spanId,
-    kind: "innerTool",
-    label: innerToolLabel(span),
-    startMs: span.startMs,
-    endMs: span.endMs,
-    durationMs: Math.max(0, span.endMs - span.startMs),
-    isError: span.isError,
-    confidence: "high",
-    traceId: span.traceId,
-    spanId: span.spanId,
-    children: [],
-    hint: "inner sandbox tool",
-  }
-}
-function tracePhase(trace: NormalizedTrace): { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } {
-  let fallback: { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } | undefined
-  for (const span of trace.spans) {
-    const detected = spanPhase(span)
-    if (!detected) continue
-    if (detected.confidence === "high") return detected
-    fallback = fallback ?? detected
-  }
-
-  const metaRole = trace.metadata.role ?? ""
-  if (SUBAGENT_METADATA_HINT.test(metaRole)) return { kind: "subagent", confidence: "high" }
-
-  if (
-    trace.spans.length > 0 &&
-    trace.spans.every((span) => span.functionId === "codemode-turn") &&
-    trace.spans.every((span) => /streamText/i.test(span.name) || span.operation === "chat")
-  ) {
-    return { kind: "agent", confidence: "high" }
-  }
-
-  const rootName = trace.rootSpanName
-  if (/ codemode$/i.test(rootName) || /toolCall codemode/i.test(rootName)) {
-    return { kind: "execute", confidence: "low" }
-  }
-  if (/generateText/i.test(rootName)) return { kind: "plan", confidence: "low" }
-  if (/streamText/i.test(rootName) && trace.spans.some((span) => span.functionId === "codemode-summary")) {
-    return { kind: "summarize", confidence: "high" }
-  }
-  if (/streamText/i.test(rootName)) return { kind: "summarize", confidence: "low" }
-
-  const loneInnerTool = standaloneInnerToolSpan(trace)
-  if (loneInnerTool) return { kind: "innerTool", confidence: "high" }
-
-  return fallback ?? { kind: "unlabeled", confidence: "low" }
-}
-
-/** Inner-tool spans of the execute trace: explicit `inner_tool` flag, else tool-call spans that aren't the codemode call itself. */
-function innerToolSpans(trace: NormalizedTrace): NormalizedSpan[] {
-  const explicit = trace.spans.filter((s) => s.isInnerTool)
-  if (explicit.length > 0) return explicit.slice().sort((a, b) => a.startMs - b.startMs)
-  return trace.spans.filter((s) => isToolCallSpan(s) && !isCodemodeExecuteSpan(s)).sort((a, b) => a.startMs - b.startMs)
-}
-
-function innerToolLabel(span: NormalizedSpan): string {
+function toolLabel(span: NormalizedSpan): string {
   if (span.toolName) return span.toolName
-  return span.name.replace(/^ai\.toolCall\s+/i, "") || span.name
+  return span.name.replace(/^ai\.toolCall\s+/i, "").trim() || span.name
 }
 
-function phaseLabel(kind: CodemodeRunNodeKind, trace: NormalizedTrace): string {
+function spanKind(
+  span: NormalizedSpan,
+  viaSubagentEdge: boolean,
+): { kind: CodemodeRunNodeKind; confidence: CodemodeRunConfidence } {
+  if (isCodeExecuteSpan(span)) return { kind: "execute", confidence: "high" }
+  if (isToolSpan(span)) return { kind: "innerTool", confidence: "high" }
+
+  // invoke_agent from here down.
+  if (span.functionId && FUNCTION_ID_KIND[span.functionId]) {
+    return { kind: FUNCTION_ID_KIND[span.functionId] as CodemodeRunNodeKind, confidence: "high" }
+  }
+  if (viaSubagentEdge || span.runId !== undefined) return { kind: "subagent", confidence: "high" }
+  if (/generateText/i.test(span.name)) return { kind: "plan", confidence: "low" }
+  if (/streamText/i.test(span.name)) return { kind: "summarize", confidence: "low" }
+  return { kind: "unlabeled", confidence: "low" }
+}
+
+function nodeLabel(
+  kind: CodemodeRunNodeKind,
+  span: NormalizedSpan,
+  traceMeta: Readonly<Record<string, string>> | undefined,
+): string {
   switch (kind) {
     case "plan":
       return "Plan"
@@ -322,72 +214,64 @@ function phaseLabel(kind: CodemodeRunNodeKind, trace: NormalizedTrace): string {
       return "Summarize"
     case "agent":
       return "Agent response"
-    case "innerTool": {
-      const toolSpan = standaloneInnerToolSpan(trace) ?? trace.spans.find((span) => span.isInnerTool)
-      return toolSpan ? innerToolLabel(toolSpan) : trace.rootSpanName || "Tool"
-    }
+    case "innerTool":
+      return toolLabel(span)
     case "subagent": {
-      const role = trace.metadata.role
+      const role = traceMeta?.role
       return role ? `Sub-agent · ${role}` : "Sub-agent"
     }
     default:
-      return trace.rootSpanName || "Unlabeled phase"
+      return span.name || "Unlabeled step"
   }
 }
 
-function phaseHint(kind: CodemodeRunNodeKind, trace: NormalizedTrace): string | null {
+function nodeHint(kind: CodemodeRunNodeKind, span: NormalizedSpan): string | null {
   switch (kind) {
     case "plan":
-      return trace.spans.some((span) => span.functionId === "codemode-plan")
-        ? "generateText · codemode-plan"
-        : "generateText"
+      return span.functionId ? `${span.name} · ${span.functionId}` : span.name
     case "agent":
-      return "streamText · codemode-turn (main agent, not sandbox)"
+      return span.functionId ? `${span.name} · ${span.functionId}` : "main agent"
     case "execute":
       return "execute_tool · codemode"
     case "summarize":
-      return trace.spans.some((span) => span.functionId === "codemode-summary")
-        ? "streamText · codemode-summary"
-        : "streamText"
+      return span.functionId ? `${span.name} · ${span.functionId}` : span.name
     case "subagent":
-      return trace.metadata.role ? `sub-agent · ${trace.metadata.role}` : "research-subagent-turn"
+      return span.functionId ?? "sub-agent"
     case "innerTool":
-      return "inner sandbox tool"
+      return span.isInnerTool ? "inner sandbox tool" : "tool call"
     default:
       return null
   }
 }
 
-function buildTraceNode(trace: NormalizedTrace): CodemodeRunNode {
-  const loneInnerTool = standaloneInnerToolSpan(trace)
-  if (loneInnerTool) {
-    return {
-      ...spanToChildNode(loneInnerTool),
-      kind: "innerTool",
-      label: innerToolLabel(loneInnerTool),
+/**
+ * Resolve the cross-trace parent of a trace-root span (a span whose `parentSpanId`
+ * is not in the session). Returns the span id it should nest under, or undefined.
+ */
+function resolveCrossParent(
+  root: NormalizedSpan,
+  codeExecuteSpans: readonly NormalizedSpan[],
+  delegateByRunId: ReadonlyMap<string, NormalizedSpan>,
+): string | undefined {
+  // Sub-agent trace → the delegate tool-call span that spawned it (shared run_id, different trace).
+  if (isAgentSpan(root) && root.runId !== undefined) {
+    const delegate = delegateByRunId.get(root.runId)
+    if (delegate && delegate.traceId !== root.traceId) return delegate.spanId
+  }
+  // Inner sandbox tool trace → the code node whose execution window contains it.
+  if (isToolSpan(root) && root.isInnerTool && !isCodeExecuteSpan(root)) {
+    const container = codeExecuteSpans.find(
+      (exec) =>
+        exec.spanId !== root.spanId &&
+        root.startMs >= exec.startMs - CONTAINMENT_TOLERANCE_MS &&
+        root.startMs <= exec.endMs + CONTAINMENT_TOLERANCE_MS,
+    )
+    if (container) return container.spanId
+    if (codeExecuteSpans.length === 1 && codeExecuteSpans[0]!.spanId !== root.spanId) {
+      return codeExecuteSpans[0]!.spanId
     }
   }
-
-  const { kind, confidence } = tracePhase(trace)
-  const children: CodemodeRunNode[] = toolChildSpans(trace, kind).map(spanToChildNode)
-
-  const primarySpan =
-    kind === "innerTool" ? (trace.spans.find((span) => span.isInnerTool && isToolCallSpan(span)) ?? null) : null
-
-  return {
-    id: primarySpan?.spanId ?? trace.traceId,
-    kind,
-    label: phaseLabel(kind, trace),
-    startMs: trace.startMs,
-    endMs: trace.endMs,
-    durationMs: Math.max(0, trace.endMs - trace.startMs),
-    isError: trace.isError,
-    confidence,
-    traceId: trace.traceId,
-    spanId: primarySpan?.spanId ?? null,
-    children,
-    hint: phaseHint(kind, trace),
-  }
+  return undefined
 }
 
 function messageText(message: CodemodeTimelineMessageInput): string {
@@ -402,123 +286,111 @@ function messageText(message: CodemodeTimelineMessageInput): string {
 }
 
 function turnLabel(userMessages: readonly CodemodeTimelineMessageInput[], turnIndex: number): string {
-  const message = userMessages[turnIndex]
-  const text = message ? messageText(message) : ""
+  const text = userMessages[turnIndex] ? messageText(userMessages[turnIndex]!) : ""
   if (!text) return `Turn ${turnIndex + 1}`
   return text.length > USER_LABEL_MAX_CHARS ? `${text.slice(0, USER_LABEL_MAX_CHARS)}…` : text
 }
 
-function assignByTurnId(traces: readonly NormalizedTrace[]): Map<string, NormalizedTrace[]> {
-  const byTurn = new Map<string, NormalizedTrace[]>()
-  // Order turn ids by the earliest trace that carries them so turn indices read chronologically.
-  const turnOrder = new Map<string, number>()
-  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
-  for (const trace of sorted) {
-    const turnId = trace.turnId ?? "unassigned"
-    if (!turnOrder.has(turnId)) turnOrder.set(turnId, turnOrder.size)
-    const bucket = byTurn.get(turnId)
-    if (bucket) bucket.push(trace)
-    else byTurn.set(turnId, [trace])
-  }
-  return byTurn
-}
+export function buildCodemodeRunTimeline(input: BuildCodemodeRunTimelineInput): CodemodeRunTimeline {
+  const spans = input.spans.map(normalizeSpan)
+  const spansById = new Map(spans.map((span) => [span.spanId, span]))
+  const traceMetaById = new Map(input.traces.map((trace) => [trace.traceId, trace.metadata ?? {}]))
 
-/** Fallback turn count/boundaries when no `turn_id`: split the chronological run at each Plan phase. */
-function assignByPlanBoundary(traces: readonly NormalizedTrace[]): NormalizedTrace[][] {
-  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
-  const groups: NormalizedTrace[][] = []
-  for (const trace of sorted) {
-    const kind = tracePhase(trace).kind
-    if (groups.length === 0 || kind === "plan") {
-      groups.push([trace])
-    } else {
-      const last = groups[groups.length - 1]
-      if (last) last.push(trace)
+  const codeExecuteSpans = spans.filter(isCodeExecuteSpan)
+  // A delegate is the tool-call span that spawned a sub-agent (shares its run_id). A sub-agent's
+  // OWN tool spans also inherit run_id, so prefer the tool span carrying parent_tool_call_id, then
+  // a trace-root tool span, before any other tool span with that run_id.
+  const delegateByRunId = new Map<string, NormalizedSpan>()
+  const delegateRank = (span: NormalizedSpan): number => {
+    if (span.parentToolCallId !== undefined) return 2
+    if (span.parentSpanId === "" || !spansById.has(span.parentSpanId)) return 1
+    return 0
+  }
+  for (const span of spans) {
+    if (!isToolSpan(span) || span.runId === undefined) continue
+    const current = delegateByRunId.get(span.runId)
+    if (!current || delegateRank(span) > delegateRank(current)) delegateByRunId.set(span.runId, span)
+  }
+
+  // Adjacency across the whole session: intra-trace parentSpanId + cross-trace edges.
+  const childrenByParent = new Map<string, NormalizedSpan[]>()
+  const rootSpans: NormalizedSpan[] = []
+  const subagentEdgeChildren = new Set<string>()
+  const addChild = (parentId: string, child: NormalizedSpan) => {
+    const bucket = childrenByParent.get(parentId)
+    if (bucket) bucket.push(child)
+    else childrenByParent.set(parentId, [child])
+  }
+
+  for (const span of spans) {
+    const intraParent = span.parentSpanId ? spansById.get(span.parentSpanId) : undefined
+    if (intraParent) {
+      addChild(intraParent.spanId, span)
+      continue
     }
-  }
-  return groups.length > 0 ? groups : [[]]
-}
-
-/** Window fallback (spec §"Turn grouping"): assign traces to turns by user-message timestamps. */
-function assignByMessageWindow(
-  traces: readonly NormalizedTrace[],
-  userMessages: readonly CodemodeTimelineMessageInput[],
-  sessionEndMs: number,
-): NormalizedTrace[][] {
-  const windows = userMessages.map((message, index) => ({
-    startMs: message.atMs ?? Number.NEGATIVE_INFINITY,
-    endMs: userMessages[index + 1]?.atMs ?? sessionEndMs,
-  }))
-  const groups: NormalizedTrace[][] = windows.map(() => [])
-  const sorted = traces.slice().sort((a, b) => a.startMs - b.startMs)
-  for (const trace of sorted) {
-    let turnIndex = 0
-    for (let i = 0; i < windows.length; i++) {
-      const window = windows[i]
-      if (window && trace.startMs >= window.startMs && trace.startMs < window.endMs) {
-        turnIndex = i
-        break
-      }
-      if (window && trace.startMs >= window.endMs) turnIndex = Math.min(i + 1, windows.length - 1)
+    const crossParent = resolveCrossParent(span, codeExecuteSpans, delegateByRunId)
+    if (crossParent) {
+      addChild(crossParent, span)
+      if (isAgentSpan(span) && span.runId !== undefined) subagentEdgeChildren.add(span.spanId)
+      continue
     }
-    groups[turnIndex]?.push(trace)
+    rootSpans.push(span)
   }
-  return groups
-}
 
-function buildTurn(
-  turnId: string,
-  turnIndex: number,
-  traces: readonly NormalizedTrace[],
-  userMessages: readonly CodemodeTimelineMessageInput[],
-): CodemodeRunTurn {
-  const nodes = traces
+  // Collapse structural noise (chat spans, bare tool wrappers), promoting kept descendants.
+  const seen = new Set<string>()
+  const collectKept = (span: NormalizedSpan): CodemodeRunNode[] => {
+    if (seen.has(span.spanId)) return []
+    seen.add(span.spanId)
+    const rawChildren = (childrenByParent.get(span.spanId) ?? []).slice().sort((a, b) => a.startMs - b.startMs)
+    const childNodes = rawChildren.flatMap(collectKept)
+    if (!isMeaningful(span)) return childNodes
+    const { kind, confidence } = spanKind(span, subagentEdgeChildren.has(span.spanId))
+    return [
+      {
+        id: span.spanId,
+        kind,
+        label: nodeLabel(kind, span, traceMetaById.get(span.traceId)),
+        startMs: span.startMs,
+        endMs: span.endMs,
+        durationMs: Math.max(0, span.endMs - span.startMs),
+        isError: span.isError,
+        confidence,
+        traceId: span.traceId,
+        spanId: span.spanId,
+        children: childNodes,
+        hint: nodeHint(kind, span),
+      },
+    ]
+  }
+
+  const forest = rootSpans
     .slice()
     .sort((a, b) => a.startMs - b.startMs)
-    .map(buildTraceNode)
-  const startMs = nodes.reduce((min, node) => Math.min(min, node.startMs), Number.POSITIVE_INFINITY)
-  const endMs = nodes.reduce((max, node) => Math.max(max, node.endMs), 0)
-  return {
-    turnId,
-    turnIndex,
-    label: turnLabel(userMessages, turnIndex),
-    startMs: Number.isFinite(startMs) ? startMs : 0,
-    endMs,
-    nodes,
-  }
-}
+    .flatMap(collectKept)
 
-export function buildCodemodeRunTimeline(input: BuildCodemodeRunTimelineInput): CodemodeRunTimeline {
-  const normalizedSpans = input.spans.map(normalizeSpan)
-  const spansByTrace = new Map<string, NormalizedSpan[]>()
-  for (const span of normalizedSpans) {
-    const bucket = spansByTrace.get(span.traceId)
-    if (bucket) bucket.push(span)
-    else spansByTrace.set(span.traceId, [span])
-  }
-
-  const traces = input.traces.map((trace) => normalizeTrace(trace, spansByTrace.get(trace.traceId) ?? []))
+  // Turn grouping: a new turn begins at each main-agent entry (agent/plan). Sub-agent,
+  // tool, code and summarize roots join the current turn. No turn_id / message-count coupling.
   const userMessages = input.messages.filter((message) => message.role === "user")
-  const sessionEndMs = toMs(input.session.endTime)
-
-  const distinctTurnIds = new Set(
-    traces.map((trace) => trace.turnId).filter((turnId): turnId is string => turnId !== undefined),
-  )
-  const canGroupByTurnId = distinctTurnIds.size > 1 || (distinctTurnIds.size === 1 && userMessages.length <= 1)
-
-  let turns: CodemodeRunTurn[]
-  if (canGroupByTurnId && distinctTurnIds.size > 0) {
-    const byTurn = assignByTurnId(traces)
-    turns = [...byTurn.entries()].map(([turnId, group], index) => buildTurn(turnId, index, group, userMessages))
-  } else {
-    const hasTimestamps = userMessages.some((message) => message.atMs !== undefined)
-    const groups =
-      hasTimestamps && userMessages.length > 0
-        ? assignByMessageWindow(traces, userMessages, sessionEndMs)
-        : assignByPlanBoundary(traces)
-    turns = groups.map((group, index) => buildTurn(`${input.session.sessionId}:${index}`, index, group, userMessages))
+  const turnsNodes: CodemodeRunNode[][] = []
+  for (const node of forest) {
+    if (turnsNodes.length === 0 || TURN_ENTRY_KINDS.has(node.kind)) turnsNodes.push([node])
+    else turnsNodes[turnsNodes.length - 1]!.push(node)
   }
+  if (turnsNodes.length === 0) turnsNodes.push([])
 
-  turns.sort((a, b) => a.startMs - b.startMs || a.turnIndex - b.turnIndex)
-  return { turns: turns.map((turn, index) => ({ ...turn, turnIndex: index })) }
+  const turns: CodemodeRunTurn[] = turnsNodes.map((nodes, index) => {
+    const startMs = nodes.reduce((min, node) => Math.min(min, node.startMs), Number.POSITIVE_INFINITY)
+    const endMs = nodes.reduce((max, node) => Math.max(max, node.endMs), 0)
+    return {
+      turnId: `${input.session.sessionId}:${index}`,
+      turnIndex: index,
+      label: turnLabel(userMessages, index),
+      startMs: Number.isFinite(startMs) ? startMs : 0,
+      endMs,
+      nodes,
+    }
+  })
+
+  return { turns }
 }

--- a/apps/web/src/lib/conversation/use-enriched-conversation-messages.ts
+++ b/apps/web/src/lib/conversation/use-enriched-conversation-messages.ts
@@ -1,0 +1,45 @@
+import { SpanId } from "@domain/shared"
+import { enrichConversationToolCalls, type SpanMessagesData } from "@domain/spans"
+import { useMemo } from "react"
+import type { GenAIMessage } from "rosetta-ai"
+import { useConversationMessageSpans } from "../../domains/spans/spans.collection.ts"
+import type { SpanMessagesRecord } from "../../domains/spans/spans.functions.ts"
+
+const toMessageSpans = (records: readonly SpanMessagesRecord[]): readonly SpanMessagesData[] =>
+  records.map((record) => ({
+    spanId: SpanId(record.spanId),
+    operation: record.operation,
+    toolCallId: record.toolCallId,
+    toolName: record.toolName,
+    toolInput: record.toolInput,
+    toolOutput: record.toolOutput,
+    inputMessages: record.inputMessages as readonly GenAIMessage[],
+    outputMessages: record.outputMessages as readonly GenAIMessage[],
+  }))
+
+export function useEnrichedConversationMessages(
+  messages: readonly GenAIMessage[],
+  {
+    projectId,
+    traceId,
+    startTime,
+    enabled = true,
+  }: {
+    readonly projectId: string
+    readonly traceId: string
+    readonly startTime: string | undefined
+    readonly enabled?: boolean
+  },
+): readonly GenAIMessage[] {
+  const { data: messageSpans } = useConversationMessageSpans({
+    projectId,
+    traceId,
+    startTime,
+    enabled: enabled && messages.length > 0,
+  })
+
+  return useMemo(() => {
+    if (!messageSpans?.length) return messages
+    return enrichConversationToolCalls(messages, toMessageSpans(messageSpans))
+  }, [messages, messageSpans])
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -25,6 +25,8 @@ export type OpenTraceOptions = {
   readonly focusAnnotationId?: string
   /** Overrides which tab the trace slot lands on. Defaults: `conversation` with focus, otherwise `trace`. */
   readonly targetTab?: TraceDetailTabId
+  /** Selects a span in the trace slot's Spans tab (Run-tab span-detail navigation). Implies `spans` as the default tab. */
+  readonly spanId?: string
 }
 
 export function SessionDetailDrawer({
@@ -53,7 +55,11 @@ export function SessionDetailDrawer({
 }) {
   const [traceId, setTraceId] = useParamState("traceId", "")
   const [signalId, setSignalId] = useParamState("signalId", "")
+  const [, setSelectedSpanId] = useParamState("spanId", "")
   const [, setFocusAnnotationId] = useParamState("annotationId", "")
+  const [, setSpanErrors] = useParamState("spanErrors", false)
+  const [, setSpanTools] = useParamState("spanTools", false)
+  const [, setSpanModel] = useParamState("spanModel", "")
   const [q] = useParamState("q", "")
   // Land on the conversation tab when arriving from an active search, so the
   // conversation tab's search-match autoscroll/highlight has something to scroll to.
@@ -110,10 +116,18 @@ export function SessionDetailDrawer({
     traceId.length > 0 ? "trace" : signalId.length > 0 && signalsEnabled ? "issue" : null
   const showDetail = detailKind !== null && !isSessionMissing
 
+  const clearSpanFilters = () => {
+    setSpanErrors(false)
+    setSpanTools(false)
+    setSpanModel("")
+  }
+
   const openTrace = (nextTraceId: string, options: OpenTraceOptions = {}) => {
-    const { focusAnnotationId, targetTab } = options
+    const { focusAnnotationId, targetTab, spanId } = options
     setFocusAnnotationId(focusAnnotationId ?? "")
-    setTraceTab(targetTab ?? (focusAnnotationId ? "conversation" : "trace"))
+    if (spanId) clearSpanFilters()
+    setSelectedSpanId(spanId ?? "")
+    setTraceTab(targetTab ?? (spanId ? "spans" : focusAnnotationId ? "conversation" : "trace"))
     setTraceId(nextTraceId)
   }
 
@@ -130,12 +144,18 @@ export function SessionDetailDrawer({
 
   const backToSession = () => {
     setFocusAnnotationId("")
+    setSelectedSpanId("")
+    setTraceTab("trace")
+    clearSpanFilters()
     setTraceId("")
     setSignalId("")
   }
 
   const handleClose = () => {
     setFocusAnnotationId("")
+    setSelectedSpanId("")
+    setTraceTab("trace")
+    clearSpanFilters()
     setTraceId("")
     setSignalId("")
     onClose()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/run-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/run-tab.tsx
@@ -1,0 +1,175 @@
+import { Icon, Skeleton, Status, Text } from "@repo/ui"
+import type { LucideIcon } from "lucide-react"
+import {
+  BotIcon,
+  CircleDashedIcon,
+  ClipboardListIcon,
+  MessageSquareIcon,
+  ScrollTextIcon,
+  TerminalIcon,
+  WrenchIcon,
+} from "lucide-react"
+import { useMemo } from "react"
+import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
+import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
+import { useTraceConversationMessages, useTraceDetail } from "../../../../../../domains/traces/traces.collection.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import {
+  buildCodemodeRunTimeline,
+  type CodemodeRunNode,
+  type CodemodeRunNodeKind,
+} from "../../../../../../lib/codemode-run-timeline/build-codemode-run-timeline.ts"
+import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
+import { formatDuration } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+
+const KIND_ICON: Record<CodemodeRunNodeKind, LucideIcon> = {
+  plan: ClipboardListIcon,
+  execute: TerminalIcon,
+  innerTool: WrenchIcon,
+  subagent: BotIcon,
+  summarize: ScrollTextIcon,
+  agent: MessageSquareIcon,
+  unlabeled: CircleDashedIcon,
+}
+
+function RunRow({
+  node,
+  depth,
+  onOpen,
+}: {
+  readonly node: CodemodeRunNode
+  readonly depth: number
+  readonly onOpen: (node: CodemodeRunNode) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(node)}
+      className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      style={{ paddingLeft: `${depth * 1.25 + 0.5}rem` }}
+    >
+      <Icon icon={KIND_ICON[node.kind]} size="sm" color="foregroundMuted" className="shrink-0" />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <Text.H5 ellipsis noWrap>
+          {node.label}
+        </Text.H5>
+        {node.hint ? (
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {node.hint}
+          </Text.H6>
+        ) : null}
+      </div>
+      {node.kind === "unlabeled" ? (
+        <Status variant="neutral" indicator={false} label="Unlabeled" className="shrink-0" />
+      ) : null}
+      <Text.H6 color="foregroundMuted" noWrap className="shrink-0">
+        {formatDuration(node.durationMs)}
+      </Text.H6>
+      {node.isError ? <Status variant="destructive" indicator={false} label="error" className="shrink-0" /> : null}
+    </button>
+  )
+}
+
+export function RunTab({
+  projectId,
+  session,
+  traces,
+  latestTraceId,
+  onOpenTrace,
+}: {
+  readonly projectId: string
+  readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
+  readonly latestTraceId: string
+  readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
+}) {
+  const { data: spans, isLoading: isSpansLoading } = useSpansBySessionCollection({
+    projectId,
+    sessionId: session.sessionId,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const { data: traceDetail } = useTraceDetail({ projectId, traceId: latestTraceId })
+  const conversation = useTraceConversationMessages({
+    projectId,
+    traceId: latestTraceId,
+    enabled: traceDetail != null,
+  })
+
+  const timeline = useMemo(() => {
+    const messages =
+      conversation.messages.length > 0 ? conversation.messages : [...session.inputMessages, ...session.outputMessages]
+    return buildCodemodeRunTimeline({
+      session: {
+        sessionId: session.sessionId,
+        startTime: session.startTime,
+        endTime: session.endTime,
+        traceIds: session.traceIds,
+      },
+      traces,
+      spans: spans ?? [],
+      messages,
+    })
+  }, [
+    session.sessionId,
+    session.startTime,
+    session.endTime,
+    session.traceIds,
+    session.inputMessages,
+    session.outputMessages,
+    traces,
+    spans,
+    conversation.messages,
+  ])
+
+  const openNode = (node: CodemodeRunNode) => {
+    if (node.spanId) onOpenTrace(node.traceId, { spanId: node.spanId, targetTab: "spans" })
+    else onOpenTrace(node.traceId)
+  }
+
+  if (isSpansLoading && (spans?.length ?? 0) === 0) {
+    return (
+      <div className="flex flex-col gap-3 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-2/3" />
+      </div>
+    )
+  }
+
+  if (timeline.turns.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-6 py-10">
+        <Text.H5 color="foregroundMuted">No run steps in this session.</Text.H5>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-4 py-6">
+      {timeline.turns.map((turn) => (
+        <div key={turn.turnId} className="flex flex-col gap-1.5">
+          <div className="flex items-baseline gap-2 px-2">
+            <Text.H6 color="foregroundMuted" noWrap>
+              Turn {turn.turnIndex + 1}
+            </Text.H6>
+            <Text.H5 ellipsis noWrap>
+              {turn.label}
+            </Text.H5>
+          </div>
+          <div className="flex flex-col">
+            {turn.nodes.map((node) => (
+              <div key={node.id} className="flex flex-col">
+                <RunRow node={node} depth={0} onOpen={openNode} />
+                {node.children.map((child) => (
+                  <RunRow key={child.id} node={child} depth={1} onOpen={openNode} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/run-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/run-tab.tsx
@@ -42,31 +42,36 @@ function RunRow({
   readonly onOpen: (node: CodemodeRunNode) => void
 }) {
   return (
-    <button
-      type="button"
-      onClick={() => onOpen(node)}
-      className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      style={{ paddingLeft: `${depth * 1.25 + 0.5}rem` }}
-    >
-      <Icon icon={KIND_ICON[node.kind]} size="sm" color="foregroundMuted" className="shrink-0" />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <Text.H5 ellipsis noWrap>
-          {node.label}
-        </Text.H5>
-        {node.hint ? (
-          <Text.H6 color="foregroundMuted" ellipsis noWrap>
-            {node.hint}
-          </Text.H6>
+    <>
+      <button
+        type="button"
+        onClick={() => onOpen(node)}
+        className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        style={{ paddingLeft: `${depth * 1.25 + 0.5}rem` }}
+      >
+        <Icon icon={KIND_ICON[node.kind]} size="sm" color="foregroundMuted" className="shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <Text.H5 ellipsis noWrap>
+            {node.label}
+          </Text.H5>
+          {node.hint ? (
+            <Text.H6 color="foregroundMuted" ellipsis noWrap>
+              {node.hint}
+            </Text.H6>
+          ) : null}
+        </div>
+        {node.kind === "unlabeled" ? (
+          <Status variant="neutral" indicator={false} label="Unlabeled" className="shrink-0" />
         ) : null}
-      </div>
-      {node.kind === "unlabeled" ? (
-        <Status variant="neutral" indicator={false} label="Unlabeled" className="shrink-0" />
-      ) : null}
-      <Text.H6 color="foregroundMuted" noWrap className="shrink-0">
-        {formatDuration(node.durationMs)}
-      </Text.H6>
-      {node.isError ? <Status variant="destructive" indicator={false} label="error" className="shrink-0" /> : null}
-    </button>
+        <Text.H6 color="foregroundMuted" noWrap className="shrink-0">
+          {formatDuration(node.durationMs)}
+        </Text.H6>
+        {node.isError ? <Status variant="destructive" indicator={false} label="error" className="shrink-0" /> : null}
+      </button>
+      {node.children.map((child) => (
+        <RunRow key={child.id} node={child} depth={depth + 1} onOpen={onOpen} />
+      ))}
+    </>
   )
 }
 
@@ -123,8 +128,7 @@ export function RunTab({
   ])
 
   const openNode = (node: CodemodeRunNode) => {
-    if (node.spanId) onOpenTrace(node.traceId, { spanId: node.spanId, targetTab: "spans" })
-    else onOpenTrace(node.traceId)
+    onOpenTrace(node.traceId, { spanId: node.spanId, targetTab: "spans" })
   }
 
   if (isSpansLoading && (spans?.length ?? 0) === 0) {
@@ -160,12 +164,7 @@ export function RunTab({
           </div>
           <div className="flex flex-col">
             {turn.nodes.map((node) => (
-              <div key={node.id} className="flex flex-col">
-                <RunRow node={node} depth={0} onOpen={openNode} />
-                {node.children.map((child) => (
-                  <RunRow key={child.id} node={child} depth={1} onOpen={openNode} />
-                ))}
-              </div>
+              <RunRow key={node.id} node={node} depth={0} onOpen={openNode} />
             ))}
           </div>
         </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -3,7 +3,7 @@ import type { FilterSet } from "@domain/shared"
 import { CopyableText, Icon, ProviderIcon, Status, type TabOption, Tabs, Text, Tooltip } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { GaugeIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon, ShieldAlertIcon } from "lucide-react"
+import { GaugeIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon, ShieldAlertIcon, WorkflowIcon } from "lucide-react"
 import { use, useEffect, useMemo, useState } from "react"
 import { useScoresBySession } from "../../../../../../domains/scores/scores.collection.ts"
 import { deriveSessionStatus, useSessionSignals } from "../../../../../../domains/sessions/sessions.collection.ts"
@@ -17,16 +17,22 @@ import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-f
 import { SpansTab } from "../trace-detail-drawer/tabs/spans-tab.tsx"
 import { ConversationTab } from "./conversation-tab.tsx"
 import { MetadataTab } from "./metadata-tab.tsx"
+import { RunTab } from "./run-tab.tsx"
 import { ScoresTab } from "./scores-tab.tsx"
 import { SessionStatusPill } from "./session-status-pill.tsx"
 import { SignalsTab } from "./signals-tab.tsx"
 
-export type SessionTabId = "session" | "conversation" | "spans" | "scores" | "issues"
+export type SessionTabId = "session" | "conversation" | "run" | "spans" | "scores" | "issues"
 
 export function isSessionTab(value: string): value is SessionTabId {
   if (value === "annotations") return true
   return (
-    value === "session" || value === "conversation" || value === "spans" || value === "scores" || value === "issues"
+    value === "session" ||
+    value === "conversation" ||
+    value === "run" ||
+    value === "spans" ||
+    value === "scores" ||
+    value === "issues"
   )
 }
 
@@ -88,9 +94,14 @@ export function SessionSlot({
   const signalsEnabled = !isSandbox
   // A single-trace session can surface its spans inline
   const singleTrace = traces.length === 1 ? traces[0] : undefined
+  // Multi-trace sessions get the chronological Run tab (the session-scoped span/trace navigator).
+  const multiTrace = traceIds.length > 1
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   const { openWithErrors, openWithModel } = useSpanFilters()
-  const requestedTab: SessionTabId = activeTab === "spans" && !singleTrace ? "session" : normalizeSessionTab(activeTab)
+  const requestedTab: SessionTabId =
+    (activeTab === "spans" && !singleTrace) || (activeTab === "run" && !multiTrace)
+      ? "session"
+      : normalizeSessionTab(activeTab)
   // A deep-linked tab for a feature that's off (sandbox) falls back to Session.
   const effectiveActiveTab: SessionTabId =
     (requestedTab === "scores" && !scoresEnabled) || (requestedTab === "issues" && !signalsEnabled)
@@ -163,6 +174,14 @@ export function SessionSlot({
         icon: <Icon icon={MessagesSquareIcon} size="sm" />,
       },
     ]
+    if (multiTrace) {
+      all.push({
+        id: "run",
+        label: "Run",
+        icon: <Icon icon={WorkflowIcon} size="sm" />,
+        suffix: countSuffix(traceIds.length),
+      })
+    }
     if (singleTrace) {
       all.push({
         id: "spans",
@@ -188,7 +207,7 @@ export function SessionSlot({
       })
     }
     return all
-  }, [scoresEnabled, signalsEnabled, scoreCount, signalCount, singleTrace])
+  }, [scoresEnabled, signalsEnabled, scoreCount, signalCount, singleTrace, multiTrace, traceIds.length])
 
   // H/L cycle the session tabs (wrapping), matching the trace drawer. Disabled
   // while a trace/issue slot is shown so they don't collide with the trace slot.
@@ -311,6 +330,17 @@ export function SessionSlot({
               focusMomentId={focusMomentId}
               {...(singleTrace ? { navigateToSpan } : {})}
               {...(searchQuery ? { searchQuery } : {})}
+            />
+          </div>
+        )}
+        {multiTrace && visitedTabs.has("run") && (
+          <div className={effectiveActiveTab === "run" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+            <RunTab
+              projectId={projectId}
+              session={session}
+              traces={traces}
+              latestTraceId={latestTraceId}
+              onOpenTrace={onOpenTrace}
             />
           </div>
         )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -475,7 +475,7 @@ export function TraceDetailBody({
             startTimeFrom={traceRecord?.startTime}
             startTimeTo={traceRecord?.endTime}
             selectedSpanId={selectedSpanId}
-            onSelectSpan={navigateToSpan}
+            onSelectSpan={onSelectedSpanIdChange}
             isActive={activeTab === "spans"}
           />
         )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -34,10 +34,10 @@ export function SpansTab({
   // TODO(frontend-use-effect-policy): clear selection when the active filter set
   // hides the currently selected span.
   useEffect(() => {
-    if (!selectedSpanId || filteredSpans.length === 0) return
+    if (!selectedSpanId || isLoading || filteredSpans.length === 0) return
     const isVisible = filteredSpans.some((span) => span.spanId === selectedSpanId)
     if (!isVisible) onSelectSpan("")
-  }, [filteredSpans, onSelectSpan, selectedSpanId])
+  }, [filteredSpans, isLoading, onSelectSpan, selectedSpanId])
 
   // TODO(frontend-use-effect-policy): scrollSpanIntoView is an imperative DOM
   // operation that cannot be derived during render. It must fire both when
@@ -105,7 +105,7 @@ export function SpansTab({
   }
 
   return (
-    <div ref={treeContainerRef} className="flex flex-col flex-1 overflow-hidden">
+    <div ref={treeContainerRef} className="flex min-h-0 flex-col flex-1 overflow-hidden">
       <SpanFiltersBar
         spans={spans}
         filters={filters}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -4,7 +4,7 @@ import { memo } from "react"
 import { INDENT_PX, ROW_HEIGHT, statusTextColor, WATERFALL_H_INSET_PX } from "./helpers.ts"
 import { SpanIcon } from "./span-icon.tsx"
 import type { FlattenedNode, TraceTimeRange } from "./tree-utils.ts"
-import { formatDuration } from "./tree-utils.ts"
+import { formatDuration, spanTreeLabel } from "./tree-utils.ts"
 import { WaterfallBar } from "./waterfall.tsx"
 
 function TreeConnectors({
@@ -106,7 +106,7 @@ export const TreeRow = memo(function TreeRow({
           color={node.span.statusCode === "error" ? "destructive" : "foreground"}
           className="flex-1 min-w-0"
         >
-          {node.span.name}
+          {spanTreeLabel(node.span)}
         </Text.H6>
 
         <Text.H6 color={statusTextColor(node.span.statusCode)} className="shrink-0">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { buildSpanTree, flattenTree } from "./tree-utils.ts"
+import { buildSpanTree, flattenTree, spanTreeLabel } from "./tree-utils.ts"
 
 function makeSpan(spanId: string, parentSpanId: string, startTime = "2024-01-01T00:00:00Z"): SpanRecord {
   return {
@@ -165,5 +165,25 @@ describe("flattenTree", () => {
   it("handles empty tree", () => {
     const flat = flattenTree([], new Set())
     expect(flat).toHaveLength(0)
+  })
+})
+
+describe("spanTreeLabel", () => {
+  it("appends toolName when span name is a generic ai.toolCall", () => {
+    const span = {
+      ...makeSpan("tool", "root"),
+      name: "ai.toolCall",
+      toolName: "getWeatherDetail",
+    }
+    expect(spanTreeLabel(span)).toBe("ai.toolCall getWeatherDetail")
+  })
+
+  it("reads tool name from ai.toolCall.name attribute when toolName column is empty", () => {
+    const span = {
+      ...makeSpan("tool", "root"),
+      name: "ai.toolCall",
+      attrString: { "ai.toolCall.name": "codemode" },
+    }
+    expect(spanTreeLabel(span)).toBe("ai.toolCall codemode")
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts
@@ -14,6 +14,16 @@ export interface TraceTimeRange {
 
 const MAX_TREE_DEPTH = 1000
 
+export function spanTreeLabel(span: Pick<SpanRecord, "name" | "toolName" | "toolNames" | "attrString">): string {
+  const name = span.name.trim()
+  const attrToolName = span.attrString?.["ai.toolCall.name"] ?? span.attrString?.["gen_ai.tool.name"] ?? ""
+  const resolvedTool = span.toolName || attrToolName || (span.toolNames.length === 1 ? span.toolNames[0] : "")
+  if (resolvedTool && (name === "ai.toolCall" || name === "execute_tool")) {
+    return `ai.toolCall ${resolvedTool}`
+  }
+  return span.name
+}
+
 export function buildSpanTree(spans: readonly SpanRecord[]): SpanTreeNode[] {
   const byId = new Map<string, SpanTreeNode>()
   const roots: SpanTreeNode[] = []

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -15,6 +15,7 @@ import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextI
 import { useMemo } from "react"
 import type { SpanRecord } from "../../../../../../../domains/spans/spans.functions.ts"
 import type { TraceDetailRecord, TraceRecord } from "../../../../../../../domains/traces/traces.functions.ts"
+import { useEnrichedConversationMessages } from "../../../../../../../lib/conversation/use-enriched-conversation-messages.ts"
 import { aggregateToolPills, ToolPillList } from "../../tool-pills.tsx"
 import { TraceOutlierBadge, type TraceOutlierMetric } from "../../trace-outlier-badge.tsx"
 import { DurationBar } from "../duration-bar.tsx"
@@ -94,6 +95,19 @@ export function TraceTab({
   const fallbackDurationMs = traceRecord ? traceRecord.durationNs / 1_000_000 : 0
   const durationWallClockMs = durationBreakdown.wallClockMs > 0 ? durationBreakdown.wallClockMs : fallbackDurationMs
   const durationBadge = traceRecord ? renderBadge("durationNs", traceRecord.durationNs) : undefined
+
+  const enrichedInputMessages = useEnrichedConversationMessages(traceDetail?.inputMessages ?? [], {
+    projectId,
+    traceId,
+    startTime: traceRecord?.startTime,
+    enabled: Boolean(traceDetail?.inputMessages.length),
+  })
+  const enrichedOutputMessages = useEnrichedConversationMessages(traceDetail?.outputMessages ?? [], {
+    projectId,
+    traceId,
+    startTime: traceRecord?.startTime,
+    enabled: Boolean(traceDetail?.outputMessages.length),
+  })
 
   const ttftValue = traceRecord ? (
     <span className="flex items-center gap-1">
@@ -245,7 +259,7 @@ export function TraceTab({
             <Skeleton className="h-20 w-full" />
           ) : traceDetail?.inputMessages.length ? (
             <div className="flex flex-col rounded-lg bg-secondary p-4">
-              <Conversation messages={traceDetail.inputMessages} />
+              <Conversation messages={enrichedInputMessages} />
             </div>
           ) : (
             <Text.H6 color="foregroundMuted" italic>
@@ -261,7 +275,7 @@ export function TraceTab({
             <Skeleton className="h-20 w-full" />
           ) : traceDetail?.outputMessages.length ? (
             <div className="flex flex-col rounded-lg bg-secondary p-4">
-              <Conversation messages={traceDetail.outputMessages} />
+              <Conversation messages={enrichedOutputMessages} />
             </div>
           ) : (
             <Text.H6 color="foregroundMuted" italic>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,6 +133,7 @@
               "telemetry/frameworks/vercel-ai-sdk",
               "telemetry/frameworks/vercel-ai-sdk-v7",
               "telemetry/frameworks/cloudflare-think",
+              "telemetry/frameworks/cloudflare-codemode",
               "telemetry/frameworks/openai-agents",
               "telemetry/frameworks/google-adk",
               "telemetry/frameworks/langchain",

--- a/docs/telemetry/frameworks/cloudflare-codemode.mdx
+++ b/docs/telemetry/frameworks/cloudflare-codemode.mdx
@@ -1,0 +1,246 @@
+---
+title: Cloudflare Code Mode
+description: Connect Cloudflare Code Mode agents to Latitude for observability.
+---
+
+## Overview
+
+Cloudflare Code Mode exposes your tools through a single `codemode` tool. The
+model writes JavaScript that orchestrates tool calls inside a sandboxed Dynamic
+Worker instead of requesting each tool separately.
+
+Latitude records Code Mode agents through the Vercel AI SDK's
+`experimental_telemetry` hook on `streamText()` or `generateText()`. Pass a
+Latitude tracer on every model turn.
+
+<Note>
+  Code Mode is experimental on Cloudflare's side and may introduce breaking
+  changes. Dynamic Worker loading in production may require Cloudflare's closed
+  beta — local Wrangler development supports it today.
+</Note>
+
+---
+
+## Requirements
+
+- A Latitude API key
+- A Latitude project slug
+- A Cloudflare Workers project using `@cloudflare/codemode`
+- The `nodejs_compat` compatibility flag enabled in your Worker
+- A Worker Loader binding for `DynamicWorkerExecutor`
+- `LATITUDE_API_KEY` and `LATITUDE_PROJECT_SLUG` configured as Worker secrets or variables
+
+---
+
+## Basic Telemetry
+
+This records model turns and the outer `codemode` tool call (including the
+generated code in tool input).
+
+<Steps>
+  <Step title="Install">
+    <CodeGroup>
+      ```bash npm
+      npm install @latitude-data/telemetry @cloudflare/codemode @cloudflare/ai-chat agents ai zod
+      ```
+
+      ```bash pnpm
+      pnpm add @latitude-data/telemetry @cloudflare/codemode @cloudflare/ai-chat agents ai zod
+      ```
+
+      ```bash yarn
+      yarn add @latitude-data/telemetry @cloudflare/codemode @cloudflare/ai-chat agents ai zod
+      ```
+
+      ```bash bun
+      bun add @latitude-data/telemetry @cloudflare/codemode @cloudflare/ai-chat agents ai zod
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Add a Worker Loader binding">
+    Code Mode executes generated code through `DynamicWorkerExecutor`, which
+    needs a Worker Loader binding:
+
+    ```jsonc
+    {
+      "compatibility_flags": ["nodejs_compat"],
+      "worker_loaders": [{ "binding": "LOADER" }]
+    }
+    ```
+  </Step>
+
+  <Step title="Wire telemetry into onChatMessage">
+    ```ts
+    import { AIChatAgent } from "@cloudflare/ai-chat"
+    import { DynamicWorkerExecutor } from "@cloudflare/codemode"
+    import { createCodeTool } from "@cloudflare/codemode/ai"
+    import { Latitude } from "@latitude-data/telemetry"
+    import { convertToModelMessages, stepCountIs, streamText, tool } from "ai"
+    import { z } from "zod"
+
+    type Env = {
+      LOADER: WorkerLoader
+      LATITUDE_API_KEY: string
+      LATITUDE_PROJECT_SLUG: string
+    }
+
+    let latitude: Latitude | undefined
+
+    function getLatitude(env: Env) {
+      latitude ??= new Latitude({
+        apiKey: env.LATITUDE_API_KEY,
+        project: env.LATITUDE_PROJECT_SLUG,
+        serviceName: "cloudflare-codemode-agent",
+      })
+
+      return latitude
+    }
+
+    const getWeather = tool({
+      description: "Get the current weather for a city.",
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => ({ city, conditions: "sunny" }),
+    })
+
+    export class MyAgent extends AIChatAgent<Env> {
+      codemodeTool() {
+        return createCodeTool({
+          tools: { getWeather },
+          executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+        })
+      }
+
+      async onChatMessage(onFinish, options) {
+        const result = streamText({
+          model,
+          messages: await convertToModelMessages(this.messages),
+          tools: { codemode: this.codemodeTool() },
+          stopWhen: stepCountIs(5),
+          experimental_telemetry: {
+            isEnabled: true,
+            tracer: getLatitude(this.env).getTracer("cloudflare-codemode"),
+            functionId: "codemode-turn",
+          },
+          onFinish,
+        })
+
+        return result.toUIMessageStreamResponse()
+      }
+
+      protected async onChatResponse() {
+        await getLatitude(this.env).flush()
+      }
+    }
+    ```
+
+    Keep one `Latitude` instance per Worker isolate. Do not create `new
+    Latitude()` on every turn.
+  </Step>
+</Steps>
+
+---
+
+## Add App Context
+
+If your app uses the default WebSocket chat entrypoint, pass context through
+`useAgentChat({ body })` from `agents/chat/react`:
+
+```tsx
+import { useAgentChat } from "agents/chat/react"
+
+const { messages, sendMessage } = useAgentChat({
+  agent,
+  body: {
+    userId: currentUser.id,
+    sessionId: session.id,
+    tags: ["cloudflare-codemode"],
+    metadata: { plan: currentUser.plan },
+  },
+})
+```
+
+Read that context in `onChatMessage()` and pass it to `getTracer()`:
+
+```ts
+import type { ContextOptions } from "@latitude-data/telemetry"
+
+async onChatMessage(onFinish, options) {
+  const context = (options?.body ?? {}) as ContextOptions
+
+  const result = streamText({
+    // ...
+    experimental_telemetry: {
+      isEnabled: true,
+      tracer: getLatitude(this.env).getTracer("cloudflare-codemode", context),
+      functionId: "codemode-turn",
+    },
+    onFinish,
+  })
+
+  return result.toUIMessageStreamResponse()
+}
+```
+
+---
+
+## Inner Tool Calls
+
+Code Mode runs generated code in a sandbox. When that code calls
+`codemode.getWeather()`, the host Worker executes your tool's `execute`
+function over RPC — but that path does **not** go through the AI SDK tool loop,
+so `experimental_telemetry` does not emit a separate `ai.toolCall` span for each
+inner tool.
+
+Latitude still captures:
+
+- Model turns (prompts, completions, tokens, latency)
+- The outer `codemode` tool call and its generated code input
+- Tool output returned from the `codemode` execution
+
+To observe individual inner tools, instrument their `execute` functions manually
+with `capture()` or `tracer.startActiveSpan()`:
+
+```ts
+import { capture } from "@latitude-data/telemetry"
+
+const getWeather = tool({
+  description: "Get the current weather for a city.",
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) =>
+    capture(
+      "codemode.getWeather",
+      async () => ({ city, conditions: "sunny" }),
+      { tags: ["cloudflare-codemode", "inner-tool"] },
+    ),
+})
+```
+
+---
+
+## Cloudflare Think
+
+If your agent already uses `@cloudflare/think`, keep using Think's `beforeTurn()`
+hook for telemetry and swap direct tools for a `codemode` tool from
+`createCodeTool()`. The telemetry wiring is the same — only the tool surface
+changes.
+
+---
+
+## Runnable Example
+
+The Latitude repository includes a runnable Code Mode example at
+[`examples/cloudflare-codemode-app`](https://github.com/latitude-dev/latitude-llm/tree/development/packages/telemetry/typescript/examples/cloudflare-codemode-app).
+It includes a `getWeather` tool, a small QA page, and a local verifier that
+checks model spans, the `codemode` tool span, `userId`, and `sessionId` against
+local Latitude.
+
+---
+
+## Seeing Your Traces
+
+Once connected, traces appear automatically in Latitude:
+
+1. Open your project in the Latitude dashboard
+2. Send a message to your Code Mode agent
+3. The turn appears with model calls, the `codemode` tool call, messages, latency, token usage, and errors

--- a/docs/telemetry/frameworks/cloudflare-codemode.mdx
+++ b/docs/telemetry/frameworks/cloudflare-codemode.mdx
@@ -77,9 +77,11 @@ generated code in tool input).
     import { createCodeTool } from "@cloudflare/codemode/ai"
     import { Latitude } from "@latitude-data/telemetry"
     import { convertToModelMessages, stepCountIs, streamText, tool } from "ai"
+    import { createWorkersAI } from "workers-ai-provider"
     import { z } from "zod"
 
     type Env = {
+      AI: Ai
       LOADER: WorkerLoader
       LATITUDE_API_KEY: string
       LATITUDE_PROJECT_SLUG: string
@@ -113,7 +115,9 @@ generated code in tool input).
 
       async onChatMessage(onFinish, options) {
         const result = streamText({
-          model,
+          model: createWorkersAI({ binding: this.env.AI })(
+            "@cf/meta/llama-4-scout-17b-16e-instruct",
+          ),
           messages: await convertToModelMessages(this.messages),
           tools: { codemode: this.codemodeTool() },
           stopWhen: stepCountIs(5),
@@ -166,6 +170,7 @@ Read that context in `onChatMessage()` and pass it to `getTracer()`:
 import type { ContextOptions } from "@latitude-data/telemetry"
 
 async onChatMessage(onFinish, options) {
+  // Validate or narrow options.body in production — the WebSocket payload is client-controlled.
   const context = (options?.body ?? {}) as ContextOptions
 
   const result = streamText({

--- a/docs/telemetry/frameworks/cloudflare-codemode.mdx
+++ b/docs/telemetry/frameworks/cloudflare-codemode.mdx
@@ -233,6 +233,11 @@ Each wrapped tool emits an `ai.toolCall` span with the same attributes the AI SD
 uses (`ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.result`, etc.), so inner
 calls show up alongside model turns and the outer `codemode` tool in Latitude.
 
+`instrumentCodemodeTools()` starts each inner tool span as a **child of the active
+OpenTelemetry span**. When the sandbox executes generated code inside the
+`ai.toolCall codemode` span, the inner tool spans nest under it in the same trace
+instead of appearing as detached siblings.
+
 For one-off spans outside Code Mode, you can still use `capture()`:
 
 ```ts
@@ -245,6 +250,77 @@ execute: async ({ city }) =>
 ```
 
 ---
+
+## Telemetry Contract
+
+A single Code Mode turn spans several traces — a plan model call, the `codemode`
+tool execution with its inner sandbox tools, optional sub-agent runs, and a
+user-facing summary. Latitude ties these together with a small set of optional
+span attributes. They are backward compatible (absent on legacy data) and emitted
+by the runnable example after wiring the tracers below.
+
+| Attribute | Values | Set on |
+|---|---|---|
+| `latitude.codemode.phase` | `plan` \| `execute` \| `summarize` | Root model/tool span of each orchestration phase |
+| `latitude.codemode.inner_tool` | `true` | Inner sandbox tool spans (set by `instrumentCodemodeTools`) |
+| `latitude.codemode.turn_id` | string (`{sessionId}:{turnIndex}`) | Every span in one user turn |
+| `latitude.agent_tool.parent_tool_call_id` | string | Delegate tool span that launched a sub-agent |
+| `latitude.agent_tool.run_id` | string | Delegate tool span and the sub-agent run it links to |
+
+Stamp `phase` and `turn_id` with `withLatitudeAttributes`, which wraps a tracer so
+every span it starts carries the given attributes:
+
+```ts
+import { withLatitudeAttributes } from "@latitude-data/telemetry"
+
+const turnTracer = withLatitudeAttributes(
+  getLatitude(this.env).getTracer("cloudflare-codemode", context),
+  { "latitude.codemode.turn_id": `${sessionId}:0` },
+)
+
+// Plan model call
+experimental_telemetry: {
+  isEnabled: true,
+  tracer: withLatitudeAttributes(turnTracer, { "latitude.codemode.phase": "plan" }),
+  functionId: "codemode-plan",
+}
+
+// Summary model call
+experimental_telemetry: {
+  isEnabled: true,
+  tracer: withLatitudeAttributes(turnTracer, { "latitude.codemode.phase": "summarize" }),
+  functionId: "codemode-summary",
+}
+```
+
+<Note>
+  Because the plan model call also emits the `ai.toolCall codemode` span, that span
+  inherits `latitude.codemode.phase=plan` from the shared tracer. Treat a span named
+  `ai.toolCall codemode` (or the parent of `inner_tool` spans) as the **execute**
+  phase regardless of the `phase` attribute — there is no `phase=execute` on it.
+</Note>
+
+For sub-agent delegation, set the link attributes on the delegate tool span (the
+inner tool that calls `runAgentTool`) so the sub-agent's traces can be reached from
+the delegate step:
+
+```ts
+import { trace } from "@opentelemetry/api"
+
+execute: async (input, options) => {
+  const toolCallId = options?.toolCallId ?? crypto.randomUUID()
+  const span = trace.getActiveSpan()
+  span?.setAttribute("latitude.agent_tool.parent_tool_call_id", toolCallId)
+
+  const result = await agent.runAgentTool(SubAgent, { parentToolCallId: toolCallId, /* ... */ })
+  span?.setAttribute("latitude.agent_tool.run_id", result.runId)
+  // ...
+}
+```
+
+Mirror `latitude.agent_tool.run_id` (and `latitude.codemode.turn_id`) onto the
+sub-agent's own tracer so its traces share the same `run_id` and turn as the
+delegate step.
 
 ## Cloudflare Think
 

--- a/docs/telemetry/frameworks/cloudflare-codemode.mdx
+++ b/docs/telemetry/frameworks/cloudflare-codemode.mdx
@@ -198,22 +198,45 @@ Latitude still captures:
 - The outer `codemode` tool call and its generated code input
 - Tool output returned from the `codemode` execution
 
-To observe individual inner tools, instrument their `execute` functions manually
-with `capture()` or `tracer.startActiveSpan()`:
+To observe individual inner tools, wrap the sandbox tool set with
+`instrumentCodemodeTools()` before passing it to `createCodeTool()`:
+
+```ts
+import { instrumentCodemodeTools } from "@latitude-data/telemetry/cloudflare"
+
+async onChatMessage(onFinish, options) {
+  const tracer = getLatitude(this.env).getTracer("cloudflare-codemode", {
+    userId: stringFromBody(options?.body, "userId"),
+    sessionId: stringFromBody(options?.body, "sessionId"),
+    tags: ["cloudflare-codemode"],
+  })
+
+  const codemode = createCodeTool({
+    tools: instrumentCodemodeTools({ getWeather }, { tracer }),
+    executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+  })
+
+  return streamText({
+    // ...
+    tools: { codemode },
+    experimental_telemetry: { isEnabled: true, tracer },
+  }).toUIMessageStreamResponse()
+}
+```
+
+Each wrapped tool emits an `ai.toolCall` span with the same attributes the AI SDK
+uses (`ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.result`, etc.), so inner
+calls show up alongside model turns and the outer `codemode` tool in Latitude.
+
+For one-off spans outside Code Mode, you can still use `capture()`:
 
 ```ts
 import { capture } from "@latitude-data/telemetry"
 
-const getWeather = tool({
-  description: "Get the current weather for a city.",
-  inputSchema: z.object({ city: z.string() }),
-  execute: async ({ city }) =>
-    capture(
-      "codemode.getWeather",
-      async () => ({ city, conditions: "sunny" }),
-      { tags: ["cloudflare-codemode", "inner-tool"] },
-    ),
-})
+execute: async ({ city }) =>
+  capture("codemode.getWeather", async () => ({ city, conditions: "sunny" }), {
+    tags: ["cloudflare-codemode", "inner-tool"],
+  }),
 ```
 
 ---

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -131,6 +131,7 @@ export type {
   TraceSearchHighlightsResult,
 } from "./use-cases/compute-trace-search-highlights.ts"
 export { computeTraceSearchHighlights } from "./use-cases/compute-trace-search-highlights.ts"
+export { enrichConversationToolCalls } from "./use-cases/enrich-conversation-tool-calls.ts"
 export type { GetSessionCohortSummaryInput } from "./use-cases/get-session-cohort-summary.ts"
 export { getSessionCohortSummaryUseCase } from "./use-cases/get-session-cohort-summary.ts"
 export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -212,6 +212,7 @@ export type {
   TraceSearchHighlightsResult,
 } from "./use-cases/compute-trace-search-highlights.ts"
 export { computeTraceSearchHighlights } from "./use-cases/compute-trace-search-highlights.ts"
+export { enrichConversationToolCalls } from "./use-cases/enrich-conversation-tool-calls.ts"
 export type { GetSessionCohortSummaryInput } from "./use-cases/get-session-cohort-summary.ts"
 export { getSessionCohortSummaryUseCase } from "./use-cases/get-session-cohort-summary.ts"
 export type {

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -22,6 +22,7 @@ export interface SpanMessagesData {
   readonly toolCallId: string
   readonly toolName: string
   readonly toolInput: string
+  readonly toolOutput: string
   readonly inputMessages: readonly GenAIMessage[]
   readonly outputMessages: readonly GenAIMessage[]
 }

--- a/packages/domain/spans/src/use-cases/enrich-conversation-tool-calls.test.ts
+++ b/packages/domain/spans/src/use-cases/enrich-conversation-tool-calls.test.ts
@@ -1,0 +1,79 @@
+import { SpanId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import type { SpanMessagesData } from "../ports/span-repository.ts"
+import { enrichConversationToolCalls } from "./enrich-conversation-tool-calls.ts"
+
+function makeExecuteToolSpan(
+  spanId: string,
+  toolName: string,
+  toolInput: string,
+  toolOutput: string,
+  toolCallId = "",
+): SpanMessagesData {
+  return {
+    spanId: SpanId(spanId),
+    operation: "execute_tool",
+    toolCallId,
+    toolName,
+    toolInput,
+    toolOutput,
+    inputMessages: [],
+    outputMessages: [],
+  }
+}
+
+describe("enrichConversationToolCalls", () => {
+  it("returns messages unchanged when spans are empty", () => {
+    const messages = [{ role: "assistant" as const, parts: [{ type: "text" as const, content: "hi" }] }]
+    expect(enrichConversationToolCalls(messages, [])).toEqual(messages)
+  })
+
+  it("fills missing tool_call arguments from span toolInput", () => {
+    const messages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "tool_call" as const, id: "call-1", name: "codemode", arguments: {} }],
+      },
+    ]
+    const spans = [makeExecuteToolSpan("span-1", "codemode", '{"code":"return 1"}', "", "call-1")]
+
+    const enriched = enrichConversationToolCalls(messages, spans)
+    expect(enriched[0]?.parts?.[0]).toMatchObject({
+      type: "tool_call",
+      arguments: { code: "return 1" },
+    })
+  })
+
+  it("appends a synthetic tool response when span has toolOutput but conversation does not", () => {
+    const messages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "tool_call" as const, id: "call-1", name: "codemode", arguments: { code: "x" } }],
+      },
+    ]
+    const spans = [makeExecuteToolSpan("span-1", "codemode", '{"code":"x"}', '{"ok":true}', "call-1")]
+
+    const enriched = enrichConversationToolCalls(messages, spans)
+    expect(enriched).toHaveLength(2)
+    expect(enriched[1]).toEqual({
+      role: "tool",
+      parts: [{ type: "tool_call_response", id: "call-1", response: { ok: true } }],
+    })
+  })
+
+  it("does not duplicate tool responses already present in messages", () => {
+    const messages = [
+      {
+        role: "assistant" as const,
+        parts: [{ type: "tool_call" as const, id: "call-1", name: "codemode", arguments: { code: "x" } }],
+      },
+      {
+        role: "tool" as const,
+        parts: [{ type: "tool_call_response" as const, id: "call-1", response: "already here" }],
+      },
+    ]
+    const spans = [makeExecuteToolSpan("span-1", "codemode", "{}", '{"ignored":true}', "call-1")]
+
+    expect(enrichConversationToolCalls(messages, spans)).toHaveLength(2)
+  })
+})

--- a/packages/domain/spans/src/use-cases/enrich-conversation-tool-calls.ts
+++ b/packages/domain/spans/src/use-cases/enrich-conversation-tool-calls.ts
@@ -1,0 +1,139 @@
+import type { GenAIMessage } from "rosetta-ai"
+import type { SpanMessagesData } from "../ports/span-repository.ts"
+import { buildConversationSpanMaps } from "./map-conversation-to-spans.ts"
+
+type ToolCallPart = {
+  readonly type: "tool_call"
+  readonly id?: string | null
+  readonly name?: string
+  readonly arguments?: unknown
+}
+
+type ToolResponsePart = {
+  readonly type: "tool_call_response"
+  readonly id?: string | null
+  readonly response?: unknown
+  readonly result?: unknown
+}
+
+function parseToolPayload(raw: string): unknown | undefined {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed) as unknown
+  } catch {
+    return trimmed
+  }
+}
+
+function isEmptyToolArgs(args: unknown): boolean {
+  if (args === undefined || args === null) return true
+  if (typeof args === "object" && !Array.isArray(args) && Object.keys(args).length === 0) return true
+  return false
+}
+
+function collectResponseIds(messages: readonly GenAIMessage[]): Set<string> {
+  const ids = new Set<string>()
+  for (const message of messages) {
+    if (message.role !== "tool") continue
+    for (const part of message.parts ?? []) {
+      if (part.type !== "tool_call_response") continue
+      const id = (part as ToolResponsePart).id
+      if (typeof id === "string" && id.length > 0) ids.add(id)
+    }
+  }
+  return ids
+}
+
+function toolDataByCallId(
+  messages: readonly GenAIMessage[],
+  spans: readonly SpanMessagesData[],
+): Map<string, { input: unknown; output: unknown }> {
+  const { toolCallSpanMap } = buildConversationSpanMaps(messages, spans)
+  const spanById = new Map(spans.map((span) => [span.spanId as string, span]))
+  const data = new Map<string, { input: unknown; output: unknown }>()
+
+  for (const [toolCallId, spanId] of Object.entries(toolCallSpanMap)) {
+    const span = spanById.get(spanId)
+    if (!span) continue
+    const input = parseToolPayload(span.toolInput)
+    const output = parseToolPayload(span.toolOutput)
+    if (input !== undefined || output !== undefined) {
+      data.set(toolCallId, { input: input ?? {}, output: output ?? null })
+    }
+  }
+
+  for (const span of spans) {
+    if (span.operation !== "execute_tool" || !span.toolCallId) continue
+    if (data.has(span.toolCallId)) continue
+    const input = parseToolPayload(span.toolInput)
+    const output = parseToolPayload(span.toolOutput)
+    if (input !== undefined || output !== undefined) {
+      data.set(span.toolCallId, { input: input ?? {}, output: output ?? null })
+    }
+  }
+
+  return data
+}
+
+function enrichAssistantMessage(
+  message: GenAIMessage,
+  toolData: ReadonlyMap<string, { input: unknown; output: unknown }>,
+): GenAIMessage {
+  const parts = message.parts ?? []
+  let changed = false
+  const nextParts = parts.map((part) => {
+    if (part.type !== "tool_call") return part
+    const call = part as ToolCallPart
+    const id = call.id ?? undefined
+    const payload = id ? toolData.get(id) : undefined
+    if (!payload || !isEmptyToolArgs(call.arguments)) return part
+    if (payload.input === undefined) return part
+    changed = true
+    return { ...call, arguments: payload.input }
+  })
+  return changed ? { ...message, parts: nextParts } : message
+}
+
+function syntheticToolResponse(toolCallId: string, output: unknown): GenAIMessage {
+  return {
+    role: "tool",
+    parts: [{ type: "tool_call_response", id: toolCallId, response: output }],
+  }
+}
+
+/** Fills missing tool_call arguments and tool results from execute_tool span I/O. */
+export function enrichConversationToolCalls(
+  messages: readonly GenAIMessage[],
+  spans: readonly SpanMessagesData[],
+): GenAIMessage[] {
+  if (messages.length === 0 || spans.length === 0) return [...messages]
+
+  const toolData = toolDataByCallId(messages, spans)
+  if (toolData.size === 0) return [...messages]
+
+  const responseIds = collectResponseIds(messages)
+  const enriched: GenAIMessage[] = []
+
+  for (const message of messages) {
+    if (!message) continue
+    if (message.role === "assistant") {
+      const next = enrichAssistantMessage(message, toolData)
+      enriched.push(next)
+      for (const part of next.parts ?? []) {
+        if (part.type !== "tool_call") continue
+        const call = part as ToolCallPart
+        const id = call.id ?? undefined
+        if (!id || responseIds.has(id)) continue
+        const payload = toolData.get(id)
+        if (payload?.output === undefined || payload.output === null) continue
+        enriched.push(syntheticToolResponse(id, payload.output))
+        responseIds.add(id)
+      }
+      continue
+    }
+    enriched.push(message)
+  }
+
+  return enriched
+}

--- a/packages/domain/spans/src/use-cases/map-conversation-to-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/map-conversation-to-spans.test.ts
@@ -20,6 +20,7 @@ function makeSpan(
     toolCallId,
     toolName: "",
     toolInput: "",
+    toolOutput: "",
     inputMessages: inputs,
     outputMessages: [output],
   }
@@ -32,6 +33,7 @@ function makeExecuteToolSpan(spanId: string, toolName: string, toolInput: string
     toolCallId,
     toolName,
     toolInput,
+    toolOutput: "",
     inputMessages: [],
     outputMessages: [],
   }

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -273,6 +273,7 @@ type SpanMessagesRow = {
   tool_call_id: string
   tool_name: string
   tool_input: string
+  tool_output: string
   input_messages: string
   output_messages: string
 }
@@ -283,6 +284,7 @@ const toDomainSpanMessages = (row: SpanMessagesRow): SpanMessagesData => ({
   toolCallId: row.tool_call_id,
   toolName: normalizeCHString(row.tool_name),
   toolInput: row.tool_input,
+  toolOutput: row.tool_output,
   inputMessages: parseMessages(row.input_messages),
   outputMessages: parseMessages(row.output_messages),
 })
@@ -801,9 +803,9 @@ export const SpanRepositoryLive = Layer.effect(
                 // merges all matching parts at query time and is the
                 // dominant memory cost for traces with heavy
                 // input/output_messages payloads.
-                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
+                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, tool_output, input_messages, output_messages
                       FROM (
-                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
+                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, tool_output, input_messages, output_messages, start_time
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
@@ -838,9 +840,9 @@ export const SpanRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
+                query: `SELECT span_id, operation, tool_call_id, tool_name, tool_input, tool_output, input_messages, output_messages
                       FROM (
-                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
+                        SELECT span_id, operation, tool_call_id, tool_name, tool_input, tool_output, input_messages, output_messages, start_time
                         FROM spans
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}

--- a/packages/telemetry/typescript/examples/README.md
+++ b/packages/telemetry/typescript/examples/README.md
@@ -91,6 +91,8 @@ These examples use `LatitudeTelemetry` — the simplest way to get started.
 | AWS Bedrock | `test_bedrock.ts` | `@aws-sdk/client-bedrock-runtime` | `"bedrock"` |
 | Google Vertex AI | `test_vertex.ts` | `@google-cloud/vertexai` | `"vertexai"` |
 | Vercel AI SDK | `test_vercel_ai.ts` | `ai`, `@ai-sdk/openai` | `latitude.getTracer("vercelai")` |
+| Cloudflare Think | `cloudflare-think-app/` | `@cloudflare/think`, `agents` | `latitude.getTracer("cloudflare-think")` in `beforeTurn()` |
+| Cloudflare Code Mode | `cloudflare-codemode-app/` | `@cloudflare/codemode`, `@cloudflare/ai-chat` | `latitude.getTracer("cloudflare-codemode")` in `onChatMessage()` |
 | LangChain | `test_langchain.ts` | `langchain`, `@langchain/openai` | `"langchain"` |
 | LlamaIndex | `test_llamaindex.ts` | `llamaindex` | `"llamaindex"` |
 

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/.dev.vars.example
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/.dev.vars.example
@@ -1,0 +1,3 @@
+# Local secrets for `wrangler dev` (copy to .dev.vars; .dev.vars is gitignored).
+# For local/self-hosted Latitude, the seed key works out of the box:
+LATITUDE_API_KEY=lat_seed_default_api_key_token

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/.gitignore
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dev.vars
+.wrangler
+dist

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/README.md
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/README.md
@@ -1,0 +1,67 @@
+# Cloudflare Code Mode + Latitude
+
+Minimal Cloudflare Code Mode project for validating Latitude telemetry.
+
+The agent exposes a single `codemode` tool via `createCodeTool()`. The React page
+uses `useAgentChat({ body })` so `onChatMessage()` can pass user/session context
+to `latitude.getTracer("cloudflare-codemode", context)`.
+
+## Run as a Worker
+
+```bash
+pnpm --filter @latitude-data/telemetry build
+cd packages/telemetry/typescript/examples/cloudflare-codemode-app
+npm install
+
+cp .dev.vars.example .dev.vars
+npx wrangler login
+
+npm run dev
+```
+
+Then open the printed URL (e.g. `http://localhost:8788`). The page shows the
+user id and session id it sends through `useAgentChat({ body })`.
+
+`LATITUDE_PROJECT_SLUG` and `LATITUDE_TELEMETRY_URL` are set as `vars` in
+`wrangler.jsonc`. `LATITUDE_TELEMETRY_URL` is only needed for local/self-hosted
+Latitude — omit it to send traces to Latitude Cloud.
+
+Code Mode requires a Worker Loader binding (`LOADER` in `wrangler.jsonc`) for
+`DynamicWorkerExecutor`. Dynamic Worker loading is available in local Wrangler
+development; production use may require Cloudflare's Dynamic Worker Loader beta.
+
+The agent uses the `@cf/meta/llama-4-scout-17b-16e-instruct` Workers AI model.
+
+## Verify Against Local Latitude
+
+```bash
+pnpm --filter @latitude-data/telemetry build
+```
+
+Then run the deterministic local verifier:
+
+```bash
+cd packages/telemetry/typescript/examples/cloudflare-codemode-app
+LATITUDE_TELEMETRY_URL=http://localhost:3002 \
+LATITUDE_API_KEY=lat_seed_default_api_key_token \
+LATITUDE_PROJECT_SLUG=default-project \
+npm run verify:local
+```
+
+The verifier uses AI SDK's mock model, forces a `codemode` tool call with
+generated code that invokes `getWeather`, sends spans with
+`latitude.getTracer("cloudflare-codemode", context)`, flushes the Latitude SDK,
+and polls local ClickHouse for the generated session. It exits non-zero if spans
+do not arrive, if no `codemode` tool span is stored, or if any span misses the
+expected user/session context.
+
+## What Latitude Captures
+
+- Model turns from `streamText()` with `experimental_telemetry`
+- The outer `codemode` tool call, including the generated code in tool input
+- User, session, tags, and metadata from `getTracer("cloudflare-codemode", context)`
+
+Inner tool calls that run inside the Code Mode sandbox (for example
+`codemode.getWeather()` in generated code) are **not** emitted as separate AI SDK
+tool spans. Instrument those `execute` functions manually if you need per-tool
+visibility. See the Cloudflare Code Mode docs page in `docs/telemetry/frameworks/cloudflare-codemode.mdx`.

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/README.md
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/README.md
@@ -2,9 +2,14 @@
 
 Minimal Cloudflare Code Mode project for validating Latitude telemetry.
 
-The agent exposes a single `codemode` tool via `createCodeTool()`. The React page
-uses `useAgentChat({ body })` so `onChatMessage()` can pass user/session context
+The orchestrator agent exposes a single `codemode` tool that can chain several host
+tools — including `delegateWeatherResearch`, which spins up a `WeatherResearchAgent`
+sub-agent with its own tool loop (`getWeatherDetail`, `scoreComfort`). Agent tools
+require `@cloudflare/ai-chat` ≥ 0.9 (for `startAgentToolRun` RPC on sub-agents).
+The React page uses `useAgentChat({ body })` so `onChatMessage()` can pass user/session context
 to `latitude.getTracer("cloudflare-codemode", context)`.
+
+Try: *Plan a weekend trip: compare Barcelona vs Paris weather and recommend one.*
 
 ## Run as a Worker
 
@@ -30,7 +35,7 @@ Code Mode requires a Worker Loader binding (`LOADER` in `wrangler.jsonc`) for
 `DynamicWorkerExecutor`. Dynamic Worker loading is available in local Wrangler
 development; production use may require Cloudflare's Dynamic Worker Loader beta.
 
-The agent uses the `@cf/meta/llama-4-scout-17b-16e-instruct` Workers AI model.
+The agent uses the `@cf/moonshotai/kimi-k2.7-code` Workers AI model. Casual messages get a normal reply; travel/weather comparison prompts run codemode server-side (the worker executes generated code even when the model leaks it as text, then streams a plain-language summary).
 
 ## Verify Against Local Latitude
 

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/index.html
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/index.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cloudflare Code Mode + Latitude</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font: 15px/1.5 system-ui, sans-serif;
+        margin: 0;
+        display: flex;
+        justify-content: center;
+      }
+      main {
+        width: 100%;
+        max-width: 680px;
+        padding: 24px 16px 96px;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 4px;
+      }
+      .sub {
+        margin: 0 0 16px;
+        opacity: 0.65;
+        font-size: 13px;
+      }
+      .meta {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+      .meta label {
+        flex: 1;
+        font-size: 12px;
+        opacity: 0.7;
+      }
+      .meta input {
+        width: 100%;
+        padding: 6px 8px;
+        margin-top: 2px;
+        border: 1px solid #8884;
+        border-radius: 6px;
+        background: transparent;
+        color: inherit;
+      }
+      #log {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .msg {
+        padding: 10px 12px;
+        border-radius: 10px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .user {
+        background: #3b82f6;
+        color: #fff;
+        align-self: flex-end;
+        max-width: 85%;
+      }
+      .assistant {
+        background: #8881;
+        align-self: flex-start;
+        max-width: 85%;
+      }
+      .status {
+        font-size: 12px;
+        opacity: 0.6;
+        align-self: flex-start;
+      }
+      .error {
+        color: #ef4444;
+      }
+      form {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        gap: 8px;
+        padding: 12px 16px;
+        background: Canvas;
+        border-top: 1px solid #8883;
+        justify-content: center;
+      }
+      form > div {
+        display: flex;
+        gap: 8px;
+        width: 100%;
+        max-width: 680px;
+      }
+      #input {
+        flex: 1;
+        padding: 10px 12px;
+        border: 1px solid #8884;
+        border-radius: 8px;
+        background: transparent;
+        color: inherit;
+      }
+      button {
+        padding: 10px 16px;
+        border: 0;
+        border-radius: 8px;
+        background: #3b82f6;
+        color: #fff;
+        cursor: pointer;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client.tsx"></script>
+  </body>
+</html>

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/package-lock.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/package-lock.json
@@ -1,0 +1,4850 @@
+{
+  "name": "latitude-cloudflare-codemode-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "latitude-cloudflare-codemode-example",
+      "dependencies": {
+        "@ai-sdk/react": "^3.0.216",
+        "@cloudflare/ai-chat": "^0.4.2",
+        "@cloudflare/codemode": "^0.4.2",
+        "@latitude-data/telemetry": "file:../..",
+        "agents": "^0.17.1",
+        "ai": "^6.0.214",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "workers-ai-provider": "^3.2.1",
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@cloudflare/vite-plugin": "^1.42.3",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.3",
+        "typescript": "^5.7.2",
+        "vite": "^8.1.0",
+        "wrangler": "^4.105.0"
+      }
+    },
+    "../..": {
+      "name": "@latitude-data/telemetry",
+      "version": "3.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "@arizeai/openinference-instrumentation-langchain": "4.0.12",
+        "@opentelemetry/api": "catalog:",
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.213.0",
+        "@opentelemetry/instrumentation": "0.213.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-node": "2.7.0",
+        "@opentelemetry/semantic-conventions": "1.40.0",
+        "@traceloop/instrumentation-anthropic": "0.27.0",
+        "@traceloop/instrumentation-bedrock": "0.27.0",
+        "@traceloop/instrumentation-cohere": "0.26.0",
+        "@traceloop/instrumentation-llamaindex": "0.27.0",
+        "@traceloop/instrumentation-openai": "0.27.0",
+        "@traceloop/instrumentation-together": "0.27.0",
+        "@traceloop/instrumentation-vertexai": "0.26.0"
+      },
+      "devDependencies": {
+        "@ai-sdk/openai": "3.0.73",
+        "@ai-sdk/openai7": "npm:@ai-sdk/openai@4.0.0-beta.74",
+        "@ai-sdk/otel": "1.0.0-beta.127",
+        "@anthropic-ai/sdk": "0.104.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1069.0",
+        "@biomejs/biome": "catalog:",
+        "@google-cloud/vertexai": "1.12.0",
+        "@langchain/core": "1.1.49",
+        "@langchain/openai": "1.4.7",
+        "@llamaindex/openai": "0.4.23",
+        "@llamaindex/workflow": "1.1.25",
+        "@openai/agents": "0.11.6",
+        "@types/node": "catalog:",
+        "@typescript/native-preview": "catalog:",
+        "ai": "6.0.208",
+        "ai7": "npm:ai@7.0.0-beta.181",
+        "cohere-ai": "7.21.0",
+        "llamaindex": "0.12.1",
+        "openai": "6.44.0",
+        "together-ai": "0.40.0",
+        "tsdown": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+        "zod": "catalog:"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.142",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.142.tgz",
+      "integrity": "sha512-Y1iwdxdebYXpoK5y/4CrcCfJGeFwEJWlEx+pMWIg/ZVWGi9KA+JXM7YBkhxcshpq/jAXx8YyQeFMyZr0TGfXZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.13",
+        "@ai-sdk/provider-utils": "4.0.35",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.13.tgz",
+      "integrity": "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.35",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.35.tgz",
+      "integrity": "sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.13",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.220",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.220.tgz",
+      "integrity": "sha512-mUqM13WXUT2jNhoU0Kf7YxAtIS+atCUtzZ1LNkhF1q42oYs4g2gWFtq4gNCejACvFMu1KusGRQU2S7ONXtVLZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.35",
+        "ai": "6.0.218",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
+      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-decorators": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
+      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/ai-chat": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.4.6.tgz",
+      "integrity": "sha512-zEWHCk7vmT2ERhGwLIeKY6FOjDTEURTW2Y+izyZyN6C0Vm8jIVS65+afB96nWoKufhlfIz1sSmt2hicHoE2H6A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ai-sdk/react": "^3.0.0",
+        "agents": ">=0.8.7 <1.0.0",
+        "ai": "^6.0.0",
+        "react": "^19.0.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/codemode": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.4.2.tgz",
+      "integrity": "sha512-6sLMZDRY2USbXirrI4tjmGSMYAYM+E/PJIaDQLLbMdvQjk1z1TmJNSLomrZwErO1zFPXvGX2kaqkkxvixkfV2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "acorn": "^8.17.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.0",
+        "@tanstack/ai": ">=0.8.0 <1.0.0",
+        "ai": "^6.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "@tanstack/ai": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.42.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.42.4.tgz",
+      "integrity": "sha512-31Sfu4NpE508YIU4oTSWGFvf31h01BjsDwPS15ufLb3whk9XscRX+rdl9+jOOAcHQu4F6lo7QVkj84IhBKlv6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.1",
+        "miniflare": "4.20260630.0",
+        "unenv": "2.0.0-rc.24",
+        "wrangler": "4.106.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "cf-vite": "bin/cf-vite"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.106.0"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260630.1.tgz",
+      "integrity": "sha512-oEVsD2NZtPAMaEvFeH2Y6N63yiFuOnPDKeAM+l8AkRbLAbFk462uWOq6/ZLn8ouY4P4coMkgsOPqcT1mkuzvzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-tar1vcQSzM+27Agrlv28BhtN1tIFKw2YHrzldEMyQJOJB/885TU8Z3oO1c/a9YOmsKABhD6I4dGFhsmXyrbK1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260630.1.tgz",
+      "integrity": "sha512-mhjIg91+ikWw5v9tY4BYO7N9vLOZBhn7EnVFvxCdxcpuUUFBKATxUYHUy1kkgYxnmiI6s93PRNbzBz1NpYQ3IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260630.1.tgz",
+      "integrity": "sha512-7g0iGvMCwGct+vE3FOKXtFWMAIGHzK2Ei9oALp44gXuL4lBcs3PPJISeTp5itquW2JwS1fw4Hnq7zrT7N/dgPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260630.1.tgz",
+      "integrity": "sha512-J5KF9VF8yRpRBib/cPSuEp6iR9q3/cKgeDVhg1ZtuwpkzwnmCb+rxMF5WFLxAN8bI2x2FMG1v6o4vVFOGZ0fOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260701.1.tgz",
+      "integrity": "sha512-eGZ+PWPlu/yUxH+BJoplV45oSA709sjYFYr2kjrqSo+601qE15X4tsuZcPz1KE6Fb3ObGA9d9ZXn53n34NtyiA==",
+      "license": "MIT OR Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@latitude-data/telemetry": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/plugin-babel": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
+      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/plugin-transform-runtime": {
+          "optional": true
+        },
+        "@babel/runtime": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agents": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.17.3.tgz",
+      "integrity": "sha512-h0rc+dXwe/B6WblHH+Q3625nN/aryZntj6NIJX7tf+VSjmnI1EZyWtVBYMdX4FJZLShpl/vcx/A1AkxytWCPNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-proposal-decorators": "^8.0.2",
+        "@cfworker/json-schema": "^4.1.1",
+        "@cloudflare/codemode": "^0.4.2",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@rolldown/plugin-babel": "^0.2.3",
+        "cron-schedule": "^6.0.0",
+        "esbuild": "^0.28.1",
+        "mimetext": "^3.0.28",
+        "nanoid": "^5.1.16",
+        "partyserver": "^0.5.8",
+        "partysocket": "1.3.0",
+        "yaml": "^2.9.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@ai-sdk/react": "^3.0.204",
+        "@tanstack/ai": ">=0.10.2 <1.0.0",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
+        "ai": "^6.0.0",
+        "chat": "^4.29.0",
+        "just-bash": "^3.0.0",
+        "react": "^19.0.0",
+        "vite": ">=6.0.0 <9.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/react": {
+          "optional": true
+        },
+        "@tanstack/ai": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "chat": {
+          "optional": true
+        },
+        "just-bash": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.218",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.218.tgz",
+      "integrity": "sha512-HsyCUNaaYgX/b/kGOoYfKkqfT1HvpUKKDb8YkN1FKeCNZjKdqXLGY+cKBpYGIRAvsPuOHskxLxZ46cK1dTBWQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.142",
+        "@ai-sdk/provider": "3.0.13",
+        "@ai-sdk/provider-utils": "4.0.35",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
+      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.383",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
+      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "devOptional": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260630.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260630.0.tgz",
+      "integrity": "sha512-lyRplDrSJJWVpzSSQPBSQtNmUuxScCZyOOkXFs37uSbdTfWRDDmw6DyFKVS2s1eYtA/i4u2xR/0FyPIsTl/HJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260630.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.5.8.tgz",
+      "integrity": "sha512-htgSwiBcBu9zIYLrsxBAOvdkjukHvncbTk0nDrJgfruvZ08rxtEN1Ab4T7j9osykP80Bq3zA2oWFd3ngc4Z9uw==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.9"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260424.1"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.3.0.tgz",
+      "integrity": "sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260630.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260630.1.tgz",
+      "integrity": "sha512-7M0AA4l14hmPGtzQ5YPHyXosIKI/uz3TdcPHeiFDbgb7/0c8ECVMzIaodSV5bZIVhDHL0OlzqITAdPiwAr+dTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260630.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260630.1",
+        "@cloudflare/workerd-linux-64": "1.20260630.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260630.1",
+        "@cloudflare/workerd-windows-64": "1.20260630.1"
+      }
+    },
+    "node_modules/workers-ai-provider": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/workers-ai-provider/-/workers-ai-provider-3.3.0.tgz",
+      "integrity": "sha512-x5GnN07O3O+3qiXzraMRLNbM34gDuQvnn+Xgw4Xqmhka+StgIWQp8dEQZ/70nVd+rOT75dEZ3/c9JGG/kDyzkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/provider": "^3.0.0",
+        "ai": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.106.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.106.0.tgz",
+      "integrity": "sha512-b6EVbsvbmAUY4bUQXT3+f8oFP8x+J5rEa5z3Akeh+6vyKiN4x8+PyZ53DPpnqdxhIihhq/a00Yq5chGJ19QXBQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260630.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260630.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260630.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/package-lock.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/package-lock.json
@@ -7,10 +7,10 @@
       "name": "latitude-cloudflare-codemode-example",
       "dependencies": {
         "@ai-sdk/react": "^3.0.216",
-        "@cloudflare/ai-chat": "^0.4.2",
+        "@cloudflare/ai-chat": "^0.9.3",
         "@cloudflare/codemode": "^0.4.2",
         "@latitude-data/telemetry": "file:../..",
-        "agents": "^0.17.1",
+        "agents": "^0.17.3",
         "ai": "^6.0.214",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -501,13 +501,16 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/ai-chat": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.4.6.tgz",
-      "integrity": "sha512-zEWHCk7vmT2ERhGwLIeKY6FOjDTEURTW2Y+izyZyN6C0Vm8jIVS65+afB96nWoKufhlfIz1sSmt2hicHoE2H6A==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/ai-chat/-/ai-chat-0.9.3.tgz",
+      "integrity": "sha512-IjOngV/V+Fmlzc4wIl9to2/dKOAB1T5iCl1p623ArLEXPD4d9T5fBQkXWkRlMlVqQvTANZyWAKjwZWHwNdO9/g==",
       "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.16"
+      },
       "peerDependencies": {
-        "@ai-sdk/react": "^3.0.0",
-        "agents": ">=0.8.7 <1.0.0",
+        "@ai-sdk/react": "^3.0.204",
+        "agents": ">=0.17.1 <1.0.0",
         "ai": "^6.0.0",
         "react": "^19.0.0",
         "zod": "^4.0.0"
@@ -2136,7 +2139,7 @@
       "version": "22.20.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3001,7 +3004,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3328,7 +3330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3349,7 +3350,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3370,7 +3370,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3391,7 +3390,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3412,7 +3410,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3433,7 +3430,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3454,7 +3450,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3475,7 +3470,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3496,7 +3490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3517,7 +3510,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3538,7 +3530,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4442,7 +4433,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.216",
-    "@cloudflare/ai-chat": "^0.4.2",
+    "@cloudflare/ai-chat": "^0.9.3",
     "@cloudflare/codemode": "^0.4.2",
     "@latitude-data/telemetry": "file:../..",
-    "agents": "^0.17.1",
+    "agents": "^0.17.3",
     "ai": "^6.0.214",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "latitude-cloudflare-codemode-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev --host 127.0.0.1 --port 8788",
+    "verify:local": "node scripts/verify-local.mjs"
+  },
+  "dependencies": {
+    "@ai-sdk/react": "^3.0.216",
+    "@cloudflare/ai-chat": "^0.4.2",
+    "@cloudflare/codemode": "^0.4.2",
+    "@latitude-data/telemetry": "file:../..",
+    "agents": "^0.17.1",
+    "ai": "^6.0.214",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "workers-ai-provider": "^3.2.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.42.3",
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^5.7.2",
+    "vite": "^8.1.0",
+    "wrangler": "^4.105.0"
+  }
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --host 127.0.0.1 --port 8788",
+    "dev": "pnpm --dir ../.. build && vite dev --host 127.0.0.1 --port 8788",
     "verify:local": "node scripts/verify-local.mjs"
   },
   "dependencies": {

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto"
 import { setTimeout as sleep } from "node:timers/promises"
-import { createCodeTool, resolveProvider } from "@cloudflare/codemode/ai"
 import { stepCountIs, streamText, tool } from "ai"
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
 import { z } from "zod"
-import { Latitude } from "../../../dist/index.js"
 
 const ingestUrl = process.env.LATITUDE_TELEMETRY_URL ?? "http://localhost:3002"
 const apiKey = process.env.LATITUDE_API_KEY ?? "lat_seed_default_api_key_token"
@@ -16,6 +14,9 @@ const clickhouseDatabase = process.env.CLICKHOUSE_DB ?? "latitude_development"
 
 process.env.LATITUDE_TELEMETRY_URL = ingestUrl
 
+const { Latitude } = await import("../../../dist/index.js")
+const { instrumentCodemodeTools } = await import("../../../dist/cloudflare/index.js")
+
 const latitude = new Latitude({
   apiKey,
   project,
@@ -24,17 +25,12 @@ const latitude = new Latitude({
 })
 
 const localExecutor = {
-  async execute(code, providersOrFns) {
-    const providers = Array.isArray(providersOrFns)
-      ? providersOrFns
-      : [resolveProvider({ tools: providersOrFns })]
-
-    const scope = Object.fromEntries(providers.map((provider) => [provider.name, provider.fns]))
+  async execute(code, toolFns) {
     const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
-    const runner = new AsyncFunction(...Object.keys(scope), `return (${code})()`)
+    const runner = new AsyncFunction("codemode", `return (${code})()`)
 
     try {
-      const result = await runner(...Object.values(scope))
+      const result = await runner(toolFns)
       return { result }
     } catch (error) {
       return { result: null, error: error instanceof Error ? error.message : String(error) }
@@ -95,7 +91,7 @@ function makeCodemodeModel() {
 const getWeather = tool({
   description: "Get the current weather for a city.",
   inputSchema: z.object({
-    city: z.string(),
+    city: z.string().describe("City to look up."),
   }),
   execute: async ({ city }) => ({
     city,
@@ -104,13 +100,38 @@ const getWeather = tool({
   }),
 })
 
-const codemode = createCodeTool({
-  tools: { getWeather },
-  executor: localExecutor,
-})
+function codemodeToolFns(sandboxTools) {
+  return Object.fromEntries(
+    Object.entries(sandboxTools).map(([name, sandboxTool]) => [
+      name,
+      (input) =>
+        sandboxTool.execute(input, {
+          toolCallId: `local-${name}`,
+          messages: [],
+        }),
+    ]),
+  )
+}
 
 async function runCodemodeTurn() {
   const sessionId = `cloudflare-codemode-local-${randomUUID()}`
+  const tracer = latitude.getTracer("cloudflare-codemode", {
+    userId: "local-codemode-user",
+    sessionId,
+    tags: ["cloudflare-codemode", "local-e2e"],
+    metadata: {
+      verifier: "cloudflare-codemode-app",
+      continuation: false,
+    },
+  })
+  const sandboxTools = instrumentCodemodeTools({ getWeather }, { tracer })
+  const codemode = tool({
+    description: "Execute generated code that orchestrates tools.",
+    inputSchema: z.object({
+      code: z.string(),
+    }),
+    execute: async ({ code }) => localExecutor.execute(code, codemodeToolFns(sandboxTools)),
+  })
 
   try {
     const result = streamText({
@@ -120,15 +141,7 @@ async function runCodemodeTurn() {
       stopWhen: stepCountIs(2),
       experimental_telemetry: {
         isEnabled: true,
-        tracer: latitude.getTracer("cloudflare-codemode", {
-          userId: "local-codemode-user",
-          sessionId,
-          tags: ["cloudflare-codemode", "local-e2e"],
-          metadata: {
-            verifier: "cloudflare-codemode-app",
-            continuation: false,
-          },
-        }),
+        tracer,
         functionId: "codemode-turn",
         metadata: { framework: "cloudflare-codemode", verifier: "local-e2e" },
       },
@@ -167,10 +180,10 @@ async function waitForSpans(sessionId) {
   const sql = `
     SELECT
       count(),
-      countIf(name ILIKE '%tool%'),
+      countIf(name ILIKE '%tool%' OR operation = 'execute_tool'),
       countIf(name = 'ai.toolCall'),
-      countIf(attributes['gen_ai.tool.name'] = 'codemode'),
-      countIf(attributes['gen_ai.tool.name'] = 'getWeather'),
+      countIf(tool_name = 'codemode'),
+      countIf(tool_name = 'getWeather'),
       countIf(user_id = 'local-codemode-user'),
       countIf(provider != '')
     FROM spans
@@ -203,6 +216,7 @@ async function waitForSpans(sessionId) {
       toolSpanCount > 0 &&
       aiToolCallCount > 0 &&
       codemodeToolCount > 0 &&
+      innerToolCount > 0 &&
       identifiedSpanCount === spanCount &&
       providerSpanCount > 0
     ) {
@@ -222,8 +236,48 @@ async function waitForSpans(sessionId) {
   throw new Error(`Expected codemode model and tool spans in ClickHouse for session ${sessionId}`)
 }
 
+async function fetchSessionSpans(sessionId) {
+  const escaped = sessionId.replaceAll("'", "''")
+  const sql = `
+    SELECT
+      name,
+      operation,
+      provider,
+      model,
+      user_id,
+      session_id,
+      tags,
+      tool_name,
+      tool_call_id,
+      substring(tool_input, 1, 200) AS tool_input_preview,
+      substring(tool_output, 1, 200) AS tool_output_preview,
+      tokens_input,
+      tokens_output,
+      finish_reasons,
+      substring(input_messages, 1, 160) AS input_messages_preview,
+      substring(output_messages, 1, 160) AS output_messages_preview,
+      start_time,
+      end_time
+    FROM spans
+    WHERE session_id = '${escaped}'
+      AND has(tags, 'cloudflare-codemode')
+      AND has(tags, 'local-e2e')
+    ORDER BY start_time ASC
+    FORMAT JSONEachRow
+  `
+
+  const body = await queryClickHouse(sql)
+  if (!body) return []
+
+  return body
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
 const { sessionId, text } = await runCodemodeTurn()
 const metrics = await waitForSpans(sessionId)
+const spans = await fetchSessionSpans(sessionId)
 
 console.log(
   JSON.stringify(
@@ -233,6 +287,7 @@ console.log(
       text,
       ...metrics,
       innerToolsVisibleToAiSdkTelemetry: metrics.innerToolCount > 0,
+      spans,
     },
     null,
     2,

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
@@ -181,7 +181,7 @@ async function waitForSpans(sessionId) {
     SELECT
       count(),
       countIf(name ILIKE '%tool%' OR operation = 'execute_tool'),
-      countIf(name = 'ai.toolCall'),
+      countIf(startsWith(name, 'ai.toolCall')),
       countIf(tool_name = 'codemode'),
       countIf(tool_name = 'getWeather'),
       countIf(user_id = 'local-codemode-user'),

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/scripts/verify-local.mjs
@@ -1,0 +1,240 @@
+import { randomUUID } from "node:crypto"
+import { setTimeout as sleep } from "node:timers/promises"
+import { createCodeTool, resolveProvider } from "@cloudflare/codemode/ai"
+import { stepCountIs, streamText, tool } from "ai"
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
+import { z } from "zod"
+import { Latitude } from "../../../dist/index.js"
+
+const ingestUrl = process.env.LATITUDE_TELEMETRY_URL ?? "http://localhost:3002"
+const apiKey = process.env.LATITUDE_API_KEY ?? "lat_seed_default_api_key_token"
+const project = process.env.LATITUDE_PROJECT_SLUG ?? "default-project"
+const clickhouseUrl = process.env.CLICKHOUSE_URL ?? "http://localhost:8123"
+const clickhouseUser = process.env.CLICKHOUSE_USER ?? "latitude"
+const clickhousePassword = process.env.CLICKHOUSE_PASSWORD ?? "secret"
+const clickhouseDatabase = process.env.CLICKHOUSE_DB ?? "latitude_development"
+
+process.env.LATITUDE_TELEMETRY_URL = ingestUrl
+
+const latitude = new Latitude({
+  apiKey,
+  project,
+  serviceName: "cloudflare-codemode-agent-local",
+  disableBatch: true,
+})
+
+const localExecutor = {
+  async execute(code, providersOrFns) {
+    const providers = Array.isArray(providersOrFns)
+      ? providersOrFns
+      : [resolveProvider({ tools: providersOrFns })]
+
+    const scope = Object.fromEntries(providers.map((provider) => [provider.name, provider.fns]))
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+    const runner = new AsyncFunction(...Object.keys(scope), `return (${code})()`)
+
+    try {
+      const result = await runner(...Object.values(scope))
+      return { result }
+    } catch (error) {
+      return { result: null, error: error instanceof Error ? error.message : String(error) }
+    }
+  },
+}
+
+function makeCodemodeModel() {
+  let calls = 0
+
+  return new MockLanguageModelV3({
+    provider: "cloudflare-workers-ai",
+    modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+    doStream: async () => {
+      calls += 1
+
+      const chunks =
+        calls === 1
+          ? [
+              { type: "stream-start", warnings: [] },
+              {
+                type: "response-metadata",
+                id: `resp_${randomUUID()}`,
+                modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                timestamp: new Date(),
+              },
+              {
+                type: "tool-call",
+                toolCallId: "call_codemode",
+                toolName: "codemode",
+                input: JSON.stringify({
+                  code: 'async () => { const weather = await codemode.getWeather({ city: "Barcelona" }); return weather; }',
+                }),
+              },
+              { type: "finish", finishReason: "tool-calls", usage: { inputTokens: 12, outputTokens: 3, totalTokens: 15 } },
+            ]
+          : [
+              { type: "stream-start", warnings: [] },
+              {
+                type: "response-metadata",
+                id: `resp_${randomUUID()}`,
+                modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                timestamp: new Date(),
+              },
+              { type: "text-start", id: "text-1" },
+              { type: "text-delta", id: "text-1", delta: "Barcelona is sunny and 21C." },
+              { type: "text-end", id: "text-1" },
+              { type: "finish", finishReason: "stop", usage: { inputTokens: 20, outputTokens: 7, totalTokens: 27 } },
+            ]
+
+      return {
+        stream: simulateReadableStream({ chunks }),
+      }
+    },
+  })
+}
+
+const getWeather = tool({
+  description: "Get the current weather for a city.",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    temperatureC: 21,
+    conditions: "sunny",
+  }),
+})
+
+const codemode = createCodeTool({
+  tools: { getWeather },
+  executor: localExecutor,
+})
+
+async function runCodemodeTurn() {
+  const sessionId = `cloudflare-codemode-local-${randomUUID()}`
+
+  try {
+    const result = streamText({
+      model: makeCodemodeModel(),
+      messages: [{ role: "user", content: "What is the weather in Barcelona? Use codemode." }],
+      tools: { codemode },
+      stopWhen: stepCountIs(2),
+      experimental_telemetry: {
+        isEnabled: true,
+        tracer: latitude.getTracer("cloudflare-codemode", {
+          userId: "local-codemode-user",
+          sessionId,
+          tags: ["cloudflare-codemode", "local-e2e"],
+          metadata: {
+            verifier: "cloudflare-codemode-app",
+            continuation: false,
+          },
+        }),
+        functionId: "codemode-turn",
+        metadata: { framework: "cloudflare-codemode", verifier: "local-e2e" },
+      },
+    })
+
+    let text = ""
+    for await (const delta of result.textStream) text += delta
+
+    return { sessionId, text }
+  } finally {
+    await latitude.flush()
+  }
+}
+
+async function queryClickHouse(sql) {
+  const url = new URL(clickhouseUrl)
+  url.searchParams.set("database", clickhouseDatabase)
+  url.searchParams.set("query", sql)
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${clickhouseUser}:${clickhousePassword}`).toString("base64")}`,
+    },
+  })
+
+  const body = await response.text()
+  if (!response.ok) {
+    throw new Error(`ClickHouse query failed (${response.status}): ${body}`)
+  }
+
+  return body.trim()
+}
+
+async function waitForSpans(sessionId) {
+  const escaped = sessionId.replaceAll("'", "''")
+  const sql = `
+    SELECT
+      count(),
+      countIf(name ILIKE '%tool%'),
+      countIf(name = 'ai.toolCall'),
+      countIf(attributes['gen_ai.tool.name'] = 'codemode'),
+      countIf(attributes['gen_ai.tool.name'] = 'getWeather'),
+      countIf(user_id = 'local-codemode-user'),
+      countIf(provider != '')
+    FROM spans
+    WHERE session_id = '${escaped}'
+      AND has(tags, 'cloudflare-codemode')
+      AND has(tags, 'local-e2e')
+    FORMAT TabSeparated
+  `
+
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    const [
+      spanCountRaw,
+      toolSpanCountRaw,
+      aiToolCallCountRaw,
+      codemodeToolCountRaw,
+      innerToolCountRaw,
+      identifiedSpanCountRaw,
+      providerSpanCountRaw,
+    ] = (await queryClickHouse(sql)).split("\t")
+    const spanCount = Number(spanCountRaw)
+    const toolSpanCount = Number(toolSpanCountRaw)
+    const aiToolCallCount = Number(aiToolCallCountRaw)
+    const codemodeToolCount = Number(codemodeToolCountRaw)
+    const innerToolCount = Number(innerToolCountRaw)
+    const identifiedSpanCount = Number(identifiedSpanCountRaw)
+    const providerSpanCount = Number(providerSpanCountRaw)
+
+    if (
+      spanCount > 0 &&
+      toolSpanCount > 0 &&
+      aiToolCallCount > 0 &&
+      codemodeToolCount > 0 &&
+      identifiedSpanCount === spanCount &&
+      providerSpanCount > 0
+    ) {
+      return {
+        spanCount,
+        toolSpanCount,
+        aiToolCallCount,
+        codemodeToolCount,
+        innerToolCount,
+        identifiedSpanCount,
+        providerSpanCount,
+      }
+    }
+    await sleep(500)
+  }
+
+  throw new Error(`Expected codemode model and tool spans in ClickHouse for session ${sessionId}`)
+}
+
+const { sessionId, text } = await runCodemodeTurn()
+const metrics = await waitForSpans(sessionId)
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      sessionId,
+      text,
+      ...metrics,
+      innerToolsVisibleToAiSdkTelemetry: metrics.innerToolCount > 0,
+    },
+    null,
+    2,
+  ),
+)

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/client.tsx
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/client.tsx
@@ -1,0 +1,80 @@
+import { useAgentChat } from "agents/chat/react"
+import { useAgent } from "agents/react"
+import { useState, type FormEvent } from "react"
+import { createRoot } from "react-dom/client"
+
+function textParts(message: { parts?: Array<{ type?: string; text?: string }> }) {
+  return (message.parts ?? [])
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("")
+}
+
+function Chat() {
+  const [input, setInput] = useState("")
+  const [userId, setUserId] = useState("qa-user")
+  const [sessionId] = useState(() => `qa-${crypto.randomUUID().slice(0, 8)}`)
+  const agent = useAgent({ agent: "MyAgent", name: sessionId })
+  const { messages, sendMessage, status, connectionError } = useAgentChat({
+    agent,
+    getInitialMessages: null,
+    body: () => ({ userId, sessionId }),
+  })
+
+  function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const message = input.trim()
+    if (!message) return
+    setInput("")
+    sendMessage({ text: message })
+  }
+
+  return (
+    <main>
+      <h1>Cloudflare Code Mode + Latitude</h1>
+      <p className='sub'>The agent exposes one codemode tool that runs generated code in a sandbox.</p>
+
+      <div className='meta'>
+        <label>
+          user id
+          <input value={userId} onChange={(event) => setUserId(event.currentTarget.value)} />
+        </label>
+        <label>
+          session id
+          <input value={sessionId} readOnly />
+        </label>
+      </div>
+
+      <div id='log'>
+        {messages.map((message) => {
+          const text = textParts(message)
+          if (!text) return null
+          return (
+            <div key={message.id} className={`msg ${message.role === "user" ? "user" : "assistant"}`}>
+              {text}
+            </div>
+          )
+        })}
+        {connectionError ? <div className='status error'>Error: {connectionError.message}</div> : null}
+        {status !== "ready" ? <div className='status'>{status}</div> : null}
+      </div>
+
+      <form onSubmit={onSubmit}>
+        <div>
+          <input
+            id='input'
+            value={input}
+            onChange={(event) => setInput(event.currentTarget.value)}
+            placeholder='Ask about the weather in a city...'
+            autoComplete='off'
+          />
+          <button type='submit' disabled={status !== "ready"}>
+            Send
+          </button>
+        </div>
+      </form>
+    </main>
+  )
+}
+
+createRoot(document.getElementById("root")!).render(<Chat />)

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/client.tsx
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/client.tsx
@@ -1,13 +1,34 @@
-import { useAgentChat } from "agents/chat/react"
+import { useAgentChat } from "@cloudflare/ai-chat/react"
 import { useAgent } from "agents/react"
 import { useState, type FormEvent } from "react"
 import { createRoot } from "react-dom/client"
+import { shouldRunCodemodeOrchestration } from "./codemode-code"
 
-function textParts(message: { parts?: Array<{ type?: string; text?: string }> }) {
-  return (message.parts ?? [])
+function messageContent(message: {
+  role?: string
+  parts?: Array<{ type?: string; text?: string; toolName?: string; output?: unknown }>
+}) {
+  const text = (message.parts ?? [])
     .filter((part) => part.type === "text" && typeof part.text === "string")
     .map((part) => part.text)
     .join("")
+  if (text) return text
+
+  const codemodeResult = (message.parts ?? []).find(
+    (part) => part.type === "tool-result" && part.toolName === "codemode",
+  )
+  if (codemodeResult?.output != null) {
+    return typeof codemodeResult.output === "string"
+      ? codemodeResult.output
+      : JSON.stringify(codemodeResult.output, null, 2)
+  }
+
+  const codemodeCall = (message.parts ?? []).find(
+    (part) => part.type === "tool-call" && part.toolName === "codemode",
+  )
+  if (codemodeCall) return "Running codemode plan…"
+
+  return null
 }
 
 function Chat() {
@@ -21,6 +42,13 @@ function Chat() {
     body: () => ({ userId, sessionId }),
   })
 
+  const lastUserText = [...messages]
+    .reverse()
+    .find((message) => message.role === "user")
+    ?.parts?.filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+
   function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const message = input.trim()
@@ -29,10 +57,18 @@ function Chat() {
     sendMessage({ text: message })
   }
 
+  const statusLabel =
+    status === "submitted" && shouldRunCodemodeOrchestration(lastUserText ?? "")
+      ? "planning trip (codemode running on server)…"
+      : status
+
   return (
     <main>
       <h1>Cloudflare Code Mode + Latitude</h1>
-      <p className='sub'>The agent exposes one codemode tool that runs generated code in a sandbox.</p>
+      <p className='sub'>
+        Casual chat works normally. Ask about travel weather (e.g. compare Barcelona vs Paris) to trigger codemode
+        orchestration with lookupCity, getWeather, delegateWeatherResearch, and formatTravelBrief.
+      </p>
 
       <div className='meta'>
         <label>
@@ -47,7 +83,7 @@ function Chat() {
 
       <div id='log'>
         {messages.map((message) => {
-          const text = textParts(message)
+          const text = messageContent(message)
           if (!text) return null
           return (
             <div key={message.id} className={`msg ${message.role === "user" ? "user" : "assistant"}`}>
@@ -56,7 +92,7 @@ function Chat() {
           )
         })}
         {connectionError ? <div className='status error'>Error: {connectionError.message}</div> : null}
-        {status !== "ready" ? <div className='status'>{status}</div> : null}
+        {status !== "ready" ? <div className='status'>{statusLabel}</div> : null}
       </div>
 
       <form onSubmit={onSubmit}>
@@ -65,7 +101,7 @@ function Chat() {
             id='input'
             value={input}
             onChange={(event) => setInput(event.currentTarget.value)}
-            placeholder='Ask about the weather in a city...'
+            placeholder='Try "hello" or "compare Barcelona vs Paris weather"'
             autoComplete='off'
           />
           <button type='submit' disabled={status !== "ready"}>

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/codemode-code.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/codemode-code.ts
@@ -1,0 +1,63 @@
+import type { ModelMessage } from "ai"
+
+export function extractCodemodeCode(text: string): string | null {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+
+  const fenced = trimmed.match(/```(?:javascript|js)?\s*\n?([\s\S]*?)```/i)
+  if (fenced?.[1]) {
+    const code = fenced[1].trim()
+    if (looksLikeCodemodeFn(code)) return code
+  }
+
+  if (looksLikeCodemodeFn(trimmed)) return trimmed
+
+  if (trimmed.includes("codemode.")) {
+    return trimmed.startsWith("async") ? trimmed : `async () => {\n${trimmed}\n}`
+  }
+
+  return null
+}
+
+function looksLikeCodemodeFn(code: string) {
+  return /async\s*\(\s*\)\s*=>/.test(code) || /await\s+codemode\./.test(code)
+}
+
+function textFromModelMessage(message: ModelMessage) {
+  if (typeof message.content === "string") return message.content
+  if (!Array.isArray(message.content)) return ""
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+}
+
+export function latestUserText(
+  uiMessages: Array<{ role: string; parts?: Array<{ type?: string; text?: string }> }>,
+  modelMessages: ModelMessage[],
+) {
+  for (let index = uiMessages.length - 1; index >= 0; index -= 1) {
+    const message = uiMessages[index]
+    if (message.role !== "user") continue
+    const text = (message.parts ?? [])
+      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .map((part) => part.text)
+      .join("")
+    if (text) return text
+  }
+
+  for (let index = modelMessages.length - 1; index >= 0; index -= 1) {
+    const message = modelMessages[index]
+    if (message.role !== "user") continue
+    const text = textFromModelMessage(message)
+    if (text) return text
+  }
+
+  return ""
+}
+
+export function shouldRunCodemodeOrchestration(text: string) {
+  return /\b(weather|trip|travel|weekend|compare|recommend|cities?|barcelona|paris|london|berlin|rome)\b/i.test(
+    text,
+  )
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/run-codemode-plan.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/run-codemode-plan.ts
@@ -1,0 +1,94 @@
+import { generateId, generateText, type ModelMessage } from "ai"
+import type { createCodeTool } from "@cloudflare/codemode/ai"
+import type { createWorkersAI } from "workers-ai-provider"
+import { extractCodemodeCode } from "./codemode-code"
+
+type CodemodeTool = ReturnType<typeof createCodeTool>
+type WorkersModel = ReturnType<ReturnType<typeof createWorkersAI>>
+
+const PLAN_TIMEOUT_MS = 90_000
+
+function withTimeout<T>(promise: Promise<T>, label: string) {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out after ${PLAN_TIMEOUT_MS / 1000}s`)), PLAN_TIMEOUT_MS)
+    }),
+  ])
+}
+
+export async function runCodemodePlan(options: {
+  model: WorkersModel
+  codemode: CodemodeTool
+  modelMessages: ModelMessage[]
+  abortSignal?: AbortSignal
+  experimental_telemetry?: Parameters<typeof generateText>[0]["experimental_telemetry"]
+}) {
+  const plan = await withTimeout(
+    generateText({
+      model: options.model,
+      system:
+        "Write one JavaScript async arrow function that solves the user's request using codemode.* tools. " +
+        "For city comparisons: call delegateWeatherResearch({ cities: ['Barcelona', 'Paris'], focus: '...' }), " +
+        "then formatTravelBrief({ headline, cities: research.cities, researchSummary: research.summary }). " +
+        "delegateWeatherResearch returns { ok, summary, cities } — use research.cities, not the input city names. " +
+        "Return only the async arrow function — no markdown fences, no prose.",
+      messages: options.modelMessages,
+      tools: { codemode: options.codemode },
+      toolChoice: { type: "tool", toolName: "codemode" },
+      abortSignal: options.abortSignal,
+      experimental_telemetry: options.experimental_telemetry,
+    }),
+    "Workers AI codemode plan",
+  )
+
+  if (plan.toolCalls.length > 0) {
+    return [...options.modelMessages, ...plan.response.messages] as ModelMessage[]
+  }
+
+  const code = extractCodemodeCode(plan.text)
+  if (!code) {
+    throw new Error("Model did not produce executable codemode output")
+  }
+
+  const toolCallId = generateId()
+  const execute = options.codemode.execute
+  if (!execute) {
+    throw new Error("codemode tool is missing execute")
+  }
+
+  const output = await execute(
+    { code },
+    {
+      toolCallId,
+      messages: options.modelMessages,
+      abortSignal: options.abortSignal,
+    },
+  )
+
+  return [
+    ...options.modelMessages,
+    {
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId,
+          toolName: "codemode",
+          input: { code },
+        },
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId,
+          toolName: "codemode",
+          output,
+        },
+      ],
+    },
+  ] as ModelMessage[]
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
@@ -2,6 +2,7 @@ import { AIChatAgent } from "@cloudflare/ai-chat"
 import { DynamicWorkerExecutor } from "@cloudflare/codemode"
 import { createCodeTool } from "@cloudflare/codemode/ai"
 import { Latitude } from "@latitude-data/telemetry"
+import { instrumentCodemodeTools } from "@latitude-data/telemetry/cloudflare"
 import { routeAgentRequest } from "agents"
 import { convertToModelMessages, stepCountIs, streamText, tool } from "ai"
 import { createWorkersAI } from "workers-ai-provider"
@@ -50,31 +51,35 @@ const getWeather = tool({
 })
 
 export class MyAgent extends AIChatAgent<Env> {
-  codemodeTool() {
+  codemodeTool(tracer: ReturnType<Latitude["getTracer"]>) {
+    const sandboxTools = instrumentCodemodeTools({ getWeather }, { tracer })
+
     return createCodeTool({
-      tools: { getWeather },
+      tools: sandboxTools,
       executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
     })
   }
 
   async onChatMessage(onFinish, options) {
+    const tracer = getLatitude(this.env).getTracer("cloudflare-codemode", {
+      userId: stringFromBody(options?.body, "userId"),
+      sessionId: stringFromBody(options?.body, "sessionId"),
+      tags: ["cloudflare-codemode"],
+      metadata: {
+        framework: "cloudflare-codemode",
+        continuation: options?.continuation ?? false,
+      },
+    })
+
     const result = streamText({
       model: createWorkersAI({ binding: this.env.AI })("@cf/meta/llama-4-scout-17b-16e-instruct"),
       messages: await convertToModelMessages(this.messages),
-      tools: { codemode: this.codemodeTool() },
+      tools: { codemode: this.codemodeTool(tracer) },
       stopWhen: stepCountIs(5),
       abortSignal: options?.abortSignal,
       experimental_telemetry: {
         isEnabled: true,
-        tracer: getLatitude(this.env).getTracer("cloudflare-codemode", {
-          userId: stringFromBody(options?.body, "userId"),
-          sessionId: stringFromBody(options?.body, "sessionId"),
-          tags: ["cloudflare-codemode"],
-          metadata: {
-            framework: "cloudflare-codemode",
-            continuation: options?.continuation ?? false,
-          },
-        }),
+        tracer,
         functionId: "codemode-turn",
       },
       onFinish,

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
@@ -1,20 +1,81 @@
-import { AIChatAgent } from "@cloudflare/ai-chat"
+import { trace } from "@opentelemetry/api"
+import { AIChatAgent, type OnChatMessageOptions } from "@cloudflare/ai-chat"
 import { DynamicWorkerExecutor } from "@cloudflare/codemode"
 import { createCodeTool } from "@cloudflare/codemode/ai"
-import { Latitude } from "@latitude-data/telemetry"
+import { Latitude, withLatitudeAttributes } from "@latitude-data/telemetry"
 import { instrumentCodemodeTools } from "@latitude-data/telemetry/cloudflare"
 import { routeAgentRequest } from "agents"
-import { convertToModelMessages, stepCountIs, streamText, tool } from "ai"
+import { convertToModelMessages, streamText, tool, type ToolSet } from "ai"
+import type { StreamTextOnFinishCallback } from "ai"
 import { createWorkersAI } from "workers-ai-provider"
 import { z } from "zod"
+import { latestUserText, shouldRunCodemodeOrchestration } from "./codemode-code"
+import { runCodemodePlan } from "./run-codemode-plan"
 
 type Env = {
   AI: Ai
   LOADER: WorkerLoader
   MyAgent: DurableObjectNamespace<MyAgent>
+  WeatherResearchAgent: DurableObjectNamespace<WeatherResearchAgent>
   LATITUDE_API_KEY: string
   LATITUDE_PROJECT_SLUG: string
   LATITUDE_TELEMETRY_URL?: string
+}
+
+type ParentContext = {
+  userId?: string
+  sessionId?: string
+  runId?: string
+}
+
+const CODEMODE_ATTRIBUTES = {
+  phase: "latitude.codemode.phase",
+  turnId: "latitude.codemode.turn_id",
+} as const
+
+const AGENT_TOOL_ATTRIBUTES = {
+  parentToolCallId: "latitude.agent_tool.parent_tool_call_id",
+  runId: "latitude.agent_tool.run_id",
+} as const
+
+function codemodeTurnId(sessionId: string | undefined, turnIndex = 0) {
+  return `${sessionId ?? "session"}:${turnIndex}`
+}
+
+type ResearchAgentInput = {
+  cities: string[]
+  focus?: string
+  sessionId?: string
+  userId?: string
+}
+
+const CHAT_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct"
+
+const CITY_DIRECTORY: Record<string, { displayName: string; country: string; timezone: string }> = {
+  barcelona: { displayName: "Barcelona", country: "Spain", timezone: "Europe/Madrid" },
+  paris: { displayName: "Paris", country: "France", timezone: "Europe/Paris" },
+  london: { displayName: "London", country: "United Kingdom", timezone: "Europe/London" },
+  berlin: { displayName: "Berlin", country: "Germany", timezone: "Europe/Berlin" },
+}
+
+const WEATHER_BY_CITY: Record<string, { temperatureC: number; conditions: string; humidity: number; windKph: number }> =
+  {
+    barcelona: { temperatureC: 21, conditions: "sunny", humidity: 55, windKph: 12 },
+    paris: { temperatureC: 16, conditions: "cloudy", humidity: 68, windKph: 18 },
+    london: { temperatureC: 14, conditions: "light rain", humidity: 74, windKph: 22 },
+    berlin: { temperatureC: 18, conditions: "partly cloudy", humidity: 61, windKph: 15 },
+  }
+
+function normalizeCity(city: string) {
+  return city.trim().toLowerCase()
+}
+
+function resolveCity(city: string) {
+  const key = normalizeCity(city)
+  const entry = CITY_DIRECTORY[key]
+  const weather = WEATHER_BY_CITY[key]
+  if (!entry || !weather) return null
+  return { key, ...entry, ...weather }
 }
 
 let latitude: Latitude | undefined
@@ -24,6 +85,7 @@ function getLatitude(env: Env) {
     apiKey: env.LATITUDE_API_KEY,
     project: env.LATITUDE_PROJECT_SLUG,
     serviceName: "cloudflare-codemode-agent",
+    disableBatch: true,
     ...(env.LATITUDE_TELEMETRY_URL ? { telemetryUrl: env.LATITUDE_TELEMETRY_URL } : {}),
   })
 
@@ -35,49 +97,266 @@ function stringFromBody(body: Record<string, unknown> | undefined, key: string) 
   return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
+function workersModel(env: Env) {
+  return createWorkersAI({ binding: env.AI })(CHAT_MODEL)
+}
+
+const lookupCity = tool({
+  description: "Normalize a city name and return coordinates metadata for planning.",
+  inputSchema: z.object({
+    city: z.string().describe("City name, e.g. Barcelona."),
+  }),
+  execute: async ({ city }) => {
+    const resolved = resolveCity(city)
+    if (!resolved) {
+      return { found: false as const, city, message: `Unknown city "${city}". Try Barcelona, Paris, London, or Berlin.` }
+    }
+    return {
+      found: true as const,
+      key: resolved.key,
+      displayName: resolved.displayName,
+      country: resolved.country,
+      timezone: resolved.timezone,
+    }
+  },
+})
+
 const getWeather = tool({
-  description: "Get the current weather for a city.",
+  description: "Get a quick weather snapshot for a known city.",
   inputSchema: z.object({
     city: z.string().describe("City to look up."),
   }),
-  execute: async ({ city }) => ({
-    city,
-    temperatureC: 21,
-    conditions: "sunny",
-  }),
+  execute: async ({ city }) => {
+    const resolved = resolveCity(city)
+    if (!resolved) return { city, error: "City not in directory" }
+    return {
+      city: resolved.displayName,
+      temperatureC: resolved.temperatureC,
+      conditions: resolved.conditions,
+    }
+  },
 })
 
-export class MyAgent extends AIChatAgent<Env> {
-  codemodeTool(tracer: ReturnType<Latitude["getTracer"]>) {
-    const sandboxTools = instrumentCodemodeTools({ getWeather }, { tracer })
+const getWeatherDetail = tool({
+  description: "Detailed weather reading for a supported city.",
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => {
+    const resolved = resolveCity(city)
+    if (!resolved) return { city, error: "City not in directory" }
+    return {
+      city: resolved.displayName,
+      country: resolved.country,
+      timezone: resolved.timezone,
+      temperatureC: resolved.temperatureC,
+      conditions: resolved.conditions,
+      humidity: resolved.humidity,
+      windKph: resolved.windKph,
+    }
+  },
+})
 
-    return createCodeTool({
-      tools: sandboxTools,
-      executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+function comfortForWeather(
+  city: string,
+  temperatureC: number,
+  conditions: string,
+  humidity = 50,
+  windKph = 10,
+) {
+  let score = 7
+  if (temperatureC < 10 || temperatureC > 30) score -= 2
+  if (conditions.toLowerCase().includes("rain")) score -= 2
+  if (humidity > 75) score -= 1
+  if (windKph > 25) score -= 1
+  if (conditions.toLowerCase().includes("sun")) score += 1
+  score = Math.max(1, Math.min(10, score))
+  return {
+    city,
+    comfortScore: score,
+    verdict: score >= 7 ? "great for walking around" : score >= 5 ? "acceptable with layers" : "consider indoor plans",
+  }
+}
+
+function cityBriefEntry(city: string) {
+  const resolved = resolveCity(city)
+  if (!resolved) return null
+  const comfort = comfortForWeather(
+    resolved.displayName,
+    resolved.temperatureC,
+    resolved.conditions,
+    resolved.humidity,
+    resolved.windKph,
+  )
+  return {
+    name: resolved.displayName,
+    temperatureC: resolved.temperatureC,
+    conditions: resolved.conditions,
+    comfortScore: comfort.comfortScore,
+    notes: comfort.verdict,
+  }
+}
+
+function cityBriefEntries(cities: string[]) {
+  return cities.flatMap((city) => {
+    const entry = cityBriefEntry(city)
+    return entry ? [entry] : []
+  })
+}
+
+const travelBriefCitySchema = z.object({
+  name: z.string(),
+  temperatureC: z.number(),
+  conditions: z.string(),
+  comfortScore: z.number().optional(),
+  notes: z.string().optional(),
+})
+
+const scoreComfort = tool({
+  description: "Score how comfortable the weather is for outdoor sightseeing (1-10).",
+  inputSchema: z.object({
+    city: z.string(),
+    temperatureC: z.number(),
+    conditions: z.string(),
+    humidity: z.number().optional(),
+    windKph: z.number().optional(),
+  }),
+  execute: async ({ city, temperatureC, conditions, humidity = 50, windKph = 10 }) =>
+    comfortForWeather(city, temperatureC, conditions, humidity, windKph),
+})
+
+const formatTravelBrief = tool({
+  description: "Turn structured research into a short travel weather brief for the user.",
+  inputSchema: z.object({
+    headline: z.string(),
+    cities: z.array(travelBriefCitySchema).min(1),
+    researchSummary: z.string().optional(),
+  }),
+  execute: async ({ headline, cities, researchSummary }) => {
+    const lines = cities.map((entry) => {
+      const comfort =
+        entry.comfortScore !== undefined ? ` comfort ${entry.comfortScore}/10` : ""
+      const notes = entry.notes ? ` — ${entry.notes}` : ""
+      return `- ${entry.name}: ${entry.temperatureC}°C, ${entry.conditions}${comfort}${notes}`
     })
+    return {
+      headline,
+      brief: [headline, "", ...lines, researchSummary ? `\nResearch notes: ${researchSummary}` : ""]
+        .filter(Boolean)
+        .join("\n"),
+    }
+  },
+})
+
+function createDelegateWeatherResearchTool(agent: MyAgent, parent: ParentContext) {
+  const delegateOutputSchema = z.discriminatedUnion("ok", [
+    z.object({
+      ok: z.literal(true),
+      summary: z.string(),
+      cities: z.array(travelBriefCitySchema),
+      research: z.unknown().optional(),
+    }),
+    z.object({
+      ok: z.literal(false),
+      status: z.string(),
+      error: z.string(),
+    }),
+  ])
+
+  return tool({
+    description:
+      "Run a dedicated weather research sub-agent that compares multiple cities with its own tool loop. Returns { ok, summary, cities } where cities is ready for formatTravelBrief.",
+    inputSchema: z.object({
+      cities: z.array(z.string()).min(1).describe("Cities to compare."),
+      focus: z.string().optional().describe("What the research should optimize for."),
+    }),
+    outputSchema: delegateOutputSchema,
+    execute: async (input, options) => {
+      const toolCallId = options?.toolCallId ?? crypto.randomUUID()
+      const span = trace.getActiveSpan()
+      span?.setAttribute(AGENT_TOOL_ATTRIBUTES.parentToolCallId, toolCallId)
+
+      const result = await agent.runAgentTool(WeatherResearchAgent, {
+        input: {
+          ...input,
+          sessionId: parent.sessionId,
+          userId: parent.userId,
+        },
+        parentToolCallId: toolCallId,
+        signal: options?.abortSignal,
+        display: { name: "Weather Researcher" },
+      })
+
+      span?.setAttribute(AGENT_TOOL_ATTRIBUTES.runId, result.runId)
+
+      if (result.status !== "completed") {
+        return {
+          ok: false as const,
+          status: result.status,
+          error: result.error ?? "Weather research sub-agent did not complete",
+        }
+      }
+
+      return {
+        ok: true as const,
+        summary: result.summary ?? "Weather research complete.",
+        cities: cityBriefEntries(input.cities),
+        research: result.output,
+      }
+    },
+  })
+}
+
+export class WeatherResearchAgent extends AIChatAgent<Env> {
+  private parentContext: ParentContext = {}
+
+  protected override formatAgentToolInput(input: ResearchAgentInput, request: { runId: string }) {
+    this.parentContext = { sessionId: input.sessionId, userId: input.userId, runId: request.runId }
+    const cities = input.cities.join(", ")
+    const focus = input.focus ?? "pick the best city for a weekend trip"
+    return {
+      id: `agent-tool-${request.runId}-input`,
+      role: "user" as const,
+      parts: [
+        {
+          type: "text" as const,
+          text: `Compare weather for ${cities}. Focus: ${focus}. For each city call getWeatherDetail, then scoreComfort, then reply with a concise comparison.`,
+        },
+      ],
+    }
   }
 
-  async onChatMessage(onFinish, options) {
-    const tracer = getLatitude(this.env).getTracer("cloudflare-codemode", {
-      userId: stringFromBody(options?.body, "userId"),
-      sessionId: stringFromBody(options?.body, "sessionId"),
-      tags: ["cloudflare-codemode"],
-      metadata: {
-        framework: "cloudflare-codemode",
-        continuation: options?.continuation ?? false,
-      },
+  async onChatMessage(
+    onFinish: StreamTextOnFinishCallback<ToolSet>,
+    options?: OnChatMessageOptions,
+  ) {
+    const baseTracer = getLatitude(this.env).getTracer("cloudflare-codemode-research", {
+      userId: this.parentContext.userId,
+      sessionId: this.parentContext.sessionId,
+      tags: ["cloudflare-codemode", "cloudflare-codemode-subagent"],
+      metadata: { role: "weather-research-subagent" },
+    })
+    const tracer = withLatitudeAttributes(baseTracer, {
+      [CODEMODE_ATTRIBUTES.turnId]: codemodeTurnId(this.parentContext.sessionId),
+      ...(this.parentContext.runId ? { [AGENT_TOOL_ATTRIBUTES.runId]: this.parentContext.runId } : {}),
     })
 
+    const tools = instrumentCodemodeTools(
+      { getWeatherDetail, scoreComfort } as ToolSet,
+      { tracer, toolCallIdPrefix: "research" },
+    ) as ToolSet
+
     const result = streamText({
-      model: createWorkersAI({ binding: this.env.AI })("@cf/meta/llama-4-scout-17b-16e-instruct"),
+      model: workersModel(this.env),
+      system:
+        "You are a weather research specialist. Always use getWeatherDetail and scoreComfort for every city before answering.",
       messages: await convertToModelMessages(this.messages),
-      tools: { codemode: this.codemodeTool(tracer) },
-      stopWhen: stepCountIs(5),
+      tools,
       abortSignal: options?.abortSignal,
       experimental_telemetry: {
         isEnabled: true,
         tracer,
-        functionId: "codemode-turn",
+        functionId: "research-subagent-turn",
       },
       onFinish,
     })
@@ -85,7 +364,124 @@ export class MyAgent extends AIChatAgent<Env> {
     return result.toUIMessageStreamResponse()
   }
 
-  override protected async onChatResponse() {
+  protected override async onChatResponse() {
+    await getLatitude(this.env).flush()
+  }
+}
+
+export class MyAgent extends AIChatAgent<Env> {
+  codemodeTool(tracer: ReturnType<Latitude["getTracer"]>, parent: ParentContext) {
+    const sandboxTools = instrumentCodemodeTools(
+      {
+        lookupCity,
+        getWeather,
+        formatTravelBrief,
+        delegateWeatherResearch: createDelegateWeatherResearchTool(this, parent),
+      } as ToolSet,
+      { tracer },
+    )
+
+    return createCodeTool({
+      tools: sandboxTools as ToolSet,
+      executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+    })
+  }
+
+  async onChatMessage(
+    onFinish: StreamTextOnFinishCallback<ToolSet>,
+    options?: OnChatMessageOptions,
+  ) {
+    const parent: ParentContext = {
+      userId: stringFromBody(options?.body, "userId"),
+      sessionId: stringFromBody(options?.body, "sessionId"),
+    }
+
+    const baseTracer = getLatitude(this.env).getTracer("cloudflare-codemode", {
+      ...parent,
+      tags: ["cloudflare-codemode", "codemode-orchestration"],
+      metadata: {
+        framework: "cloudflare-codemode",
+        continuation: options?.continuation ?? false,
+        scenario: "codemode-orchestration",
+      },
+    })
+    const tracer = withLatitudeAttributes(baseTracer, {
+      [CODEMODE_ATTRIBUTES.turnId]: codemodeTurnId(parent.sessionId),
+    })
+
+    const model = workersModel(this.env)
+    const modelMessages = await convertToModelMessages(this.messages)
+    const userText = latestUserText(this.messages, modelMessages)
+    const telemetry = {
+      isEnabled: true as const,
+      tracer,
+      functionId: "codemode-turn",
+    }
+
+    if (!shouldRunCodemodeOrchestration(userText)) {
+      const result = streamText({
+        model,
+        system: "You are a friendly assistant. Reply briefly and naturally.",
+        messages: modelMessages,
+        abortSignal: options?.abortSignal,
+        experimental_telemetry: telemetry,
+        onFinish,
+      })
+
+      return result.toUIMessageStreamResponse()
+    }
+
+    try {
+      const codemode = this.codemodeTool(tracer, parent)
+      const afterCodemode = await runCodemodePlan({
+        model,
+        codemode,
+        modelMessages,
+        abortSignal: options?.abortSignal,
+        experimental_telemetry: {
+          ...telemetry,
+          tracer: withLatitudeAttributes(tracer, { [CODEMODE_ATTRIBUTES.phase]: "plan" }),
+          functionId: "codemode-plan",
+        },
+      })
+
+      const result = streamText({
+        model,
+        system:
+          "Summarize the codemode tool result for the user in plain language. Include a clear recommendation when comparing cities. Never show code.",
+        messages: afterCodemode,
+        abortSignal: options?.abortSignal,
+        experimental_telemetry: {
+          ...telemetry,
+          tracer: withLatitudeAttributes(tracer, { [CODEMODE_ATTRIBUTES.phase]: "summarize" }),
+          functionId: "codemode-summary",
+        },
+        onFinish,
+      })
+
+      return result.toUIMessageStreamResponse()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const result = streamText({
+        model,
+        system: "You are a friendly assistant.",
+        messages: [
+          ...modelMessages,
+          {
+            role: "user",
+            content: `The codemode orchestration failed (${message}). Apologize briefly and suggest trying the travel weather comparison again.`,
+          },
+        ],
+        abortSignal: options?.abortSignal,
+        experimental_telemetry: telemetry,
+        onFinish,
+      })
+
+      return result.toUIMessageStreamResponse()
+    }
+  }
+
+  protected override async onChatResponse() {
     await getLatitude(this.env).flush()
   }
 }

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
@@ -20,14 +20,11 @@ type Env = {
 let latitude: Latitude | undefined
 
 function getLatitude(env: Env) {
-  if (env.LATITUDE_TELEMETRY_URL) {
-    process.env.LATITUDE_TELEMETRY_URL = env.LATITUDE_TELEMETRY_URL
-  }
-
   latitude ??= new Latitude({
     apiKey: env.LATITUDE_API_KEY,
     project: env.LATITUDE_PROJECT_SLUG,
     serviceName: "cloudflare-codemode-agent",
+    ...(env.LATITUDE_TELEMETRY_URL ? { telemetryUrl: env.LATITUDE_TELEMETRY_URL } : {}),
   })
 
   return latitude
@@ -88,7 +85,7 @@ export class MyAgent extends AIChatAgent<Env> {
     return result.toUIMessageStreamResponse()
   }
 
-  protected async onChatResponse() {
+  override protected async onChatResponse() {
     await getLatitude(this.env).flush()
   }
 }

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/src/worker.ts
@@ -1,0 +1,95 @@
+import { AIChatAgent } from "@cloudflare/ai-chat"
+import { DynamicWorkerExecutor } from "@cloudflare/codemode"
+import { createCodeTool } from "@cloudflare/codemode/ai"
+import { Latitude } from "@latitude-data/telemetry"
+import { routeAgentRequest } from "agents"
+import { convertToModelMessages, stepCountIs, streamText, tool } from "ai"
+import { createWorkersAI } from "workers-ai-provider"
+import { z } from "zod"
+
+type Env = {
+  AI: Ai
+  LOADER: WorkerLoader
+  MyAgent: DurableObjectNamespace<MyAgent>
+  LATITUDE_API_KEY: string
+  LATITUDE_PROJECT_SLUG: string
+  LATITUDE_TELEMETRY_URL?: string
+}
+
+let latitude: Latitude | undefined
+
+function getLatitude(env: Env) {
+  if (env.LATITUDE_TELEMETRY_URL) {
+    process.env.LATITUDE_TELEMETRY_URL = env.LATITUDE_TELEMETRY_URL
+  }
+
+  latitude ??= new Latitude({
+    apiKey: env.LATITUDE_API_KEY,
+    project: env.LATITUDE_PROJECT_SLUG,
+    serviceName: "cloudflare-codemode-agent",
+  })
+
+  return latitude
+}
+
+function stringFromBody(body: Record<string, unknown> | undefined, key: string) {
+  const value = body?.[key]
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+const getWeather = tool({
+  description: "Get the current weather for a city.",
+  inputSchema: z.object({
+    city: z.string().describe("City to look up."),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    temperatureC: 21,
+    conditions: "sunny",
+  }),
+})
+
+export class MyAgent extends AIChatAgent<Env> {
+  codemodeTool() {
+    return createCodeTool({
+      tools: { getWeather },
+      executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+    })
+  }
+
+  async onChatMessage(onFinish, options) {
+    const result = streamText({
+      model: createWorkersAI({ binding: this.env.AI })("@cf/meta/llama-4-scout-17b-16e-instruct"),
+      messages: await convertToModelMessages(this.messages),
+      tools: { codemode: this.codemodeTool() },
+      stopWhen: stepCountIs(5),
+      abortSignal: options?.abortSignal,
+      experimental_telemetry: {
+        isEnabled: true,
+        tracer: getLatitude(this.env).getTracer("cloudflare-codemode", {
+          userId: stringFromBody(options?.body, "userId"),
+          sessionId: stringFromBody(options?.body, "sessionId"),
+          tags: ["cloudflare-codemode"],
+          metadata: {
+            framework: "cloudflare-codemode",
+            continuation: options?.continuation ?? false,
+          },
+        }),
+        functionId: "codemode-turn",
+      },
+      onFinish,
+    })
+
+    return result.toUIMessageStreamResponse()
+  }
+
+  protected async onChatResponse() {
+    await getLatitude(this.env).flush()
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    return (await routeAgentRequest(request, env)) ?? new Response("Not found", { status: 404 })
+  },
+} satisfies ExportedHandler<Env>

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/tsconfig.json
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["@cloudflare/workers-types", "node", "vite/client"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/vite.config.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/vite.config.ts
@@ -1,0 +1,7 @@
+import { cloudflare } from "@cloudflare/vite-plugin"
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  plugins: [react(), cloudflare()],
+})

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/vite.config.ts
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/vite.config.ts
@@ -1,7 +1,17 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { cloudflare } from "@cloudflare/vite-plugin"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
+const telemetryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..")
+
 export default defineConfig({
   plugins: [react(), cloudflare()],
+  resolve: {
+    alias: {
+      "@latitude-data/telemetry/cloudflare": path.join(telemetryRoot, "dist/cloudflare/index.js"),
+      "@latitude-data/telemetry": path.join(telemetryRoot, "dist/index.js"),
+    },
+  },
 })

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/wrangler.jsonc
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/wrangler.jsonc
@@ -1,0 +1,37 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "latitude-cloudflare-codemode-example",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-07-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/agents/*"]
+  },
+  "ai": {
+    "binding": "AI"
+  },
+  "worker_loaders": [
+    {
+      "binding": "LOADER"
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "MyAgent",
+        "class_name": "MyAgent"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["MyAgent"]
+    }
+  ],
+  "vars": {
+    "LATITUDE_PROJECT_SLUG": "default-project",
+    "LATITUDE_TELEMETRY_URL": "http://localhost:3002"
+  }
+}

--- a/packages/telemetry/typescript/examples/cloudflare-codemode-app/wrangler.jsonc
+++ b/packages/telemetry/typescript/examples/cloudflare-codemode-app/wrangler.jsonc
@@ -9,7 +9,8 @@
     "run_worker_first": ["/agents/*"]
   },
   "ai": {
-    "binding": "AI"
+    "binding": "AI",
+    "remote": true
   },
   "worker_loaders": [
     {
@@ -21,6 +22,10 @@
       {
         "name": "MyAgent",
         "class_name": "MyAgent"
+      },
+      {
+        "name": "WeatherResearchAgent",
+        "class_name": "WeatherResearchAgent"
       }
     ]
   },
@@ -28,6 +33,10 @@
     {
       "tag": "v1",
       "new_sqlite_classes": ["MyAgent"]
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["WeatherResearchAgent"]
     }
   ],
   "vars": {

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -33,6 +33,17 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./cloudflare": {
+      "source": "./src/cloudflare/index.ts",
+      "import": {
+        "types": "./dist/cloudflare/index.d.ts",
+        "default": "./dist/cloudflare/index.js"
+      },
+      "require": {
+        "types": "./dist/cloudflare/index.d.cts",
+        "default": "./dist/cloudflare/index.cjs"
+      }
     }
   },
   "scripts": {

--- a/packages/telemetry/typescript/src/cloudflare/codemode-telemetry.test.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode-telemetry.test.ts
@@ -158,17 +158,11 @@ describe("cloudflare-codemode telemetry", () => {
           .filter((name): name is string => typeof name === "string"),
       ),
     ]
-    const spanNames = spans.map((span) => span.name)
 
     expect(spans.length).toBeGreaterThan(0)
-    expect(
-      spanNames.some((name) => name.includes("tool") || name.includes("codemode")) ||
-        spans.some((span) => span.attributes["ai.toolCall.name"] === "codemode"),
-    ).toBe(true)
+    expect(spans.some((span) => span.attributes["ai.toolCall.name"] === "codemode")).toBe(true)
+    expect(spans.some((span) => span.attributes["ai.toolCall.name"] === "getWeather")).toBe(true)
     expect(toolNames).toContain("getWeather")
-    expect(
-      toolNames.includes("codemode") || spans.some((span) => span.attributes["ai.toolCall.name"] === "codemode"),
-    ).toBe(true)
     expect(spans.some((span) => span.attributes["user.id"] === "codemode-user")).toBe(true)
     expect(spans.some((span) => span.attributes["session.id"] === "codemode-session")).toBe(true)
   })

--- a/packages/telemetry/typescript/src/cloudflare/codemode-telemetry.test.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode-telemetry.test.ts
@@ -4,7 +4,8 @@ import { stepCountIs, streamText, tool } from "ai"
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
 import { afterEach, describe, expect, it } from "vitest"
 import { z } from "zod"
-import { Latitude } from "./init.ts"
+import { Latitude } from "../sdk/init.ts"
+import { instrumentCodemodeTools } from "./codemode.ts"
 
 describe("cloudflare-codemode telemetry", () => {
   afterEach(async () => {
@@ -14,10 +15,11 @@ describe("cloudflare-codemode telemetry", () => {
 
   let latitude: Latitude | undefined
   let exporter: InMemorySpanExporter
+  let hostProvider: NodeTracerProvider
 
   function setupLatitude() {
     exporter = new InMemorySpanExporter()
-    const hostProvider = new NodeTracerProvider({
+    hostProvider = new NodeTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(exporter)],
     })
 
@@ -25,6 +27,7 @@ describe("cloudflare-codemode telemetry", () => {
       apiKey: "test-key",
       project: "test-project",
       tracerProvider: hostProvider,
+      exporter,
       disableBatch: true,
     })
 
@@ -94,8 +97,13 @@ describe("cloudflare-codemode telemetry", () => {
     } as ConstructorParameters<typeof MockLanguageModelV3>[0])
   }
 
-  it("records model turns and the outer codemode tool call via AI SDK telemetry", async () => {
+  it("records model turns, the outer codemode tool call, and inner sandbox tools", async () => {
     const sdk = setupLatitude()
+    const tracer = sdk.getTracer("cloudflare-codemode", {
+      userId: "codemode-user",
+      sessionId: "codemode-session",
+      tags: ["cloudflare-codemode"],
+    })
 
     const getWeather = tool({
       description: "Get the current weather for a city.",
@@ -103,12 +111,24 @@ describe("cloudflare-codemode telemetry", () => {
       execute: async ({ city }) => ({ city, conditions: "sunny" }),
     })
 
+    const sandboxTools = instrumentCodemodeTools({ getWeather }, { tracer })
+
     const codemode = tool({
       description: "Execute generated code.",
       inputSchema: z.object({ code: z.string() }),
       execute: async ({ code }) => {
         const runner = new Function("codemode", `return (${code})()`)
-        return runner({ getWeather: getWeather.execute })
+        const toolFns = Object.fromEntries(
+          Object.entries(sandboxTools).map(([name, sandboxTool]) => [
+            name,
+            (input: { city: string }) =>
+              sandboxTool.execute!(input, {
+                toolCallId: `test-${name}`,
+                messages: [],
+              }),
+          ]),
+        )
+        return runner(toolFns)
       },
     })
 
@@ -119,11 +139,7 @@ describe("cloudflare-codemode telemetry", () => {
       stopWhen: stepCountIs(2),
       experimental_telemetry: {
         isEnabled: true,
-        tracer: sdk.getTracer("cloudflare-codemode", {
-          userId: "codemode-user",
-          sessionId: "codemode-session",
-          tags: ["cloudflare-codemode"],
-        }),
+        tracer,
         functionId: "codemode-turn",
       },
     })
@@ -132,19 +148,27 @@ describe("cloudflare-codemode telemetry", () => {
       // drain
     }
 
-    await sdk.flush()
+    await hostProvider.forceFlush()
 
     const spans = exporter.getFinishedSpans()
-    const toolNames = spans
-      .map((span) => span.attributes["gen_ai.tool.name"])
-      .filter((name): name is string => typeof name === "string")
+    const toolNames = [
+      ...new Set(
+        spans
+          .map((span) => span.attributes["gen_ai.tool.name"])
+          .filter((name): name is string => typeof name === "string"),
+      ),
+    ]
     const spanNames = spans.map((span) => span.name)
 
     expect(spans.length).toBeGreaterThan(0)
     expect(
-      spanNames.some((name) => name.includes("tool") || name.includes("codemode")) || toolNames.includes("codemode"),
+      spanNames.some((name) => name.includes("tool") || name.includes("codemode")) ||
+        spans.some((span) => span.attributes["ai.toolCall.name"] === "codemode"),
     ).toBe(true)
-    expect(toolNames).not.toContain("getWeather")
+    expect(toolNames).toContain("getWeather")
+    expect(
+      toolNames.includes("codemode") || spans.some((span) => span.attributes["ai.toolCall.name"] === "codemode"),
+    ).toBe(true)
     expect(spans.some((span) => span.attributes["user.id"] === "codemode-user")).toBe(true)
     expect(spans.some((span) => span.attributes["session.id"] === "codemode-session")).toBe(true)
   })

--- a/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
@@ -1,0 +1,59 @@
+import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+import { tool } from "ai"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { Latitude } from "../sdk/init.ts"
+import { instrumentCodemodeTools } from "./codemode.ts"
+
+describe("instrumentCodemodeTools", () => {
+  it("emits ai.toolCall spans for wrapped tool execute functions", async () => {
+    const exporter = new InMemorySpanExporter()
+    const hostProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+
+    const latitude = new Latitude({
+      apiKey: "test-key",
+      project: "test-project",
+      tracerProvider: hostProvider,
+      exporter,
+      disableBatch: true,
+    })
+
+    const tracer = latitude.getTracer("cloudflare-codemode", {
+      userId: "codemode-user",
+      sessionId: "codemode-session",
+      tags: ["cloudflare-codemode"],
+    })
+
+    const tools = instrumentCodemodeTools(
+      {
+        getWeather: tool({
+          description: "Get weather",
+          inputSchema: z.object({ city: z.string() }),
+          execute: async ({ city }) => ({ city, conditions: "sunny" }),
+        }),
+      },
+      { tracer },
+    )
+
+    await tools.getWeather.execute!({ city: "Barcelona" }, {
+      toolCallId: "ignored",
+      messages: [],
+    })
+
+    await hostProvider.forceFlush()
+
+    const spans = exporter.getFinishedSpans().filter((span) => span.name === "ai.toolCall getWeather")
+    expect(spans.length).toBeGreaterThan(0)
+    expect(spans[0]?.name).toBe("ai.toolCall getWeather")
+    expect(spans[0]?.attributes["ai.operationId"]).toBe("ai.toolCall")
+    expect(spans[0]?.attributes["ai.toolCall.name"]).toBe("getWeather")
+    expect(spans[0]?.attributes["gen_ai.tool.name"]).toBe("getWeather")
+    expect(spans[0]?.attributes["latitude.codemode.inner_tool"]).toBe(true)
+    expect(spans[0]?.attributes["user.id"]).toBe("codemode-user")
+    expect(spans[0]?.attributes["session.id"]).toBe("codemode-session")
+
+    await latitude.shutdown()
+  })
+})

--- a/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
@@ -37,10 +37,13 @@ describe("instrumentCodemodeTools", () => {
       { tracer },
     )
 
-    await tools.getWeather.execute!({ city: "Barcelona" }, {
-      toolCallId: "ignored",
-      messages: [],
-    })
+    await tools.getWeather.execute!(
+      { city: "Barcelona" },
+      {
+        toolCallId: "ignored",
+        messages: [],
+      },
+    )
 
     await hostProvider.forceFlush()
 

--- a/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.test.ts
@@ -1,11 +1,17 @@
+import { context, trace } from "@opentelemetry/api"
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { tool } from "ai"
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { z } from "zod"
 import { Latitude } from "../sdk/init.ts"
 import { instrumentCodemodeTools } from "./codemode.ts"
 
 describe("instrumentCodemodeTools", () => {
+  beforeAll(() => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+  })
+
   it("emits ai.toolCall spans for wrapped tool execute functions", async () => {
     const exporter = new InMemorySpanExporter()
     const hostProvider = new NodeTracerProvider({
@@ -56,6 +62,100 @@ describe("instrumentCodemodeTools", () => {
     expect(spans[0]?.attributes["latitude.codemode.inner_tool"]).toBe(true)
     expect(spans[0]?.attributes["user.id"]).toBe("codemode-user")
     expect(spans[0]?.attributes["session.id"]).toBe("codemode-session")
+
+    await latitude.shutdown()
+  })
+
+  it("synthesizes tool call options when execute is invoked without a second argument", async () => {
+    const exporter = new InMemorySpanExporter()
+    const hostProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+
+    const latitude = new Latitude({
+      apiKey: "test-key",
+      project: "test-project",
+      tracerProvider: hostProvider,
+      exporter,
+      disableBatch: true,
+    })
+
+    const tracer = latitude.getTracer("cloudflare-codemode")
+    let receivedToolCallId: string | undefined
+
+    const tools = instrumentCodemodeTools(
+      {
+        recordId: tool({
+          description: "Record tool call id",
+          inputSchema: z.object({ city: z.string() }),
+          execute: async (_input, options) => {
+            receivedToolCallId = options?.toolCallId
+            return { ok: true }
+          },
+        }),
+      },
+      { tracer },
+    )
+
+    const executeWithoutOptions = tools.recordId.execute as (input: { city: string }) => Promise<{ ok: boolean }>
+    await executeWithoutOptions({ city: "Barcelona" })
+
+    expect(receivedToolCallId).toMatch(/^codemode-inner-recordId-/)
+
+    await latitude.shutdown()
+  })
+
+  it("nests inner tool spans under the active parent span", async () => {
+    const exporter = new InMemorySpanExporter()
+    const hostProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+
+    const latitude = new Latitude({
+      apiKey: "test-key",
+      project: "test-project",
+      tracerProvider: hostProvider,
+      exporter,
+      disableBatch: true,
+    })
+
+    const tracer = latitude.getTracer("cloudflare-codemode", {
+      sessionId: "codemode-session",
+      tags: ["cloudflare-codemode"],
+    })
+
+    const tools = instrumentCodemodeTools(
+      {
+        getWeather: tool({
+          description: "Get weather",
+          inputSchema: z.object({ city: z.string() }),
+          execute: async ({ city }) => ({ city, conditions: "sunny" }),
+        }),
+      },
+      { tracer },
+    )
+
+    const parentSpan = tracer.startSpan("ai.toolCall codemode")
+    await context.with(trace.setSpan(context.active(), parentSpan), async () => {
+      await tools.getWeather.execute!(
+        { city: "Barcelona" },
+        {
+          toolCallId: "call_getWeather",
+          messages: [],
+        },
+      )
+    })
+    parentSpan.end()
+
+    await hostProvider.forceFlush()
+
+    const spans = exporter.getFinishedSpans()
+    const innerSpan = spans.find((span) => span.name === "ai.toolCall getWeather")
+
+    expect(innerSpan).toBeDefined()
+    expect(innerSpan?.attributes["latitude.codemode.inner_tool"]).toBe(true)
+    expect(innerSpan?.parentSpanContext?.spanId).toBe(parentSpan.spanContext().spanId)
+    expect(innerSpan?.spanContext().traceId).toBe(parentSpan.spanContext().traceId)
 
     await latitude.shutdown()
   })

--- a/packages/telemetry/typescript/src/cloudflare/codemode.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.ts
@@ -55,10 +55,7 @@ function wrapToolExecute(toolName: string, tool: Tool, tracer: Tracer, toolCallI
   }
 }
 
-export function instrumentCodemodeTools<T extends ToolSet>(
-  tools: T,
-  options: InstrumentCodemodeToolsOptions,
-): T {
+export function instrumentCodemodeTools<T extends ToolSet>(tools: T, options: InstrumentCodemodeToolsOptions): T {
   const prefix = options.toolCallIdPrefix ?? "codemode-inner"
   const wrapped = {} as Record<string, Tool>
 

--- a/packages/telemetry/typescript/src/cloudflare/codemode.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.ts
@@ -1,0 +1,70 @@
+import { SpanStatusCode, type Tracer } from "@opentelemetry/api"
+import type { Tool, ToolSet } from "ai"
+
+export type InstrumentCodemodeToolsOptions = {
+  tracer: Tracer
+  toolCallIdPrefix?: string
+}
+
+function newToolCallId(prefix: string, toolName: string) {
+  const suffix = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`
+  return `${prefix}-${toolName}-${suffix}`
+}
+
+function wrapToolExecute(toolName: string, tool: Tool, tracer: Tracer, toolCallIdPrefix: string): Tool {
+  const execute = tool.execute
+  if (!execute) return tool
+
+  return {
+    ...tool,
+    execute: async (input, options) => {
+      const toolCallId = newToolCallId(toolCallIdPrefix, toolName)
+      const argsJson = JSON.stringify(input)
+      const span = tracer.startSpan(`ai.toolCall ${toolName}`)
+
+      span.setAttributes({
+        "ai.operationId": "ai.toolCall",
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": toolName,
+        "ai.toolCall.name": toolName,
+        "ai.toolCall.id": toolCallId,
+        "gen_ai.tool.call.id": toolCallId,
+        "ai.toolCall.args": argsJson,
+        "gen_ai.tool.call.arguments": argsJson,
+        "latitude.codemode.inner_tool": true,
+      })
+
+      try {
+        const result = await execute(input, options)
+        const resultJson = JSON.stringify(result)
+        span.setAttributes({
+          "ai.toolCall.result": resultJson,
+          "gen_ai.tool.call.result": resultJson,
+        })
+        span.setStatus({ code: SpanStatusCode.OK })
+        return result
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error))
+        span.recordException(err)
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+        throw error
+      } finally {
+        span.end()
+      }
+    },
+  }
+}
+
+export function instrumentCodemodeTools<T extends ToolSet>(
+  tools: T,
+  options: InstrumentCodemodeToolsOptions,
+): T {
+  const prefix = options.toolCallIdPrefix ?? "codemode-inner"
+  const wrapped = {} as Record<string, Tool>
+
+  for (const [name, tool] of Object.entries(tools) as [string, Tool][]) {
+    wrapped[name] = wrapToolExecute(name, tool, options.tracer, prefix)
+  }
+
+  return wrapped as T
+}

--- a/packages/telemetry/typescript/src/cloudflare/codemode.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode, type Tracer } from "@opentelemetry/api"
+import { context, SpanStatusCode, type Tracer, trace } from "@opentelemetry/api"
 import type { Tool, ToolSet } from "ai"
 
 export type InstrumentCodemodeToolsOptions = {
@@ -20,9 +20,15 @@ function wrapToolExecute(toolName: string, tool: Tool, tracer: Tracer, toolCallI
   return {
     ...tool,
     execute: async (input, options) => {
-      const toolCallId = newToolCallId(toolCallIdPrefix, toolName)
+      const toolCallId = options?.toolCallId ?? newToolCallId(toolCallIdPrefix, toolName)
+      const resolvedOptions = {
+        toolCallId,
+        messages: options?.messages ?? [],
+        ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+      }
       const argsJson = JSON.stringify(input)
-      const span = tracer.startSpan(`ai.toolCall ${toolName}`)
+      const parentContext = context.active()
+      const span = tracer.startSpan(`ai.toolCall ${toolName}`, undefined, parentContext)
 
       span.setAttributes({
         "ai.operationId": "ai.toolCall",
@@ -36,8 +42,10 @@ function wrapToolExecute(toolName: string, tool: Tool, tracer: Tracer, toolCallI
         "latitude.codemode.inner_tool": true,
       })
 
+      const spanContext = trace.setSpan(parentContext, span)
+
       try {
-        const result = await execute(input, options)
+        const result = await context.with(spanContext, () => execute(input, resolvedOptions))
         const resultJson = JSON.stringify(result)
         span.setAttributes({
           "ai.toolCall.result": resultJson,

--- a/packages/telemetry/typescript/src/cloudflare/codemode.ts
+++ b/packages/telemetry/typescript/src/cloudflare/codemode.ts
@@ -6,8 +6,10 @@ export type InstrumentCodemodeToolsOptions = {
   toolCallIdPrefix?: string
 }
 
+let toolCallIdCounter = 0
+
 function newToolCallId(prefix: string, toolName: string) {
-  const suffix = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`
+  const suffix = globalThis.crypto?.randomUUID?.() ?? String(++toolCallIdCounter)
   return `${prefix}-${toolName}-${suffix}`
 }
 

--- a/packages/telemetry/typescript/src/cloudflare/index.ts
+++ b/packages/telemetry/typescript/src/cloudflare/index.ts
@@ -1,1 +1,1 @@
-export { instrumentCodemodeTools, type InstrumentCodemodeToolsOptions } from "./codemode.ts"
+export { type InstrumentCodemodeToolsOptions, instrumentCodemodeTools } from "./codemode.ts"

--- a/packages/telemetry/typescript/src/cloudflare/index.ts
+++ b/packages/telemetry/typescript/src/cloudflare/index.ts
@@ -1,0 +1,1 @@
+export { instrumentCodemodeTools, type InstrumentCodemodeToolsOptions } from "./codemode.ts"

--- a/packages/telemetry/typescript/src/env/env.ts
+++ b/packages/telemetry/typescript/src/env/env.ts
@@ -3,5 +3,3 @@ const PRODUCTION_EXPORTER_URL = "https://ingest.latitude.so"
 export function getExporterUrl() {
   return process.env.LATITUDE_TELEMETRY_URL ?? PRODUCTION_EXPORTER_URL
 }
-
-export const env = { EXPORTER_URL: getExporterUrl() } as const

--- a/packages/telemetry/typescript/src/sdk/codemode-telemetry.test.ts
+++ b/packages/telemetry/typescript/src/sdk/codemode-telemetry.test.ts
@@ -40,9 +40,10 @@ describe("cloudflare-codemode telemetry", () => {
       doStream: async () => {
         calls += 1
 
-        const chunks =
-          calls === 1
-            ? [
+        if (calls === 1) {
+          return {
+            stream: simulateReadableStream({
+              chunks: [
                 { type: "stream-start", warnings: [] },
                 {
                   type: "response-metadata",
@@ -63,28 +64,34 @@ describe("cloudflare-codemode telemetry", () => {
                   finishReason: "tool-calls",
                   usage: { inputTokens: 12, outputTokens: 3, totalTokens: 15 },
                 },
-              ]
-            : [
-                { type: "stream-start", warnings: [] },
-                {
-                  type: "response-metadata",
-                  id: `resp_${randomUUID()}`,
-                  modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
-                  timestamp: new Date(),
-                },
-                { type: "text-start", id: "text-1" },
-                { type: "text-delta", id: "text-1", delta: "Barcelona is sunny." },
-                { type: "text-end", id: "text-1" },
-                {
-                  type: "finish",
-                  finishReason: "stop",
-                  usage: { inputTokens: 20, outputTokens: 7, totalTokens: 27 },
-                },
-              ]
+              ],
+            }),
+          }
+        }
 
-        return { stream: simulateReadableStream({ chunks }) }
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              {
+                type: "response-metadata",
+                id: `resp_${randomUUID()}`,
+                modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                timestamp: new Date(),
+              },
+              { type: "text-start", id: "text-1" },
+              { type: "text-delta", id: "text-1", delta: "Barcelona is sunny." },
+              { type: "text-end", id: "text-1" },
+              {
+                type: "finish",
+                finishReason: "stop",
+                usage: { inputTokens: 20, outputTokens: 7, totalTokens: 27 },
+              },
+            ],
+          }),
+        }
       },
-    })
+    } as ConstructorParameters<typeof MockLanguageModelV3>[0])
   }
 
   it("records model turns and the outer codemode tool call via AI SDK telemetry", async () => {

--- a/packages/telemetry/typescript/src/sdk/codemode-telemetry.test.ts
+++ b/packages/telemetry/typescript/src/sdk/codemode-telemetry.test.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto"
+import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+import { stepCountIs, streamText, tool } from "ai"
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
+import { afterEach, describe, expect, it } from "vitest"
+import { z } from "zod"
+import { Latitude } from "./init.ts"
+
+describe("cloudflare-codemode telemetry", () => {
+  afterEach(async () => {
+    await latitude?.shutdown()
+    latitude = undefined
+  })
+
+  let latitude: Latitude | undefined
+  let exporter: InMemorySpanExporter
+
+  function setupLatitude() {
+    exporter = new InMemorySpanExporter()
+    const hostProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+
+    latitude = new Latitude({
+      apiKey: "test-key",
+      project: "test-project",
+      tracerProvider: hostProvider,
+      disableBatch: true,
+    })
+
+    return latitude
+  }
+
+  function makeCodemodeModel() {
+    let calls = 0
+
+    return new MockLanguageModelV3({
+      provider: "cloudflare-workers-ai",
+      modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+      doStream: async () => {
+        calls += 1
+
+        const chunks =
+          calls === 1
+            ? [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "response-metadata",
+                  id: `resp_${randomUUID()}`,
+                  modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                  timestamp: new Date(),
+                },
+                {
+                  type: "tool-call",
+                  toolCallId: "call_codemode",
+                  toolName: "codemode",
+                  input: JSON.stringify({
+                    code: 'async () => { return await codemode.getWeather({ city: "Barcelona" }); }',
+                  }),
+                },
+                {
+                  type: "finish",
+                  finishReason: "tool-calls",
+                  usage: { inputTokens: 12, outputTokens: 3, totalTokens: 15 },
+                },
+              ]
+            : [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "response-metadata",
+                  id: `resp_${randomUUID()}`,
+                  modelId: "@cf/meta/llama-4-scout-17b-16e-instruct",
+                  timestamp: new Date(),
+                },
+                { type: "text-start", id: "text-1" },
+                { type: "text-delta", id: "text-1", delta: "Barcelona is sunny." },
+                { type: "text-end", id: "text-1" },
+                {
+                  type: "finish",
+                  finishReason: "stop",
+                  usage: { inputTokens: 20, outputTokens: 7, totalTokens: 27 },
+                },
+              ]
+
+        return { stream: simulateReadableStream({ chunks }) }
+      },
+    })
+  }
+
+  it("records model turns and the outer codemode tool call via AI SDK telemetry", async () => {
+    const sdk = setupLatitude()
+
+    const getWeather = tool({
+      description: "Get the current weather for a city.",
+      inputSchema: z.object({ city: z.string() }),
+      execute: async ({ city }) => ({ city, conditions: "sunny" }),
+    })
+
+    const codemode = tool({
+      description: "Execute generated code.",
+      inputSchema: z.object({ code: z.string() }),
+      execute: async ({ code }) => {
+        const runner = new Function("codemode", `return (${code})()`)
+        return runner({ getWeather: getWeather.execute })
+      },
+    })
+
+    const result = streamText({
+      model: makeCodemodeModel(),
+      messages: [{ role: "user", content: "Weather in Barcelona" }],
+      tools: { codemode },
+      stopWhen: stepCountIs(2),
+      experimental_telemetry: {
+        isEnabled: true,
+        tracer: sdk.getTracer("cloudflare-codemode", {
+          userId: "codemode-user",
+          sessionId: "codemode-session",
+          tags: ["cloudflare-codemode"],
+        }),
+        functionId: "codemode-turn",
+      },
+    })
+
+    for await (const _delta of result.textStream) {
+      // drain
+    }
+
+    await sdk.flush()
+
+    const spans = exporter.getFinishedSpans()
+    const toolNames = spans
+      .map((span) => span.attributes["gen_ai.tool.name"])
+      .filter((name): name is string => typeof name === "string")
+    const spanNames = spans.map((span) => span.name)
+
+    expect(spans.length).toBeGreaterThan(0)
+    expect(
+      spanNames.some((name) => name.includes("tool") || name.includes("codemode")) || toolNames.includes("codemode"),
+    ).toBe(true)
+    expect(toolNames).not.toContain("getWeather")
+    expect(spans.some((span) => span.attributes["user.id"] === "codemode-user")).toBe(true)
+    expect(spans.some((span) => span.attributes["session.id"] === "codemode-session")).toBe(true)
+  })
+})

--- a/packages/telemetry/typescript/src/sdk/index.ts
+++ b/packages/telemetry/typescript/src/sdk/index.ts
@@ -17,5 +17,5 @@ export {
   isLatitudeInstrumentationSpan,
   RedactThenExportSpanProcessor,
 } from "./span-filter.ts"
-export { getLatitudeTracer } from "./tracer.ts"
+export { getLatitudeTracer, withLatitudeAttributes } from "./tracer.ts"
 export type { ContextOptions, InitLatitudeOptions, LatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -12,7 +12,7 @@ import {
 } from "@opentelemetry/sdk-trace-node"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
 import { ATTRIBUTES } from "../constants/index.ts"
-import { env } from "../env/index.ts"
+import { getExporterUrl } from "../env/index.ts"
 import { getLatitudeContext } from "./context.ts"
 import { DEFAULT_REDACT_SPAN_PROCESSOR, RedactSpanProcessor } from "./redact.ts"
 import {
@@ -77,7 +77,7 @@ export class LatitudeSpanProcessor implements SpanProcessor {
     const baseExporter =
       options?.exporter ??
       new OTLPTraceExporter({
-        url: `${env.EXPORTER_URL}/v1/traces`,
+        url: `${getExporterUrl()}/v1/traces`,
         headers,
         timeoutMillis: 30_000,
       })

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -74,10 +74,12 @@ export class LatitudeSpanProcessor implements SpanProcessor {
     }
     if (normalizedProject) headers["X-Latitude-Project"] = normalizedProject
 
+    const exporterOrigin = options?.telemetryUrl ?? getExporterUrl()
+
     const baseExporter =
       options?.exporter ??
       new OTLPTraceExporter({
-        url: `${getExporterUrl()}/v1/traces`,
+        url: `${exporterOrigin}/v1/traces`,
         headers,
         timeoutMillis: 30_000,
       })

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -54,6 +54,10 @@ export type LatitudeOptions = SmartFilterOptions & {
   disableBatch?: boolean
   exporter?: SpanExporter
   /**
+   * OTLP ingest origin override. When omitted, uses `LATITUDE_TELEMETRY_URL` or production ingest.
+   */
+  telemetryUrl?: string
+  /**
    * Existing OpenTelemetry tracer provider to attach Latitude to.
    * Usually omitted because `new Latitude()` detects the global provider installed by Sentry,
    * Datadog, New Relic, Honeycomb, or a custom OTel SDK setup.
@@ -79,6 +83,7 @@ export type LatitudeSpanProcessorOptions = SmartFilterOptions & {
   redact?: RedactSpanProcessorOptions
   disableBatch?: boolean
   exporter?: SpanExporter
+  telemetryUrl?: string
   /**
    * Overrides the `service.name` resource attribute on spans exported through this processor.
    * Applied via an exporter wrapper, so other span processors on the host provider continue

--- a/packages/telemetry/typescript/tsdown.config.ts
+++ b/packages/telemetry/typescript/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown"
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/cloudflare/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ packages:
   - "!packages/telemetry/typescript/examples/eve-app/**"
   - "!packages/telemetry/typescript/examples/cloudflare-think-app"
   - "!packages/telemetry/typescript/examples/cloudflare-think-app/**"
+  - "!packages/telemetry/typescript/examples/cloudflare-codemode-app"
+  - "!packages/telemetry/typescript/examples/cloudflare-codemode-app/**"
   - infra
   - tools/*
 

--- a/specs/codemode-observability-ui.md
+++ b/specs/codemode-observability-ui.md
@@ -39,11 +39,11 @@ Open a codemode session and **read the orchestration top-to-bottom once**, expan
 | ID | Decision |
 |---|---|
 | **D1** | Tab name: **Run** (session drawer, multi-trace sessions only). |
-| **D2** | **Telemetry contract first** — stable span attributes before UI heuristics; example app updated in Phase 0. |
-| **D3** | **Turn grouping** — derive turns from user messages on `latestTraceId` conversation (see algorithm below); assign traces/spans to turns by time window. |
+| **D2** | **Reconstruct, don't hand-instrument.** A session's traces are disconnected islands (OTel context does not cross the sandbox / Durable-Object / isolate boundary, so `parentSpanId` never crosses a trace — verified in ClickHouse). The Run tab rebuilds one **session graph** from keys that already exist: `parentSpanId` inside a trace, `run_id` for the sub-agent edge, `inner_tool` + operation for the code node, `functionId` for roles. The only telemetry the app must emit beyond native AI-SDK spans is the sub-agent link (`run_id`, set by `runAgentTool`). No per-span `phase`/`turn_id` required. |
+| **D3** | **Turn grouping from the graph, not from messages.** A new turn begins at each top-level **main-agent entry** node (`functionId ∈ {codemode-turn, codemode-plan}`, i.e. kind `agent`/`plan`); sub-agent, tool, code and `summarize` roots join the current turn. No `turn_id` and no message-count coupling. User messages only supply turn **labels** (by index). |
 | **D4** | **Phase 1 fetches session spans** — reuse `useSpansBySessionCollection` (already used by Conversation timeline and Metadata tab). |
-| **D5** | **Sub-agent drill-in requires explicit link metadata** — no overlap-only matching in v1. Block Phase 2 drill-in on `latitude.agent_tool.parent_tool_call_id` (+ optional `run_id`). |
-| **D6** | **Phase detection priority**: (1) `latitude.codemode.phase` attr, (2) `experimental_telemetry.functionId` on span attrs (verify ingest maps it — otherwise falls through to priority 3), (3) operation + name heuristics for legacy data. |
+| **D5** | **Sub-agent edge is `run_id`.** The delegate tool-call span and every span of the sub-agent trace it spawned share `latitude.agent_tool.run_id`; the sub-agent nests under the delegate via that key (prefer the tool span carrying `parent_tool_call_id`). No time-overlap guessing. |
+| **D6** | **Node role priority**: (1) operation + tool name for the code node (`execute_tool` + `codemode`) and concrete tool calls, (2) `ai.telemetry.functionId` for agent roles (`codemode-plan`→plan, `codemode-summary`→summarize, `codemode-turn`→agent, `research-subagent-turn`→sub-agent), (3) name heuristics (`generateText`/`streamText`) at low confidence for legacy data. |
 
 ## Telemetry contract (Phase 0)
 
@@ -63,34 +63,27 @@ SDK + docs emit these **span attributes** (all optional for backward compat, req
 - Cloudflare codemode example worker: set `latitude.codemode.phase` on plan / execute / summarize tracers; set `parent_tool_call_id` when delegating to sub-agent.  
 - Document contract in `docs/telemetry/frameworks/cloudflare-codemode.mdx`.
 
-## Turn grouping algorithm
+## Session graph algorithm
 
-When **`latitude.codemode.turn_id`** is present on spans/traces, group by it directly (authoritative). The message-timestamp algorithm below is the **fallback** for legacy data lacking `turn_id`.
+`buildCodemodeRunTimeline({ session, traces, spans, messages })` builds one graph from all session spans:
 
-**Fallback algorithm** (sessions have `traceIds[]` and `latestTraceId` but no turn index):
+1. **Adjacency.** For each span: if `parentSpanId` resolves inside the session → intra-trace child. Else (a trace root) resolve a **cross-trace** parent:
+   - sub-agent root (`invoke_agent` with `run_id`) → the delegate tool span sharing that `run_id` in another trace;
+   - inner-tool root (`execute_tool` + `inner_tool`) → the code node whose `[start,end]` window contains it (or the sole code node).
+   Otherwise it is a **forest root**.
+2. **Collapse noise.** Drop `chat` (`.doStream`/`.doGenerate`) spans and bare `ai.toolCall` wrappers, promoting their kept descendants. Kept nodes = agent turns, the code node, and concrete tool calls.
+3. **Turns.** Sort forest roots by start; open a new turn at each main-agent entry (kind `agent`/`plan`); everything else joins the current turn (D3). Label from user messages by index, else `"Turn {n}"`.
 
-1. Load conversation messages from **`latestTraceId`** (existing behavior).  
-2. Enumerate **user messages** in order → each defines a turn `turnIndex` (0-based).  
-3. Turn time window: `[userMessage.atMs, nextUserMessage.atMs)` (last turn: `[atMs, session.endTime]`).  
-4. Assign each **trace** to the turn whose window contains `trace.startTime`.  
-5. Assign each **session span** to the same turn by `span.startTime`.  
-6. **Orphan traces** (no user message yet, e.g. partial ingest): fall into turn 0 or an "Unassigned" bucket shown collapsed at top.
-
-Turn label: first 80 chars of user message text, or `"Turn {n}"`.
-
-## Phase detection (within a turn)
-
-After sorting assigned traces/spans by `startTime ASC`, build the Run tree:
+## Node roles
 
 | Node | Detection (first match) |
 |---|---|
-| **Plan** | span/trace with `latitude.codemode.phase=plan`, OR name `ai.generateText` + metadata `functionId=codemode-plan` |
-| **Execute (codemode)** | span/trace with `phase=execute`, OR `ai.toolCall codemode`, OR parent of inner-tool spans. *Note: `phase=execute` may be unavailable on the `ai.toolCall codemode` span itself (emitted by `createCodeTool` / AI SDK); rely on operation name + inner-tool parent fallback there.* |
-| **Inner tool** | span with `latitude.codemode.inner_tool=true` (group under Execute; sort by startTime) |
-| **Sub-agent** | span/trace with `latitude.agent_tool.run_id` or tag/metadata `subagent` / example role metadata |
-| **Summarize** | `phase=summarize`, OR `ai.streamText` + `functionId=codemode-summary` |
+| **Execute (codemode)** | `execute_tool` with tool name `codemode` (or name ` … codemode`) — high confidence |
+| **Inner / tool** | any other `execute_tool` (concrete tool); `inner_tool=true` hints "inner sandbox tool" |
+| **Plan / Summarize / Agent / Sub-agent** | `invoke_agent` keyed by `functionId` (`codemode-plan` / `codemode-summary` / `codemode-turn` / `research-subagent-turn`), or reached via the `run_id` sub-agent edge |
+| **Legacy fallback** | `generateText`→plan, `streamText`→summarize at **low** confidence when no `functionId` |
 
-Legacy fallback (pre-Phase-0 data): infer Plan/Summarize from trace names + example tags only; show **"Unlabeled phase"** badge when confidence is low.
+Sub-agent trees nest under their delegating tool via the `run_id` edge (D5); inner tools nest under the code node.
 
 ## UI design
 

--- a/specs/codemode-observability-ui.md
+++ b/specs/codemode-observability-ui.md
@@ -1,0 +1,212 @@
+# Codemode Observability UI
+
+> **Documentation**: `dev-docs/spans.md`, `docs/telemetry/frameworks/cloudflare-codemode.mdx`  
+> **Context**: Cloudflare Code Mode example emits multi-trace orchestration (plan → sandbox tools → sub-agent → summarize). Latitude ingests all spans but the console presents them as unrelated newest-first trace rows.
+
+## Problem
+
+A single user turn in a codemode agent produces **many traces** in one session:
+
+1. `ai.generateText` — codemode plan  
+2. `ai.toolCall codemode` — sandbox execution (host)  
+3. `ai.toolCall delegateWeatherResearch` — inner tool (separate trace today)  
+4. `ai.toolCall formatTravelBrief` — inner tool (separate trace today)  
+5. Sub-agent traces — `getWeatherDetail`, `scoreComfort`, etc.  
+6. `ai.streamText` — user-facing summary  
+
+**Traces tab** lists these flat, **newest first** — the story reads backwards.
+
+**Session drawer** limitations today:
+
+- **Conversation** loads messages from `latestTraceId` but already fetches **session spans** via `useSpansBySessionCollection` for the activity scrubber. For codemode, the summary trace carries the full message chain (plan tool-call + result + assistant text), so the `codemode` block appears — but it is opaque (no code, no step list).
+- **Spans tab** is hidden for multi-trace sessions (`singleTrace` gate in `session-slot.tsx`).
+- `latitude.codemode.inner_tool` exists on spans (`instrumentCodemodeTools`) but the web app never reads it.
+
+## Goal
+
+Open a codemode session and **read the orchestration top-to-bottom once**, expanding only where something failed — without opening five trace drawers or mentally reversing a table.
+
+## Non-goals
+
+- Replacing generic trace/session views for non-codemode workloads  
+- Running or replaying codemode in the UI  
+- Cloudflare `useAgentToolEvents` UI parity (inspiration only)  
+- One root trace per user turn in ingest (future consideration, not this spec)  
+- Traces-tab "group by session" unless Phase 3 dogfood shows Phase 1–2 insufficient
+
+## Decisions
+
+| ID | Decision |
+|---|---|
+| **D1** | Tab name: **Run** (session drawer, multi-trace sessions only). |
+| **D2** | **Telemetry contract first** — stable span attributes before UI heuristics; example app updated in Phase 0. |
+| **D3** | **Turn grouping** — derive turns from user messages on `latestTraceId` conversation (see algorithm below); assign traces/spans to turns by time window. |
+| **D4** | **Phase 1 fetches session spans** — reuse `useSpansBySessionCollection` (already used by Conversation timeline and Metadata tab). |
+| **D5** | **Sub-agent drill-in requires explicit link metadata** — no overlap-only matching in v1. Block Phase 2 drill-in on `latitude.agent_tool.parent_tool_call_id` (+ optional `run_id`). |
+| **D6** | **Phase detection priority**: (1) `latitude.codemode.phase` attr, (2) `experimental_telemetry.functionId` on span attrs (verify ingest maps it — otherwise falls through to priority 3), (3) operation + name heuristics for legacy data. |
+
+## Telemetry contract (Phase 0)
+
+SDK + docs emit these **span attributes** (all optional for backward compat, required for codemode example after Phase 0):
+
+| Attribute | Values | Set on |
+|---|---|---|
+| `latitude.codemode.phase` | `plan` \| `execute` \| `summarize` | Root model/tool spans for each orchestration phase |
+| `latitude.codemode.inner_tool` | `true` | Inner sandbox tool spans (already shipped) |
+| `latitude.codemode.turn_id` | string | All spans in one user turn (default: `{sessionId}:{turnIndex}`) |
+| `latitude.agent_tool.parent_tool_call_id` | string | Sub-agent root span / traces |
+| `latitude.agent_tool.run_id` | string | Sub-agent run (when available from `runAgentTool`) |
+
+**Phase 0 telemetry code changes**
+
+- `instrumentCodemodeTools`: propagate OTel context so inner tool spans are **children** of the active `ai.toolCall codemode` span when parent context exists.  
+- Cloudflare codemode example worker: set `latitude.codemode.phase` on plan / execute / summarize tracers; set `parent_tool_call_id` when delegating to sub-agent.  
+- Document contract in `docs/telemetry/frameworks/cloudflare-codemode.mdx`.
+
+## Turn grouping algorithm
+
+When **`latitude.codemode.turn_id`** is present on spans/traces, group by it directly (authoritative). The message-timestamp algorithm below is the **fallback** for legacy data lacking `turn_id`.
+
+**Fallback algorithm** (sessions have `traceIds[]` and `latestTraceId` but no turn index):
+
+1. Load conversation messages from **`latestTraceId`** (existing behavior).  
+2. Enumerate **user messages** in order → each defines a turn `turnIndex` (0-based).  
+3. Turn time window: `[userMessage.atMs, nextUserMessage.atMs)` (last turn: `[atMs, session.endTime]`).  
+4. Assign each **trace** to the turn whose window contains `trace.startTime`.  
+5. Assign each **session span** to the same turn by `span.startTime`.  
+6. **Orphan traces** (no user message yet, e.g. partial ingest): fall into turn 0 or an "Unassigned" bucket shown collapsed at top.
+
+Turn label: first 80 chars of user message text, or `"Turn {n}"`.
+
+## Phase detection (within a turn)
+
+After sorting assigned traces/spans by `startTime ASC`, build the Run tree:
+
+| Node | Detection (first match) |
+|---|---|
+| **Plan** | span/trace with `latitude.codemode.phase=plan`, OR name `ai.generateText` + metadata `functionId=codemode-plan` |
+| **Execute (codemode)** | span/trace with `phase=execute`, OR `ai.toolCall codemode`, OR parent of inner-tool spans. *Note: `phase=execute` may be unavailable on the `ai.toolCall codemode` span itself (emitted by `createCodeTool` / AI SDK); rely on operation name + inner-tool parent fallback there.* |
+| **Inner tool** | span with `latitude.codemode.inner_tool=true` (group under Execute; sort by startTime) |
+| **Sub-agent** | span/trace with `latitude.agent_tool.run_id` or tag/metadata `subagent` / example role metadata |
+| **Summarize** | `phase=summarize`, OR `ai.streamText` + `functionId=codemode-summary` |
+
+Legacy fallback (pre-Phase-0 data): infer Plan/Summarize from trace names + example tags only; show **"Unlabeled phase"** badge when confidence is low.
+
+## UI design
+
+### Run tab (Phase 1)
+
+New tab in **session detail drawer** when `session.traceIds.length > 1`.
+
+```
+Turn 1 — "Compare Barcelona vs Paris…"
+├─ Plan · 18.3s                    [→ trace]
+├─ Codemode execution · 4.3s
+│  ├─ delegateWeatherResearch · 4.3s   [→ trace]
+│  └─ formatTravelBrief · <1ms         [→ span]
+├─ Sub-agent · WeatherResearch · 3.1s  [→ traces]  (linked via parent_tool_call_id)
+└─ Summarize · 3.2s                [→ trace]
+```
+
+- Row click → existing trace drawer or inline span detail panel.  
+- Error badge on failed span/trace; expand shows tool validation / exception from span attrs.  
+- **Traces tab unchanged** (newest-first); Run tab is the chronological debug view.
+
+**Motivation**: multi-trace sessions lack a Spans tab today — Run tab is the session-scoped span/trace navigator.
+
+### Codemode card in Conversation (Phase 2)
+
+Enhance the `codemode` tool-call block (visible on summary trace message chain):
+
+- **Collapsed**: name, duration, status, inner step count.  
+- **Expanded**: syntax-highlighted **generated code** (from tool input `code`); step list (shared `buildCodemodeRunTimeline` Execute subtree); link **Open in Run tab**.
+
+Data: session spans + `toolCallSpanMap` from existing `useSessionConversationSpanMaps`.
+
+### Sub-agent drill-in (Phase 2)
+
+Only when `latitude.agent_tool.parent_tool_call_id` matches the delegate inner-tool span's `toolCallId`:
+
+- **Sub-agent** badge on delegate row.  
+- Drill-in lists child traces/spans sharing the same `parent_tool_call_id` or `run_id`.  
+- Breadcrumb: `Session → Turn N → delegateWeatherResearch → Sub-agent`.
+
+If link metadata absent: show delegate row without drill-in (no time-overlap guessing).
+
+### Span tab enhancements (Phase 3)
+
+- **Inner tool** badge when `latitude.codemode.inner_tool`.  
+- Filter: **Codemode inner tools**.  
+- Friendly phase label from `latitude.codemode.phase` when present.  
+- With Phase 0 nesting, a single codemode trace span tree shows inner tools indented under `ai.toolCall codemode`.
+
+## Data & APIs
+
+| Phase | Data source |
+|---|---|
+| 0 | Telemetry SDK only |
+| 1 | `use-session-traces.ts` + **`useSpansBySessionCollection`** + conversation messages from `latestTraceId` |
+| 2 | Same + `toolCallSpanMap` / span detail for code + drill-in |
+| 3 | Per-trace spans (existing); optional session-span waterfall if query cost acceptable |
+
+**No new backend endpoints for Phase 1–2** — client-side `buildCodemodeRunTimeline({ session, traces, spans, messages })`.
+
+## Success metrics
+
+- Codemode QA time-to-root-cause **< 60s** without Traces tab (internal).  
+- Barcelona vs Paris example: Run tab order matches real execution order in fixture test.  
+- Example README links to Run tab workflow.
+
+## User stories
+
+1. Debug failed codemode run — see phase + failing inner tool + validation error.  
+2. Drill into sub-agent from delegate step (with link metadata).  
+3. Read generated code beside execution results.  
+4. Filter `cloudflare-codemode` sessions and open Run tab directly.
+
+## Tasks
+
+> **Status legend**: `[ ] pending`, `[~] in progress`, `[x] complete`
+
+### Phase 0 — Telemetry contract (P0)
+
+- [ ] **P0-0a**: Nest inner tool spans under codemode parent via OTel context in `instrumentCodemodeTools`.  
+- [ ] **P0-0b**: Emit `latitude.codemode.phase`, `latitude.codemode.turn_id` from codemode example worker tracers.  
+- [ ] **P0-0c**: Emit `latitude.agent_tool.parent_tool_call_id` (+ `run_id` when available) on sub-agent delegation.  
+- [ ] **P0-0d**: Document attributes in `cloudflare-codemode.mdx`.  
+- [ ] **P0-0e**: Unit test: inner span has `inner_tool` + parent span id when context active.
+
+**Exit gate**: Example session ingests spans with phase + inner_tool nesting verifiable in ClickHouse/MCP.
+
+### Phase 1 — Run tab (P0)
+
+- [ ] **P0-1**: Implement `buildCodemodeRunTimeline()` with turn algorithm + phase detection (D6 priority).  
+- [ ] **P0-2**: Add **Run** tab to session drawer (`traceIds.length > 1`).  
+- [ ] **P0-3**: Wire `useSpansBySessionCollection` + session traces + latestTrace messages.  
+- [ ] **P0-4**: Row navigation to trace drawer / span detail; error badges.  
+- [ ] **P0-5**: Vitest fixtures from codemode example session (plan → inner tools → summarize order).
+
+**Exit gate**: Run tab for `qa-a8624440`-shaped session shows correct chronological tree; legacy sessions degrade gracefully with unlabeled phases.
+
+### Phase 2 — Conversation card + sub-agent drill-in (P1)
+
+- [ ] **P1-6**: Expandable codemode tool block (code + steps + link to Run tab).  
+- [ ] **P1-7**: Sub-agent drill-in gated on `parent_tool_call_id` (D5).  
+- [ ] **P1-8**: Breadcrumb navigation session ↔ run step ↔ sub-agent.
+
+**Exit gate**: Failed inner tool visible from Conversation; sub-agent reachable when Phase 0 metadata present.
+
+### Phase 3 — Span UI polish (P2)
+
+- [ ] **P2-9**: Inner-tool badge + filter in Spans tab.  
+- [ ] **P2-10**: Phase labels on span rows.  
+- [ ] **P2-11**: (Optional) Traces tab group-by-session if dogfood warrants.
+
+**Exit gate**: Codemode trace opened in Spans tab shows nested inner tools post-Phase-0.
+
+## Review history
+
+| Round | Verdict | Notes |
+|---|---|---|
+| 1 | Approve with changes | No turn primitive; Phase 1 needs spans; example-only heuristics; overlap linking risky; consider telemetry-first reorder. |
+| 2 | **APPROVE** | All round-1 items resolved. Minor nits folded in (`turn_id` authoritative over time windows; execute phase heuristic note). Engineering cleared for Phase 0+1. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates and documents Latitude telemetry support for Cloudflare Code Mode (LAT-718).

Code Mode agents use the Vercel AI SDK under the hood. Passing `experimental_telemetry` with `latitude.getTracer("cloudflare-codemode", context)` on `streamText()` records model turns and the outer `codemode` tool call, including the generated code in tool input.

## Findings

**Supported today**
- Model spans (prompts, completions, tokens, latency)
- Outer `codemode` meta-tool call via AI SDK telemetry
- User/session/tags/metadata through `getTracer()`
- Flush after each chat turn via `onChatResponse()`

**Gap**
- Inner tools invoked inside the Code Mode sandbox (e.g. `codemode.getWeather()` in generated code) do not emit separate AI SDK `ai.toolCall` spans. The docs recommend wrapping `execute` functions with `capture()` when per-tool visibility is needed.

## Changes

- Add Mintlify docs: `docs/telemetry/frameworks/cloudflare-codemode.mdx`
- Add runnable example: `packages/telemetry/typescript/examples/cloudflare-codemode-app`
- Add local verifier script (`npm run verify:local`) and unit test (`codemode-telemetry.test.ts`)
- Register docs nav entry and exclude the standalone example from the pnpm workspace

## Test plan

- [x] `pnpm --filter @latitude-data/telemetry test -- src/sdk/codemode-telemetry.test.ts`
- [ ] `npm run verify:local` in `cloudflare-codemode-app` against local Latitude + ClickHouse (requires Docker infra)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-718](https://linear.app/latitude/issue/LAT-718/investigate-codemode-support)

<div><a href="https://cursor.com/agents/bc-c295a10d-c539-42dd-81f2-bb718fc85074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c295a10d-c539-42dd-81f2-bb718fc85074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

