### PR TITLE
fix(workflows): externalize quickjs-emscripten to stop bundling from breaking its WASM loader

### DIFF
--- a/apps/workflows/package.json
+++ b/apps/workflows/package.json
@@ -41,6 +41,7 @@
     "@temporalio/workflow": "catalog:",
     "@temporalio/worker": "catalog:",
     "effect": "catalog:",
+    "quickjs-emscripten": "catalog:",
     "tsx": "catalog:",
     "voyageai": "catalog:"
   },

--- a/apps/workflows/tsdown.config.ts
+++ b/apps/workflows/tsdown.config.ts
@@ -10,7 +10,14 @@ export default defineConfig({
   platform: "node",
   deps: {
     alwaysBundle: [/@(platform|domain|repo)\/.*/],
-    neverBundle: ["@temporalio/worker", "voyageai", /^@traceloop\//, /^@langchain\//, /^langchain($|\/)/],
+    neverBundle: [
+      "@temporalio/worker",
+      "voyageai",
+      "quickjs-emscripten",
+      /^@traceloop\//,
+      /^@langchain\//,
+      /^langchain($|\/)/,
+    ],
   },
   sourcemap: true,
   shims: true,

--- a/knip.json
+++ b/knip.json
@@ -42,6 +42,7 @@
       ],
       "ignoreDependencies": [
         "@temporalio/worker",
+        "quickjs-emscripten",
         "voyageai"
       ]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -923,6 +923,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.57
+      quickjs-emscripten:
+        specifier: 'catalog:'
+        version: 0.32.0
       tsx:
         specifier: 'catalog:'
         version: 4.21.0


### PR DESCRIPTION
## What does this PR do?

Fixes a production bundling bug in `apps/workflows`: `quickjs-emscripten` was never excluded from the app's tsdown CJS bundle, so its WASM glue (`@jitl/quickjs-wasmfile-release-sync`, which resolves its `.wasm` file via `require("url")` at runtime) broke once inlined into a bundled chunk, throwing `require is not a function`. This crashes `QuickJsScriptRuntimeLive` initialization, which the GEPA evaluation optimizer (`packages/platform/op-gepa`) and evaluation-alignment activities depend on to run sandboxed evaluation scripts.

**Datadog issue:** [`OptimizationProtocolError: QuickJS WASM initialization failed: require is not a function`](https://app.datadoghq.eu/error-tracking/issue/99555808-7570-11f1-ad28-da7ad0900005) (service `workflows`, `op-gepa`) — first seen 2026-07-01, still recurring daily as of this PR, breaking evaluation optimization runs that reach the QuickJS sandbox path.

**Root cause:** `apps/workflows` depends on `@platform/sandbox-quickjs`, which imports `quickjs-emscripten` internally. `apps/workflows/tsdown.config.ts`'s `neverBundle` list didn't include `quickjs-emscripten`, so tsdown inlined it (and its `emscripten-module.mjs` glue containing `require("url")`) into the bundle, where it doesn't resolve correctly. This is the exact same failure mode already fixed for `apps/web` in #3785 (`fix(web): externalize quickjs-emscripten so its WASM resolves at runtime`) — that fix only covered the Vite/Nitro SSR bundle, not `apps/workflows`'s separate tsdown bundle. `apps/workers` already has the correct configuration (`neverBundle: [..., "quickjs-emscripten", ...]` plus a direct `package.json` dependency), so `apps/workflows` was the one remaining app missing this treatment.

**Fix:** mirror the working `apps/workers` configuration in `apps/workflows`:
- Add `quickjs-emscripten` to `tsdown.config.ts`'s `neverBundle` list.
- Declare `quickjs-emscripten` as a direct dependency in `apps/workflows/package.json` (needed so `require("quickjs-emscripten")` resolves from `node_modules` at runtime once it's excluded from the bundle).
- Add `quickjs-emscripten` to `knip.json`'s `ignoreDependencies` for `apps/workflows` (it's only consumed transitively via `@platform/sandbox-quickjs`, so knip would otherwise flag the new direct dependency as unused).

## Related issue (if applicable)

Datadog Error Tracking issue: https://app.datadoghq.eu/error-tracking/issue/99555808-7570-11f1-ad28-da7ad0900005

## How was this tested?

This is a bundler-configuration bug, not reproducible with a standard Vitest unit test (Vitest runs against source, not the tsdown-bundled output). Verified by actually building and exercising the bundle:

1. **Reproduced before the fix:** built `apps/workflows` and confirmed the bundled `dist/server.cjs` inlined `@jitl/quickjs-wasmfile-release-sync`'s `emscripten-module.mjs`, including its `require("url")` call — the exact code path that throws `require is not a function` when it ends up inside a bundled chunk instead of loaded from `node_modules`.
2. **Verified after the fix:** rebuilt `apps/workflows` and confirmed:
   - No bundled chunk references `emscripten-module` or `@jitl/quickjs-*` anymore.
   - `dist/server.cjs` now does a plain `require("quickjs-emscripten")`.
   - Running that `require` and initializing a QuickJS context/runtime from within `apps/workflows`'s resolved `node_modules` succeeds and evaluates code correctly.
3. Ran the full `@app/workflows` and `@platform/sandbox-quickjs` test suites (87 tests) — all pass.
4. `pnpm --filter @app/workflows typecheck` and `pnpm --filter @platform/sandbox-quickjs typecheck` — clean.
5. `pnpm install --frozen-lockfile` — lockfile change is consistent and minimal (3 lines, just the new `quickjs-emscripten` entry for the `apps/workflows` importer).

**Post-deploy verification:** occurrences of Datadog issue `99555808-7570-11f1-ad28-da7ad0900005` should drop to zero after this deploys.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

---

🤖 Generated by an automated Datadog error-triage routine.

https://claude.ai/code/session_01KFNBWd9K6QJHyNjYnHLHuo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFNBWd9K6QJHyNjYnHLHuo)_