### PR TITLE
fix(signals): stop semantic-similarity live evals from persisting permanent false negatives

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-preview-step.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-preview-step.tsx
@@ -5,12 +5,13 @@ import { useState } from "react"
 import { useTraceConversationMessages } from "../../../../../../../domains/traces/traces.collection.ts"
 
 type PreviewRow = Extract<SignalPreviewResult, { status: "done" }>["items"][number]
-type Verdict = "match" | "no-match" | "errored"
+type Verdict = "match" | "no-match" | "skipped" | "errored"
 
+// `skipped` is checked first: a skipped row has `passed: null`, which would otherwise read as "no match".
 const verdictOf = (row: PreviewRow): Verdict =>
-  row.error !== null ? "errored" : row.passed === true ? "match" : "no-match"
-// Matches first (the signal of interest), then non-matches, then errors.
-const verdictRank: Record<Verdict, number> = { match: 0, "no-match": 1, errored: 2 }
+  row.skipped ? "skipped" : row.error !== null ? "errored" : row.passed === true ? "match" : "no-match"
+// Matches first (the signal of interest), then non-matches, then skipped, then errors.
+const verdictRank: Record<Verdict, number> = { match: 0, "no-match": 1, skipped: 2, errored: 3 }
 
 const formatDuration = (ns: number): string => {
   const ms = ns / 1_000_000
@@ -28,6 +29,7 @@ const formatTokens = (tokens: number): string => (tokens >= 1000 ? `${(tokens / 
 
 function VerdictBadge({ verdict }: { readonly verdict: Verdict }) {
   if (verdict === "errored") return <Badge variant="warningMuted">errored</Badge>
+  if (verdict === "skipped") return <Badge variant="outlineMuted">skipped</Badge>
   if (verdict === "match") return <Badge variant="accent">match</Badge>
   return <Badge variant="muted">no match</Badge>
 }
@@ -92,7 +94,10 @@ function PreviewResultCard({
 }) {
   const verdict = verdictOf(row)
   const prompt = row.summary?.firstUserMessage?.trim()
-  const reason = row.error ?? (row.feedback.trim().length > 0 ? row.feedback : null)
+  const reason =
+    verdict === "skipped"
+      ? "Session not embedded yet — it'll be scored once embeddings are ready"
+      : (row.error ?? (row.feedback.trim().length > 0 ? row.feedback : null))
 
   return (
     <div

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -47,6 +47,7 @@
     "@domain/monitors": "workspace:*",
     "@domain/notifications": "workspace:*",
     "@domain/queue": "workspace:*",
+    "@domain/sandbox": "workspace:*",
     "@domain/sandboxes": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -240,6 +240,7 @@ const bootstrap = async () => {
     createProductFeedbackWorker(ctx)
     createTraceSearchWorker({
       consumer: ctx.consumer,
+      publisher: ctx.publisher,
       clickhouseClient: ctx.clickhouseClient,
       postgresClient: ctx.postgresClient,
       redisClient: ctx.redisClient,

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -105,10 +105,7 @@ describe("domain-events dispatcher", () => {
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
     // signals:match is no longer fanned out here — trace-end publishes it once the trace settles.
-    expect(published.map((p) => `${p.queue}:${p.task}`).sort()).toEqual([
-      "projects:checkFirstTrace",
-      "trace-end:run",
-    ])
+    expect(published.map((p) => `${p.queue}:${p.task}`).sort()).toEqual(["projects:checkFirstTrace", "trace-end:run"])
 
     const traceEnd = published.find((p) => p.queue === "trace-end")
     const firstTrace = published.find((p) => p.task === "checkFirstTrace")

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -104,14 +104,13 @@ describe("domain-events dispatcher", () => {
 
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
+    // signals:match is no longer fanned out here — trace-end publishes it once the trace settles.
     expect(published.map((p) => `${p.queue}:${p.task}`).sort()).toEqual([
       "projects:checkFirstTrace",
-      "signals:match",
       "trace-end:run",
     ])
 
     const traceEnd = published.find((p) => p.queue === "trace-end")
-    const signalsMatch = published.find((p) => p.queue === "signals")
     const firstTrace = published.find((p) => p.task === "checkFirstTrace")
 
     expect(traceEnd?.payload).toEqual({
@@ -124,16 +123,7 @@ describe("domain-events dispatcher", () => {
       dedupeKey: "trace-end:run:org-1:proj-1:trace-abc",
       debounceMs: TRACE_END_DEBOUNCE_MS,
     })
-    expect(signalsMatch?.payload).toEqual({
-      organizationId: "org-1",
-      projectId: "proj-1",
-      traceId: "trace-abc",
-      isSandbox: false,
-    })
-    expect(signalsMatch?.options).toEqual({
-      dedupeKey: "signals:match:org-1:proj-1:trace-abc",
-      debounceMs: TRACE_END_DEBOUNCE_MS,
-    })
+    expect(published.some((p) => p.queue === "signals")).toBe(false)
     expect(firstTrace?.options?.dedupeKey).toBe("projects:first-trace:proj-1")
   })
 
@@ -162,12 +152,11 @@ describe("domain-events dispatcher", () => {
 
     const traceEnd = published.find((p) => p.queue === "trace-end")
     const billing = published.find((p) => p.queue === "billing")
-    const signalsMatch = published.find((p) => p.queue === "signals")
     expect((traceEnd?.payload as { isSandbox?: boolean }).isSandbox).toBe(true)
     expect((billing?.payload as { isSandbox?: boolean }).isSandbox).toBe(true)
     expect(published.map((p) => `${p.queue}:${p.task}`)).toContain("projects:checkFirstTrace")
-    // signals:match is fanned out unconditionally too; the signals-match worker owns the sandbox skip.
-    expect((signalsMatch?.payload as { isSandbox?: boolean }).isSandbox).toBe(true)
+    // signals:match is not fanned out here anymore; trace-end publishes it (and skips sandbox itself).
+    expect(published.some((p) => p.queue === "signals")).toBe(false)
   })
 
   it("routes TracesIngested billing snapshots to billing:recordTraceUsageBatch", async () => {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -112,29 +112,8 @@ export const createDomainEventsWorker = ({
               },
             ),
           ),
-          // The signals matching pipeline runs every active evaluation against the trace. Published
-          // unconditionally with `isSandbox` in the payload (like trace-end); the consumer skips
-          // sandbox traces. Debounced like trace-end so evaluations fire on the settled trace.
-          ...event.payload.traceIds.map((traceId) =>
-            pub.publish(
-              "signals",
-              "match",
-              {
-                organizationId: event.payload.organizationId,
-                projectId: event.payload.projectId,
-                traceId,
-                isSandbox,
-              },
-              {
-                dedupeKey: buildTraceIngestedDedupeKey("signals:match", {
-                  organizationId: event.payload.organizationId,
-                  projectId: event.payload.projectId,
-                  traceId,
-                }),
-                debounceMs: TRACE_END_DEBOUNCE_MS,
-              },
-            ),
-          ),
+          // signals:match is now published from the trace-end job itself ("trace ends → match
+          // signals"), so it runs on the settled trace after trace-end's own debounce.
           // Not gated on `isSandbox`: first-trace detection is onboarding/marketing
           // telemetry, not LLM work. Outbound marketing/notification suppression for
           // sandbox orgs is AGE-113's concern (handled downstream), not this PR's.

--- a/apps/workers/src/workers/live-monitoring.test.ts
+++ b/apps/workers/src/workers/live-monitoring.test.ts
@@ -242,7 +242,7 @@ describe("live monitoring integration", () => {
     await pg.db.delete(evaluations)
   })
 
-  it("debounces TracesIngested into signals:match before publishing execute work", async () => {
+  it("runs the pipeline from TracesIngested through trace-end into a live-evaluation execute", async () => {
     await ch.client.insert({
       table: "spans",
       values: [makeTraceRow()],
@@ -280,6 +280,7 @@ describe("live monitoring integration", () => {
 
     await harness.consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
+    // domain-events debounces only trace-end now; signals:match is published from the trace-end job.
     expect(harness.getDelayed("trace-end")).toEqual([
       {
         queue: "trace-end",
@@ -296,26 +297,7 @@ describe("live monitoring integration", () => {
         },
       },
     ])
-
-    expect(harness.getDelayed("signals")).toEqual([
-      {
-        queue: "signals",
-        task: "match",
-        payload: {
-          organizationId: ORGANIZATION_ID,
-          projectId: PROJECT_ID,
-          traceId: TRACE_ID,
-          isSandbox: false,
-        },
-        options: {
-          dedupeKey: `signals:match:${ORGANIZATION_ID}:${PROJECT_ID}:${TRACE_ID}`,
-          debounceMs: TRACE_END_DEBOUNCE_MS,
-        },
-      },
-    ])
-
-    await harness.flushDelayed("trace-end")
-    await harness.flushDelayed("signals")
+    expect(harness.getDelayed("signals")).toEqual([])
 
     expect(harness.published).toContainEqual({
       queue: "projects",
@@ -329,6 +311,29 @@ describe("live monitoring integration", () => {
         dedupeKey: `projects:first-trace:${PROJECT_ID}`,
       },
     })
+
+    await harness.flushDelayed("trace-end")
+
+    // trace-end publishes signals:match immediately (no debounce) with reason "ingest".
+    const signalsMatch = harness.published.find((message) => message.queue === "signals" && message.task === "match")
+    if (signalsMatch === undefined) throw new Error("trace-end did not publish signals:match")
+    expect(signalsMatch).toEqual({
+      queue: "signals",
+      task: "match",
+      payload: {
+        organizationId: ORGANIZATION_ID,
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        isSandbox: false,
+        reason: "ingest",
+      },
+      options: {
+        dedupeKey: `org:${ORGANIZATION_ID}:signals-match:${PROJECT_ID}:${TRACE_ID}`,
+      },
+    })
+
+    await harness.consumer.dispatchTask("signals", "match", signalsMatch.payload)
+
     expect(harness.published).toContainEqual({
       queue: "live-evaluations",
       task: "execute",
@@ -349,7 +354,7 @@ describe("live monitoring integration", () => {
     })
   }, 15_000)
 
-  it("replaces debounced signals:match when TracesIngested is dispatched twice for the same trace", async () => {
+  it("does not double-run the evaluation when TracesIngested is dispatched twice for the same trace", async () => {
     await ch.client.insert({
       table: "spans",
       values: [makeTraceRow()],
@@ -389,6 +394,7 @@ describe("live monitoring integration", () => {
     await harness.consumer.dispatchTask("domain-events", "dispatch", dispatchPayload)
     await harness.consumer.dispatchTask("domain-events", "dispatch", dispatchPayload)
 
+    // The two dispatches collapse to a single debounced trace-end job (same dedupeKey).
     const delayedTraceEnd = harness.getDelayed("trace-end")
     expect(delayedTraceEnd).toHaveLength(1)
     expect(delayedTraceEnd[0]).toEqual({
@@ -406,24 +412,17 @@ describe("live monitoring integration", () => {
       },
     })
 
-    const delayedSignalsMatch = harness.getDelayed("signals")
-    expect(delayedSignalsMatch).toHaveLength(1)
-    expect(delayedSignalsMatch[0]).toEqual({
-      queue: "signals",
-      task: "match",
-      payload: {
-        organizationId: ORGANIZATION_ID,
-        projectId: PROJECT_ID,
-        traceId: TRACE_ID,
-        isSandbox: false,
-      },
-      options: {
-        dedupeKey: `signals:match:${ORGANIZATION_ID}:${PROJECT_ID}:${TRACE_ID}`,
-        debounceMs: TRACE_END_DEBOUNCE_MS,
-      },
-    })
+    await harness.flushDelayed("trace-end")
 
-    await harness.flushDelayed("signals")
+    // The single trace-end run publishes exactly one signals:match.
+    const signalsMatches = harness.published.filter(
+      (message) => message.queue === "signals" && message.task === "match",
+    )
+    expect(signalsMatches).toHaveLength(1)
+
+    const signalsMatch = signalsMatches[0]
+    if (signalsMatch === undefined) throw new Error("trace-end did not publish signals:match")
+    await harness.consumer.dispatchTask("signals", "match", signalsMatch.payload)
 
     const liveEvalExecutePublishes = harness.published.filter(
       (message) => message.queue === "live-evaluations" && message.task === "execute",

--- a/apps/workers/src/workers/signals-match.test.ts
+++ b/apps/workers/src/workers/signals-match.test.ts
@@ -401,10 +401,12 @@ describe("runSignalsMatchJob", () => {
     const semanticEvalId = "d".repeat(24)
 
     await insertTraceRows([makeTraceRow({ projectId, traceId })])
-    await pg.db.insert(signals).values([
-      makeSignalRow({ id: "b".repeat(24), projectId, uuid: "33333333-3333-4333-8333-333333333333" }),
-      makeSignalRow({ id: "c".repeat(24), projectId, uuid: "66666666-6666-4666-8666-666666666666" }),
-    ])
+    await pg.db
+      .insert(signals)
+      .values([
+        makeSignalRow({ id: "b".repeat(24), projectId, uuid: "33333333-3333-4333-8333-333333333333" }),
+        makeSignalRow({ id: "c".repeat(24), projectId, uuid: "66666666-6666-4666-8666-666666666666" }),
+      ])
     await pg.db.insert(evaluations).values([
       makeEvaluationRow({
         id: semanticEvalId,

--- a/apps/workers/src/workers/signals-match.test.ts
+++ b/apps/workers/src/workers/signals-match.test.ts
@@ -122,6 +122,7 @@ const makeEvaluationRow = (input: {
   readonly turn?: EvaluationTurn
   readonly projectId?: string
   readonly signalId?: string
+  readonly script?: string
 }) =>
   evaluationSchema.parse({
     id: input.id,
@@ -130,7 +131,7 @@ const makeEvaluationRow = (input: {
     signalId: input.signalId ?? SIGNAL_ID,
     name: `evaluation-${input.id.slice(0, 6)}`,
     description: "Signals match worker live evaluation",
-    script: "export default async function evaluate() { return { value: 1 } }",
+    script: input.script ?? "export default async function evaluate() { return { value: 1 } }",
     trigger: {
       ...defaultEvaluationTrigger(),
       filter: input.filter ?? {},
@@ -393,6 +394,58 @@ describe("runSignalsMatchJob", () => {
     const executePublishes = published.filter((p) => p.queue === "live-evaluations" && p.task === "execute")
     expect(executePublishes).toHaveLength(1)
   })
+
+  it("on an embeddings-ready re-trigger, publishes only semantic evals with a distinct dedupeKey", async () => {
+    const projectId = "y".repeat(24)
+    const traceId = "w".repeat(32)
+    const semanticEvalId = "d".repeat(24)
+
+    await insertTraceRows([makeTraceRow({ projectId, traceId })])
+    await pg.db.insert(signals).values([
+      makeSignalRow({ id: "b".repeat(24), projectId, uuid: "33333333-3333-4333-8333-333333333333" }),
+      makeSignalRow({ id: "c".repeat(24), projectId, uuid: "66666666-6666-4666-8666-666666666666" }),
+    ])
+    await pg.db.insert(evaluations).values([
+      makeEvaluationRow({
+        id: semanticEvalId,
+        projectId,
+        signalId: "b".repeat(24),
+        script: "return Passed((await semanticSimilarity('frustration')) >= 0.5 ? 1 : 0)",
+      }),
+      makeEvaluationRow({ id: "r".repeat(24), projectId, signalId: "c".repeat(24) }),
+    ])
+
+    const { publisher, published } = createFakeQueuePublisher()
+    const redisClient = createFakeRedisClient()
+
+    const result = await Effect.runPromise(
+      runSignalsMatchJob({
+        publisher,
+        postgresClient: pg.appPostgresClient,
+        clickhouseClient: ch.client,
+        redisClient,
+      })({
+        organizationId: ORGANIZATION_ID,
+        projectId,
+        traceId,
+        reason: "embeddings-ready",
+      }),
+    )
+
+    expect(result.action).toBe("completed")
+
+    const executePublishes = published.filter((p) => p.queue === "live-evaluations" && p.task === "execute")
+    expect(executePublishes).toHaveLength(1)
+    expect(executePublishes[0]?.payload).toMatchObject({ evaluationId: semanticEvalId })
+    expect(executePublishes[0]?.options).toMatchObject({
+      dedupeKey: `${buildLiveEvaluationExecuteTraceDedupeKey({
+        organizationId: ORGANIZATION_ID,
+        projectId,
+        evaluationId: semanticEvalId,
+        traceId,
+      })}:embeddings-ready`,
+    })
+  })
 })
 
 describe("createRunHandler", () => {
@@ -449,6 +502,7 @@ describe("createRunHandler", () => {
       organizationId: ORGANIZATION_ID,
       projectId,
       traceId,
+      reason: "ingest",
       outcome: "completed",
       sessionId,
       activeEvaluationsScanned: 1,

--- a/apps/workers/src/workers/signals-match.ts
+++ b/apps/workers/src/workers/signals-match.ts
@@ -4,6 +4,7 @@ import {
   orchestrateTraceEndLiveEvaluationExecutesUseCase,
 } from "@domain/evaluations"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
+import { requiresEmbedding } from "@domain/sandbox"
 import { type FilterSet, OrganizationId, ProjectId, SignalId } from "@domain/shared"
 import { SignalRepository } from "@domain/signals"
 import {
@@ -41,6 +42,7 @@ interface SignalsMatchPayload {
   readonly projectId: string
   readonly traceId: string
   readonly isSandbox?: boolean
+  readonly reason?: "ingest" | "embeddings-ready"
 }
 
 type SignalsMatchLogger = Pick<ReturnType<typeof createLogger>, "info" | "error">
@@ -87,6 +89,7 @@ const buildRunLogContext = (payload: SignalsMatchPayload) => ({
   organizationId: payload.organizationId,
   projectId: payload.projectId,
   traceId: payload.traceId,
+  reason: payload.reason ?? "ingest",
 })
 
 /**
@@ -144,6 +147,13 @@ export const runSignalsMatchJob =
         .filter(([key]) => decisions[key]?.selected === true)
         .map(([, evaluation]) => evaluation)
 
+      // An embeddings-ready re-trigger from trace-search concerns only semantic evals — the ones that
+      // deferred waiting for vectors. Non-semantic evals already ran on the ingest pass.
+      const isEmbeddingsReady = payload.reason === "embeddings-ready"
+      const evaluationsToPublish = isEmbeddingsReady
+        ? selectedEvaluations.filter((evaluation) => requiresEmbedding(evaluation.script))
+        : selectedEvaluations
+
       const { skippedTurnCount, publishedExecuteCount } = yield* orchestrateTraceEndLiveEvaluationExecutesUseCase({
         publishExecute: (pubInput) =>
           publisher.publish(
@@ -156,7 +166,12 @@ export const runSignalsMatchJob =
               traceId: pubInput.traceId,
             },
             {
-              ...(pubInput.dedupeKey !== undefined ? { dedupeKey: pubInput.dedupeKey } : {}),
+              // A bare execute dedupeKey rides a jobId that removeOnComplete retains, so a re-trigger
+              // with the same key is shadowed. Suffix embeddings-ready so recovery is never dropped;
+              // existsByEvaluationIdAndTraceId guards against a double run against the ingest pass.
+              ...(pubInput.dedupeKey !== undefined
+                ? { dedupeKey: isEmbeddingsReady ? `${pubInput.dedupeKey}:embeddings-ready` : pubInput.dedupeKey }
+                : {}),
               ...(pubInput.debounceMs !== undefined ? { debounceMs: pubInput.debounceMs } : {}),
             },
           ),
@@ -167,7 +182,7 @@ export const runSignalsMatchJob =
         traceProjectId: traceDetail.projectId,
         traceRowId: traceDetail.traceId,
         sessionId: traceDetail.sessionId ?? null,
-        selectedEvaluations,
+        selectedEvaluations: evaluationsToPublish,
       })
 
       return {

--- a/apps/workers/src/workers/trace-end.test.ts
+++ b/apps/workers/src/workers/trace-end.test.ts
@@ -398,6 +398,19 @@ describe("runTraceEndJob", () => {
       projectId: PROJECT_ID,
       traceId: TRACE_ID,
     })
+
+    // trace-end now owns the signals:match publish ("trace ends → match signals")
+    const signalsMatchPublish = published.find((p) => p.queue === "signals")
+    expect(signalsMatchPublish?.task).toBe("match")
+    expect(signalsMatchPublish?.payload).toMatchObject({
+      organizationId: ORGANIZATION_ID,
+      projectId: PROJECT_ID,
+      traceId: TRACE_ID,
+      reason: "ingest",
+    })
+    expect(signalsMatchPublish?.options).toMatchObject({
+      dedupeKey: `org:${ORGANIZATION_ID}:signals-match:${PROJECT_ID}:${TRACE_ID}`,
+    })
   })
 })
 

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -178,6 +178,29 @@ export const runTraceEndJob =
         isSandbox: payload.isSandbox ?? false,
       })
 
+      // "Trace ends → match signals": run every active evaluation against the now-settled trace.
+      // The sandbox early-return above means this never fires for sandbox traces.
+      yield* publisher
+        .publish(
+          "signals",
+          "match",
+          {
+            organizationId: payload.organizationId,
+            projectId: payload.projectId,
+            traceId: payload.traceId,
+            isSandbox: payload.isSandbox ?? false,
+            reason: "ingest",
+          },
+          {
+            dedupeKey: `org:${payload.organizationId}:signals-match:${payload.projectId}:${payload.traceId}`,
+          },
+        )
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logError("Failed to enqueue signals match", { ...buildRunLogContext(payload), error }),
+          ),
+        )
+
       // Saved-search firing check, throttled to one run per project per 5 min.
       // Leading-edge: runs immediately so its trailing evaluation window covers
       // the traces that triggered it, instead of sliding 5 min past them.

--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -61,11 +61,15 @@ describe("resolveTraceSearchRetentionDays", () => {
 
 describe("shouldRetriggerSignalsMatch", () => {
   it("re-triggers when messages were freshly embedded this run", () => {
-    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 0, embeddedCount: 2 })).toBe(true)
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 0, embeddedCount: 2 })).toBe(
+      true,
+    )
   })
 
   it("re-triggers when all vectors were pre-existing hash hits (embeddedCount 0)", () => {
-    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 3, embeddedCount: 0 })).toBe(true)
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 3, embeddedCount: 0 })).toBe(
+      true,
+    )
   })
 
   it("does not re-trigger when the trace has no vectors (over budget / provider failure)", () => {

--- a/apps/workers/src/workers/trace-search.test.ts
+++ b/apps/workers/src/workers/trace-search.test.ts
@@ -41,7 +41,7 @@ vi.mock("../clients.ts", () => ({
   getRedisClient: vi.fn(() => ({})),
 }))
 
-import { processRefreshTrace, resolveTraceSearchRetentionDays } from "./trace-search.ts"
+import { processRefreshTrace, resolveTraceSearchRetentionDays, shouldRetriggerSignalsMatch } from "./trace-search.ts"
 
 describe("resolveTraceSearchRetentionDays", () => {
   beforeEach(() => {
@@ -56,6 +56,28 @@ describe("resolveTraceSearchRetentionDays", () => {
     )
 
     expect(retentionDays).toBe(30)
+  })
+})
+
+describe("shouldRetriggerSignalsMatch", () => {
+  it("re-triggers when messages were freshly embedded this run", () => {
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 0, embeddedCount: 2 })).toBe(true)
+  })
+
+  it("re-triggers when all vectors were pre-existing hash hits (embeddedCount 0)", () => {
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 3, embeddedCount: 0 })).toBe(true)
+  })
+
+  it("does not re-trigger when the trace has no vectors (over budget / provider failure)", () => {
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: true, existingCount: 0, embeddedCount: 0 })).toBe(
+      false,
+    )
+  })
+
+  it("does not re-trigger when the embedding config could not be resolved", () => {
+    expect(shouldRetriggerSignalsMatch({ embeddingConfigResolved: false, existingCount: 5, embeddedCount: 5 })).toBe(
+      false,
+    )
   })
 })
 

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -315,7 +315,7 @@ export const processRefreshTrace = (payload: RefreshTracePayload, publisher?: Qu
           "signals",
           "match",
           { organizationId, projectId, traceId, reason: "embeddings-ready" },
-          { dedupeKey: `org:${organizationId}:signals-match-embeddings-ready:${traceId}` },
+          { dedupeKey: `org:${organizationId}:signals-match-embeddings-ready:${projectId}:${traceId}` },
         )
         .pipe(
           Effect.tap(() =>

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -1,6 +1,6 @@
 import { AI, type AIProviderModelConfig, resolveEmbeddingConfig } from "@domain/ai"
 import { ProjectRepository } from "@domain/projects"
-import type { QueueConsumer } from "@domain/queue"
+import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { LATITUDE_TELEMETRY_PROJECT_SLUGS, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import {
   buildTraceSearchDocument,
@@ -43,6 +43,7 @@ const TRACE_SEARCH_FALLBACK_RETENTION_DAYS = 30
 
 interface TraceSearchDeps {
   consumer: QueueConsumer
+  publisher: QueuePublisherShape
   clickhouseClient: ClickHouseClient
   postgresClient: PostgresClient
   redisClient: RedisClient
@@ -52,6 +53,8 @@ interface TraceSearchRunDeps {
   clickhouseClient: ClickHouseClient
   postgresClient: PostgresClient
   redisClient: RedisClient
+  // Absent for backfills, which must not fan out a re-trigger per historical trace.
+  publisher?: QueuePublisherShape
 }
 
 interface RefreshTracePayload {
@@ -117,6 +120,17 @@ const uniqueMessagesByHash = <T extends { readonly contentHash: string }>(messag
   return [...byHash.values()]
 }
 
+/**
+ * A trace is ready to re-trigger semantic evals when it has any vector for the active model — counting
+ * both messages embedded this run AND pre-existing hash hits (vectors a sibling trace already wrote).
+ * Gating on embeddedCount alone would miss the all-hash-hit case and leave those evals stuck.
+ */
+export const shouldRetriggerSignalsMatch = (input: {
+  readonly embeddingConfigResolved: boolean
+  readonly existingCount: number
+  readonly embeddedCount: number
+}): boolean => input.embeddingConfigResolved && input.existingCount + input.embeddedCount > 0
+
 const isLatitudeTelemetryProject = (projectId: string) =>
   Effect.gen(function* () {
     const projectRepo = yield* ProjectRepository
@@ -140,8 +154,10 @@ const isLatitudeTelemetryProject = (projectId: string) =>
  *     independently of which messages already have embeddings.
  *  4. Canonicalize each semantic-search eligible message, ensure shared vectors exist, and
  *     insert per-trace occurrence rows unconditionally.
+ *  5. Once the trace has embeddings, re-trigger signals:match so semantic evals that deferred while
+ *     waiting for vectors run the moment they land.
  */
-export const processRefreshTrace = (payload: RefreshTracePayload) =>
+export const processRefreshTrace = (payload: RefreshTracePayload, publisher?: QueuePublisherShape) =>
   Effect.gen(function* () {
     if (payload.isSandbox) return
 
@@ -287,6 +303,29 @@ export const processRefreshTrace = (payload: RefreshTracePayload) =>
     logger.info(
       `Indexed semantic search messages for trace ${traceId}: ${embeddedCount} embedded, ${skippedDuplicate} hash hits, ${hashedMessages.length} occurrences`,
     )
+
+    const hasEmbeddings = shouldRetriggerSignalsMatch({
+      embeddingConfigResolved: embeddingConfig != null,
+      existingCount: existing.length,
+      embeddedCount,
+    })
+    if (hasEmbeddings && publisher) {
+      yield* publisher
+        .publish(
+          "signals",
+          "match",
+          { organizationId, projectId, traceId, reason: "embeddings-ready" },
+          { dedupeKey: `org:${organizationId}:signals-match-embeddings-ready:${traceId}` },
+        )
+        .pipe(
+          Effect.tap(() =>
+            Effect.sync(() => logger.info(`Re-triggered signals:match for trace ${traceId} after embeddings landed`)),
+          ),
+          Effect.catch((error) =>
+            Effect.sync(() => logger.error(`Failed to re-trigger signals:match for trace ${traceId}`, error)),
+          ),
+        )
+    }
   }).pipe(
     Effect.withSpan("trace-search.refreshTrace"),
     Effect.tapError((error) =>
@@ -299,6 +338,7 @@ export const processRefreshTrace = (payload: RefreshTracePayload) =>
 
 export const createTraceSearchWorker = ({
   consumer,
+  publisher,
   clickhouseClient,
   postgresClient,
   redisClient,
@@ -313,6 +353,7 @@ export const createTraceSearchWorker = ({
         clickhouseClient: chClient,
         postgresClient: pgClient,
         redisClient: rdClient,
+        publisher,
       }),
   })
 }
@@ -323,7 +364,7 @@ export const runTraceSearchRefresh = (payload: RefreshTracePayload, deps: TraceS
   const redisClient = deps.redisClient
   const budgetLayer = Layer.provide(TraceSearchBudgetLive(redisClient), EmbedBudgetResolverLive)
 
-  return processRefreshTrace(payload).pipe(
+  return processRefreshTrace(payload, deps.publisher).pipe(
     withPostgres(
       Layer.mergeAll(
         BillingOverrideRepositoryLive,

--- a/packages/domain/evaluations/src/runtime/has-session-embeddings.test.ts
+++ b/packages/domain/evaluations/src/runtime/has-session-embeddings.test.ts
@@ -1,0 +1,98 @@
+import { OrganizationId, ProjectId } from "@domain/shared"
+import { type MessageEmbedding, MessageEmbeddingRepository, TraceSearchRepository } from "@domain/spans"
+import { createFakeMessageEmbeddingRepository, createFakeTraceSearchRepository } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { hasSessionEmbeddings } from "./has-session-embeddings.ts"
+
+const ORG = OrganizationId("org")
+const PROJECT = ProjectId("proj")
+
+const embeddingRow = (contentHash: string, embeddingModel: string): MessageEmbedding => ({
+  organizationId: ORG,
+  projectId: PROJECT,
+  contentHash,
+  embedding: [1, 0, 0],
+  embeddingModel,
+  insertedAt: new Date(0),
+})
+
+const run = (opts: {
+  readonly traceIds?: readonly string[]
+  readonly occurrences?: ReadonlyArray<{ contentHash: string; role: "user" | "assistant" }>
+  readonly storedModel?: string | null
+}) => {
+  const findByHashesModels: Array<string | undefined> = []
+  const occurrenceCalls: number[] = []
+
+  const traceSearchRepo = createFakeTraceSearchRepository({
+    listMessageOccurrencesForTraces: () => {
+      occurrenceCalls.push(1)
+      return Effect.succeed(opts.occurrences ?? [])
+    },
+  }).repository
+
+  const embeddingRepo = createFakeMessageEmbeddingRepository({
+    findByHashes: ({ contentHashes, embeddingModel }) => {
+      findByHashesModels.push(embeddingModel)
+      if (opts.storedModel == null || opts.storedModel !== embeddingModel) return Effect.succeed([])
+      return Effect.succeed(contentHashes.map((contentHash) => embeddingRow(contentHash, embeddingModel)))
+    },
+  }).repository
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(MessageEmbeddingRepository, embeddingRepo),
+    Layer.succeed(TraceSearchRepository, traceSearchRepo),
+  )
+
+  const ready = Effect.runSync(
+    hasSessionEmbeddings({
+      organizationId: ORG,
+      projectId: PROJECT,
+      traceIds: opts.traceIds ?? ["t1"],
+    }).pipe(Effect.provide(layer)),
+  )
+
+  return { ready, findByHashesModels, occurrenceCalls }
+}
+
+describe("hasSessionEmbeddings", () => {
+  it("is false without touching the repos when no trace ids are given", () => {
+    const { ready, occurrenceCalls } = run({ traceIds: [] })
+    expect(ready).toBe(false)
+    expect(occurrenceCalls).toHaveLength(0)
+  })
+
+  it("is false when the session has no occurrences", () => {
+    const { ready } = run({ occurrences: [] })
+    expect(ready).toBe(false)
+  })
+
+  it("is false when occurrences exist but no vectors are stored (over budget / provider failure)", () => {
+    const { ready } = run({
+      occurrences: [
+        { contentHash: "hash-a", role: "user" },
+        { contentHash: "hash-b", role: "assistant" },
+      ],
+      storedModel: null,
+    })
+    expect(ready).toBe(false)
+  })
+
+  it("is true when at least one occurrence has a vector for the active model", () => {
+    const { ready, findByHashesModels } = run({
+      occurrences: [{ contentHash: "hash-a", role: "user" }],
+      storedModel: "voyage-4-large",
+    })
+    expect(ready).toBe(true)
+    expect(findByHashesModels).toEqual(["voyage-4-large"])
+  })
+
+  it("is false when vectors exist only under a different embedding model", () => {
+    const { ready } = run({
+      occurrences: [{ contentHash: "hash-a", role: "user" }],
+      storedModel: "some-old-model",
+    })
+    expect(ready).toBe(false)
+  })
+})

--- a/packages/domain/evaluations/src/runtime/has-session-embeddings.ts
+++ b/packages/domain/evaluations/src/runtime/has-session-embeddings.ts
@@ -1,0 +1,46 @@
+import { type AIProviderModelConfig, resolveEmbeddingConfig } from "@domain/ai"
+import { type OrganizationId, type ProjectId, TraceId } from "@domain/shared"
+import { MessageEmbeddingRepository, TraceSearchRepository } from "@domain/spans"
+import { Effect } from "effect"
+
+/**
+ * Whether any of the given traces' messages have vectors in `message_embeddings` for the active model.
+ * `trace_message_occurrences` is written at ingest even when embedding is skipped (over budget, provider
+ * failure), so a semantic evaluation must gate on embeddings — not occurrences — or it would score 0
+ * against nothing. Reused by the live readiness pre-check and the builder preview.
+ *
+ * `traceIds` is the trigger trace for the live gate; the whole session for preview.
+ */
+export const hasSessionEmbeddings = ({
+  organizationId,
+  projectId,
+  traceIds,
+}: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly traceIds: readonly string[]
+}) =>
+  Effect.gen(function* () {
+    if (traceIds.length === 0) return false
+
+    const traceSearchRepo = yield* TraceSearchRepository
+    const embeddingRepo = yield* MessageEmbeddingRepository
+    const config: AIProviderModelConfig = yield* resolveEmbeddingConfig()
+
+    const occurrences = yield* traceSearchRepo.listMessageOccurrencesForTraces({
+      organizationId,
+      projectId,
+      traceIds: traceIds.map((traceId) => TraceId(traceId)),
+    })
+    const contentHashes = [...new Set(occurrences.map((occurrence) => occurrence.contentHash))]
+    if (contentHashes.length === 0) return false
+
+    // Model-keyed: findByHashes filters by embedding_model, so a stale-model vector never counts as ready.
+    const rows = yield* embeddingRepo.findByHashes({
+      organizationId,
+      projectId,
+      contentHashes,
+      embeddingModel: config.model,
+    })
+    return rows.length > 0
+  })

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -269,6 +269,9 @@ function createUseCaseLayer(input: {
   readonly scriptRuntimeLayer?: ReturnType<typeof createFakeScriptRuntime>["layer"] | undefined
   readonly detectorHealthLayer?: ReturnType<typeof createFakeDetectorHealthTracker>["layer"] | undefined
   readonly traceSearchRepository?: ReturnType<typeof createFakeTraceSearchRepository>["repository"] | undefined
+  readonly messageEmbeddingRepository?:
+    | ReturnType<typeof createFakeMessageEmbeddingRepository>["repository"]
+    | undefined
   readonly publisher?: QueuePublisherShape | undefined
 }): Layer.Layer<
   | AI
@@ -299,7 +302,10 @@ function createUseCaseLayer(input: {
     Layer.succeed(TraceRepository, input.traceRepository),
     Layer.succeed(SessionRepository, createFakeSessionRepository().repository),
     Layer.succeed(SpanRepository, createFakeSpanRepository().repository),
-    Layer.succeed(MessageEmbeddingRepository, createFakeMessageEmbeddingRepository().repository),
+    Layer.succeed(
+      MessageEmbeddingRepository,
+      input.messageEmbeddingRepository ?? createFakeMessageEmbeddingRepository().repository,
+    ),
     Layer.succeed(TraceSearchRepository, input.traceSearchRepository ?? createFakeTraceSearchRepository().repository),
     Layer.succeed(QueuePublisher, input.publisher ?? createNoopPublisher()),
     Layer.succeed(EvaluationRepository, input.evaluationRepository),
@@ -931,7 +937,31 @@ describe("runLiveEvaluationUseCase", () => {
 
   const EMBEDDING_SCRIPT = "return Passed((await semanticSimilarity('frustration')) >= 0.5 ? 1 : 0)"
 
-  it("defers an embedding-capability evaluation and re-publishes when the session's embeddings are not indexed yet", async () => {
+  // Occurrences are written at ingest even when embedding is skipped (over budget); the readiness gate
+  // must key off embeddings, not occurrences. `withEmbeddings` seeds vectors for those occurrences.
+  const embeddingGateRepos = (opts: { readonly withEmbeddings: boolean }) => {
+    const traceSearchRepository = createFakeTraceSearchRepository({
+      listMessageOccurrencesForTraces: () => Effect.succeed([{ contentHash: "hash-a", role: "user" as const }]),
+    }).repository
+    const messageEmbeddingRepository = createFakeMessageEmbeddingRepository({
+      findByHashes: ({ contentHashes, embeddingModel }) =>
+        Effect.succeed(
+          opts.withEmbeddings
+            ? contentHashes.map((contentHash) => ({
+                organizationId: OrganizationId(INPUT.organizationId),
+                projectId: ProjectId(INPUT.projectId),
+                contentHash,
+                embedding: [1, 0, 0],
+                embeddingModel: embeddingModel ?? "voyage-4-large",
+                insertedAt: new Date(0),
+              }))
+            : [],
+        ),
+    }).repository
+    return { traceSearchRepository, messageEmbeddingRepository }
+  }
+
+  it("defers a semantic evaluation and re-publishes when the session has occurrences but no embeddings yet", async () => {
     const evaluation = makeEvaluation({ script: EMBEDDING_SCRIPT })
     const traceDetail = makeTraceDetail()
     const { repository: traceRepository } = createFakeTraceRepository({
@@ -961,7 +991,7 @@ describe("runLiveEvaluationUseCase", () => {
             signalRepository,
             publisher,
             scriptRuntimeLayer: scriptRuntime.layer,
-            // Default fake returns no occurrences → embeddings not indexed yet.
+            ...embeddingGateRepos({ withEmbeddings: false }),
           }),
         ),
       ),
@@ -983,7 +1013,56 @@ describe("runLiveEvaluationUseCase", () => {
     expect(scriptRuntime.calls.run).toHaveLength(0)
   })
 
-  it("runs an embedding-capability evaluation anyway once the wait attempts are exhausted", async () => {
+  it("skips a semantic evaluation without persisting a score once the wait attempts are exhausted", async () => {
+    const evaluation = makeEvaluation({ script: EMBEDDING_SCRIPT })
+    const traceDetail = makeTraceDetail()
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(traceDetail),
+    })
+    const evaluationRepository = createEvaluationRepository(() => Effect.succeed(evaluation))
+    const signalRepository = createSignalRepository(() =>
+      Effect.die("Signal should not be loaded when embeddings are unavailable"),
+    )
+    const scriptRuntime = createFakeScriptRuntime({
+      run: () => Effect.die("Script should not run when embeddings are unavailable"),
+    })
+    const { persistedScores, scoreWriteLayer } = createTrackedScoreWriteFixture()
+    const published: unknown[] = []
+    const publisher = createNoopPublisher({
+      publish: (_queue, _task, payload) =>
+        Effect.sync(() => {
+          published.push(payload)
+        }),
+    })
+
+    const result = await Effect.runPromise(
+      runLiveEvaluationUseCase({ ...INPUT, embeddingWaitAttempt: 99 }).pipe(
+        Effect.provide(
+          createUseCaseLayer({
+            traceRepository,
+            evaluationRepository,
+            signalRepository,
+            publisher,
+            scoreWriteLayer,
+            scriptRuntimeLayer: scriptRuntime.layer,
+            ...embeddingGateRepos({ withEmbeddings: false }),
+          }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "embeddings-unavailable",
+      evaluationId: INPUT.evaluationId,
+      traceId: INPUT.traceId,
+    })
+    expect(published).toHaveLength(0)
+    expect(scriptRuntime.calls.run).toHaveLength(0)
+    expect(persistedScores).toHaveLength(0)
+  })
+
+  it("runs a semantic evaluation when the session's embeddings are indexed", async () => {
     const evaluation = makeEvaluation({ script: EMBEDDING_SCRIPT })
     const issue = makeSignal({ id: SignalId(evaluation.signalId) })
     const traceDetail = makeTraceDetail()
@@ -1004,7 +1083,7 @@ describe("runLiveEvaluationUseCase", () => {
     })
 
     const result = await Effect.runPromise(
-      runLiveEvaluationUseCase({ ...INPUT, embeddingWaitAttempt: 99 }).pipe(
+      runLiveEvaluationUseCase(INPUT).pipe(
         Effect.provide(
           createUseCaseLayer({
             traceRepository,
@@ -1013,6 +1092,7 @@ describe("runLiveEvaluationUseCase", () => {
             publisher,
             billingLayer: createBillingLayer(),
             scriptRuntimeLayer: scriptRuntime.layer,
+            ...embeddingGateRepos({ withEmbeddings: true }),
           }),
         ),
       ),

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -12,7 +12,12 @@ import {
 } from "@domain/billing"
 import { OutboxEventWriter } from "@domain/events"
 import { type QueuePublishError, QueuePublisher } from "@domain/queue"
-import { DETECTOR_HEALTH_WINDOW_SECONDS, DetectorHealthTracker, requiresEmbedding, type ScriptRuntime } from "@domain/sandbox"
+import {
+  DETECTOR_HEALTH_WINDOW_SECONDS,
+  DetectorHealthTracker,
+  requiresEmbedding,
+  type ScriptRuntime,
+} from "@domain/sandbox"
 import {
   type EvaluationScore,
   type ScoreAnalyticsRepository,
@@ -36,7 +41,7 @@ import {
   type SpanRepository,
   type TraceDetail,
   TraceRepository,
-  TraceSearchRepository,
+  type TraceSearchRepository,
 } from "@domain/spans"
 import { Cause, Effect, Exit } from "effect"
 import type { Evaluation } from "../../entities/evaluation.ts"

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -12,13 +12,7 @@ import {
 } from "@domain/billing"
 import { OutboxEventWriter } from "@domain/events"
 import { type QueuePublishError, QueuePublisher } from "@domain/queue"
-import {
-  DETECTOR_HEALTH_WINDOW_SECONDS,
-  DetectorHealthTracker,
-  detectScriptCapabilities,
-  hasEmbeddingCapability,
-  type ScriptRuntime,
-} from "@domain/sandbox"
+import { DETECTOR_HEALTH_WINDOW_SECONDS, DetectorHealthTracker, requiresEmbedding, type ScriptRuntime } from "@domain/sandbox"
 import {
   type EvaluationScore,
   type ScoreAnalyticsRepository,
@@ -50,6 +44,7 @@ import { getLiveEvaluationEligibility } from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 import { EvaluationSignalRepository } from "../../ports/evaluation-signal-repository.ts"
 import { buildEvaluationJudgeLiveTelemetryCapture } from "../../runtime/ai-telemetry.ts"
+import { hasSessionEmbeddings } from "../../runtime/has-session-embeddings.ts"
 import { loadScriptSessionContext } from "../../runtime/load-session-context.ts"
 import {
   executeLiveEvaluationUseCase,
@@ -58,13 +53,15 @@ import {
 } from "./execute-live-evaluation.ts"
 
 /**
- * Readiness gate for embedding-capability evaluations: `signals:match` and `trace-end` are siblings off
- * `TracesIngested`, and `trace-search` (which writes `message_embeddings`) runs after `trace-end`, so
- * embeddings usually aren't indexed when the eval first fires. Defer with a bounded delayed re-publish;
- * on the final attempt run anyway (the host returns 0 for whatever's still missing).
+ * Readiness gate for scripts that call `semanticSimilarity()`: `trace-search` (which writes
+ * `message_embeddings`) runs after the eval first fires, so embeddings usually aren't indexed yet.
+ * Defer with a bounded delayed re-publish; once attempts are exhausted, skip WITHOUT persisting a
+ * score — a persisted 0 would block every future retry via `existsByEvaluationIdAndTraceId`. The
+ * primary recovery is `trace-search` re-triggering `signals:match` once embeddings land; this timed
+ * backstop covers a lost re-trigger.
  */
-const MAX_EMBEDDING_WAIT_ATTEMPTS = 6
-const EMBEDDING_WAIT_DELAY_MS = 5_000
+const MAX_EMBEDDING_WAIT_ATTEMPTS = 3
+const EMBEDDING_WAIT_DELAY_MS = 120_000
 
 export interface RunLiveEvaluationInput {
   readonly organizationId: string
@@ -125,6 +122,7 @@ export type RunLiveEvaluationResult =
         | "result-already-exists"
         | "billing-blocked"
         | "awaiting-embeddings"
+        | "embeddings-unavailable"
       readonly evaluationId: string
       readonly traceId: string
     }
@@ -225,47 +223,52 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
       } satisfies RunLiveEvaluationResult
     }
 
-    // Readiness gate — only for embedding-capability scripts, before any billing or execution work.
-    // We only check the triggering trace: it's the one whose embeddings race this run, and older traces
-    // in the session were embedded on their own ingest cycles. If an older trace's vectors happen to be
-    // missing anyway, the host degrades gracefully (returns 0 for the absent vectors), so single-trace
-    // readiness is sufficient here.
-    if (hasEmbeddingCapability(detectScriptCapabilities(evaluation.script))) {
-      const traceSearchRepository = yield* TraceSearchRepository
-      const occurrences = yield* traceSearchRepository.listMessageOccurrencesForTraces({
+    // Readiness gate — only for scripts that call semanticSimilarity(), before any billing or execution
+    // work. We check the triggering trace: it's the one whose embeddings race this run, and older traces
+    // in the session were embedded on their own ingest cycles.
+    if (requiresEmbedding(evaluation.script)) {
+      const embeddingsReady = yield* hasSessionEmbeddings({
         organizationId: OrganizationId(input.organizationId),
         projectId,
-        traceIds: [TraceId(input.traceId)],
-      })
-      if (occurrences.length === 0) {
+        traceIds: [input.traceId],
+      }).pipe(
+        // A malformed embedding config surfaces through execution's AIError handling, not the gate.
+        Effect.catchTag("AIError", () => Effect.succeed(true)),
+      )
+      if (!embeddingsReady) {
         const attempt = input.embeddingWaitAttempt ?? 0
-        if (attempt < MAX_EMBEDDING_WAIT_ATTEMPTS) {
-          const nextAttempt = attempt + 1
-          const publisher = yield* QueuePublisher
-          yield* publisher.publish(
-            "live-evaluations",
-            "execute",
-            {
-              organizationId: input.organizationId,
-              projectId: input.projectId,
-              evaluationId: input.evaluationId,
-              traceId: input.traceId,
-              embeddingWaitAttempt: nextAttempt,
-            },
-            {
-              dedupeKey: `org:${input.organizationId}:live-eval-embedding-wait:${input.evaluationId}:${input.traceId}:${nextAttempt}`,
-              debounceMs: EMBEDDING_WAIT_DELAY_MS,
-            },
-          )
+        if (attempt >= MAX_EMBEDDING_WAIT_ATTEMPTS) {
+          yield* Effect.annotateCurrentSpan("evaluation.embeddingsUnavailable", true)
           return {
             action: "skipped",
-            reason: "awaiting-embeddings",
+            reason: "embeddings-unavailable",
             evaluationId: input.evaluationId,
             traceId: input.traceId,
           } satisfies RunLiveEvaluationResult
         }
-        // Out of attempts: run anyway (host returns 0 for the missing vectors). Metric proxy for "never arrived".
-        yield* Effect.annotateCurrentSpan("evaluation.embeddingsMissingAtRun", true)
+        const nextAttempt = attempt + 1
+        const publisher = yield* QueuePublisher
+        yield* publisher.publish(
+          "live-evaluations",
+          "execute",
+          {
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            evaluationId: input.evaluationId,
+            traceId: input.traceId,
+            embeddingWaitAttempt: nextAttempt,
+          },
+          {
+            dedupeKey: `org:${input.organizationId}:live-eval-embedding-wait:${input.evaluationId}:${input.traceId}:${nextAttempt}`,
+            debounceMs: EMBEDDING_WAIT_DELAY_MS,
+          },
+        )
+        return {
+          action: "skipped",
+          reason: "awaiting-embeddings",
+          evaluationId: input.evaluationId,
+          traceId: input.traceId,
+        } satisfies RunLiveEvaluationResult
       }
     }
 

--- a/packages/domain/evaluations/src/use-cases/preview-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/preview-evaluation.test.ts
@@ -15,6 +15,7 @@ import {
   MessageEmbeddingRepository,
   type Session,
   SessionRepository,
+  type Span,
   SpanRepository,
   type TraceDetail,
   TraceRepository,
@@ -26,6 +27,7 @@ import {
   createFakeSpanRepository,
   createFakeTraceRepository,
   createFakeTraceSearchRepository,
+  stubListSpan,
 } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -108,10 +110,26 @@ const makeTraceDetail = (traceId: string, sessionId: string): TraceDetail => ({
   allMessages: [{ role: "assistant", parts: [{ type: "text", content: "done" }] }],
 })
 
+const makeSpan = (traceId: string): Span =>
+  stubListSpan({
+    organizationId: OrganizationId(organizationId),
+    projectId: ProjectId(projectId),
+    traceId: TraceId(traceId),
+    sessionId: SessionId("session"),
+    spanId: SpanId("s".repeat(16)),
+    operation: "chat",
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:01.000Z"),
+  })
+
 const buildLayer = (input: {
   readonly sessions: readonly Session[]
   readonly listSpy?: (filters: FilterSet | undefined) => void
   readonly scriptRuntimeLayer?: ReturnType<typeof createFakeScriptRuntime>["layer"]
+  /** When true, the session has both occurrences and vectors, so a semantic eval runs instead of skipping. */
+  readonly withEmbeddings?: boolean
+  /** Spans backing the loaded session; needed so a semantic eval sees non-empty session traces. */
+  readonly spans?: readonly Span[]
 }) =>
   Layer.mergeAll(
     Layer.succeed(
@@ -123,15 +141,41 @@ const buildLayer = (input: {
         },
       }).repository,
     ),
-    Layer.succeed(SpanRepository, createFakeSpanRepository().repository),
+    Layer.succeed(
+      SpanRepository,
+      createFakeSpanRepository({ listBySessionId: () => Effect.succeed(input.spans ?? []) }).repository,
+    ),
     Layer.succeed(
       TraceRepository,
       createFakeTraceRepository({
         findByTraceId: ({ traceId }) => Effect.succeed(makeTraceDetail(traceId as string, "session")),
       }).repository,
     ),
-    Layer.succeed(MessageEmbeddingRepository, createFakeMessageEmbeddingRepository().repository),
-    Layer.succeed(TraceSearchRepository, createFakeTraceSearchRepository().repository),
+    Layer.succeed(
+      MessageEmbeddingRepository,
+      createFakeMessageEmbeddingRepository({
+        findByHashes: ({ contentHashes, embeddingModel }) =>
+          Effect.succeed(
+            input.withEmbeddings
+              ? contentHashes.map((contentHash) => ({
+                  organizationId: OrganizationId(organizationId),
+                  projectId: ProjectId(projectId),
+                  contentHash,
+                  embedding: [1, 0, 0],
+                  embeddingModel: embeddingModel ?? "voyage-4-large",
+                  insertedAt: new Date(0),
+                }))
+              : [],
+          ),
+      }).repository,
+    ),
+    Layer.succeed(
+      TraceSearchRepository,
+      createFakeTraceSearchRepository({
+        listMessageOccurrencesForTraces: () =>
+          Effect.succeed(input.withEmbeddings ? [{ contentHash: "hash-a", role: "user" as const }] : []),
+      }).repository,
+    ),
     createFakeAI().layer,
     input.scriptRuntimeLayer ?? createFakeScriptRuntime().layer,
   )
@@ -188,6 +232,41 @@ describe("previewEvaluationUseCase", () => {
     expect(result.items).toHaveLength(2)
     expect(result.items.filter((r) => r.error !== null)).toHaveLength(1)
     expect(result.items.filter((r) => r.passed === true)).toHaveLength(1)
+  })
+
+  const semanticEvaluation = { script: "return Passed((await semanticSimilarity('frustration')) >= 0.5 ? 1 : 0)" }
+
+  it("skips a semantic eval (never runs it) when the session has no embeddings", async () => {
+    const traceId = "t1".padEnd(32, "1")
+    const sessions = [makeSession("s1", [traceId])]
+    const runtime = createFakeScriptRuntime({
+      run: () => Effect.die("Script must not run when the session has no embeddings"),
+    })
+
+    const result = await Effect.runPromise(
+      previewEvaluationUseCase({ organizationId, projectId, evaluation: semanticEvaluation }).pipe(
+        Effect.provide(buildLayer({ sessions, scriptRuntimeLayer: runtime.layer, spans: [makeSpan(traceId)] })),
+      ),
+    )
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({ sessionId: "s1", skipped: true, passed: null, value: null, error: null })
+    // The row still carries the session summary so it's recognizable in the preview.
+    expect(result.items[0]?.summary).not.toBeNull()
+  })
+
+  it("runs a semantic eval when the session's embeddings are present", async () => {
+    const traceId = "t1".padEnd(32, "1")
+    const sessions = [makeSession("s1", [traceId])]
+
+    const result = await Effect.runPromise(
+      previewEvaluationUseCase({ organizationId, projectId, evaluation: semanticEvaluation }).pipe(
+        Effect.provide(buildLayer({ sessions, withEmbeddings: true, spans: [makeSpan(traceId)] })),
+      ),
+    )
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({ sessionId: "s1", skipped: false, passed: true })
   })
 
   it("passes the supplied filters through to the session query", async () => {

--- a/packages/domain/evaluations/src/use-cases/preview-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/preview-evaluation.ts
@@ -1,5 +1,10 @@
 import type { AI } from "@domain/ai"
-import { requiresEmbedding, type ScriptCompileError, type ScriptRuntime, type ScriptSessionContext } from "@domain/sandbox"
+import {
+  requiresEmbedding,
+  type ScriptCompileError,
+  type ScriptRuntime,
+  type ScriptSessionContext,
+} from "@domain/sandbox"
 import {
   cuidSchema,
   describeError,

--- a/packages/domain/evaluations/src/use-cases/preview-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/preview-evaluation.ts
@@ -1,5 +1,5 @@
 import type { AI } from "@domain/ai"
-import type { ScriptCompileError, ScriptRuntime, ScriptSessionContext } from "@domain/sandbox"
+import { requiresEmbedding, type ScriptCompileError, type ScriptRuntime, type ScriptSessionContext } from "@domain/sandbox"
 import {
   cuidSchema,
   describeError,
@@ -22,6 +22,7 @@ import { Effect } from "effect"
 import { z } from "zod"
 import { compileSettingsToScript } from "../codegen/compile-settings-to-script.ts"
 import { validateEvaluationScriptCompiles } from "../codegen/validate-evaluation-script.ts"
+import { hasSessionEmbeddings } from "../runtime/has-session-embeddings.ts"
 import { loadScriptSessionContext } from "../runtime/load-session-context.ts"
 import { executeEvaluationScriptSandboxed } from "../runtime/sandbox-execution.ts"
 import { buildSemanticSimilarityHost } from "../runtime/semantic-similarity.ts"
@@ -59,6 +60,8 @@ export interface PreviewEvaluationRow {
   readonly feedback: string
   /** Set when this sample's run errored; the rest of the preview still returns. */
   readonly error: string | null
+  /** True when a semantic eval was not run because the session has no embeddings yet (no retry here). */
+  readonly skipped: boolean
   /** Session content + metrics; `null` only when the session itself couldn't be loaded. */
   readonly summary: PreviewSessionSummary | null
 }
@@ -99,6 +102,8 @@ export const previewEvaluationUseCase = (input: PreviewEvaluationInput) =>
       "settings" in parsed.evaluation ? compileSettingsToScript(parsed.evaluation.settings) : parsed.evaluation.script
     yield* validateEvaluationScriptCompiles(script)
 
+    const needsEmbedding = requiresEmbedding(script)
+
     const filters: FilterSet | undefined = parsed.filters ?? undefined
     const sessionRepository = yield* SessionRepository
     const traceRepository = yield* TraceRepository
@@ -134,6 +139,27 @@ export const previewEvaluationUseCase = (input: PreviewEvaluationInput) =>
             projectId: parsed.projectId,
             traceDetail,
           })
+
+          if (needsEmbedding) {
+            const embeddingsReady = yield* hasSessionEmbeddings({
+              organizationId: parsed.organizationId,
+              projectId: parsed.projectId,
+              traceIds: scriptSession.traces.map((trace) => trace.id),
+            })
+            if (!embeddingsReady) {
+              return {
+                sessionId: session.sessionId,
+                traceId,
+                passed: null,
+                value: null,
+                feedback: "",
+                error: null,
+                skipped: true,
+                summary: buildSummary(scriptSession),
+              } satisfies PreviewEvaluationRow
+            }
+          }
+
           const similarity = yield* buildSemanticSimilarityHost({
             organizationId: parsed.organizationId,
             projectId: parsed.projectId,
@@ -147,6 +173,7 @@ export const previewEvaluationUseCase = (input: PreviewEvaluationInput) =>
             value: execution.result.value,
             feedback: execution.result.feedback,
             error: null,
+            skipped: false,
             summary: buildSummary(scriptSession),
           } satisfies PreviewEvaluationRow
         }).pipe(
@@ -159,6 +186,7 @@ export const previewEvaluationUseCase = (input: PreviewEvaluationInput) =>
               value: null,
               feedback: "",
               error: describeError(error),
+              skipped: false,
               summary: null,
             }),
           }),

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -428,6 +428,8 @@ const _registry = {
       readonly projectId: string
       readonly traceId: string
       readonly isSandbox?: boolean
+      /** "embeddings-ready" re-triggers are filtered to semantic evals; absent/"ingest" is the trace-end pass. */
+      readonly reason?: "ingest" | "embeddings-ready"
     }
   }>(),
 

--- a/packages/domain/sandbox/src/capabilities.test.ts
+++ b/packages/domain/sandbox/src/capabilities.test.ts
@@ -3,6 +3,7 @@ import {
   detectScriptCapabilities,
   hasEmbeddingCapability,
   hasLlmCapability,
+  requiresEmbedding,
   resolveScriptCapabilities,
 } from "./capabilities.ts"
 
@@ -38,5 +39,11 @@ describe("detectScriptCapabilities", () => {
     expect(hasLlmCapability([])).toBe(false)
     expect(hasEmbeddingCapability(["embedding"])).toBe(true)
     expect(hasEmbeddingCapability(["llm"])).toBe(false)
+  })
+
+  it("requiresEmbedding is true only when the source calls semanticSimilarity()", () => {
+    expect(requiresEmbedding("const s = await semanticSimilarity('frustration'); return Score(s)")).toBe(true)
+    expect(requiresEmbedding("await llm(`x`); return Score(1)")).toBe(false)
+    expect(requiresEmbedding("return Score(1)")).toBe(false)
   })
 })

--- a/packages/domain/sandbox/src/capabilities.ts
+++ b/packages/domain/sandbox/src/capabilities.ts
@@ -17,6 +17,9 @@ export const detectScriptCapabilities = (source: string): readonly ScriptCapabil
   return capabilities
 }
 
+/** Whether a raw script source calls `semanticSimilarity()` and therefore needs message embeddings. */
+export const requiresEmbedding = (source: string): boolean => EMBEDDING_REFERENCE_PATTERN.test(source)
+
 export const resolveScriptCapabilities = (input: {
   readonly source: string
   readonly declared?: readonly ScriptCapability[] | undefined

--- a/packages/domain/sandbox/src/index.ts
+++ b/packages/domain/sandbox/src/index.ts
@@ -2,6 +2,7 @@ export {
   detectScriptCapabilities,
   hasEmbeddingCapability,
   hasLlmCapability,
+  requiresEmbedding,
   resolveScriptCapabilities,
   SCRIPT_CAPABILITIES,
   type ScriptCapability,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,6 +733,9 @@ importers:
       '@domain/queue':
         specifier: workspace:*
         version: link:../../packages/domain/queue
+      '@domain/sandbox':
+        specifier: workspace:*
+        version: link:../../packages/domain/sandbox
       '@domain/sandboxes':
         specifier: workspace:*
         version: link:../../packages/domain/sandboxes


### PR DESCRIPTION
## What this fixes

Semantic-similarity signal evaluations could persist **permanent false negatives**.

`trace-search` writes `trace_message_occurrences` for a trace even when the org is over its embed budget (or the embed provider fails), so `message_embeddings` stays empty. The live-eval readiness gate checked *occurrences*, not embeddings — it saw the trace as ready, ran the eval immediately, `semanticSimilarity()` short-circuited to `0` (nothing to compare against), and a canonical `passed=false` score was persisted. `existsByEvaluationIdAndTraceId` then blocked every retry, so a session that genuinely matched the query never joined the signal — even after its embeddings later landed.

A semantic eval now never persists a `0` for "we couldn't embed it yet." It skips (no score, no billing) when the session has no embeddings, runs for real when they exist, and is re-triggered automatically once `trace-search` writes them. Non-semantic evals are unchanged.

## Readiness is embeddings, not occurrences

Two small helpers drive the gating:

- `requiresEmbedding(script)` — true when a script calls `semanticSimilarity()`. Replaces the previous `hasEmbeddingCapability(detectScriptCapabilities(script))`.
- `hasSessionEmbeddings({ organizationId, projectId, traceIds })` — true when the session's messages have vectors in `message_embeddings` for the active embedding model (model-keyed `findByHashes`, the same read the host does).

The live readiness gate (`run-live-evaluation`) now checks `hasSessionEmbeddings` for the trigger trace. When embeddings are missing it defers with a bounded delayed re-publish (3 attempts, 2 min apart); once those are exhausted it skips with a new terminal reason `embeddings-unavailable` and **persists nothing**. The old "run anyway on the last attempt → persist 0" fall-through is gone — that was the line that poisoned the trace.

## Recovery: event-driven re-trigger + bounded backstop

Primary path: after `trace-search` writes (or confirms) a trace's embeddings, it publishes a `signals:match` with `reason: "embeddings-ready"`, so a deferred semantic eval runs the moment vectors exist. The readiness check counts both freshly embedded messages **and** pre-existing hash hits (`shouldRetriggerSignalsMatch`) — a trace whose vectors all came from a sibling trace is ready too, and gating on the fresh count alone would leave it stuck.

`signals:match` filters `embeddings-ready` re-triggers to semantic evals only (non-semantic evals already ran on the ingest pass) and suffixes the re-trigger's `live-evaluations:execute` dedupeKey with `:embeddings-ready`. That suffix matters: a bare execute dedupeKey rides a BullMQ `jobId` that `removeOnComplete` retains, so without it the re-trigger would be shadowed by the completed ingest-path execute. A double run against the ingest pass is harmless — `existsByEvaluationIdAndTraceId` guards the persist.

Backstop: the bounded timed re-publish in `run-live-evaluation` stays as a safety net for a lost re-trigger or an ingest race. It always skips-never-persists.

## trace-end owns the match publish

`signals:match` moved out of the `TracesIngested` fan-out and into the `trace-end` job — "trace ends → match signals" — so it runs on the settled trace after trace-end's own debounce. trace-end already skips sandbox traces, so the publish never fires for them; the consumer keeps its own sandbox skip as belt-and-suspenders.

## Builder preview

The preview pre-checks embeddings for semantic evals: a session with no vectors renders as a new **skipped** verdict (no run, no retry) instead of a misleading `0` / "no match". `PreviewEvaluationRow` gains a `skipped` flag; the preview UI checks it before error/passed (a skipped row has `passed: null` and would otherwise read as "no match") and shows a "session not embedded yet" reason.

## Testing

Unit coverage for `requiresEmbedding`, `hasSessionEmbeddings` (occurrences-but-no-vectors → false, model mismatch → false), the live gate (defer → terminal skip, never persists a score; runs when embeddings present), `shouldRetriggerSignalsMatch`, the `signals:match` reason filter + dedupeKey suffix, the trace-end publish, and the preview skipped/runs rows. Full workspace typecheck passes; touched `@domain/evaluations` and `@app/workers` suites pass (including the ClickHouse-backed ones).

## Out of scope

Already-persisted false-`0` rows stay blocked until a separate cleanup — this PR stops new ones. Budget-recovery re-embedding of old traces is unchanged: embeddings are only written on ingest, so a stuck trace self-heals when its content is later embedded (a sibling trace or a backfill).
