### PR TITLE
Fix setup guide button width on integration detail page

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -157,7 +157,7 @@ const CLAUDE_ROUTINE_TEMPLATE =
 
 function IntegrationDocsButton({ kind }: { readonly kind: AgentDispatchKindKey }) {
   return (
-    <Button asChild variant="outline" size="sm">
+    <Button asChild variant="outline" size="sm" className="w-auto shrink-0">
       <a href={INTEGRATION_DOC_URLS[kind]} target="_blank" rel="noreferrer">
         <Icon icon={BookOpen} size="sm" />
         Setup guide
@@ -337,7 +337,7 @@ export function AgentDispatchIntegrationDetails({
   return (
     <div className="flex flex-col gap-8">
       <div className="flex max-w-3xl flex-col gap-3 rounded-lg border border-border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-1">
+        <div className="flex min-w-0 flex-col gap-1">
           <Text.H5 display="block" weight="semibold">
             {KIND_LABELS[kind]} setup guide
           </Text.H5>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The setup guide button on the integration detail page was stretching across the full width of the card. The shared `Button` component defaults to `w-full`, which caused it to expand inside the flex row layout.

Override with `w-auto shrink-0` on `IntegrationDocsButton` so the button sizes to its content and stays right-aligned via the existing `justify-between` layout. Also add `min-w-0` to the text column so long copy doesn't fight the button for space.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fdb1de0-a20d-4649-a15f-6c319d54c074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fdb1de0-a20d-4649-a15f-6c319d54c074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

