### PR TITLE
fix(spans): recover Vercel AI SDK v6 output when the GenAI compat layer shadows the Vercel parser

### DIFF
--- a/packages/domain/spans/src/otlp/content/genai.test.ts
+++ b/packages/domain/spans/src/otlp/content/genai.test.ts
@@ -547,4 +547,61 @@ describe("parseContent (GenAI current — gen_ai.{input,output}.messages)", () =
       expect((parts.find((p) => p.type === "text") as { content: string }).content).toBe("It is sunny.")
     })
   })
+
+  // Vercel AI SDK v6 emits gen_ai.input.messages (so this parser wins dispatch) but keeps the
+  // model's turn only in ai.response.* — no gen_ai.output.messages. Regression for output going
+  // blank while input still rendered.
+  describe("Vercel AI SDK v6 hybrid — gen_ai input + ai.response output", () => {
+    it("recovers output from ai.response.text when gen_ai.output.messages is absent", () => {
+      const result = parseContent([
+        str(
+          "gen_ai.input.messages",
+          JSON.stringify([{ role: "user", parts: [{ type: "text", content: "Summarize this lead." }] }]),
+        ),
+        str("ai.prompt.messages", JSON.stringify([{ role: "user", content: "Summarize this lead." }])),
+        str("ai.response.text", "Here is the summary."),
+      ])
+
+      expect(result.inputMessages).toEqual([
+        { role: "user", parts: [{ type: "text", content: "Summarize this lead." }] },
+      ])
+      expect(result.outputMessages).toEqual([
+        { role: "assistant", parts: [{ type: "text", content: "Here is the summary." }] },
+      ])
+    })
+
+    it("recovers tool-call output from ai.response.toolCalls when gen_ai.output.messages is absent", () => {
+      const result = parseContent([
+        str(
+          "gen_ai.input.messages",
+          JSON.stringify([{ role: "user", parts: [{ type: "text", content: "weather in SF?" }] }]),
+        ),
+        str(
+          "ai.response.toolCalls",
+          JSON.stringify([{ toolCallId: "call_1", toolName: "get_weather", input: { city: "SF" } }]),
+        ),
+      ])
+
+      const assistant = result.outputMessages.find((m) => m.role === "assistant")
+      expect(assistant).toBeDefined()
+      const parts = (assistant as { parts: { type: string; name?: string }[] }).parts
+      const toolCall = parts.find((p) => p.type === "tool_call")
+      expect((toolCall as { name: string }).name).toBe("get_weather")
+    })
+
+    it("prefers a content-bearing gen_ai.output.messages over the Vercel fallback", () => {
+      const result = parseContent([
+        str("gen_ai.input.messages", JSON.stringify([{ role: "user", parts: [{ type: "text", content: "hi" }] }])),
+        str(
+          "gen_ai.output.messages",
+          JSON.stringify([{ role: "assistant", parts: [{ type: "text", content: "canonical output" }] }]),
+        ),
+        str("ai.response.text", "stale vercel output"),
+      ])
+
+      expect(result.outputMessages).toEqual([
+        { role: "assistant", parts: [{ type: "text", content: "canonical output" }] },
+      ])
+    })
+  })
 })

--- a/packages/domain/spans/src/otlp/content/genai.ts
+++ b/packages/domain/spans/src/otlp/content/genai.ts
@@ -9,6 +9,7 @@ import type { OtlpAnyValue, OtlpKeyValue } from "../types.ts"
 import { parseGenAIDeprecated } from "./genai_deprecated.ts"
 import type { ParsedContent } from "./index.ts"
 import { toToolDefinition } from "./utils.ts"
+import { parseVercelOutput } from "./vercel.ts"
 
 function messagesHaveContent(messages: readonly GenAIMessage[]): boolean {
   return messages.some((m) => Array.isArray(m.parts) && m.parts.length > 0)
@@ -154,6 +155,14 @@ export function parseGenAICurrent(attrs: readonly OtlpKeyValue[]): ParsedContent
     if (toolDefinitions.length === 0 && deprecated.toolDefinitions.length > 0) {
       toolDefinitions = [...deprecated.toolDefinitions]
     }
+  }
+
+  // Vercel AI SDK v6's GenAI compat layer emits gen_ai.input.messages but keeps the
+  // model's turn only in ai.response.* (no gen_ai.output.messages). This parser wins
+  // dispatch on the input key, so recover the output from the Vercel attributes.
+  if (!messagesHaveContent(outputMessages)) {
+    const vercelOutput = parseVercelOutput(attrs)
+    if (vercelOutput.length > 0) outputMessages = [...vercelOutput]
   }
 
   // Reconcile inline role:"system" turns with any separated gen_ai.system_instructions into

