### PR TITLE
Improve subagent visibility in trace span UI

### DIFF
--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,6 +1,6 @@
 import { ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
 import type { Operation, Span, SpanDetail, SpanKind, SpanMessagesData, SpanStatusCode } from "@domain/spans"
-import { SpanRepository } from "@domain/spans"
+import { resolveSpanLabels, SpanRepository } from "@domain/spans"
 import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -39,6 +39,8 @@ export interface SpanRecord {
   readonly startTime: string
   readonly endTime: string
   readonly ingestedAt: string
+  readonly displayLabel: string
+  readonly isSubagent: boolean
 }
 
 export interface SpanDetailRecord extends SpanRecord {
@@ -78,7 +80,7 @@ export interface SpanDetailRecord extends SpanRecord {
   readonly toolOutput: string
 }
 
-const serializeSpan = (span: Span): SpanRecord => ({
+const serializeSpanBase = (span: Span): Omit<SpanRecord, "displayLabel" | "isSubagent"> => ({
   organizationId: span.organizationId,
   projectId: span.projectId,
   traceId: span.traceId,
@@ -105,43 +107,61 @@ const serializeSpan = (span: Span): SpanRecord => ({
   ingestedAt: span.ingestedAt.toISOString(),
 })
 
-const serializeSpanDetail = (span: SpanDetail): SpanDetailRecord => ({
-  ...serializeSpan(span),
-  sessionId: span.sessionId,
-  userId: span.userId,
-  apiKeyId: span.apiKeyId,
-  responseModel: span.responseModel,
-  traceFlags: span.traceFlags,
-  traceState: span.traceState,
-  errorType: span.errorType,
-  tags: span.tags,
-  metadata: span.metadata,
-  eventsJson: span.eventsJson,
-  linksJson: span.linksJson,
-  tokensCacheRead: span.tokensCacheRead,
-  tokensCacheCreate: span.tokensCacheCreate,
-  tokensReasoning: span.tokensReasoning,
-  costInputMicrocents: span.costInputMicrocents,
-  costOutputMicrocents: span.costOutputMicrocents,
-  costTotalMicrocents: span.costTotalMicrocents,
-  costIsEstimated: span.costIsEstimated,
-  responseId: span.responseId,
-  finishReasons: span.finishReasons,
-  attrString: span.attrString,
-  attrInt: span.attrInt,
-  attrFloat: span.attrFloat,
-  attrBool: span.attrBool,
-  resourceString: span.resourceString,
-  scopeName: span.scopeName,
-  scopeVersion: span.scopeVersion,
-  inputMessages: span.inputMessages as readonly object[],
-  outputMessages: span.outputMessages as readonly object[],
-  systemInstructions: span.systemInstructions as readonly object[],
-  toolDefinitions: span.toolDefinitions as readonly object[],
-  toolCallId: span.toolCallId,
-  toolInput: span.toolInput,
-  toolOutput: span.toolOutput,
-})
+const serializeSpans = (spans: readonly Span[]): SpanRecord[] => {
+  const labels = resolveSpanLabels(spans)
+  return spans.map((span) => {
+    const label = labels.get(span.spanId)
+    return {
+      ...serializeSpanBase(span),
+      displayLabel: label?.displayLabel ?? span.name,
+      isSubagent: label?.isSubagent ?? false,
+    }
+  })
+}
+
+const serializeSpanDetail = (span: SpanDetail, siblings: readonly Span[] = []): SpanDetailRecord => {
+  const labels = resolveSpanLabels(siblings.length > 0 ? siblings : [span])
+  const label = labels.get(span.spanId)
+  return {
+    ...serializeSpanBase(span),
+    displayLabel: label?.displayLabel ?? span.name,
+    isSubagent: label?.isSubagent ?? false,
+    sessionId: span.sessionId,
+    userId: span.userId,
+    apiKeyId: span.apiKeyId,
+    responseModel: span.responseModel,
+    traceFlags: span.traceFlags,
+    traceState: span.traceState,
+    errorType: span.errorType,
+    tags: span.tags,
+    metadata: span.metadata,
+    eventsJson: span.eventsJson,
+    linksJson: span.linksJson,
+    tokensCacheRead: span.tokensCacheRead,
+    tokensCacheCreate: span.tokensCacheCreate,
+    tokensReasoning: span.tokensReasoning,
+    costInputMicrocents: span.costInputMicrocents,
+    costOutputMicrocents: span.costOutputMicrocents,
+    costTotalMicrocents: span.costTotalMicrocents,
+    costIsEstimated: span.costIsEstimated,
+    responseId: span.responseId,
+    finishReasons: span.finishReasons,
+    attrString: span.attrString,
+    attrInt: span.attrInt,
+    attrFloat: span.attrFloat,
+    attrBool: span.attrBool,
+    resourceString: span.resourceString,
+    scopeName: span.scopeName,
+    scopeVersion: span.scopeVersion,
+    inputMessages: span.inputMessages as readonly object[],
+    outputMessages: span.outputMessages as readonly object[],
+    systemInstructions: span.systemInstructions as readonly object[],
+    toolDefinitions: span.toolDefinitions as readonly object[],
+    toolCallId: span.toolCallId,
+    toolInput: span.toolInput,
+    toolOutput: span.toolOutput,
+  }
+}
 
 export const listSpansByTrace = createServerFn({ method: "GET" })
   .inputValidator(
@@ -167,7 +187,7 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
         })
       }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
-    return spans.map(serializeSpan)
+    return serializeSpans(spans)
   })
 
 export const listSpansBySession = createServerFn({ method: "GET" })
@@ -194,7 +214,7 @@ export const listSpansBySession = createServerFn({ method: "GET" })
         })
       }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
