### PR TITLE
Add design.latitude.so Vercel CNAME to production DNS

### DIFF
--- a/infra/lib/dns.ts
+++ b/infra/lib/dns.ts
@@ -300,6 +300,16 @@ export function createDnsRecords(
       allowOverwrite: true,
     })
 
+    // CNAME for design.latitude.so -> Vercel
+    records.designCname = new aws.route53.Record(`${name}-design-cname`, {
+      zoneId: hostedZoneId,
+      name: "design.latitude.so",
+      type: "CNAME",
+      records: ["6ac0d6b5a212d2a5.vercel-dns-016.com."],
+      ttl: 300,
+      allowOverwrite: true,
+    })
+
     // CNAME for go.latitude.so -> customers.withbaker.com
     records.goCname = new aws.route53.Record(`${name}-go-cname`, {
       zoneId: hostedZoneId,


### PR DESCRIPTION
## Summary

Adds a production Route53 CNAME for `design.latitude.so` pointing to Vercel (`6ac0d6b5a212d2a5.vercel-dns-016.com.`), matching the pattern used for other Vercel-hosted subdomains like `one-pager.latitude.so` and `41st.latitude.so`.

The record was already applied to production via `pulumi up --stack production` so this PR keeps infrastructure code in sync with live DNS.

## Test plan

- [x] `pulumi preview --stack production` showed only `latitude-production-design-cname` create
- [x] `pulumi up --stack production` applied the record
- [x] `dig +short design.latitude.so CNAME` returns `6ac0d6b5a212d2a5.vercel-dns-016.com.`


Made with [Cursor](https://cursor.com)