### PR TITLE
fix(email): restore CTA button styling in Gmail

### DIFF
--- a/packages/domain/email/src/components/EmailButton.tsx
+++ b/packages/domain/email/src/components/EmailButton.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@react-email/components"
-// @ts-expect-error TS6133 - React required at runtime for JSX in workers
+// @ts-expect-error TS6133 - React required at runtime for JSX in workers       
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
 import React from "react"
-import { emailButtonStyle } from "../tokens/design-system.js"
+import { emailButtonStyle, emailDesignTokens } from "../tokens/design-system.js"
 
 interface EmailButtonProps {
   readonly href: string
@@ -11,9 +11,27 @@ interface EmailButtonProps {
 }
 
 export function EmailButton({ href, label, variant = "default" }: EmailButtonProps) {
+  const buttonStyle = emailButtonStyle(variant)
+  const isDefault = variant === "default"
+
   return (
-    <Link href={href} style={emailButtonStyle(variant)}>
-      {label}
+    <Link
+      href={href}
+      className={`inline-block text-center no-underline ${emailDesignTokens.radius.button} ${isDefault ? "bg-primary-dark-1 p-[1px] pb-[3px]" : ""}`}
+      style={{
+        fontFamily: emailDesignTokens.fontFamily,
+        color: isDefault ? emailDesignTokens.colors.primaryForeground : undefined,
+      }}
+    >
+      <span
+        className={`inline-block ${emailDesignTokens.typography.button} ${emailDesignTokens.radius.button} ${isDefault ? "border border-transparent" : ""}`}
+        style={{
+          ...buttonStyle,
+          display: "inline-block",
+        }}
+      >
+        {label}
+      </span>
     </Link>
   )
 }

--- a/packages/domain/email/src/components/EmailButton.tsx
+++ b/packages/domain/email/src/components/EmailButton.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@react-email/components"
-// @ts-expect-error TS6133 - React required at runtime for JSX in workers       
+// @ts-expect-error TS6133 - React required at runtime for JSX in workers
 // biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
 import React from "react"
 import { emailButtonStyle, emailDesignTokens } from "../tokens/design-system.js"

--- a/packages/domain/email/src/tokens/design-system.ts
+++ b/packages/domain/email/src/tokens/design-system.ts
@@ -12,6 +12,7 @@ export const emailDesignTokens = {
     foreground: "#030712",
     mutedForeground: "#545E69",
     primary: "#0080FF",
+    primaryDark: "#0064CC",
     primaryForeground: "#F8FAFB",
     input: "#D8D8D8",
     accent: "#EFF7FF",
@@ -101,6 +102,7 @@ export const emailTailwindConfig = {
         },
         primary: {
           DEFAULT: emailDesignTokens.colors.primary,
+          "dark-1": emailDesignTokens.colors.primaryDark,
           foreground: emailDesignTokens.colors.primaryForeground,
         },
         input: emailDesignTokens.colors.input,


### PR DESCRIPTION
## What does this PR do?

Fixes the rendering of CTA buttons in real email clients.

The email buttons rendered correctly in the React Email development preview but lost their styling when viewed in Gmail. This change updates the shared email button implementation to improve compatibility while preserving the existing component API and design.

## Related issue (if applicable)

Closes #3832

## How was this tested?

- Verified rendering in the React Email preview.
- Sent test emails to Gmail.
- Confirmed that the CTA button now renders with the expected styling in Gmail.

## Checklist

- [ ] Lint, type-checking, and tests pass locally
- [x] PR title follows Conventional Commits
- [ ] I have signed the CLA