### PR TITLE
fix(web): add frosted background to changelog minimize button

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/changelog/changelog-banner.tsx
+++ b/apps/web/src/routes/_authenticated/-components/changelog/changelog-banner.tsx
@@ -1,5 +1,5 @@
 import { FULL_CHANGELOG_URL } from "@domain/changelog"
-import { Button, cn, Icon, Text, type TextColor } from "@repo/ui"
+import { Button, cn, Icon, Text } from "@repo/ui"
 import { Minus } from "lucide-react"
 
 /** Default cover when a Framer entry has no image (Figma `type=no-cover`). */
@@ -22,7 +22,6 @@ const hasCover = (coverUrl: string | null): coverUrl is string =>
  */
 export function ChangelogBanner({ title, description, coverUrl, onCollapse, className }: ChangelogBannerProps) {
   const coverSrc = hasCover(coverUrl) ? coverUrl : CHANGELOG_FALLBACK_COVER_URL
-  const collapseIconColor: TextColor = hasCover(coverUrl) ? "foreground" : "white"
 
   return (
     <article className={cn("relative flex w-full flex-col overflow-hidden rounded-2xl bg-secondary", className)}>
@@ -53,11 +52,11 @@ export function ChangelogBanner({ title, description, coverUrl, onCollapse, clas
           type="button"
           variant="ghost"
           size="icon"
-          className="h-8 w-8 shrink-0"
+          className="h-8 w-8 shrink-0 border border-border/60 bg-background/70 shadow-sm backdrop-blur-sm hover:bg-background/85"
           onClick={onCollapse}
           aria-label="Collapse changelog"
         >
-          <Icon icon={Minus} size="sm" color={collapseIconColor} />
+          <Icon icon={Minus} size="sm" color="foreground" />
         </Button>
       </div>
     </article>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The collapse (minimize) button on the sidebar changelog banner was hard to see when the cover image was mostly white — the ghost button had no background and relied on icon color alone.

## Change

Adds a frosted translucent background to the minimize button:

- `bg-background/70` with `backdrop-blur-sm` for a glass effect
- Subtle `border-border/60` and `shadow-sm` for contrast on light covers
- Icon color is now always `foreground`, since the button carries its own surface

## Verification

- `pnpm --filter @app/web check` passes
- Visual preview confirms the button remains visible on a white cover image (see screenshot in agent summary)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-395d7d3e-d0df-4a0b-94c8-62bf8332c891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-395d7d3e-d0df-4a0b-94c8-62bf8332c891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

