### PR TITLE
feat(projects): reserve the lat-demo project slug globally (G2)

### DIFF
--- a/packages/domain/projects/src/use-cases/update-project.test.ts
+++ b/packages/domain/projects/src/use-cases/update-project.test.ts
@@ -74,6 +74,18 @@ describe("updateProjectUseCase", () => {
     expect(error._tag).toBe("InvalidProjectSlugError")
   })
 
+  it("rejects a reserved slug typed by the user", async () => {
+    const id = ProjectId("1".repeat(24))
+    const { layer, rows } = makeLayer([makeProject({ id, slug: "checkout-agent", name: "Checkout agent" })])
+
+    const error = await Effect.runPromise(
+      updateProjectUseCase({ id, slug: "Lat Demo" }).pipe(Effect.provide(layer), Effect.flip),
+    )
+
+    expect(error._tag).toBe("InvalidProjectSlugError")
+    expect(rows.get(id)?.slug).toBe("checkout-agent")
+  })
+
   it("rejects a slug with no URL-safe characters", async () => {
     const id = ProjectId("1".repeat(24))
     const { layer } = makeLayer([makeProject({ id, slug: "checkout-agent", name: "Checkout agent" })])

--- a/packages/domain/projects/src/use-cases/update-project.ts
+++ b/packages/domain/projects/src/use-cases/update-project.ts
@@ -1,5 +1,6 @@
 import {
   type ConflictError,
+  isReservedProjectSlug,
   type NotFoundError,
   type ProjectId,
   type ProjectSettings,
@@ -84,6 +85,12 @@ export const updateProjectUseCase = Effect.fn("projects.updateProject")(function
           return yield* new InvalidProjectSlugError({
             slug: input.slug,
             reason: "Slug must contain at least one URL-safe character",
+          })
+        }
+        if (isReservedProjectSlug(desiredSlug)) {
+          return yield* new InvalidProjectSlugError({
+            slug: desiredSlug,
+            reason: "This slug is reserved",
           })
         }
         if (desiredSlug !== existingProject.slug) {

--- a/packages/domain/shared/src/slug.test.ts
+++ b/packages/domain/shared/src/slug.test.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
-import { generateSlug, SLUG_MAX_LENGTH } from "./slug.ts"
+import { generateSlug, isReservedProjectSlug, RESERVED_PROJECT_SLUGS, SLUG_MAX_LENGTH } from "./slug.ts"
 
 const counts =
   (taken: ReadonlyMap<string, number>) =>
@@ -97,5 +97,38 @@ describe("generateSlug", () => {
 
     const exit = await Effect.runPromiseExit(generateSlug({ name: "Anything", count: failingCount }))
     expect(exit._tag).toBe("Failure")
+  })
+
+  it("auto-suffixes a reserved base even when count reports it free", async () => {
+    const result = await Effect.runPromise(
+      generateSlug({
+        name: "Lat Demo",
+        count: counts(new Map()),
+      }),
+    )
+    expect(result).toMatch(/^lat-demo-[a-z0-9]{4}$/)
+  })
+
+  it("auto-suffixes a reserved base when no count callback is provided", async () => {
+    const result = await Effect.runPromise(generateSlug({ name: "Lat Demo" }))
+    expect(result).toMatch(/^lat-demo-[a-z0-9]{4}$/)
+    expect(isReservedProjectSlug(result)).toBe(false)
+  })
+
+  it("does not treat a non-reserved base as reserved", async () => {
+    const result = await Effect.runPromise(generateSlug({ name: "Demo" }))
+    expect(result).toBe("demo")
+  })
+})
+
+describe("isReservedProjectSlug", () => {
+  it("reserves lat-demo", () => {
+    expect(RESERVED_PROJECT_SLUGS).toContain("lat-demo")
+    expect(isReservedProjectSlug("lat-demo")).toBe(true)
+  })
+
+  it("treats other slugs as free", () => {
+    expect(isReservedProjectSlug("demo")).toBe(false)
+    expect(isReservedProjectSlug("lat-demo-1")).toBe(false)
   })
 })

--- a/packages/domain/shared/src/slug.ts
+++ b/packages/domain/shared/src/slug.ts
@@ -54,6 +54,12 @@ const MAX_ATTEMPTS = 100
 const RANDOM_SUFFIX_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789"
 const RANDOM_SUFFIX_LENGTH = 4
 
+/** Slug bases reserved for the product; enforced app-layer for every {@link generateSlug} caller. */
+export const RESERVED_PROJECT_SLUGS = ["lat-demo"] as const
+
+export const isReservedProjectSlug = (slug: string): boolean =>
+  (RESERVED_PROJECT_SLUGS as readonly string[]).includes(slug)
+
 export class InvalidSlugInputError extends Data.TaggedError("InvalidSlugInputError")<{
   readonly name: string
   readonly reason: string
@@ -103,8 +109,11 @@ export interface GenerateSlugInput<E, R> {
  *
  * 1. Normalize `name` to a base slug via {@link toSlug}, trim trailing hyphens
  *    after slicing to {@link SLUG_MAX_LENGTH}.
- * 2. If no `count` callback is provided, return the base slug.
- * 3. Call `count(base)`. If it reports `0`, return the base slug.
+ * 2. If no `count` callback is provided, return the base slug (a reserved base
+ *    is auto-suffixed with a random 4-char string since there is nothing to
+ *    count against).
+ * 3. Call `count(base)` — or treat a base in {@link RESERVED_PROJECT_SLUGS} as
+ *    already taken. If free, return the base slug.
  * 4. Append `-{4 random url-safe lowercase chars}` to the base. Truncate the
  *    base further if needed so the joined string still fits.
  * 5. Call `count(candidate)`. If `0`, return it.
@@ -127,9 +136,15 @@ export const generateSlug = Effect.fn("shared.generateSlug")(function* <E, R>(ar
     })
   }
 
-  if (!args.count) return baseSlug
+  const baseReserved = isReservedProjectSlug(baseSlug)
 
-  const baseCount = yield* args.count(baseSlug)
+  if (!args.count) {
+    // No uniqueness check to lean on. A reserved base still must not be handed
+    // out, so append a random suffix — a suffixed slug is never itself reserved.
+    return baseReserved ? truncateAndJoin(baseSlug, `-${randomSuffix()}`) : baseSlug
+  }
+
+  const baseCount = baseReserved ? 1 : yield* args.count(baseSlug)
   if (baseCount === 0) return baseSlug
 
   // First retry: append a random 4-char url-safe suffix. With 36^4 ≈ 1.7M


### PR DESCRIPTION
## Task G2 — Reserved-slug enforcement

Part of the **Showcase Demo Project** effort. Umbrella spec/tracking PR: #3821.

The showcase feature addresses one shared demo project via a stable, user-visible URL `/projects/lat-demo`. For that reserved slug to stay safe, **no user project may claim `lat-demo`**. DB uniqueness for project slugs is per-org (`organization_id, slug, deleted_at`) and `countBySlug` is org-scoped, so a *global* reservation can only be enforced at the app layer. This PR is that enforcement.

### What changed

- **`@domain/shared` (`slug.ts`)** — new `RESERVED_PROJECT_SLUGS = ['lat-demo']` constant + `isReservedProjectSlug()` helper, living next to the slug logic (already re-exported via the package index).
- **`generateSlug` (`slug.ts`)** — a reserved base is now treated like a collision and auto-suffixed. This covers **every derived-slug path at once**: `createProjectUseCase`, the signup sample project (`provision-organization-workspace.ts`), backoffice `create-demo-project.ts`, and the sandbox linked project. Handles both the `count`-callback case (force the collision branch) and the no-`count` case (append a random suffix, since there is nothing to count against and a suffixed slug is never itself reserved).
- **`updateProjectUseCase` (`update-project.ts`)** — the **only user-typed-slug path** (it never calls `generateSlug`), so it now explicitly rejects a reserved slug with `InvalidProjectSlugError` (surfaces in the settings `ChangeSlugForm`).
- **Tests** — added to `slug.test.ts` (reserved base auto-suffixes with/without a `count` callback; non-reserved bases unaffected; `isReservedProjectSlug` behavior) and `update-project.test.ts` (user-typed reserved slug rejected, row unchanged).

### Behavior-neutral / additive

Nothing user-visible changes: the only string blocked is `lat-demo`, **verified unused in production** (no rename migration needed — re-check just before the Phase 3 cutover). No existing project produces `lat-demo` from a name today.

### Deliberately skipped

The spec lists an **optional** `.refine` on the project entity `slug` schema (`project.ts`) as extra defense-in-depth. I left it out on purpose: `generateSlug` + `updateProjectUseCase` already cover both slug-assignment paths, and a hard schema-level reject risks interfering with Phase 2 showcase-project creation if the underlying project's real slug ever normalizes near the reserved word. Easy to add later if reviewers prefer belt-and-suspenders.

### Where to focus review

- `generateSlug` integration — confirm the reserved-base branch is correct in both the `count`-present and `count`-absent cases, and that non-reserved slugs are byte-identical to before.
- The placement of the reject in `updateProjectUseCase` (after the empty-slug check, before the org-scoped collision check) and whether rejecting unconditionally (even when `desiredSlug === existingProject.slug`) is desired.
- The choice to reserve globally inside the generic `generateSlug` (shared across monitors/signals/datasets/etc.) rather than only project paths — `lat-demo` is rare enough that a global reservation is harmless, and it matches the spec's instruction to enforce in `generateSlug`.

### Verification

- `pnpm --filter @domain/shared typecheck` ✅
- `pnpm --filter @domain/projects typecheck` ✅
- `pnpm --filter @domain/shared exec vitest run src/slug.test.ts` ✅ (15 passed)
- `pnpm --filter @domain/projects exec vitest run src/use-cases/update-project.test.ts` ✅ (7 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)