### PR TITLE
fix(outbox): retry failed polls so the outbox consumer survives transient DB errors

### DIFF
--- a/packages/platform/db-postgres/src/outbox-consumer.test.ts
+++ b/packages/platform/db-postgres/src/outbox-consumer.test.ts
@@ -1,0 +1,146 @@
+import type { DomainEvent } from "@domain/events"
+import { Effect } from "effect"
+import type { Pool, PoolClient } from "pg"
+import { describe, expect, it, vi } from "vitest"
+import { createPollingOutboxConsumer, type OutboxEventRow } from "./outbox-consumer.ts"
+
+const makeOutboxRow = (id: string): OutboxEventRow => ({
+  id,
+  event_name: "MagicLinkEmailRequested",
+  aggregate_id: "user-1",
+  workspace_id: "org-1",
+  payload: { email: "user@example.com" },
+  published: false,
+  published_at: null,
+  occurred_at: new Date(),
+  created_at: new Date(),
+})
+
+interface FakeClientOptions {
+  rowBatches: OutboxEventRow[][]
+  failQueriesMatching?: { pattern: string; times: number }
+}
+
+const makeFakeClient = (options: FakeClientOptions) => {
+  let remainingQueryFailures = options.failQueriesMatching?.times ?? 0
+  const queries: string[] = []
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql)
+      if (
+        options.failQueriesMatching &&
+        sql.includes(options.failQueriesMatching.pattern) &&
+        remainingQueryFailures > 0
+      ) {
+        remainingQueryFailures -= 1
+        throw new Error("terminating connection due to administrator command")
+      }
+      if (sql.includes("FROM latitude.outbox_events")) {
+        return { rows: options.rowBatches.shift() ?? [] }
+      }
+      return { rows: [] }
+    }),
+    release: vi.fn(),
+  }
+  return { client, queries }
+}
+
+interface FakePoolOptions {
+  connectFailures?: number
+  clientOptions: FakeClientOptions
+}
+
+const makeFakePool = (options: FakePoolOptions) => {
+  let remainingConnectFailures = options.connectFailures ?? 0
+  const { client, queries } = makeFakeClient(options.clientOptions)
+  const pool = {
+    connect: vi.fn(async () => {
+      if (remainingConnectFailures > 0) {
+        remainingConnectFailures -= 1
+        throw new Error("connection refused")
+      }
+      return client as unknown as PoolClient
+    }),
+  } as unknown as Pool
+  return { pool, client, queries }
+}
+
+const makeRecordingPublisher = () => {
+  const published: DomainEvent[] = []
+  return {
+    published,
+    publisher: {
+      publish: (event: DomainEvent) =>
+        Effect.sync(() => {
+          published.push(event)
+        }),
+    },
+  }
+}
+
+const startConsumer = async (pool: Pool, publisher: { publish: (event: DomainEvent) => Effect.Effect<void> }) => {
+  const consumer = await Effect.runPromise(
+    createPollingOutboxConsumer({ pool, pollIntervalMs: 5, batchSize: 10 }, publisher),
+  )
+  await Effect.runPromise(consumer.start())
+  return consumer
+}
+
+describe("createPollingOutboxConsumer", () => {
+  it("keeps polling after pool.connect failures and drains the backlog once the database recovers", async () => {
+    const { pool } = makeFakePool({
+      connectFailures: 2,
+      clientOptions: { rowBatches: [[makeOutboxRow("evt-1")]] },
+    })
+    const { published, publisher } = makeRecordingPublisher()
+
+    const consumer = await startConsumer(pool, publisher)
+    try {
+      await vi.waitFor(() => expect(published).toHaveLength(1))
+    } finally {
+      await Effect.runPromise(consumer.stop())
+    }
+
+    expect((pool.connect as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect(published[0]?.name).toBe("MagicLinkEmailRequested")
+  })
+
+  it("keeps polling after an in-transaction failure and releases the failed client", async () => {
+    const { pool, client } = makeFakePool({
+      clientOptions: {
+        rowBatches: [[makeOutboxRow("evt-1")]],
+        failQueriesMatching: { pattern: "BEGIN", times: 1 },
+      },
+    })
+    const { published, publisher } = makeRecordingPublisher()
+
+    const consumer = await startConsumer(pool, publisher)
+    try {
+      await vi.waitFor(() => expect(published).toHaveLength(1))
+    } finally {
+      await Effect.runPromise(consumer.stop())
+    }
+
+    expect(client.release.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("marks published events and stops polling cleanly on stop()", async () => {
+    const { pool, queries } = makeFakePool({
+      clientOptions: { rowBatches: [[makeOutboxRow("evt-1"), makeOutboxRow("evt-2")]] },
+    })
+    const { published, publisher } = makeRecordingPublisher()
+
+    const consumer = await startConsumer(pool, publisher)
+    try {
+      await vi.waitFor(() => expect(published).toHaveLength(2))
+    } finally {
+      await Effect.runPromise(consumer.stop())
+    }
+
+    expect(queries.some((sql) => sql.includes("UPDATE latitude.outbox_events"))).toBe(true)
+
+    const connectCallsAfterStop = (pool.connect as ReturnType<typeof vi.fn>).mock.calls.length
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect((pool.connect as ReturnType<typeof vi.fn>).mock.calls.length).toBe(connectCallsAfterStop)
+  })
+})

--- a/packages/platform/db-postgres/src/outbox-consumer.ts
+++ b/packages/platform/db-postgres/src/outbox-consumer.ts
@@ -130,7 +130,13 @@ export const createPollingOutboxConsumer = <TPublishError>(
       Effect.gen(function* () {
         if (fiber !== null) return
 
-        const pollingEffect = Effect.repeat(pollEffect(config, publisher), schedule).pipe(Effect.asVoid)
+        // Effect.repeat stops at the first failure — without the retry, one transient DB error kills the loop forever.
+        const pollingEffect = pollEffect(config, publisher).pipe(
+          Effect.tapError((error) => Effect.logError(`Outbox poll failed: ${error}`)),
+          Effect.retry(schedule),
+          Effect.repeat(schedule),
+          Effect.asVoid,
+        )
 
         fiber = yield* Effect.forkDetach(pollingEffect)
 


### PR DESCRIPTION
## What does this PR do?

The polling outbox consumer's loop was built as `Effect.repeat(pollEffect, schedule)` forked with `Effect.forkDetach`. `Effect.repeat` stops at the first failure, and every DB interaction in a poll (`pool.connect()`, `BEGIN`, the `SELECT ... FOR UPDATE`, `COMMIT`) is a failable `Effect.tryPromise` — so a single connection-level error (a Postgres restart is enough, and with a 1s poll interval one almost guarantees an in-flight poll fails) terminated the repetition permanently. Because the fiber is detached and unobserved, it died silently: no log, health checks green, sign-in still returning `{"status":true}` while magic-link/invitation emails and billing events piled up unpublished until the workers service was restarted. This is the failure reported in #3835, where a self-hosted deployment lost auth emails for 5 days after a routine Postgres resize.

The fix pipes the poll through `Effect.tapError` (so a failed poll is logged) and `Effect.retry(schedule)` (so it is retried on the same spaced schedule) before `Effect.repeat`. Typed failures can no longer end the loop; interruption from `stop()` is untouched, so shutdown behaves as before. `tapError`/`retry` operate on the error channel only — deliberately not `tapCause`/`catchCause`, which would also intercept the interrupt from `stop()`.

Note for reviewers: the claim in #2514 that the outbox consumer "naturally handles connection drops" via `Effect.repeat` inverts the documented semantics — repeat continues on success only. Pool-level recovery works but cannot resurrect a terminated repeat loop; this PR is what makes the loop itself survive.

Cheap follow-ups worth doing separately: a monitor on unpublished-outbox age (`max(now() - created_at) WHERE published = false`), and exposing last-successful-poll through the workers health endpoint so orchestrators can self-heal a dead relay.

## Related issue (if applicable)

Closes #3835

## How was this tested?

New `outbox-consumer.test.ts` with a fake `pg.Pool`/client and a recording publisher:

- keeps polling after `pool.connect()` rejections and drains the backlog once the DB recovers
- keeps polling after an in-transaction failure (`BEGIN` throws) and releases the failed client
- happy path: publishes, marks rows published, and `stop()` cleanly halts polling

The first two fail against the previous implementation (loop dies after the first error) and pass with the fix. `pnpm --filter @platform/db-postgres typecheck` and Biome pass; the rest of the package suite is unaffected.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9t31iXAAVkCmUFd8WxVBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9t31iXAAVkCmUFd8WxVBF)_