### PR TITLE
fix(core): batch workspace deletion so it survives the statement timeout

### DIFF
--- a/packages/core/src/jobs/job-definitions/maintenance/destroyWorkspaceJob.ts
+++ b/packages/core/src/jobs/job-definitions/maintenance/destroyWorkspaceJob.ts
@@ -1,7 +1,6 @@
 import { Job } from 'bullmq'
 
 import { unsafelyFindWorkspace } from '../../../data-access/workspaces'
-import { Result } from '../../../lib/Result'
 import { destroyWorkspace } from '../../../services/workspaces/destroy'
 import { queues } from '../../queues'
 
@@ -32,6 +31,11 @@ export async function enqueueDestroyWorkspaceJob(workspaceId: number) {
 /**
  * Background job that permanently destroys a workspace and all associated data.
  * Delegates to the destroyWorkspace service for the actual deletion logic.
+ *
+ * Throws when the deletion fails so BullMQ retries the job and the failure is
+ * visible, instead of silently reporting a completed job with a swallowed
+ * `Result.error`. The deletion is idempotent, so retries resume where the
+ * previous attempt left off.
  */
 export const destroyWorkspaceJob = async (
   job: Job<DestroyWorkspaceJobData>,
@@ -39,9 +43,7 @@ export const destroyWorkspaceJob = async (
   const { workspaceId } = job.data
 
   const workspace = await unsafelyFindWorkspace(workspaceId)
-  if (!workspace) {
-    return Result.nil()
-  }
+  if (!workspace) return
 
-  return destroyWorkspace(workspace)
+  await destroyWorkspace(workspace).then((r) => r.unwrap())
 }

--- a/packages/core/src/services/workspaces/destroy.test.ts
+++ b/packages/core/src/services/workspaces/destroy.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { faker } from '@faker-js/faker'
+import { eq } from 'drizzle-orm'
 import { LogSources, Providers } from '@latitude-data/constants'
 import { database } from '../../client'
 import { unsafelyFindWorkspace } from '../../data-access/workspaces'
+import Transaction from '../../lib/Transaction'
 import { events } from '../../schema/models/events'
+import { spans } from '../../schema/models/spans'
 import { documentLogs } from '../../schema/legacyModels/documentLogs'
 import { evaluationResults } from '../../schema/legacyModels/evaluationResults'
 import {
@@ -124,5 +127,125 @@ describe('destroyWorkspace', () => {
 
     expect(result.ok).toBe(true)
     expect(await unsafelyFindWorkspace(workspace.id)).toBeUndefined()
+  })
+
+  it('destroys a workspace whose data exceeds a single delete batch', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      user,
+      name: 'provider',
+      type: Providers.OpenAI,
+    })
+    const { apiKey } = await createApiKey({
+      workspace,
+      name: faker.string.alpha(),
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await createSpan({ workspaceId: workspace.id, apiKeyId: apiKey.id })
+
+      await database.insert(providerLogs).values({
+        uuid: faker.string.uuid(),
+        workspaceId: workspace.id,
+        providerId: provider.id,
+        apiKeyId: apiKey.id,
+        source: LogSources.API,
+      })
+
+      await database.insert(documentLogs).values({
+        uuid: faker.string.uuid(),
+        workspaceId: workspace.id,
+        documentUuid: faker.string.uuid(),
+        commitId: commit.id,
+        resolvedContent: 'content',
+        contentHash: 'hash',
+        parameters: {},
+        source: LogSources.API,
+      })
+
+      await database.insert(events).values({
+        workspaceId: workspace.id,
+        type: 'workspaceCreated',
+        data: {},
+      })
+    }
+
+    const result = await destroyWorkspace(workspace, new Transaction(), 2)
+
+    expect(result.ok).toBe(true)
+    expect(await unsafelyFindWorkspace(workspace.id)).toBeUndefined()
+    expect(
+      await database
+        .select()
+        .from(spans)
+        .where(eq(spans.workspaceId, workspace.id)),
+    ).toHaveLength(0)
+    expect(
+      await database
+        .select()
+        .from(providerLogs)
+        .where(eq(providerLogs.workspaceId, workspace.id)),
+    ).toHaveLength(0)
+  })
+
+  it('destroys a workspace with legacy logs missing workspace_id', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      user,
+      name: 'provider',
+      type: Providers.OpenAI,
+    })
+    const { apiKey } = await createApiKey({
+      workspace,
+      name: faker.string.alpha(),
+    })
+
+    // Legacy provider_logs rows predate the workspace_id column, but still
+    // block deleting the workspace's provider/API keys (onDelete: 'restrict').
+    // They are only reachable through their provider.
+    const [orphanProviderLog] = await database
+      .insert(providerLogs)
+      .values({
+        uuid: faker.string.uuid(),
+        workspaceId: null,
+        providerId: provider.id,
+        apiKeyId: apiKey.id,
+        source: LogSources.API,
+      })
+      .returning()
+
+    // Legacy document_logs rows predate the workspace_id column, but still
+    // block the workspace cascade through commits (onDelete: 'restrict').
+    // They are only reachable through their commit.
+    const [orphanDocumentLog] = await database
+      .insert(documentLogs)
+      .values({
+        uuid: faker.string.uuid(),
+        workspaceId: null,
+        documentUuid: faker.string.uuid(),
+        commitId: commit.id,
+        resolvedContent: 'content',
+        contentHash: 'hash',
+        parameters: {},
+        source: LogSources.API,
+      })
+      .returning()
+
+    const result = await destroyWorkspace(workspace)
+
+    expect(result.ok).toBe(true)
+    expect(await unsafelyFindWorkspace(workspace.id)).toBeUndefined()
+    expect(
+      await database
+        .select()
+        .from(providerLogs)
+        .where(eq(providerLogs.id, orphanProviderLog!.id)),
+    ).toHaveLength(0)
+    expect(
+      await database
+        .select()
+        .from(documentLogs)
+        .where(eq(documentLogs.id, orphanDocumentLog!.id)),
+    ).toHaveLength(0)
   })
 })

