### PR TITLE
Remove columns and My signals controls from signals page

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
@@ -33,19 +33,6 @@ import { formatPercent, formatSeenAgeParts, getPrimaryLifecycleState } from "./s
 import { SignalLifecycleStatuses } from "./signal-lifecycle-statuses.tsx"
 import { SignalTrendBar } from "./signal-trend-bar.tsx"
 
-export const ISSUES_COLUMN_OPTIONS = [
-  { id: "issue", label: "Signal", required: true },
-  { id: "tags", label: "Tags" },
-  { id: "status", label: "Status" },
-  { id: "assignee", label: "Assignee" },
-  { id: "trend", label: "Trend" },
-  { id: "seenAt", label: "Seen at" },
-  { id: "occurrences", label: "Occurrences" },
-  { id: "affectedTraces", label: "Affected sessions" },
-] as const
-
-export type SignalsColumnId = (typeof ISSUES_COLUMN_OPTIONS)[number]["id"]
-
 function SeenAtCell({
   lastSeenAtIso,
   firstSeenAtIso,
@@ -151,7 +138,6 @@ export function SignalsView({
   sorting,
   occurrencesSum,
   priorityCounts,
-  visibleColumnIds,
   selection,
   onSortChange,
   projectSlug,
@@ -163,14 +149,13 @@ export function SignalsView({
   readonly sorting: SignalsTableSorting
   readonly occurrencesSum: number
   readonly priorityCounts: SignalsListResultRecord["priorityCounts"]
-  readonly visibleColumnIds: readonly SignalsColumnId[]
   readonly selection: InfiniteTableSelection
   readonly onSortChange: (sorting: SignalsTableSorting) => void
   readonly projectSlug: string
 }) {
   const memberByUserId = useMemberByUserIdMap()
 
-  const allColumns: readonly InfiniteTableColumn<SignalRecord>[] = [
+  const columns: InfiniteTableColumn<SignalRecord>[] = [
     {
       key: "issue",
       header: "Signal",
@@ -308,12 +293,6 @@ export function SignalsView({
       },
     },
   ]
-
-  const columnsById = new Map(allColumns.map((column) => [column.key, column]))
-  const columns = visibleColumnIds.flatMap((columnId) => {
-    const column = columnsById.get(columnId)
-    return column ? [column] : []
-  })
 
   return (
     <Layout.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
@@ -1,6 +1,5 @@
 import type { FilterSet } from "@domain/shared"
 import {
-  Badge,
   Button,
   CloseTrigger,
   DotIndicator,
@@ -51,7 +50,6 @@ function SignalsBreadcrumb() {
 import {
   ActivityIcon,
   ArchiveIcon,
-  CircleUserRoundIcon,
   DownloadIcon,
   PauseIcon,
   PlayIcon,
@@ -70,7 +68,6 @@ import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { EMPTY_SELECTION, type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
-import { useAuthenticatedUser } from "../../../-route-data.ts"
 import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { parseFilters } from "../-components/trace-page-state.ts"
@@ -155,7 +152,6 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sign
 
 function SignalsPage() {
   const project = useRouteProject()
-  const me = useAuthenticatedUser()
   const [lifecycleGroup, setLifecycleGroup] = useParamState("signalsLifecycle", "active", {
     validate: (value): value is "active" | "archived" => value === "active" || value === "archived",
   })
@@ -219,11 +215,6 @@ function SignalsPage() {
     (next: readonly string[]) => setAssigneesParam(serializeAssignees(next)),
     [setAssigneesParam],
   )
-  const isMySignalsActive = assigneeIds.length === 1 && assigneeIds[0] === me.id
-  const toggleMySignals = useCallback(
-    () => setAssigneeIds(isMySignalsActive ? [] : [me.id]),
-    [isMySignalsActive, me.id, setAssigneeIds],
-  )
 
   const {
     data: signalsData,
@@ -231,7 +222,6 @@ function SignalsPage() {
     analytics,
     occurrencesSum,
     priorityCounts,
-    mySignalsCount,
     totalCount,
     hasAnySignals,
     isLoading,
@@ -405,18 +395,6 @@ function SignalsPage() {
                 <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               </div>
               <AssigneeFilter value={assigneeIds} onChange={setAssigneeIds} />
-              <Button
-                variant={isMySignalsActive ? "secondary" : "outline"}
-                size="sm"
-                onClick={toggleMySignals}
-                aria-pressed={isMySignalsActive}
-              >
-                <Icon icon={CircleUserRoundIcon} size="sm" />
-                My signals
-                <Badge variant={isMySignalsActive ? "default" : "muted"} size="small">
-                  {mySignalsCount.toLocaleString()}
-                </Badge>
-              </Button>
               <Tabs
                 variant="bordered"
                 size="sm"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
@@ -71,9 +71,7 @@ import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { EMPTY_SELECTION, type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { useAuthenticatedUser } from "../../../-route-data.ts"
-import { ColumnsSelector } from "../-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
-import { useTableColumnSettings } from "../-components/table-column-settings.ts"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { parseFilters } from "../-components/trace-page-state.ts"
 import { useRouteProject } from "../-route-data.ts"
@@ -81,12 +79,7 @@ import { AssigneeFilter, UNASSIGNED_FILTER_TOKEN } from "./-components/assignee-
 import { SignalBuilderModal } from "./-components/builder/signal-builder-modal.tsx"
 import { SignalsAnalyticsPanel } from "./-components/signals-analytics-panel.tsx"
 import { SignalsEmptyState } from "./-components/signals-empty-state.tsx"
-import {
-  ISSUES_COLUMN_OPTIONS,
-  type SignalsColumnId,
-  type SignalsTableSorting,
-  SignalsView,
-} from "./-components/signals-view.tsx"
+import { type SignalsTableSorting, SignalsView } from "./-components/signals-view.tsx"
 
 const DEFAULT_SORTING: SignalsTableSorting = { column: "lastSeen", direction: "desc" }
 const SIGNAL_SEARCH_DEBOUNCE_MS = 300
@@ -212,10 +205,6 @@ function SignalsPage() {
     [searchInput, searchQuery, setSearchQuery],
   )
 
-  const columnSettings = useTableColumnSettings<SignalsColumnId>({
-    storageKey: "projects.issues.columns.v1",
-    columns: ISSUES_COLUMN_OPTIONS,
-  })
   const timeRange = useMemo(() => {
     const toMs = timeTo ? Date.parse(timeTo) : Date.now()
     const fromMs = timeFrom ? Date.parse(timeFrom) : toMs - DEFAULT_SIGNALS_RANGE_SECONDS * 1000
@@ -405,12 +394,6 @@ function SignalsPage() {
               />
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
-              <ColumnsSelector
-                columns={columnSettings.columns}
-                selectedColumnIds={columnSettings.visibleColumnIds}
-                onChange={(nextColumnIds) => columnSettings.setVisibleColumnIds(nextColumnIds as SignalsColumnId[])}
-                onOrderChange={(nextColumnIds) => columnSettings.setColumnIds(nextColumnIds as SignalsColumnId[])}
-              />
               <div className="relative">
                 <Input
                   value={searchInput}
@@ -491,7 +474,6 @@ function SignalsPage() {
           sorting={sorting}
           occurrencesSum={occurrencesSum}
           priorityCounts={priorityCounts}
-          visibleColumnIds={columnSettings.visibleColumnIds}
           selection={selection}
           onSortChange={setSorting}
           projectSlug={project.slug}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
@@ -47,15 +47,7 @@ function SignalsBreadcrumb() {
   )
 }
 
-import {
-  ActivityIcon,
-  ArchiveIcon,
-  DownloadIcon,
-  PauseIcon,
-  PlayIcon,
-  PlusIcon,
-  SearchIcon,
-} from "lucide-react"
+import { ActivityIcon, ArchiveIcon, DownloadIcon, PauseIcon, PlayIcon, PlusIcon, SearchIcon } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { invalidateSignalQueries, useSignals } from "../../../../../domains/signals/signals.collection.ts"
 import {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the Columns and My signals buttons from the project signals list page.

The signals table now always renders the full default column set (Signal, Tags, Status, Assignee, Trend, Seen at, Occurrences, Affected sessions). Column visibility and reordering via local storage are no longer exposed in the UI.

The My signals quick-filter toggle and count badge are also removed. Assignee filtering is still available through the assignee dropdown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a71bbae-705a-4b31-bfba-b3db64808c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a71bbae-705a-4b31-bfba-b3db64808c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

