### PR TITLE
feat(web): central mutation error handling (showcase G1)

### DIFF
--- a/apps/web/src/domains/api-keys/api-keys.collection.ts
+++ b/apps/web/src/domains/api-keys/api-keys.collection.ts
@@ -1,12 +1,13 @@
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import type { ApiKeyRecord } from "./api-keys.functions.ts"
 import { createApiKey, deleteApiKey, listApiKeys, updateApiKey } from "./api-keys.functions.ts"
 
 const queryClient = getQueryClient()
 
-const apiKeysCollection = createCollection(
+const apiKeysCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: ["apiKeys"],

--- a/apps/web/src/domains/flaggers/flaggers.collection.ts
+++ b/apps/web/src/domains/flaggers/flaggers.collection.ts
@@ -1,6 +1,7 @@
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import type { Context, QueryBuilder, SchemaFromSource } from "@tanstack/react-db"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { type FlaggerRecord, listFlaggersByProject, updateFlagger } from "./flaggers.functions.ts"
 
@@ -8,7 +9,7 @@ const queryClient = getQueryClient()
 const flaggersQueryKey = (projectId: string) => ["flaggers", projectId] as const
 
 const makeProjectFlaggersCollection = (projectId: string) =>
-  createCollection(
+  createAppCollection(
     queryCollectionOptions({
       queryClient,
       queryKey: flaggersQueryKey(projectId),

--- a/apps/web/src/domains/members/members.collection.ts
+++ b/apps/web/src/domains/members/members.collection.ts
@@ -1,6 +1,7 @@
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
-import { createCollection, createOptimisticAction, useLiveQuery } from "@tanstack/react-db"
+import { createOptimisticAction, useLiveQuery } from "@tanstack/react-db"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import type { MemberRecord } from "./members.functions.ts"
 import {
@@ -20,7 +21,7 @@ const MEMBERS_QUERY_KEY = ["members"] as const
 
 const EMPTY_MEMBER_BY_USER_ID_MAP: ReadonlyMap<string, MemberRecord> = new Map()
 
-const membersCollection = createCollection(
+const membersCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: MEMBERS_QUERY_KEY,

--- a/apps/web/src/domains/oauth/oauth-keys.collection.ts
+++ b/apps/web/src/domains/oauth/oauth-keys.collection.ts
@@ -1,11 +1,12 @@
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { listOAuthKeys, type OAuthKeyRecord, revokeOAuthKey } from "./oauth-keys.functions.ts"
 
 const queryClient = getQueryClient()
 
-const oauthKeysCollection = createCollection(
+const oauthKeysCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: ["oauthKeys"],

--- a/apps/web/src/domains/organizations/organizations.collection.ts
+++ b/apps/web/src/domains/organizations/organizations.collection.ts
@@ -1,13 +1,14 @@
 import type { Organization } from "@domain/organizations"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import type { Context, QueryBuilder, SchemaFromSource } from "@tanstack/react-db"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { listOrganizations, updateOrganization } from "./organizations.functions.ts"
 
 const queryClient = getQueryClient()
 
-const organizationsCollection = createCollection(
+const organizationsCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: ["organizations"],

--- a/apps/web/src/domains/projects/projects.collection.ts
+++ b/apps/web/src/domains/projects/projects.collection.ts
@@ -1,14 +1,15 @@
 import { generateId, OrganizationId, ProjectId } from "@domain/shared"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import type { Context, QueryBuilder, SchemaFromSource } from "@tanstack/react-db"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import type { ProjectRecord } from "./projects.functions.ts"
 import { createProject, deleteProject, listProjects, updateProject } from "./projects.functions.ts"
 
 const queryClient = getQueryClient()
 
-const projectsCollection = createCollection(
+const projectsCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: ["projects"],

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -2,10 +2,11 @@ import { SpanId } from "@domain/shared"
 import type { SpanMessagesData } from "@domain/spans"
 import { buildConversationSpanMaps } from "@domain/spans"
 import { queryCollectionOptions } from "@tanstack/query-db-collection"
-import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
 import { use } from "react"
 import type { GenAIMessage } from "rosetta-ai"
+import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import { TraceScopeContext } from "../traces/trace-scope.tsx"
 import {
@@ -28,7 +29,7 @@ const makeSpansByTraceCollection = (
   startTimeTo: string | undefined,
   sandboxOrgId: string | undefined,
 ) =>
-  createCollection(
+  createAppCollection(
     queryCollectionOptions({
       queryClient,
       queryKey: ["spans", "trace", sandboxOrgId, projectId, traceId, startTimeFrom, startTimeTo],
@@ -89,7 +90,7 @@ const makeSpansBySessionCollection = (
   startTimeTo: string | undefined,
   sandboxOrgId: string | undefined,
 ) =>
-  createCollection(
+  createAppCollection(
     queryCollectionOptions({
       queryClient,
       queryKey: ["spans", "session", sandboxOrgId, projectId, sessionId, startTimeFrom, startTimeTo],

--- a/apps/web/src/lib/data/create-app-collection.test.ts
+++ b/apps/web/src/lib/data/create-app-collection.test.ts
@@ -1,0 +1,120 @@
+import type { Collection } from "@tanstack/react-db"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+type TransactionReturningKeys = {
+  [K in keyof Collection]-?: NonNullable<Collection[K]> extends (...args: never[]) => infer R
+    ? R extends { isPersisted: unknown }
+      ? K
+      : never
+    : never
+}[keyof Collection] &
+  string
+
+type Exhaustive<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+const handleMutationErrorMock = vi.hoisted(() => vi.fn())
+vi.mock("./handle-mutation-error.ts", () => ({ handleMutationError: handleMutationErrorMock }))
+
+const dbState = vi.hoisted(() => ({
+  collection: null as Record<string, unknown> | null,
+  activeTransaction: undefined as unknown,
+}))
+vi.mock("@tanstack/react-db", () => ({
+  createCollection: () => dbState.collection,
+  getActiveTransaction: () => dbState.activeTransaction,
+}))
+
+import { createAppCollection, type MUTATOR_METHODS } from "./create-app-collection.ts"
+
+type Tx = { isPersisted: { promise: Promise<unknown> }; readonly id: string }
+
+const makeTransaction = (): { tx: Tx; reject: (error: unknown) => void } => {
+  let reject!: (error: unknown) => void
+  const promise = new Promise<unknown>((_resolve, rejectFn) => {
+    reject = rejectFn
+  })
+  return { tx: { id: "tx-1", isPersisted: { promise } }, reject }
+}
+
+const build = (methods: Record<string, () => Tx>) => {
+  dbState.collection = methods
+  return (createAppCollection as unknown as (options: unknown) => Record<string, (...args: unknown[]) => Tx>)({})
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("createAppCollection", () => {
+  beforeEach(() => {
+    handleMutationErrorMock.mockClear()
+    dbState.activeTransaction = undefined
+  })
+
+  it("routes an un-awaited transaction rejection to handleMutationError", async () => {
+    const { tx, reject } = makeTransaction()
+    const collection = build({ insert: () => tx })
+
+    collection.insert({})
+    reject(new Error("persist failed"))
+    await flush()
+
+    expect(handleMutationErrorMock).toHaveBeenCalledTimes(1)
+    expect(handleMutationErrorMock).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it("does not route when the caller observes the transaction (reads isPersisted)", async () => {
+    const { tx, reject } = makeTransaction()
+    const collection = build({ update: () => tx })
+
+    const returned = collection.update("id")
+    const observed = returned.isPersisted.promise.catch(() => {})
+    reject(new Error("persist failed"))
+    await observed
+    await flush()
+
+    expect(handleMutationErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("skips mutations that join an ambient transaction and returns it untouched", async () => {
+    const { tx, reject } = makeTransaction()
+    tx.isPersisted.promise.catch(() => {})
+    dbState.activeTransaction = { id: "ambient" }
+    const collection = build({ delete: () => tx })
+
+    const returned = collection.delete("id")
+    expect(returned).toBe(tx)
+
+    reject(new Error("persist failed"))
+    await flush()
+
+    expect(handleMutationErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("forwards the transaction so its own fields remain reachable through the proxy", () => {
+    const { tx } = makeTransaction()
+    tx.isPersisted.promise.catch(() => {})
+    const collection = build({ insert: () => tx })
+
+    const returned = collection.insert({})
+    expect(returned.id).toBe("tx-1")
+  })
+
+  it("calls the original mutator with the collection as receiver (preserves `this`)", () => {
+    const { tx } = makeTransaction()
+    tx.isPersisted.promise.catch(() => {})
+    let receiver: unknown
+    const collection = build({
+      insert(this: unknown) {
+        receiver = this
+        return tx
+      },
+    })
+
+    collection.insert({})
+    expect(receiver).toBe(collection)
+  })
+
+  it("MUTATOR_METHODS covers every transaction-returning collection method", () => {
+    const exhaustive: Exhaustive<(typeof MUTATOR_METHODS)[number], TransactionReturningKeys> = true
+    expect(exhaustive).toBe(true)
+  })
+})

--- a/apps/web/src/lib/data/create-app-collection.ts
+++ b/apps/web/src/lib/data/create-app-collection.ts
@@ -1,0 +1,60 @@
+import { createCollection, getActiveTransaction } from "@tanstack/react-db"
+import { handleMutationError } from "./handle-mutation-error.ts"
+
+/** The slice of a TanStack DB transaction the error routing relies on. */
+interface MutationTransaction {
+  readonly isPersisted: { readonly promise: Promise<unknown> }
+}
+
+export const MUTATOR_METHODS = ["insert", "update", "delete"] as const
+
+/**
+ * Wraps a collection mutation transaction so an un-awaited persistence failure
+ * routes to {@link handleMutationError} instead of becoming an unhandled promise
+ * rejection. Stays out of the way when the caller observes the transaction
+ * itself: reading `.isPersisted` marks the error as caller-owned (forms via
+ * `createFormSubmitHandler`, modals awaiting `tx.isPersisted.promise`), so the
+ * central handler never double-toasts what the caller already surfaces.
+ */
+function routeTransactionErrors<T extends MutationTransaction>(tx: T): T {
+  let ownedByCaller = false
+
+  void tx.isPersisted.promise.catch((error: unknown) => {
+    if (!ownedByCaller) handleMutationError(error)
+  })
+
+  return new Proxy(tx, {
+    get(target, prop, receiver) {
+      if (prop === "isPersisted") ownedByCaller = true
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
+
+/**
+ * `createCollection` with central mutation error handling wired in. Behaves
+ * exactly like `createCollection`, but decorates `insert`/`update`/`delete` so
+ * each transaction's rejection reaches {@link handleMutationError} — closing the
+ * unhandled-rejection gap TanStack DB leaves (`@tanstack/db` exposes no
+ * global/collection `onError`; mutation errors surface only via
+ * `tx.isPersisted.promise`). Mutations that join an ambient transaction (e.g. a
+ * `createOptimisticAction` `onMutate`) are left untouched — the ambient
+ * transaction's owner handles its errors.
+ */
+export const createAppCollection = ((options: unknown) => {
+  const collection = (createCollection as unknown as (o: unknown) => Record<string, unknown>)(options)
+
+  for (const method of MUTATOR_METHODS) {
+    const original = collection[method]
+    if (typeof original !== "function") continue
+
+    const mutate = original as (...args: unknown[]) => unknown
+    collection[method] = (...args: unknown[]) => {
+      const transaction = Reflect.apply(mutate, collection, args)
+      if (getActiveTransaction()) return transaction
+      return routeTransactionErrors(transaction as MutationTransaction)
+    }
+  }
+
+  return collection
+}) as unknown as typeof createCollection

--- a/apps/web/src/lib/data/handle-mutation-error.test.ts
+++ b/apps/web/src/lib/data/handle-mutation-error.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const toastMock = vi.hoisted(() => vi.fn())
+vi.mock("@repo/ui", () => ({ toast: toastMock }))
+
+import { handleMutationError, READ_ONLY_PROJECT_ERROR_TAG } from "./handle-mutation-error.ts"
+
+const serverError = (payload: { _tag?: string; message: string; status?: number }) =>
+  new Error(JSON.stringify({ status: 500, ...payload }))
+
+describe("handleMutationError", () => {
+  beforeEach(() => toastMock.mockClear())
+
+  it("toasts the decoded message for a generic server error", () => {
+    handleMutationError(serverError({ message: "Something broke" }))
+
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    expect(toastMock).toHaveBeenCalledWith({ variant: "destructive", description: "Something broke" })
+  })
+
+  it("toasts the raw message for a plain (non-JSON) error", () => {
+    handleMutationError(new Error("plain failure"))
+
+    expect(toastMock).toHaveBeenCalledWith({ variant: "destructive", description: "plain failure" })
+  })
+
+  it("does not toast when generic toasting is opted out (useMutation path default)", () => {
+    handleMutationError(serverError({ message: "handled elsewhere" }), { toastGenericError: false })
+
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it("stays dormant for a ReadOnlyProjectError — no toast today", () => {
+    handleMutationError(serverError({ _tag: READ_ONLY_PROJECT_ERROR_TAG, message: "read only", status: 403 }))
+
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps the ReadOnlyProjectError branch dormant even when generic toasting is requested", () => {
+    handleMutationError(serverError({ _tag: READ_ONLY_PROJECT_ERROR_TAG, message: "read only", status: 403 }), {
+      toastGenericError: true,
+    })
+
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/data/handle-mutation-error.ts
+++ b/apps/web/src/lib/data/handle-mutation-error.ts
@@ -1,0 +1,51 @@
+import { toast } from "@repo/ui"
+import { parseServerError } from "../errors.ts"
+
+/**
+ * `_tag` of the server-side error the showcase read-only write-gate will throw
+ * (Phase 2). Matched here so the future "read-only showcase" modal branch can be
+ * lit up without re-touching this file. No code throws it today — the write-gate
+ * is unwired and scope defaults to live — so the branch below is dormant.
+ */
+export const READ_ONLY_PROJECT_ERROR_TAG = "ReadOnlyProjectError"
+
+interface HandleMutationErrorOptions {
+  /**
+   * Whether an otherwise-unhandled generic error should surface as a toast.
+   * The collection safety net (see `createAppCollection`) only reaches here for
+   * errors no caller observed, so it defaults to `true`. The `useMutation` path
+   * (`MutationCache.onError`) passes `false` unless a mutation opts in, because
+   * its callers already surface their own errors (`mutateAsync` + catch, per-call
+   * `onError`, form handlers) and a global toast would double-handle them.
+   */
+  readonly toastGenericError?: boolean
+}
+
+/**
+ * Single sink for mutation errors from both mutation styles: TanStack Query
+ * `useMutation` (via `MutationCache.onError`) and TanStack DB collections (via
+ * `createAppCollection`). TanStack DB has no global/collection `onError`, so
+ * collection errors otherwise surface only through `tx.isPersisted.promise` and
+ * an un-awaited one becomes an unhandled promise rejection — routing both paths
+ * here closes that gap. Owns only otherwise-unhandled errors: callers that catch
+ * an error themselves opt out at their layer, so this never double-toasts them.
+ */
+export function handleMutationError(error: unknown, options: HandleMutationErrorOptions = {}): void {
+  const { toastGenericError = true } = options
+  const parsed = parseServerError(error)
+
+  if (parsed._tag === READ_ONLY_PROJECT_ERROR_TAG) {
+    // DORMANT (showcase Phase 2): open the "read-only showcase — create your own
+    // project" modal and route to /projects. Dispatch a CustomEvent here (keep
+    // this file .ts) — a provider mounted at the app root listens, holds the open
+    // state locally, and renders the modal; this function runs outside React
+    // (MutationCache.onError / a promise .catch) so it can't render JSX itself.
+    // The write-gate that throws this never fires today, so this is a no-op now.
+    // See spec 'Read-only enforcement' layer 3 + D13.
+    return
+  }
+
+  if (toastGenericError) {
+    toast({ variant: "destructive", description: parsed.message })
+  }
+}

--- a/apps/web/src/lib/data/query-client.tsx
+++ b/apps/web/src/lib/data/query-client.tsx
@@ -1,8 +1,16 @@
-import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { isServer, MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
+import { handleMutationError } from "./handle-mutation-error.ts"
 
 const makeQueryClient = () =>
   new QueryClient({
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        // opt-in: most callers already surface errors (mutateAsync+catch, form handlers)
+        const meta = mutation.options.meta as Record<string, unknown> | undefined
+        handleMutationError(error, { toastGenericError: meta?.globalErrorToast === true })
+      },
+    }),
     defaultOptions: {
       queries: {
         staleTime: 30_000,

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -118,7 +118,7 @@ export function ProjectBreadcrumbSegment() {
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
           />
-          <ComboboxList>{(item: ProjectOption) => <ProjectOptionRow item={item} />}</ComboboxList>
+          <ComboboxList>{(item: ProjectOption) => <ProjectOptionRow key={item.key} item={item} />}</ComboboxList>
           <ComboboxEmpty>No projects found.</ComboboxEmpty>
         </ComboboxContent>
       </Combobox>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-drawer-evaluations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signal-drawer-evaluations.tsx
@@ -381,7 +381,10 @@ export function SignalDrawerEvaluations({
       await deleteSignal.mutateAsync(signalId)
       toast({ description: "Signal deleted." })
       setDeleteSignalOpen(false)
-      void navigate({ to: "/projects/$projectSlug/signals", params: { projectSlug: projectSlug ?? "" } })
+      void navigate({
+        to: "/projects/$projectSlug/signals",
+        params: { projectSlug: projectSlug ?? "" },
+      })
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
       setIsDeleting(false)
@@ -521,120 +524,116 @@ export function SignalDrawerEvaluations({
     <>
       <div className="flex w-full flex-col gap-2 px-1 pt-2">
         {primaryEvaluation ? (
-          <>
-            <div className="flex flex-row flex-wrap items-end gap-8">
-              <SummaryField
-                label="Alignment"
-                value={
-                  primaryEvaluation.alignment ? (
-                    <Tooltip
-                      asChild
-                      trigger={
-                        <span className="inline-flex">
-                          <Status
-                            variant={getAlignmentVariant(primaryEvaluation.alignment.metrics.alignmentMetric)}
-                            label={formatPercent(primaryEvaluation.alignment.metrics.alignmentMetric)}
-                          />
-                        </span>
-                      }
-                    >
-                      <AlignmentTooltipContent
-                        evaluation={primaryEvaluation}
-                        onOpenStats={() => setStatsEvaluation(primaryEvaluation)}
-                      />
-                    </Tooltip>
-                  ) : (
-                    <Text.H6 color="foregroundMuted">Not aligned</Text.H6>
-                  )
-                }
-              />
-              <SummaryField
-                label="Sampling"
-                value={
-                  // User signals edit sampling in the builder, so the detail page shows it read-only;
-                  // system signals (no builder) keep the inline click-to-change control.
-                  isUserOriginEvaluation ? (
-                    <Text.H5 color="foreground">{formatPercent(primaryEvaluation.trigger.sampling / 100)}</Text.H5>
-                  ) : (
-                    <Tooltip
-                      asChild
-                      trigger={
-                        <button
-                          type="button"
-                          onClick={() => setSamplingEvaluation(primaryEvaluation)}
-                          disabled={isActionPending}
-                          className="inline-flex h-5 cursor-pointer items-center gap-1 bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                          <Text.H5 color="foreground">
-                            {formatPercent(primaryEvaluation.trigger.sampling / 100)}
-                          </Text.H5>
-                          <Icon icon={PencilIcon} size="xs" color="foregroundMuted" />
-                        </button>
-                      }
-                    >
-                      <Text.H6 color="foregroundMuted">
-                        Click to change. We evaluate this signal on{" "}
-                        {formatPercent(primaryEvaluation.trigger.sampling / 100)} of the incoming traces.
-                      </Text.H6>
-                    </Tooltip>
-                  )
-                }
-              />
-              {!isUserOriginEvaluation ? (
-                <div className="flex min-w-0 flex-1 items-end justify-end gap-x-1">
+          <div className="flex flex-row flex-wrap items-end gap-8">
+            <SummaryField
+              label="Alignment"
+              value={
+                primaryEvaluation.alignment ? (
                   <Tooltip
                     asChild
                     trigger={
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-foreground group-hover:text-secondary-foreground/80"
-                        onClick={() => setDeleteEvaluationId(primaryEvaluation.id)}
-                        disabled={isActionPending}
-                        aria-label="Remove evaluation"
-                      >
-                        <Icon icon={XIcon} size="sm" />
-                      </Button>
+                      <span className="inline-flex">
+                        <Status
+                          variant={getAlignmentVariant(primaryEvaluation.alignment.metrics.alignmentMetric)}
+                          label={formatPercent(primaryEvaluation.alignment.metrics.alignmentMetric)}
+                        />
+                      </span>
                     }
                   >
-                    <Text.H6 color="foregroundMuted">Remove evaluation</Text.H6>
+                    <AlignmentTooltipContent
+                      evaluation={primaryEvaluation}
+                      onOpenStats={() => setStatsEvaluation(primaryEvaluation)}
+                    />
                   </Tooltip>
-                  <Button
-                    variant="outline"
-                    onClick={() => setRealignEvaluationId(primaryEvaluation.id)}
-                    disabled={isActionPending}
-                    isLoading={isPrimaryEvaluationRealigning}
-                  >
-                    <Icon icon={RotateCwIcon} size="sm" />
-                    {isPrimaryEvaluationRealigning ? "Realigning" : "Realign"}
-                  </Button>
-                </div>
-              ) : editableDetector !== null ? (
-                <div className="flex min-w-0 flex-1 items-end justify-end gap-x-1">
+                ) : (
+                  <Text.H6 color="foregroundMuted">Not aligned</Text.H6>
+                )
+              }
+            />
+            <SummaryField
+              label="Sampling"
+              value={
+                // User signals edit sampling in the builder, so the detail page shows it read-only;
+                // system signals (no builder) keep the inline click-to-change control.
+                isUserOriginEvaluation ? (
+                  <Text.H5 color="foreground">{formatPercent(primaryEvaluation.trigger.sampling / 100)}</Text.H5>
+                ) : (
                   <Tooltip
                     asChild
                     trigger={
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setDeleteSignalOpen(true)}
+                      <button
+                        type="button"
+                        onClick={() => setSamplingEvaluation(primaryEvaluation)}
                         disabled={isActionPending}
-                        aria-label="Delete signal"
+                        className="inline-flex h-5 cursor-pointer items-center gap-1 bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        <Icon icon={Trash2Icon} size="sm" />
-                      </Button>
+                        <Text.H5 color="foreground">{formatPercent(primaryEvaluation.trigger.sampling / 100)}</Text.H5>
+                        <Icon icon={PencilIcon} size="xs" color="foregroundMuted" />
+                      </button>
                     }
                   >
-                    <Text.H6 color="foregroundMuted">Delete signal</Text.H6>
+                    <Text.H6 color="foregroundMuted">
+                      Click to change. We evaluate this signal on{" "}
+                      {formatPercent(primaryEvaluation.trigger.sampling / 100)} of the incoming traces.
+                    </Text.H6>
                   </Tooltip>
-                  <Button variant="outline" onClick={() => setBuilderOpen(true)} disabled={isActionPending}>
-                    <Icon icon={PencilIcon} size="sm" />
-                    Edit
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          </>
+                )
+              }
+            />
+            {!isUserOriginEvaluation ? (
+              <div className="flex min-w-0 flex-1 items-end justify-end gap-x-1">
+                <Tooltip
+                  asChild
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-foreground group-hover:text-secondary-foreground/80"
+                      onClick={() => setDeleteEvaluationId(primaryEvaluation.id)}
+                      disabled={isActionPending}
+                      aria-label="Remove evaluation"
+                    >
+                      <Icon icon={XIcon} size="sm" />
+                    </Button>
+                  }
+                >
+                  <Text.H6 color="foregroundMuted">Remove evaluation</Text.H6>
+                </Tooltip>
+                <Button
+                  variant="outline"
+                  onClick={() => setRealignEvaluationId(primaryEvaluation.id)}
+                  disabled={isActionPending}
+                  isLoading={isPrimaryEvaluationRealigning}
+                >
+                  <Icon icon={RotateCwIcon} size="sm" />
+                  {isPrimaryEvaluationRealigning ? "Realigning" : "Realign"}
+                </Button>
+              </div>
+            ) : editableDetector !== null ? (
+              <div className="flex min-w-0 flex-1 items-end justify-end gap-x-1">
+                <Tooltip
+                  asChild
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setDeleteSignalOpen(true)}
+                      disabled={isActionPending}
+                      aria-label="Delete signal"
+                    >
+                      <Icon icon={Trash2Icon} size="sm" />
+                    </Button>
+                  }
+                >
+                  <Text.H6 color="foregroundMuted">Delete signal</Text.H6>
+                </Tooltip>
+                <Button variant="outline" onClick={() => setBuilderOpen(true)} disabled={isActionPending}>
+                  <Icon icon={PencilIcon} size="sm" />
+                  Edit
+                </Button>
+              </div>
+            ) : null}
+          </div>
         ) : null}
         {hiddenEvaluationCount > 0 ? (
           <Text.H6 className="self-center text-center" color="foregroundMuted">

--- a/biome.json
+++ b/biome.json
@@ -66,6 +66,39 @@
                     ],
                     "message": "Do not import test utilities in production code. Expose them via a /testing subpath export instead."
                   }
+                ],
+                "paths": {
+                  "@tanstack/react-db": {
+                    "importNames": ["createCollection"],
+                    "message": "Use createAppCollection from apps/web/src/lib/data/create-app-collection.ts — it routes mutation errors into handleMutationError. Raw createCollection leaks unhandled rejections."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["apps/web/src/lib/data/create-app-collection.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": [
+                      "./test/*",
+                      "./testing/*",
+                      "../test/*",
+                      "../testing/*",
+                      "../../test/*",
+                      "../../testing/*"
+                    ],
+                    "message": "Do not import test utilities in production code. Expose them via a /testing subpath export instead."
+                  }
                 ]
               }
             }

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -286,9 +286,11 @@ describe("SpanRepository", () => {
       // Equal start_time → span_id DESC tiebreaker gives a total order.
       const page1 = await runCh(repo.listByProjectId({ ...base, options: opts }))
       expect(page1.items.map((span) => span.name)).toEqual(["third", "second"])
-      expect(page1.nextCursor).not.toBeNull()
+      const cursor = page1.nextCursor
+      expect(cursor).not.toBeNull()
+      if (cursor === null) return
 
-      const page2 = await runCh(repo.listByProjectId({ ...base, options: { ...opts, cursor: page1.nextCursor! } }))
+      const page2 = await runCh(repo.listByProjectId({ ...base, options: { ...opts, cursor } }))
       expect(page2.items.map((span) => span.name)).toEqual(["first"])
       expect(page2.nextCursor).toBeNull()
     })
@@ -328,8 +330,11 @@ describe("SpanRepository", () => {
 
       const page1 = await runCh(repo.listByProjectId({ ...base, options: opts }))
       expect(page1.items.map((span) => span.name)).toEqual(["d3", "d2"])
+      const cursor = page1.nextCursor
+      expect(cursor).not.toBeNull()
+      if (cursor === null) return
 
-      const page2 = await runCh(repo.listByProjectId({ ...base, options: { ...opts, cursor: page1.nextCursor! } }))
+      const page2 = await runCh(repo.listByProjectId({ ...base, options: { ...opts, cursor } }))
       expect(page2.items.map((span) => span.name)).toEqual(["d1"])
     })
   })


### PR DESCRIPTION
## Task G1 — Central mutation error handling

Part of the **Showcase Demo Project** (umbrella spec PR #3821, `specs/showcase-demo-project.md`, task **G1**). See spec *Read-only enforcement* layer 3 + **D13**.

**Behavior-neutral groundwork.** No user-visible change today: the showcase write-gate never fires, scope defaults to live, and the `ReadOnlyProjectError` branch is dormant. Happy paths are unchanged, and every current mutation call site already awaits/handles its own errors, so no new toasts fire.

### What this does
Introduces one `handleMutationError(error)` and routes **both** mutation styles into it, closing a **latent unhandled-rejection bug** in the TanStack DB collection path (a genuine improvement, still behavior-neutral for happy paths).

- **`useMutation` path** — adds `MutationCache({ onError })` to the single `QueryClient` factory (`query-client.tsx`, none before). Generic toasts are **opt-in per mutation** (`meta.globalErrorToast`) because today's callers already surface their own errors (`mutateAsync` + catch, per-call `onError`, `createFormSubmitHandler`) — a blanket global toast would double-handle them (e.g. `monitor-create-modal`, `monitor-rename-modal`). This keeps the path strictly behavior-neutral while installing the routing + dormant modal branch.
- **TanStack DB collection path** — new **`createAppCollection`** factory decorates `insert`/`update`/`delete` so each transaction's rejection reaches `handleMutationError`. `@tanstack/db@0.6.8` has no global/collection `onError`; errors surface only via `tx.isPersisted.promise`, and un-awaited ones are unhandled rejections today. The handler owns **only otherwise-unhandled** errors:
  - reading `.isPersisted` (a form/modal awaiting the promise) marks the error **caller-owned** → no double-toast;
  - mutations joining an **ambient transaction** (`createOptimisticAction.onMutate`) are left to that transaction's owner.
  - Migrated all **8** `createCollection` sites (projects, api-keys, organizations, oauth-keys, members, flaggers, spans×2).
- **Dormant `ReadOnlyProjectError` branch** left clearly marked for showcase Phase 2 (the "read-only showcase — create your own project" modal → `/projects`). No code throws that tag today, so it is a no-op.

### Where to focus review
- `create-app-collection.ts` — the proxy/`ownedByCaller` flag and the `getActiveTransaction()` guard (the two mechanisms that prevent double-toasting).
- `query-client.tsx` — the opt-in `meta.globalErrorToast` gate: is opt-in (vs. skip-if-`onError`) the right default for behavior-neutrality? (Chose opt-in because per-call `onError`/`mutateAsync`+catch are invisible to `MutationCache`.)

### Tests
- `handle-mutation-error.test.ts` — generic toast, opt-out suppression, dormant `ReadOnlyProjectError`.
- `create-app-collection.test.ts` — routes un-awaited rejections; does **not** route when the caller observes the transaction; skips ambient transactions; forwards transaction fields through the proxy.

`pnpm --filter web typecheck` clean; full web suite green (520 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)