-    return spans.map(serializeSpan)
+    return serializeSpans(spans)
   })
 
 export interface SpanMessagesRecord {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -24,7 +24,7 @@ export function SpansTab({
   readonly onSelectSpan: (spanId: string) => void
   readonly isActive: boolean
 }) {
-  const { filters, clearFilters, toggleErrors, toggleTools, selectModel } = useSpanFilters()
+  const { filters, clearFilters, toggleErrors, toggleTools, toggleSubagents, selectModel } = useSpanFilters()
   // Shares the cached spans collection with the Trace tab's fetch (same key → one fetch).
   const { data: spans, isLoading } = useSpansByTraceCollection({ projectId, traceId, startTimeFrom, startTimeTo })
   const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
@@ -94,6 +94,7 @@ export function SpansTab({
           filters={filters}
           onToggleErrors={toggleErrors}
           onToggleTools={toggleTools}
+          onToggleSubagents={toggleSubagents}
           onSelectModel={selectModel}
           onClearFilters={clearFilters}
         />
@@ -111,6 +112,7 @@ export function SpansTab({
         filters={filters}
         onToggleErrors={toggleErrors}
         onToggleTools={toggleTools}
+        onToggleSubagents={toggleSubagents}
         onSelectModel={selectModel}
         onClearFilters={clearFilters}
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
@@ -8,10 +8,10 @@ import { IdentifiersSection } from "./identifiers-section.tsx"
 import { LlmSections } from "./llm-sections.tsx"
 import { OperationalMetadataSection } from "./operational-metadata-section.tsx"
 import { RawTelemetrySections } from "./raw-telemetry-sections.tsx"
+import { SubagentSection } from "./subagent-section.tsx"
 import { isToolExecutionSpan, ToolExecutionSection } from "./tool-execution-section.tsx"
 import { hasAnyUsage, UsageSummary } from "./usage-summary.tsx"
 import { UserContextSection } from "./user-context-section.tsx"
-import { SubagentSection } from "./subagent-section.tsx"
 
 type ExceptionInfo = {
   type?: string

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
@@ -11,6 +11,7 @@ import { RawTelemetrySections } from "./raw-telemetry-sections.tsx"
 import { isToolExecutionSpan, ToolExecutionSection } from "./tool-execution-section.tsx"
 import { hasAnyUsage, UsageSummary } from "./usage-summary.tsx"
 import { UserContextSection } from "./user-context-section.tsx"
+import { SubagentSection } from "./subagent-section.tsx"
 
 type ExceptionInfo = {
   type?: string
@@ -136,6 +137,9 @@ export function SpanDetailContent({ span }: { readonly span: SpanDetailRecord })
 
       {/* ── User context: tags + metadata ── */}
       <UserContextSection span={span} />
+
+      {/* ── Subagent metadata ── */}
+      <SubagentSection span={span} />
 
       {/* ── LLM content ── */}
       {isLlmSpan && <LlmSections span={span} />}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/subagent-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/subagent-section.tsx
@@ -1,5 +1,5 @@
-import { DetailSection, DetailSummary } from "@repo/ui"
 import { resolveAgentLabel } from "@domain/spans"
+import { DetailSection, DetailSummary } from "@repo/ui"
 import { BotIcon } from "lucide-react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/subagent-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/subagent-section.tsx
@@ -1,0 +1,37 @@
+import { DetailSection, DetailSummary } from "@repo/ui"
+import { resolveAgentLabel } from "@domain/spans"
+import { BotIcon } from "lucide-react"
+import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
+
+const SUBAGENT_DETAIL_KEYS = [
+  ["Agent", "gen_ai.agent.name"],
+  ["Subagent", "subagent.id"],
+  ["Subagent type", "subagent.type"],
+  ["OpenClaw label", "openclaw.subagent.label"],
+  ["OpenClaw agent id", "openclaw.subagent.agent_id"],
+  ["OpenClaw outcome", "openclaw.subagent.outcome"],
+  ["OpenClaw reason", "openclaw.subagent.reason"],
+  ["Interaction kind", "interaction.kind"],
+] as const
+
+export function SubagentSection({ span }: { readonly span: SpanDetailRecord }) {
+  if (!span.isSubagent) return null
+
+  const items = SUBAGENT_DETAIL_KEYS.flatMap(([label, key]) => {
+    const value = span.attrString[key]?.trim()
+    return value ? [{ label, value }] : []
+  })
+
+  const agentLabel = resolveAgentLabel(span.attrString)
+  if (agentLabel && !items.some((item) => item.value === agentLabel)) {
+    items.unshift({ label: "Agent", value: agentLabel })
+  }
+
+  if (items.length === 0) return null
+
+  return (
+    <DetailSection icon={<BotIcon className="w-4 h-4" />} label="Subagent">
+      <DetailSummary items={items} />
+    </DetailSection>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx
@@ -1,6 +1,6 @@
 import { cn, Icon, Select, type SelectOption, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
-import { AlertTriangleIcon, WrenchIcon, XIcon } from "lucide-react"
+import { AlertTriangleIcon, BotIcon, WrenchIcon, XIcon } from "lucide-react"
 import type { ReactNode } from "react"
 import type { SpanRecord } from "../../../../../../../../domains/spans/spans.functions.ts"
 import { collectSpanModels, countMatchingSpans, hasActiveSpanFilters, type SpanFilters } from "./span-filters.ts"
@@ -10,6 +10,7 @@ type SpanFiltersBarProps = {
   readonly filters: SpanFilters
   readonly onToggleErrors: () => void
   readonly onToggleTools: () => void
+  readonly onToggleSubagents: () => void
   readonly onSelectModel: (model: string) => void
   readonly onClearFilters: () => void
 }
@@ -51,6 +52,7 @@ export function SpanFiltersBar({
   filters,
   onToggleErrors,
   onToggleTools,
+  onToggleSubagents,
   onSelectModel,
   onClearFilters,
 }: SpanFiltersBarProps) {
@@ -86,6 +88,17 @@ export function SpanFiltersBar({
           >
             <Icon icon={WrenchIcon} size="xs" color={filters.tools ? "accentForeground" : "foregroundMuted"} />
             <span>Tools</span>
+          </FilterToggle>
+
+          <FilterToggle
+            active={filters.subagents}
+            activeClassName="border-primary/30 bg-primary/10 text-primary"
+            inactiveClassName="border-border bg-secondary text-muted-foreground hover:bg-muted"
+            onClick={onToggleSubagents}
+            ariaLabel={filters.subagents ? "Show all spans" : "Show only subagent spans"}
+          >
+            <Icon icon={BotIcon} size="xs" color={filters.subagents ? "primary" : "foregroundMuted"} />
+            <span>Subagents</span>
           </FilterToggle>
 
           {models.length > 0 ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
@@ -53,9 +53,16 @@ describe("span filters", () => {
       makeSpan({ spanId: "other", parentSpanId: "root", model: "claude-fable-5" }),
     ]
 
-    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, subagents: false, model: "claude-opus-4-8" })
+    const filtered = filterSpansWithAncestors(spans, {
+      errors: false,
+      tools: false,
+      subagents: false,
+      model: "claude-opus-4-8",
+    })
     expect(filtered.map((span) => span.spanId)).toEqual(["root", "child"])
-    expect(countMatchingSpans(spans, { errors: false, tools: false, subagents: false, model: "claude-opus-4-8" })).toBe(1)
+    expect(countMatchingSpans(spans, { errors: false, tools: false, subagents: false, model: "claude-opus-4-8" })).toBe(
+      1,
+    )
   })
 
   it("filters by errors and tools together", () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
@@ -8,13 +8,13 @@ import {
 } from "./span-filters.ts"
 
 function makeSpan(partial: Partial<SpanRecord> & Pick<SpanRecord, "spanId">): SpanRecord {
+  const name = partial.name ?? partial.spanId
   return {
     organizationId: "org",
     projectId: "proj",
     traceId: "trace",
     parentSpanId: "",
     simulationId: "",
-    name: partial.spanId,
     serviceName: "svc",
     kind: "internal",
     statusCode: "ok",
@@ -33,14 +33,17 @@ function makeSpan(partial: Partial<SpanRecord> & Pick<SpanRecord, "spanId">): Sp
     endTime: "2024-01-01T00:00:01Z",
     ingestedAt: "2024-01-01T00:00:01Z",
     ...partial,
+    name,
+    displayLabel: partial.displayLabel ?? name,
+    isSubagent: partial.isSubagent ?? false,
   }
 }
 
 describe("span filters", () => {
   it("returns all spans when no filters are active", () => {
     const spans = [makeSpan({ spanId: "a" }), makeSpan({ spanId: "b" })]
-    expect(hasActiveSpanFilters({ errors: false, tools: false, model: "" })).toBe(false)
-    expect(filterSpansWithAncestors(spans, { errors: false, tools: false, model: "" })).toEqual(spans)
+    expect(hasActiveSpanFilters({ errors: false, tools: false, subagents: false, model: "" })).toBe(false)
+    expect(filterSpansWithAncestors(spans, { errors: false, tools: false, subagents: false, model: "" })).toEqual(spans)
   })
 
   it("filters by model and keeps ancestors", () => {
@@ -50,9 +53,9 @@ describe("span filters", () => {
       makeSpan({ spanId: "other", parentSpanId: "root", model: "claude-fable-5" }),
     ]
 
-    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, model: "claude-opus-4-8" })
+    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, subagents: false, model: "claude-opus-4-8" })
     expect(filtered.map((span) => span.spanId)).toEqual(["root", "child"])
-    expect(countMatchingSpans(spans, { errors: false, tools: false, model: "claude-opus-4-8" })).toBe(1)
+    expect(countMatchingSpans(spans, { errors: false, tools: false, subagents: false, model: "claude-opus-4-8" })).toBe(1)
   })
 
   it("filters by errors and tools together", () => {
@@ -62,7 +65,7 @@ describe("span filters", () => {
       makeSpan({ spanId: "chat-err", operation: "chat", statusCode: "error" }),
     ]
 
-    const filtered = filterSpansWithAncestors(spans, { errors: true, tools: true, model: "" })
+    const filtered = filterSpansWithAncestors(spans, { errors: true, tools: true, subagents: false, model: "" })
     expect(filtered.map((span) => span.spanId)).toEqual(["tool-err"])
   })
 
@@ -74,5 +77,23 @@ describe("span filters", () => {
     ]
 
     expect(collectSpanModels(spans)).toEqual(["claude-fable-5", "claude-opus-4-8"])
+  })
+
+  it("filters by subagents and keeps ancestors", () => {
+    const spans = [
+      makeSpan({ spanId: "root", parentSpanId: "" }),
+      makeSpan({ spanId: "tool", parentSpanId: "root", operation: "execute_tool" }),
+      makeSpan({
+        spanId: "child",
+        parentSpanId: "tool",
+        operation: "invoke_agent",
+        isSubagent: true,
+        displayLabel: "invoke_agent gpt-4o · explore",
+      }),
+      makeSpan({ spanId: "chat", parentSpanId: "root", operation: "chat" }),
+    ]
+
+    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, subagents: true, model: "" })
+    expect(filtered.map((span) => span.spanId)).toEqual(["root", "tool", "child"])
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.ts
@@ -3,22 +3,25 @@ import type { SpanRecord } from "../../../../../../../../domains/spans/spans.fun
 export type SpanFilters = {
   readonly errors: boolean
   readonly tools: boolean
+  readonly subagents: boolean
   readonly model: string
 }
 
 export const EMPTY_SPAN_FILTERS: SpanFilters = {
   errors: false,
   tools: false,
+  subagents: false,
   model: "",
 }
 
 export function hasActiveSpanFilters(filters: SpanFilters): boolean {
-  return filters.errors || filters.tools || filters.model.length > 0
+  return filters.errors || filters.tools || filters.subagents || filters.model.length > 0
 }
 
 function spanMatchesFilters(span: SpanRecord, filters: SpanFilters): boolean {
   if (filters.errors && span.statusCode !== "error") return false
   if (filters.tools && span.operation !== "execute_tool") return false
+  if (filters.subagents && !span.isSubagent) return false
   if (filters.model.length > 0 && span.model !== filters.model) return false
   return true
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -106,7 +106,7 @@ export const TreeRow = memo(function TreeRow({
           color={node.span.statusCode === "error" ? "destructive" : "foreground"}
           className="flex-1 min-w-0"
         >
-          {node.span.name}
+          {node.span.displayLabel}
         </Text.H6>
 
         <Text.H6 color={statusTextColor(node.span.statusCode)} className="shrink-0">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.test.ts
@@ -28,6 +28,8 @@ function makeSpan(spanId: string, parentSpanId: string, startTime = "2024-01-01T
     startTime,
     endTime: "2024-01-01T00:00:01Z",
     ingestedAt: "2024-01-01T00:00:00Z",
+    displayLabel: `span-${spanId}`,
+    isSubagent: false,
   }
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/use-span-filters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/use-span-filters.ts
@@ -4,13 +4,15 @@ import { EMPTY_SPAN_FILTERS, type SpanFilters } from "./span-filters.ts"
 export function useSpanFilters() {
   const [errors, setErrors] = useParamState("spanErrors", false)
   const [tools, setTools] = useParamState("spanTools", false)
+  const [subagents, setSubagents] = useParamState("spanSubagents", false)
   const [model, setModel] = useParamState("spanModel", "")
 
-  const filters: SpanFilters = { errors, tools, model }
+  const filters: SpanFilters = { errors, tools, subagents, model }
 
   function setFilters(next: SpanFilters) {
     setErrors(next.errors)
     setTools(next.tools)
+    setSubagents(next.subagents)
     setModel(next.model)
   }
 
@@ -34,6 +36,7 @@ export function useSpanFilters() {
     openWithModel,
     toggleErrors: () => setErrors(!errors),
     toggleTools: () => setTools(!tools),
+    toggleSubagents: () => setSubagents(!subagents),
     selectModel: (nextModel: string) => setModel(nextModel),
   }
 }

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -48,6 +48,13 @@ export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
+export {
+  formatSpanDisplayLabel,
+  isSubagentSpan,
+  resolveAgentLabel,
+  resolveSpanLabels,
+  type SpanLabelInput,
+} from "./helpers/span-display.ts"
 export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export { resolveTraceIdFromRef, type TraceRef, traceRefSchema } from "./helpers/trace-ref.ts"
 export {

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -48,6 +48,7 @@ export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
+export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export {
   formatSpanDisplayLabel,
   isSubagentSpan,
@@ -55,7 +56,6 @@ export {
   resolveSpanLabels,
   type SpanLabelInput,
 } from "./helpers/span-display.ts"
-export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export { resolveTraceIdFromRef, type TraceRef, traceRefSchema } from "./helpers/trace-ref.ts"
 export {
   alignUnixSecondsToHistogramBucket,

--- a/packages/domain/spans/src/helpers/span-display.test.ts
+++ b/packages/domain/spans/src/helpers/span-display.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import {
+  formatSpanDisplayLabel,
+  isSubagentSpan,
+  resolveAgentLabel,
+  resolveSpanLabels,
+} from "./span-display.ts"
+
+describe("span-display", () => {
+  it("resolves agent labels from OTel and framework-specific attributes", () => {
+    expect(resolveAgentLabel({ "gen_ai.agent.name": "travel-agent" })).toBe("travel-agent")
+    expect(resolveAgentLabel({ "openclaw.subagent.label": "research" })).toBe("research")
+    expect(resolveAgentLabel({ "subagent.id": "Explore:a4dabb47" })).toBe("Explore:a4dabb47")
+  })
+
+  it("detects subagent spans across semconv and framework shapes", () => {
+    expect(isSubagentSpan({ name: "subagent", operation: "create_agent" })).toBe(true)
+    expect(
+      isSubagentSpan({
+        name: "interaction",
+        operation: "invoke_agent",
+        attrString: { "interaction.kind": "subagent" },
+      }),
+    ).toBe(true)
+    expect(
+      isSubagentSpan({
+        name: "invoke_agent gpt-4o",
+        operation: "invoke_agent",
+        parentOperation: "execute_tool",
+      }),
+    ).toBe(true)
+    expect(isSubagentSpan({ name: "chat gpt-4o", operation: "chat" })).toBe(false)
+  })
+
+  it("appends agent labels without duplicating text already in the span name", () => {
+    expect(
+      formatSpanDisplayLabel({
+        name: "invoke_agent gpt-4o",
+        operation: "invoke_agent",
+        attrString: { "gen_ai.agent.name": "travel-agent" },
+      }),
+    ).toBe("invoke_agent gpt-4o · travel-agent")
+
+    expect(
+      formatSpanDisplayLabel({
+        name: "invoke_agent travel-agent",
+        operation: "invoke_agent",
+        attrString: { "gen_ai.agent.name": "travel-agent" },
+      }),
+    ).toBe("invoke_agent travel-agent")
+  })
+
+  it("resolves labels for an entire trace with parent context", () => {
+    const labels = resolveSpanLabels([
+      {
+        spanId: "tool",
+        parentSpanId: "root",
+        name: "execute_tool runSubagent",
+        operation: "execute_tool",
+        attrString: {},
+      },
+      {
+        spanId: "child",
+        parentSpanId: "tool",
+        name: "invoke_agent gpt-4o",
+        operation: "invoke_agent",
+        attrString: { "gen_ai.agent.name": "explore" },
+      },
+    ])
+
+    expect(labels.get("child")).toEqual({
+      displayLabel: "invoke_agent gpt-4o · explore",
+      isSubagent: true,
+    })
+  })
+})

--- a/packages/domain/spans/src/helpers/span-display.test.ts
+++ b/packages/domain/spans/src/helpers/span-display.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  formatSpanDisplayLabel,
-  isSubagentSpan,
-  resolveAgentLabel,
-  resolveSpanLabels,
-} from "./span-display.ts"
+import { formatSpanDisplayLabel, isSubagentSpan, resolveAgentLabel, resolveSpanLabels } from "./span-display.ts"
 
 describe("span-display", () => {
   it("resolves agent labels from OTel and framework-specific attributes", () => {

--- a/packages/domain/spans/src/helpers/span-display.ts
+++ b/packages/domain/spans/src/helpers/span-display.ts
@@ -1,0 +1,70 @@
+export interface SpanLabelInput {
+  readonly name: string
+  readonly operation: string
+  readonly attrString?: Readonly<Record<string, string>>
+  readonly parentOperation?: string
+}
+
+const AGENT_LABEL_ATTR_KEYS = [
+  "gen_ai.agent.name",
+  "openclaw.subagent.label",
+  "subagent.id",
+  "openclaw.subagent.agent_id",
+  "subagent.type",
+] as const
+
+export function resolveAgentLabel(attrString: Readonly<Record<string, string>> | undefined): string | undefined {
+  if (!attrString) return undefined
+  for (const key of AGENT_LABEL_ATTR_KEYS) {
+    const value = attrString[key]?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
+export function isSubagentSpan(input: SpanLabelInput): boolean {
+  if (input.operation === "create_agent") return true
+  if (input.name === "subagent") return true
+  if (input.attrString?.["interaction.kind"] === "subagent") return true
+  if (input.operation === "invoke_agent" && input.parentOperation === "execute_tool") return true
+  return false
+}
+
+export function formatSpanDisplayLabel(input: SpanLabelInput): string {
+  const base = input.name.trim() || input.operation
+  const agentLabel = resolveAgentLabel(input.attrString)
+  if (!agentLabel || base.includes(agentLabel)) return base
+  if (isSubagentSpan(input) || input.operation === "invoke_agent" || input.operation === "create_agent") {
+    return `${base} · ${agentLabel}`
+  }
+  return base
+}
+
+export function resolveSpanLabels(
+  spans: readonly {
+    readonly spanId: string
+    readonly parentSpanId: string
+    readonly name: string
+    readonly operation: string
+    readonly attrString: Readonly<Record<string, string>>
+  }[],
+): ReadonlyMap<string, { readonly displayLabel: string; readonly isSubagent: boolean }> {
+  const byId = new Map(spans.map((span) => [span.spanId, span]))
+  const labels = new Map<string, { displayLabel: string; isSubagent: boolean }>()
+
+  for (const span of spans) {
+    const parent = span.parentSpanId ? byId.get(span.parentSpanId) : undefined
+    const input: SpanLabelInput = {
+      name: span.name,
+      operation: span.operation,
+      attrString: span.attrString,
+      ...(parent ? { parentOperation: parent.operation } : {}),
+    }
+    labels.set(span.spanId, {
+      displayLabel: formatSpanDisplayLabel(input),
+      isSubagent: isSubagentSpan(input),
+    })
+  }
+
+  return labels
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -70,6 +70,7 @@ export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
+export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export {
   formatSpanDisplayLabel,
   isSubagentSpan,
@@ -77,7 +78,6 @@ export {
   resolveSpanLabels,
   type SpanLabelInput,
 } from "./helpers/span-display.ts"
-export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export { tokenizePhrase } from "./helpers/tokenize-phrase.ts"
 export {
   resolveTraceIdFromRef,

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -70,6 +70,13 @@ export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
+export {
+  formatSpanDisplayLabel,
+  isSubagentSpan,
+  resolveAgentLabel,
+  resolveSpanLabels,
+  type SpanLabelInput,
+} from "./helpers/span-display.ts"
 export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
 export { tokenizePhrase } from "./helpers/tokenize-phrase.ts"
 export {

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -74,6 +74,16 @@ const OPENCLAW_SPAN_OPERATION: Record<string, Operation> = {
   "openclaw.tool.execution": "execute_tool",
 }
 
+const OPENCLAW_PLUGIN_SCOPE_PREFIX = "@latitude-data/openclaw-telemetry"
+
+function operationFromOpenClawPluginSpan(spanName: string): Operation | undefined {
+  if (spanName === "agent") return "invoke_agent"
+  if (spanName === "subagent") return "create_agent"
+  if (spanName === "model_call") return "chat"
+  if (spanName.startsWith("tool_call:")) return "execute_tool"
+  return undefined
+}
+
 const CLAUDE_CODE_NATIVE_SPAN_PREFIX = "claude_code."
 
 /**
@@ -102,6 +112,9 @@ const operationCandidates = [
 // LLM leaf), so classify those `chat` for the rollup; other frameworks' AGENT spans keep
 // `invoke_agent` (they have real LLM leaves).
 export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: string, scopeName = ""): string {
+  if (stringAttr(spanAttrs, "interaction.kind") === "subagent") {
+    return "invoke_agent"
+  }
   if (
     scopeName.startsWith(CREWAI_OPENINFERENCE_SCOPE) &&
     stringAttr(spanAttrs, "openinference.span.kind") === "AGENT"
@@ -110,6 +123,10 @@ export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: s
   }
   if (scopeName === OPENCLAW_TELEMETRY_SCOPE) {
     const mapped = OPENCLAW_SPAN_OPERATION[spanName]
+    if (mapped) return mapped
+  }
+  if (scopeName.startsWith(OPENCLAW_PLUGIN_SCOPE_PREFIX)) {
+    const mapped = operationFromOpenClawPluginSpan(spanName)
     if (mapped) return mapped
   }
   return first(operationCandidates, spanAttrs) ?? operationFromClaudeCodeNativeSpanName(spanName) ?? "unspecified"

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -325,6 +325,33 @@ describe("resolveAttributes", () => {
       ).toBe("chat")
     })
 
+    it("maps OpenClaw plugin span names and subagent interaction kinds", () => {
+      expect(
+        resolveAttributes({
+          spanAttrs: [],
+          statusCode: "unset",
+          spanName: "subagent",
+          scopeName: "@latitude-data/openclaw-telemetry",
+        }).operation,
+      ).toBe("create_agent")
+      expect(
+        resolveAttributes({
+          spanAttrs: [],
+          statusCode: "unset",
+          spanName: "tool_call:bash",
+          scopeName: "@latitude-data/openclaw-telemetry",
+        }).operation,
+      ).toBe("execute_tool")
+      expect(
+        resolveAttributes({
+          spanAttrs: [strAttr("interaction.kind", "subagent"), strAttr("span.type", "interaction")],
+          statusCode: "unset",
+          spanName: "interaction",
+          scopeName: "@latitude-data/claude-code-telemetry",
+        }).operation,
+      ).toBe("invoke_agent")
+    })
+
     it("maps OpenLLMetry request types", () => {
       const cases: [string, string][] = [
         ["chat", "chat"],

--- a/packages/domain/spans/src/otlp/tests/openclaw.test.ts
+++ b/packages/domain/spans/src/otlp/tests/openclaw.test.ts
@@ -103,6 +103,32 @@ describe("OpenClaw diagnostics-otel ingest", () => {
     expect(tool?.toolName).toBe("bash")
   })
 
+  it("classifies OpenClaw plugin subagent spans as create_agent", () => {
+    const trace: OtlpExportTraceServiceRequest = {
+      resourceSpans: [
+        {
+          resource: { attributes: [str("service.name", "openclaw-gateway")] },
+          scopeSpans: [
+            {
+              scope: { name: "@latitude-data/openclaw-telemetry", version: "0.1.0" },
+              spans: [
+                span("aaaaaaaaaaaaaaaa", "agent", []),
+                span("bbbbbbbbbbbbbbbb", "subagent", [
+                  str("openclaw.subagent.label", "research"),
+                  str("openclaw.subagent.agent_id", "child-1"),
+                ]),
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const pluginSpans = transformOtlpToSpans(trace, CONTEXT).spans
+    const subagent = pluginSpans.find((s) => s.name === "subagent")
+    expect(subagent?.operation).toBe("create_agent")
+    expect(subagent?.attrString["openclaw.subagent.label"]).toBe("research")
+  })
+
   it("resolves successful spans to ok status even though OTel status arrives unset", () => {
     // OpenClaw signals success out-of-band, not via OTel status — so these would
     // otherwise render with the neutral/gray status in the waterfall.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes latitude-dev/latitude-llm#3796

Subagent work was already landing in OTLP traces — nested `invoke_agent` spans under tool calls, OpenClaw `subagent` spans, Claude Code `interaction.kind=subagent` — but the spans tab showed raw span names with no agent identity and no way to filter down to delegated work.

## Ingest

- Map `@latitude-data/openclaw-telemetry` span names (`agent`, `subagent`, `model_call`, `tool_call:*`) to the right operations; `subagent` → `create_agent`.
- Treat `interaction.kind=subagent` as `invoke_agent` so Claude Code subagent turns classify correctly.

## Display helpers (`@domain/spans`)

- `resolveSpanLabels` derives `displayLabel` (span name + `gen_ai.agent.name` / `subagent.id` / `openclaw.subagent.*`) and `isSubagent` from span attributes and parent context (nested `invoke_agent` under `execute_tool`).

## UI

- Span waterfall rows use `displayLabel` instead of raw `name`.
- Span detail shows a **Subagent** section when `isSubagent` is true.
- Spans tab adds a **Subagents** filter (keeps ancestor chain for navigation).

## Testing

- `@domain/spans`: `span-display.test.ts`, extended `resolvers.test.ts` and `openclaw.test.ts` (106 tests in touched files).
- `pnpm --filter @domain/spans typecheck` and `pnpm --filter web typecheck` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-719](https://linear.app/latitude/issue/LAT-719/investigate-support-for-subagents)

<div><a href="https://cursor.com/agents/bc-a24e0a1c-66c0-484c-b1cd-c32ddb5d299c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a24e0a1c-66c0-484c-b1cd-c32ddb5d299c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