--- a/packages/core/src/services/workspaces/destroy.ts
+++ b/packages/core/src/services/workspaces/destroy.ts
@@ -1,48 +1,240 @@
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 
+import { database } from '../../client'
 import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
+import { documentLogs } from '../../schema/legacyModels/documentLogs'
 import { evaluationResults } from '../../schema/legacyModels/evaluationResults'
 import { evaluations } from '../../schema/legacyModels/evaluations'
 import { providerLogs } from '../../schema/legacyModels/providerLogs'
 import { apiKeys } from '../../schema/models/apiKeys'
 import { claimedRewards } from '../../schema/models/claimedRewards'
+import { commits } from '../../schema/models/commits'
+import { datasetRows } from '../../schema/models/datasetRows'
+import { evaluationResultsV2 } from '../../schema/models/evaluationResultsV2'
 import { events } from '../../schema/models/events'
 import { integrations } from '../../schema/models/integrations'
+import { projects } from '../../schema/models/projects'
 import { providerApiKeys } from '../../schema/models/providerApiKeys'
 import { spans } from '../../schema/models/spans'
 import { subscriptions } from '../../schema/models/subscriptions'
 import { workspaces } from '../../schema/models/workspaces'
 import type { Workspace } from '../../schema/models/types/Workspace'
 
