### PR TITLE
feat(showcase): showcase resolver chokepoint (S2)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "@domain/saved-searches": "workspace:*",
     "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
+    "@domain/showcase": "workspace:*",
     "@domain/spans": "workspace:*",
     "@domain/sso": "workspace:*",
     "@domain/taxonomy": "workspace:*",

--- a/apps/web/src/server/resolve-showcase-access.ts
+++ b/apps/web/src/server/resolve-showcase-access.ts
@@ -1,0 +1,43 @@
+import { type ResolvedShowcase, resolveShowcaseUseCase } from "@domain/showcase"
+import { RedisCacheStoreLive } from "@platform/cache-redis"
+import { OrganizationRepositoryLive, ShowcaseRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { Effect, Layer } from "effect"
+import { requireSession } from "./auth.ts"
+import { getPostgresClient, getRedisClient } from "./clients.ts"
+
+/**
+ * The showcase read chokepoint, mirroring `resolveSandboxAccess` /
+ * `resolveOrgScope`. Resolves the pinned showcase org+project from the
+ * `latitude.showcase` pointer (Redis-cached) after authorizing on the requesting
+ * session: authenticated AND the requesting org's `wantsShowcase` flag is true,
+ * else the use-case fails `NotFoundError` (→ 404).
+ *
+ * The returned `organizationId` is the SINGLE resolved value a caller must hand
+ * to every layer — `withPostgres`/`withClickHouse` *and* the repo method arg.
+ * ClickHouse has no RLS backstop, so the layer org and the query-param org must
+ * be this same value or a read escapes the intended tenant. Both the session
+ * lookup and the resolution are plain function calls — no server fn invokes
+ * another server fn — and the scope is server-resolved, never taken from input,
+ * so this path can only ever resolve the one showcase project.
+ *
+ * The `organizations` + `showcase` reads run under the requesting org's own
+ * Postgres scope: `organizations` has no RLS policy, and the showcase pointer is
+ * a system/config table with no policy either, so both read correctly without an
+ * RLS bypass.
+ */
+export async function resolveShowcaseAccess(): Promise<ResolvedShowcase> {
+  const { organizationId } = await requireSession()
+
+  return Effect.runPromise(
+    resolveShowcaseUseCase({ requestingOrganizationId: organizationId }).pipe(
+      withPostgres(
+        Layer.merge(OrganizationRepositoryLive, ShowcaseRepositoryLive),
+        getPostgresClient(),
+        organizationId,
+      ),
+      Effect.provide(RedisCacheStoreLive(getRedisClient())),
+      withTracing,
+    ),
+  )
+}

--- a/knip.json
+++ b/knip.json
@@ -55,7 +55,11 @@
         "src/routes/**/*.tsx"
       ],
       "project": ["src/**/*.ts", "src/**/*.tsx"],
