### PR TITLE
fix(flaggers): treat prompt-too-long model failures as no-match, not a crash

### DIFF
--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1092,6 +1092,116 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(result).toEqual({ matched: false })
   })
 
+  it("recovers to matched=false when the trace evidence exceeds the model's context window", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error(
+      "The model returned the following errors: prompt is too long: 219045 tokens > 200000 maximum",
+    )
+    sdkError.name = "AI_APICallError"
+
+    const { layer: aiLayer } = createFakeAI({
+      generate: () =>
+        Effect.fail(
+          new AIError({
+            message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+            cause: sdkError,
+          }),
+        ),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("drops matched annotations when the reviewer call fails because the evidence is too long for the model", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Please do the task." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "text", content: "I'll look into that." }],
+            },
+          ]),
+        ),
+    })
+
+    const sdkError = new Error(
+      "The model returned the following errors: prompt is too long: 219045 tokens > 200000 maximum",
+    )
+    sdkError.name = "AI_APICallError"
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        const isAnnotationReview = input.system?.includes("adversarial quality reviewer") ?? false
+        if (isAnnotationReview) {
+          return Effect.fail(
+            new AIError({
+              message: `AI generation failed (${FLAGGER_DEFAULT_CLASSIFIER_MODEL.provider}/${FLAGGER_DEFAULT_CLASSIFIER_MODEL.model}): ${sdkError.message}`,
+              cause: sdkError,
+            }),
+          )
+        }
+        return Effect.succeed({
+          object: { matched: true, feedback: "The assistant refused a benign request." } as T,
+          tokens: 20,
+          duration: 90_000_000,
+        })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "refusal" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(2)
+  })
+
   it("uses flagger-specific prompt for laziness with work signals", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -580,15 +580,22 @@ const loadTraceDetail = (input: RunFlaggerInput) =>
   })
 
 // The Vercel AI SDK raises `NoObjectGeneratedError` / `NoOutputGeneratedError`
-// when the model returns output that does not materialize as the requested schema.
-// The flagger treats this as a "no match" signal instead of propagating the failure
-// — the model effectively failed to classify, which for a triage flagger is
-// indistinguishable from matched=false.
+// when the model returns output that does not materialize as the requested schema,
+// and `AI_APICallError` with a "prompt is too long" message when the trace evidence
+// exceeds the model's context window. The flagger treats both as a "no match" signal
+// instead of propagating the failure — the model effectively failed to classify,
+// which for a triage flagger is indistinguishable from matched=false.
 const isSchemaMismatchCause = (cause: unknown): boolean => {
   if (!(cause instanceof Error)) return false
   if (cause.name === "AI_NoObjectGeneratedError" || cause.name === "AI_NoOutputGeneratedError") return true
   return typeof cause.message === "string" && cause.message.includes("response did not match schema")
 }
