### PR TITLE
fix(web): orphan-session blankslate when LLM activity filter hides rows

### DIFF
--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -37,35 +37,27 @@ export function deriveSessionStatus(endTime: string | Date, now: number = Date.n
 }
 
 /**
- * Default-on session filter: hide "orphan fragment" rows that carry no LLM
- * activity (sessions whose every span produced 0 tokens and no model name —
- * typically OTel-direct customers with mixed span/session-id propagation where
- * framework spans split off into their own session).
+ * Normalizes the optional `hasLlmActivity` session filter before it reaches
+ * the repo. Hides "orphan fragment" rows (sessions with 0 tokens and no model)
+ * only when the user explicitly turns the sidebar toggle on.
  *
  * URL representation of the sidebar toggle:
- *   - key absent          → default ON; this helper injects the filter.
- *   - `{op:"eq",value:true}`  → explicit ON; equivalent to absent, filter is kept.
- *   - `{op:"eq",value:false}` → sentinel meaning "user opted out of the default";
- *                                this helper STRIPS the field so the repo applies
- *                                no `hasLlmActivity` clause at all (i.e. shows
- *                                both LLM-active sessions and orphan fragments).
- *
- * The `false` sentinel lives in the URL so the toggle state is shareable, but
- * never reaches the repo as a filter condition — sending `false` to the
- * synthetic clause would otherwise narrow the list to *only* orphans, which is
- * not what "Including orphan fragments" means.
+ *   - key absent → off; no `hasLlmActivity` clause is applied.
+ *   - `{op:"eq",value:true}` → on; filter is kept.
+ *   - `{op:"eq",value:false}` → legacy off sentinel from the old default-on
+ *     toggle; stripped so the repo sees no clause (same as absent).
  */
 export function withSessionDefaults(filters: FilterSet | undefined): FilterSet {
-  if (filters?.hasLlmActivity !== undefined) {
-    const explicit = filters.hasLlmActivity
-    const optedOut = explicit.some((c) => c.op === "eq" && (c.value === false || c.value === "false"))
-    if (optedOut) {
-      const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
-      return rest as FilterSet
-    }
-    return filters
+  if (filters?.hasLlmActivity === undefined) {
+    return filters ?? {}
   }
-  return { ...(filters ?? {}), hasLlmActivity: [{ op: "eq", value: true }] }
+  const explicit = filters.hasLlmActivity
+  const legacyOff = explicit.some((c) => c.op === "eq" && (c.value === false || c.value === "false"))
+  if (legacyOff) {
+    const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
+    return rest as FilterSet
+  }
+  return filters
 }
 
 export function useSessionsInfiniteScroll({

--- a/apps/web/src/domains/sessions/sessions.collection.ts
+++ b/apps/web/src/domains/sessions/sessions.collection.ts
@@ -37,27 +37,38 @@ export function deriveSessionStatus(endTime: string | Date, now: number = Date.n
 }
 
 /**
- * Normalizes the optional `hasLlmActivity` session filter before it reaches
- * the repo. Hides "orphan fragment" rows (sessions with 0 tokens and no model)
- * only when the user explicitly turns the sidebar toggle on.
+ * Default-on session filter: hide "orphan fragment" rows that carry no LLM
+ * activity (sessions whose every span produced 0 tokens and no model name).
  *
  * URL representation of the sidebar toggle:
- *   - key absent → off; no `hasLlmActivity` clause is applied.
- *   - `{op:"eq",value:true}` → on; filter is kept.
- *   - `{op:"eq",value:false}` → legacy off sentinel from the old default-on
- *     toggle; stripped so the repo sees no clause (same as absent).
+ *   - key absent → default ON; this helper injects the filter.
+ *   - `{op:"eq",value:true}` → explicit ON; equivalent to absent.
+ *   - `{op:"eq",value:false}` → user opted out; stripped before querying so
+ *     the repo applies no `hasLlmActivity` clause.
  */
 export function withSessionDefaults(filters: FilterSet | undefined): FilterSet {
-  if (filters?.hasLlmActivity === undefined) {
-    return filters ?? {}
+  if (filters?.hasLlmActivity !== undefined) {
+    const explicit = filters.hasLlmActivity
+    const optedOut = explicit.some((c) => c.op === "eq" && (c.value === false || c.value === "false"))
+    if (optedOut) {
+      const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
+      return rest as FilterSet
+    }
+    return filters
   }
-  const explicit = filters.hasLlmActivity
-  const legacyOff = explicit.some((c) => c.op === "eq" && (c.value === false || c.value === "false"))
-  if (legacyOff) {
-    const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
-    return rest as FilterSet
-  }
-  return filters
+  return { ...(filters ?? {}), hasLlmActivity: [{ op: "eq", value: true }] }
+}
+
+export function isHasLlmActivityFilterOn(filters: FilterSet | undefined): boolean {
+  const cond = filters?.hasLlmActivity?.find((c) => c.op === "eq")
+  if (cond === undefined) return true
+  return cond.value !== false && cond.value !== "false"
+}
+
+function withoutHasLlmActivityFilter(filters: FilterSet): FilterSet {
+  if (!("hasLlmActivity" in filters)) return filters
+  const { hasLlmActivity: _drop, ...rest } = filters as Record<string, readonly FilterCondition[]>
+  return rest as FilterSet
 }
 
 export function useSessionsInfiniteScroll({
@@ -172,6 +183,47 @@ export function useSessionsCount({
   return {
     totalCount: data?.totalCount ?? 0,
     matchingTraceCount: data?.matchingTraceCount,
+    isLoading,
+  }
+}
+
+export function useSessionsCountWithoutLlmActivityFilter({
+  projectId,
+  filters,
+  searchQuery,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly filters?: FilterSet
+  readonly searchQuery?: string
+  readonly enabled?: boolean
+}) {
+  const scope = use(TraceScopeContext)
+  const filtersWithoutLlmActivity = useMemo(() => withoutHasLlmActivityFilter(withSessionDefaults(filters)), [filters])
+
+  const { data, isLoading } = useQuery({
+    queryKey: [
+      ...traceScopeKey(scope),
+      "sessionsCountWithoutLlmActivity",
+      projectId,
+      filtersWithoutLlmActivity,
+      searchQuery,
+    ],
+    queryFn: () =>
+      countSessionsByProject({
+        data: {
+          ...traceScopeData(scope),
+          projectId,
+          filters: filtersWithoutLlmActivity,
+          ...(searchQuery ? { searchQuery } : {}),
+        },
+      }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+
+  return {
+    totalCount: data?.totalCount ?? 0,
     isLoading,
   }
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -660,10 +660,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
         </CollapsibleSection>
 
         {mode === "sessions" && (
-          <CollapsibleSection
-            label="Has LLM activity"
-            defaultOpen={getHasLlmActivityOn(filters)}
-          >
+          <CollapsibleSection label="Has LLM activity" defaultOpen={getHasLlmActivityOn(filters)}>
             <div className="flex items-center justify-between gap-2">
               <Text.H7 color="foregroundMuted">
                 {getHasLlmActivityOn(filters) ? "Hiding sessions without any LLM call." : "Including orphan fragments."}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -20,6 +20,7 @@ import { PercentileFilter } from "../../../../../components/filters-builder/perc
 import { StatusFilter, type StatusFilterValue } from "../../../../../components/filters-builder/status-filter.tsx"
 import type { DistinctColumn } from "../../../../../components/filters-builder/types.ts"
 import { useMembersCollection } from "../../../../../domains/members/members.collection.ts"
+import { isHasLlmActivityFilterOn } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useTopicFilterOptions } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { authClient } from "../../../../../lib/auth-client.ts"
@@ -96,8 +97,7 @@ function getStatusValues(filters: FilterSet, field: string): readonly StatusFilt
 }
 
 function getHasLlmActivityOn(filters: FilterSet): boolean {
-  const cond = filters.hasLlmActivity?.find((c) => c.op === "eq")
-  return cond?.value === true || cond?.value === "true"
+  return isHasLlmActivityFilterOn(filters)
 }
 
 function setFieldConditions(filters: FilterSet, field: string, conditions: FilterCondition[]): FilterSet {
@@ -471,7 +471,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
 
   const setHasLlmActivity = useCallback(
     (on: boolean) => {
-      setField("hasLlmActivity", on ? [{ op: "eq", value: true }] : [])
+      setField("hasLlmActivity", on ? [] : [{ op: "eq", value: false }])
     },
     [setField],
   )
@@ -660,7 +660,10 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
         </CollapsibleSection>
 
         {mode === "sessions" && (
-          <CollapsibleSection label="Has LLM activity" defaultOpen={getHasLlmActivityOn(filters)}>
+          <CollapsibleSection
+            label="Has LLM activity"
+            defaultOpen={filters.hasLlmActivity !== undefined && !getHasLlmActivityOn(filters)}
+          >
             <div className="flex items-center justify-between gap-2">
               <Text.H7 color="foregroundMuted">
                 {getHasLlmActivityOn(filters) ? "Hiding sessions without any LLM call." : "Including orphan fragments."}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -95,19 +95,9 @@ function getStatusValues(filters: FilterSet, field: string): readonly StatusFilt
   return raw.filter((v): v is StatusFilterValue => (STATUS_VALUES as readonly string[]).includes(v))
 }
 
-/**
- * Tri-state for the "Has LLM activity" toggle:
- * - URL key absent → treated as on (the default chip applies at the call site).
- * - `[{op: "eq", value: false}]` → off (user explicitly opted out).
- * - `[{op: "eq", value: true}]` → on (explicit; equivalent to absent).
- *
- * Returning a plain boolean lets the Switch render the right state regardless
- * of which representation lives in the URL.
- */
 function getHasLlmActivityOn(filters: FilterSet): boolean {
   const cond = filters.hasLlmActivity?.find((c) => c.op === "eq")
-  if (cond === undefined) return true
-  return cond.value !== false && cond.value !== "false"
+  return cond?.value === true || cond?.value === "true"
 }
 
 function setFieldConditions(filters: FilterSet, field: string, conditions: FilterCondition[]): FilterSet {
@@ -481,7 +471,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
 
   const setHasLlmActivity = useCallback(
     (on: boolean) => {
-      setField("hasLlmActivity", on ? [] : [{ op: "eq", value: false }])
+      setField("hasLlmActivity", on ? [{ op: "eq", value: true }] : [])
     },
     [setField],
   )
@@ -672,7 +662,7 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
         {mode === "sessions" && (
           <CollapsibleSection
             label="Has LLM activity"
-            defaultOpen={filters.hasLlmActivity !== undefined && !getHasLlmActivityOn(filters)}
+            defaultOpen={getHasLlmActivityOn(filters)}
           >
             <div className="flex items-center justify-between gap-2">
               <Text.H7 color="foregroundMuted">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/filters-sidebar.tsx
@@ -96,10 +96,6 @@ function getStatusValues(filters: FilterSet, field: string): readonly StatusFilt
   return raw.filter((v): v is StatusFilterValue => (STATUS_VALUES as readonly string[]).includes(v))
 }
 
-function getHasLlmActivityOn(filters: FilterSet): boolean {
-  return isHasLlmActivityFilterOn(filters)
-}
-
 function setFieldConditions(filters: FilterSet, field: string, conditions: FilterCondition[]): FilterSet {
   if (conditions.length === 0) {
     const { [field]: _, ...rest } = filters
@@ -662,14 +658,16 @@ export function FiltersSidebar({ mode, projectId, filters, onFiltersChange, onCl
         {mode === "sessions" && (
           <CollapsibleSection
             label="Has LLM activity"
-            defaultOpen={filters.hasLlmActivity !== undefined && !getHasLlmActivityOn(filters)}
+            defaultOpen={filters.hasLlmActivity !== undefined && !isHasLlmActivityFilterOn(filters)}
           >
             <div className="flex items-center justify-between gap-2">
               <Text.H7 color="foregroundMuted">
-                {getHasLlmActivityOn(filters) ? "Hiding sessions without any LLM call." : "Including orphan fragments."}
+                {isHasLlmActivityFilterOn(filters)
+                  ? "Hiding sessions without any LLM call."
+                  : "Including orphan fragments."}
               </Text.H7>
               <Switch
-                checked={getHasLlmActivityOn(filters)}
+                checked={isHasLlmActivityFilterOn(filters)}
                 onCheckedChange={(next) => setHasLlmActivity(next === true)}
               />
             </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -238,11 +238,11 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       startTime: [{ op: "gte" as const, value: new Date(fromMs).toISOString() }],
     }
   }, [filters, isSessions])
-  // The Sessions surface hooks apply `withSessionDefaults` internally so an
-  // explicit `hasLlmActivity` toggle is honored consistently. Trace-side
-  // surfaces here (count, export, add-to-dataset) need the same normalization
-  // in Sessions mode. In Traces mode `hasLlmActivity` is session-only and is
-  // not part of the trace filter registry, so we keep the raw filter set.
+  // Sessions hooks apply `withSessionDefaults` internally so orphan-fragment
+  // sessions stay hidden unless the user opts out. Trace-side surfaces here
+  // (count, export, add-to-dataset) need the same default in Sessions mode.
+  // In Traces mode `hasLlmActivity` is session-only and isn't in the trace
+  // filter registry, so we keep the raw filter set there.
   const effectiveFilters = useMemo(() => (isSessions ? withSessionDefaults(filters) : filters), [filters, isSessions])
   const traceColumnSettings = useTableColumnSettings<TraceColumnId>({
     storageKey: "projects.traces.columns.v1",
@@ -702,6 +702,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
           onCloseSession={closeSessionPanel}
           visibleColumnIds={sessionColumnSettings.visibleColumnIds}
           isSearching={hasSearchQuery}
+          hasUserAppliedFilters={hasActiveFilters}
           {...(hasSearchQuery ? { searchQuery: query } : {})}
         />
       ) : (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -238,13 +238,11 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       startTime: [{ op: "gte" as const, value: new Date(fromMs).toISOString() }],
     }
   }, [filters, isSessions])
-  // The Sessions surface's hooks (useSessionsInfiniteScroll / useSessionsCount)
-  // apply `withSessionDefaults` internally to hide orphan-fragment sessions
-  // by default. The trace-side surfaces here (count, export, add-to-dataset)
-  // need the same default applied in Sessions mode so a Select-All export
-  // doesn't sweep traces the user never saw. In Traces mode `hasLlmActivity`
-  // is a session-only synthetic and isn't part of the trace filter registry,
-  // so we keep the raw filter set there.
+  // The Sessions surface hooks apply `withSessionDefaults` internally so an
+  // explicit `hasLlmActivity` toggle is honored consistently. Trace-side
+  // surfaces here (count, export, add-to-dataset) need the same normalization
+  // in Sessions mode. In Traces mode `hasLlmActivity` is session-only and is
+  // not part of the trace filter registry, so we keep the raw filter set.
   const effectiveFilters = useMemo(() => (isSessions ? withSessionDefaults(filters) : filters), [filters, isSessions])
   const traceColumnSettings = useTableColumnSettings<TraceColumnId>({
     storageKey: "projects.traces.columns.v1",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -307,6 +307,10 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     setRawFilters(serializeFilters(next) ?? "")
   }
 
+  const onShowAllSessions = useCallback(() => {
+    setRawFilters(serializeFilters({ ...filters, hasLlmActivity: [{ op: "eq", value: false as const }] }) ?? "")
+  }, [filters, setRawFilters])
+
   const onTimeRangeSelect = useCallback((range: { from: string; to: string } | null) => {
     setRawFilters((prev) => {
       const current = parseFilters(prev || undefined)
@@ -697,6 +701,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
           onSelectionChange={setSelectionState}
           totalTraceCount={totalTraceCount}
           onFiltersChange={onFiltersChange}
+          onShowAllSessions={onShowAllSessions}
           onFiltersClose={() => setFiltersOpen(false)}
           onOpenSession={onOpenSession}
           onCloseSession={closeSessionPanel}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-orphan-fragments-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-orphan-fragments-blank-slate.tsx
@@ -1,0 +1,40 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { ExternalLinkIcon, MessagesSquareIcon } from "lucide-react"
+
+export function SessionsOrphanFragmentsBlankSlate({ onShowAllSessions }: { readonly onShowAllSessions: () => void }) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={MessagesSquareIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>Sessions lack LLM activity</Text.H3>
+          <Text.H5 color="foregroundMuted" centered>
+            Latitude received telemetry for this project, but none of the sessions in this time range include an LLM
+            call (no tokens or model recorded). Review your instrumentation so LLM spans are captured correctly, or
+            contact support if you think this is wrong.
+          </Text.H5>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button variant="outline" onClick={onShowAllSessions}>
+            Show all sessions
+          </Button>
+          <a href="https://docs.latitude.so/telemetry/start-tracing" target="_blank" rel="noopener noreferrer">
+            <Button variant="outline">
+              <Icon size="sm" icon={ExternalLinkIcon} />
+              Read the docs
+            </Button>
+          </a>
+          <a
+            href="mailto:hello@latitude.so?subject=Sessions%20lack%20LLM%20activity"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant="outline">Contact support</Button>
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-orphan-fragments-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-orphan-fragments-blank-slate.tsx
@@ -1,3 +1,4 @@
+import { show as showIntercom } from "@intercom/messenger-js-sdk"
 import { Button, Icon, Text } from "@repo/ui"
 import { ExternalLinkIcon, MessagesSquareIcon } from "lucide-react"
 
@@ -26,13 +27,9 @@ export function SessionsOrphanFragmentsBlankSlate({ onShowAllSessions }: { reado
               Read the docs
             </Button>
           </a>
-          <a
-            href="mailto:hello@latitude.so?subject=Sessions%20lack%20LLM%20activity"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button variant="outline">Contact support</Button>
-          </a>
+          <Button variant="outline" onClick={() => showIntercom()}>
+            Contact support
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -15,7 +15,12 @@ import { useQueries } from "@tanstack/react-query"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
 import { use, useCallback, useMemo, useState } from "react"
 import { useAnnotationCountsByTraceIds } from "../../../../../domains/annotations/annotations.collection.ts"
-import { useSessionMetrics, useSessionsInfiniteScroll } from "../../../../../domains/sessions/sessions.collection.ts"
+import {
+  isHasLlmActivityFilterOn,
+  useSessionMetrics,
+  useSessionsCountWithoutLlmActivityFilter,
+  useSessionsInfiniteScroll,
+} from "../../../../../domains/sessions/sessions.collection.ts"
 import type { SessionRecord } from "../../../../../domains/sessions/sessions.functions.ts"
 import { TraceScopeContext } from "../../../../../domains/traces/trace-scope.tsx"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
@@ -25,6 +30,7 @@ import type { SelectionState } from "../../../../../lib/hooks/useSelectableRows.
 import { FiltersSidebar } from "./filters-sidebar.tsx"
 import { sessionTracesQueryOptions } from "./session-detail-drawer/use-session-traces.ts"
 import { SessionOutlierBadge } from "./session-outlier-badge.tsx"
+import { SessionsOrphanFragmentsBlankSlate } from "./sessions-orphan-fragments-blank-slate.tsx"
 import { CacheHitRateSubheader } from "./table/cache-hit-rate-subheader.tsx"
 import { IndicatorsCell } from "./table/indicators-cell.tsx"
 import { TableMetricSubheader } from "./table/metric-subheader.tsx"
@@ -116,6 +122,7 @@ interface SessionsViewProps {
   readonly onCloseSession: () => void
   readonly visibleColumnIds: readonly SessionColumnId[]
   readonly isSearching: boolean
+  readonly hasUserAppliedFilters: boolean
   readonly selectable?: boolean
   readonly searchQuery?: string
 }
@@ -137,6 +144,7 @@ export function SessionsView({
   onCloseSession,
   visibleColumnIds,
   isSearching,
+  hasUserAppliedFilters,
   searchQuery,
   selectable = true,
 }: SessionsViewProps) {
@@ -201,7 +209,6 @@ export function SessionsView({
     })
   }, [])
 
-  const hasActiveFilters = Object.keys(filters).length > 0
   const isRelevanceSort = sorting.column === RELEVANCE_SORT_COLUMN
 
   const {
@@ -212,14 +219,38 @@ export function SessionsView({
   } = useSessionsInfiniteScroll({
     projectId,
     sorting,
-    ...(hasActiveFilters ? { filters } : {}),
+    filters,
     ...(searchQuery ? { searchQuery } : {}),
   })
 
   const { data: sessionMetrics, isLoading: sessionMetricsLoading } = useSessionMetrics({
     projectId,
-    ...(hasActiveFilters ? { filters } : {}),
+    filters,
   })
+
+  const shouldCheckOrphanFragmentSessions = !isLoading && sessions.length === 0 && isHasLlmActivityFilterOn(filters)
+  const { totalCount: sessionsWithoutLlmActivityCount, isLoading: isOrphanFragmentCountLoading } =
+    useSessionsCountWithoutLlmActivityFilter({
+      projectId,
+      filters,
+      ...(searchQuery ? { searchQuery } : {}),
+      enabled: shouldCheckOrphanFragmentSessions,
+    })
+  const hasOrphanFragmentSessions =
+    shouldCheckOrphanFragmentSessions && !isOrphanFragmentCountLoading && sessionsWithoutLlmActivityCount > 0
+
+  const showAllSessions = useCallback(() => {
+    onFiltersChange({ ...filters, hasLlmActivity: [{ op: "eq", value: false }] })
+  }, [filters, onFiltersChange])
+
+  const blankSlate = useMemo(() => {
+    if (hasOrphanFragmentSessions) {
+      return <SessionsOrphanFragmentsBlankSlate onShowAllSessions={showAllSessions} />
+    }
+    if (searchQuery) return "No sessions match the current search"
+    if (hasUserAppliedFilters) return "No sessions match the current filters"
+    return "No sessions found"
+  }, [hasOrphanFragmentSessions, hasUserAppliedFilters, searchQuery, showAllSessions])
 
   // Fetch annotation counts for every trace that could show in the visible
   // session rows (trace_ids on each session) so the Indicators column can
@@ -692,7 +723,7 @@ export function SessionsView({
           sorting={sorting}
           defaultSorting={searchQuery ? DEFAULT_SEARCH_SORTING : DEFAULT_SESSION_SORTING}
           onSortChange={onSortingChange}
-          blankSlate={hasActiveFilters || searchQuery ? "No sessions match the current search" : "No sessions found"}
+          blankSlate={blankSlate}
           expandedRowKeys={expandedIds}
           getExpandedRows={getExpandedRows}
           isRowExpandable={isSessionExpandable}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -117,6 +117,7 @@ interface SessionsViewProps {
   readonly onSelectionChange: (state: SelectionState<string>) => void
   readonly totalTraceCount: number
   readonly onFiltersChange: (filters: FilterSet) => void
+  readonly onShowAllSessions: () => void
   readonly onFiltersClose: () => void
   readonly onOpenSession: (sessionId: string, traceId?: string) => void
   readonly onCloseSession: () => void
@@ -139,6 +140,7 @@ export function SessionsView({
   onSelectionChange,
   totalTraceCount,
   onFiltersChange,
+  onShowAllSessions,
   onFiltersClose,
   onOpenSession,
   onCloseSession,
@@ -228,29 +230,25 @@ export function SessionsView({
     filters,
   })
 
-  const shouldCheckOrphanFragmentSessions = !isLoading && sessions.length === 0 && isHasLlmActivityFilterOn(filters)
+  const shouldCheckOrphanFragmentSessions =
+    !isLoading && sessions.length === 0 && isHasLlmActivityFilterOn(filters) && !searchQuery
   const { totalCount: sessionsWithoutLlmActivityCount, isLoading: isOrphanFragmentCountLoading } =
     useSessionsCountWithoutLlmActivityFilter({
       projectId,
       filters,
-      ...(searchQuery ? { searchQuery } : {}),
       enabled: shouldCheckOrphanFragmentSessions,
     })
   const hasOrphanFragmentSessions =
     shouldCheckOrphanFragmentSessions && !isOrphanFragmentCountLoading && sessionsWithoutLlmActivityCount > 0
 
-  const showAllSessions = useCallback(() => {
-    onFiltersChange({ ...filters, hasLlmActivity: [{ op: "eq", value: false }] })
-  }, [filters, onFiltersChange])
-
   const blankSlate = useMemo(() => {
-    if (hasOrphanFragmentSessions) {
-      return <SessionsOrphanFragmentsBlankSlate onShowAllSessions={showAllSessions} />
-    }
     if (searchQuery) return "No sessions match the current search"
+    if (hasOrphanFragmentSessions) {
+      return <SessionsOrphanFragmentsBlankSlate onShowAllSessions={onShowAllSessions} />
+    }
     if (hasUserAppliedFilters) return "No sessions match the current filters"
     return "No sessions found"
-  }, [hasOrphanFragmentSessions, hasUserAppliedFilters, searchQuery, showAllSessions])
+  }, [hasOrphanFragmentSessions, hasUserAppliedFilters, onShowAllSessions, searchQuery])
 
   // Fetch annotation counts for every trace that could show in the visible
   // session rows (trace_ids on each session) so the Indicators column can

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -343,6 +343,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
           onCloseSession={closeSessionPanel}
           visibleColumnIds={sessionColumnSettings.visibleColumnIds}
           isSearching={false}
+          hasUserAppliedFilters={hasActiveFilters}
           selectable={false}
         />
       )}

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -131,6 +131,10 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
     setRawFilters(serializeFilters(next) ?? "")
   }
 
+  const onShowAllSessions = useCallback(() => {
+    setRawFilters(serializeFilters({ ...filters, hasLlmActivity: [{ op: "eq", value: false as const }] }) ?? "")
+  }, [filters, setRawFilters])
+
   const closeTraceDrawer = useCallback(() => {
     setActiveTraceId("")
     setSelectedSpanId("")
@@ -338,6 +342,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
           onSelectionChange={setSelectionState}
           totalTraceCount={totalCount}
           onFiltersChange={onFiltersChange}
+          onShowAllSessions={onShowAllSessions}
           onFiltersClose={() => setFiltersOpen(false)}
           onOpenSession={onOpenSession}
           onCloseSession={closeSessionPanel}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When a project receives telemetry but every session is an "orphan fragment" (no tokens or model recorded), the default **Has LLM activity** filter hides them all. The sessions table looked empty with a generic message, which was misleading for new integrations.

## What changed

- **Keeps `hasLlmActivity` on by default** — reverts the earlier default-off approach.
- **Detects the orphan-fragment case** — when the filtered list is empty but sessions exist without the LLM-activity filter, the table shows a dedicated blankslate instead of a generic empty message.
- **Blankslate copy** explains that telemetry arrived but no LLM calls were recorded, and suggests reviewing instrumentation or contacting support.
- **Actions:** "Show all sessions" (opts out of the default filter), docs link, and **Contact support** opens the Finn/Intercom chat (`showIntercom()`, same as the header Help button).
- **Other empty states** now distinguish search/filter misses ("No sessions match the current filters/search") from a genuinely empty project.

## Implementation

- `useSessionsCountWithoutLlmActivityFilter` — secondary count query, enabled only when the main list is empty and the LLM filter is on.
- `SessionsOrphanFragmentsBlankSlate` — new component for the integration-hint UI.
- `isHasLlmActivityFilterOn` — shared helper for sidebar toggle + blankslate gating.

## Validation

- `pnpm --filter web typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d92000b8-53fc-4d4d-94b5-f0d99864bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d92000b8-53fc-4d4d-94b5-f0d99864bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