--- a/packages/domain/spans/src/otlp/content/vercel.ts
+++ b/packages/domain/spans/src/otlp/content/vercel.ts
@@ -91,7 +91,7 @@ function parseInputFromCallLevel(attrs: readonly OtlpKeyValue[]): {
   return { messages: result.messages as GenAIMessage[], system: result.system ?? [] }
 }
 
-function parseOutput(attrs: readonly OtlpKeyValue[]): GenAIMessage[] {
+export function parseVercelOutput(attrs: readonly OtlpKeyValue[]): GenAIMessage[] {
   const text = rawStringAttr(attrs, "ai.response.text")
   const objectJson = rawStringAttr(attrs, "ai.response.object")
   const toolCallsJson = rawStringAttr(attrs, "ai.response.toolCalls")
@@ -140,7 +140,7 @@ export function parseVercel(attrs: readonly OtlpKeyValue[]): ParsedContent {
     }
   }
 
-  const outputMessages = parseOutput(attrs)
+  const outputMessages = parseVercelOutput(attrs)
   const toolDefinitions = parseToolDefinitions(attrs)
 
   return {

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -1160,3 +1160,84 @@ describe("Vercel AI SDK v7 — LegacyOpenTelemetry ai.* spans (v7 ModelMessage s
     expect(userParts.some((p) => p.type === "uri" || p.type === "blob" || p.type === "file")).toBe(true)
   })
 })