+
+const isPromptTooLongCause = (cause: unknown): boolean =>
+  cause instanceof Error && typeof cause.message === "string" && cause.message.includes("prompt is too long")
+
+const isUnclassifiableModelFailureCause = (cause: unknown): boolean =>
+  isSchemaMismatchCause(cause) || isPromptTooLongCause(cause)
 
 /**
  * LLM classification for an already-loaded trace.
@@ -648,7 +655,7 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
     .pipe(
       Effect.map((result) => parseFlaggerOutput(result.object)),
       Effect.catchIf(
-        (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
+        (error): error is AIError => error instanceof AIError && isUnclassifiableModelFailureCause(error.cause),
         () =>
           Effect.gen(function* () {
             yield* Effect.annotateCurrentSpan("flagger.flaggerSchemaMismatch", true)
@@ -680,7 +687,7 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
     .pipe(
       Effect.map((result) => result.object),
       Effect.catchIf(
-        (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
+        (error): error is AIError => error instanceof AIError && isUnclassifiableModelFailureCause(error.cause),
         () =>
           Effect.gen(function* () {
             yield* Effect.annotateCurrentSpan("flagger.annotationReviewSchemaMismatch", true)


### PR DESCRIPTION
## What does this PR do?

Fixes a production error surfaced by Datadog Error Tracking in `apps/workflows` (service: `workflows`): flagger classification and annotation-review calls throw an uncaught `AIError` when a trace's evidence exceeds the model's context window (Bedrock: `prompt is too long: N tokens > 200000 maximum`). Because the failure is deterministic on input size, retries never help, so the flagger run for that trace permanently fails instead of degrading gracefully.

**Datadog issues addressed:**
- [`9be6cc90-5df2-11f1-aa8e-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/9be6cc90-5df2-11f1-aa8e-da7ad0900005) — `AI_APICallError: prompt is too long: 219045 tokens > 200000 maximum` (24 occurrences/7d, `resource:flagger.classify`)
- [`9be69de2-5df2-11f1-bade-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/9be69de2-5df2-11f1-bade-da7ad0900005) — `AIError` wrapper of the same failure (24 occurrences/7d)
- Sibling smaller issue `45bc12b4-78ad-11f1-b995-da7ad0900005` (`APICallError`, 8 occurrences/7d) is the same root cause at a slightly lower token count.

This issue had been auto-resolved once by Datadog's naive heuristic and then regressed — it had not previously received a manual triage verdict (unlike several sibling `workflows` AI-error issues from earlier this week, which were already reviewed and classified as expected/handled noise).

**Root cause:** `getInspectedAgentContext`/`classifyTraceForFlaggerUseCase` in `packages/domain/flaggers/src/use-cases/run-flagger.ts` already anticipates the Vercel AI SDK's `NoObjectGeneratedError`/`NoOutputGeneratedError` (schema-mismatch) failures via `isSchemaMismatchCause`, catching them and returning `{ matched: false }` — the model effectively failed to classify, which for a triage flagger is indistinguishable from "no match". The same reasoning applies when the model can't process the input at all because it's too long, but that failure class (`AI_APICallError` with a "prompt is too long" message) wasn't covered by the existing predicate, so it propagated uncaught out of the use case and failed the Temporal activity.

**Fix:** broadened the recovery predicate (renamed to `isUnclassifiableModelFailureCause`) to also match `AI_APICallError`-style causes whose message includes `"prompt is too long"`, applied at both call sites that already had schema-mismatch recovery (the classification call and the annotation-review call).

## Related issue (if applicable)

Closes #

## How was this tested?

Added two new tests in `packages/domain/flaggers/src/use-cases/run-flagger.test.ts` mirroring the existing schema-mismatch coverage:
- `recovers to matched=false when the trace evidence exceeds the model's context window` — classification-stage failure.
- `drops matched annotations when the reviewer call fails because the evidence is too long for the model` — annotation-review-stage failure.

Confirmed both fail without the fix (`AIError` propagates uncaught, matching the production stack traces) and pass with it. Full package suite: `pnpm --filter @domain/flaggers test -- run-flagger.test.ts` → 230/230 passing (2 unrelated pre-existing failing suites due to an environment-local `@latitude-data/sdk` resolution gap, reproduced identically on `development` HEAD without this change). Typecheck (`pnpm --filter @domain/flaggers typecheck`) shows the same pre-existing, unrelated `@latitude-data/telemetry`/`@latitude-data/sdk` module-resolution errors on `development` HEAD as well. `pnpm exec biome check` clean on both changed files.

**Verification after deploy:** occurrences of Datadog issues `9be6cc90-5df2-11f1-aa8e-da7ad0900005` / `9be69de2-5df2-11f1-bade-da7ad0900005` should drop to zero for new occurrences (the flagger should instead complete with `matched: false` for oversized traces, annotated with `flagger.flaggerSchemaMismatch`/`flagger.annotationReviewSchemaMismatch` on the span).

## Checklist

- [x] Lint, type-checking, and tests pass locally (pre-existing unrelated failures noted above)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_013UG4fbs7PnFtgwsCbeTWKH)_