### PR TITLE
feat(showcase): reserved-slug loader + client-collection merge (S3)

### DIFF
--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -10,13 +10,8 @@ import type { AnnotationScore, ScoreListPage } from "@domain/scores"
 import { annotationAnchorSchema, ScoreRepository, scoreDraftModeSchema } from "@domain/scores"
 import { ProjectId, ScoreId, TraceId } from "@domain/shared"
 import { AIEmbedLive, withAi } from "@platform/ai"
-import {
-  ScoreAnalyticsRepositoryLive,
-  SpanRepositoryLive,
-  TraceRepositoryLive,
-  withClickHouse,
-} from "@platform/db-clickhouse"
-import { OutboxEventWriterLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { ScoreAnalyticsRepositoryLive, SpanRepositoryLive, TraceRepositoryLive } from "@platform/db-clickhouse"
+import { OutboxEventWriterLive, ScoreRepositoryLive } from "@platform/db-postgres"
 import { QueuePublisherLive } from "@platform/queue-bullmq"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -30,6 +25,9 @@ import {
   getRedisClient,
   getWorkflowStarter,
 } from "../../server/clients.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 
 const toRecord = (score: AnnotationScore) => ({
   id: score.id as string,
@@ -102,8 +100,9 @@ export const createAnnotation = createServerFn({ method: "POST" })
       signalId: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<AnnotationRecord> => {
-    const { userId, organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<AnnotationRecord> => {
+    const { userId } = await requireSession()
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
     const chClient = getClickhouseClient()
     const publisher = await getQueuePublisher()
@@ -125,8 +124,8 @@ export const createAnnotation = createServerFn({ method: "POST" })
         feedback: data.feedback,
         anchor: data.anchor,
       }).pipe(
-        withPostgres(repositoriesLayer, client, organizationId),
-        withClickHouse(
+        withScopedPostgres(repositoriesLayer, client, organizationId),
+        withScopedClickHouse(
           Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive, SpanRepositoryLive),
           chClient,
           organizationId,
@@ -151,8 +150,8 @@ export const updateAnnotation = createServerFn({ method: "POST" })
       signalId: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<AnnotationRecord> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<AnnotationRecord> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
     const chClient = getClickhouseClient()
     const publisher = await getQueuePublisher()
@@ -171,8 +170,8 @@ export const updateAnnotation = createServerFn({ method: "POST" })
         passed: data.passed,
         feedback: data.feedback,
       }).pipe(
-        withPostgres(repositoriesLayer, client, organizationId),
-        withClickHouse(
+        withScopedPostgres(repositoriesLayer, client, organizationId),
+        withScopedClickHouse(
           Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive, SpanRepositoryLive),
           chClient,
           organizationId,
@@ -187,15 +186,15 @@ export const updateAnnotation = createServerFn({ method: "POST" })
 
 export const deleteAnnotation = createServerFn({ method: "POST" })
   .inputValidator(z.object({ scoreId: z.string(), projectId: z.string() }))
-  .handler(async ({ data }): Promise<void> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<void> => {
+    const organizationId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const postgresLayer = Layer.mergeAll(ScoreRepositoryLive, OutboxEventWriterLive)
 
     await Effect.runPromise(
       deleteAnnotationUseCase({ scoreId: ScoreId(data.scoreId) }).pipe(
-        withPostgres(postgresLayer, pgClient, organizationId),
+        withScopedPostgres(postgresLayer, pgClient, organizationId),
         withTracing,
       ),
     )
@@ -211,8 +210,8 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
       draftMode: scoreDraftModeSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<AnnotationListResult> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<AnnotationListResult> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -222,7 +221,7 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include", // draft-aware by default for trace-scoped reads
-      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+      }).pipe(withScopedPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
     )
 
     return toListResult(result)
@@ -244,12 +243,12 @@ export const listAnnotationsBySession = createServerFn({ method: "GET" })
       draftMode: scoreDraftModeSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<AnnotationListResult> => {
+  .handler(async ({ data, context }): Promise<AnnotationListResult> => {
     if (data.traceIds.length === 0) {
       return { items: [], hasMore: false, limit: data.limit ?? 50, offset: data.offset ?? 0 }
     }
 
-    const { organizationId } = await requireSession()
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -265,7 +264,7 @@ export const listAnnotationsBySession = createServerFn({ method: "GET" })
             draftMode: data.draftMode ?? "include",
           },
         })
-      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+      }).pipe(withScopedPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
     )
 
     return toListResult(result)
@@ -279,10 +278,10 @@ export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
       draftMode: scoreDraftModeSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly TraceAnnotationCountsRecord[]> => {
+  .handler(async ({ data, context }): Promise<readonly TraceAnnotationCountsRecord[]> => {
     if (data.traceIds.length === 0) return []
 
-    const { organizationId } = await requireSession()
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -293,7 +292,7 @@ export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
           traceIds: data.traceIds.map(TraceId),
           options: { draftMode: data.draftMode ?? "include" },
         })
-      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+      }).pipe(withScopedPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
     )
 
     return result.map(toCountsRecord)
@@ -301,8 +300,8 @@ export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
 
 export const approveSystemAnnotation = createServerFn({ method: "POST" })
   .inputValidator(z.object({ scoreId: z.string(), comment: z.string().optional() }))
-  .handler(async ({ data }): Promise<{ action: "approved" | "already-published" }> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<{ action: "approved" | "already-published" }> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
     const workflowStarter = await getWorkflowStarter()
     const publisher = await getQueuePublisher()
@@ -313,7 +312,7 @@ export const approveSystemAnnotation = createServerFn({ method: "POST" })
         ...(data.comment !== undefined ? { comment: data.comment } : {}),
       }).pipe(
         Effect.provide(Layer.mergeAll(Layer.succeed(WorkflowStarter, workflowStarter), QueuePublisherLive(publisher))),
-        withPostgres(ScoreRepositoryLive, client, organizationId),
+        withScopedPostgres(ScoreRepositoryLive, client, organizationId),
         withTracing,
       ),
     )
@@ -323,8 +322,8 @@ export const approveSystemAnnotation = createServerFn({ method: "POST" })
 
 export const rejectSystemAnnotation = createServerFn({ method: "POST" })
   .inputValidator(z.object({ scoreId: z.string(), comment: z.string().min(1) }))
-  .handler(async ({ data }): Promise<{ action: "rejected" }> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<{ action: "rejected" }> => {
+    const organizationId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const publisher = await getQueuePublisher()
 
@@ -333,7 +332,7 @@ export const rejectSystemAnnotation = createServerFn({ method: "POST" })
     await Effect.runPromise(
       rejectSystemAnnotationUseCase({ scoreId: ScoreId(data.scoreId), comment: data.comment }).pipe(
         Effect.provide(QueuePublisherLive(publisher)),
-        withPostgres(postgresLayer, pgClient, organizationId),
+        withScopedPostgres(postgresLayer, pgClient, organizationId),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -33,7 +33,7 @@ import {
   DatasetVersionId,
   filterSetSchema,
   isValidId,
-  OrganizationId,
+  type OrganizationId,
   ProjectId,
   putInDisk,
   SignalId,
@@ -49,14 +49,8 @@ import {
   ScoreAnalyticsRepositoryLive,
   TaxonomyClusterIntelligenceRepositoryLive,
   TraceRepositoryLive,
-  withClickHouse,
 } from "@platform/db-clickhouse"
-import {
-  DatasetRepositoryLive,
-  OutboxEventWriterLive,
-  TaxonomyClusterRepositoryLive,
-  withPostgres,
-} from "@platform/db-postgres"
+import { DatasetRepositoryLive, OutboxEventWriterLive, TaxonomyClusterRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
@@ -71,6 +65,9 @@ import {
   getRedisClient,
   getStorageDisk,
 } from "../../server/clients.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 import { applyMapping } from "./column-mapping.ts"
 
 const rowSelectionSchema = z.discriminatedUnion("mode", [
@@ -194,9 +191,8 @@ export const listDatasetsByProject = createServerFn({ method: "GET" })
         },
       ),
   )
-  .handler(async ({ data }): Promise<DatasetListResult> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetListResult> => {
+    const orgId = await resolveOrgScope(context)
 
     const page = await Effect.runPromise(
       listDatasets({
@@ -207,7 +203,7 @@ export const listDatasetsByProject = createServerFn({ method: "GET" })
           ...(data.sortBy ? { sortBy: data.sortBy } : {}),
           ...(data.sortDirection ? { sortDirection: data.sortDirection } : {}),
         },
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     const datasets = page.datasets.map(toDatasetRecord)
@@ -239,16 +235,15 @@ export const searchDatasetsOrgWide = createServerFn({ method: "GET" })
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly DatasetSearchRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly DatasetSearchRecord[]> => {
+    const orgId = await resolveOrgScope(context)
 
     const results = await Effect.runPromise(
       searchDatasets({
         ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
         ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     return results.map(
@@ -265,9 +260,8 @@ export const searchDatasetsOrgWide = createServerFn({ method: "GET" })
 
 export const getDatasetQuery = createServerFn({ method: "GET" })
   .inputValidator(z.object({ datasetId: z.string() }))
-  .handler(async ({ data }): Promise<DatasetRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetRecord | null> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -276,7 +270,7 @@ export const getDatasetQuery = createServerFn({ method: "GET" })
         return toDatasetRecord(dataset)
       }).pipe(
         Effect.catchTag("DatasetNotFoundError", () => Effect.succeed(null)),
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -305,13 +299,13 @@ export const listRowsQuery = createServerFn({ method: "GET" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       rows: DatasetRowRecord[]
       total?: number
       nextCursor?: { createdAt: string; rowId: string }
     }> => {
-      const { organizationId } = await requireSession()
-      const orgId = OrganizationId(organizationId)
+      const orgId = await resolveOrgScope(context)
 
       const sortBy = data.sortBy ?? "createdAt"
       const sortDirection = data.sortDirection ?? "desc"
@@ -333,8 +327,8 @@ export const listRowsQuery = createServerFn({ method: "GET" })
               }
             : { offset: data.offset }),
         }).pipe(
-          withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-          withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+          withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+          withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
           withTracing,
         ),
       )
@@ -355,9 +349,8 @@ export const getRowQuery = createServerFn({ method: "GET" })
       versionId: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<DatasetRowRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetRowRecord | null> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       getRowDetail({
@@ -367,8 +360,8 @@ export const getRowQuery = createServerFn({ method: "GET" })
       }).pipe(
         Effect.map(toRowRecord),
         Effect.catchTag("RowNotFoundError", () => Effect.succeed(null)),
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -382,16 +375,15 @@ export const updateDataset = createServerFn({ method: "POST" })
       description: z.string().nullable().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<DatasetRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetRecord> => {
+    const orgId = await resolveOrgScope(context)
 
     const dataset = await Effect.runPromise(
       updateDatasetDetails({
         datasetId: DatasetId(data.datasetId),
         name: data.name,
         description: data.description ?? null,
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     return toDatasetRecord(dataset)
@@ -399,14 +391,13 @@ export const updateDataset = createServerFn({ method: "POST" })
 
 export const deleteDatasetFunction = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string() }))
-  .handler(async ({ data }): Promise<void> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<void> => {
+    const orgId = await resolveOrgScope(context)
 
     await Effect.runPromise(
       deleteDataset({
         datasetId: DatasetId(data.datasetId),
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
   })
 
@@ -421,7 +412,7 @@ export const downloadDatasetExport = createServerFn({ method: "POST" })
       selection: rowSelectionSchema,
     }),
   )
-  .handler(async ({ data }): Promise<DownloadDatasetExportResult> => {
+  .handler(async ({ data, context }): Promise<DownloadDatasetExportResult> => {
     const session = await ensureSession()
     const email = session?.user?.email
     const organizationId = getSessionOrganizationId(session)
@@ -430,18 +421,18 @@ export const downloadDatasetExport = createServerFn({ method: "POST" })
       throw new UnauthorizedError({ message: "Unauthorized" })
     }
 
-    const orgId = OrganizationId(organizationId)
+    const orgId = await resolveOrgScope(context)
     const datasetId = DatasetId(data.datasetId)
 
     const result = await Effect.runPromise(
       prepareDatasetExportUseCase({
         datasetId,
         selection: data.selection,
-        organizationId,
+        organizationId: orgId,
         recipientEmail: email,
       }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -477,9 +468,9 @@ export const createDatasetFunction = createServerFn({ method: "POST" })
       name: z.string(),
     }),
   )
-  .handler(async ({ data }): Promise<DatasetRecord> => {
-    const { organizationId, userId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetRecord> => {
+    const { userId } = await requireSession()
+    const orgId = await resolveOrgScope(context)
 
     const dataset = await Effect.runPromise(
       createDataset({
@@ -488,8 +479,8 @@ export const createDatasetFunction = createServerFn({ method: "POST" })
         name: data.name,
         actorUserId: userId,
       }).pipe(
-        withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -507,9 +498,8 @@ export const saveDatasetCsv = createServerFn({ method: "POST" })
     const data = saveDatasetCsvDataSchema.parse(JSON.parse(dataRaw))
     return { file, data }
   })
-  .handler(async ({ data: { file, data } }): Promise<{ version: number; rowCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data: { file, data }, context }): Promise<{ version: number; rowCount: number }> => {
+    const orgId = await resolveOrgScope(context)
     const { datasetId, projectId, mapping, options } = data
 
     const content = await file.text()
@@ -530,7 +520,7 @@ export const saveDatasetCsv = createServerFn({ method: "POST" })
           id: DatasetId(datasetId),
           fileKey,
         })
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     const { rows } = parseDatasetCsv(content)
@@ -546,8 +536,8 @@ export const saveDatasetCsv = createServerFn({ method: "POST" })
         rows: mappedRows,
         source: "csv",
       }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -569,13 +559,13 @@ export const insertDatasetRow = createServerFn({ method: "POST" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       readonly versionId: string
       readonly version: number
       readonly rowId: string
     }> => {
-      const { organizationId } = await requireSession()
-      const orgId = OrganizationId(organizationId)
+      const orgId = await resolveOrgScope(context)
 
       const result = await Effect.runPromise(
         insertRows({
@@ -591,8 +581,8 @@ export const insertDatasetRow = createServerFn({ method: "POST" })
           ],
           source: "web",
         }).pipe(
-          withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-          withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+          withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+          withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
           withTracing,
         ),
       )
@@ -622,9 +612,8 @@ export const updateDatasetRow = createServerFn({ method: "POST" })
       custom: z.record(z.string(), z.string()).optional(),
     }),
   )
-  .handler(async ({ data }) => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }) => {
+    const orgId = await resolveOrgScope(context)
 
     const result = await Effect.runPromise(
       updateRow({
@@ -636,8 +625,8 @@ export const updateDatasetRow = createServerFn({ method: "POST" })
         metadata: data.metadata,
         ...(data.custom ? { custom: data.custom } : {}),
       }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -652,9 +641,8 @@ export const deleteDatasetRows = createServerFn({ method: "POST" })
       selection: rowSelectionSchema,
     }),
   )
-  .handler(async ({ data }): Promise<{ versionId: string; version: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ versionId: string; version: number }> => {
+    const orgId = await resolveOrgScope(context)
 
     const selection: DeleteRowsSelection =
       data.selection.mode === "all"
@@ -669,8 +657,8 @@ export const deleteDatasetRows = createServerFn({ method: "POST" })
         datasetId: DatasetId(data.datasetId),
         selection,
       }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -698,9 +686,8 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
       filters: filterSetSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<{ versionId: string; version: number; rowCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ versionId: string; version: number; rowCount: number }> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
 
     const result = await Effect.runPromise(
@@ -712,10 +699,10 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
         ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         ...(data.filters ? { filters: data.filters } : {}),
       }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
-        withClickHouse(TraceRepositoryLive, chClient, orgId),
-        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(DatasetRowRepositoryLive, chClient, orgId),
+        withScopedClickHouse(TraceRepositoryLive, chClient, orgId),
+        withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -750,14 +737,14 @@ export const createDatasetFromTracesFunction = createServerFn({
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       datasetId: string
       versionId: string
       version: number
       rowCount: number
     }> => {
-      const { organizationId } = await requireSession()
-      const orgId = OrganizationId(organizationId)
+      const orgId = await resolveOrgScope(context)
       const pgClient = getPostgresClient()
       const chClient = getClickhouseClient()
 
@@ -771,10 +758,10 @@ export const createDatasetFromTracesFunction = createServerFn({
           ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
           ...(data.filters ? { filters: data.filters } : {}),
         }).pipe(
-          withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), pgClient, orgId),
-          withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
-          withClickHouse(TraceRepositoryLive, chClient, orgId),
-          withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+          withScopedPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), pgClient, orgId),
+          withScopedClickHouse(DatasetRowRepositoryLive, chClient, orgId),
+          withScopedClickHouse(TraceRepositoryLive, chClient, orgId),
+          withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
           withAi(AIEmbedLive, getRedisClient()),
           withTracing,
         ),
@@ -844,9 +831,8 @@ export const addClusterSessionsToDatasetFunction = createServerFn({ method: "POS
       selection: rowSelectionSchema,
     }),
   )
-  .handler(async ({ data }): Promise<{ versionId: string; version: number; rowCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ versionId: string; version: number; rowCount: number }> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const chClient = getClickhouseClient()
 
@@ -860,8 +846,12 @@ export const addClusterSessionsToDatasetFunction = createServerFn({ method: "POS
           selection: { mode: "selected", traceIds },
         })
       }).pipe(
-        withPostgres(Layer.mergeAll(DatasetRepositoryLive, TaxonomyClusterRepositoryLive), getPostgresClient(), orgId),
-        withClickHouse(
+        withScopedPostgres(
+          Layer.mergeAll(DatasetRepositoryLive, TaxonomyClusterRepositoryLive),
+          getPostgresClient(),
+          orgId,
+        ),
+        withScopedClickHouse(
           Layer.mergeAll(
             DatasetRowRepositoryLive,
             TraceRepositoryLive,
@@ -892,59 +882,59 @@ export const createDatasetFromClusterSessionsFunction = createServerFn({ method:
       selection: rowSelectionSchema,
     }),
   )
-  .handler(async ({ data }): Promise<{ datasetId: string; versionId: string; version: number; rowCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
-    const projectId = ProjectId(data.projectId)
-    const chClient = getClickhouseClient()
+  .handler(
+    async ({ data, context }): Promise<{ datasetId: string; versionId: string; version: number; rowCount: number }> => {
+      const orgId = await resolveOrgScope(context)
+      const projectId = ProjectId(data.projectId)
+      const chClient = getClickhouseClient()
 
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const traceIds = yield* resolveClusterTraceIds(orgId, projectId, data.cluster, data.selection)
-        return yield* createDatasetFromTraces({
-          projectId,
-          name: data.name,
-          source: { kind: "project" },
-          selection: { mode: "selected", traceIds },
-        })
-      }).pipe(
-        withPostgres(
-          Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive, TaxonomyClusterRepositoryLive),
-          getPostgresClient(),
-          orgId,
-        ),
-        withClickHouse(
-          Layer.mergeAll(
-            DatasetRowRepositoryLive,
-            TraceRepositoryLive,
-            ScoreAnalyticsRepositoryLive,
-            TaxonomyClusterIntelligenceRepositoryLive,
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const traceIds = yield* resolveClusterTraceIds(orgId, projectId, data.cluster, data.selection)
+          return yield* createDatasetFromTraces({
+            projectId,
+            name: data.name,
+            source: { kind: "project" },
+            selection: { mode: "selected", traceIds },
+          })
+        }).pipe(
+          withScopedPostgres(
+            Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive, TaxonomyClusterRepositoryLive),
+            getPostgresClient(),
+            orgId,
           ),
-          chClient,
-          orgId,
+          withScopedClickHouse(
+            Layer.mergeAll(
+              DatasetRowRepositoryLive,
+              TraceRepositoryLive,
+              ScoreAnalyticsRepositoryLive,
+              TaxonomyClusterIntelligenceRepositoryLive,
+            ),
+            chClient,
+            orgId,
+          ),
+          withAi(AIEmbedLive, getRedisClient()),
+          withTracing,
         ),
-        withAi(AIEmbedLive, getRedisClient()),
-        withTracing,
-      ),
-    )
+      )
 
-    return {
-      datasetId: result.datasetId as string,
-      versionId: result.versionId as string,
-      version: result.version,
-      rowCount: result.rowIds.length,
-    }
-  })
+      return {
+        datasetId: result.datasetId as string,
+        versionId: result.versionId as string,
+        version: result.version,
+        rowCount: result.rowIds.length,
+      }
+    },
+  )
 
 export const addDatasetColumn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string(), name: z.string().min(1) }))
-  .handler(async ({ data }): Promise<DatasetColumn> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetColumn> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       addColumn({ datasetId: DatasetId(data.datasetId), name: data.name }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -952,13 +942,12 @@ export const addDatasetColumn = createServerFn({ method: "POST" })
 
 export const updateDatasetColumn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string(), identifier: z.string().min(1), name: z.string().min(1) }))
-  .handler(async ({ data }): Promise<DatasetColumn> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetColumn> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       updateColumn({ datasetId: DatasetId(data.datasetId), identifier: data.identifier, name: data.name }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -966,13 +955,12 @@ export const updateDatasetColumn = createServerFn({ method: "POST" })
 
 export const removeDatasetColumn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string(), identifier: z.string().min(1) }))
-  .handler(async ({ data }): Promise<{ ok: true }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ ok: true }> => {
+    const orgId = await resolveOrgScope(context)
 
     await Effect.runPromise(
       removeColumn({ datasetId: DatasetId(data.datasetId), identifier: data.identifier }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -981,13 +969,12 @@ export const removeDatasetColumn = createServerFn({ method: "POST" })
 
 export const reorderDatasetColumns = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string(), order: z.array(z.string().min(1)) }))
-  .handler(async ({ data }): Promise<DatasetColumn[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetColumn[]> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       reorderColumns({ datasetId: DatasetId(data.datasetId), order: data.order }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -995,13 +982,12 @@ export const reorderDatasetColumns = createServerFn({ method: "POST" })
 
 export const restoreDatasetColumn = createServerFn({ method: "POST" })
   .inputValidator(z.object({ datasetId: z.string(), identifier: z.string().min(1) }))
-  .handler(async ({ data }): Promise<DatasetColumn> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<DatasetColumn> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       restoreColumn({ datasetId: DatasetId(data.datasetId), identifier: data.identifier }).pipe(
-        withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withScopedPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/end-users/end-users.functions.ts
+++ b/apps/web/src/domains/end-users/end-users.functions.ts
@@ -1,4 +1,4 @@
-import { ExternalUserId, OrganizationId, ProjectId } from "@domain/shared"
+import { ExternalUserId, ProjectId } from "@domain/shared"
 import { buildHistogramBucketScaffold, fillBuckets, listUserSignalsUseCase } from "@domain/signals"
 import type { ProjectUserSummary, UserProfile, UsersOverview, UserUsageSlice } from "@domain/spans"
 import { USER_SORT_FIELDS, UserAnalyticsRepository } from "@domain/spans"
@@ -7,15 +7,16 @@ import {
   ScoreAnalyticsRepositoryLive,
   TaxonomyObservationRepositoryLive,
   UserAnalyticsRepositoryLive,
-  withClickHouse,
 } from "@platform/db-clickhouse"
-import { SignalRepositoryLive, TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { SignalRepositoryLive, TaxonomyClusterRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
-import { requireSession } from "../../server/auth.ts"
 import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 
 const DAY_SECONDS = 24 * 60 * 60
 const HOUR_SECONDS = 60 * 60
@@ -96,9 +97,8 @@ export interface ProjectUsersPageRecord {
 
 export const listProjectUsers = createServerFn({ method: "GET" })
   .inputValidator(listProjectUsersInputSchema)
-  .handler(async ({ data }): Promise<ProjectUsersPageRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<ProjectUsersPageRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
     const trimmedSearchQuery = data.searchQuery?.trim() || undefined
@@ -137,7 +137,7 @@ export const listProjectUsers = createServerFn({ method: "GET" })
             : []
 
         return { page, activitySeries }
-      }).pipe(withClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     const activityByUserId = new Map(result.activitySeries.map((series) => [series.userId, series.buckets] as const))
@@ -182,9 +182,8 @@ export type UsersOverviewRecord = ReturnType<typeof toUsersOverviewRecord>
 
 export const getUsersOverview = createServerFn({ method: "GET" })
   .inputValidator(usersOverviewInputSchema)
-  .handler(async ({ data }): Promise<UsersOverviewRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<UsersOverviewRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
     const { from, to } = resolveRange(data.timeRange, DEFAULT_OVERVIEW_DAYS)
@@ -199,7 +198,7 @@ export const getUsersOverview = createServerFn({ method: "GET" })
           timeRange: { from, to },
           bucketSeconds,
         })
-      }).pipe(withClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     return toUsersOverviewRecord(overview, { from, to, bucketSeconds })
@@ -234,9 +233,8 @@ export type UserProfileRecord = ReturnType<typeof toUserProfileRecord>
 
 export const getUserProfile = createServerFn({ method: "GET" })
   .inputValidator(userProfileInputSchema)
-  .handler(async ({ data }): Promise<UserProfileRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<UserProfileRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
 
     const profile = await Effect.runPromise(
@@ -250,7 +248,7 @@ export const getUserProfile = createServerFn({ method: "GET" })
             ...(data.errorsOnly ? { errorsOnly: true } : {}),
           })
           .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-      }).pipe(withClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     return profile ? toUserProfileRecord(profile) : null
@@ -272,9 +270,8 @@ export interface UserActivityRecord {
 
 export const getUserActivity = createServerFn({ method: "GET" })
   .inputValidator(userActivityInputSchema)
-  .handler(async ({ data }): Promise<UserActivityRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<UserActivityRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const { from, to } = resolveRange(data.timeRange, DEFAULT_OVERVIEW_DAYS)
     const bucketSeconds = bucketSecondsFor(from, to)
@@ -291,7 +288,7 @@ export const getUserActivity = createServerFn({ method: "GET" })
           bucketSeconds,
           ...(data.errorsOnly ? { errorsOnly: true } : {}),
         })
-      }).pipe(withClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     const byBucket = new Map((series[0]?.buckets ?? []).map((bucket) => [bucket.bucket, bucket] as const))
@@ -323,9 +320,8 @@ export interface UserUsageSliceRecord {
 
 export const getUserUsage = createServerFn({ method: "GET" })
   .inputValidator(userUsageInputSchema)
-  .handler(async ({ data }): Promise<readonly UserUsageSliceRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly UserUsageSliceRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
 
     const slices = await Effect.runPromise(
@@ -339,7 +335,7 @@ export const getUserUsage = createServerFn({ method: "GET" })
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
           ...(data.errorsOnly ? { errorsOnly: true } : {}),
         })
-      }).pipe(withClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(UserAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     return slices.map((slice: UserUsageSlice) => ({ value: slice.value, traceCount: slice.traceCount }))
@@ -359,9 +355,8 @@ export interface UserSignalRecord {
 
 export const listUserSignals = createServerFn({ method: "GET" })
   .inputValidator(userInputSchema)
-  .handler(async ({ data }): Promise<readonly UserSignalRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly UserSignalRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const chClient = getClickhouseClient()
 
@@ -371,8 +366,8 @@ export const listUserSignals = createServerFn({ method: "GET" })
         projectId: ProjectId(data.projectId),
         userId: ExternalUserId(data.userId),
       }).pipe(
-        withPostgres(SignalRepositoryLive, pgClient, orgId),
-        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withScopedPostgres(SignalRepositoryLive, pgClient, orgId),
+        withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
         withTracing,
       ),
     )
@@ -403,9 +398,8 @@ export interface UserBehaviourRecord {
 
 export const listUserBehaviours = createServerFn({ method: "GET" })
   .inputValidator(userInputSchema)
-  .handler(async ({ data }): Promise<readonly UserBehaviourRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly UserBehaviourRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const chClient = getClickhouseClient()
 
@@ -415,8 +409,8 @@ export const listUserBehaviours = createServerFn({ method: "GET" })
         projectId: ProjectId(data.projectId),
         userId: ExternalUserId(data.userId),
       }).pipe(
-        withPostgres(TaxonomyClusterRepositoryLive, pgClient, orgId),
-        withClickHouse(TaxonomyObservationRepositoryLive, chClient, orgId),
+        withScopedPostgres(TaxonomyClusterRepositoryLive, pgClient, orgId),
+        withScopedClickHouse(TaxonomyObservationRepositoryLive, chClient, orgId),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/monitors/monitors.functions.ts
+++ b/apps/web/src/domains/monitors/monitors.functions.ts
@@ -31,13 +31,12 @@ import {
   filterSetSchema,
   MonitorId,
   monitorStreamSchema,
-  OrganizationId,
   ProjectId,
   SavedSearchId,
   SignalId,
 } from "@domain/shared"
 import { SignalRepository } from "@domain/signals"
-import { MetricSeriesReaderLive, withClickHouse } from "@platform/db-clickhouse"
+import { MetricSeriesReaderLive } from "@platform/db-clickhouse"
 import {
   IncidentRepositoryLive,
   MonitorRepositoryLive,
@@ -45,14 +44,16 @@ import {
   OutboxEventWriterLive,
   SavedSearchRepositoryLive,
   SignalRepositoryLive,
-  withPostgres,
 } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
-import { requireSession } from "../../server/auth.ts"
 import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+import type { ScopedOrgId } from "../../server/resolve-org-scope.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 
 interface SavedSearchRef {
   readonly name: string
@@ -164,7 +165,7 @@ const toMonitorRecord = (monitor: Monitor, savedSearchRefs: ReadonlyMap<string, 
 export type MonitorRecord = ReturnType<typeof toMonitorRecord>
 
 const resolveSavedSearchRefs = async (
-  orgId: OrganizationId,
+  orgId: ScopedOrgId,
   projectId: ProjectId,
   monitors: readonly Monitor[],
 ): Promise<ReadonlyMap<string, SavedSearchRef>> => {
@@ -172,7 +173,7 @@ const resolveSavedSearchRefs = async (
   if (!referencesSavedSearch) return new Map()
   const page = await Effect.runPromise(
     listSavedSearches({ projectId }).pipe(
-      withPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId),
+      withScopedPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId),
       withTracing,
     ),
   )
@@ -180,7 +181,7 @@ const resolveSavedSearchRefs = async (
 }
 
 /** Resolve saved-search refs for a single monitor, then map it to its wire record. */
-const toMonitorRecordResolved = async (orgId: OrganizationId, monitor: Monitor): Promise<MonitorRecord> => {
+const toMonitorRecordResolved = async (orgId: ScopedOrgId, monitor: Monitor): Promise<MonitorRecord> => {
   const refs = await resolveSavedSearchRefs(orgId, monitor.projectId, [monitor])
   return toMonitorRecord(monitor, refs)
 }
@@ -232,9 +233,8 @@ const listMonitorsInputSchema = z.object({
 
 export const listMonitors = createServerFn({ method: "GET" })
   .inputValidator(listMonitorsInputSchema)
-  .handler(async ({ data }): Promise<ListMonitorsResultRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<ListMonitorsResultRecord> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -244,7 +244,7 @@ export const listMonitors = createServerFn({ method: "GET" })
         ...(data.offset !== undefined ? { offset: data.offset } : {}),
         ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         ...(data.system !== undefined ? { system: data.system } : {}),
-      }).pipe(withPostgres(MonitorRepositoryLive, pgClient, orgId), withTracing),
+      }).pipe(withScopedPostgres(MonitorRepositoryLive, pgClient, orgId), withTracing),
     )
 
     const refs = await resolveSavedSearchRefs(orgId, ProjectId(data.projectId), result.items)
@@ -261,16 +261,15 @@ const listMonitorsForTargetInputSchema = z.object({
 /** Live unified monitors targeting a specific tool/user — backs the in-context "monitors for this X" card. */
 export const listMonitorsForTarget = createServerFn({ method: "GET" })
   .inputValidator(listMonitorsForTargetInputSchema)
-  .handler(async ({ data }): Promise<MonitorRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const monitors = await Effect.runPromise(
       listMonitorsForTargetUseCase({
         projectId: ProjectId(data.projectId),
         ...(data.targetKind !== undefined ? { targetType: data.targetKind } : {}),
         filterSetContains: data.filterSetContains,
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -330,9 +329,8 @@ const resolveMetricTarget = (monitor: Monitor) =>
 /** The monitor's tracked metric as a per-bucket series over `[fromMs, toMs)` — powers the monitor page histogram. */
 export const getMonitorMetricSeries = createServerFn({ method: "GET" })
   .inputValidator(getMonitorMetricSeriesInputSchema)
-  .handler(async ({ data }): Promise<MonitorMetricSeriesRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorMetricSeriesRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const bucketMs = data.bucketMs
     const to = new Date(data.toMs)
@@ -361,7 +359,7 @@ export const getMonitorMetricSeries = createServerFn({ method: "GET" })
         const bucketStartsMs = values.map((_, index) => data.toMs - (count - index) * bucketMs)
         return { bucketStartsMs, values, bucketMs } satisfies MonitorMetricSeriesRecord
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -371,7 +369,7 @@ export const getMonitorMetricSeries = createServerFn({ method: "GET" })
           getPostgresClient(),
           orgId,
         ),
-        withClickHouse(MetricSeriesReaderLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(MetricSeriesReaderLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -412,8 +410,8 @@ export const searchMonitorsOrgWide = createServerFn({ method: "GET" })
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly MonitorSearchRecord[]> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<readonly MonitorSearchRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const results = await Effect.runPromise(
@@ -421,7 +419,7 @@ export const searchMonitorsOrgWide = createServerFn({ method: "GET" })
         ...(data.searchQuery !== undefined ? { searchQuery: data.searchQuery } : {}),
         ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
-      }).pipe(withPostgres(MonitorRepositoryLive, pgClient, OrganizationId(organizationId)), withTracing),
+      }).pipe(withScopedPostgres(MonitorRepositoryLive, pgClient, orgId), withTracing),
     )
 
     return results.map(toMonitorSearchRecord)
@@ -434,15 +432,14 @@ const getMonitorInputSchema = z.object({
 
 export const getMonitorBySlug = createServerFn({ method: "GET" })
   .inputValidator(getMonitorInputSchema)
-  .handler(async ({ data }): Promise<MonitorRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const monitor = await Effect.runPromise(
       getMonitorBySlugUseCase({ projectId: ProjectId(data.projectId), slug: data.slug }).pipe(
         Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
-        withPostgres(MonitorRepositoryLive, pgClient, orgId),
+        withScopedPostgres(MonitorRepositoryLive, pgClient, orgId),
         withTracing,
       ),
     )
@@ -452,14 +449,17 @@ export const getMonitorBySlug = createServerFn({ method: "GET" })
 
 const monitorMutationInputSchema = z.object({ monitorId: z.string() })
 
-const runMonitorMute = async (monitorId: string, muted: boolean): Promise<MonitorRecord> => {
-  const { organizationId } = await requireSession()
-  const orgId = OrganizationId(organizationId)
+const runMonitorMute = async (
+  monitorId: string,
+  muted: boolean,
+  context: Parameters<typeof resolveOrgScope>[0],
+): Promise<MonitorRecord> => {
+  const orgId = await resolveOrgScope(context)
   const useCase = muted ? muteMonitorUseCase : unmuteMonitorUseCase
 
   const monitor = await Effect.runPromise(
     useCase({ id: MonitorId(monitorId) }).pipe(
-      withPostgres(MonitorRepositoryLive, getPostgresClient(), orgId),
+      withScopedPostgres(MonitorRepositoryLive, getPostgresClient(), orgId),
       withTracing,
     ),
   )
@@ -468,11 +468,11 @@ const runMonitorMute = async (monitorId: string, muted: boolean): Promise<Monito
 
 export const muteMonitor = createServerFn({ method: "POST" })
   .inputValidator(monitorMutationInputSchema)
-  .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, true))
+  .handler(({ data, context }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, true, context))
 
 export const unmuteMonitor = createServerFn({ method: "POST" })
   .inputValidator(monitorMutationInputSchema)
-  .handler(({ data }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, false))
+  .handler(({ data, context }): Promise<MonitorRecord> => runMonitorMute(data.monitorId, false, context))
 
 const bulkMonitorsInputSchema = z.object({
   projectId: z.string(),
@@ -488,7 +488,7 @@ type BulkMonitorsInput = z.infer<typeof bulkMonitorsInputSchema>
 const BULK_MONITORS_BATCH_SIZE = 100
 
 const resolveBulkSelectionMonitorIds = async (
-  orgId: OrganizationId,
+  orgId: ScopedOrgId,
   data: BulkMonitorsInput,
 ): Promise<readonly string[]> => {
   if (data.selection.mode === "selected") return data.selection.rowIds
@@ -516,7 +516,7 @@ const resolveBulkSelectionMonitorIds = async (
         if (!page.hasMore) break
         offset += page.limit
       }
-    }).pipe(withPostgres(MonitorRepositoryLive, getPostgresClient(), orgId), withTracing),
+    }).pipe(withScopedPostgres(MonitorRepositoryLive, getPostgresClient(), orgId), withTracing),
   )
 
   return ids
@@ -524,9 +524,8 @@ const resolveBulkSelectionMonitorIds = async (
 
 export const bulkMuteMonitors = createServerFn({ method: "POST" })
   .inputValidator(bulkMonitorsInputSchema)
-  .handler(async ({ data }): Promise<{ readonly mutedCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ readonly mutedCount: number }> => {
+    const orgId = await resolveOrgScope(context)
     const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
 
     const mutedCount = await Effect.runPromise(
@@ -540,7 +539,7 @@ export const bulkMuteMonitors = createServerFn({ method: "POST" })
         }
         return count
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -559,50 +558,50 @@ export const bulkMuteMonitors = createServerFn({ method: "POST" })
 
 export const bulkDeleteMonitors = createServerFn({ method: "POST" })
   .inputValidator(bulkMonitorsInputSchema)
-  .handler(async ({ data }): Promise<{ readonly deletedCount: number; readonly skippedSystemCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
-    const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
+  .handler(
+    async ({ data, context }): Promise<{ readonly deletedCount: number; readonly skippedSystemCount: number }> => {
+      const orgId = await resolveOrgScope(context)
+      const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
 
-    const counts = await Effect.runPromise(
-      Effect.gen(function* () {
-        let deletedCount = 0
-        let skippedSystemCount = 0
-        for (const monitorId of monitorIds) {
-          const outcome = yield* deleteMonitorUseCase({ id: MonitorId(monitorId) }).pipe(
-            Effect.as("deleted" as const),
-            Effect.catchTags({
-              SystemMonitorForbiddenError: () => Effect.succeed("skipped" as const),
-              NotFoundError: () => Effect.succeed("missing" as const),
-            }),
-          )
-          if (outcome === "deleted") deletedCount += 1
-          if (outcome === "skipped") skippedSystemCount += 1
-        }
-        return { deletedCount, skippedSystemCount }
-      }).pipe(
-        withPostgres(
-          Layer.mergeAll(
-            MonitorRepositoryLive,
-            SavedSearchRepositoryLive,
-            IncidentRepositoryLive,
-            OutboxEventWriterLive,
+      const counts = await Effect.runPromise(
+        Effect.gen(function* () {
+          let deletedCount = 0
+          let skippedSystemCount = 0
+          for (const monitorId of monitorIds) {
+            const outcome = yield* deleteMonitorUseCase({ id: MonitorId(monitorId) }).pipe(
+              Effect.as("deleted" as const),
+              Effect.catchTags({
+                SystemMonitorForbiddenError: () => Effect.succeed("skipped" as const),
+                NotFoundError: () => Effect.succeed("missing" as const),
+              }),
+            )
+            if (outcome === "deleted") deletedCount += 1
+            if (outcome === "skipped") skippedSystemCount += 1
+          }
+          return { deletedCount, skippedSystemCount }
+        }).pipe(
+          withScopedPostgres(
+            Layer.mergeAll(
+              MonitorRepositoryLive,
+              SavedSearchRepositoryLive,
+              IncidentRepositoryLive,
+              OutboxEventWriterLive,
+            ),
+            getPostgresClient(),
+            orgId,
           ),
-          getPostgresClient(),
-          orgId,
+          withTracing,
         ),
-        withTracing,
-      ),
-    )
+      )
 
-    return counts
-  })
+      return counts
+    },
+  )
 
 export const bulkResolveMonitorLastIncidents = createServerFn({ method: "POST" })
   .inputValidator(bulkMonitorsInputSchema)
-  .handler(async ({ data }): Promise<{ readonly resolvedCount: number }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ readonly resolvedCount: number }> => {
+    const orgId = await resolveOrgScope(context)
     const monitorIds = await resolveBulkSelectionMonitorIds(orgId, data)
 
     const resolvedCount = await Effect.runPromise(
@@ -619,7 +618,7 @@ export const bulkResolveMonitorLastIncidents = createServerFn({ method: "POST" }
         }
         return count
       }).pipe(
-        withPostgres(Layer.mergeAll(IncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withScopedPostgres(Layer.mergeAll(IncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -631,13 +630,12 @@ const resolveIncidentInputSchema = z.object({ incidentId: z.string() })
 
 export const resolveMonitorIncident = createServerFn({ method: "POST" })
   .inputValidator(resolveIncidentInputSchema)
-  .handler(async ({ data }): Promise<{ readonly id: string; readonly endedAtIso: string | null }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ readonly id: string; readonly endedAtIso: string | null }> => {
+    const orgId = await resolveOrgScope(context)
 
     const incident = await Effect.runPromise(
       resolveIncidentUseCase({ id: AlertIncidentId(data.incidentId), endedAt: new Date() }).pipe(
-        withPostgres(Layer.mergeAll(IncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withScopedPostgres(Layer.mergeAll(IncidentRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
         withTracing,
       ),
     )
@@ -674,9 +672,8 @@ const createMonitorInputSchema = z.object({
 
 export const createMonitor = createServerFn({ method: "POST" })
   .inputValidator(createMonitorInputSchema)
-  .handler(async ({ data }): Promise<MonitorRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorRecord> => {
+    const orgId = await resolveOrgScope(context)
 
     const monitor = await Effect.runPromise(
       (() => {
@@ -708,7 +705,7 @@ export const createMonitor = createServerFn({ method: "POST" })
         })
       })().pipe(
         // SavedSearchRepository backs the semantic-search monitorability check on the watched search.
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -732,9 +729,8 @@ const updateMonitorInputSchema = z.object({
 
 export const updateMonitor = createServerFn({ method: "POST" })
   .inputValidator(updateMonitorInputSchema)
-  .handler(async ({ data }): Promise<MonitorRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorRecord> => {
+    const orgId = await resolveOrgScope(context)
 
     const monitor = await Effect.runPromise(
       updateMonitorUseCase({
@@ -742,7 +738,7 @@ export const updateMonitor = createServerFn({ method: "POST" })
         ...(data.name !== undefined ? { name: data.name } : {}),
         ...(data.description !== undefined ? { description: data.description } : {}),
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -760,13 +756,12 @@ export const updateMonitor = createServerFn({ method: "POST" })
 
 export const deleteMonitor = createServerFn({ method: "POST" })
   .inputValidator(monitorMutationInputSchema)
-  .handler(async ({ data }): Promise<{ readonly id: string }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ readonly id: string }> => {
+    const orgId = await resolveOrgScope(context)
 
     const monitor = await Effect.runPromise(
       deleteMonitorUseCase({ id: MonitorId(data.monitorId) }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(MonitorRepositoryLive, IncidentRepositoryLive, OutboxEventWriterLive),
           getPostgresClient(),
           orgId,
@@ -801,9 +796,8 @@ const configWithCondition = (
 
 export const updateMonitorRule = createServerFn({ method: "POST" })
   .inputValidator(updateMonitorRuleInputSchema)
-  .handler(async ({ data }): Promise<MonitorRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<MonitorRecord> => {
+    const orgId = await resolveOrgScope(context)
 
     const monitor = await Effect.runPromise(
       Effect.gen(function* () {
@@ -830,7 +824,7 @@ export const updateMonitorRule = createServerFn({ method: "POST" })
           },
         })
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(
             MonitorRepositoryLive,
             SavedSearchRepositoryLive,
@@ -857,6 +851,7 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       readonly total: number
       readonly firstStartedAtIso: string | null
@@ -864,14 +859,13 @@ export const getMonitorIncidentStats = createServerFn({ method: "GET" })
       readonly lastStartedAtIso: string | null
       readonly lastEndedAtIso: string | null
     }> => {
-      const { organizationId } = await requireSession()
-      const orgId = OrganizationId(organizationId)
+      const orgId = await resolveOrgScope(context)
 
       const stats = await Effect.runPromise(
         Effect.gen(function* () {
           const repository = yield* IncidentRepository
           return yield* repository.statsByMonitorId(MonitorId(data.monitorId))
-        }).pipe(withPostgres(IncidentRepositoryLive, getPostgresClient(), orgId), withTracing),
+        }).pipe(withScopedPostgres(IncidentRepositoryLive, getPostgresClient(), orgId), withTracing),
       )
 
       return {
@@ -933,13 +927,13 @@ export const listMonitorIncidents = createServerFn({ method: "GET" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       readonly items: readonly MonitorIncidentRecord[]
       readonly nextCursor: MonitorIncidentsCursor | null
       readonly hasMore: boolean
     }> => {
-      const { organizationId } = await requireSession()
-      const orgId = OrganizationId(organizationId)
+      const orgId = await resolveOrgScope(context)
       const projectId = ProjectId(data.projectId)
       const pgClient = getPostgresClient()
 
@@ -957,7 +951,7 @@ export const listMonitorIncidents = createServerFn({ method: "GET" })
               }
             : {}),
         }).pipe(
-          withPostgres(Layer.mergeAll(IncidentRepositoryLive, NotificationRepositoryLive), pgClient, orgId),
+          withScopedPostgres(Layer.mergeAll(IncidentRepositoryLive, NotificationRepositoryLive), pgClient, orgId),
           withTracing,
         ),
       )
@@ -976,7 +970,7 @@ export const listMonitorIncidents = createServerFn({ method: "GET" })
           Effect.gen(function* () {
             const repository = yield* SignalRepository
             return yield* repository.findByIds({ projectId, signalIds: signalIds.map(SignalId) })
-          }).pipe(withPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
+          }).pipe(withScopedPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
         )
         for (const issue of issues) signalNameById.set(issue.id, issue.name)
       }

--- a/apps/web/src/domains/projects/project-scope.test.tsx
+++ b/apps/web/src/domains/projects/project-scope.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest"
+import { getCurrentProjectScope, LIVE_SCOPE, SHOWCASE_SCOPE } from "./project-scope.tsx"
+
+const at = (path: string) => window.history.pushState({}, "", path)
+
+afterEach(() => at("/"))
+
+describe("getCurrentProjectScope (derived from the URL)", () => {
+  it("is live by default", () => {
+    expect(getCurrentProjectScope()).toEqual(LIVE_SCOPE)
+  })
+
+  it("is live for an ordinary project", () => {
+    at("/projects/my-project/signals")
+    expect(getCurrentProjectScope()).toEqual(LIVE_SCOPE)
+  })
+
+  it("is showcase for the reserved slug and its subpaths", () => {
+    at("/projects/lat-demo")
+    expect(getCurrentProjectScope()).toEqual(SHOWCASE_SCOPE)
+    at("/projects/lat-demo/monitors")
+    expect(getCurrentProjectScope()).toEqual(SHOWCASE_SCOPE)
+  })
+
+  it("is sandbox with the org id from the path", () => {
+    at("/sandbox/org_abc123/projects/x")
+    expect(getCurrentProjectScope()).toEqual({ kind: "sandbox", orgId: "org_abc123" })
+  })
+
+  it("is live outside the project/sandbox routes", () => {
+    at("/settings/billing")
+    expect(getCurrentProjectScope()).toEqual(LIVE_SCOPE)
+  })
+})

--- a/apps/web/src/domains/projects/project-scope.tsx
+++ b/apps/web/src/domains/projects/project-scope.tsx
@@ -1,3 +1,4 @@
+import { isShowcaseProjectSlug } from "@domain/shared"
 import { createContext, type ReactNode, use } from "react"
 
 /**
@@ -25,6 +26,9 @@ export type ProjectScope =
 
 /** The default scope. A stable reference so Live consumers keep memo identity. */
 export const LIVE_SCOPE: ProjectScope = { kind: "live" }
+
+/** The shared read-only Showcase scope. A stable reference (its org is resolved server-side). */
+export const SHOWCASE_SCOPE: ProjectScope = { kind: "showcase" }
 
 /** The scope context. Read it with {@link useProjectScope} (defaults to {@link LIVE_SCOPE}). */
 const ProjectScopeContext = createContext<ProjectScope>(LIVE_SCOPE)
@@ -60,7 +64,9 @@ export function projectScopeKey(scope: ProjectScope): readonly unknown[] {
  * `showcase` adds nothing here. Spread into the payload:
  * `{ ...projectScopeData(scope), projectId, … }`.
  */
-export function projectScopeData(scope: ProjectScope): { sandboxOrgId?: string } {
+export function projectScopeData(scope: ProjectScope): {
+  sandboxOrgId?: string
+} {
   return scope.kind === "sandbox" ? { sandboxOrgId: scope.orgId } : {}
 }
 
@@ -82,12 +88,26 @@ export function isReadOnlyScope(scope: ProjectScope): boolean {
   return scope.kind === "showcase"
 }
 
+const SANDBOX_PATH = /^\/sandbox\/([^/]+)(?:\/|$)/
+const PROJECT_PATH = /^\/projects\/([^/]+)(?:\/|$)/
+
 /**
  * The current scope for consumers that run outside React and so cannot read it
  * via {@link useProjectScope} — notably the client-side write-gate middleware,
- * which stamps the scope onto outgoing server-fn requests. Defaults to
- * {@link LIVE_SCOPE}.
+ * which stamps the scope onto outgoing server-fn requests.
+ *
+ * Derived from the URL (the same source of truth the `$projectSlug` loader uses:
+ * the reserved showcase slug), so it's stateless and always current at request
+ * time — no mounted-provider mirror to keep in sync. **Client-only**: it reads
+ * `window.location`, and the server never calls this — it reads the per-request
+ * `context.projectScope` the write-gate stamps. Defaults to {@link LIVE_SCOPE}.
  */
 export function getCurrentProjectScope(): ProjectScope {
+  if (typeof window === "undefined") return LIVE_SCOPE
+  const path = window.location.pathname
+  const sandbox = SANDBOX_PATH.exec(path)
+  if (sandbox) return { kind: "sandbox", orgId: decodeURIComponent(sandbox[1]) }
+  const project = PROJECT_PATH.exec(path)
+  if (project && isShowcaseProjectSlug(decodeURIComponent(project[1]))) return SHOWCASE_SCOPE
   return LIVE_SCOPE
 }

--- a/apps/web/src/domains/projects/projects.collection.ts
+++ b/apps/web/src/domains/projects/projects.collection.ts
@@ -4,16 +4,35 @@ import type { Context, QueryBuilder, SchemaFromSource } from "@tanstack/react-db
 import { useLiveQuery } from "@tanstack/react-db"
 import { createAppCollection } from "../../lib/data/create-app-collection.ts"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
+import { getShowcaseProjectRecord } from "../showcase/showcase.functions.ts"
 import type { ProjectRecord } from "./projects.functions.ts"
 import { createProject, deleteProject, listProjects, updateProject } from "./projects.functions.ts"
+import { mergeShowcaseProject } from "./showcase-project.ts"
 
 const queryClient = getQueryClient()
 
+// The org-scoped project list (RLS-pure) plus the cross-org Showcase row, merged
+// client-side. The Showcase lives in a different org, so `listProjects` never
+// returns it; the merge is the single injection point and appears only when the
+// org's `wantsShowcase` is true and a showcase has been built (else the fetch
+// returns null). This one merge feeds both the switcher entry and the by-slug
+// current-project lookups that read the collection.
 const projectsCollection = createAppCollection(
   queryCollectionOptions({
     queryClient,
     queryKey: ["projects"],
-    queryFn: () => listProjects(),
+    queryFn: async () => {
+      // The showcase fetch is best-effort: a transient failure (5xx/network)
+      // must not break the switcher + by-slug lookups when `listProjects`
+      // succeeded. `allSettled` keeps both results independent; a genuine
+      // `listProjects` failure still rejects the query, while a failed showcase
+      // fetch degrades to null. The server fn already returns null when there's
+      // no showcase or the org opted out.
+      const [projectsResult, showcaseResult] = await Promise.allSettled([listProjects(), getShowcaseProjectRecord()])
+      if (projectsResult.status === "rejected") throw projectsResult.reason
+      const showcase = showcaseResult.status === "fulfilled" ? showcaseResult.value : null
+      return mergeShowcaseProject(projectsResult.value, showcase)
+    },
     getKey: (item: ProjectRecord) => item.id,
     onInsert: async ({ transaction }) => {
       await Promise.all(
@@ -83,6 +102,7 @@ export function createProjectMutation(name: string) {
     deletedAt: null,
     createdAt: now,
     updatedAt: now,
+    isShowcase: false,
   })
 
   return { projectId, transaction }

--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -73,6 +73,9 @@ export const toRecord = (project: Project) => ({
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
   createdAt: project.createdAt.toISOString(),
   updatedAt: project.updatedAt.toISOString(),
+  // The shared read-only Showcase row (merged client-side into the projects
+  // collection) sets this true; every org-owned project is false.
+  isShowcase: false,
 })
 
 export type ProjectRecord = ReturnType<typeof toRecord>

--- a/apps/web/src/domains/projects/showcase-project.test.ts
+++ b/apps/web/src/domains/projects/showcase-project.test.ts
@@ -1,0 +1,95 @@
+import { OrganizationId, ProjectId, SHOWCASE_PROJECT_SLUG } from "@domain/shared"
+import { describe, expect, it, vi } from "vitest"
+import type { ProjectRecord } from "./projects.functions.ts"
+import { loadProjectRouteData, mergeShowcaseProject } from "./showcase-project.ts"
+
+const makeProject = (over: Partial<ProjectRecord> = {}): ProjectRecord => ({
+  id: ProjectId("proj_1"),
+  organizationId: OrganizationId("org_1"),
+  name: "My project",
+  slug: "my-project",
+  settings: {
+    keepMonitoring: undefined,
+    notifications: undefined,
+    escalation: undefined,
+    onboardingType: undefined,
+    onboardingCompleted: undefined,
+    isSample: undefined,
+    sampling: undefined,
+  },
+  firstTraceAt: null,
+  deletedAt: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  isShowcase: false,
+  ...over,
+})
+
+describe("mergeShowcaseProject", () => {
+  it("appends the showcase row when one is resolved", () => {
+    const projects = [makeProject({ id: ProjectId("proj_a") }), makeProject({ id: ProjectId("proj_b") })]
+    const showcase = makeProject({ id: ProjectId("proj_demo"), slug: SHOWCASE_PROJECT_SLUG, isShowcase: true })
+
+    const merged = mergeShowcaseProject(projects, showcase)
+
+    expect(merged).toHaveLength(3)
+    expect(merged.at(-1)).toBe(showcase)
+    expect(merged.filter((p) => p.isShowcase)).toHaveLength(1)
+  })
+
+  it("returns a copy of the list without a showcase entry when none is resolved (absent or org opted out)", () => {
+    const projects = [makeProject({ id: ProjectId("proj_a") })]
+
+    const merged = mergeShowcaseProject(projects, null)
+
+    expect(merged).toEqual(projects)
+    expect(merged.some((p) => p.isShowcase)).toBe(false)
+    expect(merged).not.toBe(projects)
+  })
+})
+
+describe("loadProjectRouteData", () => {
+  it("resolves the reserved showcase slug through the showcase resolver", async () => {
+    const showcase = makeProject({ slug: SHOWCASE_PROJECT_SLUG, isShowcase: true })
+    const loadShowcaseProject = vi.fn().mockResolvedValue(showcase)
+    const loadProjectBySlug = vi.fn()
+
+    const result = await loadProjectRouteData({
+      slug: SHOWCASE_PROJECT_SLUG,
+      loadShowcaseProject,
+      loadProjectBySlug,
+    })
+
+    expect(result).toEqual({ project: showcase, isShowcase: true })
+    expect(loadShowcaseProject).toHaveBeenCalledOnce()
+    expect(loadProjectBySlug).not.toHaveBeenCalled()
+  })
+
+  it("throws for the reserved slug when the showcase is absent or the org opted out", async () => {
+    const loadShowcaseProject = vi.fn().mockResolvedValue(null)
+
+    await expect(
+      loadProjectRouteData({
+        slug: SHOWCASE_PROJECT_SLUG,
+        loadShowcaseProject,
+        loadProjectBySlug: vi.fn(),
+      }),
+    ).rejects.toThrow()
+  })
+
+  it("resolves a normal slug org-scoped and never touches the showcase resolver", async () => {
+    const project = makeProject({ slug: "real-project" })
+    const loadShowcaseProject = vi.fn()
+    const loadProjectBySlug = vi.fn().mockResolvedValue(project)
+
+    const result = await loadProjectRouteData({
+      slug: "real-project",
+      loadShowcaseProject,
+      loadProjectBySlug,
+    })
+
+    expect(result).toEqual({ project, isShowcase: false })
+    expect(loadProjectBySlug).toHaveBeenCalledWith("real-project")
+    expect(loadShowcaseProject).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/domains/projects/showcase-project.ts
+++ b/apps/web/src/domains/projects/showcase-project.ts
@@ -1,0 +1,45 @@
+import { isShowcaseProjectSlug } from "@domain/shared"
+import type { ProjectRecord } from "./projects.functions.ts"
+
+/** Display name for the shared Showcase entry in the switcher and project chrome. */
+export const SHOWCASE_PROJECT_NAME = "Latitude Demo"
+
+/**
+ * Appends the (optional) resolved Showcase row to the org-scoped project list.
+ * The server projects repository stays pure/org-scoped — the Showcase lives in a
+ * different org, so it is merged here at the client collection, never injected
+ * into `listProjects`. `showcase` is `null` when no showcase exists or the org's
+ * `wantsShowcase` is false (the resolver 404s → the server fn returns null), so
+ * the entry appears only for opted-in orgs once a showcase has been built.
+ */
+export function mergeShowcaseProject(
+  projects: readonly ProjectRecord[],
+  showcase: ProjectRecord | null,
+): ProjectRecord[] {
+  return showcase ? [...projects, showcase] : [...projects]
+}
+
+/**
+ * Decides how the `$projectSlug` loader resolves a project. The reserved
+ * Showcase slug routes through the cross-org showcase resolver (and scopes
+ * descendant reads to the showcase org); every other slug resolves org-scoped.
+ * A missing/unauthorized showcase throws so the route's catch redirects to `/`.
+ */
+export async function loadProjectRouteData({
+  slug,
+  loadShowcaseProject,
+  loadProjectBySlug,
+}: {
+  readonly slug: string
+  readonly loadShowcaseProject: () => Promise<ProjectRecord | null>
+  readonly loadProjectBySlug: (slug: string) => Promise<ProjectRecord>
+}): Promise<{ project: ProjectRecord; isShowcase: boolean }> {
+  if (isShowcaseProjectSlug(slug)) {
+    const project = await loadShowcaseProject()
+    if (!project) throw new Error("Showcase unavailable")
+    return { project, isShowcase: true }
+  }
+
+  const project = await loadProjectBySlug(slug)
+  return { project, isShowcase: false }
+}

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -2,7 +2,6 @@ import { ScoreAnalyticsRepository } from "@domain/scores"
 import {
   type FilterSet,
   filterSetSchema,
-  type OrganizationId,
   PERCENTILE_SESSION_FILTER_FIELDS,
   type PercentileSessionFilterField,
   ProjectId,
@@ -30,13 +29,8 @@ import {
 import { TaxonomyClusterRepository } from "@domain/taxonomy"
 import { AIEmbedLive, withAi } from "@platform/ai"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
-import {
-  ScoreAnalyticsRepositoryLive,
-  SessionRepositoryLive,
-  SpanRepositoryLive,
-  withClickHouse,
-} from "@platform/db-clickhouse"
-import { SignalRepositoryLive, TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { ScoreAnalyticsRepositoryLive, SessionRepositoryLive, SpanRepositoryLive } from "@platform/db-clickhouse"
+import { SignalRepositoryLive, TaxonomyClusterRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { cacheHitRate } from "@repo/utils"
 import { createServerFn } from "@tanstack/react-start"
@@ -44,7 +38,10 @@ import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
 import { z } from "zod"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../../server/clients.ts"
+import type { ScopedOrgId } from "../../server/resolve-org-scope.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 
 export const serializeSession = (session: Session) => ({
   organizationId: session.organizationId,
@@ -116,7 +113,6 @@ interface SessionListResult {
 export const listSessionsByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       limit: z.number().optional(),
       cursor: sessionListCursorSchema.optional(),
@@ -126,8 +122,8 @@ export const listSessionsByProject = createServerFn({ method: "GET" })
       searchQuery: z.string().max(500).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<SessionListResult> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SessionListResult> => {
+    const orgId = await resolveOrgScope(context)
     const filters = await expandTopicFilters(orgId, ProjectId(data.projectId), data.filters)
 
     const page = await Effect.runPromise(
@@ -146,7 +142,7 @@ export const listSessionsByProject = createServerFn({ method: "GET" })
           },
         })
       }).pipe(
-        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -169,7 +165,6 @@ export const listSessionsByProject = createServerFn({ method: "GET" })
 export const countSessionsByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       filters: filterSetSchema.optional(),
       searchQuery: z.string().max(500).optional(),
@@ -178,11 +173,12 @@ export const countSessionsByProject = createServerFn({ method: "GET" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{
       readonly totalCount: number
       readonly matchingTraceCount?: number
     }> => {
-      const orgId = await resolveOrgScope(data)
+      const orgId = await resolveOrgScope(context)
       const filters = await expandTopicFilters(orgId, ProjectId(data.projectId), data.filters)
 
       const result = await Effect.runPromise(
@@ -195,7 +191,7 @@ export const countSessionsByProject = createServerFn({ method: "GET" })
             ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
           })
         }).pipe(
-          withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+          withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
           withAi(AIEmbedLive, getRedisClient()),
           withTracing,
         ),
@@ -214,7 +210,7 @@ export const countSessionsByProject = createServerFn({ method: "GET" })
  * expands each selected node into its subtree ids before ClickHouse sees it.
  */
 const expandTopicFilters = async (
-  orgId: OrganizationId,
+  orgId: ScopedOrgId,
   projectId: ProjectId,
   filters: FilterSet | undefined,
 ): Promise<FilterSet | undefined> => {
@@ -230,7 +226,7 @@ const expandTopicFilters = async (
         for (const subtreeId of subtree) ids.add(subtreeId)
       }
       return [...ids]
-    }).pipe(withPostgres(TaxonomyClusterRepositoryLive, getPostgresClient(), orgId), withTracing),
+    }).pipe(withScopedPostgres(TaxonomyClusterRepositoryLive, getPostgresClient(), orgId), withTracing),
   )
   // A selection that expands to nothing (e.g. a persisted filter pointing at
   // a since-merged cluster) must match ZERO sessions — an empty in-list would
@@ -240,7 +236,6 @@ const expandTopicFilters = async (
 }
 
 const sessionHistogramInputSchema = z.object({
-  sandboxOrgId: z.string().optional(),
   projectId: z.string(),
   filters: filterSetSchema.optional(),
   rangeStartIso: z.string(),
@@ -254,14 +249,14 @@ const sessionHistogramInputSchema = z.object({
 
 export const getSessionTimeHistogramByProject = createServerFn({ method: "GET" })
   .inputValidator(sessionHistogramInputSchema)
-  .handler(async ({ data }): Promise<readonly TraceTimeHistogramBucket[]> => {
+  .handler(async ({ data, context }): Promise<readonly TraceTimeHistogramBucket[]> => {
     const startMs = Date.parse(data.rangeStartIso)
     const endMs = Date.parse(data.rangeEndIso)
     if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
       return []
     }
 
-    const orgId = await resolveOrgScope(data)
+    const orgId = await resolveOrgScope(context)
 
     const expandedFilters = await expandTopicFilters(orgId, ProjectId(data.projectId), data.filters)
     const mergedFilters = mergeTraceHistogramTimeFilters(expandedFilters, data.rangeStartIso, data.rangeEndIso)
@@ -275,16 +270,14 @@ export const getSessionTimeHistogramByProject = createServerFn({ method: "GET" }
           filters: mergedFilters,
           bucketSeconds: data.bucketSeconds,
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
 export const getSessionMetricsByProject = createServerFn({ method: "GET" })
-  .inputValidator(
-    z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), filters: filterSetSchema.optional() }),
-  )
-  .handler(async ({ data }): Promise<SessionMetrics | null> => {
-    const orgId = await resolveOrgScope(data)
+  .inputValidator(z.object({ projectId: z.string(), filters: filterSetSchema.optional() }))
+  .handler(async ({ data, context }): Promise<SessionMetrics | null> => {
+    const orgId = await resolveOrgScope(context)
     const filters = await expandTopicFilters(orgId, ProjectId(data.projectId), data.filters)
 
     return Effect.runPromise(
@@ -295,21 +288,21 @@ export const getSessionMetricsByProject = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           ...(filters ? { filters } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
 export const getSessionCohortSummary = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string() }))
-  .handler(async ({ data }): Promise<CohortSummary> => {
-    const orgId = await resolveOrgScope(data)
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data, context }): Promise<CohortSummary> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       getSessionCohortSummaryUseCase({
         organizationId: orgId,
         projectId: ProjectId(data.projectId),
       }).pipe(
-        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),
         withTracing,
       ),
@@ -338,9 +331,9 @@ const serializeSessionDetail = (session: SessionDetail, latestTraceId: string): 
 })
 
 export const getSessionDetail = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), sessionId: z.string() }))
-  .handler(async ({ data }) => {
-    const orgId = await resolveOrgScope(data)
+  .inputValidator(z.object({ projectId: z.string(), sessionId: z.string() }))
+  .handler(async ({ data, context }) => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
 
     const result = await Effect.runPromise(
@@ -365,7 +358,7 @@ export const getSessionDetail = createServerFn({ method: "GET" })
         })
         return serializeSessionDetail(detail, latestTraceId ?? "")
       }).pipe(
-        withClickHouse(Layer.mergeAll(SessionRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
+        withScopedClickHouse(Layer.mergeAll(SessionRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -398,15 +391,14 @@ export interface SessionSignalRecord {
 export const listSessionSignals = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceIds: z.array(z.string().length(32)).max(500),
     }),
   )
-  .handler(async ({ data }): Promise<readonly SessionSignalRecord[]> => {
+  .handler(async ({ data, context }): Promise<readonly SessionSignalRecord[]> => {
     if (data.traceIds.length === 0) return []
 
-    const orgId = await resolveOrgScope(data)
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const now = new Date()
 
@@ -453,8 +445,8 @@ export const listSessionSignals = createServerFn({ method: "GET" })
           ]
         })
       }).pipe(
-        withPostgres(SignalRepositoryLive, getPostgresClient(), orgId),
-        withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId),
+        withScopedPostgres(SignalRepositoryLive, getPostgresClient(), orgId),
+        withScopedClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -463,13 +455,12 @@ export const listSessionSignals = createServerFn({ method: "GET" })
 export const getSessionDistribution = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       field: z.enum(PERCENTILE_SESSION_FILTER_FIELDS),
     }),
   )
-  .handler(async ({ data }): Promise<TraceDistribution> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<TraceDistribution> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -480,7 +471,7 @@ export const getSessionDistribution = createServerFn({ method: "GET" })
           field: data.field as PercentileSessionFilterField,
         })
       }).pipe(
-        withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -492,15 +483,14 @@ const DISTINCT_COLUMNS = ["userId", "tags", "models", "providers", "serviceNames
 export const getSessionDistinctValues = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       column: z.enum(DISTINCT_COLUMNS),
       limit: z.number().optional(),
       search: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly string[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly string[]> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -512,6 +502,6 @@ export const getSessionDistinctValues = createServerFn({ method: "GET" })
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
           ...(data.search ? { search: data.search } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })

--- a/apps/web/src/domains/showcase/showcase.functions.ts
+++ b/apps/web/src/domains/showcase/showcase.functions.ts
@@ -1,0 +1,64 @@
+import { ProjectRepository } from "@domain/projects"
+import { SHOWCASE_PROJECT_SLUG } from "@domain/shared"
+import { resolveShowcaseUseCase } from "@domain/showcase"
+import { RedisCacheStoreLive } from "@platform/cache-redis"
+import {
+  OrganizationRepositoryLive,
+  ProjectRepositoryLive,
+  ShowcaseRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect, Layer } from "effect"
+import { requireSession } from "../../server/auth.ts"
+import { getPostgresClient, getRedisClient } from "../../server/clients.ts"
+import { type ProjectRecord, toRecord } from "../projects/projects.functions.ts"
+import { SHOWCASE_PROJECT_NAME } from "../projects/showcase-project.ts"
+
+/**
+ * Resolves the current shared Showcase project as a `ProjectRecord`, or `null`
+ * when no showcase exists or the requesting org's `wantsShowcase` is false (both
+ * surface as the resolver's `NotFoundError`, swallowed to `null` here).
+ *
+ * Two Postgres scopes, deliberately: the resolver runs under the *requesting*
+ * org (it authorizes on that org's flag and reads the RLS-free pointer/org
+ * tables), while the project read runs under the *resolved showcase* org — the
+ * single org id the resolver hands back — since the project row belongs to that
+ * tenant and org-scoped RLS would otherwise hide it.
+ *
+ * The returned record presents the reserved slug + demo name (not the underlying
+ * project's real slug/name), so the client-collection merge and the
+ * `/projects/lat-demo` loader both key off the stable sentinel while blue/green
+ * regeneration rotates the real project id underneath.
+ */
+export const getShowcaseProjectRecord = createServerFn({ method: "GET" }).handler(
+  async (): Promise<ProjectRecord | null> => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const resolved = await Effect.runPromise(
+      resolveShowcaseUseCase({ requestingOrganizationId: organizationId }).pipe(
+        Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+        withPostgres(Layer.merge(OrganizationRepositoryLive, ShowcaseRepositoryLive), client, organizationId),
+        Effect.provide(RedisCacheStoreLive(getRedisClient())),
+        withTracing,
+      ),
+    )
+    if (!resolved) return null
+
+    const project = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ProjectRepository
+        return yield* repo.findById(resolved.currentProjectId)
+      }).pipe(withPostgres(ProjectRepositoryLive, client, resolved.organizationId), withTracing),
+    )
+
+    return {
+      ...toRecord(project),
+      name: SHOWCASE_PROJECT_NAME,
+      slug: SHOWCASE_PROJECT_SLUG,
+      isShowcase: true,
+    }
+  },
+)

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -17,7 +17,6 @@ import {
   type FilterSet,
   filterSetSchema,
   generateId,
-  OrganizationId,
   ProjectId,
   resolveSettings,
   SettingsReader,
@@ -62,12 +61,7 @@ import {
 } from "@domain/signals"
 import { SessionRepository } from "@domain/spans"
 import { AIEmbedLive, withAi } from "@platform/ai"
-import {
-  ScoreAnalyticsRepositoryLive,
-  SessionRepositoryLive,
-  TraceRepositoryLive,
-  withClickHouse,
-} from "@platform/db-clickhouse"
+import { ScoreAnalyticsRepositoryLive, SessionRepositoryLive, TraceRepositoryLive } from "@platform/db-clickhouse"
 import {
   EvaluationRepositoryLive,
   MembershipRepositoryLive,
@@ -75,7 +69,6 @@ import {
   ScoreRepositoryLive,
   SettingsReaderLive,
   SignalRepositoryLive,
-  withPostgres,
 } from "@platform/db-postgres"
 import { QuickJsScriptRuntimeLive } from "@platform/sandbox-quickjs"
 import { withTracing } from "@repo/observability"
@@ -86,6 +79,9 @@ import { enforceExportRequestRateLimit } from "../../domains/exports/export-rate
 import { ensureSession } from "../../domains/sessions/session.functions.ts"
 import { getSessionOrganizationId, requireSession } from "../../server/auth.ts"
 import { getClickhouseClient, getPostgresClient, getQueuePublisher, getRedisClient } from "../../server/clients.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 import {
   type EvaluationSummaryRecord,
   toEvaluationSummaryRecord,
@@ -347,9 +343,10 @@ type ListSignalsRequest = z.infer<typeof listSignalsInputSchema>
 const runSignalsList = async (
   data: ListSignalsRequest,
   options: { readonly includeAnalytics: boolean; readonly includeItems?: boolean },
+  context: Parameters<typeof resolveOrgScope>[0],
 ): Promise<SignalsListResultRecord> => {
-  const { organizationId, userId } = await requireSession()
-  const orgId = OrganizationId(organizationId)
+  const { userId } = await requireSession()
+  const orgId = await resolveOrgScope(context)
   const pgClient = getPostgresClient()
   const chClient = getClickhouseClient()
   const redisClient = getRedisClient()
@@ -379,7 +376,7 @@ const runSignalsList = async (
       const search =
         options.includeAnalytics && trimmedSearchQuery && !directMatch
           ? yield* embedSignalSearchQueryUseCase({
-              organizationId,
+              organizationId: orgId,
               projectId: data.projectId,
               query: trimmedSearchQuery,
             })
@@ -394,7 +391,7 @@ const runSignalsList = async (
           : undefined
 
       return yield* listSignalsUseCase({
-        organizationId,
+        organizationId: orgId,
         projectId: data.projectId,
         ...(data.limit !== undefined ? { limit: data.limit } : {}),
         ...(data.offset !== undefined ? { offset: data.offset } : {}),
@@ -418,8 +415,8 @@ const runSignalsList = async (
               : {}),
       })
     }).pipe(
-      withPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), pgClient, orgId),
-      withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
+      withScopedPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), pgClient, orgId),
+      withScopedClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
       withAi(AIEmbedLive, redisClient),
       withTracing,
     ),
@@ -430,20 +427,22 @@ const runSignalsList = async (
 
 export const listSignals = createServerFn({ method: "GET" })
   .inputValidator(listSignalsInputSchema)
-  .handler(async ({ data }): Promise<SignalsListResultRecord> => runSignalsList(data, { includeAnalytics: false }))
+  .handler(
+    async ({ data, context }): Promise<SignalsListResultRecord> =>
+      runSignalsList(data, { includeAnalytics: false }, context),
+  )
 
 export const getSignalsAnalytics = createServerFn({ method: "GET" })
   .inputValidator(listSignalsInputSchema)
   .handler(
-    async ({ data }): Promise<SignalsListResultRecord> =>
-      runSignalsList(data, { includeAnalytics: true, includeItems: false }),
+    async ({ data, context }): Promise<SignalsListResultRecord> =>
+      runSignalsList(data, { includeAnalytics: true, includeItems: false }, context),
   )
 
 export const getSignalRowMetrics = createServerFn({ method: "GET" })
   .inputValidator(signalRowMetricsInputSchema)
-  .handler(async ({ data }): Promise<SignalRowMetricsRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalRowMetricsRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const timeRange =
       data.timeRange?.fromIso || data.timeRange?.toIso
@@ -524,7 +523,7 @@ export const getSignalRowMetrics = createServerFn({ method: "GET" })
           ),
         } satisfies SignalRowMetricsRecord
       }).pipe(
-        withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
+        withScopedClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
         withTracing,
       ),
     )
@@ -566,9 +565,8 @@ export const searchOrgSignals = createServerFn({ method: "GET" })
       limit: z.number().int().min(1).max(25).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly OrgSignalSearchRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly OrgSignalSearchRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const redisClient = getRedisClient()
 
@@ -576,10 +574,10 @@ export const searchOrgSignals = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const search = data.semantic
           ? yield* embedSignalSearchQueryUseCase({
-              organizationId,
+              organizationId: orgId,
               // Org-wide search has no single project; `projectId` is telemetry-only on this
               // use-case (it does not scope the embedding), so we tag it with the org id.
-              projectId: organizationId,
+              projectId: orgId,
               query: data.searchQuery,
             })
           : undefined
@@ -591,7 +589,7 @@ export const searchOrgSignals = createServerFn({ method: "GET" })
           ...(data.preferProjectId !== undefined ? { preferProjectId: ProjectId(data.preferProjectId) } : {}),
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
         })
-      }).pipe(withPostgres(SignalRepositoryLive, pgClient, orgId), withAi(AIEmbedLive, redisClient), withTracing),
+      }).pipe(withScopedPostgres(SignalRepositoryLive, pgClient, orgId), withAi(AIEmbedLive, redisClient), withTracing),
     )
 
     return results.map(toOrgSignalSearchRecord)
@@ -599,9 +597,8 @@ export const searchOrgSignals = createServerFn({ method: "GET" })
 
 export const getSignal = createServerFn({ method: "GET" })
   .inputValidator(signalInputSchema)
-  .handler(async ({ data }): Promise<SignalSummaryRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalSummaryRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
@@ -616,7 +613,7 @@ export const getSignal = createServerFn({ method: "GET" })
         const issue = issues[0]
 
         return issue ? toSignalSummaryRecord(issue) : null
-      }).pipe(withPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
+      }).pipe(withScopedPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
     )
   })
 
@@ -633,9 +630,8 @@ export interface SignalLifecycleSummaryRecord {
  */
 export const getSignalLifecycleSummary = createServerFn({ method: "GET" })
   .inputValidator(signalInputSchema)
-  .handler(async ({ data }): Promise<SignalLifecycleSummaryRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalLifecycleSummaryRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
@@ -654,15 +650,14 @@ export const getSignalLifecycleSummary = createServerFn({ method: "GET" })
           now,
         })
         return { id: issue.id, name: issue.name, states: [...states] }
-      }).pipe(withPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
+      }).pipe(withScopedPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
     )
   })
 
 export const getSignalDetail = createServerFn({ method: "GET" })
   .inputValidator(signalDetailInputSchema)
-  .handler(async ({ data }): Promise<SignalDetailRecord | null> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalDetailRecord | null> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
@@ -784,12 +779,12 @@ export const getSignalDetail = createServerFn({ method: "GET" })
           keepMonitoringDefault: settings.keepMonitoring,
         })
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive, ScoreRepositoryLive, SettingsReaderLive),
           pgClient,
           orgId,
         ),
-        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
         withTracing,
       ),
     )
@@ -806,9 +801,8 @@ export type SignalSessionPageRecord = ReturnType<typeof toSignalSessionPageRecor
 
 export const listSignalSessions = createServerFn({ method: "GET" })
   .inputValidator(signalTracesInputSchema)
-  .handler(async ({ data }): Promise<SignalSessionPageRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalSessionPageRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
@@ -839,7 +833,9 @@ export const listSignalSessions = createServerFn({ method: "GET" })
           limit: sessionPage.limit,
           offset: sessionPage.offset,
         }
-      }).pipe(withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId)),
+      }).pipe(
+        withScopedClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
+      ),
     )
 
     return toSignalSessionPageRecord(result)
@@ -847,9 +843,8 @@ export const listSignalSessions = createServerFn({ method: "GET" })
 
 export const countSignalSessions = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string(), signalId: z.string() }))
-  .handler(async ({ data }): Promise<number> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<number> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -859,22 +854,21 @@ export const countSignalSessions = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           signalId: SignalId(data.signalId),
         })
-      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withScopedClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), orgId)),
     )
   })
 
 export const getSignalImpact = createServerFn({ method: "GET" })
   .inputValidator(signalImpactInputSchema)
-  .handler(async ({ data }): Promise<SignalImpactRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalImpactRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
 
     return Effect.runPromise(
       getSignalImpactUseCase({ organizationId: orgId, projectId, signalId }).pipe(
-        withClickHouse(
+        withScopedClickHouse(
           Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive, SessionRepositoryLive),
           chClient,
           orgId,
@@ -895,9 +889,8 @@ export interface SignalDimensionsRecord {
 
 export const getSignalDimensions = createServerFn({ method: "GET" })
   .inputValidator(signalDimensionsInputSchema)
-  .handler(async ({ data }): Promise<SignalDimensionsRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalDimensionsRecord> => {
+    const orgId = await resolveOrgScope(context)
     const chClient = getClickhouseClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
@@ -911,7 +904,7 @@ export const getSignalDimensions = createServerFn({ method: "GET" })
           signalId,
           dimension: data.dimension,
         })
-      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId), withTracing),
+      }).pipe(withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
 
     return {
@@ -948,9 +941,8 @@ export interface RelatedSignalRecord {
 
 export const getRelatedSignals = createServerFn({ method: "GET" })
   .inputValidator(relatedSignalsInputSchema)
-  .handler(async ({ data }): Promise<readonly RelatedSignalRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly RelatedSignalRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const chClient = getClickhouseClient()
 
@@ -960,8 +952,8 @@ export const getRelatedSignals = createServerFn({ method: "GET" })
         projectId: ProjectId(data.projectId),
         signalId: SignalId(data.signalId),
       }).pipe(
-        withPostgres(SignalRepositoryLive, pgClient, orgId),
-        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withScopedPostgres(SignalRepositoryLive, pgClient, orgId),
+        withScopedClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
         withTracing,
       ),
     )
@@ -1008,9 +1000,8 @@ export interface SignalOccurrenceRecord {
  */
 export const getSignalOccurrences = createServerFn({ method: "GET" })
   .inputValidator(signalOccurrencesInputSchema)
-  .handler(async ({ data }): Promise<{ readonly items: readonly SignalOccurrenceRecord[] }> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<{ readonly items: readonly SignalOccurrenceRecord[] }> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const projectId = ProjectId(data.projectId)
     const signalId = SignalId(data.signalId)
@@ -1024,7 +1015,7 @@ export const getSignalOccurrences = createServerFn({ method: "GET" })
           source: "annotation",
           options: { limit: SIGNAL_EXAMPLES_LIMIT, draftMode: "exclude" },
         })
-      }).pipe(withPostgres(ScoreRepositoryLive, pgClient, orgId), withTracing),
+      }).pipe(withScopedPostgres(ScoreRepositoryLive, pgClient, orgId), withTracing),
     )
 
     const items = page.items.flatMap((score): SignalOccurrenceRecord[] => {
@@ -1066,9 +1057,9 @@ export interface UpdateSignalTriageRecord {
 
 export const updateSignalTriage = createServerFn({ method: "POST" })
   .inputValidator(updateSignalTriageInputSchema)
-  .handler(async ({ data }): Promise<UpdateSignalTriageRecord> => {
-    const { organizationId, userId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<UpdateSignalTriageRecord> => {
+    const { userId } = await requireSession()
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -1079,7 +1070,7 @@ export const updateSignalTriage = createServerFn({ method: "POST" })
         ...(data.assigneeId !== undefined ? { assigneeId: data.assigneeId } : {}),
         ...(data.priority !== undefined ? { priority: data.priority } : {}),
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(SignalRepositoryLive, MembershipRepositoryLive, OutboxEventWriterLive),
           pgClient,
           orgId,
@@ -1099,9 +1090,8 @@ export const updateSignalTriage = createServerFn({ method: "POST" })
 
 export const applySignalLifecycleAction = createServerFn({ method: "POST" })
   .inputValidator(signalLifecycleActionInputSchema)
-  .handler(async ({ data }): Promise<SignalLifecycleCommandRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalLifecycleCommandRecord> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
 
     const result = await Effect.runPromise(
@@ -1111,7 +1101,7 @@ export const applySignalLifecycleAction = createServerFn({ method: "POST" })
         command: data.command,
         keepMonitoring: data.keepMonitoring,
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive, OutboxEventWriterLive, SettingsReaderLive),
           pgClient,
           orgId,
@@ -1149,9 +1139,8 @@ const BULK_ACTION_BATCH_SIZE = 100
 
 export const applyBulkSignalLifecycleAction = createServerFn({ method: "POST" })
   .inputValidator(bulkSignalLifecycleActionInputSchema)
-  .handler(async ({ data }): Promise<SignalLifecycleCommandRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<SignalLifecycleCommandRecord> => {
+    const orgId = await resolveOrgScope(context)
     const pgClient = getPostgresClient()
     const chClient = getClickhouseClient()
     const redisClient = getRedisClient()
@@ -1168,7 +1157,7 @@ export const applyBulkSignalLifecycleAction = createServerFn({ method: "POST" })
         Effect.gen(function* () {
           const search = trimmedSearchQuery
             ? yield* embedSignalSearchQueryUseCase({
-                organizationId,
+                organizationId: orgId,
                 projectId: data.projectId,
                 query: trimmedSearchQuery,
               })
@@ -1185,7 +1174,7 @@ export const applyBulkSignalLifecycleAction = createServerFn({ method: "POST" })
           let offset = 0
           while (true) {
             const page = yield* listSignalsUseCase({
-              organizationId,
+              organizationId: orgId,
               projectId: data.projectId,
               limit: BULK_ACTION_BATCH_SIZE,
               offset,
@@ -1217,8 +1206,8 @@ export const applyBulkSignalLifecycleAction = createServerFn({ method: "POST" })
             offset += page.limit
           }
         }).pipe(
-          withPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), pgClient, orgId),
-          withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
+          withScopedPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), pgClient, orgId),
+          withScopedClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, SessionRepositoryLive), chClient, orgId),
           withAi(AIEmbedLive, redisClient),
           withTracing,
         ),
@@ -1240,7 +1229,7 @@ export const applyBulkSignalLifecycleAction = createServerFn({ method: "POST" })
         command: data.command,
         keepMonitoring: data.keepMonitoring,
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive, OutboxEventWriterLive, SettingsReaderLive),
           pgClient,
           orgId,
@@ -1342,8 +1331,8 @@ export interface CreateSignalRecord {
 /** Creates a user-origin signal with its membership detector (settings or raw script). */
 export const createSignal = createServerFn({ method: "POST" })
   .inputValidator(createSignalInputSchema)
-  .handler(async ({ data }): Promise<CreateSignalRecord> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<CreateSignalRecord> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     return Effect.runPromise(
@@ -1357,10 +1346,10 @@ export const createSignal = createServerFn({ method: "POST" })
         ...(data.sampling !== undefined ? { sampling: data.sampling } : {}),
         evaluation: data.evaluation,
       }).pipe(
-        withPostgres(
+        withScopedPostgres(
           Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive, OutboxEventWriterLive),
           client,
-          OrganizationId(organizationId),
+          organizationId,
         ),
         Effect.provide(QuickJsScriptRuntimeLive),
         withTracing,
@@ -1379,8 +1368,8 @@ const updateSignalInputSchema = z.object({
 /** Updates a signal's name/description and its canonical `filters` pre-gate. */
 export const updateSignal = createServerFn({ method: "POST" })
   .inputValidator(updateSignalInputSchema)
-  .handler(async ({ data }): Promise<{ readonly signalId: string; readonly changed: boolean }> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<{ readonly signalId: string; readonly changed: boolean }> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     return Effect.runPromise(
@@ -1391,11 +1380,7 @@ export const updateSignal = createServerFn({ method: "POST" })
         ...(data.description !== undefined ? { description: data.description } : {}),
         ...(data.filters !== undefined ? { filters: data.filters } : {}),
       }).pipe(
-        withPostgres(
-          Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive),
-          client,
-          OrganizationId(organizationId),
-        ),
+        withScopedPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), client, organizationId),
         withTracing,
       ),
     )
@@ -1414,8 +1399,9 @@ export const updateSignalEvaluation = createServerFn({ method: "POST" })
   .handler(
     async ({
       data,
+      context,
     }): Promise<{ readonly signalId: string; readonly evaluationId: string; readonly changed: boolean }> => {
-      const { organizationId } = await requireSession()
+      const organizationId = await resolveOrgScope(context)
       const client = getPostgresClient()
 
       return Effect.runPromise(
@@ -1425,11 +1411,7 @@ export const updateSignalEvaluation = createServerFn({ method: "POST" })
           evaluation: data.evaluation,
           ...(data.sampling !== undefined ? { sampling: data.sampling } : {}),
         }).pipe(
-          withPostgres(
-            Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive),
-            client,
-            OrganizationId(organizationId),
-          ),
+          withScopedPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), client, organizationId),
           Effect.provide(QuickJsScriptRuntimeLive),
           withTracing,
         ),
@@ -1442,17 +1424,13 @@ const deleteSignalInputSchema = z.object({ projectId: z.string(), signalId: z.st
 /** Soft-deletes a signal and archives its evaluation. */
 export const deleteSignal = createServerFn({ method: "POST" })
   .inputValidator(deleteSignalInputSchema)
-  .handler(async ({ data }): Promise<{ readonly signalId: string }> => {
-    const { organizationId } = await requireSession()
+  .handler(async ({ data, context }): Promise<{ readonly signalId: string }> => {
+    const organizationId = await resolveOrgScope(context)
     const client = getPostgresClient()
 
     return Effect.runPromise(
       deleteSignalUseCase({ projectId: data.projectId, signalId: data.signalId }).pipe(
-        withPostgres(
-          Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive),
-          client,
-          OrganizationId(organizationId),
-        ),
+        withScopedPostgres(Layer.mergeAll(SignalRepositoryLive, EvaluationRepositoryLive), client, organizationId),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,13 +1,14 @@
 import { ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
 import type { Operation, Span, SpanDetail, SpanKind, SpanMessagesData, SpanStatusCode } from "@domain/spans"
 import { SpanRepository } from "@domain/spans"
-import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { SpanRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
 import { getClickhouseClient } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 
 const dateTimeParamSchema = z
   .string()
@@ -146,15 +147,14 @@ const serializeSpanDetail = (span: SpanDetail): SpanDetailRecord => ({
 export const listSpansByTrace = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceId: z.string(),
       startTimeFrom: dateTimeParamSchema.optional(),
       startTimeTo: dateTimeParamSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<SpanRecord[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SpanRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const spans = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* SpanRepository
@@ -165,7 +165,7 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
           ...(data.startTimeFrom ? { startTimeFrom: data.startTimeFrom } : {}),
           ...(data.startTimeTo ? { startTimeTo: data.startTimeTo } : {}),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return spans.map(serializeSpan)
   })
@@ -173,15 +173,14 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
 export const listSpansBySession = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       sessionId: z.string(),
       startTimeFrom: dateTimeParamSchema.optional(),
       startTimeTo: dateTimeParamSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<SpanRecord[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SpanRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const spans = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* SpanRepository
@@ -192,7 +191,7 @@ export const listSpansBySession = createServerFn({ method: "GET" })
           ...(data.startTimeFrom ? { startTimeFrom: data.startTimeFrom } : {}),
           ...(data.startTimeTo ? { startTimeTo: data.startTimeTo } : {}),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return spans.map(serializeSpan)
   })
@@ -224,14 +223,13 @@ const serializeSpanMessages = (span: SpanMessagesData): SpanMessagesRecord => ({
 export const listConversationMessageSpans = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceId: z.string(),
       startTime: dateTimeParamSchema,
     }),
   )
-  .handler(async ({ data }): Promise<SpanMessagesRecord[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SpanMessagesRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const spans = await Effect.runPromise(
       Effect.gen(function* () {
         const spanRepo = yield* SpanRepository
@@ -242,7 +240,7 @@ export const listConversationMessageSpans = createServerFn({ method: "GET" })
           startTimeFrom: new Date(data.startTime.getTime() - 60 * 1000),
           startTimeTo: new Date(data.startTime.getTime() + 24 * 60 * 60 * 1000),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return spans.map(serializeSpanMessages)
   })
@@ -250,15 +248,14 @@ export const listConversationMessageSpans = createServerFn({ method: "GET" })
 export const listSessionConversationMessageSpans = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       sessionId: z.string(),
       sessionStartTime: dateTimeParamSchema,
       sessionEndTime: dateTimeParamSchema,
     }),
   )
-  .handler(async ({ data }): Promise<SpanMessagesRecord[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SpanMessagesRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const spans = await Effect.runPromise(
       Effect.gen(function* () {
         const spanRepo = yield* SpanRepository
@@ -269,7 +266,7 @@ export const listSessionConversationMessageSpans = createServerFn({ method: "GET
           startTimeFrom: new Date(data.sessionStartTime.getTime() - 60 * 1000),
           startTimeTo: new Date(data.sessionEndTime.getTime() + 24 * 60 * 60 * 1000),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return spans.map(serializeSpanMessages)
   })
@@ -277,7 +274,6 @@ export const listSessionConversationMessageSpans = createServerFn({ method: "GET
 export const getSpanDetail = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceId: z.string(),
       spanId: z.string(),
@@ -285,8 +281,8 @@ export const getSpanDetail = createServerFn({ method: "GET" })
       startTimeTo: dateTimeParamSchema.optional(),
     }),
   )
-  .handler(async ({ data }): Promise<SpanDetailRecord> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<SpanDetailRecord> => {
+    const orgId = await resolveOrgScope(context)
     const span = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* SpanRepository
@@ -298,7 +294,7 @@ export const getSpanDetail = createServerFn({ method: "GET" })
           ...(data.startTimeFrom ? { startTimeFrom: data.startTimeFrom } : {}),
           ...(data.startTimeTo ? { startTimeTo: data.startTimeTo } : {}),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return serializeSpanDetail(span)
   })

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -1,5 +1,5 @@
 import { MOMENT_KINDS, type MomentKind } from "@domain/conversation-intelligence"
-import { normalizeCentroid, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { normalizeCentroid, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import {
   type ClusterAnalysisAggregate,
   getClusterSessionIntelligenceUseCase,
@@ -11,18 +11,16 @@ import {
   TaxonomyClusterRepository,
   type TaxonomyClusterTrendSummary,
 } from "@domain/taxonomy"
-import {
-  TaxonomyClusterIntelligenceRepositoryLive,
-  TaxonomyObservationRepositoryLive,
-  withClickHouse,
-} from "@platform/db-clickhouse"
-import { TaxonomyClusterRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { TaxonomyClusterIntelligenceRepositoryLive, TaxonomyObservationRepositoryLive } from "@platform/db-clickhouse"
+import { TaxonomyClusterRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
-import { requireSession } from "../../server/auth.ts"
 import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
+import { withScopedPostgres } from "../../server/scoped-postgres.ts"
 import { type CentroidPoint2D, projectCentroidsTo2D } from "./centroid-projection.ts"
 
 export interface TaxonomyClusterRecord {
@@ -338,9 +336,8 @@ interface TopicFilterOptionRecord {
  */
 export const getTopicFilterOptions = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string() }))
-  .handler(async ({ data }): Promise<readonly TopicFilterOptionRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<readonly TopicFilterOptionRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
 
     return Effect.runPromise(
@@ -372,7 +369,7 @@ export const getTopicFilterOptions = createServerFn({ method: "GET" })
         const rootChildren = roots.length === 1 && roots[0] ? (childrenByParent.get(roots[0].id) ?? []) : []
         walk(roots.length === 1 && rootChildren.length > 0 ? rootChildren : roots)
         return out
-      }).pipe(withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
     )
   })
 
@@ -388,9 +385,8 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
       timeRange: behaviourTimeRangeSchema,
     }),
   )
-  .handler(async ({ data }): Promise<ProjectBehavioursRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<ProjectBehavioursRecord> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const timeRange = parseBehaviourTimeRange(data.timeRange)
 
@@ -444,8 +440,8 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
         const displayTopics = data.segment === "high_escalation" ? pruneToHighEscalation(topics) : topics
         return { topics: countBehaviourNodes(displayTopics) >= 2 ? displayTopics : [] }
       }).pipe(
-        withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
-        withClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
+        withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
         withTracing,
       ),
     )
@@ -469,9 +465,8 @@ export const getBehaviourTrajectory = createServerFn({ method: "GET" })
       timeRange: behaviourTimeRangeSchema,
     }),
   )
-  .handler(async ({ data }): Promise<BehaviourTrajectoryRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<BehaviourTrajectoryRecord> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const timeRange = parseBehaviourTimeRange(data.timeRange)
     const categoryClusterIds = [...new Set(data.categoryClusterIds)].filter((id) => id.length > 0)
@@ -488,7 +483,7 @@ export const getBehaviourTrajectory = createServerFn({ method: "GET" })
               .pipe(Effect.map((clusterIds) => [clusterId, clusterIds] as const)),
           { concurrency: 6 },
         )
-      }).pipe(withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
     )
 
     const bucketExpression = trajectoryBucketExpression(data.axis)
@@ -547,7 +542,7 @@ export const getBehaviourTrajectory = createServerFn({ method: "GET" })
             ORDER BY ${data.axis === "day" ? "bucket ASC" : "toUInt16(bucket) ASC"}
           `,
           query_params: {
-            organizationId,
+            organizationId: orgId,
             projectId: data.projectId,
             clusterIds,
             axis: data.axis,
@@ -693,9 +688,8 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
       momentRange: behaviourMomentRangeSchema,
     }),
   )
-  .handler(async ({ data }): Promise<BehaviourSessionsRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<BehaviourSessionsRecord> => {
+    const orgId = await resolveOrgScope(context)
     const offset = data.offset ?? 0
     const limit = data.limit ?? 50
     const filter = data.filter ?? "all"
@@ -709,7 +703,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           clusterId: TaxonomyClusterId(data.clusterId),
         })
-      }).pipe(withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
+      }).pipe(withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
     )
     const timeFromClause = timeRange.from ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
     const timeToClause = timeRange.to ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
@@ -731,7 +725,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
               LIMIT {pageSize:UInt32}
               OFFSET {offset:UInt32}`,
       query_params: {
-        organizationId,
+        organizationId: orgId,
         projectId: data.projectId,
         clusterIds,
         filter,
@@ -766,7 +760,7 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
               GROUP BY startTime
               ORDER BY startTime ASC`,
       query_params: {
-        organizationId,
+        organizationId: orgId,
         projectId: data.projectId,
         clusterIds,
         filter,
@@ -806,9 +800,8 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
 
 export const getClusterProfile = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string(), clusterId: z.string(), timeRange: behaviourTimeRangeSchema }))
-  .handler(async ({ data }): Promise<ClusterSessionIntelligenceRecord> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
+  .handler(async ({ data, context }): Promise<ClusterSessionIntelligenceRecord> => {
+    const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
     const timeRange = parseBehaviourTimeRange(data.timeRange)
 
@@ -827,8 +820,8 @@ export const getClusterProfile = createServerFn({ method: "GET" })
             Object.fromEntries(Object.entries(example).map(([key, value]) => [key, String(value)])),
           ),
         })),
-        withPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
-        withClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
+        withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
         withTracing,
       ),
     )

--- a/apps/web/src/domains/tools/tools.functions.ts
+++ b/apps/web/src/domains/tools/tools.functions.ts
@@ -13,13 +13,14 @@ import type {
   ToolUsageMetrics,
 } from "@domain/spans"
 import { ToolAnalyticsRepository } from "@domain/spans"
-import { ToolAnalyticsRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { ToolAnalyticsRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
 import { getClickhouseClient } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 
 // Wire records: Dates serialized to ISO strings.
 
@@ -135,7 +136,6 @@ const toRecentDefiningSpanRecord = (span: RecentDefiningSpan): RecentDefiningSpa
 })
 
 const toolsScopeSchema = z.object({
-  sandboxOrgId: z.string().optional(),
   projectId: z.string(),
   fromIso: z.string().datetime(),
   toIso: z.string().datetime(),
@@ -160,8 +160,8 @@ export const listProjectTools = createServerFn({ method: "GET" })
         .max(90 * 24 * 60 * 60),
     }),
   )
-  .handler(async ({ data }): Promise<ToolsAnalyticsRecord> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<ToolsAnalyticsRecord> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -173,14 +173,14 @@ export const listProjectTools = createServerFn({ method: "GET" })
           totals: analytics.totals,
           tools: analytics.tools.map(toToolSummaryRecord),
         }
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
 export const getProjectToolDetail = createServerFn({ method: "GET" })
   .inputValidator(toolsScopeSchema.extend({ toolName: toolNameSchema, errorsOnly: z.boolean().optional() }))
-  .handler(async ({ data }): Promise<ToolDetailRecord> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<ToolDetailRecord> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -202,7 +202,7 @@ export const getProjectToolDetail = createServerFn({ method: "GET" })
           usage: usage ? toUsageMetricsRecord(usage) : null,
           errorsUsage: errorsUsage ? toUsageMetricsRecord(errorsUsage) : null,
         }
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -218,8 +218,8 @@ export const getToolCallHistogram = createServerFn({ method: "GET" })
       errorsOnly: z.boolean().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly ToolCallHistogramBucket[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly ToolCallHistogramBucket[]> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -229,7 +229,7 @@ export const getToolCallHistogram = createServerFn({ method: "GET" })
           ...(data.toolName === undefined ? {} : { toolName: data.toolName }),
           ...(data.errorsOnly === undefined ? {} : { errorsOnly: data.errorsOnly }),
         })
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -242,8 +242,8 @@ export const getToolParameterStats = createServerFn({ method: "GET" })
       errorsOnly: z.boolean().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<ToolParameterStatsResult> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<ToolParameterStatsResult> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -254,7 +254,7 @@ export const getToolParameterStats = createServerFn({ method: "GET" })
           ...(data.topValuesPerKey === undefined ? {} : { topValuesPerKey: data.topValuesPerKey }),
           ...(data.errorsOnly === undefined ? {} : { errorsOnly: data.errorsOnly }),
         })
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -266,8 +266,8 @@ export const getToolContextBreakdown = createServerFn({ method: "GET" })
       errorsOnly: z.boolean().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly ToolContextBreakdownRow[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly ToolContextBreakdownRow[]> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -277,7 +277,7 @@ export const getToolContextBreakdown = createServerFn({ method: "GET" })
           dimension: data.dimension,
           ...(data.errorsOnly === undefined ? {} : { errorsOnly: data.errorsOnly }),
         })
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -289,8 +289,8 @@ export const getToolCoOccurrence = createServerFn({ method: "GET" })
       errorsOnly: z.boolean().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly ToolCoOccurrenceRow[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly ToolCoOccurrenceRow[]> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -300,7 +300,7 @@ export const getToolCoOccurrence = createServerFn({ method: "GET" })
           ...(data.limit === undefined ? {} : { limit: data.limit }),
           ...(data.errorsOnly === undefined ? {} : { errorsOnly: data.errorsOnly }),
         })
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -311,8 +311,8 @@ export const getToolErrorBreakdown = createServerFn({ method: "GET" })
       limit: z.number().int().min(1).max(50).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly ToolErrorBreakdownRow[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly ToolErrorBreakdownRow[]> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -321,7 +321,7 @@ export const getToolErrorBreakdown = createServerFn({ method: "GET" })
           toolName: data.toolName,
           ...(data.limit === undefined ? {} : { limit: data.limit }),
         })
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -333,8 +333,8 @@ export const listRecentDefiningSpans = createServerFn({ method: "GET" })
       cursor: z.object({ startTimeIso: z.string().datetime(), spanId: z.string().length(16) }).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<RecentDefiningSpansPageRecord> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<RecentDefiningSpansPageRecord> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ToolAnalyticsRepository
@@ -358,6 +358,6 @@ export const listRecentDefiningSpans = createServerFn({ method: "GET" })
               }
             : {}),
         }
-      }).pipe(withClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(ToolAnalyticsRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -33,7 +33,6 @@ import {
   TaxonomyObservationRepositoryLive,
   TraceRepositoryLive,
   TraceSearchRepositoryLive,
-  withClickHouse,
 } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { cacheHitRate } from "@repo/utils"
@@ -46,6 +45,7 @@ import { ensureSession } from "../../domains/sessions/session.functions.ts"
 import { getSessionOrganizationId } from "../../server/auth.ts"
 import { getClickhouseClient, getQueuePublisher, getRedisClient } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
+import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 
 export interface TraceRecord {
   readonly organizationId: string
@@ -183,7 +183,6 @@ interface TraceListResult {
 export const listTracesByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       limit: z.number().optional(),
       cursor: traceListCursorSchema.optional(),
@@ -193,8 +192,8 @@ export const listTracesByProject = createServerFn({ method: "GET" })
       searchQuery: z.string().max(500).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<TraceListResult> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<TraceListResult> => {
+    const orgId = await resolveOrgScope(context)
 
     const page = await Effect.runPromise(
       Effect.gen(function* () {
@@ -212,7 +211,7 @@ export const listTracesByProject = createServerFn({ method: "GET" })
           },
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -231,14 +230,13 @@ export const listTracesByProject = createServerFn({ method: "GET" })
 export const countTracesByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       filters: filterSetSchema.optional(),
       searchQuery: z.string().max(500).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<number> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<number> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -250,7 +248,7 @@ export const countTracesByProject = createServerFn({ method: "GET" })
           ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -260,14 +258,13 @@ export const countTracesByProject = createServerFn({ method: "GET" })
 export const getTraceMetricsByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       filters: filterSetSchema.optional(),
       searchQuery: z.string().max(500).optional(),
     }),
   )
-  .handler(async ({ data }): Promise<TraceMetrics | null> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<TraceMetrics | null> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -279,7 +276,7 @@ export const getTraceMetricsByProject = createServerFn({ method: "GET" })
           ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -287,16 +284,16 @@ export const getTraceMetricsByProject = createServerFn({ method: "GET" })
   })
 
 export const getTraceCohortSummary = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string() }))
-  .handler(async ({ data }): Promise<CohortSummary> => {
-    const orgId = await resolveOrgScope(data)
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data, context }): Promise<CohortSummary> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       getTraceCohortSummaryUseCase({
         organizationId: orgId,
         projectId: ProjectId(data.projectId),
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),
         withTracing,
       ),
@@ -304,7 +301,6 @@ export const getTraceCohortSummary = createServerFn({ method: "GET" })
   })
 
 const traceHistogramInputSchema = z.object({
-  sandboxOrgId: z.string().optional(),
   projectId: z.string(),
   filters: filterSetSchema.optional(),
   rangeStartIso: z.string(),
@@ -319,14 +315,14 @@ const traceHistogramInputSchema = z.object({
 
 export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
   .inputValidator(traceHistogramInputSchema)
-  .handler(async ({ data }): Promise<readonly TraceTimeHistogramBucket[]> => {
+  .handler(async ({ data, context }): Promise<readonly TraceTimeHistogramBucket[]> => {
     const startMs = Date.parse(data.rangeStartIso)
     const endMs = Date.parse(data.rangeEndIso)
     if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
       return []
     }
 
-    const orgId = await resolveOrgScope(data)
+    const orgId = await resolveOrgScope(context)
 
     const mergedFilters = mergeTraceHistogramTimeFilters(data.filters, data.rangeStartIso, data.rangeEndIso)
 
@@ -341,7 +337,7 @@ export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
           ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -351,14 +347,13 @@ export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
 export const getTraceSearchHighlights = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceId: z.string(),
       searchQuery: z.string().max(500),
     }),
   )
-  .handler(async ({ data }): Promise<TraceSearchHighlightsResult> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<TraceSearchHighlightsResult> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       getTraceSearchHighlightsUseCase({
@@ -367,7 +362,7 @@ export const getTraceSearchHighlights = createServerFn({ method: "GET" })
         traceId: TraceId(data.traceId),
         searchQuery: data.searchQuery,
       }).pipe(
-        withClickHouse(Layer.merge(TraceRepositoryLive, TraceSearchRepositoryLive), getClickhouseClient(), orgId),
+        withScopedClickHouse(Layer.merge(TraceRepositoryLive, TraceSearchRepositoryLive), getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
         Effect.orElseSucceed((): TraceSearchHighlightsResult => ({ highlights: [], firstMatchIndex: -1 })),
@@ -378,14 +373,13 @@ export const getTraceSearchHighlights = createServerFn({ method: "GET" })
 export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       sessionId: z.string(),
       analysisHash: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly SessionMomentIntelligenceRecord[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly SessionMomentIntelligenceRecord[]> => {
+    const orgId = await resolveOrgScope(context)
     return Effect.runPromise(
       listSessionMomentIntelligenceUseCase({
         organizationId: orgId,
@@ -421,7 +415,7 @@ export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
             })),
           })),
         ),
-        withClickHouse(
+        withScopedClickHouse(
           Layer.mergeAll(
             SessionSemanticMomentRepositoryLive,
             SessionMomentLabelRepositoryLive,
@@ -437,9 +431,9 @@ export const getSessionMomentIntelligence = createServerFn({ method: "GET" })
   })
 
 export const getTraceDetail = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ sandboxOrgId: z.string().optional(), projectId: z.string(), traceId: z.string() }))
-  .handler(async ({ data }) => {
-    const orgId = await resolveOrgScope(data)
+  .inputValidator(z.object({ projectId: z.string(), traceId: z.string() }))
+  .handler(async ({ data, context }) => {
+    const orgId = await resolveOrgScope(context)
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -453,7 +447,7 @@ export const getTraceDetail = createServerFn({ method: "GET" })
           .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
         return trace ? serializeTraceDetail(trace) : null
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -465,15 +459,14 @@ export const getTraceDetail = createServerFn({ method: "GET" })
 export const getTraceConversationChunk = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       traceId: z.string(),
       offset: z.number().int().nonnegative().optional(),
       limit: z.number().int().positive().max(100).optional(),
     }),
   )
-  .handler(async ({ data }) => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }) => {
+    const orgId = await resolveOrgScope(context)
     const offset = data.offset ?? 0
     const limit = data.limit ?? 25
 
@@ -484,7 +477,7 @@ export const getTraceConversationChunk = createServerFn({ method: "GET" })
         traceId: TraceId(data.traceId),
         offset,
         limit,
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
+      }).pipe(withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
 
     return result as never
@@ -541,13 +534,12 @@ export const enqueueTracesExport = createServerFn({ method: "POST" })
 export const getTraceDistribution = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       field: z.enum(PERCENTILE_TRACE_FILTER_FIELDS),
     }),
   )
-  .handler(async ({ data }): Promise<TraceDistribution> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<TraceDistribution> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -558,7 +550,7 @@ export const getTraceDistribution = createServerFn({ method: "GET" })
           field: data.field as PercentileTraceFilterField,
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -568,15 +560,14 @@ export const getTraceDistribution = createServerFn({ method: "GET" })
 export const getTraceDistinctValues = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
-      sandboxOrgId: z.string().optional(),
       projectId: z.string(),
       column: z.enum(DISTINCT_COLUMNS),
       limit: z.number().optional(),
       search: z.string().optional(),
     }),
   )
-  .handler(async ({ data }): Promise<readonly string[]> => {
-    const orgId = await resolveOrgScope(data)
+  .handler(async ({ data, context }): Promise<readonly string[]> => {
+    const orgId = await resolveOrgScope(context)
 
     return Effect.runPromise(
       Effect.gen(function* () {
@@ -589,7 +580,7 @@ export const getTraceDistinctValues = createServerFn({ method: "GET" })
           ...(data.search ? { search: data.search } : {}),
         })
       }).pipe(
-        withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),

--- a/apps/web/src/middlewares/write-gate-middleware.test.ts
+++ b/apps/web/src/middlewares/write-gate-middleware.test.ts
@@ -25,8 +25,13 @@ describe("isBlockedWrite", () => {
     expect(isBlockedWrite({ scope: SHOWCASE, method: "POST", serverFnName: "createMonitor" })).toBe(true)
   })
 
-  it("allows the POST-read allowlist under the read-only showcase scope", () => {
-    for (const serverFnName of ["previewEvaluation", "listLinearTeamsForApiKey", "listCursorRepositoriesForApiKey"]) {
+  it("allows the POST-read/session-write allowlist under the read-only showcase scope", () => {
+    for (const serverFnName of [
+      "previewEvaluation",
+      "listLinearTeamsForApiKey",
+      "listCursorRepositoriesForApiKey",
+      "rememberLastProjectSlug",
+    ]) {
       expect(isBlockedWrite({ scope: SHOWCASE, method: "POST", serverFnName })).toBe(false)
     }
   })

--- a/apps/web/src/middlewares/write-gate-middleware.ts
+++ b/apps/web/src/middlewares/write-gate-middleware.ts
@@ -8,14 +8,26 @@ import {
   type ProjectScope,
 } from "../domains/projects/project-scope.tsx"
 
-// POST server fns that are genuine reads (no mutation), so they stay allowed
-// even under a read-only scope. Every other POST is treated as a write. The
-// `*ForApiKey` reads are POST because they carry a raw API key (which must not
-// ride in a GET URL), so they need listing here to survive the gate.
+// POST server fns that are NOT project-data mutations, so they stay allowed
+// even under a read-only scope. Every other POST is treated as a write. Two
+// kinds live here: genuine reads that must be POST because they carry a raw API
+// key (which must not ride in a GET URL — the `*ForApiKey` fns), and session/
+// chrome-state writes that touch no tenant data (e.g. `rememberLastProjectSlug`
+// sets the last-visited cookie — it fires from the project layout's mount
+// effect on every page, showcase included, so blocking it would reject on every
+// showcase visit as an unhandled rejection).
+//
+// These strings must match the compiler-embedded `serverFnMeta.name`. Renaming
+// one of these fns without updating this set makes it throw ReadOnlyProjectError
+// under showcase (fail-closed — visible, not a bypass). Grep the fn name here
+// when renaming: previewEvaluation (@domain/evaluations preview),
+// listLinearTeamsForApiKey / listCursorRepositoriesForApiKey (agent-dispatch),
+// rememberLastProjectSlug (projects.functions.ts).
 const POST_READ_ALLOWLIST: ReadonlySet<string> = new Set([
   "previewEvaluation",
   "listLinearTeamsForApiKey",
   "listCursorRepositoriesForApiKey",
+  "rememberLastProjectSlug",
 ])
 
 /**

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -9,9 +9,12 @@ import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
 import { CHANGELOG_UI_ENABLED } from "../../../domains/changelog/changelog.collection.ts"
+import { ProjectScopeProvider, SHOWCASE_SCOPE } from "../../../domains/projects/project-scope.tsx"
 import { PROJECT_SETTINGS_SECTION, useVisibleProjectSectionGroups } from "../../../domains/projects/project-sections.ts"
 import { useProjectsCollection } from "../../../domains/projects/projects.collection.ts"
 import { type ProjectRecord, rememberLastProjectSlug, toRecord } from "../../../domains/projects/projects.functions.ts"
+import { loadProjectRouteData } from "../../../domains/projects/showcase-project.ts"
+import { getShowcaseProjectRecord } from "../../../domains/showcase/showcase.functions.ts"
 import { getLatestWrappedReportForProject } from "../../../domains/wrapped/wrapped.functions.ts"
 import { AppSidebar, NavItem } from "../../../layouts/AppSidebar/index.tsx"
 import { ContentErrorBoundary } from "../../../lib/client-error-reporting.tsx"
@@ -47,13 +50,16 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug")({
   // Keep the rendered project record in `loader` so TanStack Router can cache
   // it across same-route search-param navigations. `beforeLoad` is better for
   // middleware-only checks, while descendants can read cached loader data with
-  // `useLoaderData({ select })`.
+  // `useLoaderData({ select })`. The reserved showcase slug resolves cross-org
+  // via the showcase resolver and marks the data `isShowcase` so the layout
+  // scopes descendant reads to the showcase org.
   loader: async ({ params }) => {
     try {
-      const project = await getProjectBySlug({
-        data: { slug: params.projectSlug },
+      return await loadProjectRouteData({
+        slug: params.projectSlug,
+        loadShowcaseProject: () => getShowcaseProjectRecord(),
+        loadProjectBySlug: (slug) => getProjectBySlug({ data: { slug } }),
       })
-      return { project }
     } catch {
       throw redirect({ to: "/" })
     }
@@ -152,6 +158,18 @@ function SampleProjectStrip() {
 }
 
 function ProjectLayout() {
+  const isShowcase = Route.useLoaderData({ select: (data) => data.isShowcase })
+  if (isShowcase) {
+    return (
+      <ProjectScopeProvider scope={SHOWCASE_SCOPE}>
+        <ProjectLayoutContent />
+      </ProjectScopeProvider>
+    )
+  }
+  return <ProjectLayoutContent />
+}
+
+function ProjectLayoutContent() {
   const { projectSlug } = Route.useParams()
   const projectFromLoader = Route.useLoaderData({ select: (data) => data.project })
   const { data: projectFromCollection } = useProjectsCollection(

--- a/apps/web/src/server/resolve-org-scope.ts
+++ b/apps/web/src/server/resolve-org-scope.ts
@@ -1,22 +1,61 @@
 import type { OrganizationId } from "@domain/shared"
+import type { ProjectScope } from "../domains/projects/project-scope.tsx"
 import { requireSession } from "./auth.ts"
+import { resolveShowcaseAccess } from "./resolve-showcase-access.ts"
 import { resolveSandboxAccess } from "./sandbox-access.ts"
 
+declare const scopedOrgIdBrand: unique symbol
+
 /**
- * Resolves the organization a trace/session read should be scoped to.
- *
- * Live (no `sandboxOrgId`) → the session's active org, as always. Sandbox → the
- * sandbox org, but only after `resolveSandboxAccess` confirms the caller is a
- * member of its parent org (the same gate `sandboxMiddleware` uses). Both the
- * session lookup and the sandbox authorization are plain function calls — no
- * server fn invokes another server fn. The returned id is the *only* org handed
- * to the data layer, so a sandbox read can never touch Live and vice-versa.
+ * An organization id that has been resolved *and authorized* for the current
+ * request scope by {@link resolveOrgScope} — the only place allowed to mint one.
+ * `withScopedClickHouse` requires this brand, so a ClickHouse read (which has no
+ * RLS backstop) cannot run against a raw session/user-supplied org: it must come
+ * from the resolver. Structurally makes "forgot to scope this read" a compile
+ * error, not a silently-wrong query.
  */
-export async function resolveOrgScope(data: { readonly sandboxOrgId?: string | undefined }): Promise<OrganizationId> {
-  const { userId, organizationId } = await requireSession()
-  if (data.sandboxOrgId) {
-    const sandbox = await resolveSandboxAccess({ sandboxOrgId: data.sandboxOrgId, userId })
-    return sandbox.organizationId
+export type ScopedOrgId = OrganizationId & { readonly [scopedOrgIdBrand]: true }
+
+/**
+ * The single chokepoint that resolves which organization a scoped read must run
+ * against, from the request's {@link ProjectScope} (stamped onto every server-fn
+ * request by the write-gate client middleware, so it arrives in `context` here —
+ * per-request, never a shared singleton on the server).
+ *
+ * - `live` (default) → the session's active org, as always.
+ * - `sandbox` → the sandbox org, but only after `resolveSandboxAccess` confirms
+ *   the caller is a member of its parent org (same gate as `sandboxMiddleware`).
+ * - `showcase` → the pinned showcase org, but only after `resolveShowcaseAccess`
+ *   authorizes the requesting org's `wantsShowcase` (else 404).
+ *
+ * Every scope authorizes server-side and returns exactly one org id — the *only*
+ * value a caller hands to both the data layer (`withPostgres`/`withClickHouse`)
+ * and the repo/query arg. New scoped reads call this and nothing else, so a new
+ * scope kind is wired here once, never fanned out across read endpoints. The
+ * scope kind is client-supplied but every non-live branch re-authorizes, so it
+ * can only ever resolve an org the caller is already entitled to.
+ */
+export async function resolveOrgScope(context: {
+  readonly projectScope?: ProjectScope | undefined
+}): Promise<ScopedOrgId> {
+  const scope: ProjectScope = context.projectScope ?? { kind: "live" }
+
+  // The `as ScopedOrgId` casts below are the *only* sanctioned mint points: each
+  // sits on the far side of an authorization (session / sandbox membership /
+  // wantsShowcase), so the brand certifies "authorized for this request scope".
+  switch (scope.kind) {
+    case "live": {
+      const { organizationId } = await requireSession()
+      return organizationId as ScopedOrgId
+    }
+    case "sandbox": {
+      const { userId } = await requireSession()
+      const sandbox = await resolveSandboxAccess({ sandboxOrgId: scope.orgId, userId })
+      return sandbox.organizationId as ScopedOrgId
+    }
+    case "showcase": {
+      const { organizationId } = await resolveShowcaseAccess()
+      return organizationId as ScopedOrgId
+    }
   }
-  return organizationId
 }

--- a/apps/web/src/server/scoped-clickhouse.ts
+++ b/apps/web/src/server/scoped-clickhouse.ts
@@ -1,0 +1,22 @@
+import { withClickHouse } from "@platform/db-clickhouse"
+import type { Layer } from "effect"
+import type { ScopedOrgId } from "./resolve-org-scope.ts"
+
+/**
+ * The org-scoped ClickHouse entry point for web server functions. Identical to
+ * {@link withClickHouse} except its org id is a {@link ScopedOrgId} — a brand only
+ * {@link resolveOrgScope} can mint. ClickHouse has no RLS backstop, so the query's
+ * org param is the *only* tenant boundary; requiring the brand here makes it a
+ * compile error to run a scoped read against a raw session/user-supplied org
+ * instead of the resolver's authorized one.
+ *
+ * Every multi-tenant CH read in the web app must go through this, not raw
+ * `withClickHouse` (enforced by lint on the read domains). Non-web callers
+ * (api / workers / workflows) keep using `withClickHouse` directly — they have
+ * their own org context and no request scope to resolve.
+ */
+export const withScopedClickHouse = <A, E, R>(
+  layer: Layer.Layer<A, E, R>,
+  client: Parameters<typeof withClickHouse>[1],
+  organizationId: ScopedOrgId,
+) => withClickHouse(layer, client, organizationId)

--- a/apps/web/src/server/scoped-postgres.ts
+++ b/apps/web/src/server/scoped-postgres.ts
@@ -1,0 +1,24 @@
+import { withPostgres } from "@platform/db-postgres"
+import type { Layer } from "effect"
+import type { ScopedOrgId } from "./resolve-org-scope.ts"
+
+/**
+ * The org-scoped Postgres entry point for web read/write server functions in the
+ * project-scoped domains. Identical to {@link withPostgres} except its org id is a
+ * {@link ScopedOrgId} — a brand only {@link resolveOrgScope} can mint. Unlike
+ * ClickHouse, Postgres has RLS, so this isn't a *security* boundary; it's a
+ * *correctness* one: under a non-live scope (showcase/sandbox) the intended org
+ * is NOT the session's, and passing the raw session org would silently read/write
+ * the wrong tenant's data (RLS happily allows it — same viewer). Requiring the
+ * brand makes "forgot to scope this" a compile error.
+ *
+ * Only the project-section domains (the surfaces the showcase renders) use this.
+ * Settings/account/org/admin and other genuinely session- or cross-org-scoped
+ * functions keep raw `withPostgres` (they never run under a non-live scope, or
+ * resolve a non-session org deliberately).
+ */
+export const withScopedPostgres = <A, E, R>(
+  layer: Layer.Layer<A, E, R>,
+  client: Parameters<typeof withPostgres>[1],
+  organizationId: ScopedOrgId,
+) => withPostgres(layer, client, organizationId)

--- a/biome.json
+++ b/biome.json
@@ -105,6 +105,106 @@
           }
         }
       }
+    },
+    {
+      "includes": [
+        "apps/web/src/domains/**/*.functions.ts",
+        "!apps/web/src/domains/admin/**",
+        "!apps/web/src/domains/agent-dispatch/**",
+        "!apps/web/src/domains/destinations/**"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": [
+                      "./test/*",
+                      "./testing/*",
+                      "../test/*",
+                      "../testing/*",
+                      "../../test/*",
+                      "../../testing/*"
+                    ],
+                    "message": "Do not import test utilities in production code. Expose them via a /testing subpath export instead."
+                  }
+                ],
+                "paths": {
+                  "@platform/db-clickhouse": {
+                    "importNames": ["withClickHouse"],
+                    "message": "Multi-tenant reads must use withScopedClickHouse (apps/web/src/server/scoped-clickhouse.ts): its org comes from resolveOrgScope, so ClickHouse (no RLS) can only read a scoped, authorized org. Exempt: admin/** (cross-org backoffice) and session-org config domains that resolve the viewer's own org, not the project scope (agent-dispatch, destinations)."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "apps/web/src/domains/**/*.functions.ts",
+        "!apps/web/src/domains/admin/**",
+        "!apps/web/src/domains/agent-dispatch/**",
+        "!apps/web/src/domains/alerts/**",
+        "!apps/web/src/domains/api-keys/**",
+        "!apps/web/src/domains/auth/**",
+        "!apps/web/src/domains/billing/**",
+        "!apps/web/src/domains/destinations/**",
+        "!apps/web/src/domains/evaluations/**",
+        "!apps/web/src/domains/feature-flags/**",
+        "!apps/web/src/domains/flaggers/**",
+        "!apps/web/src/domains/integrations/**",
+        "!apps/web/src/domains/members/**",
+        "!apps/web/src/domains/notifications/**",
+        "!apps/web/src/domains/oauth/**",
+        "!apps/web/src/domains/organizations/**",
+        "!apps/web/src/domains/projects/**",
+        "!apps/web/src/domains/sandbox/**",
+        "!apps/web/src/domains/saved-searches/**",
+        "!apps/web/src/domains/scores/**",
+        "!apps/web/src/domains/showcase/**",
+        "!apps/web/src/domains/sso/**",
+        "!apps/web/src/domains/users/**",
+        "!apps/web/src/domains/wrapped/**"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "patterns": [
+                  {
+                    "group": [
+                      "./test/*",
+                      "./testing/*",
+                      "../test/*",
+                      "../testing/*",
+                      "../../test/*",
+                      "../../testing/*"
+                    ],
+                    "message": "Do not import test utilities in production code. Expose them via a /testing subpath export instead."
+                  }
+                ],
+                "paths": {
+                  "@platform/db-clickhouse": {
+                    "importNames": ["withClickHouse"],
+                    "message": "Use withScopedClickHouse (apps/web/src/server/scoped-clickhouse.ts) — org must come from resolveOrgScope."
+                  },
+                  "@platform/db-postgres": {
+                    "importNames": ["withPostgres"],
+                    "message": "Use withScopedPostgres (apps/web/src/server/scoped-postgres.ts): its org comes from resolveOrgScope, so under a showcase/sandbox scope it resolves the project's org, not the viewer's session org. If this domain is genuinely session- or cross-org (settings/account/org/admin/config), add it to this rule's exclude-list instead. NOTE: the exclude-list still contains session-org domains pending migration to withScopedPostgres — see #3908; the goal is to shrink it to only the truly non-scopable domains (admin, organizations, sandbox, auth, oauth, sso, showcase, agent-dispatch, destinations)."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/domain/shared/src/slug.test.ts
+++ b/packages/domain/shared/src/slug.test.ts
@@ -1,6 +1,13 @@
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
-import { generateSlug, isReservedProjectSlug, RESERVED_PROJECT_SLUGS, SLUG_MAX_LENGTH } from "./slug.ts"
+import {
+  generateSlug,
+  isReservedProjectSlug,
+  isShowcaseProjectSlug,
+  RESERVED_PROJECT_SLUGS,
+  SHOWCASE_PROJECT_SLUG,
+  SLUG_MAX_LENGTH,
+} from "./slug.ts"
 
 const counts =
   (taken: ReadonlyMap<string, number>) =>
@@ -130,5 +137,14 @@ describe("isReservedProjectSlug", () => {
   it("treats other slugs as free", () => {
     expect(isReservedProjectSlug("demo")).toBe(false)
     expect(isReservedProjectSlug("lat-demo-1")).toBe(false)
+  })
+})
+
+describe("isShowcaseProjectSlug", () => {
+  it("matches only the reserved showcase slug", () => {
+    expect(SHOWCASE_PROJECT_SLUG).toBe("lat-demo")
+    expect(isShowcaseProjectSlug(SHOWCASE_PROJECT_SLUG)).toBe(true)
+    expect(isShowcaseProjectSlug("demo")).toBe(false)
+    expect(isShowcaseProjectSlug("lat-demo-1")).toBe(false)
   })
 })

--- a/packages/domain/shared/src/slug.ts
+++ b/packages/domain/shared/src/slug.ts
@@ -54,11 +54,24 @@ const MAX_ATTEMPTS = 100
 const RANDOM_SUFFIX_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789"
 const RANDOM_SUFFIX_LENGTH = 4
 
+/**
+ * The stable, user-visible slug the shared read-only Showcase project is
+ * always addressed by (`/projects/lat-demo`). It is a route sentinel resolved
+ * through the showcase pointer, so the URL stays constant even as blue/green
+ * regeneration rotates the underlying project id. `lat-demo` (over a generic
+ * `demo`) minimizes the odds a user already picked it, shrinking the
+ * reservation's collision/migration risk.
+ */
+export const SHOWCASE_PROJECT_SLUG = "lat-demo"
+
 /** Slug bases reserved for the product; enforced app-layer for every {@link generateSlug} caller. */
-export const RESERVED_PROJECT_SLUGS = ["lat-demo"] as const
+export const RESERVED_PROJECT_SLUGS = [SHOWCASE_PROJECT_SLUG] as const
 
 export const isReservedProjectSlug = (slug: string): boolean =>
   (RESERVED_PROJECT_SLUGS as readonly string[]).includes(slug)
+
+/** Whether `slug` addresses the shared Showcase project (the reserved route sentinel). */
+export const isShowcaseProjectSlug = (slug: string): boolean => slug === SHOWCASE_PROJECT_SLUG
 
 export class InvalidSlugInputError extends Data.TaggedError("InvalidSlugInputError")<{
   readonly name: string


### PR DESCRIPTION
Introduces one enforced way to answer **"which organization does this read/write belong to?"** — so the shared read-only **Showcase** (and the Test‑Mode sandbox) resolve the *project's* org instead of the viewer's session org, and a new query **can't silently get it wrong**.

## The rule

Every scoped read/write gets its org from **`resolveOrgScope(context)`** — never from the raw session.

1. The request's **`ProjectScope`** (`live` / `sandbox` / `showcase`) is set by the route and rides in the server-fn `context`.
2. `resolveOrgScope` maps it to exactly one **authorized** org id, branded **`ScopedOrgId`** (it's the only thing that can mint one; every non-live branch re-authorizes).
3. The data-layer wrappers **`withScopedClickHouse` / `withScopedPostgres`** require that brand.
4. **Biome bans** raw `withClickHouse` / `withPostgres` in scoped domains.

Net: forgetting to scope a query is a **compile/lint error**, not a silent wrong-tenant read. Behaviour is identical under `live` (`resolveOrgScope` returns the session org).

## Scope of enforcement

- **ClickHouse** — enforced domains-wide. No RLS, so the query's org is the *only* tenant boundary → security boundary.
- **Postgres** — enforced on the project-section domains. RLS backstops the rest, so a miss there is a *correctness* gap, not a leak. Exclude-list shrinks in #3909.
- **Exempt** — domains that resolve the viewer's *own* org, not the project ("where do my things go?"): `agent-dispatch`, `destinations`, `admin`, `organizations`, `sandbox`, auth/oauth, `sso`, `showcase`.

## Also in here (task S3)

Surfaces the Showcase in the UI: the `/projects/lat-demo` reserved-slug loader (resolves cross-org via the pointer) + a marked read-only row merged into the client projects collection. Behaviour-neutral until a showcase exists and the org has `wantsShowcase`.

Umbrella: #3821 · Follow-up: #3909
