### PR TITLE
fix(spans): bound session span-list reads to stop ClickHouse OOMs

### DIFF
--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -77,7 +77,11 @@ export interface SpanRepositoryShape {
    * Every span in a session. Membership mirrors the `sessions_mv` grouping key
    * (`coalesce(nullIf(session_id, ''), toString(trace_id))`), so it covers both
    * conversation-id sessions and orphan single-trace sessions (whose spans carry
-   * no `session_id` and are keyed on their `trace_id`).
+   * no `session_id` and are keyed on their `trace_id`). The dynamic attribute
+   * maps (`attrString`/`attrInt`/`attrFloat`/`attrBool`/`resourceString`) come
+   * back empty: a session's span count is unbounded and instrumentors can put
+   * whole conversations into attributes, so reading them here is a memory
+   * hazard — fetch a span's attributes via `findBySpanId`.
    */
   listBySessionId(input: {
     readonly organizationId: OrganizationId

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -158,6 +158,140 @@ describe("SpanRepository", () => {
     })
   })
 
+  describe("listBySessionId", () => {
+    const SESSION_ID = SessionId("session-list")
+    const HEX32_SESSION_ID = SessionId("99999999999999999999999999999999")
+    const ORPHAN_TRACE = TraceId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    const insertListFixture = () =>
+      runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            session_id: SESSION_ID,
+            span_id: "aaaa000000000001",
+            name: "older",
+            attr_string: { "ai.prompt": "huge-blob" },
+            attr_int: { retries: 2 },
+            resource_string: { host: "h1" },
+            ingested_at: "2026-01-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            span_id: "aaaa000000000001",
+            name: "newer",
+            attr_string: { "ai.prompt": "huge-blob" },
+            ingested_at: "2026-01-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            session_id: "session-other",
+            trace_id: TraceId("cccccccccccccccccccccccccccccccc"),
+            span_id: "cccc000000000001",
+            name: "other-session",
+          }),
+          // Orphan span whose trace id doubles as its session id.
+          makeSpanRow({
+            session_id: "",
+            trace_id: ORPHAN_TRACE,
+            span_id: "dddd000000000001",
+            name: "orphan",
+          }),
+          // Conversation session whose id happens to be 32 chars long.
+          makeSpanRow({
+            session_id: HEX32_SESSION_ID,
+            trace_id: TraceId("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+            span_id: "eeee000000000001",
+            name: "hex32-named-session",
+          }),
+        ]),
+      )
+
+    it("returns the session's deduped spans with empty attribute maps", async () => {
+      await insertListFixture()
+
+      const spans = await runCh(
+        repo.listBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: SESSION_ID }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["newer"])
+      expect(spans[0]?.attrString).toEqual({})
+      expect(spans[0]?.attrInt).toEqual({})
+      expect(spans[0]?.attrFloat).toEqual({})
+      expect(spans[0]?.attrBool).toEqual({})
+      expect(spans[0]?.resourceString).toEqual({})
+
+      const detail = await runCh(
+        repo.findBySpanId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TRACE_ID,
+          spanId: SpanId("aaaa000000000001"),
+        }),
+      )
+      expect(detail.attrString).toEqual({ "ai.prompt": "huge-blob" })
+    })
+
+    it("matches orphan single-trace sessions keyed by trace id", async () => {
+      await insertListFixture()
+
+      const spans = await runCh(
+        repo.listBySessionId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          sessionId: SessionId(ORPHAN_TRACE as string),
+        }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["orphan"])
+    })
+
+    it("matches a conversation session whose id is 32 chars long", async () => {
+      await insertListFixture()
+
+      const spans = await runCh(
+        repo.listBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: HEX32_SESSION_ID }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["hex32-named-session"])
+    })
+
+    it("matches nothing for an empty session id (never the orphan spans)", async () => {
+      await insertListFixture()
+
+      const spans = await runCh(
+        repo.listBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: SessionId("") }),
+      )
+
+      expect(spans).toEqual([])
+    })
+
+    it("scopes by the optional start-time window", async () => {
+      await insertListFixture()
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            session_id: SESSION_ID,
+            span_id: "aaaa000000000002",
+            name: "outside-window",
+            start_time: "2026-02-01 00:00:00.000000000",
+            end_time: "2026-02-01 00:00:01.000000000",
+          }),
+        ]),
+      )
+
+      const spans = await runCh(
+        repo.listBySessionId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          sessionId: SESSION_ID,
+          startTimeFrom: new Date("2026-01-01T00:00:00.000Z"),
+          startTimeTo: new Date("2026-01-01T00:00:01.000Z"),
+        }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["newer"])
+    })
+  })
+
   describe("listByProjectId", () => {
     it("uses direct time predicates and dedupes before pagination", async () => {
       await runCh(

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -64,8 +64,9 @@ const INT_TO_STATUS_CODE: Record<number, SpanStatusCode> = {
   2: "error",
 }
 
-// Columns selected for list/trace queries (excludes large blob payloads).
-const LIST_COLUMNS = `
+// Columns selected for list/trace queries, minus the dynamic attribute maps
+// (excludes large blob payloads).
+const LIST_COLUMNS_LEAN = `
   organization_id, project_id, session_id, user_id, user_email, trace_id, span_id,
   parent_span_id, api_key_id, simulation_id, start_time, end_time,
   name, service_name, kind, status_code, status_message,
@@ -79,10 +80,30 @@ const LIST_COLUMNS = `
   cost_total_microcents, cost_is_estimated,
   time_to_first_token_ns, is_streaming,
   response_id, finish_reasons,
-  attr_string, attr_int, attr_float, attr_bool,
-  resource_string, scope_name, scope_version,
+  scope_name, scope_version,
   ingested_at
 `
+
+// Dynamic attribute maps are unbounded user data — instrumentors like the
+// Vercel AI SDK put the full conversation into `ai.prompt*` attributes, so
+// `attr_string` alone can reach GiBs per session. Only reads whose consumers
+// render attributes may select these.
+const ATTR_MAP_COLUMNS = `
+  attr_string, attr_int, attr_float, attr_bool, resource_string
+`
+
+// Same row shape with the maps as empty literals — ClickHouse never reads
+// them from storage.
+const EMPTY_ATTR_MAP_COLUMNS = `
+  CAST(map(), 'Map(String, String)') AS attr_string,
+  CAST(map(), 'Map(String, Int64)') AS attr_int,
+  CAST(map(), 'Map(String, Float64)') AS attr_float,
+  CAST(map(), 'Map(String, UInt8)') AS attr_bool,
+  CAST(map(), 'Map(String, String)') AS resource_string
+`
+
+// Columns selected for list/trace queries (excludes large blob payloads).
+const LIST_COLUMNS = `${LIST_COLUMNS_LEAN}, ${ATTR_MAP_COLUMNS}`
 
 // `LIST_COLUMNS` plus the large payload columns a `SpanDetail` needs. Selected
 // explicitly (never `SELECT *`) so reads project exactly the typed row and skip
@@ -363,6 +384,35 @@ const toInsertRow = (span: SpanDetail) => ({
   ingested_at: toClickhouseDateTime(span.ingestedAt),
 })
 
+// Session membership mirrors the sessions_mv grouping key
+// (`coalesce(nullIf(session_id, ''), toString(trace_id))`): conversation-id
+// sessions match on session_id, orphan single-trace sessions (empty
+// session_id) match on their trace_id. Split into bare column equalities —
+// the coalesce form wraps both columns in functions, defeating the
+// idx_session_id / idx_trace_id bloom-filter skip indexes, so it scanned
+// every granule of the org/project. Orphan session ids are 32-hex trace ids;
+// any other length cannot match a FixedString(32) trace_id, so the trace arm
+// is dropped (toFixedString on a longer value would throw).
+const sessionMembership = (sessionId: string): { clause: string; params: Record<string, string> } => {
+  if (sessionId.length === 0) return { clause: "1 = 0", params: {} }
+  if (sessionId.length === 32) {
+    return {
+      clause: "(session_id = {sessionId:String} OR (session_id = '' AND trace_id = {sessionTraceId:FixedString(32)}))",
+      params: { sessionId, sessionTraceId: sessionId },
+    }
+  }
+  return { clause: "session_id = {sessionId:String}", params: { sessionId } }
+}
+
+// Defense-in-depth for multi-span reads: single-threaded formatting + a
+// per-query memory cap so a pathological query fails its own request
+// (retryable RepositoryError) rather than tripping the server-wide
+// OvercommitTracker and killing unrelated tenants' queries.
+const BOUNDED_READ_SETTINGS = {
+  output_format_parallel_formatting: 0,
+  max_memory_usage: "4000000000",
+} as const
+
 // `listByProjectId` keyset pagination. The sort column is an enum → fixed column
 // (never user-interpolated raw SQL); the cursor param is typed to match it so the
 // tuple comparison is valid. Only `start_time` is in the table's primary key
@@ -430,6 +480,7 @@ export const SpanRepositoryLive = Layer.effect(
                 ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
               },
               format: "JSONEachRow",
+              clickhouse_settings: BOUNDED_READ_SETTINGS,
             })
             return result.json<SpanListRow>()
           })
@@ -496,6 +547,7 @@ export const SpanRepositoryLive = Layer.effect(
                   : {}),
               },
               format: "JSONEachRow",
