### PR TITLE
fix(web): exclude digits from emoji regex match

### DIFF
--- a/packages/utils/src/extractLeadingEmoji.test.ts
+++ b/packages/utils/src/extractLeadingEmoji.test.ts
@@ -16,4 +16,12 @@ describe("extractLeadingEmoji", () => {
     expect(extractLeadingEmoji("😀 hi")).toEqual(["😀", "hi"])
     expect(extractLeadingEmoji("🎉party")).toEqual(["🎉", "party"])
   })
+
+  it("extracts the full flag emoji even when it precedes a title", () => {
+  expect(extractLeadingEmoji("🇺🇸 Team")).toEqual(["🇺🇸", "Team"])
+})
+
+  it("extracts the full keycap emoji even when it precedes a title", () => {
+    expect(extractLeadingEmoji("1️⃣ Team")).toEqual(["1️⃣", "Team"])
+  })
 })

--- a/packages/utils/src/extractLeadingEmoji.test.ts
+++ b/packages/utils/src/extractLeadingEmoji.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
+
+describe("extractLeadingEmoji", () => {
+  it("returns null when there is no leading emoji", () => {
+    expect(extractLeadingEmoji("hello world")).toEqual([null, "hello world"])
+    expect(extractLeadingEmoji("")).toEqual([null, ""])
+  })
+
+  it("does not treat leading digits as emoji", () => {
+    expect(extractLeadingEmoji("1 Demo Project")).toEqual([null, "1 Demo Project"])
+    expect(extractLeadingEmoji("42 Demo Project")).toEqual([null, "42 Demo Project"])
+  })
+
+  it("extracts a simple emoji", () => {
+    expect(extractLeadingEmoji("😀 hi")).toEqual(["😀", "hi"])
+    expect(extractLeadingEmoji("🎉party")).toEqual(["🎉", "party"])
+  })
+})

--- a/packages/utils/src/extractLeadingEmoji.test.ts
+++ b/packages/utils/src/extractLeadingEmoji.test.ts
@@ -18,8 +18,8 @@ describe("extractLeadingEmoji", () => {
   })
 
   it("extracts the full flag emoji even when it precedes a title", () => {
-  expect(extractLeadingEmoji("🇺🇸 Team")).toEqual(["🇺🇸", "Team"])
-})
+    expect(extractLeadingEmoji("🇺🇸 Team")).toEqual(["🇺🇸", "Team"])
+  })
 
   it("extracts the full keycap emoji even when it precedes a title", () => {
     expect(extractLeadingEmoji("1️⃣ Team")).toEqual(["1️⃣", "Team"])

--- a/packages/utils/src/extractLeadingEmoji.ts
+++ b/packages/utils/src/extractLeadingEmoji.ts
@@ -1,5 +1,5 @@
 const EMOJI_REGEX =
-  /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Emoji_Component}(?:\u200D\p{Emoji_Presentation})*)\s*/u
+/^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|[0-9#*]\uFE0F?\u20E3|\p{Regional_Indicator}{2})\s*/u
 
 export function extractLeadingEmoji(text: string): [string | null, string] {
   const match = text.match(EMOJI_REGEX)

--- a/packages/utils/src/extractLeadingEmoji.ts
+++ b/packages/utils/src/extractLeadingEmoji.ts
@@ -1,5 +1,5 @@
 const EMOJI_REGEX =
-/^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|[0-9#*]\uFE0F?\u20E3|\p{Regional_Indicator}{2})\s*/u
+  /^(\p{Regional_Indicator}{2}|[0-9#*]\uFE0F?\u20E3|\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?)\s*/u
 
 export function extractLeadingEmoji(text: string): [string | null, string] {
   const match = text.match(EMOJI_REGEX)


### PR DESCRIPTION
## What does this PR do?
Fixes `EMOJI_REGEX` function so it doesn't match digits as an emoji

## Related issue (if applicable)
Closes #3894

## How was this tested?
Created a test file `extractLeadingEmoji.test.ts`

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
