### PR TITLE
fix(api): externalize quickjs-emscripten to stop bundling from breaking its WASM loader

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -54,6 +54,7 @@
     "@repo/observability": "workspace:*",
     "@repo/utils": "workspace:*",
     "effect": "catalog:",
+    "quickjs-emscripten": "catalog:",
     "hono": "catalog:",
     "tsx": "catalog:",
     "voyageai": "catalog:",

--- a/apps/api/tsdown.config.ts
+++ b/apps/api/tsdown.config.ts
@@ -8,7 +8,12 @@ export default defineConfig({
   platform: "node",
   deps: {
     alwaysBundle: [/@(platform|domain|repo)\/.*/],
-    neverBundle: [/^@traceloop\//, /^@langchain\//, /^langchain($|\/)/],
+    neverBundle: [
+      "quickjs-emscripten",
+      /^@traceloop\//,
+      /^@langchain\//,
+      /^langchain($|\/)/,
+    ],
   },
   sourcemap: true,
   shims: true,

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,7 @@
         "src/**/*.ts"
       ],
       "ignoreDependencies": [
+        "quickjs-emscripten",
         "voyageai"
       ]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       hono:
         specifier: 4.12.16
         version: 4.12.16
+      quickjs-emscripten:
+        specifier: 'catalog:'
+        version: 0.32.0
       tsx:
         specifier: 'catalog:'
         version: 4.21.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`apps/api` was bundling `quickjs-emscripten` into its tsdown CJS output. The `@jitl/quickjs-wasmfile-release-sync` glue resolves its `.wasm` via `require("url")` inside the bundle, which breaks at runtime with `QuickJS WASM initialization failed: require is not a function`.

This surfaced on `POST /v1/projects/:projectSlug/signals` when the API tried to run QuickJS-backed evaluation scripts ([Datadog issue 3e08778a-7743-11f1-bf14-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/3e08778a-7743-11f1-bf14-da7ad0900005)) — 3 occurrences on 2026-07-04, first seen in deploy `e7bb368`.

## Fix

Same treatment already applied to `apps/workers` (#3819), `apps/workflows` (#3819), and `apps/web` (#3785):

- Add `quickjs-emscripten` to tsdown `neverBundle` so the WASM loader resolves from `node_modules` at runtime
- Declare `quickjs-emscripten` as a direct dependency in `apps/api/package.json`
- Ignore it in knip (consumed transitively via `@platform/sandbox-quickjs`)

## Verification

- Rebuilt `apps/api`: bundle now `require("quickjs-emscripten")` from `node_modules` instead of inlining the WASM glue; no `@jitl/quickjs-wasmfile` references in `dist/`
- Confirmed `getQuickJS()` loads and evaluates code successfully from the api app's `node_modules`
- `pnpm --filter @app/api typecheck` passes

After deploy, occurrences of issue `3e08778a-7743-11f1-bf14-da7ad0900005` should drop to zero.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7529215-645e-4cb7-b491-05d741696e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7529215-645e-4cb7-b491-05d741696e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