+              clickhouse_settings: BOUNDED_READ_SETTINGS,
             })
             return result.json<SpanListRow>()
           })
@@ -531,20 +583,23 @@ export const SpanRepositoryLive = Layer.effect(
         const startToClause = startTimeTo
           ? "AND start_time <= parseDateTime64BestEffort({startTimeTo:String}, 9, 'UTC')"
           : ""
+        const membership = sessionMembership(sessionId as string)
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Session membership mirrors the sessions_mv grouping key exactly:
-              // conversation-id sessions match on session_id, orphan single-trace
-              // sessions (empty session_id) match on toString(trace_id). Same
-              // `LIMIT 1 BY span_id` dedupe as listByTraceId.
-              query: `SELECT ${LIST_COLUMNS}
+              // Same `LIMIT 1 BY span_id` dedupe as listByTraceId. The attr maps
+              // come back as empty literals: a session is unbounded in span count
+              // and `attr_string` alone can hold the full conversation per span
+              // (Vercel AI SDK `ai.prompt*`), so reading them here has OOMed the
+              // server on long agent sessions. No session-level consumer renders
+              // attributes — the span detail view reads them via findBySpanId.
+              query: `SELECT ${LIST_COLUMNS_LEAN}, ${EMPTY_ATTR_MAP_COLUMNS}
                     FROM (
-                      SELECT ${LIST_COLUMNS}
+                      SELECT ${LIST_COLUMNS_LEAN}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
-                        AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
+                        AND ${membership.clause}
                         ${startFromClause}
                         ${startToClause}
                       ORDER BY span_id, ingested_at DESC
@@ -554,11 +609,12 @@ export const SpanRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                sessionId: sessionId as string,
+                ...membership.params,
                 ...(startTimeFrom ? { startTimeFrom: toClickhouseDateTime(startTimeFrom) } : {}),
                 ...(startTimeTo ? { startTimeTo: toClickhouseDateTime(startTimeTo) } : {}),
               },
               format: "JSONEachRow",
+              clickhouse_settings: BOUNDED_READ_SETTINGS,
             })
             return result.json<SpanListRow>()
           })