+const DELETE_BATCH_SIZE = 5_000
+
 /**
  * Permanently destroys a workspace and all associated data.
  * This is a destructive operation that cannot be undone.
  *
- * The deletion order is forced by the foreign key graph and must not be
- * reordered casually:
+ * The deletion runs in two phases and is therefore NOT atomic: it is designed
+ * to be retried until it completes, and every step is idempotent.
+ *
+ * Phase 1 drains the unbounded-growth tables (logs, spans, results, events,
+ * dataset rows) in batches of `batchSize` rows, each batch in its own implicit
+ * transaction. A single-statement `DELETE ... WHERE workspace_id = ?` on these
+ * tables exceeds the pool's 30s `statement_timeout` for any sizable workspace
+ * (see `POOL_CONFIG` in `client/index.ts`), which is exactly how workspace
+ * deletion silently failed in production before this existed.
+ *
+ * Phase 2 removes the remaining bounded tables and the workspace row inside a
+ * single transaction, re-sweeping the phase 1 tables to catch rows written
+ * while phase 1 was running. The delete order is forced by the foreign key
+ * graph and must not be reordered casually:
  *
  * - `spans` and `provider_logs` reference `apiKeys`/`providerApiKeys` with
  *   `onDelete: 'restrict'`, so they must be deleted before those keys.
- * - `evaluation_results` (legacy v1) references `provider_logs` without a
- *   cascade and has no `workspaceId` of its own, so it must be deleted (scoped
- *   through its `evaluations`) before the provider logs.
+ * - `evaluation_results` (legacy v1) references `provider_logs` and
+ *   `document_logs` without a cascade and has no `workspaceId` of its own, so
+ *   it must be deleted (scoped through its `evaluations`) before them.
+ * - `provider_logs` and `document_logs` have a nullable `workspaceId`, so
+ *   legacy rows are additionally purged through their `providerApiKeys` and
+ *   `commits` references, which otherwise block those deletes with
+ *   `onDelete: 'restrict'`.
  * - `apiKeys`, `providerApiKeys`, `claimedRewards`, `integrations` and `events`
  *   reference `workspaces` without a cascade, so they must be deleted before
  *   the workspace row.
  * - `workspaces.currentSubscriptionId` references `subscriptions`, so the
  *   workspace must be deleted before its subscriptions.
  *
- * All other related tables (projects, memberships, document logs, evaluations,
- * etc.) are removed by database cascade delete constraints when the workspace
- * row is deleted.
+ * All other related tables (projects, memberships, evaluations, etc.) are
+ * removed by database cascade delete constraints when the workspace row is
+ * deleted. The phase 2 transaction raises its `statement_timeout` because that
+ * cascade is a single statement that can legitimately outlive the pool's 30s
+ * default.
  */
 export async function destroyWorkspace(
   workspace: Workspace,
   transaction = new Transaction(),
+  batchSize = DELETE_BATCH_SIZE,
 ) {
+  const workspaceId = workspace.id
+
+  const workspaceEvaluations = database
+    .select({ id: evaluations.id })
+    .from(evaluations)
+    .where(eq(evaluations.workspaceId, workspaceId))
+
+  await purgeInBatches(() =>
+    database
+      .delete(evaluationResults)
+      .where(
+        inArray(
+          evaluationResults.id,
+          database
+            .select({ id: evaluationResults.id })
+            .from(evaluationResults)
+            .where(
+              inArray(evaluationResults.evaluationId, workspaceEvaluations),
+            )
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(evaluationResultsV2)
+      .where(
+        inArray(
+          evaluationResultsV2.id,
+          database
+            .select({ id: evaluationResultsV2.id })
+            .from(evaluationResultsV2)
+            .where(eq(evaluationResultsV2.workspaceId, workspaceId))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(spans)
+      .where(
+        and(
+          eq(spans.workspaceId, workspaceId),
+          inArray(
+            spans.traceId,
+            database
+              .select({ traceId: spans.traceId })
+              .from(spans)
+              .where(eq(spans.workspaceId, workspaceId))
+              .limit(batchSize),
+          ),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(providerLogs)
+      .where(
+        inArray(
+          providerLogs.id,
+          database
+            .select({ id: providerLogs.id })
+            .from(providerLogs)
+            .where(eq(providerLogs.workspaceId, workspaceId))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  const workspaceProviderApiKeys = database
+    .select({ id: providerApiKeys.id })
+    .from(providerApiKeys)
+    .where(eq(providerApiKeys.workspaceId, workspaceId))
+
+  await purgeInBatches(() =>
+    database
+      .delete(providerLogs)
+      .where(
+        inArray(
+          providerLogs.id,
+          database
+            .select({ id: providerLogs.id })
+            .from(providerLogs)
+            .where(inArray(providerLogs.providerId, workspaceProviderApiKeys))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(documentLogs)
+      .where(
+        inArray(
+          documentLogs.id,
+          database
+            .select({ id: documentLogs.id })
+            .from(documentLogs)
+            .where(eq(documentLogs.workspaceId, workspaceId))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  const workspaceCommits = database
+    .select({ id: commits.id })
+    .from(commits)
+    .where(
+      inArray(
+        commits.projectId,
+        database
+          .select({ id: projects.id })
+          .from(projects)
+          .where(eq(projects.workspaceId, workspaceId)),
+      ),
+    )
+
+  await purgeInBatches(() =>
+    database
+      .delete(documentLogs)
+      .where(
+        inArray(
+          documentLogs.id,
+          database
+            .select({ id: documentLogs.id })
+            .from(documentLogs)
+            .where(inArray(documentLogs.commitId, workspaceCommits))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(datasetRows)
+      .where(
+        inArray(
+          datasetRows.id,
+          database
+            .select({ id: datasetRows.id })
+            .from(datasetRows)
+            .where(eq(datasetRows.workspaceId, workspaceId))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
+  await purgeInBatches(() =>
+    database
+      .delete(events)
+      .where(
+        inArray(
+          events.id,
+          database
+            .select({ id: events.id })
+            .from(events)
+            .where(eq(events.workspaceId, workspaceId))
+            .limit(batchSize),
+        ),
+      ),
+  )
+
   return transaction.call(async (tx) => {
-    const workspaceId = workspace.id
+    await tx.execute(sql`SET LOCAL statement_timeout = '5min'`)
 
     await tx
       .delete(evaluationResults)
@@ -86,4 +278,14 @@ export async function destroyWorkspace(
 
     return Result.ok(workspace)
   })
+}
+
+async function purgeInBatches(
+  runBatch: () => Promise<{ rowCount: number | null }>,
+) {
+  let deleted = 0
+  do {
+    const result = await runBatch()
+    deleted = result.rowCount ?? 0
+  } while (deleted > 0)
 }


### PR DESCRIPTION
Backoffice workspace deletion still never deletes the workspace. #3296 fixed the foreign key ordering and is deployed, but the deletion now dies further along: for any workspace with real traffic, the single-statement `DELETE FROM provider_logs WHERE workspace_id = $1` exceeds the 30-second `statement_timeout` our own pg pool sets (`POOL_CONFIG` in `packages/core/src/client/index.ts`), Postgres kills it, and the transaction rolls back. The failure is invisible because of the follow-up #3296 called out and deferred: the job returns the service `Result` without unwrapping it, so BullMQ records a completed job — no retry, no error tracking.

This is not a guess: the Datadog trace for today's deletion attempts of workspace 14242 shows `evaluation_results` deleted in 158ms, `spans` in 8.1s, then `provider_logs` cancelled at exactly 30,003ms with "canceling statement due to statement timeout", followed by a rollback and a job span with status ok.

## the fix

`destroyWorkspace` now runs in two phases and is no longer atomic — it is idempotent and designed to be retried until it completes:

- **Phase 1** drains the unbounded-growth tables (`evaluation_results`, `evaluation_results_v2`, `spans`, `provider_logs`, `document_logs`, `dataset_rows`, `events`) in batches of 5,000 rows, each batch its own implicit transaction, so no single statement approaches the 30s limit. Same approach as `cleanupWorkspaceOldLogsJob`. All batch subqueries run on indexed columns.
- **Phase 2** is the previous transactional delete, unchanged in order, now operating on near-empty big tables. It re-sweeps the phase 1 tables to catch rows written concurrently during phase 1, and raises its `statement_timeout` to 5 minutes with `SET LOCAL` because the final `DELETE FROM workspaces` cascade is one statement that can legitimately outlive the 30s default even after the big tables are drained.

`destroyWorkspaceJob` now unwraps the result and throws on failure, closing the #3296 follow-up. BullMQ retries it (3 attempts with backoff were already configured on enqueue, but never triggered because the job never threw), keeps the failed job for debugging, and the error becomes visible in APM instead of a green "completed".

## legacy rows without workspace_id

`provider_logs.workspace_id` and `document_logs.workspace_id` are nullable and old rows were never backfilled. Those rows are invisible to a workspace-scoped delete but still block the deletion: provider logs through `provider_api_keys`/`api_keys` (`onDelete: 'restrict'`) and document logs through the `commits` cascade (`onDelete: 'restrict'`). Phase 1 purges them through those references (provider logs via the workspace's provider keys, document logs via the workspace's commits). One shape is deliberately not pre-swept: provider logs with NULL workspace **and** NULL provider but an `api_key_id` set — `provider_logs.api_key_id` has no index, so a batched sweep on it would seq-scan per batch. If such rows exist, the deletion now fails loudly and we'll see it.

## how this was verified

The delete order was re-checked against the live FK graph, not the Drizzle files: all 279 migrations applied to a scratch database, then `pg_constraint` queried for every `RESTRICT`/`NO ACTION` edge into tables reachable from the workspace cascade and into the manually-deleted tables. Everything found is handled.

Tests cover an empty workspace, the #3296 scenario (spans, provider logs, events, legacy evaluation chain), data volumes larger than one batch (run with `batchSize: 2` to exercise the loop), and legacy NULL-`workspace_id` logs. Each new sweep was confirmed load-bearing by removing it and watching its test fail.

## out of scope

Workspace deletion only touches Postgres; spans backfilled to ClickHouse are never cleaned up. That predates this change and stays a follow-up.
