### PR TITLE
fix(spans): reject oversized trace/span IDs before ClickHouse insert

### DIFF
--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -305,3 +305,59 @@ describe("transformOtlpToSpans trace ID normalization", () => {
     expect(spans[0]?.traceId).toBe("0af7651916cd43dd8448eb211c80319c")
   })
 })
+
+describe("transformOtlpToSpans oversized ID rejection", () => {
+  const ctx = {
+    ...baseContext,
+    defaultProjectId: "proj-default",
+    projectIdBySlug: new Map<string, string>(),
+  }
+
+  const buildOneSpan = (traceId: string, spanId: string): OtlpExportTraceServiceRequest => ({
+    resourceSpans: [
+      {
+        resource: { attributes: [str("service.name", "test")] },
+        scopeSpans: [
+          {
+            scope: { name: "scope", version: "1" },
+            spans: [
+              {
+                traceId,
+                spanId,
+                name: "n1",
+                startTimeUnixNano: "1710590400000000000",
+                endTimeUnixNano: "1710590401000000000",
+                attributes: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  })
+
+  it("rejects a span whose trace ID exceeds the ClickHouse FixedString(32) bound", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(buildOneSpan("a".repeat(33), "n1"), ctx)
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+
+  it("rejects a span whose span ID exceeds the ClickHouse FixedString(16) bound", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(buildOneSpan(TRACE, "a".repeat(17)), ctx)
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+
+  it("keeps a short, arbitrary span ID unaffected (ClickHouse zero-pads short FixedString values)", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(buildOneSpan(TRACE, "n1"), ctx)
+    expect(spans).toHaveLength(1)
+    expect(rejectedSpans).toBe(0)
+  })
+
+  it("rejects a 40-char hex trace ID (e.g. a non-conformant SHA-1-style exporter)", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(buildOneSpan("a".repeat(40), "n1"), ctx)
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -1,4 +1,14 @@
-import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
+import {
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SPAN_ID_LENGTH,
+  SpanId,
+  TRACE_ID_LENGTH,
+  TraceId,
+} from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
 import { stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
@@ -247,6 +257,13 @@ export function transformOtlpToSpans(
         if (isDroppedSpan(scopeName, span.name ?? "")) continue
         const projectId = resolveSpanProjectId(span.attributes ?? [], resourceAttrs, context)
         if (!projectId) {
+          rejectedSpans++
+          continue
+        }
+        // ClickHouse stores these as FixedString(32)/FixedString(16); an oversized value (a
+        // non-conformant exporter, or a bytes-typed protobuf field wider than 16/8 bytes) fails
+        // the whole batch insert, not just this row.
+        if (span.traceId.replace(/-/g, "").length > TRACE_ID_LENGTH || span.spanId.length > SPAN_ID_LENGTH) {
           rejectedSpans++
           continue
         }


### PR DESCRIPTION
## What does this PR do?

Fixes a recurring production error where the `workers` service fails to insert an entire batch of ingested spans into ClickHouse:

```
Repository insert failed: Repository query failed: Too large value for FixedString(32): (while reading the value of key trace_id): (at row 1)
: While executing WaitForAsyncInsert.
```
and the sibling:
```
Too large value for FixedString(16): (while reading the value of key span_id): (at row 1)
```

**Datadog issues addressed:**
- [`ff6f0454-76e7-11f1-bc51-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/ff6f0454-76e7-11f1-bc51-da7ad0900005) — `trace_id` FixedString(32) overflow (8 occurrences/7d)
- [`ff694870-76e7-11f1-bc51-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/ff694870-76e7-11f1-bc51-da7ad0900005) — `span_id` FixedString(16) overflow (4 occurrences/7d)

Both are recent (first seen 2026-07-03) and still recurring as of today.

**Root cause:** `packages/domain/spans/src/otlp/transform.ts` builds each span's `traceId`/`spanId` straight from the untrusted OTLP wire payload (`span.traceId.replace(/-/g, "")` / `span.spanId`) via the unchecked `TraceId(...)`/`SpanId(...)` brand casts (`packages/domain/shared/src/id.ts`) — there is no length check anywhere on the ingestion path before the value reaches ClickHouse's `spans` table, whose `trace_id`/`span_id` columns are `FixedString(32)`/`FixedString(16)` (see `db-clickhouse/clickhouse/migrations/*/00001_create_spans.sql`). A non-conformant exporter (or a `bytes`-typed protobuf `trace_id`/`span_id` field wider than 16/8 bytes) produces a hex string longer than those bounds. ClickHouse then fails the **whole async-insert batch**, not just the offending row — so one malformed span currently drops every other (valid) span in the same OTLP payload.

The code already had a dash-stripping normalization for UUID-format trace IDs (`0af76519-16cd-...` → `0af7651916cd...`, 36→32 chars) with a dedicated test, but nothing validated the *resulting* length, and `span_id` had no normalization or validation at all.

**Fix:** `transformOtlpToSpans` already rejects a span when its `latitude.project` slug doesn't resolve to a project (incrementing a `rejectedSpans` counter and skipping just that span). This PR extends the same rejection path to spans whose normalized `traceId`/`spanId` exceed the ClickHouse column bounds, reusing the existing `TRACE_ID_LENGTH` (32) / `SPAN_ID_LENGTH` (16) constants from `@domain/shared` (already used by that package's own `traceIdSchema`/`spanIdSchema`, just never applied on this ingestion path). This is a `max`-length guard, not an exact-length one — ClickHouse silently zero-pads *shorter* `FixedString` values, and a large slice of the test suite already relies on short, arbitrary span IDs (e.g. `"n1"`), so exact-length enforcement would be a much larger, riskier behavior change than this bug needs.

## Related issue (if applicable)

N/A — found via Datadog Error Tracking, not a filed GitHub issue.

## How was this tested?

Added 4 new unit tests in `packages/domain/spans/src/otlp/tests/project-scoping.test.ts`:
- rejects a trace ID > 32 chars (confirmed the test fails without the fix)
- rejects a span ID > 16 chars
- keeps a short, arbitrary span ID (`"n1"`) unaffected — regression guard for existing behavior/tests
- rejects a 40-char hex trace ID (simulating a non-conformant SHA-1-style exporter)

Ran:
- `pnpm --filter @domain/spans test` — all 888 tests pass except 13 pre-existing failures in `ingest-spans.test.ts` unrelated to this change (a `Uint8Array.prototype.toBase64` Node-version issue in this sandbox — confirmed present on `development` HEAD before this change too).
- `pnpm --filter @domain/spans typecheck` — clean (via `tsgo`, after `pnpm build`).
- `pnpm exec biome check` on both changed files — clean.

**Verification after deploy:** occurrences of issues `ff6f0454-76e7-11f1-bc51-da7ad0900005` and `ff694870-76e7-11f1-bc51-da7ad0900005` should drop to zero (the offending span is now dropped individually instead of the whole batch failing).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01HMSdS11UrevXNrDwhs2qp8)_