+
+// Recent Vercel AI SDK v6 builds emit a GenAI compat layer *alongside* the native ai.*
+// attributes: the turn's input arrives as gen_ai.input.messages but the model's reply stays
+// only in ai.response.text — there is NO gen_ai.output.messages. The gen_ai parser wins
+// dispatch on the input key, so before the fix input rendered while output went blank
+// (tokens/cost/model still resolved). This locks the end-to-end recovery of output from the
+// Vercel attributes.
+describe("Vercel AI SDK v6 hybrid — gen_ai.input.messages + ai.response.text (no gen_ai.output.messages)", () => {
+  const SYSTEM = "You are a helpful assistant. Be concise."
+  const USER = "Summarize the key points."
+  const ANSWER = "Here is a concise summary of the key points."
+
+  function buildHybridTrace(): OtlpExportTraceServiceRequest {
+    return {
+      resourceSpans: [
+        {
+          resource: { attributes: [str("service.name", SERVICE_NAME)] },
+          scopeSpans: [
+            {
+              scope: { name: "ai", version: "6.0.0" },
+              spans: [
+                {
+                  traceId: TRACE_ID,
+                  spanId: "ab11ab11ab11ab11",
+                  name: "generate_content claude-sonnet-4-6",
+                  kind: 1,
+                  startTimeUnixNano: "1710590600000000000",
+                  endTimeUnixNano: "1710590601000000000",
+                  attributes: [
+                    str("ai.operationId", "ai.generateText.doGenerate"),
+                    str("ai.model.provider", "anthropic.messages"),
+                    str("ai.model.id", "claude-sonnet-4-6"),
+                    int("ai.usage.promptTokens", 3026),
+                    int("ai.usage.completionTokens", 139),
+                    // Native Vercel input, also present as the GenAI compat attribute.
+                    str("ai.prompt.messages", JSON.stringify([{ role: "user", content: USER }])),
+                    str("gen_ai.system_instructions", JSON.stringify([{ type: "text", content: SYSTEM }])),
+                    str(
+                      "gen_ai.input.messages",
+                      JSON.stringify([{ role: "user", parts: [{ type: "text", content: USER }] }]),
+                    ),
+                    // Output lives ONLY here — no gen_ai.output.messages is emitted.
+                    str("ai.response.text", ANSWER),
+                    str("ai.response.finishReason", "stop"),
+                    str("ai.response.id", "msg_hybrid_001"),
+                  ],
+                  status: { code: 1 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  it("recovers assistant output from ai.response.text while keeping gen_ai input + usage", () => {
+    const { spans } = transformOtlpToSpans(buildHybridTrace(), CONTEXT)
+    const span = spans[0]
+    expect(span).toBeDefined()
+
+    // Envelope resolves regardless (this is why the trace looked populated but empty).
+    expect(span?.model).toBe("claude-sonnet-4-6")
+    expect(span?.provider).toBe("anthropic")
+    expect(span?.tokensInput).toBe(3026)
+    expect(span?.tokensOutput).toBe(139)
+
+    // Input parsed from gen_ai.input.messages.
+    const userMsg = span?.inputMessages.find((m) => m.role === "user")
+    expect(userMsg).toBeDefined()
+    expect((userMsg as { parts: { type: string; content?: string }[] }).parts[0]?.content).toBe(USER)
+    expect(span?.systemInstructions.some((p) => (p.content as string).includes("helpful assistant"))).toBe(true)
+
+    // Output recovered from ai.response.text (the fix).
+    expect(span?.outputMessages).toHaveLength(1)
+    const assistant = span?.outputMessages[0]
+    expect(assistant?.role).toBe("assistant")
+    const parts = (assistant as { parts: { type: string; content?: string }[] }).parts
+    expect((parts.find((p) => p.type === "text") as { content: string }).content).toBe(ANSWER)
+  })
+})


### PR DESCRIPTION
## Problem

Traces in some projects show a fully populated envelope — model badges, tokens, cost, duration, full span tree — but the **input/output message content isn't visible**, even though the data is correct upstream and renders in other tools (e.g. LangSmith).

Diagnosed by inspecting the raw stored span attributes in production ClickHouse. On the affected LLM spans:

| attribute | present? |
| --- | --- |
| `gen_ai.input.messages` | ✅ |
| `gen_ai.output.messages` | ❌ **absent** |
| `ai.response.text` | ✅ |
| `ai.prompt` / `ai.prompt.messages` | ✅ |

`input_messages` was populated but `output_messages` was **empty** on every LLM span — even though `ai.response.text` was present.

## Root cause

Recent **Vercel AI SDK v6** builds emit a GenAI SemConv compat layer *alongside* the native `ai.*` attributes. The asymmetry is the bug: input is emitted as `gen_ai.input.messages`, but the model's reply stays **only** in `ai.response.text` — no `gen_ai.output.messages` is produced.

Content-parser dispatch (`content/index.ts`) is **first-match-wins**, and the first parser claims any span carrying `gen_ai.input.messages`:

```ts
canHandle: (attrs) => hasKey(attrs, "gen_ai.input.messages") || hasKey(attrs, "gen_ai.output.messages"),
parse: parseGenAICurrent,
```

So these spans route to `parseGenAICurrent`, which parses input fine but reads output from `gen_ai.output.messages` (absent) with a fallback only to the deprecated `gen_ai.completion.*` (also absent). It never looks at `ai.response.text`. `parseVercel` — the one parser that *does* read `ai.response.text` — is shadowed and never runs.

The envelope (tokens/cost/model) resolves from a **separate** enrichment path (`resolveAttributes`), which is why the trace looks complete while output is blank.

## Upstream (Vercel)

This is an incomplete-semconv emission on Vercel's side, part of their ongoing GenAI-semconv alignment: **[vercel/ai#2590 — Make Vercel AI SDK tracing fully compatible with OTEL GenAI semantic conventions](https://github.com/vercel/ai/issues/2590)**.

Confirmed version boundary from testing:
- **`ai@6.0.197`** — has the bug (emits `gen_ai.input.messages`, output only in `ai.response.text`).
- **`ai@6.0.218`+** — fixed upstream: emits `gen_ai.output.messages`, which `parseGenAICurrent`'s primary path already handles.

We still want this ingestion fix because:
1. It **retroactively surfaces traces already ingested** from the `≤6.0.197` era — an SDK upgrade only helps new traces.
2. It makes us **robust to any customer** pinned to the affected v6 range, without requiring them to upgrade first.

Customers should also be advised to move `ai` to `≥6.0.218` for clean output at the source.

## Fix

`parseGenAICurrent` now falls back to the Vercel output extractor when `gen_ai.output.messages` yields no content — mirroring the existing deprecated split-attr fallback. A content-bearing `gen_ai.output.messages` still takes precedence.

- `content/vercel.ts` — export `parseVercelOutput` (was a private `parseOutput`).
- `content/genai.ts` — after the deprecated fallback, recover output via `parseVercelOutput` when output is still empty.

## Tests

- **`content/genai.test.ts`** — unit coverage for the hybrid dispatch: recovers `ai.response.text` and `ai.response.toolCalls` output when `gen_ai.output.messages` is absent, and confirms a real `gen_ai.output.messages` still wins over the Vercel fallback.
- **`tests/vercel.test.ts`** — end-to-end ingestion example (an `ai`-scope span with `gen_ai.input.messages` + `gen_ai.system_instructions` + `ai.response.text`, no `gen_ai.output.messages`): asserts input, system, usage, model **and** output all resolve through `transformOtlpToSpans`.

Full `@domain/spans` suite: **884 passing**. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)