### PR TITLE
Spec: observability platform migration tool (LAT-721)

### DIFF
--- a/specs/observability-migration.md
+++ b/specs/observability-migration.md
@@ -1,0 +1,604 @@
+# Observability platform migration tool
+
+> **Spec only — no implementation.** Investigation + design for importing historical telemetry from Langfuse, LangSmith, or Braintrust into Latitude.
+>
+> **Origin:** LAT-721. Customer feedback from the Braintrust workshop (Manu): evaluators need a credible path to bring **historical** traces/sessions into Latitude, not just forward OTLP ingestion (Latitude already resolves `langfuse.*`, `langsmith.*`, and `braintrust.*` attributes on live spans).
+>
+> **Related:** OTLP attribute resolvers in `packages/domain/spans/src/otlp/resolvers/`; outbound sync design in `dev-docs/data-destinations.md` (inverse problem); session model in `packages/domain/spans/src/entities/session.ts` and CH MV `sessions_mv`.
+
+## Contents
+
+1. [Problem](#problem)
+2. [Recommendation summary](#recommendation-summary)
+3. [Source platform capabilities](#source-platform-capabilities)
+4. [Latitude target model](#latitude-target-model)
+5. [Entity mapping tables](#entity-mapping-tables)
+6. [Product surface and UX](#product-surface-and-ux)
+7. [Technical approach options](#technical-approach-options)
+8. [Prioritization and phasing](#prioritization-and-phasing)
+9. [MVP non-goals](#mvp-non-goals)
+10. [Open questions](#open-questions)
+11. [Implementation tasks](#implementation-tasks)
+
+---
+
+## Problem
+
+Customers evaluating or leaving Langfuse, LangSmith, or Braintrust need to migrate **historical** observability data into Latitude. Forward ingestion already works: Latitude's OTLP pipeline resolves vendor session/user/tag/metadata attributes from live spans. What is missing is a **backfill path** for data already stored in another platform.
+
+Without a migration tool, customers face a cold start: no session history, no cost baselines, no annotation/eval context, and weaker evaluation of Latitude against incumbents. A migration tool is a sales and retention enabler, not just an ops convenience.
+
+Constraints:
+
+- Historical imports must respect org/project tenancy, retention, and billing.
+- Imports must be **idempotent** and **resumable** — migrations fail mid-run; customers re-run.
+- Some vendor fields have no Latitude equivalent; the spec must define **degraded import** behavior explicitly.
+- Latitude has **no prompt registry** entity; prompt migration is out of scope for parity unless we add one later.
+
+---
+
+## Recommendation summary
+
+| Decision | Recommendation |
+| --- | --- |
+| First source platform | **Langfuse** — OSS/self-host path, richest export surface (blob + API), existing OTLP resolver coverage, and direct competitive overlap |
+| MVP entity set | **Traces, spans, sessions, identity** (session id, user id/email, tags, metadata), **LLM usage/cost** where source provides it |
+| Primary architecture | **Hybrid:** API pull for small/on-demand imports; **vendor blob/Parquet export → transform → internal bulk write** for production-scale backfills |
+| Write path | **Internal span write path** (reuse `SpanRepository.insert` + domain validation), not OTLP HTTP roundtrip — avoids double-encoding and ingest rate limits |
+| Product surface | **CLI** (`latitude migrate import …`) for engineers + **staff backoffice job** for assisted migrations; self-serve UI wizard deferred to Phase 2 |
+| Session boundaries | **Import as-is** by default — preserve source `session_id`; optional re-segmentation by idle gap is post-MVP |
+| Dedupe key | `(organization_id, project_id, source_platform, source_trace_id, source_span_id)` mapped to stable Latitude `trace_id` / `span_id` |
+
+---
+
+## Source platform capabilities
+
+### Langfuse
+
+#### Exportable entities
+
+| Entity | Exportable? | Mechanism | Notes |
+| --- | --- | --- | --- |
+| Traces | Yes | Observations API v2 (group by `traceId`), legacy trace API, blob export (`traces/` legacy mode), UI batch export | v2 returns observation rows, not trace objects — reconstruct traces client-side |
+| Spans / observations | Yes | Observations API v2, blob export (`observations_v2/` enriched mode recommended), legacy `observations/` | Types: `GENERATION`, `SPAN`, `EVENT` |
+| Sessions | Yes (as field) | `sessionId` on observations / enriched export rows | No separate session table — session is a trace attribute |
+| Scores / evals | Yes | Scores API, blob export (`scores/`), UI batch export (CSV/JSON) | Numeric/categorical scores; linked to trace/observation |
+| Datasets | Yes | Datasets API (100–1000 req/min by plan) | Items + runs for experiments |
+| Prompts / versions | Yes | Prompts GET API (no rate limit on cloud), Postgres on self-host | Versioned prompts with labels; stored in PG, not CH |
+| Users | Partial | `userId`, `userId` on trace context in enriched exports | External user ids, not Langfuse auth users |
+| Tags | Yes | `tags` in `trace_context` field group / trace rows | String array |
+| Metadata | Yes | `metadata` field group; trace + observation level | JSON object |
+
+#### Export mechanisms
+
+| Mechanism | Scope | Format | Best for |
+| --- | --- | --- | --- |
+| **Observations API v2** | Row-level observations | JSON, cursor pagination | Programmatic pull, incremental sync |
+| **Blob storage integration** | Scheduled bulk export | JSON/JSONL/CSV (optional gzip) to S3/GCS/Azure | Large backfills, warehouse-style pipelines |
+| **Legacy read APIs** | Traces, observations, sessions | JSON, offset pagination | Deprecated; slow at scale |
+| **UI batch export** | Scores, ad-hoc traces | CSV/JSON | Small one-offs |
+| **Self-host DB access** | PG (config) + ClickHouse (telemetry) | SQL | Fastest for self-hosters with DB access; schema is Prisma-managed |
+
+Blob export modes ([Langfuse docs](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields)):
+
+- **Enriched observations (recommended):** `observations_v2/` + `scores/` — trace-level fields (`user_id`, `session_id`, `tags`, etc.) denormalized onto each observation row. No warehouse join required.
+- **Legacy:** separate `traces/`, `observations/`, `scores/` files — join on `trace_id`.
+
+Schedule: every 20 minutes, hourly, daily, or weekly per integration.
+
+#### Rate limits, pagination, retention
+
+| Resource | Cloud limit (typical) | Pagination | Retention |
+| --- | --- | --- | --- |
+| Observations API v2 | "All other APIs" bucket: 30–1000 req/min by plan | Cursor-based; default limit 50, max 1000 | Plan-defined; Hobby/Core/Pro tiers differ |
+| Legacy read APIs | 15–100 req/min | Offset (slow) | Same |
+| Metrics API v2 | 100–2000 req/day | N/A (aggregates) | Same |
+| Blob export | No per-request limit; bounded by export window size | Time-window files | Exports only cover data retained at export time |
+| Self-host | No hard API limits | Same APIs | Customer-controlled |
+
+v2 Observations API is **cloud-only** today; self-hosted deployments use legacy endpoints or direct DB/CH access until v2 lands.
+
+Data from older SDKs without `x-langfuse-ingestion-version: 4` can be delayed up to **10 minutes** on v2 endpoints.
+
+#### Lossiness and fidelity gaps
+
+- v2 API returns I/O as **strings by default** (`parseIoAsJson: true` optional) — migration must handle both.
+- `EVENT`-type observations may lack parent linkage or duration semantics Latitude expects.
+- Prompt references (`promptId`, `promptName`, `promptVersion`) are metadata only — Latitude has no prompt entity to link.
+- Media attachments (Langfuse media upload) are not in standard observation fields — may require separate media API or blob paths.
+- Cost fields may use string decimals in v2 for precision.
+
+#### Licensing / ToS
+
+Langfuse is **MIT-licensed** OSS. Bulk export of a customer's own project data via API or self-host DB is standard data portability. Re-hosting Langfuse's **service** or redistributing their **software** is a separate concern from importing a customer's telemetry into Latitude. Cloud ToS should be reviewed before offering a managed "we pull your Langfuse cloud data" service; self-host and customer-initiated export paths are lower risk.
+
+---
+
+### LangSmith
+
+#### Exportable entities
+
+| Entity | Exportable? | Mechanism | Notes |
+| --- | --- | --- | --- |
+| Traces | Yes (as run trees) | `list_runs` / `POST /runs/query`, bulk export | Root run + child runs form a trace |
+| Spans / runs | Yes | Same | `run_type`: chain, llm, tool, retriever, etc. |
+| Sessions | Partial | `session_id` on runs is the **LangSmith project id**, not a conversation session | Conversation grouping uses `extra.metadata` or thread ids — see mapping table |
+| Scores / feedback | Yes | Feedback API; `feedback_stats` in bulk export | Annotations and eval scores |
+| Datasets | Yes | Dataset API | Examples + splits |
+| Prompts | Yes | Hub / prompt API (separate from traces) | LangChain Hub prompts — not embedded in run export by default |
+| Users | Partial | `extra.metadata.user_id`, session metadata | Inconsistent across SDKs |
+| Tags | Yes | `tags` list on runs | |
+| Metadata | Yes | `extra` JSON blob | Includes `ls_*` keys from LangChain |
+
+#### Export mechanisms
+
+| Mechanism | Scope | Format | Tier |
+| --- | --- | --- | --- |
+| **`list_runs` / runs query API** | Per-project runs | JSON, cursor pagination | All tiers (rate-limited) |
+| **Bulk export to S3** | Project or all experiments, date range | Parquet (Run data format) | **Plus / Enterprise only** |
+| **Scheduled bulk export** | Recurring windows | Parquet to customer bucket | Plus / Enterprise; Helm ≥ 0.10.42 self-host |
+| **SDK export helpers** | Programmatic | JSON | All tiers |
+
+Bulk export path pattern:
+
+```
+<bucket>/<prefix>/export_id=<id>/tenant_id=<id>/session_id=<project_id>/runs/year=…/month=…/day=…
+```
+
+#### Rate limits, pagination, retention
+
+**Runs query API** ([LangSmith docs](https://docs.langchain.com/langsmith/export-traces)):
+
+| Query type | Limit |
+| --- | --- |
+| Short window (≤ 7 days), no search | 10 req / 10 sec |
+| Large window (> 7 days) | 3 req / 10 sec |
+| Full-text search | 1–3 req / 10 sec |
+| Select `child_run_ids` | Stricter tier |
+
+Always set `start_time`; use `select` to limit fields; prefer structured filters over `search()`.
+
+**Bulk export:**
+
+- 72-hour runtime timeout per job; automatic retries.
+- Cloud: 250 bulk export **creations** per hour per workspace; 200 active **scheduled** exports max.
+- `all_experiments` exports capped at 250 experiments on cloud.
+- Self-host: limits configurable / absent by default.
+
+**Retention:** `trace_tier` on runs indicates retention level; expired traces are not exportable.
+
+#### Lossiness and fidelity gaps
+
+- LangSmith `session_id` in run export = **project UUID**, not conversation id — session migration requires extracting conversation keys from `extra` or metadata.
+- `dotted_order` encodes hierarchy but parent links also via `parent_run_id`.
+- Bulk export `feedback_stats` omits non-string feedback value breakdowns — numeric/boolean feedback needs separate feedback export.
+- Experiments vs production traces use the same run format but different project/session scoping.
+
+#### Licensing / ToS
+
+LangSmith is a commercial LangChain product. Bulk export requires **Plus/Enterprise** for the S3 path; API read access is broader but rate-limited. A Latitude migration tool that asks customers to provide their own API keys and export to **their** bucket (or reads via API with consent) stays within normal data-portability expectations. Storing or re-selling LangSmith data is out of scope. Confirm current ToS before marketing "official LangSmith migration."
+
+---
+
+### Braintrust
+
+#### Exportable entities
+
+| Entity | Exportable? | Mechanism | Notes |
+| --- | --- | --- | --- |
+| Traces | Yes | BTQL `project_logs(…)` with `shape => 'traces'` | Trace = root span + children |
+| Spans | Yes | BTQL `project_logs(…)` default / `log_spans` export | Nested via `span_id` / `root_span_id` |
+| Sessions | Partial | Session-root span pattern in logs; metadata grouping | No first-class "session" entity — convention-based |
+| Scores / evals | Yes | Scores API; BTQL on logs/experiments | Human annotations, automated scorers |
+| Datasets | Yes | BTQL `project_dataset(project_id, dataset_id)` | input, expected, metadata |
+| Prompts | Yes | Prompts API (`/v1/prompt`) | Version-controlled prompt registry |
+| Users | Partial | `metadata.user_id` and related fields | |
+| Tags | Yes | `tags` array on logs | |
+| Metadata | Yes | `metadata` JSON | Also `braintrust.metadata` OTLP on live ingest |
+
+#### Export mechanisms
+
+| Mechanism | Scope | Format |
+| --- | --- | --- |
+| **BTQL API** (`POST /btql`) |任意 query | JSON or Parquet |
+| **UI export** | Filtered logs view | JSON or CSV |
+| **Cloud storage automation** | Scheduled `log_traces` or `log_spans` | JSON Lines or Parquet to S3/GCS |
+| **Custom BTQL automation** | User-defined query | Parquet default |
+
+Automations require `POST /brainstore/automation/reset-cursors` after creation to start exporting.
+
+#### Rate limits, pagination, retention
+
+- BTQL: practical limits depend on query scope and plan; large exports should use Parquet format and narrow time filters.
+- Export automations: interval as low as **1 second** (typically hourly+ for bulk).
+- Traces do **not** auto-close — "in progress" traces remain until explicitly ended; historical exports may include incomplete traces.
+- Data retention automations can delete old logs — export before retention runs.
+
+#### Lossiness and fidelity gaps
+
+- **Session idle timeout** in Braintrust UI (Topics automation, default 600s) controls when **Topics processing** runs, not when traces/sessions close. It does **not** split conversations into sessions — session boundaries come from customer instrumentation (session-root span pattern).
+- Multi-turn stitching depends on `parent` / `root_span_id` — migrations must preserve these.
+- `expected` field on logs (human corrections) maps to annotation-like data, not a first-class Latitude field on spans.
+- Prompt registry is separate from span payloads.
+
+#### Licensing / ToS
+
+Braintrust is commercial. BTQL export and cloud storage automations are standard product features. Customer-initiated export with their API key is the expected migration path. Review ToS for any managed migration service positioning.
+
+---
+
+## Latitude target model
+
+### Storage split
+
+| Layer | Stores | Migration writes |
+| --- | --- | --- |
+| **ClickHouse `spans`** | Canonical telemetry rows | **Primary import target** — insert spans; `traces` and `sessions` materialized views rebuild automatically |
+| **ClickHouse `traces` / `sessions`** | AggregatingMergeTree rollups | Do **not** write directly |
+| **Postgres control plane** | Projects, scores, datasets, evaluations, signals | Scores/datasets in Phase 2+; not MVP |
+| **Object storage** | Ingest staging (>50 KB OTLP batches), dataset CSV, exports | Optional staging for bulk import batches; span **content** lives inline in CH |
+
+### Identity and hierarchy
+
+| Latitude field | Source | Notes |
+| --- | --- | --- |
+| `trace_id` | Vendor trace id | **32 lowercase hex, no dashes** — normalize on import |
+| `span_id` | Vendor span/observation/run id | **16 lowercase hex** — may need deterministic hash if vendor ids are UUIDs |
+| `parent_span_id` | Vendor parent link | Empty or `0000000000000000` = root |
+| `session_id` | Resolved from vendor session keys | See resolvers below; empty → CH MV uses `trace_id` as session key (1-trace session) |
+| `user_id`, `user_email` | Vendor user fields | External ids, not PG users |
+| `tags` | Vendor tags | String array |
+| `metadata` | Vendor metadata maps | `Map(String, String)` — stringified values |
+
+**Existing OTLP resolvers** (for live ingest; migration mappers should produce the same normalized fields):
+
+```108:139:packages/domain/spans/src/otlp/resolvers/identity.ts
+export const sessionIdCandidates = [
+  fromString("session.id"),
+  fromString("gen_ai.session.id"),
+  fromString("langfuse.session.id"),
+  // ...
+  fromString("langsmith.trace.session_id"),
+  // ...
+]
+
+export const userIdCandidates = [
+  // ...
+  fromString("langsmith.metadata.user_id"),
+  fromString("langfuse.user.id"),
+]
+```
+
+```24:36:packages/domain/spans/src/otlp/resolvers/enrichment.ts
+export const tagsCandidates: Candidate<string[]>[] = [
+  fromJsonStringArray("latitude.tags"),
+  fromStringArray("langfuse.trace.tags"),
+  fromStringArray("braintrust.tags"),
+  fromStringArray("tag.tags"),
+  fromString<string[]>("langsmith.span.tags", (v) => /* comma-split */),
+]
+```
+
+### Messages, usage, cost
+
+| Latitude column | Source mapping |
+| --- | --- |
+| `input_messages`, `output_messages`, `system_instructions` | Parse vendor I/O into GenAI message JSON (same shape as OTLP transform) |
+| `tool_definitions`, `tool_*` | Tool calls from vendor tool/run-type fields |
+| `tokens_*`, `cost_*_microcents` | Vendor usage/cost; USD → microcents (1 USD = 100,000,000) |
+| `operation`, `provider`, `model` | Map vendor run types / model names |
+| `attr_*`, `resource_string` | Unmapped vendor fields preserved for fidelity |
+
+### Scores and annotations
+
+Postgres `scores` is canonical; ClickHouse `scores` is analytics projection.
+
+| Latitude | Source |
+| --- | --- |
+| `scores.source_type = 'annotation'` | Human labels / Braintrust `expected` corrections |
+| `scores.source_type = 'evaluation'` | Automated eval scores (Phase 2 — requires signal/eval linkage) |
+| `scores.source_type = 'custom'` | Vendor numeric scores without eval config |
+| Anchors: `trace_id`, `span_id`, `session_id` | From migrated span ids |
+
+Draft scores (`drafted_at` set) stay PG-only until published.
+
+### Prompts
+
+**No Latitude prompt registry exists.** Options:
+
+1. **MVP:** Store prompt name/version in span `metadata` (e.g. `import.prompt_name`, `import.prompt_version`).
+2. **Phase 3:** Introduce a prompt entity or map to Latitude prompt templates if product adds one.
+
+### What cannot be migrated faithfully
+
+| Gap | Degraded import behavior |
+| --- | --- |
+| LangSmith conversation sessions | Import with `session_id = trace_id` unless customer provides a metadata key mapping; document how to configure `extra.metadata.thread_id` or similar |
+| Langfuse media attachments | Skip or store URL in metadata; no binary pull in MVP |
+| Vendor eval configs (judges, scorers) | Import resulting scores only; do not recreate Evaluation + Signal graph |
+| Braintrust in-progress traces | Import with best-effort `end_time` = last event or `start_time`; mark metadata `import.incomplete = true` |
+| Prompt registry (all vendors) | Metadata-only reference on spans |
+| LangSmith Hub prompts | Out of scope MVP |
+| Real-time eval triggers / automations | Not migrated |
+| User accounts (vendor auth users) | Only external `user_id` on spans |
+
+---
+
+## Entity mapping tables
+
+### Langfuse → Latitude
+
+| Langfuse entity / field | Latitude target | Transform notes |
+| --- | --- | --- |
+| `traceId` | `spans.trace_id` | Strip dashes if UUID format |
+| `id` (observation) | `spans.span_id` | Hash to 16 hex if not OTEL-shaped |
+| `parentObservationId` | `spans.parent_span_id` | |
+| `type` GENERATION/SPAN/EVENT | `spans.operation`, `spans.kind` | GENERATION → LLM operation |
+| `sessionId` | `spans.session_id` | Direct |
+| `userId` | `spans.user_id` | |
+| `tags` | `spans.tags` | From trace_context |
+| `metadata` | `spans.metadata` | Stringify values |
+| `input`, `output` | `input_messages`, `output_messages` | Parse JSON; map to GenAI message arrays |
+| `usageDetails`, `costDetails` | `tokens_*`, `cost_*_microcents` | |
+| `providedModelName` | `spans.model` | |
+| `promptName`, `promptVersion` | `metadata.import.prompt_*` | No prompt entity |
+| Score rows | PG `scores` (Phase 2) | Link by migrated trace/span id |
+| Dataset items | PG `datasets` + CH `dataset_rows` (Phase 3) | |
+
+### LangSmith → Latitude
+
+| LangSmith entity / field | Latitude target | Transform notes |
+| --- | --- | --- |
+| `trace_id` | `spans.trace_id` | UUID → 32 hex |
+| `id` (run) | `spans.span_id` | UUID → 16 hex (deterministic truncate/hash) |
+| `parent_run_id` | `spans.parent_span_id` | |
+| `run_type` | `spans.operation` | llm→chat, tool→tool, chain→agent, etc. |
+| `session_id` | **Not conversation session** | Do **not** map to `spans.session_id`; use `extra.metadata.session_id` or thread id if present |
+| `tags` | `spans.tags` | |
+| `extra` | `spans.metadata` | Flatten `ls_*` keys; preserve full JSON in `attr_string` if needed |
+| `inputs`, `outputs` | message columns | LangChain message format → GenAI |
+| `total_tokens`, `total_cost` | usage/cost columns | |
+| `feedback_stats` / feedback API | PG `scores` (Phase 2) | |
+| `reference_example_id` | `metadata.import.dataset_example_id` | |
+| Dataset examples | PG+CH datasets (Phase 3) | |
+
+**LangSmith session id disambiguation:** LangSmith uses `session_id` for **project id** in bulk export. Conversation grouping keys vary by SDK (`metadata.thread_id`, custom metadata). Migration config should accept `--session-metadata-key extra.thread_id` (example) for LangSmith imports.
+
+### Braintrust → Latitude
+
+| Braintrust entity / field | Latitude target | Transform notes |
+| --- | --- | --- |
+| `root_span_id` / trace root | `spans.trace_id` | Derive trace id from root |
+| `span_id` | `spans.span_id` | |
+| `parent_span_id` | `spans.parent_span_id` | |
+| Session-root span | `spans.session_id` | Use root span id or explicit `metadata.session_id` if set |
+| `tags` | `spans.tags` | |
+| `metadata` | `spans.metadata` | |
+| `input`, `output` | message columns | |
+| `metrics` (tokens, duration) | usage/performance columns | |
+| `expected` | PG `scores` annotation (Phase 2) | Human correction |
+| `scores` | PG `scores` | |
+| Dataset rows | PG+CH datasets (Phase 3) | |
+| Prompts (`/v1/prompt`) | metadata only (MVP) | |
+
+---
+
+## Product surface and UX
+
+### Surfaces (by phase)
+
+| Surface | Phase | Audience | Rationale |
+| --- | --- | --- | --- |
+| **CLI** (`latitude migrate …`) | MVP | Customer engineers | Scriptable, CI-friendly, matches `latitude` CLI pattern; credentials stay local |
+| **Backoffice admin job** | MVP | Latitude staff | Assisted migrations for enterprise evals; mirrors other staff-only ops |
+| **Self-serve UI wizard** | Phase 2 | Customer admins | Connect source → preview → import; higher build cost |
+| **API endpoint** | Phase 2+ | Automation | `POST /v1/projects/{slug}/imports` for headless ops |
+
+### Core UX requirements (all surfaces)
+
+| Requirement | Behavior |
+| --- | --- |
+| **Org/project scoping** | Import targets one Latitude project slug; source credentials scoped to one vendor project |
+| **Dry-run** | `--dry-run` counts records, validates mapping, shows sample normalized span; no writes |
+| **Progress reporting** | Structured logs + periodic stats: fetched / transformed / written / skipped / failed |
+| **Idempotency** | Re-run with same source ids produces ReplacingMergeTree dedupe (same logical ids → same CH keys) or explicit skip |
+| **Resume on failure** | Persist cursor (last exported timestamp + last source id) in PG import job table |
+| **Time range filter** | `--from` / `--to` aligned to source semantics (LangSmith: `start_time` inclusive; bulk export: window bounds) |
+| **Rate limit handling** | Exponential backoff on 429; respect `Retry-After` |
+
+### Session boundary policy
+
+| Option | Behavior | Recommendation |
+| --- | --- | --- |
+| **Import as-is** | Preserve vendor `session_id` on every span | **Default** — respects customer instrumentation |
+| **Re-segment by idle gap** | Split spans into new session ids when gap > N minutes | Post-MVP optional flag (`--resegment-idle-minutes`); Braintrust Topics idle timeout is **not** a session splitter |
+| **One trace = one session** | Force empty session id (MV fallback) | Fallback when source has no session concept |
+
+Latitude UI "live vs idle" ([`sessions.collection.ts`](apps/web/src/domains/sessions/sessions.collection.ts)) is client-side (5-minute threshold on `max_end_time`) — imports do not need to compute it.
+
+---
+
+## Technical approach options
+
+### Option A: Pull via vendor APIs → normalize → ingest pipeline
+
+```
+Vendor API ──► Migrator worker ──► normalize to internal span batch ──► processIngestedSpansUseCase / SpanRepository.insert
+                     │                              │
+                     └── cursor in PG               └── skip OTLP HTTP; optional BullMQ for chunking
+```
+
+| Aspect | Assessment |
+| --- | --- |
+| **Throughput** | Langfuse v2: 50–1000 rows/req, 30–1000 req/min → ~30k–1M obs/hour cloud. LangSmith: 10 req/10s (7-day window) → ~100s of runs/min with small pages. Braintrust BTQL: varies; Parquet for large pulls. |
+| **Dedupe** | Stable id mapping from vendor ids; `ingested_at` = import timestamp; ReplacingMergeTree handles retries |
+| **Backfill vs cutover** | API pull suits incremental sync and smaller histories; large backfills hit rate limits (LangSmith especially) |
+| **Operational risk** | Low infra — no customer bucket setup; high **time** risk on large datasets; vendor API changes |
+| **Pros** | No S3 setup; works for cloud trials; good for MVP validation |
+| **Cons** | Rate limits; LangSmith bulk export tier gap; Langfuse v2 cloud-only |
+
+### Option B: Direct DB / blob import → transform → bulk load
+
+```
+S3/GCS export files ──► Migrator (stream Parquet/JSONL) ──► transform ──► CH batch insert (+ PG scores)
+        or
+Self-host PG/CH ──► SQL dump / direct read ──► transform ──► bulk insert
+```
+
+| Aspect | Assessment |
+| --- | --- |
+| **Throughput** | Limited by Latitude CH insert rate and worker CPU; blob paths avoid vendor API throttles — **10×–100× faster** for millions of spans |
+| **Dedupe** | Same stable id mapping; file boundaries are not idempotency boundaries — cursor per record |
+| **Backfill vs cutover** | Primary path for production migrations; API for delta after cutover |
+| **Operational risk** | Customer must configure export bucket or grant DB read; credential handling; schema drift on vendor upgrades |
+| **Pros** | Scales to full history; matches how vendors expect warehouse export |
+| **Cons** | Higher setup friction; self-host DB path is Langfuse-specific; Parquet schema versioning (LangSmith `format_version`) |
+
+### Comparison and recommendation
+
+| Criterion | Option A (API) | Option B (blob/DB) |
+| --- | --- | --- |
+| Setup friction | Low | Medium–high |
+| Max volume | Medium | High |
+| LangSmith cloud | Poor (rate limits; bulk export needs Plus) | Good (Parquet bulk export) |
+| Langfuse self-host | Medium (legacy API) | Excellent (CH + PG) |
+| Braintrust | Good (BTQL) | Excellent (automations) |
+| Idempotency | Same | Same |
+
+**Recommendation:** Implement **both**, with shared normalize + write core. Default CLI flow tries API for `--dry-run` and small `--limit`; `--source-uri s3://…` or `--langfuse-blob-prefix` activates blob path. LangSmith migrations should **document** Plus bulk export as the supported path for >100k runs.
+
+### Internal write path vs OTLP
+
+| Path | Use |
+| --- | --- |
+| **Internal** (`SpanRepository.insert` via migrator use-case) | Bulk import — no double encoding, no ingest rate limits, direct control of `retention_days` |
+| **OTLP HTTP** (`POST /v1/traces`) | Only for testing parity with live ingest; optional `--via-otlp` flag for QA |
+
+Post-import, publish `TracesIngested` domain events (or a dedicated `ImportBatchCompleted` event) so trace-search indexing, first-trace detection, and billing run — **billing policy for imported spans** is an open question (likely exclude from ingest metering or tag `metadata.import.source`).
+
+### Throughput estimates (order of magnitude)
+
+Assumptions: 500-byte avg span row, 10k spans/sec CH insert burst (conservative), single worker.
+
+| Volume | API-only (Langfuse cloud) | Blob/DB path |
+| --- | --- | --- |
+| 100k spans | ~2–6 hours | ~1–5 minutes |
+| 1M spans | ~1–3 days | ~10–30 minutes |
+| 10M spans | Impractical API-only | ~2–4 hours (parallel workers) |
+
+Parallelization: shard by time window or trace id prefix; **one import job per (org, project, source)** at a time (hard guard like data-destinations backfill).
+
+---
+
+## Prioritization and phasing
+
+### Platform order
+
+| Priority | Platform | Why |
+| --- | --- | --- |
+| **1** | Langfuse | OSS/self-host (DB + blob paths), competitive eval overlap, existing resolver coverage, enriched blob export is migration-friendly |
+| **2** | Braintrust | Workshop ask; BTQL + Parquet export; strong eval/dataset overlap; session-root patterns documented |
+| **3** | LangSmith | Large market but bulk export gated to Plus/Enterprise; `session_id` naming collision; heavy LangChain-specific `extra` parsing |
+
+### MVP vs full parity
+
+| Phase | Entities | Exit gate |
+| --- | --- | --- |
+| **Phase 0 — Spec** | This document | PR merged; tasks filed |
+| **Phase 1 — MVP** | Traces, spans, sessions (as id), user/tags/metadata, usage/cost, messages | Import 100k Langfuse observations in staging; idempotent re-run; traces/sessions visible in UI |
+| **Phase 2 — Scores + LangSmith** | Scores/annotations; LangSmith API + Parquet path; CLI polish | LangSmith project import with feedback; scores on traces |
+| **Phase 3 — Datasets + prompts metadata** | Dataset rows; prompt metadata; Braintrust automations path | Dataset slug import; eval set parity for fine-tuning workflows |
+| **Phase 4 — Self-serve UI + incremental sync** | Wizard; scheduled delta sync | Customer completes import without staff help |
+
+---
+
+## MVP non-goals
+
+- Self-serve UI wizard
+- LangSmith migration without Plus bulk export or accepting API rate-limit duration
+- Prompt registry creation in Latitude
+- Eval config / signal / evaluation recreation
+- Vendor user account migration
+- Binary media / attachment migration (Langfuse media)
+- Real-time dual-write or continuous sync (batch only in MVP)
+- Session re-segmentation by idle timeout
+- Import into sandbox organizations (mirror data-destinations sandbox exclusion)
+- Cross-org import (single org credentials per job)
+- Mutable source upsert (imports are append-only historical backfill)
+- Legal/compliance review automation (customer responsible for export authorization)
+
+---
+
+## Open questions
+
+1. **Billing:** Do imported spans count toward ingest quotas and billing meters, or are they tagged exempt?
+2. **Retention:** Set `retention_days` from org plan at import time, or preserve vendor retention metadata?
+3. **Search indexing:** Trigger full trace-search reindex for imported windows, or rely on existing `TracesIngested` consumers?
+4. **Span id mapping:** Deterministic UUID→hex truncation vs hash — document collision risk and pick one algorithm globally.
+5. **LangSmith session key:** Standardize default metadata keys per LangChain SDK version, or require explicit CLI config?
+6. **Staff-only vs customer CLI credentials:** Store encrypted vendor credentials in PG for UI wizard (Phase 2), or ephemeral env vars only for MVP?
+7. **CH direct insert vs queue:** Synchronous batch insert in migrator vs BullMQ `span-ingestion` topic for backpressure — likely dedicated `migration-import` queue.
+8. **Provenance:** Expose `metadata.import.source_platform`, `import.job_id`, `import.original_id` on every span for support/debug?
+9. **Partial trace handling:** Reject entire traces with unmapped parent ids, or import orphan spans with warning?
+10. **Langfuse v2 self-host timeline:** Block Langfuse cloud-parity self-host migrations until v2 ships, or invest in legacy API adapter?
+
+---
+
+## Implementation tasks
+
+### Phase 0 — Spec (this PR)
+
+- [x] `specs/observability-migration.md`
+- [x] Entity mapping tables per source platform
+- [x] MVP non-goals
+- [x] Architecture comparison and recommendation
+- [ ] Linear LAT-721 → link PR
+
+### Phase 1 — Langfuse MVP (estimated 3–5 PRs)
+
+- [ ] **P1-a** Domain: `ImportJob` entity + port (PG table: org, project, source, cursor, status, stats, error)
+- [ ] **P1-b** Normalizer: Langfuse observation row → Latitude `SpanInsertRow` (enriched export + v2 API shapes)
+- [ ] **P1-c** Id mapping: trace/span id normalization utilities + unit tests (UUID, OTEL hex)
+- [ ] **P1-d** Use-case: `importSpansBatch` — validate, insert CH, emit events; idempotent dedupe
+- [ ] **P1-e** Worker: `migration-import` queue + job runner with backoff and cursor persistence
+- [ ] **P1-f** CLI: `latitude migrate import langfuse --project <slug> --from --to --dry-run [--limit]`
+- [ ] **P1-g** Langfuse blob reader: S3/GCS JSONL/JSON.gz stream parser for `observations_v2/`
+- [ ] **P1-h** Backoffice: staff trigger + job status view (minimal)
+- [ ] **P1-i** Integration test: fixture Langfuse export → CH spans → UI trace/session smoke
+- [ ] **P1-j** Docs: Mintlify "Migrating from Langfuse" guide
+
+**Phase 1 exit gate:** 100k observation import in staging completes with <0.1% error rate; re-run duplicates skipped; sessions group correctly when `sessionId` present.
+
+### Phase 2 — Scores + LangSmith
+
+- [ ] **P2-a** Score normalizers (Langfuse scores, LangSmith feedback, Braintrust scores)
+- [ ] **P2-b** `saveScore` + CH analytics sync for imported scores
+- [ ] **P2-c** LangSmith run → span normalizer + `--session-metadata-key`
+- [ ] **P2-d** LangSmith Parquet bulk export reader
+- [ ] **P2-e** CLI: `latitude migrate import langsmith …`
+- [ ] **P2-f** Braintrust BTQL pull adapter
+
+**Phase 2 exit gate:** LangSmith project with feedback imports; scores visible on trace detail.
+
+### Phase 3 — Datasets + Braintrust parity
+
+- [ ] **P3-a** Dataset + dataset_rows import path
+- [ ] **P3-b** Braintrust blob automation / Parquet reader
+- [ ] **P3-c** Prompt metadata enrichment on spans
+- [ ] **P3-d** CLI: `latitude migrate import braintrust …`
+
+### Phase 4 — Productization
+
+- [ ] **P4-a** Self-serve import wizard in project settings
+- [ ] **P4-b** Incremental scheduled sync (optional continuous migration pre-cutover)
+- [ ] **P4-c** Import provenance UI (filter by `import.source_platform`)
+- [ ] **P4-d** `--resegment-idle-minutes` optional session splitter
+
+---
+
+## References
+
+- Langfuse: [Public API](https://langfuse.com/docs/api-and-data-platform/features/public-api), [Observations API v2](https://langfuse.com/docs/api-and-data-platform/features/observations-api), [Blob storage export](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage), [API limits](https://langfuse.com/faq/all/api-limits)
+- LangSmith: [Export traces](https://docs.langchain.com/langsmith/export-traces), [Bulk export](https://docs.langchain.com/langsmith/data-export)
+- Braintrust: [API reference](https://www.braintrust.dev/docs/api-reference), [Export annotated data](https://www.braintrust.dev/docs/annotate/export), [Cloud storage automations](https://www.braintrust.dev/docs/admin/automations/export-to-cloud-storage), [Topics idle timeout (automation only)](https://www.braintrust.dev/docs/kb/topics-automation-idle-timeout-and-trace-update-behavior)
+- Latitude: `packages/domain/spans/src/otlp/resolvers/`, `packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql`, `dev-docs/data-destinations.md`

--- a/specs/observability-migration.md
+++ b/specs/observability-migration.md
@@ -8,71 +8,51 @@
 
 ## Contents
 
-1. [Design decisions](#design-decisions)
-2. [Architecture](#architecture)
-3. [Limits and defaults](#limits-and-defaults)
-4. [UI flow](#ui-flow)
-5. [Implementation phases](#implementation-phases)
-6. [Source adapter interface](#source-adapter-interface)
-7. [MVP scope cuts](#mvp-scope-cuts)
-8. [Appendix: source mapping notes](#appendix-source-mapping-notes)
+1. [Purpose](#purpose)
+2. [Summary](#summary)
+3. [Architecture](#architecture)
+4. [Limits and defaults](#limits-and-defaults)
+5. [UI flow](#ui-flow)
+6. [Implementation phases](#implementation-phases)
+7. [Source adapter interface](#source-adapter-interface)
+8. [Non-goals](#non-goals)
+9. [Appendix: source mapping notes](#appendix-source-mapping-notes)
 
 ---
 
-## Design decisions
+## Purpose
 
-The first draft of this spec prioritized CLI/backoffice and deferred the UI. This revision reflects the product requirement: a **self-serve project settings wizard** with bounded, scalable imports from **all three** source platforms through **one engine**.
+Customers evaluating or leaving Langfuse, LangSmith, or Braintrust need to migrate **historical** observability data into Latitude. Forward ingestion already works: Latitude's OTLP pipeline resolves vendor session/user/tag/metadata attributes on live spans. This spec defines a self-serve **Observability imports** feature in project settings that backfills traces and spans from those platforms.
 
-### Misaligned with UI-first requirement
+Constraints:
 
-- It makes the MVP **CLI-first** (`latitude migrate import ...`) and **staff/backoffice assisted**, with the self-serve UI deferred to Phase 4.
-- It treats credentials as local CLI inputs or staff-operated secrets instead of defining a project-settings flow with encrypted credentials, dry-run preview, confirmation, progress, cancellation, and completion.
-- It does not reference the current project settings structure:
-  - settings nav lives in `apps/web/src/domains/projects/project-sections.ts`;
-  - settings pages use `SettingsPage` under `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/`;
-  - project settings server functions live under `apps/web/src/domains/*/*.functions.ts`.
+- Historical imports respect org/project tenancy, retention, and billing.
+- Imports are **idempotent** and **resumable**.
+- Some vendor fields have no Latitude equivalent; degraded import behavior is defined explicitly.
+- Latitude has **no prompt registry** entity; prompt references land in span metadata only.
 
-### Too many ingestion paths
+---
 
-- It recommends a hybrid of API pull, vendor blob export, self-host DB access, CLI, and backoffice. That is too much for a self-serve MVP.
-- It implies three source-specific migration tracks. The simpler shape is **one import engine** with source adapters for Langfuse, LangSmith, and Braintrust.
-- It discusses OTLP HTTP as an optional write path. Historical imports should not round-trip through public OTLP HTTP; they should normalize to Latitude span rows and write through the same ClickHouse repository boundary used after ingestion transforms.
+## Summary
 
-### Limits are not concrete enough
-
-- It warns that large backfills are dangerous, but does not define user-visible defaults or hard caps.
-- It does not define:
-  - default lookback window;
-  - hard self-serve lookback cap;
-  - max spans per import;
-  - max active imports per org;
-  - worker concurrency;
-  - source API rate limits;
-  - dry-run preview cap;
-  - cancellation and credential retention behavior.
-- It risks a user selecting "all history" against years of data and tying up workers or source APIs for days.
-
-### Scale and tenancy are under-specified
-
-- It says imports must be idempotent/resumable, but does not define the queue granularity. A single BullMQ job must not run for hours. The engine should process one bounded page/window per job, persist cursor/stats, then re-enqueue the next page.
-- It does not define an org-level concurrency guard. Multi-tenant imports need a hard **one active import per organization** default.
-- It does not specify how progress is stored for the UI. Users need stable PG-backed state, not worker logs.
-- It does not distinguish imported historical telemetry from live ingest for billing and live-evaluation fan-out.
-
-### Scope is too broad for a minimal MVP
-
-- Scores, datasets, prompt registries, media attachments, source DB access, Parquet/blob paths, and continuous sync are valuable later but distract from the user requirement: self-serve historical span import.
-- The previous phase order ships Langfuse first and LangSmith/Braintrust later. The user requirement is to support **all three source platforms** behind one UX and one engine.
+| Decision | Choice |
+| --- | --- |
+| Product surface | Self-serve wizard in project settings (`/projects/$slug/settings/imports`) |
+| Source platforms | Langfuse, LangSmith, Braintrust — one engine, three adapters |
+| MVP entities | Traces, spans, session identity, user identity, tags, metadata, messages, usage, cost |
+| Write path | Internal `SpanRepository.insert` — not OTLP HTTP |
+| Queue model | BullMQ page chain: one bounded source page per job, cursor in Postgres |
+| Session boundaries | Import as-is — preserve source `session_id` |
+| Id mapping | Deterministic `trace_id` / `span_id` from source ids; re-runs dedupe via ReplacingMergeTree |
+| Billing | Imported spans are not billable by default; no live evaluation fan-out |
 
 ---
 
 ## Architecture
 
-### Recommendation
-
 Build one self-serve **Observability imports** feature in project settings.
 
-The MVP imports **traces/spans/sessions identity, user identity, tags, metadata, messages, usage, and cost** from Langfuse, LangSmith, and Braintrust. It does not import scores, datasets, prompts, media, or continuous sync.
+The MVP imports **traces/spans/sessions identity, user identity, tags, metadata, messages, usage, and cost** from Langfuse, LangSmith, and Braintrust. Scores, datasets, prompts, media, and continuous sync are out of scope (see [Non-goals](#non-goals)).
 
 The implementation is one queue-driven import engine:
 
@@ -116,16 +96,15 @@ flowchart TD
   DONE --> W
 ```
 
-### Why this is the simplest architecture
+### Existing patterns to reuse
 
-It reuses existing Latitude rails instead of adding a migration subsystem:
-
-- **Project settings UI:** follow the data-destinations settings shape under `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/`.
-- **Server functions:** follow `apps/web/src/domains/destinations/destinations.functions.ts` for org-scoped `createServerFn`, Zod validation, RLS-backed Postgres access, and queue publication.
-- **Queue registry:** add one topic to `packages/domain/queue/src/topic-registry.ts`, then subscribe in `apps/workers/src/workers/observability-imports.ts`.
-- **Worker shape:** mirror `apps/workers/src/workers/span-ingestion.ts` for Effect layers, tracing, ClickHouse/Postgres clients, and bounded concurrency.
-- **Bounded historical processing:** mirror the data-destinations backfill idea from `dev-docs/data-destinations.md`: one low-priority lane, one page/window at a time, cursor advances only after the page writes.
-- **ClickHouse writes:** reuse `SpanRepository.insert` and the existing `spans` table. Do not write `traces` or `sessions`; materialized views rebuild from spans.
+- **Project settings UI:** data-destinations settings shape under `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/`.
+- **Server functions:** `apps/web/src/domains/destinations/destinations.functions.ts` — org-scoped `createServerFn`, Zod validation, RLS-backed Postgres, queue publication.
+- **Settings nav:** `apps/web/src/domains/projects/project-sections.ts`; page shell via `SettingsPage` in `settings/-components/`.
+- **Queue registry:** one topic in `packages/domain/queue/src/topic-registry.ts`, worker in `apps/workers/src/workers/observability-imports.ts`.
+- **Worker shape:** mirror `apps/workers/src/workers/span-ingestion.ts` for Effect layers, tracing, and bounded concurrency.
+- **Bounded backfill:** mirror data-destinations backfill from `dev-docs/data-destinations.md` — one page at a time, cursor advances only after the page writes.
+- **ClickHouse writes:** `SpanRepository.insert` on the `spans` table; do not write `traces` or `sessions` directly.
 
 ### Data model
 
@@ -217,7 +196,7 @@ Worker:
   8. Re-enqueues `fetchPage` when the adapter reports more data and caps are not reached.
   9. Marks terminal state when done/capped/cancelled/failed.
 
-No Temporal workflow is needed. A self-advancing BullMQ page chain is enough and matches data-destinations backfill.
+No Temporal workflow — a self-advancing BullMQ page chain matches the data-destinations backfill model.
 
 ### Imported span policy
 
@@ -289,8 +268,6 @@ If a user asks for more than the hard cap:
 ---
 
 ## UI flow
-
-Surface: project settings, not CLI and not backoffice.
 
 Add a settings item in `apps/web/src/domains/projects/project-sections.ts`:
 
@@ -400,18 +377,13 @@ Each phase is PR-sized. The MVP is complete after Phase 4: UI wizard, queue engi
 
 > **Status legend:** `[ ] pending`, `[~] in progress`, `[x] complete`
 
-### Phase 0 - Spec refinement
+### Phase 0 — Spec (LAT-721)
 
-- [x] Replace the old CLI/backoffice-first plan with a UI-first, bounded, queue-based import plan.
-- [x] Define concrete limits/defaults.
-- [x] Define one adapter interface for Langfuse, LangSmith, and Braintrust.
-- [x] Define PR-sized implementation phases.
+- [x] `specs/observability-migration.md`
 
-**Exit gate:**
+**Exit gate:** Spec merged; implementation follows phases below.
 
-- This spec is merged and becomes the implementation reference for LAT-721.
-
-### Phase 1 - Domain model, schemas, and settings route shell
+### Phase 1 — Domain model, schemas, and settings route shell
 
 - [ ] Create `packages/domain/observability-imports/`.
   - Entities:
@@ -701,55 +673,35 @@ Adapter constraints:
 
 ---
 
-## MVP scope cuts
+## Non-goals
 
-Cut these from the MVP:
+MVP excludes:
 
-1. **CLI-first implementation**
-   - No `latitude migrate import ...` in MVP.
-   - CLI can be a post-MVP wrapper around the same server-side APIs if needed.
+1. **CLI import command** — no `latitude migrate import …`; a CLI wrapper over the same APIs may follow post-MVP.
 
-2. **Staff-only backoffice migration**
-   - No backoffice trigger/status UI in MVP.
-   - Operators can inspect PG rows, worker logs, and metrics.
+2. **Backoffice migration UI** — operators use PG rows, worker logs, and metrics.
 
-3. **Separate pipelines per source**
-   - Do not build Langfuse/LangSmith/Braintrust-specific engines.
-   - Build one engine and three adapters.
+3. **Separate pipelines per source** — one engine, three adapters.
 
-4. **Vendor blob/Parquet/self-host DB import**
-   - Defer to post-MVP enterprise scale.
-   - The self-serve MVP uses source APIs with hard caps.
+4. **Vendor blob/Parquet/self-host DB import** — post-MVP enterprise scale; self-serve MVP uses source APIs with hard caps.
 
-5. **Scores, annotations, datasets, prompt registries**
-   - Import spans/traces/sessions identity first.
-   - Vendor scores and datasets require separate domain decisions and should not block historical observability import.
+5. **Scores, annotations, datasets, prompt registries** — span import first; vendor scores and datasets need separate domain work.
 
-6. **Binary media/attachments**
-   - Store source URLs/metadata only if already present in span metadata.
-   - Do not pull media files in MVP.
+6. **Binary media/attachments** — store source URLs in metadata only if already present; no binary pull.
 
-7. **Continuous sync / dual-write**
-   - This feature is a historical backfill job, not an ongoing integration.
-   - Live data should keep flowing through OTLP instrumentation.
+7. **Continuous sync / dual-write** — historical backfill only; live data flows through OTLP.
 
-8. **Temporal workflow**
-   - BullMQ page-chain is sufficient and simpler.
-   - No durable multi-step workflow versioning burden.
+8. **Temporal workflow** — BullMQ page chain is sufficient.
 
-9. **Unbounded "all history"**
-   - UI may say "as far back as selected limits allow", never "all history".
-   - The backend enforces 365 days and 1M spans hard caps.
+9. **Unbounded history** — UI never offers "all history"; backend enforces 365-day and 1M-span caps.
 
-10. **Publishing normal live-ingest fan-out for every imported trace**
-    - Avoid billing and live evaluation/flagger scans for historical imports.
-    - Add import-specific downstream refresh only if product requires it.
+10. **Live-ingest fan-out for imported traces** — no billing or evaluation/flagger scans on historical imports unless a dedicated refresh task is added later.
 
 ---
 
 ## Appendix: source mapping notes
 
-The prior spec's source research remains useful as adapter implementation guidance. Keep these details in adapter tests and docs, but do not let them expand the MVP surface.
+Adapter implementation reference for Langfuse, LangSmith, and Braintrust normalizers.
 
 ### Latitude target model
 

--- a/specs/observability-migration.md
+++ b/specs/observability-migration.md
@@ -8,21 +8,20 @@
 
 ## Contents
 
-1. [A. Critique of current spec](#a-critique-of-current-spec)
-2. [B. Revised architecture (keep it simple)](#b-revised-architecture-keep-it-simple)
-3. [C. Limits and defaults (concrete numbers)](#c-limits-and-defaults-concrete-numbers)
-4. [D. UI flow (step-by-step for users)](#d-ui-flow-step-by-step-for-users)
-5. [E. Implementation phases (step-by-step for engineers)](#e-implementation-phases-step-by-step-for-engineers)
-6. [F. Source adapter interface](#f-source-adapter-interface)
-7. [G. What to remove/simplify from current spec](#g-what-to-removesimplify-from-current-spec)
-8. [H. Full markdown patch](#h-full-markdown-patch)
-9. [Appendix: source mapping notes](#appendix-source-mapping-notes)
+1. [Design decisions](#design-decisions)
+2. [Architecture](#architecture)
+3. [Limits and defaults](#limits-and-defaults)
+4. [UI flow](#ui-flow)
+5. [Implementation phases](#implementation-phases)
+6. [Source adapter interface](#source-adapter-interface)
+7. [MVP scope cuts](#mvp-scope-cuts)
+8. [Appendix: source mapping notes](#appendix-source-mapping-notes)
 
 ---
 
-## A. Critique of current spec
+## Design decisions
 
-The previous spec has useful source-platform research and mapping notes, but it does not yet describe the product Latitude should build first.
+The first draft of this spec prioritized CLI/backoffice and deferred the UI. This revision reflects the product requirement: a **self-serve project settings wizard** with bounded, scalable imports from **all three** source platforms through **one engine**.
 
 ### Misaligned with UI-first requirement
 
@@ -67,7 +66,7 @@ The previous spec has useful source-platform research and mapping notes, but it 
 
 ---
 
-## B. Revised architecture (keep it simple)
+## Architecture
 
 ### Recommendation
 
@@ -248,7 +247,7 @@ Billing/live automation:
 
 ---
 
-## C. Limits and defaults (concrete numbers)
+## Limits and defaults
 
 All limits are enforced server-side in domain use-cases and snapshotted onto the import job at confirmation. UI controls may expose narrower values, but the backend owns the cap.
 
@@ -289,7 +288,7 @@ If a user asks for more than the hard cap:
 
 ---
 
-## D. UI flow (step-by-step for users)
+## UI flow
 
 Surface: project settings, not CLI and not backoffice.
 
@@ -395,7 +394,7 @@ Route files:
 
 ---
 
-## E. Implementation phases (step-by-step for engineers)
+## Implementation phases
 
 Each phase is PR-sized. The MVP is complete after Phase 4: UI wizard, queue engine, and all three source adapters.
 
@@ -425,7 +424,7 @@ Each phase is PR-sized. The MVP is complete after Phase 4: UI wizard, queue engi
     - `ObservabilityImportJobRepository`
     - `ObservabilityImportRunRepository`
     - `ObservabilityImportSourceAdapters`
-  - Constants from [Limits and defaults](#c-limits-and-defaults-concrete-numbers).
+  - Constants from [Limits and defaults](#limits-and-defaults).
 - [ ] Add Postgres schema files:
   - `packages/platform/db-postgres/src/schema/observability-import-jobs.ts`
   - `packages/platform/db-postgres/src/schema/observability-import-runs.ts`
@@ -582,7 +581,7 @@ Each phase is PR-sized. The MVP is complete after Phase 4: UI wizard, queue engi
 
 ---
 
-## F. Source adapter interface
+## Source adapter interface
 
 The engine owns scheduling, cursor persistence, limits, retries, idempotency, stats, and ClickHouse writes. Adapters own source-specific API calls and normalization.
 
@@ -702,7 +701,7 @@ Adapter constraints:
 
 ---
 
-## G. What to remove/simplify from current spec
+## MVP scope cuts
 
 Cut these from the MVP:
 
@@ -745,21 +744,6 @@ Cut these from the MVP:
 10. **Publishing normal live-ingest fan-out for every imported trace**
     - Avoid billing and live evaluation/flagger scans for historical imports.
     - Add import-specific downstream refresh only if product requires it.
-
----
-
-## H. Full markdown patch
-
-This file is the full replacement patch for `specs/observability-migration.md`.
-
-The important implementation decisions are:
-
-- ship a **self-serve project settings wizard** first;
-- support **Langfuse, LangSmith, and Braintrust** through one adapter interface;
-- enforce concrete, server-side limits before any import starts;
-- process imports through a **BullMQ page chain** with bounded platform concurrency;
-- write normalized spans through `SpanRepository.insert`;
-- defer CLI, backoffice, blob/Parquet, scores, datasets, prompt registry, and continuous sync.
 
 ---
 

--- a/specs/observability-migration.md
+++ b/specs/observability-migration.md
@@ -1,604 +1,861 @@
 # Observability platform migration tool
 
-> **Spec only — no implementation.** Investigation + design for importing historical telemetry from Langfuse, LangSmith, or Braintrust into Latitude.
+> **Spec only - no production implementation.** Concrete implementation plan for a self-serve project settings wizard that imports historical traces/spans from Langfuse, LangSmith, or Braintrust into Latitude.
 >
-> **Origin:** LAT-721. Customer feedback from the Braintrust workshop (Manu): evaluators need a credible path to bring **historical** traces/sessions into Latitude, not just forward OTLP ingestion (Latitude already resolves `langfuse.*`, `langsmith.*`, and `braintrust.*` attributes on live spans).
+> **Origin:** LAT-721. Customer feedback from the Braintrust workshop: evaluators need a credible way to bring historical observability data into Latitude, not only forward OTLP ingestion.
 >
-> **Related:** OTLP attribute resolvers in `packages/domain/spans/src/otlp/resolvers/`; outbound sync design in `dev-docs/data-destinations.md` (inverse problem); session model in `packages/domain/spans/src/entities/session.ts` and CH MV `sessions_mv`.
+> **Related:** `dev-docs/data-destinations.md`, `packages/domain/spans/src/use-cases/process-ingested-spans.ts`, `packages/domain/spans/src/ports/span-repository.ts`, `apps/workers/src/workers/span-ingestion.ts`, `packages/domain/queue/src/topic-registry.ts`, `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/`.
 
 ## Contents
 
-1. [Problem](#problem)
-2. [Recommendation summary](#recommendation-summary)
-3. [Source platform capabilities](#source-platform-capabilities)
-4. [Latitude target model](#latitude-target-model)
-5. [Entity mapping tables](#entity-mapping-tables)
-6. [Product surface and UX](#product-surface-and-ux)
-7. [Technical approach options](#technical-approach-options)
-8. [Prioritization and phasing](#prioritization-and-phasing)
-9. [MVP non-goals](#mvp-non-goals)
-10. [Open questions](#open-questions)
-11. [Implementation tasks](#implementation-tasks)
+1. [A. Critique of current spec](#a-critique-of-current-spec)
+2. [B. Revised architecture (keep it simple)](#b-revised-architecture-keep-it-simple)
+3. [C. Limits and defaults (concrete numbers)](#c-limits-and-defaults-concrete-numbers)
+4. [D. UI flow (step-by-step for users)](#d-ui-flow-step-by-step-for-users)
+5. [E. Implementation phases (step-by-step for engineers)](#e-implementation-phases-step-by-step-for-engineers)
+6. [F. Source adapter interface](#f-source-adapter-interface)
+7. [G. What to remove/simplify from current spec](#g-what-to-removesimplify-from-current-spec)
+8. [H. Full markdown patch](#h-full-markdown-patch)
+9. [Appendix: source mapping notes](#appendix-source-mapping-notes)
 
 ---
 
-## Problem
+## A. Critique of current spec
 
-Customers evaluating or leaving Langfuse, LangSmith, or Braintrust need to migrate **historical** observability data into Latitude. Forward ingestion already works: Latitude's OTLP pipeline resolves vendor session/user/tag/metadata attributes from live spans. What is missing is a **backfill path** for data already stored in another platform.
+The previous spec has useful source-platform research and mapping notes, but it does not yet describe the product Latitude should build first.
 
-Without a migration tool, customers face a cold start: no session history, no cost baselines, no annotation/eval context, and weaker evaluation of Latitude against incumbents. A migration tool is a sales and retention enabler, not just an ops convenience.
+### Misaligned with UI-first requirement
 
-Constraints:
+- It makes the MVP **CLI-first** (`latitude migrate import ...`) and **staff/backoffice assisted**, with the self-serve UI deferred to Phase 4.
+- It treats credentials as local CLI inputs or staff-operated secrets instead of defining a project-settings flow with encrypted credentials, dry-run preview, confirmation, progress, cancellation, and completion.
+- It does not reference the current project settings structure:
+  - settings nav lives in `apps/web/src/domains/projects/project-sections.ts`;
+  - settings pages use `SettingsPage` under `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/`;
+  - project settings server functions live under `apps/web/src/domains/*/*.functions.ts`.
 
-- Historical imports must respect org/project tenancy, retention, and billing.
-- Imports must be **idempotent** and **resumable** — migrations fail mid-run; customers re-run.
-- Some vendor fields have no Latitude equivalent; the spec must define **degraded import** behavior explicitly.
-- Latitude has **no prompt registry** entity; prompt migration is out of scope for parity unless we add one later.
+### Too many ingestion paths
+
+- It recommends a hybrid of API pull, vendor blob export, self-host DB access, CLI, and backoffice. That is too much for a self-serve MVP.
+- It implies three source-specific migration tracks. The simpler shape is **one import engine** with source adapters for Langfuse, LangSmith, and Braintrust.
+- It discusses OTLP HTTP as an optional write path. Historical imports should not round-trip through public OTLP HTTP; they should normalize to Latitude span rows and write through the same ClickHouse repository boundary used after ingestion transforms.
+
+### Limits are not concrete enough
+
+- It warns that large backfills are dangerous, but does not define user-visible defaults or hard caps.
+- It does not define:
+  - default lookback window;
+  - hard self-serve lookback cap;
+  - max spans per import;
+  - max active imports per org;
+  - worker concurrency;
+  - source API rate limits;
+  - dry-run preview cap;
+  - cancellation and credential retention behavior.
+- It risks a user selecting "all history" against years of data and tying up workers or source APIs for days.
+
+### Scale and tenancy are under-specified
+
+- It says imports must be idempotent/resumable, but does not define the queue granularity. A single BullMQ job must not run for hours. The engine should process one bounded page/window per job, persist cursor/stats, then re-enqueue the next page.
+- It does not define an org-level concurrency guard. Multi-tenant imports need a hard **one active import per organization** default.
+- It does not specify how progress is stored for the UI. Users need stable PG-backed state, not worker logs.
+- It does not distinguish imported historical telemetry from live ingest for billing and live-evaluation fan-out.
+
+### Scope is too broad for a minimal MVP
+
+- Scores, datasets, prompt registries, media attachments, source DB access, Parquet/blob paths, and continuous sync are valuable later but distract from the user requirement: self-serve historical span import.
+- The previous phase order ships Langfuse first and LangSmith/Braintrust later. The user requirement is to support **all three source platforms** behind one UX and one engine.
 
 ---
 
-## Recommendation summary
+## B. Revised architecture (keep it simple)
 
-| Decision | Recommendation |
+### Recommendation
+
+Build one self-serve **Observability imports** feature in project settings.
+
+The MVP imports **traces/spans/sessions identity, user identity, tags, metadata, messages, usage, and cost** from Langfuse, LangSmith, and Braintrust. It does not import scores, datasets, prompts, media, or continuous sync.
+
+The implementation is one queue-driven import engine:
+
+- UI creates a project-scoped import job after dry-run preview.
+- The job stores encrypted source credentials, non-secret config, cursor, stats, limits, status, and sanitized errors in Postgres.
+- A BullMQ topic processes one source page/window at a time.
+- Source adapters fetch vendor rows and normalize them to Latitude `SpanDetail` rows.
+- The engine writes normalized spans through `SpanRepository.insert` (`packages/domain/spans/src/ports/span-repository.ts`), not through OTLP HTTP.
+- The engine persists progress after every page and re-enqueues itself until the range/cap is exhausted, cancelled, or failed.
+- Imported spans are tagged with provenance metadata and are **not billable by default**.
+
+### Architecture diagram
+
+```mermaid
+flowchart TD
+  U[User in project settings] --> W[Observability import wizard]
+  W --> SF[apps/web server functions]
+  SF --> UC[domain observability-imports use-cases]
+  UC --> PG[(Postgres import_jobs + import_runs)]
+  UC --> Q[BullMQ topic: observability-imports]
+
+  Q --> WK[apps/workers observability-imports worker]
+  WK --> CL[claim next page and org slot]
+  CL --> REG[Source adapter registry]
+  REG --> LF[Langfuse adapter]
+  REG --> LS[LangSmith adapter]
+  REG --> BT[Braintrust adapter]
+
+  LF --> SRC[(Source API)]
+  LS --> SRC
+  BT --> SRC
+
+  SRC --> PAGE[Bounded source page]
+  PAGE --> NORM[Normalize vendor rows to SpanDetail]
+  NORM --> CH[(ClickHouse spans via SpanRepository.insert)]
+  NORM --> RUN[Persist page stats/errors]
+  RUN --> PG
+  RUN --> NEXT{More pages and under caps?}
+  NEXT -- yes --> Q
+  NEXT -- no --> DONE[Job succeeded / capped / cancelled / failed]
+  DONE --> W
+```
+
+### Why this is the simplest architecture
+
+It reuses existing Latitude rails instead of adding a migration subsystem:
+
+- **Project settings UI:** follow the data-destinations settings shape under `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/`.
+- **Server functions:** follow `apps/web/src/domains/destinations/destinations.functions.ts` for org-scoped `createServerFn`, Zod validation, RLS-backed Postgres access, and queue publication.
+- **Queue registry:** add one topic to `packages/domain/queue/src/topic-registry.ts`, then subscribe in `apps/workers/src/workers/observability-imports.ts`.
+- **Worker shape:** mirror `apps/workers/src/workers/span-ingestion.ts` for Effect layers, tracing, ClickHouse/Postgres clients, and bounded concurrency.
+- **Bounded historical processing:** mirror the data-destinations backfill idea from `dev-docs/data-destinations.md`: one low-priority lane, one page/window at a time, cursor advances only after the page writes.
+- **ClickHouse writes:** reuse `SpanRepository.insert` and the existing `spans` table. Do not write `traces` or `sessions`; materialized views rebuild from spans.
+
+### Data model
+
+Create a small `@domain/observability-imports` package and Postgres tables in `@platform/db-postgres`.
+
+#### `observability_import_jobs`
+
+One row per user-confirmed import.
+
+| Column | Purpose |
 | --- | --- |
-| First source platform | **Langfuse** — OSS/self-host path, richest export surface (blob + API), existing OTLP resolver coverage, and direct competitive overlap |
-| MVP entity set | **Traces, spans, sessions, identity** (session id, user id/email, tags, metadata), **LLM usage/cost** where source provides it |
-| Primary architecture | **Hybrid:** API pull for small/on-demand imports; **vendor blob/Parquet export → transform → internal bulk write** for production-scale backfills |
-| Write path | **Internal span write path** (reuse `SpanRepository.insert` + domain validation), not OTLP HTTP roundtrip — avoids double-encoding and ingest rate limits |
-| Product surface | **CLI** (`latitude migrate import …`) for engineers + **staff backoffice job** for assisted migrations; self-serve UI wizard deferred to Phase 2 |
-| Session boundaries | **Import as-is** by default — preserve source `session_id`; optional re-segmentation by idle gap is post-MVP |
-| Dedupe key | `(organization_id, project_id, source_platform, source_trace_id, source_span_id)` mapped to stable Latitude `trace_id` / `span_id` |
+| `id` | CUID primary key |
+| `organization_id` | RLS and org concurrency |
+| `project_id` | Target Latitude project |
+| `source` | `langfuse | langsmith | braintrust` |
+| `source_project_id` | Vendor project/workspace identifier selected by user |
+| `source_project_name` | Snapshot for UI |
+| `status` | `queued | running | succeeded | capped | cancelled | failed` |
+| `config` | Non-secret config: time range, max spans, session metadata key, include content |
+| `credentials` | Encrypted source credentials while runnable; nullable after terminal scrub; never returned to the client |
+| `cursor` | Adapter cursor JSON, updated after each successful page |
+| `stats` | Counts: fetched, imported, skipped, failed, estimated total |
+| `limits` | Effective caps snapshotted at confirmation |
+| `last_error` | Sanitized error string/category |
+| `cancel_requested_at` | UI cancellation marker checked between pages |
+| `started_at`, `finished_at` | UI progress and audit |
+| timestamps | `created_at`, `updated_at` |
+
+Indexes:
+
+- `(organization_id, status)` for active-org guard.
+- `(organization_id, project_id, created_at desc)` for settings UI.
+- Partial unique index for one queued/running import per org: `organization_id where status in ('queued', 'running')`.
+
+No foreign keys, matching repository conventions. A `ProjectDeleted` domain-event consumer should cancel/delete project imports in a later hardening PR.
+
+#### `observability_import_runs`
+
+One audit row per processed page/window. Retain 30 days.
+
+| Column | Purpose |
+| --- | --- |
+| `id` | CUID primary key |
+| `organization_id` | RLS |
+| `job_id` | Import job id |
+| `status` | `succeeded | failed | skipped` |
+| `cursor_start`, `cursor_end` | JSON cursor snapshots |
+| `window_start`, `window_end` | Source time window for this page |
+| `records_fetched` | Source records read |
+| `spans_imported` | Normalized spans inserted |
+| `spans_skipped` | Dropped by mapping/validation/idempotency |
+| `error` | Sanitized error |
+| `started_at`, `finished_at` | Page timing |
+
+This mirrors `destination_sync_runs` enough to power "latest page, counts, errors" UI without adding a complex run-history product.
+
+### Queue topic
+
+Add one topic in `packages/domain/queue/src/topic-registry.ts`:
+
+```ts
+"observability-imports": payloads<{
+  start: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly importJobId: string
+  }
+  fetchPage: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly importJobId: string
+  }
+  pruneRuns: Record<string, never>
+}>()
+```
+
+Worker:
+
+- `apps/workers/src/workers/observability-imports.ts`
+- Subscribe with platform concurrency `8`.
+- Every `fetchPage` job:
+  1. Reloads the import job from Postgres.
+  2. Skips if cancelled, terminal, project/org mismatch, or over cap.
+  3. Acquires/validates the org-level active slot.
+  4. Calls adapter `fetchPage` with the persisted cursor, time range, and page limit.
+  5. Normalizes rows to `SpanDetail`.
+  6. Inserts spans through `SpanRepository.insert`.
+  7. Writes one `observability_import_runs` row and advances job stats/cursor.
+  8. Re-enqueues `fetchPage` when the adapter reports more data and caps are not reached.
+  9. Marks terminal state when done/capped/cancelled/failed.
+
+No Temporal workflow is needed. A self-advancing BullMQ page chain is enough and matches data-destinations backfill.
+
+### Imported span policy
+
+Normalized spans must include provenance:
+
+```ts
+metadata: {
+  "import.job_id": importJobId,
+  "import.source": source,
+  "import.source_project_id": sourceProjectId,
+  "import.source_trace_id": sourceTraceId,
+  "import.source_span_id": sourceSpanId,
+}
+```
+
+Id mapping:
+
+- `trace_id`: deterministic 32-character lowercase hex from source trace/root id.
+- `span_id`: deterministic 16-character lowercase hex from source span/run/observation id.
+- `parent_span_id`: deterministic mapping of source parent id, empty for root.
+- Same source ids always map to the same Latitude ids, so re-runs are idempotent through ClickHouse `ReplacingMergeTree(ingested_at)` behavior.
+
+Billing/live automation:
+
+- Historical imports should not pass billing context into any ingest event.
+- MVP should not fan out live evaluation/flagger scans for every imported trace. If search indexing needs a refresh, add a capped import-specific refresh task later rather than publishing `TracesIngested` blindly for millions of historical traces.
 
 ---
 
-## Source platform capabilities
+## C. Limits and defaults (concrete numbers)
+
+All limits are enforced server-side in domain use-cases and snapshotted onto the import job at confirmation. UI controls may expose narrower values, but the backend owns the cap.
+
+| Limit | Default | Hard cap | Scope | Rationale |
+| --- | ---: | ---: | --- | --- |
+| Default lookback | 90 days | 365 days | Per import | Recent history is what evaluators need first; avoids accidental multi-year imports. |
+| Minimum lookback | 1 day | N/A | Per import | Keeps previews and source filters sane. |
+| Max spans per import | 250,000 | 1,000,000 | Per import job | Matches data-destinations' 1M backfill ceiling as an operational guard. |
+| Max queued/running imports | 1 | 1 | Per org | Fairness and predictable source/API pressure. |
+| Max concurrent import pages | 8 | 8 | Platform workers | Low-priority lane that cannot starve ingestion or other workers. |
+| Worker job unit | 1 page/window | 1 page/window | BullMQ task | Each job should finish quickly and re-enqueue; no hour-long jobs. |
+| Source page size | 1,000 source records | 5,000 | API adapters | Good default for source APIs; adapters may lower it by platform. |
+| ClickHouse insert chunk | 5,000 spans | 10,000 | Per worker page | Keeps memory/parts bounded while preserving insert efficiency. |
+| Dry-run source scan | 5 pages or 5,000 records | 10 pages or 10,000 records | Per preview | Gives a useful estimate/sample without starting a migration. |
+| Dry-run timeout | 30 seconds | 60 seconds | Per preview request | UI request must remain interactive. |
+| Import page timeout | 120 seconds | 120 seconds | Per BullMQ job | Failed page retries without holding a worker forever. |
+| BullMQ attempts | 5 | 5 | Per page job | Existing retry convention; terminal failure is visible in PG. |
+| Retry backoff | Exponential, 10s start, 10m max | Same | Per page job | Handles transient 429/5xx without hot looping. |
+| Langfuse rate limit | 60 req/min | Configurable lower of plan/request headers | Per org+source | Safe under common cloud buckets; respect `Retry-After`. |
+| LangSmith rate limit | 12 req/min | Configurable lower of response headers | Per org+source | Safe for large-window limits (3 req / 10 sec). |
+| Braintrust rate limit | 60 req/min | Configurable lower of response headers | Per org+source | Conservative default; BTQL performance varies by query. |
+| Source project listing | 100 projects/page | 500 total in UI | Preview/list call | Keeps wizard fast; search can be added later. |
+| Run audit retention | 30 days | 30 days | `observability_import_runs` | Matches destination sync-run retention. |
+| Credential retention | Until terminal + 7 days | 7 days after terminal | Import job | Allows retry/debug window while limiting secret exposure. |
+| Cancel latency | Current page finishes first | 120 seconds target | Per job | Cancellation is cooperative between pages. |
+
+Default UI selection:
+
+- Time range: "Last 90 days".
+- Max spans: `250,000`.
+- Content import: enabled by default; a checkbox can exclude message/tool payloads for compliance, mapping content fields to empty values while preserving metadata, timing, tokens, cost, ids, and status.
+- For LangSmith, show an optional "Conversation/session metadata key" field. Default candidates are `thread_id`, `session_id`, `conversation_id`, and `user_id`, searched under `extra.metadata`.
+
+If a user asks for more than the hard cap:
+
+- The UI must state that the import will stop at the newest 1,000,000 spans in the selected range.
+- The terminal status should be `capped`, not `succeeded`, when the cap stops the job before the source range is exhausted.
+
+---
+
+## D. UI flow (step-by-step for users)
+
+Surface: project settings, not CLI and not backoffice.
+
+Add a settings item in `apps/web/src/domains/projects/project-sections.ts`:
+
+- Group: `Project` or `Organization` (recommended: `Project`, because the target is one Latitude project).
+- Label: `Imports`.
+- Path: `/projects/$projectSlug/settings/imports`.
+
+Route files:
+
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/imports.tsx`
+- supporting components in `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/imports/`
+- server functions in `apps/web/src/domains/observability-imports/imports.functions.ts`
+- optional collection/query helpers in `apps/web/src/domains/observability-imports/imports.collection.ts`
+
+### Wizard steps
+
+1. **Start**
+   - User opens Project settings -> Imports.
+   - Page explains that imports are historical, bounded, and asynchronous.
+   - Shows existing/past imports with status, source, time range, counts, and latest error.
+   - Primary action: `Import traces`.
+
+2. **Choose source**
+   - User selects one source:
+     - Langfuse
+     - LangSmith
+     - Braintrust
+   - The wizard shows source-specific credential fields but keeps the rest of the flow identical.
+
+3. **Connect credentials**
+   - User enters source credentials:
+     - Langfuse: host/base URL, public key, secret key.
+     - LangSmith: API key, workspace/tenant if required by API.
+     - Braintrust: API key, org/project selectors as supported by API.
+   - Button: `Test connection`.
+   - Server function calls adapter `testConnection`.
+   - Credentials are not persisted until confirmation, except in memory for the wizard request.
+   - Error messages are sanitized; never echo upstream response bodies or secrets.
+
+4. **Pick source project**
+   - After connection succeeds, server function calls adapter `listSourceProjects`.
+   - User selects the source project/workspace/dataset that maps to the current Latitude project.
+   - The selected source project name/id are snapshotted into the import job.
+
+5. **Configure time range and limits**
+   - Defaults:
+     - Time range: last 90 days.
+     - Max spans: 250,000.
+     - Include content: on.
+   - User may reduce the range/count.
+   - User may increase up to hard caps:
+     - 365 days.
+     - 1,000,000 spans.
+   - For LangSmith, optional field: `Session metadata key`.
+   - UI copy must state that imports are newest-first within the selected range when a cap is applied.
+
+6. **Dry-run preview**
+   - Button: `Preview import`.
+   - Server function calls adapter `preview`.
+   - Preview returns:
+     - estimated source records/spans if available;
+     - whether the selected range is likely capped;
+     - sample normalized span fields;
+     - detected session/user/tag fields;
+     - warnings, for example "LangSmith session_id is project id; using metadata.thread_id for sessions".
+   - No spans are written.
+   - No queue job is started.
+
+7. **Confirm**
+   - User reviews:
+     - source;
+     - source project;
+     - target Latitude project;
+     - time range;
+     - max spans;
+     - content inclusion;
+     - warnings.
+   - User clicks `Start import`.
+   - Server creates `observability_import_jobs` with encrypted credentials and publishes `observability-imports:start`.
+   - If org already has an active import, return a clear conflict error and link to the running job.
+
+8. **Progress**
+   - The import detail view polls every 3 seconds while `queued` or `running`.
+   - Show:
+     - status;
+     - spans imported / max spans;
+     - source records fetched;
+     - skipped/failed rows;
+     - latest page timing;
+     - latest sanitized error;
+     - time range and source project.
+   - Actions:
+     - `Cancel import` while queued/running.
+     - `Retry failed import` after failure, reusing non-secret config and asking for credentials again if expired.
+
+9. **Completion/errors**
+   - `succeeded`: show imported counts and link to sessions/traces.
+   - `capped`: show imported counts and explain that the hard cap stopped the import before all source data was read.
+   - `failed`: show sanitized reason and retry action.
+   - `cancelled`: show partial imported count and note that already imported spans remain.
+
+---
+
+## E. Implementation phases (step-by-step for engineers)
+
+Each phase is PR-sized. The MVP is complete after Phase 4: UI wizard, queue engine, and all three source adapters.
+
+> **Status legend:** `[ ] pending`, `[~] in progress`, `[x] complete`
+
+### Phase 0 - Spec refinement
+
+- [x] Replace the old CLI/backoffice-first plan with a UI-first, bounded, queue-based import plan.
+- [x] Define concrete limits/defaults.
+- [x] Define one adapter interface for Langfuse, LangSmith, and Braintrust.
+- [x] Define PR-sized implementation phases.
+
+**Exit gate:**
+
+- This spec is merged and becomes the implementation reference for LAT-721.
+
+### Phase 1 - Domain model, schemas, and settings route shell
+
+- [ ] Create `packages/domain/observability-imports/`.
+  - Entities:
+    - `ObservabilityImportJob`
+    - `ObservabilityImportRun`
+    - `ObservabilityImportSource`
+    - `ObservabilityImportStatus`
+  - Zod schemas for job config, limits, credentials input, preview input, and source-specific credential shapes.
+  - Ports:
+    - `ObservabilityImportJobRepository`
+    - `ObservabilityImportRunRepository`
+    - `ObservabilityImportSourceAdapters`
+  - Constants from [Limits and defaults](#c-limits-and-defaults-concrete-numbers).
+- [ ] Add Postgres schema files:
+  - `packages/platform/db-postgres/src/schema/observability-import-jobs.ts`
+  - `packages/platform/db-postgres/src/schema/observability-import-runs.ts`
+- [ ] Add repository implementations:
+  - `packages/platform/db-postgres/src/repositories/observability-import-job-repository.ts`
+  - `packages/platform/db-postgres/src/repositories/observability-import-run-repository.ts`
+  - Encrypt/decrypt credentials at repository boundary, matching data-destinations/slack credential patterns.
+- [ ] Add Drizzle migration for the new tables/indexes/RLS policies.
+- [ ] Add settings nav item in `apps/web/src/domains/projects/project-sections.ts`.
+- [ ] Add route shell:
+  - `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/imports.tsx`
+  - `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/imports/imports-page.tsx`
+  - use `SettingsPage`.
+- [ ] Add server function skeleton:
+  - `apps/web/src/domains/observability-imports/imports.functions.ts`
+  - `listObservabilityImports`
+  - `getObservabilityImport`
+  - no queue execution yet.
+
+**Exit gate:**
+
+- Empty Imports settings page renders for a project.
+- Import jobs/runs can be listed from Postgres under org RLS.
+- Unit tests cover entity validation and repository credential redaction.
+
+### Phase 2 - Preview wizard and fake adapter
+
+- [ ] Add route-local wizard components:
+  - source selection;
+  - credentials form;
+  - source project picker;
+  - limits/time-range form;
+  - preview/confirm step.
+- [ ] Add `previewObservabilityImport` server function.
+- [ ] Add `testObservabilityImportConnection` server function.
+- [ ] Add `listObservabilityImportSourceProjects` server function.
+- [ ] Add an in-memory/fake adapter in domain testing for deterministic preview tests.
+- [ ] Implement frontend validation using TanStack Form plus `createFormSubmitHandler` and `fieldErrorsAsStrings`.
+- [ ] Add UI states for warnings and capped previews.
+
+**Exit gate:**
+
+- Users can complete the wizard through dry-run preview using a fake/test adapter.
+- No spans are written and no queue jobs are created.
+- Preview enforces lookback, max-span, page, and timeout limits.
+
+### Phase 3 - Queue topic and import engine
+
+- [ ] Add `observability-imports` topic in `packages/domain/queue/src/topic-registry.ts`.
+- [ ] Add use-cases in `packages/domain/observability-imports/src/use-cases/`:
+  - `create-observability-import-job.ts`
+  - `start-observability-import.ts`
+  - `process-observability-import-page.ts`
+  - `cancel-observability-import.ts`
+  - `retry-observability-import.ts`
+  - `prune-observability-import-runs.ts`
+- [ ] Implement server functions:
+  - `createObservabilityImport`
+  - `cancelObservabilityImport`
+  - `retryObservabilityImport`
+- [ ] Add worker:
+  - `apps/workers/src/workers/observability-imports.ts`
+  - wire it in `apps/workers/src/server.ts`
+  - subscribe with concurrency `8`.
+- [ ] Implement page-chain behavior:
+  - `start` marks job running and publishes `fetchPage`;
+  - `fetchPage` processes one page and re-enqueues itself;
+  - terminal states update job and scrub credentials after retention policy.
+- [ ] Write normalized spans via `SpanRepository.insert`.
+- [ ] Persist one `observability_import_runs` row per page.
+- [ ] Enforce one active import per org through a DB constraint plus use-case checks.
+- [ ] Add cancellation semantics checked between pages.
+
+**Exit gate:**
+
+- With the fake adapter, a confirmed import writes spans to ClickHouse.
+- Progress updates in the UI while the worker runs.
+- Re-running the same fixture is idempotent at the span id level.
+- Cancel stops after the current page.
+- Max spans cap produces `capped` terminal status.
+
+### Phase 4 - Real source adapters for all three platforms
+
+- [ ] Create `packages/platform/observability-import-sources/`.
+- [ ] Implement adapter registry:
+  - `langfuse`
+  - `langsmith`
+  - `braintrust`
+- [ ] Langfuse adapter:
+  - Test connection with configured host and API keys.
+  - List projects if API supports it; otherwise validate supplied project id.
+  - Fetch observations/traces using API pagination.
+  - Normalize `traceId`, `id`, `parentObservationId`, `sessionId`, `userId`, tags, metadata, I/O, usage, cost.
+- [ ] LangSmith adapter:
+  - Test API key.
+  - List projects/sessions.
+  - Fetch runs with `start_time`/`end_time`, selected fields, and cursor pagination.
+  - Normalize run tree fields and support configurable session metadata key.
+- [ ] Braintrust adapter:
+  - Test API key.
+  - List projects.
+  - Fetch logs/spans through BTQL with bounded time filters and pagination.
+  - Normalize `root_span_id`, `span_id`, `parent_span_id`, metadata, tags, metrics, input/output.
+- [ ] Map source HTTP/API errors to shared categories:
+  - `auth`
+  - `rate_limited`
+  - `server_error`
+  - `transport`
+  - `config`
+  - `mapping`
+- [ ] Respect `Retry-After` and adapter-specific rate limits.
+- [ ] Add fixture-based tests per adapter.
+
+**Exit gate:**
+
+- A user can run the full UI import flow for Langfuse, LangSmith, and Braintrust in staging.
+- Each adapter imports at least 10k fixture/source spans.
+- Failed credentials never create a job.
+- 429s retry without marking credentials broken.
+
+### Phase 5 - Product hardening and docs
+
+- [ ] Add import detail run-history table (last 25 page runs) if needed beyond summary.
+- [ ] Add `observability-imports:pruneRuns` repeatable schedule in `apps/workers/src/server.ts`.
+- [ ] Add ProjectDeleted cleanup consumer.
+- [ ] Add docs page under `docs/`:
+  - "Import historical traces from Langfuse"
+  - "Import historical traces from LangSmith"
+  - "Import historical traces from Braintrust"
+- [ ] Add product analytics event for import started/succeeded/failed/capped.
+- [ ] Add Datadog metrics/logs for:
+  - active imports;
+  - spans imported;
+  - page failures by source/category;
+  - capped imports;
+  - rate-limit waits.
+- [ ] Add admin observability only through existing logs/metrics; no backoffice UI in MVP.
+
+**Exit gate:**
+
+- Docs explain limits and source-specific caveats.
+- Worker metrics are observable.
+- Import runs are pruned.
+- Deleted projects do not leave runnable import jobs.
+
+### Post-MVP phases
+
+- [ ] Blob/Parquet imports for enterprise-scale migrations.
+- [ ] Scores/annotations import.
+- [ ] Dataset import.
+- [ ] Prompt metadata enrichment beyond span metadata.
+- [ ] Trace-search import-specific refresh if imported traces need indexing outside ClickHouse views.
+- [ ] Enterprise override for more than 1M spans, gated by plan/staff policy.
+
+---
+
+## F. Source adapter interface
+
+The engine owns scheduling, cursor persistence, limits, retries, idempotency, stats, and ClickHouse writes. Adapters own source-specific API calls and normalization.
+
+```ts
+export type ObservabilityImportSource = "langfuse" | "langsmith" | "braintrust"
+
+export type ImportErrorCategory =
+  | "auth"
+  | "rate_limited"
+  | "server_error"
+  | "transport"
+  | "config"
+  | "mapping"
+
+export interface ImportSourceError {
+  readonly category: ImportErrorCategory
+  readonly message: string
+  readonly retryable: boolean
+  readonly retryAfterMs?: number
+  readonly upstreamStatus?: number
+}
+
+export interface SourceProject {
+  readonly id: string
+  readonly name: string
+  readonly metadata?: Record<string, string>
+}
+
+export interface ImportPreview {
+  readonly estimatedRecords: number | null
+  readonly estimatedSpans: number | null
+  readonly sample: readonly NormalizedSpanPreview[]
+  readonly warnings: readonly string[]
+  readonly likelyCapped: boolean
+}
+
+export interface FetchPageInput<TCredentials, TConfig, TCursor> {
+  readonly credentials: TCredentials
+  readonly sourceProjectId: string
+  readonly config: TConfig
+  readonly cursor: TCursor | null
+  readonly range: {
+    readonly from: Date
+    readonly to: Date
+  }
+  readonly limit: number
+}
+
+export interface SourcePage<TRow, TCursor> {
+  readonly rows: readonly TRow[]
+  readonly nextCursor: TCursor | null
+  readonly hasMore: boolean
+  readonly sourceWindowStart: Date | null
+  readonly sourceWindowEnd: Date | null
+}
+
+export interface NormalizeContext {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly importJobId: string
+  readonly sourceProjectId: string
+  readonly ingestedAt: Date
+  readonly retentionDays: number
+  readonly includeContent: boolean
+}
+
+export type NormalizeResult =
+  | { readonly status: "ok"; readonly span: SpanDetail }
+  | { readonly status: "skip"; readonly reason: string }
+
+export interface ObservabilityImportSourceAdapter<
+  TCredentials,
+  TConfig,
+  TCursor,
+  TRow,
+> {
+  readonly source: ObservabilityImportSource
+
+  testConnection(input: {
+    readonly credentials: TCredentials
+  }): Effect.Effect<void, ImportSourceError>
+
+  listProjects(input: {
+    readonly credentials: TCredentials
+    readonly cursor?: string
+    readonly limit: number
+  }): Effect.Effect<{
+    readonly projects: readonly SourceProject[]
+    readonly nextCursor: string | null
+  }, ImportSourceError>
+
+  preview(input: {
+    readonly credentials: TCredentials
+    readonly sourceProjectId: string
+    readonly config: TConfig
+    readonly range: { readonly from: Date; readonly to: Date }
+    readonly maxRecords: number
+  }): Effect.Effect<ImportPreview, ImportSourceError>
+
+  fetchPage(input: FetchPageInput<TCredentials, TConfig, TCursor>): Effect.Effect<
+    SourcePage<TRow, TCursor>,
+    ImportSourceError
+  >
+
+  normalize(row: TRow, context: NormalizeContext, config: TConfig): NormalizeResult
+}
+```
+
+Adapter constraints:
+
+- `normalize` should be deterministic and side-effect free.
+- `fetchPage` must obey the provided time range and limit.
+- `fetchPage` must return a cursor that can be stored as JSON and reused after retries.
+- Adapters must never return secrets in errors, previews, project metadata, or run rows.
+- Adapters must map 429/throttle responses to `rate_limited` with `retryAfterMs` when available.
+- Adapters must emit source ids needed for deterministic `trace_id` and `span_id` mapping.
+
+---
+
+## G. What to remove/simplify from current spec
+
+Cut these from the MVP:
+
+1. **CLI-first implementation**
+   - No `latitude migrate import ...` in MVP.
+   - CLI can be a post-MVP wrapper around the same server-side APIs if needed.
+
+2. **Staff-only backoffice migration**
+   - No backoffice trigger/status UI in MVP.
+   - Operators can inspect PG rows, worker logs, and metrics.
+
+3. **Separate pipelines per source**
+   - Do not build Langfuse/LangSmith/Braintrust-specific engines.
+   - Build one engine and three adapters.
+
+4. **Vendor blob/Parquet/self-host DB import**
+   - Defer to post-MVP enterprise scale.
+   - The self-serve MVP uses source APIs with hard caps.
+
+5. **Scores, annotations, datasets, prompt registries**
+   - Import spans/traces/sessions identity first.
+   - Vendor scores and datasets require separate domain decisions and should not block historical observability import.
+
+6. **Binary media/attachments**
+   - Store source URLs/metadata only if already present in span metadata.
+   - Do not pull media files in MVP.
+
+7. **Continuous sync / dual-write**
+   - This feature is a historical backfill job, not an ongoing integration.
+   - Live data should keep flowing through OTLP instrumentation.
+
+8. **Temporal workflow**
+   - BullMQ page-chain is sufficient and simpler.
+   - No durable multi-step workflow versioning burden.
+
+9. **Unbounded "all history"**
+   - UI may say "as far back as selected limits allow", never "all history".
+   - The backend enforces 365 days and 1M spans hard caps.
+
+10. **Publishing normal live-ingest fan-out for every imported trace**
+    - Avoid billing and live evaluation/flagger scans for historical imports.
+    - Add import-specific downstream refresh only if product requires it.
+
+---
+
+## H. Full markdown patch
+
+This file is the full replacement patch for `specs/observability-migration.md`.
+
+The important implementation decisions are:
+
+- ship a **self-serve project settings wizard** first;
+- support **Langfuse, LangSmith, and Braintrust** through one adapter interface;
+- enforce concrete, server-side limits before any import starts;
+- process imports through a **BullMQ page chain** with bounded platform concurrency;
+- write normalized spans through `SpanRepository.insert`;
+- defer CLI, backoffice, blob/Parquet, scores, datasets, prompt registry, and continuous sync.
+
+---
+
+## Appendix: source mapping notes
+
+The prior spec's source research remains useful as adapter implementation guidance. Keep these details in adapter tests and docs, but do not let them expand the MVP surface.
+
+### Latitude target model
+
+| Layer | Stores | Import behavior |
+| --- | --- | --- |
+| ClickHouse `spans` | Canonical telemetry rows | Primary target; write normalized `SpanDetail` rows through `SpanRepository.insert`. |
+| ClickHouse `traces` / `sessions` | Materialized/rollup views | Do not write directly. |
+| Postgres control plane | Import jobs/runs, projects | Store import state and encrypted credentials. |
+| Object storage | Ingest staging/export files | Not needed for API-based MVP. |
+
+### Common normalized fields
+
+| Latitude field | Source |
+| --- | --- |
+| `trace_id` | Deterministic 32-hex mapping from vendor trace/root id. |
+| `span_id` | Deterministic 16-hex mapping from vendor observation/run/span id. |
+| `parent_span_id` | Deterministic mapping from vendor parent id; empty for root. |
+| `session_id` | Vendor session id or configured metadata key; empty means trace-id fallback in session views. |
+| `user_id`, `user_email` | Vendor user fields/metadata. |
+| `tags` | Vendor tags. |
+| `metadata` | Stringified vendor metadata plus `import.*` provenance. |
+| `input_messages`, `output_messages`, `system_instructions` | Best-effort GenAI message mapping from source input/output. |
+| `tokens_*`, `cost_*_microcents` | Vendor usage/cost when present. |
+| `operation`, `provider`, `model` | Vendor run/observation type and model metadata. |
 
 ### Langfuse
 
-#### Exportable entities
-
-| Entity | Exportable? | Mechanism | Notes |
-| --- | --- | --- | --- |
-| Traces | Yes | Observations API v2 (group by `traceId`), legacy trace API, blob export (`traces/` legacy mode), UI batch export | v2 returns observation rows, not trace objects — reconstruct traces client-side |
-| Spans / observations | Yes | Observations API v2, blob export (`observations_v2/` enriched mode recommended), legacy `observations/` | Types: `GENERATION`, `SPAN`, `EVENT` |
-| Sessions | Yes (as field) | `sessionId` on observations / enriched export rows | No separate session table — session is a trace attribute |
-| Scores / evals | Yes | Scores API, blob export (`scores/`), UI batch export (CSV/JSON) | Numeric/categorical scores; linked to trace/observation |
-| Datasets | Yes | Datasets API (100–1000 req/min by plan) | Items + runs for experiments |
-| Prompts / versions | Yes | Prompts GET API (no rate limit on cloud), Postgres on self-host | Versioned prompts with labels; stored in PG, not CH |
-| Users | Partial | `userId`, `userId` on trace context in enriched exports | External user ids, not Langfuse auth users |
-| Tags | Yes | `tags` in `trace_context` field group / trace rows | String array |
-| Metadata | Yes | `metadata` field group; trace + observation level | JSON object |
-
-#### Export mechanisms
-
-| Mechanism | Scope | Format | Best for |
-| --- | --- | --- | --- |
-| **Observations API v2** | Row-level observations | JSON, cursor pagination | Programmatic pull, incremental sync |
-| **Blob storage integration** | Scheduled bulk export | JSON/JSONL/CSV (optional gzip) to S3/GCS/Azure | Large backfills, warehouse-style pipelines |
-| **Legacy read APIs** | Traces, observations, sessions | JSON, offset pagination | Deprecated; slow at scale |
-| **UI batch export** | Scores, ad-hoc traces | CSV/JSON | Small one-offs |
-| **Self-host DB access** | PG (config) + ClickHouse (telemetry) | SQL | Fastest for self-hosters with DB access; schema is Prisma-managed |
-
-Blob export modes ([Langfuse docs](https://langfuse.com/docs/api-and-data-platform/features/blob-storage-export-fields)):
-
-- **Enriched observations (recommended):** `observations_v2/` + `scores/` — trace-level fields (`user_id`, `session_id`, `tags`, etc.) denormalized onto each observation row. No warehouse join required.
-- **Legacy:** separate `traces/`, `observations/`, `scores/` files — join on `trace_id`.
-
-Schedule: every 20 minutes, hourly, daily, or weekly per integration.
-
-#### Rate limits, pagination, retention
-
-| Resource | Cloud limit (typical) | Pagination | Retention |
-| --- | --- | --- | --- |
-| Observations API v2 | "All other APIs" bucket: 30–1000 req/min by plan | Cursor-based; default limit 50, max 1000 | Plan-defined; Hobby/Core/Pro tiers differ |
-| Legacy read APIs | 15–100 req/min | Offset (slow) | Same |
-| Metrics API v2 | 100–2000 req/day | N/A (aggregates) | Same |
-| Blob export | No per-request limit; bounded by export window size | Time-window files | Exports only cover data retained at export time |
-| Self-host | No hard API limits | Same APIs | Customer-controlled |
-
-v2 Observations API is **cloud-only** today; self-hosted deployments use legacy endpoints or direct DB/CH access until v2 lands.
-
-Data from older SDKs without `x-langfuse-ingestion-version: 4` can be delayed up to **10 minutes** on v2 endpoints.
-
-#### Lossiness and fidelity gaps
-
-- v2 API returns I/O as **strings by default** (`parseIoAsJson: true` optional) — migration must handle both.
-- `EVENT`-type observations may lack parent linkage or duration semantics Latitude expects.
-- Prompt references (`promptId`, `promptName`, `promptVersion`) are metadata only — Latitude has no prompt entity to link.
-- Media attachments (Langfuse media upload) are not in standard observation fields — may require separate media API or blob paths.
-- Cost fields may use string decimals in v2 for precision.
-
-#### Licensing / ToS
-
-Langfuse is **MIT-licensed** OSS. Bulk export of a customer's own project data via API or self-host DB is standard data portability. Re-hosting Langfuse's **service** or redistributing their **software** is a separate concern from importing a customer's telemetry into Latitude. Cloud ToS should be reviewed before offering a managed "we pull your Langfuse cloud data" service; self-host and customer-initiated export paths are lower risk.
-
----
+| Source field | Latitude target | Notes |
+| --- | --- | --- |
+| `traceId` | `trace_id` | Strip dashes/hash to 32 hex if needed. |
+| `id` observation | `span_id` | Hash to 16 hex if not already OTEL-shaped. |
+| `parentObservationId` | `parent_span_id` | Empty for root. |
+| `type` | `operation`, `kind` | `GENERATION` maps to LLM operation. |
+| `sessionId` | `session_id` | Direct. |
+| `userId` | `user_id` | External user id. |
+| `tags` | `tags` | From trace context/enriched fields. |
+| `metadata` | `metadata` | Stringify nested values. |
+| `input`, `output` | message columns | Parse JSON when possible. |
+| `usageDetails`, `costDetails` | token/cost columns | Convert USD to microcents. |
+| `providedModelName` | `model` | Preserve raw model name. |
+| `promptName`, `promptVersion` | `metadata.import.prompt_*` | No prompt entity in MVP. |
 
 ### LangSmith
 
-#### Exportable entities
-
-| Entity | Exportable? | Mechanism | Notes |
-| --- | --- | --- | --- |
-| Traces | Yes (as run trees) | `list_runs` / `POST /runs/query`, bulk export | Root run + child runs form a trace |
-| Spans / runs | Yes | Same | `run_type`: chain, llm, tool, retriever, etc. |
-| Sessions | Partial | `session_id` on runs is the **LangSmith project id**, not a conversation session | Conversation grouping uses `extra.metadata` or thread ids — see mapping table |
-| Scores / feedback | Yes | Feedback API; `feedback_stats` in bulk export | Annotations and eval scores |
-| Datasets | Yes | Dataset API | Examples + splits |
-| Prompts | Yes | Hub / prompt API (separate from traces) | LangChain Hub prompts — not embedded in run export by default |
-| Users | Partial | `extra.metadata.user_id`, session metadata | Inconsistent across SDKs |
-| Tags | Yes | `tags` list on runs | |
-| Metadata | Yes | `extra` JSON blob | Includes `ls_*` keys from LangChain |
-
-#### Export mechanisms
-
-| Mechanism | Scope | Format | Tier |
-| --- | --- | --- | --- |
-| **`list_runs` / runs query API** | Per-project runs | JSON, cursor pagination | All tiers (rate-limited) |
-| **Bulk export to S3** | Project or all experiments, date range | Parquet (Run data format) | **Plus / Enterprise only** |
-| **Scheduled bulk export** | Recurring windows | Parquet to customer bucket | Plus / Enterprise; Helm ≥ 0.10.42 self-host |
-| **SDK export helpers** | Programmatic | JSON | All tiers |
-
-Bulk export path pattern:
-
-```
-<bucket>/<prefix>/export_id=<id>/tenant_id=<id>/session_id=<project_id>/runs/year=…/month=…/day=…
-```
-
-#### Rate limits, pagination, retention
-
-**Runs query API** ([LangSmith docs](https://docs.langchain.com/langsmith/export-traces)):
-
-| Query type | Limit |
-| --- | --- |
-| Short window (≤ 7 days), no search | 10 req / 10 sec |
-| Large window (> 7 days) | 3 req / 10 sec |
-| Full-text search | 1–3 req / 10 sec |
-| Select `child_run_ids` | Stricter tier |
-
-Always set `start_time`; use `select` to limit fields; prefer structured filters over `search()`.
-
-**Bulk export:**
-
-- 72-hour runtime timeout per job; automatic retries.
-- Cloud: 250 bulk export **creations** per hour per workspace; 200 active **scheduled** exports max.
-- `all_experiments` exports capped at 250 experiments on cloud.
-- Self-host: limits configurable / absent by default.
-
-**Retention:** `trace_tier` on runs indicates retention level; expired traces are not exportable.
-
-#### Lossiness and fidelity gaps
-
-- LangSmith `session_id` in run export = **project UUID**, not conversation id — session migration requires extracting conversation keys from `extra` or metadata.
-- `dotted_order` encodes hierarchy but parent links also via `parent_run_id`.
-- Bulk export `feedback_stats` omits non-string feedback value breakdowns — numeric/boolean feedback needs separate feedback export.
-- Experiments vs production traces use the same run format but different project/session scoping.
-
-#### Licensing / ToS
-
-LangSmith is a commercial LangChain product. Bulk export requires **Plus/Enterprise** for the S3 path; API read access is broader but rate-limited. A Latitude migration tool that asks customers to provide their own API keys and export to **their** bucket (or reads via API with consent) stays within normal data-portability expectations. Storing or re-selling LangSmith data is out of scope. Confirm current ToS before marketing "official LangSmith migration."
-
----
+| Source field | Latitude target | Notes |
+| --- | --- | --- |
+| `trace_id` | `trace_id` | UUID to deterministic 32 hex. |
+| `id` run | `span_id` | UUID to deterministic 16 hex. |
+| `parent_run_id` | `parent_span_id` | Empty for root. |
+| `run_type` | `operation` | `llm`, `tool`, `chain`, etc. |
+| `session_id` | Source project id | Do not map directly to Latitude `session_id`. |
+| `extra.metadata.<key>` | `session_id` | Use configured/default metadata key. |
+| `tags` | `tags` | Direct. |
+| `extra` | `metadata` | Preserve useful `ls_*` keys. |
+| `inputs`, `outputs` | message columns | LangChain message format to GenAI messages. |
+| token/cost fields | token/cost columns | Best effort. |
 
 ### Braintrust
 
-#### Exportable entities
-
-| Entity | Exportable? | Mechanism | Notes |
-| --- | --- | --- | --- |
-| Traces | Yes | BTQL `project_logs(…)` with `shape => 'traces'` | Trace = root span + children |
-| Spans | Yes | BTQL `project_logs(…)` default / `log_spans` export | Nested via `span_id` / `root_span_id` |
-| Sessions | Partial | Session-root span pattern in logs; metadata grouping | No first-class "session" entity — convention-based |
-| Scores / evals | Yes | Scores API; BTQL on logs/experiments | Human annotations, automated scorers |
-| Datasets | Yes | BTQL `project_dataset(project_id, dataset_id)` | input, expected, metadata |
-| Prompts | Yes | Prompts API (`/v1/prompt`) | Version-controlled prompt registry |
-| Users | Partial | `metadata.user_id` and related fields | |
-| Tags | Yes | `tags` array on logs | |
-| Metadata | Yes | `metadata` JSON | Also `braintrust.metadata` OTLP on live ingest |
-
-#### Export mechanisms
-
-| Mechanism | Scope | Format |
+| Source field | Latitude target | Notes |
 | --- | --- | --- |
-| **BTQL API** (`POST /btql`) |任意 query | JSON or Parquet |
-| **UI export** | Filtered logs view | JSON or CSV |
-| **Cloud storage automation** | Scheduled `log_traces` or `log_spans` | JSON Lines or Parquet to S3/GCS |
-| **Custom BTQL automation** | User-defined query | Parquet default |
+| `root_span_id` | `trace_id` | Derive trace id from root. |
+| `span_id` | `span_id` | Deterministic 16 hex. |
+| `parent_span_id` | `parent_span_id` | Direct/hash. |
+| session-root span or `metadata.session_id` | `session_id` | Prefer explicit metadata session id. |
+| `tags` | `tags` | Direct. |
+| `metadata` | `metadata` | Stringify nested values. |
+| `input`, `output` | message columns | Best effort. |
+| `metrics` | token/performance fields | Best effort. |
+| prompt fields | `metadata.import.prompt_*` | No prompt entity in MVP. |
 
-Automations require `POST /brainstore/automation/reset-cursors` after creation to start exporting.
+### Fidelity gaps
 
-#### Rate limits, pagination, retention
-
-- BTQL: practical limits depend on query scope and plan; large exports should use Parquet format and narrow time filters.
-- Export automations: interval as low as **1 second** (typically hourly+ for bulk).
-- Traces do **not** auto-close — "in progress" traces remain until explicitly ended; historical exports may include incomplete traces.
-- Data retention automations can delete old logs — export before retention runs.
-
-#### Lossiness and fidelity gaps
-
-- **Session idle timeout** in Braintrust UI (Topics automation, default 600s) controls when **Topics processing** runs, not when traces/sessions close. It does **not** split conversations into sessions — session boundaries come from customer instrumentation (session-root span pattern).
-- Multi-turn stitching depends on `parent` / `root_span_id` — migrations must preserve these.
-- `expected` field on logs (human corrections) maps to annotation-like data, not a first-class Latitude field on spans.
-- Prompt registry is separate from span payloads.
-
-#### Licensing / ToS
-
-Braintrust is commercial. BTQL export and cloud storage automations are standard product features. Customer-initiated export with their API key is the expected migration path. Review ToS for any managed migration service positioning.
-
----
-
-## Latitude target model
-
-### Storage split
-
-| Layer | Stores | Migration writes |
-| --- | --- | --- |
-| **ClickHouse `spans`** | Canonical telemetry rows | **Primary import target** — insert spans; `traces` and `sessions` materialized views rebuild automatically |
-| **ClickHouse `traces` / `sessions`** | AggregatingMergeTree rollups | Do **not** write directly |
-| **Postgres control plane** | Projects, scores, datasets, evaluations, signals | Scores/datasets in Phase 2+; not MVP |
-| **Object storage** | Ingest staging (>50 KB OTLP batches), dataset CSV, exports | Optional staging for bulk import batches; span **content** lives inline in CH |
-
-### Identity and hierarchy
-
-| Latitude field | Source | Notes |
-| --- | --- | --- |
-| `trace_id` | Vendor trace id | **32 lowercase hex, no dashes** — normalize on import |
-| `span_id` | Vendor span/observation/run id | **16 lowercase hex** — may need deterministic hash if vendor ids are UUIDs |
-| `parent_span_id` | Vendor parent link | Empty or `0000000000000000` = root |
-| `session_id` | Resolved from vendor session keys | See resolvers below; empty → CH MV uses `trace_id` as session key (1-trace session) |
-| `user_id`, `user_email` | Vendor user fields | External ids, not PG users |
-| `tags` | Vendor tags | String array |
-| `metadata` | Vendor metadata maps | `Map(String, String)` — stringified values |
-
-**Existing OTLP resolvers** (for live ingest; migration mappers should produce the same normalized fields):
-
-```108:139:packages/domain/spans/src/otlp/resolvers/identity.ts
-export const sessionIdCandidates = [
-  fromString("session.id"),
-  fromString("gen_ai.session.id"),
-  fromString("langfuse.session.id"),
-  // ...
-  fromString("langsmith.trace.session_id"),
-  // ...
-]
-
-export const userIdCandidates = [
-  // ...
-  fromString("langsmith.metadata.user_id"),
-  fromString("langfuse.user.id"),
-]
-```
-
-```24:36:packages/domain/spans/src/otlp/resolvers/enrichment.ts
-export const tagsCandidates: Candidate<string[]>[] = [
-  fromJsonStringArray("latitude.tags"),
-  fromStringArray("langfuse.trace.tags"),
-  fromStringArray("braintrust.tags"),
-  fromStringArray("tag.tags"),
-  fromString<string[]>("langsmith.span.tags", (v) => /* comma-split */),
-]
-```
-
-### Messages, usage, cost
-
-| Latitude column | Source mapping |
+| Gap | MVP behavior |
 | --- | --- |
-| `input_messages`, `output_messages`, `system_instructions` | Parse vendor I/O into GenAI message JSON (same shape as OTLP transform) |
-| `tool_definitions`, `tool_*` | Tool calls from vendor tool/run-type fields |
-| `tokens_*`, `cost_*_microcents` | Vendor usage/cost; USD → microcents (1 USD = 100,000,000) |
-| `operation`, `provider`, `model` | Map vendor run types / model names |
-| `attr_*`, `resource_string` | Unmapped vendor fields preserved for fidelity |
-
-### Scores and annotations
-
-Postgres `scores` is canonical; ClickHouse `scores` is analytics projection.
-
-| Latitude | Source |
-| --- | --- |
-| `scores.source_type = 'annotation'` | Human labels / Braintrust `expected` corrections |
-| `scores.source_type = 'evaluation'` | Automated eval scores (Phase 2 — requires signal/eval linkage) |
-| `scores.source_type = 'custom'` | Vendor numeric scores without eval config |
-| Anchors: `trace_id`, `span_id`, `session_id` | From migrated span ids |
-
-Draft scores (`drafted_at` set) stay PG-only until published.
-
-### Prompts
-
-**No Latitude prompt registry exists.** Options:
-
-1. **MVP:** Store prompt name/version in span `metadata` (e.g. `import.prompt_name`, `import.prompt_version`).
-2. **Phase 3:** Introduce a prompt entity or map to Latitude prompt templates if product adds one.
-
-### What cannot be migrated faithfully
-
-| Gap | Degraded import behavior |
-| --- | --- |
-| LangSmith conversation sessions | Import with `session_id = trace_id` unless customer provides a metadata key mapping; document how to configure `extra.metadata.thread_id` or similar |
-| Langfuse media attachments | Skip or store URL in metadata; no binary pull in MVP |
-| Vendor eval configs (judges, scorers) | Import resulting scores only; do not recreate Evaluation + Signal graph |
-| Braintrust in-progress traces | Import with best-effort `end_time` = last event or `start_time`; mark metadata `import.incomplete = true` |
-| Prompt registry (all vendors) | Metadata-only reference on spans |
-| LangSmith Hub prompts | Out of scope MVP |
-| Real-time eval triggers / automations | Not migrated |
-| User accounts (vendor auth users) | Only external `user_id` on spans |
-
----
-
-## Entity mapping tables
-
-### Langfuse → Latitude
-
-| Langfuse entity / field | Latitude target | Transform notes |
-| --- | --- | --- |
-| `traceId` | `spans.trace_id` | Strip dashes if UUID format |
-| `id` (observation) | `spans.span_id` | Hash to 16 hex if not OTEL-shaped |
-| `parentObservationId` | `spans.parent_span_id` | |
-| `type` GENERATION/SPAN/EVENT | `spans.operation`, `spans.kind` | GENERATION → LLM operation |
-| `sessionId` | `spans.session_id` | Direct |
-| `userId` | `spans.user_id` | |
-| `tags` | `spans.tags` | From trace_context |
-| `metadata` | `spans.metadata` | Stringify values |
-| `input`, `output` | `input_messages`, `output_messages` | Parse JSON; map to GenAI message arrays |
-| `usageDetails`, `costDetails` | `tokens_*`, `cost_*_microcents` | |
-| `providedModelName` | `spans.model` | |
-| `promptName`, `promptVersion` | `metadata.import.prompt_*` | No prompt entity |
-| Score rows | PG `scores` (Phase 2) | Link by migrated trace/span id |
-| Dataset items | PG `datasets` + CH `dataset_rows` (Phase 3) | |
-
-### LangSmith → Latitude
-
-| LangSmith entity / field | Latitude target | Transform notes |
-| --- | --- | --- |
-| `trace_id` | `spans.trace_id` | UUID → 32 hex |
-| `id` (run) | `spans.span_id` | UUID → 16 hex (deterministic truncate/hash) |
-| `parent_run_id` | `spans.parent_span_id` | |
-| `run_type` | `spans.operation` | llm→chat, tool→tool, chain→agent, etc. |
-| `session_id` | **Not conversation session** | Do **not** map to `spans.session_id`; use `extra.metadata.session_id` or thread id if present |
-| `tags` | `spans.tags` | |
-| `extra` | `spans.metadata` | Flatten `ls_*` keys; preserve full JSON in `attr_string` if needed |
-| `inputs`, `outputs` | message columns | LangChain message format → GenAI |
-| `total_tokens`, `total_cost` | usage/cost columns | |
-| `feedback_stats` / feedback API | PG `scores` (Phase 2) | |
-| `reference_example_id` | `metadata.import.dataset_example_id` | |
-| Dataset examples | PG+CH datasets (Phase 3) | |
-
-**LangSmith session id disambiguation:** LangSmith uses `session_id` for **project id** in bulk export. Conversation grouping keys vary by SDK (`metadata.thread_id`, custom metadata). Migration config should accept `--session-metadata-key extra.thread_id` (example) for LangSmith imports.
-
-### Braintrust → Latitude
-
-| Braintrust entity / field | Latitude target | Transform notes |
-| --- | --- | --- |
-| `root_span_id` / trace root | `spans.trace_id` | Derive trace id from root |
-| `span_id` | `spans.span_id` | |
-| `parent_span_id` | `spans.parent_span_id` | |
-| Session-root span | `spans.session_id` | Use root span id or explicit `metadata.session_id` if set |
-| `tags` | `spans.tags` | |
-| `metadata` | `spans.metadata` | |
-| `input`, `output` | message columns | |
-| `metrics` (tokens, duration) | usage/performance columns | |
-| `expected` | PG `scores` annotation (Phase 2) | Human correction |
-| `scores` | PG `scores` | |
-| Dataset rows | PG+CH datasets (Phase 3) | |
-| Prompts (`/v1/prompt`) | metadata only (MVP) | |
-
----
-
-## Product surface and UX
-
-### Surfaces (by phase)
-
-| Surface | Phase | Audience | Rationale |
-| --- | --- | --- | --- |
-| **CLI** (`latitude migrate …`) | MVP | Customer engineers | Scriptable, CI-friendly, matches `latitude` CLI pattern; credentials stay local |
-| **Backoffice admin job** | MVP | Latitude staff | Assisted migrations for enterprise evals; mirrors other staff-only ops |
-| **Self-serve UI wizard** | Phase 2 | Customer admins | Connect source → preview → import; higher build cost |
-| **API endpoint** | Phase 2+ | Automation | `POST /v1/projects/{slug}/imports` for headless ops |
-
-### Core UX requirements (all surfaces)
-
-| Requirement | Behavior |
-| --- | --- |
-| **Org/project scoping** | Import targets one Latitude project slug; source credentials scoped to one vendor project |
-| **Dry-run** | `--dry-run` counts records, validates mapping, shows sample normalized span; no writes |
-| **Progress reporting** | Structured logs + periodic stats: fetched / transformed / written / skipped / failed |
-| **Idempotency** | Re-run with same source ids produces ReplacingMergeTree dedupe (same logical ids → same CH keys) or explicit skip |
-| **Resume on failure** | Persist cursor (last exported timestamp + last source id) in PG import job table |
-| **Time range filter** | `--from` / `--to` aligned to source semantics (LangSmith: `start_time` inclusive; bulk export: window bounds) |
-| **Rate limit handling** | Exponential backoff on 429; respect `Retry-After` |
-
-### Session boundary policy
-
-| Option | Behavior | Recommendation |
-| --- | --- | --- |
-| **Import as-is** | Preserve vendor `session_id` on every span | **Default** — respects customer instrumentation |
-| **Re-segment by idle gap** | Split spans into new session ids when gap > N minutes | Post-MVP optional flag (`--resegment-idle-minutes`); Braintrust Topics idle timeout is **not** a session splitter |
-| **One trace = one session** | Force empty session id (MV fallback) | Fallback when source has no session concept |
-
-Latitude UI "live vs idle" ([`sessions.collection.ts`](apps/web/src/domains/sessions/sessions.collection.ts)) is client-side (5-minute threshold on `max_end_time`) — imports do not need to compute it.
-
----
-
-## Technical approach options
-
-### Option A: Pull via vendor APIs → normalize → ingest pipeline
-
-```
-Vendor API ──► Migrator worker ──► normalize to internal span batch ──► processIngestedSpansUseCase / SpanRepository.insert
-                     │                              │
-                     └── cursor in PG               └── skip OTLP HTTP; optional BullMQ for chunking
-```
-
-| Aspect | Assessment |
-| --- | --- |
-| **Throughput** | Langfuse v2: 50–1000 rows/req, 30–1000 req/min → ~30k–1M obs/hour cloud. LangSmith: 10 req/10s (7-day window) → ~100s of runs/min with small pages. Braintrust BTQL: varies; Parquet for large pulls. |
-| **Dedupe** | Stable id mapping from vendor ids; `ingested_at` = import timestamp; ReplacingMergeTree handles retries |
-| **Backfill vs cutover** | API pull suits incremental sync and smaller histories; large backfills hit rate limits (LangSmith especially) |
-| **Operational risk** | Low infra — no customer bucket setup; high **time** risk on large datasets; vendor API changes |
-| **Pros** | No S3 setup; works for cloud trials; good for MVP validation |
-| **Cons** | Rate limits; LangSmith bulk export tier gap; Langfuse v2 cloud-only |
-
-### Option B: Direct DB / blob import → transform → bulk load
-
-```
-S3/GCS export files ──► Migrator (stream Parquet/JSONL) ──► transform ──► CH batch insert (+ PG scores)
-        or
-Self-host PG/CH ──► SQL dump / direct read ──► transform ──► bulk insert
-```
-
-| Aspect | Assessment |
-| --- | --- |
-| **Throughput** | Limited by Latitude CH insert rate and worker CPU; blob paths avoid vendor API throttles — **10×–100× faster** for millions of spans |
-| **Dedupe** | Same stable id mapping; file boundaries are not idempotency boundaries — cursor per record |
-| **Backfill vs cutover** | Primary path for production migrations; API for delta after cutover |
-| **Operational risk** | Customer must configure export bucket or grant DB read; credential handling; schema drift on vendor upgrades |
-| **Pros** | Scales to full history; matches how vendors expect warehouse export |
-| **Cons** | Higher setup friction; self-host DB path is Langfuse-specific; Parquet schema versioning (LangSmith `format_version`) |
-
-### Comparison and recommendation
-
-| Criterion | Option A (API) | Option B (blob/DB) |
-| --- | --- | --- |
-| Setup friction | Low | Medium–high |
-| Max volume | Medium | High |
-| LangSmith cloud | Poor (rate limits; bulk export needs Plus) | Good (Parquet bulk export) |
-| Langfuse self-host | Medium (legacy API) | Excellent (CH + PG) |
-| Braintrust | Good (BTQL) | Excellent (automations) |
-| Idempotency | Same | Same |
-
-**Recommendation:** Implement **both**, with shared normalize + write core. Default CLI flow tries API for `--dry-run` and small `--limit`; `--source-uri s3://…` or `--langfuse-blob-prefix` activates blob path. LangSmith migrations should **document** Plus bulk export as the supported path for >100k runs.
-
-### Internal write path vs OTLP
-
-| Path | Use |
-| --- | --- |
-| **Internal** (`SpanRepository.insert` via migrator use-case) | Bulk import — no double encoding, no ingest rate limits, direct control of `retention_days` |
-| **OTLP HTTP** (`POST /v1/traces`) | Only for testing parity with live ingest; optional `--via-otlp` flag for QA |
-
-Post-import, publish `TracesIngested` domain events (or a dedicated `ImportBatchCompleted` event) so trace-search indexing, first-trace detection, and billing run — **billing policy for imported spans** is an open question (likely exclude from ingest metering or tag `metadata.import.source`).
-
-### Throughput estimates (order of magnitude)
-
-Assumptions: 500-byte avg span row, 10k spans/sec CH insert burst (conservative), single worker.
-
-| Volume | API-only (Langfuse cloud) | Blob/DB path |
-| --- | --- | --- |
-| 100k spans | ~2–6 hours | ~1–5 minutes |
-| 1M spans | ~1–3 days | ~10–30 minutes |
-| 10M spans | Impractical API-only | ~2–4 hours (parallel workers) |
-
-Parallelization: shard by time window or trace id prefix; **one import job per (org, project, source)** at a time (hard guard like data-destinations backfill).
-
----
-
-## Prioritization and phasing
-
-### Platform order
-
-| Priority | Platform | Why |
-| --- | --- | --- |
-| **1** | Langfuse | OSS/self-host (DB + blob paths), competitive eval overlap, existing resolver coverage, enriched blob export is migration-friendly |
-| **2** | Braintrust | Workshop ask; BTQL + Parquet export; strong eval/dataset overlap; session-root patterns documented |
-| **3** | LangSmith | Large market but bulk export gated to Plus/Enterprise; `session_id` naming collision; heavy LangChain-specific `extra` parsing |
-
-### MVP vs full parity
-
-| Phase | Entities | Exit gate |
-| --- | --- | --- |
-| **Phase 0 — Spec** | This document | PR merged; tasks filed |
-| **Phase 1 — MVP** | Traces, spans, sessions (as id), user/tags/metadata, usage/cost, messages | Import 100k Langfuse observations in staging; idempotent re-run; traces/sessions visible in UI |
-| **Phase 2 — Scores + LangSmith** | Scores/annotations; LangSmith API + Parquet path; CLI polish | LangSmith project import with feedback; scores on traces |
-| **Phase 3 — Datasets + prompts metadata** | Dataset rows; prompt metadata; Braintrust automations path | Dataset slug import; eval set parity for fine-tuning workflows |
-| **Phase 4 — Self-serve UI + incremental sync** | Wizard; scheduled delta sync | Customer completes import without staff help |
-
----
-
-## MVP non-goals
-
-- Self-serve UI wizard
-- LangSmith migration without Plus bulk export or accepting API rate-limit duration
-- Prompt registry creation in Latitude
-- Eval config / signal / evaluation recreation
-- Vendor user account migration
-- Binary media / attachment migration (Langfuse media)
-- Real-time dual-write or continuous sync (batch only in MVP)
-- Session re-segmentation by idle timeout
-- Import into sandbox organizations (mirror data-destinations sandbox exclusion)
-- Cross-org import (single org credentials per job)
-- Mutable source upsert (imports are append-only historical backfill)
-- Legal/compliance review automation (customer responsible for export authorization)
-
----
-
-## Open questions
-
-1. **Billing:** Do imported spans count toward ingest quotas and billing meters, or are they tagged exempt?
-2. **Retention:** Set `retention_days` from org plan at import time, or preserve vendor retention metadata?
-3. **Search indexing:** Trigger full trace-search reindex for imported windows, or rely on existing `TracesIngested` consumers?
-4. **Span id mapping:** Deterministic UUID→hex truncation vs hash — document collision risk and pick one algorithm globally.
-5. **LangSmith session key:** Standardize default metadata keys per LangChain SDK version, or require explicit CLI config?
-6. **Staff-only vs customer CLI credentials:** Store encrypted vendor credentials in PG for UI wizard (Phase 2), or ephemeral env vars only for MVP?
-7. **CH direct insert vs queue:** Synchronous batch insert in migrator vs BullMQ `span-ingestion` topic for backpressure — likely dedicated `migration-import` queue.
-8. **Provenance:** Expose `metadata.import.source_platform`, `import.job_id`, `import.original_id` on every span for support/debug?
-9. **Partial trace handling:** Reject entire traces with unmapped parent ids, or import orphan spans with warning?
-10. **Langfuse v2 self-host timeline:** Block Langfuse cloud-parity self-host migrations until v2 ships, or invest in legacy API adapter?
-
----
-
-## Implementation tasks
-
-### Phase 0 — Spec (this PR)
-
-- [x] `specs/observability-migration.md`
-- [x] Entity mapping tables per source platform
-- [x] MVP non-goals
-- [x] Architecture comparison and recommendation
-- [ ] Linear LAT-721 → link PR
-
-### Phase 1 — Langfuse MVP (estimated 3–5 PRs)
-
-- [ ] **P1-a** Domain: `ImportJob` entity + port (PG table: org, project, source, cursor, status, stats, error)
-- [ ] **P1-b** Normalizer: Langfuse observation row → Latitude `SpanInsertRow` (enriched export + v2 API shapes)
-- [ ] **P1-c** Id mapping: trace/span id normalization utilities + unit tests (UUID, OTEL hex)
-- [ ] **P1-d** Use-case: `importSpansBatch` — validate, insert CH, emit events; idempotent dedupe
-- [ ] **P1-e** Worker: `migration-import` queue + job runner with backoff and cursor persistence
-- [ ] **P1-f** CLI: `latitude migrate import langfuse --project <slug> --from --to --dry-run [--limit]`
-- [ ] **P1-g** Langfuse blob reader: S3/GCS JSONL/JSON.gz stream parser for `observations_v2/`
-- [ ] **P1-h** Backoffice: staff trigger + job status view (minimal)
-- [ ] **P1-i** Integration test: fixture Langfuse export → CH spans → UI trace/session smoke
-- [ ] **P1-j** Docs: Mintlify "Migrating from Langfuse" guide
-
-**Phase 1 exit gate:** 100k observation import in staging completes with <0.1% error rate; re-run duplicates skipped; sessions group correctly when `sessionId` present.
-
-### Phase 2 — Scores + LangSmith
-
-- [ ] **P2-a** Score normalizers (Langfuse scores, LangSmith feedback, Braintrust scores)
-- [ ] **P2-b** `saveScore` + CH analytics sync for imported scores
-- [ ] **P2-c** LangSmith run → span normalizer + `--session-metadata-key`
-- [ ] **P2-d** LangSmith Parquet bulk export reader
-- [ ] **P2-e** CLI: `latitude migrate import langsmith …`
-- [ ] **P2-f** Braintrust BTQL pull adapter
-
-**Phase 2 exit gate:** LangSmith project with feedback imports; scores visible on trace detail.
-
-### Phase 3 — Datasets + Braintrust parity
-
-- [ ] **P3-a** Dataset + dataset_rows import path
-- [ ] **P3-b** Braintrust blob automation / Parquet reader
-- [ ] **P3-c** Prompt metadata enrichment on spans
-- [ ] **P3-d** CLI: `latitude migrate import braintrust …`
-
-### Phase 4 — Productization
-
-- [ ] **P4-a** Self-serve import wizard in project settings
-- [ ] **P4-b** Incremental scheduled sync (optional continuous migration pre-cutover)
-- [ ] **P4-c** Import provenance UI (filter by `import.source_platform`)
-- [ ] **P4-d** `--resegment-idle-minutes` optional session splitter
-
----
-
-## References
-
-- Langfuse: [Public API](https://langfuse.com/docs/api-and-data-platform/features/public-api), [Observations API v2](https://langfuse.com/docs/api-and-data-platform/features/observations-api), [Blob storage export](https://langfuse.com/docs/api-and-data-platform/features/export-to-blob-storage), [API limits](https://langfuse.com/faq/all/api-limits)
-- LangSmith: [Export traces](https://docs.langchain.com/langsmith/export-traces), [Bulk export](https://docs.langchain.com/langsmith/data-export)
-- Braintrust: [API reference](https://www.braintrust.dev/docs/api-reference), [Export annotated data](https://www.braintrust.dev/docs/annotate/export), [Cloud storage automations](https://www.braintrust.dev/docs/admin/automations/export-to-cloud-storage), [Topics idle timeout (automation only)](https://www.braintrust.dev/docs/kb/topics-automation-idle-timeout-and-trace-update-behavior)
-- Latitude: `packages/domain/spans/src/otlp/resolvers/`, `packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00016_session_parity.sql`, `dev-docs/data-destinations.md`
+| LangSmith `session_id` means project id | Require/detect metadata key for conversation sessions; otherwise one trace becomes one session. |
+| Prompt registries | Store prompt name/version/reference in metadata only. |
+| Scores/evals | Do not import in MVP. |
+| Datasets | Do not import in MVP. |
+| Binary media | Do not import in MVP. |
+| Braintrust in-progress traces | Import best effort and mark `metadata.import.incomplete = true` when detectable. |
+| Source records with invalid hierarchy | Import orphan span with warning if core ids/timestamps are valid; skip only if required fields are missing. |
+
+### References
+
+- `dev-docs/data-destinations.md`
+- `packages/domain/queue/src/topic-registry.ts`
+- `apps/workers/src/workers/span-ingestion.ts`
+- `packages/domain/spans/src/use-cases/process-ingested-spans.ts`
+- `packages/domain/spans/src/ports/span-repository.ts`
+- `packages/platform/db-clickhouse/src/repositories/span-repository.ts`
+- `apps/web/src/domains/destinations/destinations.functions.ts`
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/destination-form-modal.tsx`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds and refines `specs/observability-migration.md` — investigation and concrete implementation plan for importing historical telemetry from Langfuse, LangSmith, and Braintrust into Latitude. Spec only; no production code.

Closes LAT-721.

## What changed

The spec was refined from an investigation doc into a **UI-first implementation plan**:

- **Self-serve wizard** in project settings (`/projects/$slug/settings/imports`) — not CLI-first or backoffice
- **One import engine** with pluggable Langfuse / LangSmith / Braintrust adapters
- **Concrete limits**: 90-day default lookback (365-day hard cap), 250k default / 1M hard max spans, one active import per org, 8 platform worker concurrency
- **BullMQ page chain**: one bounded source page per job, cursor persistence, idempotent span writes via `SpanRepository.insert`
- **Step-by-step phases** (0–5) with PR-sized tasks and exit gates; MVP complete after Phase 4 (UI + engine + all three adapters)

## Key architecture

```
Settings wizard → server functions → PG import_jobs → BullMQ observability-imports
  → worker (8 concurrent) → source adapter → normalize → ClickHouse spans
```

Reuses data-destinations patterns (encrypted credentials, sync-run audit rows, bounded backfill) and existing span repository — no OTLP HTTP roundtrip, no Temporal, no blob/Parquet in MVP.

## Deferred from MVP

CLI, backoffice UI, scores/datasets/prompts, blob/Parquet imports, continuous sync, unbounded history.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-721](https://linear.app/latitude/issue/LAT-721/spec-observability-platform-migration-tool-langfuse-langsmith)

<div><a href="https://cursor.com/agents/bc-0416e719-f95a-42d6-8121-1ca57f88905f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0416e719-f95a-42d6-8121-1ca57f88905f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

