### PR TITLE
fix(web): scroll to semantic search highlights in session conversations

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -138,6 +138,7 @@ function ConversationContent({
   const navItemRefs = useRef<(HTMLDivElement | null)[]>([])
   const clearSelectionRef = useRef<(() => void) | null>(null)
   const autoLoadingMoreRef = useRef(false)
+  const hasScrolledToSearchRef = useRef<string | null>(null)
 
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
@@ -441,10 +442,22 @@ function ConversationContent({
   // TODO(frontend-use-effect-policy): scrolls to the active search match after highlight DOM mounts.
   useEffect(() => {
     const container = scrollRef.current
-    if (!container || !searchScrollTarget) return
+    if (!container || !searchScrollTarget) {
+      hasScrolledToSearchRef.current = null
+      return
+    }
     if (searchScrollTarget.messageIndex >= messages.length) return
+
+    const scrollKey = JSON.stringify({
+      query: activeSearchQuery,
+      matchIndex: activeMatchIndex,
+      target: searchScrollTarget,
+    })
+    if (hasScrolledToSearchRef.current === scrollKey) return
+    hasScrolledToSearchRef.current = scrollKey
+
     return scrollToSearchMatch(container, searchScrollTarget)
-  }, [messages.length, scrollRef, searchScrollTarget])
+  }, [activeMatchIndex, activeSearchQuery, messages.length, scrollRef, searchScrollTarget])
 
   if (textSelectionPopoverControlsRef) {
     textSelectionPopoverControlsRef.current = {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -47,8 +47,13 @@ import {
   formatConversationSearchForBackend,
 } from "./compute-loaded-conversation-highlights.ts"
 import { ConversationSearchBar } from "./conversation-search-bar.tsx"
-import { getNavigableSearchHighlights, toSearchHighlightRanges } from "./navigable-search-highlights.ts"
-import { scrollToHighlightMatch } from "./scroll-to-highlight-match.ts"
+import {
+  getFirstMatchHint,
+  getNavigableSearchHighlights,
+  resolveSearchScrollTarget,
+  toSearchHighlightRanges,
+} from "./navigable-search-highlights.ts"
+import { scrollToSearchMatch } from "./scroll-to-highlight-match.ts"
 import { SearchMatchNavigator } from "./search-match-navigator.tsx"
 
 const LOAD_MORE_THRESHOLD_PX = 1200
@@ -397,11 +402,10 @@ function ConversationContent({
     [annotationHighlightRanges, searchHighlightRanges],
   )
 
-  const firstMatchHint = useMemo<FirstMatchHint | null>(() => {
-    const first = navigableMatches[0]
-    if (!first) return null
-    return { messageIndex: first.messageIndex, partIndex: first.partIndex }
-  }, [navigableMatches])
+  const firstMatchHint = useMemo<FirstMatchHint | null>(
+    () => getFirstMatchHint(searchHighlightsData),
+    [searchHighlightsData],
+  )
 
   // TODO(frontend-use-effect-policy): loading search target pages is a query-side effect keyed by async highlight results.
   useEffect(() => {
@@ -422,16 +426,25 @@ function ConversationContent({
     loadMoreMessages()
   }, [focusMessageIndex, messages.length, loadMoreMessages])
 
+  const searchScrollTarget = useMemo(
+    () =>
+      activeSearchQuery.length > 0
+        ? resolveSearchScrollTarget({
+            result: searchHighlightsData,
+            navigableMatches,
+            activeNavigableIndex: activeMatchIndex,
+          })
+        : null,
+    [activeMatchIndex, activeSearchQuery, navigableMatches, searchHighlightsData],
+  )
+
   // TODO(frontend-use-effect-policy): scrolls to the active search match after highlight DOM mounts.
   useEffect(() => {
     const container = scrollRef.current
-    const match = navigableMatches[activeMatchIndex]
-    if (!container || !match || !searchNavigationActive) return
-    return scrollToHighlightMatch(container, {
-      messageIndex: match.messageIndex,
-      startOffset: match.startOffset,
-    })
-  }, [activeMatchIndex, navigableMatches, scrollRef, searchNavigationActive])
+    if (!container || !searchScrollTarget) return
+    if (searchScrollTarget.messageIndex >= messages.length) return
+    return scrollToSearchMatch(container, searchScrollTarget)
+  }, [messages.length, scrollRef, searchScrollTarget])
 
   if (textSelectionPopoverControlsRef) {
     textSelectionPopoverControlsRef.current = {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
@@ -84,9 +84,7 @@ describe("getFirstMatchHint", () => {
   })
 
   it("falls back to the first highlight when firstMatchIndex is out of bounds", () => {
-    const highlights = [
-      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 5 }),
-    ]
+    const highlights = [highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 5 })]
 
     expect(getFirstMatchHint({ highlights, firstMatchIndex: 99 })).toEqual({
       messageIndex: 5,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
@@ -70,6 +70,29 @@ describe("getFirstMatchHint", () => {
       partIndex: 0,
     })
   })
+
+  it("respects firstMatchIndex when it points past container markers", () => {
+    const highlights = [
+      highlight({ type: "search-container", startOffset: 0, endOffset: 0, messageIndex: 3 }),
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 18, partIndex: 0 }),
+    ]
+
+    expect(getFirstMatchHint({ highlights, firstMatchIndex: 1 })).toEqual({
+      messageIndex: 18,
+      partIndex: 0,
+    })
+  })
+
+  it("falls back to the first highlight when firstMatchIndex is out of bounds", () => {
+    const highlights = [
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 5 }),
+    ]
+
+    expect(getFirstMatchHint({ highlights, firstMatchIndex: 99 })).toEqual({
+      messageIndex: 5,
+      partIndex: 0,
+    })
+  })
 })
 
 describe("resolveSearchScrollTarget", () => {
@@ -96,6 +119,21 @@ describe("resolveSearchScrollTarget", () => {
     expect(
       resolveSearchScrollTarget({
         result: { highlights, firstMatchIndex: 0 },
+        navigableMatches: [],
+        activeNavigableIndex: 0,
+      }),
+    ).toEqual({ kind: "message", messageIndex: 18 })
+  })
+
+  it("uses firstMatchIndex in the semantic fallback path", () => {
+    const highlights = [
+      highlight({ type: "search-container", startOffset: 0, endOffset: 0, messageIndex: 3 }),
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 18, partIndex: 0 }),
+    ]
+
+    expect(
+      resolveSearchScrollTarget({
+        result: { highlights, firstMatchIndex: 1 },
         navigableMatches: [],
         activeNavigableIndex: 0,
       }),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.test.ts
@@ -1,6 +1,12 @@
 import type { TraceHighlight } from "@domain/spans"
 import { describe, expect, it } from "vitest"
-import { getNavigableSearchHighlights, toSearchHighlightRanges } from "./navigable-search-highlights.ts"
+import {
+  getFirstMatchHint,
+  getNavigableSearchHighlights,
+  getSearchScrollTarget,
+  resolveSearchScrollTarget,
+  toSearchHighlightRanges,
+} from "./navigable-search-highlights.ts"
 
 function highlight(overrides: Partial<TraceHighlight> & Pick<TraceHighlight, "type">): TraceHighlight {
   return {
@@ -49,5 +55,60 @@ describe("toSearchHighlightRanges", () => {
 
     expect(ranges[0]?.searchActive).toBeUndefined()
     expect(ranges[1]?.searchActive).toBe(true)
+  })
+})
+
+describe("getFirstMatchHint", () => {
+  it("returns the first highlight including semantic regions", () => {
+    const highlights = [
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 12, partIndex: 0 }),
+      highlight({ type: "search-literal", messageIndex: 12, startOffset: 4, endOffset: 10 }),
+    ]
+
+    expect(getFirstMatchHint({ highlights, firstMatchIndex: 0 })).toEqual({
+      messageIndex: 12,
+      partIndex: 0,
+    })
+  })
+})
+
+describe("resolveSearchScrollTarget", () => {
+  it("scrolls to the active navigable match when one exists", () => {
+    const highlights = [
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 5 }),
+      highlight({ type: "search-literal", messageIndex: 5, startOffset: 10, endOffset: 16 }),
+    ]
+
+    expect(
+      resolveSearchScrollTarget({
+        result: { highlights, firstMatchIndex: 0 },
+        navigableMatches: getNavigableSearchHighlights(highlights),
+        activeNavigableIndex: 0,
+      }),
+    ).toEqual({ kind: "inline", messageIndex: 5, startOffset: 10 })
+  })
+
+  it("falls back to the first semantic region when there are no navigable matches", () => {
+    const highlights = [
+      highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 18, partIndex: 0 }),
+    ]
+
+    expect(
+      resolveSearchScrollTarget({
+        result: { highlights, firstMatchIndex: 0 },
+        navigableMatches: [],
+        activeNavigableIndex: 0,
+      }),
+    ).toEqual({ kind: "message", messageIndex: 18 })
+  })
+})
+
+describe("getSearchScrollTarget", () => {
+  it("maps semantic regions to message anchors", () => {
+    expect(
+      getSearchScrollTarget(
+        highlight({ type: "search-semantic-region", startOffset: 0, endOffset: 0, messageIndex: 7 }),
+      ),
+    ).toEqual({ kind: "message", messageIndex: 7 })
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.ts
@@ -1,12 +1,55 @@
 import type { TraceHighlight, TraceSearchHighlightsResult } from "@domain/spans"
-import type { HighlightRange } from "@repo/ui"
+import type { FirstMatchHint, HighlightRange } from "@repo/ui"
+
+export type SearchScrollTarget =
+  | { readonly kind: "inline"; readonly messageIndex: number; readonly startOffset: number }
+  | { readonly kind: "message"; readonly messageIndex: number }
 
 export function getNavigableSearchHighlights(highlights: readonly TraceHighlight[]): readonly TraceHighlight[] {
-  return highlights.filter(
-    (highlight) =>
-      (highlight.type === "search-literal" || highlight.type === "search-token") &&
-      highlight.endOffset > highlight.startOffset,
+  return highlights.filter(isInlineNavigableHighlight)
+}
+
+function isInlineNavigableHighlight(highlight: TraceHighlight): boolean {
+  return (
+    (highlight.type === "search-literal" || highlight.type === "search-token") &&
+    highlight.endOffset > highlight.startOffset
   )
+}
+
+export function getSearchScrollTarget(highlight: TraceHighlight): SearchScrollTarget {
+  if (isInlineNavigableHighlight(highlight)) {
+    return {
+      kind: "inline",
+      messageIndex: highlight.messageIndex,
+      startOffset: highlight.startOffset,
+    }
+  }
+  return { kind: "message", messageIndex: highlight.messageIndex }
+}
+
+export function getFirstMatchHint(result: TraceSearchHighlightsResult | undefined): FirstMatchHint | null {
+  if (!result || result.highlights.length === 0) return null
+  const index = result.firstMatchIndex >= 0 ? result.firstMatchIndex : 0
+  const first = result.highlights[index] ?? result.highlights[0]
+  if (!first) return null
+  return { messageIndex: first.messageIndex, partIndex: first.partIndex }
+}
+
+export function resolveSearchScrollTarget(args: {
+  readonly result: TraceSearchHighlightsResult | undefined
+  readonly navigableMatches: readonly TraceHighlight[]
+  readonly activeNavigableIndex: number
+}): SearchScrollTarget | null {
+  const { result, navigableMatches, activeNavigableIndex } = args
+  if (!result || result.highlights.length === 0) return null
+
+  const activeNavigable = navigableMatches[activeNavigableIndex]
+  if (activeNavigable) return getSearchScrollTarget(activeNavigable)
+
+  const index = result.firstMatchIndex >= 0 ? result.firstMatchIndex : 0
+  const first = result.highlights[index] ?? result.highlights[0]
+  if (!first) return null
+  return getSearchScrollTarget(first)
 }
 
 export function toSearchHighlightRanges(
@@ -17,9 +60,7 @@ export function toSearchHighlightRanges(
 
   let navigableIdx = 0
   return result.highlights.map((highlight) => {
-    const isNavigable =
-      (highlight.type === "search-literal" || highlight.type === "search-token") &&
-      highlight.endOffset > highlight.startOffset
+    const isNavigable = isInlineNavigableHighlight(highlight)
 
     const range: HighlightRange = {
       messageIndex: highlight.messageIndex,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/navigable-search-highlights.ts
@@ -16,6 +16,12 @@ function isInlineNavigableHighlight(highlight: TraceHighlight): boolean {
   )
 }
 
+function getFirstOrderedHighlight(result: TraceSearchHighlightsResult): TraceHighlight | null {
+  if (result.highlights.length === 0) return null
+  const index = result.firstMatchIndex >= 0 ? result.firstMatchIndex : 0
+  return result.highlights[index] ?? result.highlights[0] ?? null
+}
+
 export function getSearchScrollTarget(highlight: TraceHighlight): SearchScrollTarget {
   if (isInlineNavigableHighlight(highlight)) {
     return {
@@ -28,9 +34,8 @@ export function getSearchScrollTarget(highlight: TraceHighlight): SearchScrollTa
 }
 
 export function getFirstMatchHint(result: TraceSearchHighlightsResult | undefined): FirstMatchHint | null {
-  if (!result || result.highlights.length === 0) return null
-  const index = result.firstMatchIndex >= 0 ? result.firstMatchIndex : 0
-  const first = result.highlights[index] ?? result.highlights[0]
+  if (!result) return null
+  const first = getFirstOrderedHighlight(result)
   if (!first) return null
   return { messageIndex: first.messageIndex, partIndex: first.partIndex }
 }
@@ -46,8 +51,7 @@ export function resolveSearchScrollTarget(args: {
   const activeNavigable = navigableMatches[activeNavigableIndex]
   if (activeNavigable) return getSearchScrollTarget(activeNavigable)
 
-  const index = result.firstMatchIndex >= 0 ? result.firstMatchIndex : 0
-  const first = result.highlights[index] ?? result.highlights[0]
+  const first = getFirstOrderedHighlight(result)
   if (!first) return null
   return getSearchScrollTarget(first)
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/scroll-to-highlight-match.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/scroll-to-highlight-match.ts
@@ -1,22 +1,22 @@
+import { findNearestMessageAnchor } from "../../conversation-timeline/flash-highlight.ts"
 import { centerHighlightInView, findHighlightNode } from "./find-highlight-node.ts"
+import type { SearchScrollTarget } from "./navigable-search-highlights.ts"
 
 const SCROLL_OBSERVER_TIMEOUT_MS = 2000
 
-type HighlightScrollTarget = {
-  readonly messageIndex: number
-  readonly startOffset: number
-}
-
-export function scrollToHighlightMatch(
+export function scrollToSearchMatch(
   container: HTMLElement,
-  target: HighlightScrollTarget,
+  target: SearchScrollTarget,
   behavior: ScrollBehavior = "smooth",
 ): () => void {
   let done = false
 
   function tryScroll(): boolean {
     if (done) return true
-    const node = findHighlightNode(container, target.messageIndex, target.startOffset)
+    const node =
+      target.kind === "inline"
+        ? findHighlightNode(container, target.messageIndex, target.startOffset)
+        : findNearestMessageAnchor(container, target.messageIndex)
     if (!node) return false
     centerHighlightInView(container, node, behavior)
     return true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes auto-scroll when opening a session conversation from semantic session search. The semantic region frame was rendering correctly, but the drawer stayed at the top of the conversation.

## Root cause

Auto-scroll in the conversation tab only ran for **navigable** literal/token chip matches (`search-literal`, `search-token`). Pure semantic queries emit `search-semantic-region` highlights instead — those render the framed region but were excluded from both:

1. **`firstMatchHint`** — derived from navigable matches only, so chunk loading never targeted the matched message in large conversations
2. **Scroll effect** — gated on `searchNavigationActive`, which requires at least one navigable match

## Fix

- Derive `firstMatchHint` from the full highlight result (respecting `firstMatchIndex`), including semantic regions
- Resolve scroll targets from either the active navigable match or the first highlight in the result
- Scroll to the message anchor (`[data-message-index]`) when there is no inline chip to target
- Keep the existing MutationObserver retry so scroll still works after chunk load / markdown render
- Address Claude review nits: shared `getFirstOrderedHighlight` helper, additional edge-case tests, and a one-shot scroll guard so later chunk loads do not jump the viewport

## Testing

- Added unit tests for `getFirstMatchHint`, `resolveSearchScrollTarget`, and `getSearchScrollTarget`
- Manual: open a session from semantic search on a large conversation (`qa-deep-20-1` fixture) — drawer should land scrolled to the framed semantic region once chunks load

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-304a4cfe-3ff2-4098-85a3-31354a1a89df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-304a4cfe-3ff2-4098-85a3-31354a1a89df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