@@ -575,17 +631,18 @@ export const SpanRepositoryLive = Layer.effect(
     }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const membership = sessionMembership(sessionId as string)
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Session membership mirrors sessions_mv (see listBySessionId); only execute_tool spans.
+              // Session membership mirrors sessions_mv (see sessionMembership); only execute_tool spans.
               query: `SELECT trace_id, tool_name, tool_input, tool_output, status_code, error_type, duration_ns
                     FROM (
                       SELECT span_id, trace_id, tool_name, tool_input, tool_output, status_code, error_type, duration_ns, start_time, ingested_at
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
-                        AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
+                        AND ${membership.clause}
                         AND operation = 'execute_tool'
                       ORDER BY span_id, ingested_at DESC
                       LIMIT 1 BY span_id
@@ -594,9 +651,10 @@ export const SpanRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
-                sessionId: sessionId as string,
+                ...membership.params,
               },
               format: "JSONEachRow",
+              clickhouse_settings: BOUNDED_READ_SETTINGS,
             })
             return result.json<SessionToolSpanRow>()
           })
@@ -670,15 +728,10 @@ export const SpanRepositoryLive = Layer.effect(
                 limit,
               },
               format: "JSONEachRow",
-              // Defense-in-depth: single-threaded formatting + a per-query memory cap so a
-              // pathological page fails its own job (retryable RepositoryError → BullMQ retry
-              // → recorded failed run) rather than tripping the server-wide OvercommitTracker
-              // and killing unrelated tenants' queries. With late materialization a window
-              // peaks well under this, so it should never fire.
-              clickhouse_settings: {
-                output_format_parallel_formatting: 0,
-                max_memory_usage: "4000000000",
-              },
+              // With late materialization a window peaks well under the cap, so it
+              // should never fire; a pathological page becomes a BullMQ retry →
+              // recorded failed run.
+              clickhouse_settings: BOUNDED_READ_SETTINGS,
             })
             return result.json<SpanDetailRow>()
           })
@@ -751,6 +804,7 @@ export const SpanRepositoryLive = Layer.effect(
                   limit,
                 },
                 format: "JSONEachRow",
+                clickhouse_settings: BOUNDED_READ_SETTINGS,
               })
               return result.json<SpanDetailRow>()
             })
@@ -880,6 +934,7 @@ export const SpanRepositoryLive = Layer.effect(
                   traceId,
                 },
                 format: "JSONEachRow",
+                clickhouse_settings: BOUNDED_READ_SETTINGS,
               })
               return result.json<SpanMessagesRow>()
             })
@@ -892,6 +947,7 @@ export const SpanRepositoryLive = Layer.effect(
       findMessagesForSession: ({ organizationId, projectId, sessionId, startTimeFrom, startTimeTo }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const membership = sessionMembership(sessionId as string)
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
@@ -903,7 +959,7 @@ export const SpanRepositoryLive = Layer.effect(
                           AND project_id = {projectId:String}
                           AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
                           AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
-                          AND coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId:String}
+                          AND ${membership.clause}
                           AND operation IN ('chat', 'text_completion', 'generate_content', 'execute_tool')
                         ORDER BY span_id, ingested_at DESC
                         LIMIT 1 BY span_id
@@ -914,9 +970,10 @@ export const SpanRepositoryLive = Layer.effect(
                   projectId: projectId as string,
                   startTimeFrom: toClickhouseDateTime(startTimeFrom),
                   startTimeTo: toClickhouseDateTime(startTimeTo),
-                  sessionId: sessionId as string,
+                  ...membership.params,
                 },
                 format: "JSONEachRow",
+                clickhouse_settings: BOUNDED_READ_SETTINGS,
               })
               return result.json<SpanMessagesRow>()
             })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [Datadog issue 92bd265a](https://app.datadoghq.eu/error-tracking/issue/92bd265a-77d8-11f1-8550-da7ad0900005): `RepositoryError: Repository listBySessionId failed: (total) memory limit exceeded: would use 16.63 GiB … (while reading column attr_string)` — opening a session detail drawer killed the query at the server-wide OvercommitTracker, endangering other tenants' queries on the same replica.

## root cause

The session was an 11-hour agent run with ~11,700 spans, instrumented with the Vercel AI SDK, which puts the **entire conversation history** into the `ai.prompt` / `ai.prompt.messages` string attributes of every generation span. Ingest stores attributes verbatim (by design), so this one session carries **~30 GiB of uncompressed `attr_string`** (avg 2.6 MiB per span, measured on production).

`listBySessionId` selected `LIST_COLUMNS` — which included `attr_string`/`attr_int`/`attr_float`/`attr_bool`/`resource_string` — for every span in the session, with no limit and no per-query memory cap. With ~935 rows per read granule × 2.6 MiB, a single decompressed block of `attr_string` is multi-GiB, and the multi-threaded PrefetchedReadPool reads several concurrently → instant OOM at the 14.4 GiB replica cap.

No session-level consumer renders these maps: the session drawer computes duration breakdowns and tool pills from timing/tool columns, and the only UI that shows attributes is the single-span detail view, which reads them through `findBySpanId`.

## changes

**`listBySessionId` no longer reads the attribute maps.** The inner scan selects a lean column set; the outer select returns the maps as empty typed literals (`CAST(map(), …)`), so ClickHouse never touches those columns on storage. The row shape and the `Span` domain type are unchanged; the port JSDoc documents that the maps come back empty and points attribute consumers at `findBySpanId`. Verified against the exact production session that OOMed: the rewritten query returns all 11,745 spans in **1.1 s reading 1.4 MiB** (previously: killed after allocating 16+ GiB).

**Session membership predicate is now sargable.** `coalesce(nullIf(session_id, ''), toString(trace_id)) = {sessionId}` wraps both columns in functions, defeating the `idx_session_id`/`idx_trace_id` bloom-filter skip indexes — every granule of the org/project was scanned (matters most for the evaluation-runtime callers, which pass no time bounds; the table PK `(org, project, start_time)` can't prune those). It's split into bare column equalities: `session_id = {sessionId}`, plus an `OR (session_id = '' AND trace_id = {sessionId})` arm only when the id is 32 chars (orphan session ids are trace ids; any other length can't match a `FixedString(32)`). Production check on the same project without time bounds: 693,700 rows read with the old predicate vs 76,696 with the new one, identical counts. Applied to the three sharers of the predicate: `listBySessionId`, `listToolSpansBySessionId`, `findMessagesForSession`.

**Bounded-read settings on all multi-span reads.** The `max_memory_usage: 4 GB` + `output_format_parallel_formatting: 0` defense that `listByIngestedAtWindow` already used is extracted into a shared constant and applied to `listByTraceId`, `listByProjectId`, `listBySessionId`, `listToolSpansBySessionId`, `findMessagesForTrace`, `findMessagesForSession`, and `listRecentDetailsByProjectId` — a pathological query now fails its own request with a retryable `RepositoryError` instead of tripping the server-wide OvercommitTracker.

Ingest is deliberately untouched: attributes keep being stored verbatim as they came, with message extraction into the denormalized payload columns as today.

## tests

New `listBySessionId` suite (chdb, real schema): attribute maps come back empty while `findBySpanId` still returns them; orphan single-trace sessions keyed by trace id still match; a conversation session whose id happens to be 32 chars still matches; an empty session id matches nothing (the naive predicate split would have matched every orphan span); optional time-window scoping. Full `@platform/db-clickhouse` suite passes (388 tests), typecheck (`tsgo`) and biome clean.

## verification after deploy

Occurrences of issue `92bd265a-77d8-11f1-8550-da7ad0900005` should stop; opening the session drawer for session `tsk_r2S9n6loNm9ebb` (project `gu0lbj2fu843hghax4rdi1ie`) should render instead of erroring.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1783190893830399?thread_ts=1783190893.830399&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-e3d6da95-a843-5c2c-9db9-0e7257f84ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3d6da95-a843-5c2c-9db9-0e7257f84ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

