### PR TITLE
fix(spans): guard trace search formatting when message parts are missing

### DIFF
--- a/packages/domain/spans/src/use-cases/build-trace-search-document.test.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-search-document.test.ts
@@ -324,6 +324,17 @@ describe("buildTraceSearchDocument", () => {
       expect(document.searchText).toBe("")
     })
 
+    it("skips messages with missing parts instead of throwing", async () => {
+      const document = await build([
+        textMessage("user", "before gap"),
+        { role: "assistant" } as GenAIMessage,
+        textMessage("user", "after gap"),
+      ])
+
+      expect(document.searchText).toBe("before gap after gap")
+      expect(document.chunks).toHaveLength(1)
+    })
+
     it("assigns stable chunk content hashes that vary by chunk index", async () => {
       const turn = "z".repeat(TRACE_SEARCH_CHUNK_MAX_CHARS * 2)
       const a = await build([textMessage("user", turn)])

--- a/packages/domain/spans/src/use-cases/build-trace-search-document.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-search-document.ts
@@ -87,7 +87,7 @@ function formatPartForLexical(part: GenAIPart): string {
 }
 
 function formatMessage(message: GenAIMessage, formatter: (p: GenAIPart) => string): string {
-  return message.parts
+  return (message.parts ?? [])
     .map((p) => formatter(p))
     .join("\n")
     .trim()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a production `TypeError` in the trace-search worker when a stored `GenAIMessage` has no `parts` array.

## Datadog issue

- [TypeError: Cannot read properties of undefined (reading 'map')](https://app.datadoghq.eu/error-tracking/issue/bbeeb746-791d-11f1-9cc5-da7ad0900005) — `workers` / `process trace-search`, ~378 occurrences since first seen today (2026-07-06).

## Root cause

`buildTraceSearchDocument` → `formatMessage` called `.map()` on `message.parts` without a null guard. Ingested conversations can contain messages that pass the permissive `genAIMessageSchema` (any non-null object) but omit `parts`; other call sites already use `message.parts ?? []`.

Stack: `formatMessage` → `extractTurns` → `buildTraceSearchDocument` in `packages/domain/spans/src/use-cases/build-trace-search-document.ts`.

## Fix

Use `(message.parts ?? [])` in `formatMessage`, matching `map-conversation-to-spans`, `conversation.tsx`, and `build-conversation-timeline`.

## Tests

Added a regression test that feeds a message with `{ role: "assistant" }` and no `parts`; the document builds successfully and skips the empty message.

```
pnpm --filter @domain/spans test build-trace-search-document.test.ts
pnpm --filter @domain/spans typecheck
```

## Verification

After deploy, occurrences of issue `bbeeb746-791d-11f1-9cc5-da7ad0900005` should drop to zero. Locally, the new test fails without the guard and passes with it.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1783330692512289?thread_ts=1783330692.512289&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-a734bdc3-901e-56cd-9a3e-d1317d20a3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a734bdc3-901e-56cd-9a3e-d1317d20a3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

