### PR TITLE
feat(api): global rate limit on account bootstrap

### DIFF
--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -142,3 +142,28 @@ export const createTierRateLimiter = (tier: RateLimitTier) => {
     errorMessage: `Rate limit exceeded for ${tier}-tier endpoints. Please slow down.`,
   })
 }
+
+/**
+ * Global (tenant-agnostic) rate limiter: one shared counter across every
+ * caller, keyed only by `key`. It bounds the *total* request rate instead of
+ * partitioning per org/IP like {@link createTierRateLimiter} — use it to shield
+ * an unauthenticated surface from bulk abuse when there's no per-caller
+ * identity or CAPTCHA to key on (e.g. account bootstrap). Stack it after a
+ * per-IP tier so a single greedy IP is rejected before it burns global budget.
+ */
+export const createGlobalRateLimiter = ({
+  key,
+  maxRequests,
+  windowSeconds,
+}: {
+  key: string
+  maxRequests: number
+  windowSeconds: number
+}) =>
+  createRedisRateLimiter({
+    maxRequests,
+    windowSeconds,
+    keyPrefix: `ratelimit:global:${key}`,
+    keyGenerator: () => "all",
+    errorMessage: "Too many requests to this endpoint right now. Please retry shortly.",
+  })

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -18,7 +18,7 @@ import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getAdminPostgresClient } from "../clients.ts"
 import { defineApiEndpoint } from "../mcp/index.ts"
-import { createTierRateLimiter } from "../middleware/rate-limiter.ts"
+import { createGlobalRateLimiter, createTierRateLimiter } from "../middleware/rate-limiter.ts"
 import {
   errorResponse,
   jsonBody,
@@ -190,7 +190,15 @@ export const registerBootstrapRoute = ({
 }) => {
   const adminClient = adminDatabase ?? getAdminPostgresClient()
 
+  // The unauthenticated bootstrap surface has no CAPTCHA/Turnstile, so a botnet
+  // spread across many IPs slips past the per-IP `max` tier. The per-IP limiter
+  // runs first (cheaply rejecting a single greedy IP), then a global cap on the
+  // total creation rate acts as a second line of defense against distributed abuse.
   app.use("/account/bootstrap", createTierRateLimiter("max"))
+  app.use(
+    "/account/bootstrap",
+    createGlobalRateLimiter({ key: "account-bootstrap", maxRequests: 1000, windowSeconds: 60 }),
+  )
 
   app.openapi(bootstrapRoute, async (c) => {
     const body = c.req.valid("json")


### PR DESCRIPTION
## What

Adds a **global (tenant-agnostic) rate limiter** and applies it to the unauthenticated `POST /v1/account/bootstrap` endpoint, capping total temporary-account creation at **1000/min** across all callers.

## Why

The bootstrap surface is unauthenticated and has no CAPTCHA/Turnstile. The existing per-IP `max` tier (1/min) stops a single greedy IP, but a botnet spread across many IPs — one request each — slips right past it. A global cap on the *total* creation rate is a second line of defense against distributed abuse.

## How

- **`createGlobalRateLimiter({ key, maxRequests, windowSeconds })`** in `middleware/rate-limiter.ts` — mirrors `createTierRateLimiter` but shares a single counter keyed only by `key` (`ratelimit:global:<key>:all`), so it bounds the total rate instead of partitioning per org/IP.
- Applied to `/account/bootstrap` **after** the per-IP `max` tier. Order matters: the per-IP limiter runs first, so a single greedy IP is rejected before it increments — and burns — the global budget.

## Notes

- The test harness's `createFakeRedis` only implements `get/set/setex/del` (not `pipeline/incr/ttl/expire`), so both limiters deliberately fail-open in tests, matching the existing behavior. No rate-limiter unit tests exist yet; happy to extend the fake Redis to exercise the counter as a follow-up if wanted.
- Typecheck clean; all 263 `@app/api` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)