+      "ignore": [
+        "src/server/resolve-showcase-access.ts"
+      ],
       "ignoreDependencies": [
+        "@domain/showcase",
         "@temporalio/client",
         "quickjs-emscripten",
         "voyageai"

--- a/packages/domain/showcase/src/index.ts
+++ b/packages/domain/showcase/src/index.ts
@@ -15,3 +15,10 @@ export {
   SHOWCASE_ORG_NAME,
   SHOWCASE_ORG_SLUG,
 } from "./use-cases/create-showcase.ts"
+export {
+  type ResolvedShowcase,
+  type ResolveShowcaseError,
+  type ResolveShowcaseInput,
+  resolveShowcaseUseCase,
+  SHOWCASE_POINTER_CACHE_KEY,
+} from "./use-cases/resolve-showcase.ts"

--- a/packages/domain/showcase/src/use-cases/resolve-showcase.test.ts
+++ b/packages/domain/showcase/src/use-cases/resolve-showcase.test.ts
@@ -1,0 +1,144 @@
+import { createOrganization, type Organization, OrganizationRepository } from "@domain/organizations"
+import {
+  CacheStore,
+  type CacheStoreShape,
+  NotFoundError,
+  OrganizationId,
+  ProjectId,
+  SqlClient,
+  type SqlClientShape,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { createShowcase } from "../entities/showcase.ts"
+import { ShowcaseRepository } from "../ports/showcase-repository.ts"
+import { createFakeShowcaseRepository } from "../testing/fake-showcase-repository.ts"
+import { resolveShowcaseUseCase } from "./resolve-showcase.ts"
+
+const REQUESTING_ORG_ID = OrganizationId("requestingorgggggggggg01")
+const SHOWCASE_ORG_ID = OrganizationId("showcaseorgggggggggggg01")
+const SHOWCASE_PROJECT_ID = ProjectId("showcaseprojectttttttt01")
+
+const sqlClient: SqlClientShape = {
+  organizationId: REQUESTING_ORG_ID,
+  transaction: (effect) => effect,
+  query: () => Effect.die(new Error("unexpected query")),
+}
+
+const noopCache: CacheStoreShape = {
+  get: () => Effect.succeed(null),
+  set: () => Effect.void,
+  delete: () => Effect.void,
+}
+
+const provideDeps = <A, E>(
+  effect: Effect.Effect<A, E, SqlClient | CacheStore | ShowcaseRepository | OrganizationRepository>,
+  {
+    requestingOrg,
+    showcaseRepository,
+  }: {
+    requestingOrg: Organization | null
+    showcaseRepository: ReturnType<typeof createFakeShowcaseRepository>["repository"]
+  },
+) =>
+  effect.pipe(
+    Effect.provideService(SqlClient, sqlClient),
+    Effect.provideService(CacheStore, noopCache),
+    Effect.provideService(ShowcaseRepository, showcaseRepository),
+    Effect.provideService(OrganizationRepository, {
+      findById: (id) =>
+        requestingOrg ? Effect.succeed(requestingOrg) : Effect.fail(new NotFoundError({ entity: "Organization", id })),
+      listByUserId: () => Effect.die(new Error("unused")),
+      save: () => Effect.die(new Error("unused")),
+      delete: () => Effect.die(new Error("unused")),
+      countBySlug: () => Effect.die(new Error("unused")),
+      listExpiredUnclaimed: () => Effect.die(new Error("unused")),
+    }),
+  )
+
+const orgWithFlag = (wantsShowcase: boolean | undefined) =>
+  createOrganization({
+    id: REQUESTING_ORG_ID,
+    name: "Requesting Org",
+    slug: "requesting-org",
+    settings: wantsShowcase === undefined ? null : { wantsShowcase },
+  })
+
+const liveShowcase = () =>
+  createFakeShowcaseRepository(
+    createShowcase({ organizationId: SHOWCASE_ORG_ID, currentProjectId: SHOWCASE_PROJECT_ID }),
+  )
+
+describe("resolveShowcaseUseCase", () => {
+  it("resolves the pinned showcase org+project when the requesting org wants the showcase", async () => {
+    const { repository } = liveShowcase()
+
+    const resolved = await Effect.runPromise(
+      provideDeps(resolveShowcaseUseCase({ requestingOrganizationId: REQUESTING_ORG_ID }), {
+        requestingOrg: orgWithFlag(true),
+        showcaseRepository: repository,
+      }),
+    )
+
+    expect(resolved).toEqual({
+      organizationId: SHOWCASE_ORG_ID,
+      currentProjectId: SHOWCASE_PROJECT_ID,
+    })
+  })
+
+  it("404s when the requesting org's wantsShowcase flag is false", async () => {
+    const { repository } = liveShowcase()
+
+    const error = await Effect.runPromise(
+      provideDeps(resolveShowcaseUseCase({ requestingOrganizationId: REQUESTING_ORG_ID }), {
+        requestingOrg: orgWithFlag(false),
+        showcaseRepository: repository,
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect((error as NotFoundError).httpStatus).toBe(404)
+  })
+
+  it("404s when the requesting org has no showcase preference set", async () => {
+    const { repository } = liveShowcase()
+
+    const error = await Effect.runPromise(
+      provideDeps(resolveShowcaseUseCase({ requestingOrganizationId: REQUESTING_ORG_ID }), {
+        requestingOrg: orgWithFlag(undefined),
+        showcaseRepository: repository,
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(NotFoundError)
+  })
+
+  it("404s when no showcase exists even though the org wants it", async () => {
+    const { repository } = createFakeShowcaseRepository(null)
+
+    const error = await Effect.runPromise(
+      provideDeps(resolveShowcaseUseCase({ requestingOrganizationId: REQUESTING_ORG_ID }), {
+        requestingOrg: orgWithFlag(true),
+        showcaseRepository: repository,
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(NotFoundError)
+    expect((error as NotFoundError).httpStatus).toBe(404)
+  })
+
+  it("404s when a showcase row exists but no project has been built yet (currentProjectId null)", async () => {
+    const { repository } = createFakeShowcaseRepository(
+      createShowcase({ organizationId: SHOWCASE_ORG_ID, currentProjectId: null }),
+    )
+
+    const error = await Effect.runPromise(
+      provideDeps(resolveShowcaseUseCase({ requestingOrganizationId: REQUESTING_ORG_ID }), {
+        requestingOrg: orgWithFlag(true),
+        showcaseRepository: repository,
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(NotFoundError)
+  })
+})

--- a/packages/domain/showcase/src/use-cases/resolve-showcase.ts
+++ b/packages/domain/showcase/src/use-cases/resolve-showcase.ts
@@ -1,0 +1,127 @@
+import { OrganizationRepository } from "@domain/organizations"
+import {
+  CacheStore,
+  NotFoundError,
+  type OrganizationId,
+  organizationIdSchema,
+  type ProjectId,
+  projectIdSchema,
+  type RepositoryError,
+  type SqlClient,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { z } from "zod"
+import { ShowcaseRepository } from "../ports/showcase-repository.ts"
+
+/**
+ * Redis key for the resolved showcase pointer. It names the one live showcase
+ * org+project, so it is global (not org-scoped) and carries no `org:` prefix;
+ * the `latitude:` namespace is applied by the Redis client. The pointer table
+ * is the source of truth and invalidates this key when it changes.
+ */
+export const SHOWCASE_POINTER_CACHE_KEY = "showcase:current"
+
+const SHOWCASE_POINTER_CACHE_TTL_SECONDS = 300
+
+/**
+ * The single value the resolver hands to callers. Its `organizationId` MUST be
+ * passed identically to both `withPostgres`/`withClickHouse` and the repo method
+ * arg: ClickHouse has no RLS backstop, so the layer org and the query-param org
+ * must be the same resolved value or a mismatch reads the wrong tenant.
+ */
+export interface ResolvedShowcase {
+  readonly organizationId: OrganizationId
+  readonly currentProjectId: ProjectId
+}
+
+const resolvedShowcaseSchema = z.object({
+  organizationId: organizationIdSchema,
+  currentProjectId: projectIdSchema,
+})
+
+const parseCachedPointer = (json: string): ResolvedShowcase | null => {
+  try {
+    const result = resolvedShowcaseSchema.safeParse(JSON.parse(json))
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reads the pinned showcase org+current-project from the pointer, Redis-cached.
+ * Returns `null` when no showcase exists yet or no project has been built
+ * (`currentProjectId` null) — the caller turns that into a 404. Cache errors
+ * degrade to the DB read; only live resolutions are cached (never the null).
+ */
+const resolveShowcasePointer = Effect.fn("showcase.resolvePointer")(function* () {
+  const cache = yield* CacheStore
+
+  const cachedJson = yield* cache
+    .get(SHOWCASE_POINTER_CACHE_KEY)
+    .pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
+  if (cachedJson !== null) {
+    const parsed = parseCachedPointer(cachedJson)
+    if (parsed !== null) {
+      yield* Effect.annotateCurrentSpan("cache.hit", true)
+      return parsed
+    }
+  }
+  yield* Effect.annotateCurrentSpan("cache.hit", false)
+
+  const showcaseRepo = yield* ShowcaseRepository
+  const pointer = yield* showcaseRepo.find()
+  if (!pointer || pointer.currentProjectId === null) {
+    return null
+  }
+
+  const resolved: ResolvedShowcase = {
+    organizationId: pointer.organizationId,
+    currentProjectId: pointer.currentProjectId,
+  }
+  yield* cache
+    .set(SHOWCASE_POINTER_CACHE_KEY, JSON.stringify(resolved), { ttlSeconds: SHOWCASE_POINTER_CACHE_TTL_SECONDS })
+    .pipe(Effect.catchTag("CacheError", () => Effect.void))
+  return resolved
+})
+
+export interface ResolveShowcaseInput {
+  readonly requestingOrganizationId: OrganizationId
+}
+
+export type ResolveShowcaseError = NotFoundError | RepositoryError
+
+/**
+ * The showcase read chokepoint. Authorizes "authenticated AND the requesting
+ * org's `wantsShowcase` flag is true" — else a plain 404 — then resolves the
+ * pinned showcase org+project from the pointer. Returns exactly one org id for
+ * the caller to thread into every layer (Postgres, ClickHouse, and the repo
+ * arg), which is what keeps the RLS-less ClickHouse read scoped correctly.
+ *
+ * A missing requesting org and a false/absent flag are indistinguishable from
+ * "no showcase" to the caller — all three are the same 404, so a dismissed org
+ * leaks nothing about whether a showcase exists.
+ */
+export const resolveShowcaseUseCase = Effect.fn("showcase.resolve")(function* (input: ResolveShowcaseInput) {
+  const organizationRepo = yield* OrganizationRepository
+  const requestingOrg = yield* organizationRepo
+    .findById(input.requestingOrganizationId)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+
+  if (requestingOrg?.settings?.wantsShowcase !== true) {
+    return yield* Effect.fail(new NotFoundError({ entity: "Showcase", id: input.requestingOrganizationId }))
+  }
+
+  const resolved = yield* resolveShowcasePointer()
+  if (!resolved) {
+    return yield* Effect.fail(new NotFoundError({ entity: "Showcase", id: input.requestingOrganizationId }))
+  }
+
+  return resolved
+}) satisfies (
+  input: ResolveShowcaseInput,
+) => Effect.Effect<
+  ResolvedShowcase,
+  ResolveShowcaseError,
+  SqlClient | CacheStore | ShowcaseRepository | OrganizationRepository
+>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,9 @@ importers:
       '@domain/shared':
         specifier: workspace:*
         version: link:../../packages/domain/shared
+      '@domain/showcase':
+        specifier: workspace:*
+        version: link:../../packages/domain/showcase
       '@domain/signals':
         specifier: workspace:*
         version: link:../../packages/domain/signals


### PR DESCRIPTION
## Task S2 — Showcase resolver

Part of the **Showcase Demo Project** effort — umbrella PR #3821. Builds on the Phase-1 groundwork + S1 (pointer table `latitude.showcase` + `@domain/showcase` repo, `wantsShowcase` org flag from G5) already on `development`.

Implements the **single read chokepoint** that resolves the pinned showcase project + org from the `latitude.showcase` pointer.

### What it does
- **`resolveShowcaseUseCase`** (`@domain/showcase`): the resolver core.
  - **Authorization:** "authenticated **AND** the requesting org's `wantsShowcase` flag is true" → else `NotFoundError` (404). A missing org and a false/absent flag are indistinguishable from "no showcase" — all 404, so a dismissed org leaks nothing.
  - **Pointer read is Redis-cached** (`showcase:current`, global key, no `org:` prefix since the pointer isn't org-scoped). Cache errors degrade to the DB read; only live resolutions are cached, never the null.
  - Returns **exactly one** `{ organizationId, currentProjectId }`. Callers must thread that same `organizationId` into **both** `withPostgres`/`withClickHouse` **and** the repo method arg — ClickHouse has no RLS backstop, so the layer org and the query-param org must be the same value.
- **`resolveShowcaseAccess`** (`apps/web/src/server`): thin session + Live-layer wiring, modeled on `resolveSandboxAccess` / `resolveOrgScope`. Reads run under the requesting org's own Postgres scope (both `organizations` and the pointer table have no RLS policy), no RLS bypass.

### Scope / non-goals
Per the task: **only** the resolver. No `$projectSlug` loader branch, no `useProjectsCollection` merge, no routes, no regeneration, no UI (those are S3/S4+).

**Behavior-neutral:** nothing calls the resolver yet (S3 wires it). `knip.json` ignores the dormant server file + `@domain/showcase` dep for `apps/web` until S3 removes them.

### Tests
`resolve-showcase.test.ts` — authz true (resolves), authz false → 404, no preference set → 404, no showcase → 404, showcase row with `currentProjectId = null` → 404. All 7 `@domain/showcase` tests pass.

### Verification
- `pnpm --filter @domain/showcase typecheck` ✅
- `pnpm --filter @domain/showcase test` ✅ (7 passed)
- `pnpm --filter @app/web typecheck` ✅
- `knip` ✅

### Review focus
- The authz predicate + the "one org id into all layers" invariant (the CH-no-RLS trap).
- Cache key/TTL choice and cache-error degradation.
- The temporary `knip.json` ignore entries (to be removed by S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)