### PR TITLE
fix(web): show onboarding illustrations in the claim flow

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -16,8 +16,7 @@ import { submitOnboarding } from "../../../../../domains/users/user.functions.ts
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { createFormSubmitHandler } from "../../../../../lib/form-server-action.ts"
-import { CarouselSlide, CarouselTrack } from "./onboarding/carousel-track.tsx"
-import { OnboardingGallery } from "./onboarding/onboarding-gallery.tsx"
+import { OnboardingRightPane } from "./onboarding/onboarding-right-pane.tsx"
 import * as FlaggersStep from "./onboarding/steps/flaggers-step.tsx"
 import * as RoleStep from "./onboarding/steps/role-step.tsx"
 import * as SlackStep from "./onboarding/steps/slack-step.tsx"
@@ -257,17 +256,9 @@ export function OnboardingFlow({
 
   const telemetryBackStep: OnboardingStep = slackStepEnabled ? "slack" : "flaggers"
 
-  type RightSlide = "intro" | "flaggers" | "slack" | "telemetry"
-  const STEP_TO_RIGHT_SLIDE: Record<OnboardingStep, RightSlide> = {
-    role: "intro",
-    flaggers: "flaggers",
-    slack: "slack",
-    telemetry: "telemetry",
-  }
-  const visibleRightSlides: ReadonlyArray<RightSlide> = slackStepEnabled
-    ? ["intro", "flaggers", "slack", "telemetry"]
-    : ["intro", "flaggers", "telemetry"]
-  const activeRightSlideIndex = Math.max(0, visibleRightSlides.indexOf(STEP_TO_RIGHT_SLIDE[step]))
+  const activeSteps: ReadonlyArray<OnboardingStep> = slackStepEnabled
+    ? ["role", "flaggers", "slack", "telemetry"]
+    : ["role", "flaggers", "telemetry"]
 
   return (
     <div className="flex h-full min-h-0 w-full min-w-0 flex-1 flex-row overflow-hidden bg-background">
@@ -309,23 +300,13 @@ export function OnboardingFlow({
         )}
       </div>
 
-      <div className="hidden h-full min-h-0 min-w-0 shrink-0 flex-col overflow-hidden bg-secondary lg:flex lg:w-1/2">
-        <CarouselTrack activeIndex={activeRightSlideIndex}>
-          {visibleRightSlides.map((slide) => (
-            <CarouselSlide key={slide}>
-              {slide === "intro" ? (
-                <OnboardingGallery />
-              ) : slide === "flaggers" ? (
-                <FlaggersStep.Right enabledFlaggerSlugs={enabledFlaggerSlugs} availableFlaggers={availableFlaggers} />
-              ) : slide === "slack" ? (
-                <SlackStep.Right isActive={step === "slack"} />
-              ) : (
-                <TelemetryStep.Right traceReceived={traceReceived} />
-              )}
-            </CarouselSlide>
-          ))}
-        </CarouselTrack>
-      </div>
+      <OnboardingRightPane
+        steps={activeSteps}
+        currentStep={step}
+        enabledFlaggerSlugs={enabledFlaggerSlugs}
+        availableFlaggers={availableFlaggers}
+        traceReceived={traceReceived}
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/onboarding-right-pane.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding/onboarding-right-pane.tsx
@@ -1,0 +1,55 @@
+import type { ComponentProps } from "react"
+import type { OnboardingStep } from "../onboarding-flow.tsx"
+import { CarouselSlide, CarouselTrack } from "./carousel-track.tsx"
+import { OnboardingGallery } from "./onboarding-gallery.tsx"
+import * as FlaggersStep from "./steps/flaggers-step.tsx"
+import * as SlackStep from "./steps/slack-step.tsx"
+import * as TelemetryStep from "./steps/telemetry-step.tsx"
+
+type RightSlide = "intro" | "flaggers" | "slack" | "telemetry"
+
+const STEP_TO_RIGHT_SLIDE: Record<OnboardingStep, RightSlide> = {
+  role: "intro",
+  flaggers: "flaggers",
+  slack: "slack",
+  telemetry: "telemetry",
+}
+
+// The step visuals live here, not as a prop on the step components — a flow that renders
+// only `Step.Left` gets no illustrations, so every onboarding flow must mount this pane too.
+export function OnboardingRightPane({
+  steps,
+  currentStep,
+  enabledFlaggerSlugs,
+  availableFlaggers,
+  traceReceived = false,
+}: {
+  readonly steps: ReadonlyArray<OnboardingStep>
+  readonly currentStep: OnboardingStep
+  readonly enabledFlaggerSlugs: ComponentProps<typeof FlaggersStep.Right>["enabledFlaggerSlugs"]
+  readonly availableFlaggers: ComponentProps<typeof FlaggersStep.Right>["availableFlaggers"]
+  readonly traceReceived?: boolean
+}) {
+  const visibleRightSlides = steps.map((step) => STEP_TO_RIGHT_SLIDE[step])
+  const activeRightSlideIndex = Math.max(0, steps.indexOf(currentStep))
+
+  return (
+    <div className="hidden h-full min-h-0 min-w-0 shrink-0 flex-col overflow-hidden bg-secondary lg:flex lg:w-1/2">
+      <CarouselTrack activeIndex={activeRightSlideIndex}>
+        {visibleRightSlides.map((slide) => (
+          <CarouselSlide key={slide}>
+            {slide === "intro" ? (
+              <OnboardingGallery />
+            ) : slide === "flaggers" ? (
+              <FlaggersStep.Right enabledFlaggerSlugs={enabledFlaggerSlugs} availableFlaggers={availableFlaggers} />
+            ) : slide === "slack" ? (
+              <SlackStep.Right isActive={currentStep === "slack"} />
+            ) : (
+              <TelemetryStep.Right traceReceived={traceReceived} />
+            )}
+          </CarouselSlide>
+        ))}
+      </CarouselTrack>
+    </div>
+  )
+}

--- a/apps/web/src/routes/claim.$token.tsx
+++ b/apps/web/src/routes/claim.$token.tsx
@@ -21,6 +21,7 @@ import { submitOnboarding } from "../domains/users/user.functions.ts"
 import { getQueryClient } from "../lib/data/query-client.tsx"
 import { toUserMessage } from "../lib/errors.ts"
 import { createFormSubmitHandler } from "../lib/form-server-action.ts"
+import { OnboardingRightPane } from "./_authenticated/projects/$projectSlug/-components/onboarding/onboarding-right-pane.tsx"
 import * as FlaggersStep from "./_authenticated/projects/$projectSlug/-components/onboarding/steps/flaggers-step.tsx"
 import * as RoleStep from "./_authenticated/projects/$projectSlug/-components/onboarding/steps/role-step.tsx"
 import * as SlackStep from "./_authenticated/projects/$projectSlug/-components/onboarding/steps/slack-step.tsx"
@@ -285,9 +286,13 @@ function ClaimOnboarding({
     }
   }
 
+  const activeSteps: ReadonlyArray<ClaimOnboardingStep> = slackEnvConfigured
+    ? ["role", "flaggers", "slack"]
+    : ["role", "flaggers"]
+
   return (
-    <div className="flex min-h-screen w-full flex-col overflow-y-auto bg-background px-6 py-12 sm:px-12">
-      <div className="mx-auto flex w-full max-w-[880px] flex-1 flex-col justify-center">
+    <div className="flex h-screen min-h-0 w-full min-w-0 flex-row overflow-hidden bg-background">
+      <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-y-auto overscroll-y-contain px-6 pt-12 pb-16 sm:px-12 sm:pt-16 sm:pb-20 lg:w-1/2 lg:border-r lg:border-border lg:px-24 lg:pt-24 lg:pb-32 [scrollbar-gutter:stable]">
         {step === "role" ? (
           <RoleStep.Left
             form={form}
@@ -316,6 +321,13 @@ function ClaimOnboarding({
           />
         )}
       </div>
+
+      <OnboardingRightPane
+        steps={activeSteps}
+        currentStep={step}
+        enabledFlaggerSlugs={enabledFlaggerSlugs}
+        availableFlaggers={availableFlaggers}
+      />
     </div>
   )
 }


### PR DESCRIPTION
The temporary-organization **claim** onboarding reused the same step components as the normal project onboarding, but only showed the left-hand form on each step — none of the right-side illustrations. Everything else (traces intro gallery, signals feed, Slack queue mock) was missing.

## Cause

The step visuals aren't a prop on the step components. Each step module (`role`, `flaggers`, `slack`, `telemetry`) exports two separate components: `Left` (the form/content) and `Right` (the illustration). The normal `OnboardingFlow` renders a two-column layout where the right column is a carousel of `OnboardingGallery` + each step's `Right`. `ClaimOnboarding` rendered only `Step.Left` in a single centered column and never mounted a right pane, so reusing the step components got the left halves only.

## Change

Extract the normal flow's right-column carousel into a shared `OnboardingRightPane` and mount it in both flows.

- **`onboarding-right-pane.tsx`** (new) — takes the flow's ordered `steps` + `currentStep` and renders the carousel, sliding to the slide that matches the current step. One source of truth for the onboarding visuals.
- **`onboarding-flow.tsx`** — swaps its inline right column for `OnboardingRightPane`. Behavior is unchanged: `activeSteps.map(→slide)` reproduces the old visible-slides list and `steps.indexOf(currentStep)` reproduces the old active index.
- **`claim.$token.tsx`** — `ClaimOnboarding` now uses the same two-column shell (left column matches the normal flow's layout) and mounts `OnboardingRightPane`. Its `activeSteps` is `["role","flaggers","slack"]` when Slack is configured, else `["role","flaggers"]`, so the claim flow shows the intro/flaggers/slack visuals matching its steps.

## Validation

`pnpm --filter @app/web typecheck` and `biome check` pass. No behavior change to the normal onboarding flow; the claim flow now renders the illustrations on every step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)