### PR TITLE
Show billing counter in red when free plan hits credit limit

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -107,6 +107,8 @@ function BillingCreditCounter({ organizationId }: { readonly organizationId: str
   const hasIncludedCredits = includedCredits !== null && includedCredits > 0
   const progress = hasIncludedCredits ? Math.min(totalUsedCredits / includedCredits, 1) : 1
   const isOverage = overview.overageCredits > 0
+  const isAtIncludedLimit = hasIncludedCredits && totalUsedCredits >= includedCredits
+  const showLimitState = isOverage || (overview.planSlug === "free" && isAtIncludedLimit)
   const strokeOffset = BILLING_COUNTER_CIRCUMFERENCE * (1 - progress)
   const consumedLabel = numberFormatter.format(totalUsedCredits)
   const includedLabel = includedCredits === null ? "custom" : numberFormatter.format(includedCredits)
@@ -170,14 +172,14 @@ function BillingCreditCounter({ organizationId }: { readonly organizationId: str
                   strokeDasharray={BILLING_COUNTER_CIRCUMFERENCE}
                   strokeDashoffset={strokeOffset}
                   className={cn("transition-colors", {
-                    "text-primary": !isOverage,
-                    "text-destructive": isOverage,
+                    "text-primary": !showLimitState,
+                    "text-destructive": showLimitState,
                   })}
                 />
               </svg>
             </span>
             <div className="hidden items-baseline gap-1 md:flex">
-              <Text.H6 weight="medium" color={isOverage ? "destructive" : "foreground"}>
+              <Text.H6 weight="medium" color={showLimitState ? "destructive" : "foreground"}>
                 {usageLabel}
               </Text.H6>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Free plan organizations at 100% included usage now show the header billing counter (progress ring and label) in red, matching the existing overage styling on paid plans.

## Problem

The header `BillingCreditCounter` only switched to destructive styling when `overageCredits > 0`. Free plan users are hard-capped at their included allowance, so at 20K/20K they had a blue ring and default text even though they had hit their limit.

## Change

Introduce `showLimitState`, which is true when either:

- the org has metered overage credits (existing behavior), or
- the org is on the free plan and `consumedCredits >= includedCredits`

Use `showLimitState` for both the SVG progress stroke and the counter label color.

## Screenshot

[Free plan at credit limit — red counter and progress ring](https://cursor.com/agents/bc-c1169ef3-f80a-4345-8bd5-2bfe9d266ccb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffree-plan-credit-limit-red.png)

## Testing

- `pnpm --filter @app/web typecheck`
- Visual preview of the at-limit header state

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1169ef3-f80a-4345-8bd5-2bfe9d266ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1169ef3-f80a-4345-8bd5-2bfe9d266ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

