### PR TITLE
Fix modal searchable selects

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/advanced-detector-editor.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/advanced-detector-editor.tsx
@@ -9,12 +9,14 @@ import { Button, RichTextEditor, Text } from "@repo/ui"
 export function AdvancedDetectorEditor({
   compiled,
   script,
+  placeholder,
   onScriptChange,
   onDetach,
 }: {
   /** Script compiled client-side from the active settings draft; null when none is valid. */
   readonly compiled: { readonly kind: "rule" | "judge"; readonly script: string } | null
   readonly script: string
+  readonly placeholder?: string
   readonly onScriptChange: (value: string) => void
   readonly onDetach: () => void
 }) {
@@ -43,7 +45,12 @@ export function AdvancedDetectorEditor({
   return (
     <div className="flex flex-col gap-1.5">
       <Text.H6>Evaluation script</Text.H6>
-      <RichTextEditor value={script} onChange={onScriptChange} minHeight="200px" />
+      <RichTextEditor
+        value={script}
+        onChange={onScriptChange}
+        minHeight="200px"
+        {...(placeholder !== undefined ? { placeholder } : {})}
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-builder-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/builder/signal-builder-modal.tsx
@@ -25,24 +25,18 @@ type DetectorTab = "rules" | "llm" | "advanced"
 type StepId = "detector" | "scope" | "test" | "details"
 type EditTab = "detector" | "scope" | "test"
 
-const DETECTOR_TABS: ReadonlyArray<{ readonly id: DetectorTab; readonly title: string; readonly summary: string }> = [
+const DETECTOR_TABS: ReadonlyArray<{ readonly id: DetectorTab; readonly title: string }> = [
   {
     id: "rules",
     title: "Set of conditions",
-    summary:
-      "Match concrete facts about a session: a phrase in the reply, a failed tool, latency or cost over a limit. It's free and runs instantly.",
   },
   {
     id: "llm",
     title: "LLM as judge",
-    summary:
-      "Describe the behavior in your own words and an LLM reads each session and decides. Good for fuzzy things like tone or frustration.",
   },
   {
     id: "advanced",
     title: "Custom script",
-    summary:
-      "The evaluation as the exact script Latitude runs. Compiled from your settings, or written by hand for anything the other two can't express.",
   },
 ]
 
@@ -72,6 +66,11 @@ const GENERATION_STAGES = [
 ]
 
 const emptyRuleDraft: RuleDraft = { match: "all", conditions: [] }
+const DEFAULT_ADVANCED_SCRIPT_PLACEHOLDER = compileSettingsToScript({
+  kind: "rule",
+  match: "any",
+  conditions: [{ type: "error" }],
+})
 
 const filterSetOrNull = (filter: FilterSet): FilterSet | null => (Object.keys(filter).length === 0 ? null : filter)
 
@@ -409,7 +408,6 @@ export function SignalBuilderModal({
   // All three tabs are available in create and edit alike: an evaluation can be re-authored across kinds
   // (settings ⇄ raw script), and the update use-case persists whichever kind the user lands on.
   const detectorTabOptions = DETECTOR_TABS.map(({ id, title }) => ({ id, label: title }))
-  const activeMethod = DETECTOR_TABS.find((method) => method.id === tab)
 
   const footer = inConditionSubStep ? (
     <>
@@ -517,7 +515,6 @@ export function SignalBuilderModal({
                 active={tab}
                 onSelect={selectDetectorTab}
               />
-              {activeMethod ? <Text.H6 color="foregroundMuted">{activeMethod.summary}</Text.H6> : null}
             </div>
             {tab === "rules" ? (
               <RuleConditionList draft={ruleDraft} onChange={setRuleDraft} onEditCondition={openConditionEditor} />
@@ -527,6 +524,7 @@ export function SignalBuilderModal({
               <AdvancedDetectorEditor
                 compiled={compiledView}
                 script={scriptDraft}
+                placeholder={DEFAULT_ADVANCED_SCRIPT_PLACEHOLDER}
                 onScriptChange={setScriptDraft}
                 onDetach={detachToScript}
               />

--- a/packages/ui/src/components/popover/primitives.tsx
+++ b/packages/ui/src/components/popover/primitives.tsx
@@ -14,16 +14,10 @@ const PopoverAnchor = PopoverPrimitive.Anchor
 const PopoverClose = PopoverPrimitive.Close
 
 type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
-  portaled?: boolean
+  container?: ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal>["container"]
 }
 
-function PopoverContent({
-  className,
-  align = "center",
-  sideOffset = 4,
-  portaled = true,
-  ...props
-}: PopoverContentProps) {
+function PopoverContent({ className, align = "center", sideOffset = 4, container, ...props }: PopoverContentProps) {
   const content = (
     <DismissableLayerBranch>
       <PopoverPrimitive.Content
@@ -45,9 +39,7 @@ function PopoverContent({
     </DismissableLayerBranch>
   )
 
-  if (!portaled) return content
-
-  return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
+  return <PopoverPrimitive.Portal container={container}>{content}</PopoverPrimitive.Portal>
 }
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 

--- a/packages/ui/src/components/popover/primitives.tsx
+++ b/packages/ui/src/components/popover/primitives.tsx
@@ -13,34 +13,41 @@ const PopoverAnchor = PopoverPrimitive.Anchor
 
 const PopoverClose = PopoverPrimitive.Close
 
+type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+  portaled?: boolean
+}
+
 function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  portaled = true,
   ...props
-}: ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>) {
-  return (
-    <PopoverPrimitive.Portal>
-      <DismissableLayerBranch>
-        <PopoverPrimitive.Content
-          data-no-navigate
-          align={align}
-          sideOffset={sideOffset}
-          className={cn(
-            "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-popover outline-none",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out",
-            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-            "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
-            "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            zIndex.popover,
-            className,
-          )}
-          {...props}
-        />
-      </DismissableLayerBranch>
-    </PopoverPrimitive.Portal>
+}: PopoverContentProps) {
+  const content = (
+    <DismissableLayerBranch>
+      <PopoverPrimitive.Content
+        data-no-navigate
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-popover outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          zIndex.popover,
+          className,
+        )}
+        {...props}
+      />
+    </DismissableLayerBranch>
   )
+
+  if (!portaled) return content
+
+  return <PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
 }
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 

--- a/packages/ui/src/components/popover/primitives.tsx
+++ b/packages/ui/src/components/popover/primitives.tsx
@@ -18,28 +18,28 @@ type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Cont
 }
 
 function PopoverContent({ className, align = "center", sideOffset = 4, container, ...props }: PopoverContentProps) {
-  const content = (
-    <DismissableLayerBranch>
-      <PopoverPrimitive.Content
-        data-no-navigate
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-popover outline-none",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out",
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
-          "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          zIndex.popover,
-          className,
-        )}
-        {...props}
-      />
-    </DismissableLayerBranch>
+  return (
+    <PopoverPrimitive.Portal container={container}>
+      <DismissableLayerBranch>
+        <PopoverPrimitive.Content
+          data-no-navigate
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-popover outline-none",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+            "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+            "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            zIndex.popover,
+            className,
+          )}
+          {...props}
+        />
+      </DismissableLayerBranch>
+    </PopoverPrimitive.Portal>
   )
-
-  return <PopoverPrimitive.Portal container={container}>{content}</PopoverPrimitive.Portal>
 }
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 

--- a/packages/ui/src/components/rich-text-editor/codemirror-editor.tsx
+++ b/packages/ui/src/components/rich-text-editor/codemirror-editor.tsx
@@ -2,7 +2,7 @@ import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirro
 import { json } from "@codemirror/lang-json"
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language"
 import { EditorState } from "@codemirror/state"
-import { EditorView, keymap, lineNumbers } from "@codemirror/view"
+import { EditorView, keymap, lineNumbers, placeholder } from "@codemirror/view"
 import { useEffect, useRef } from "react"
 import { useMountEffect } from "../../hooks/use-mount-effect.ts"
 import { cn } from "../../utils/cn.ts"
@@ -32,6 +32,10 @@ const baseTheme = EditorView.theme({
     caretColor: "hsl(var(--secondary-foreground))",
     backgroundColor: "hsl(var(--secondary))",
   },
+  ".cm-placeholder": {
+    color: "hsl(var(--muted-foreground))",
+    whiteSpace: "pre-wrap",
+  },
   ".cm-gutters": {
     backgroundColor: "hsl(var(--secondary))",
     borderRight: "1px solid hsl(var(--secondary))",
@@ -56,11 +60,13 @@ function buildState({
   doc,
   isJsonContent,
   readOnly,
+  placeholderText,
   onChangeRef,
 }: {
   doc: string
   isJsonContent: boolean
   readOnly: boolean
+  placeholderText?: string | undefined
   onChangeRef: React.RefObject<((value: string) => void) | undefined>
 }) {
   const extensions = [
@@ -77,6 +83,10 @@ function buildState({
     }),
   ]
 
+  if (placeholderText !== undefined) {
+    extensions.push(placeholder(placeholderText))
+  }
+
   if (isJsonContent) {
     extensions.push(json())
   }
@@ -88,7 +98,14 @@ function buildState({
   return EditorState.create({ doc, extensions })
 }
 
-export function CodeMirrorEditor({ value, onChange, readOnly = false, className, minHeight }: RichTextEditorProps) {
+export function CodeMirrorEditor({
+  value,
+  onChange,
+  readOnly = false,
+  className,
+  minHeight,
+  placeholder: placeholderText,
+}: RichTextEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
   const onChangeRef = useRef(onChange)
@@ -105,6 +122,7 @@ export function CodeMirrorEditor({ value, onChange, readOnly = false, className,
         doc: initialValueRef.current,
         isJsonContent,
         readOnly,
+        placeholderText,
         onChangeRef,
       }),
       parent: container,
@@ -127,9 +145,9 @@ export function CodeMirrorEditor({ value, onChange, readOnly = false, className,
     const currentDoc = view.state.doc.toString()
     const isReadOnly = view.state.facet(EditorState.readOnly)
     if (currentDoc !== value || isReadOnly !== readOnly) {
-      view.setState(buildState({ doc: value, isJsonContent, readOnly, onChangeRef }))
+      view.setState(buildState({ doc: value, isJsonContent, readOnly, placeholderText, onChangeRef }))
     }
-  }, [value, isJsonContent, readOnly])
+  }, [value, isJsonContent, readOnly, placeholderText])
 
   return (
     <div

--- a/packages/ui/src/components/rich-text-editor/rich-text-editor.tsx
+++ b/packages/ui/src/components/rich-text-editor/rich-text-editor.tsx
@@ -7,6 +7,7 @@ export interface RichTextEditorProps {
   readOnly?: boolean
   className?: string
   minHeight?: string
+  placeholder?: string
 }
 
 const CodeMirrorEditor = lazy(() => import("./codemirror-editor.tsx").then((m) => ({ default: m.CodeMirrorEditor })))

--- a/packages/ui/src/components/select/index.tsx
+++ b/packages/ui/src/components/select/index.tsx
@@ -156,6 +156,7 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
   } = selectProps
   const [internalSelected, setInternalSelected] = useState<V | undefined>(defaultValue)
   const [internalIsOpen, setInternalIsOpen] = useState(false)
+  const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null)
 
   const selectedValue = isControlled ? value : internalSelected
   const isOpen = controlledOpen !== undefined ? controlledOpen : internalIsOpen
@@ -213,7 +214,7 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
       errors={errors}
       className={width === "full" ? "w-full" : "w-auto"}
     >
-      <div className={width === "full" ? "w-full" : "w-auto"}>
+      <div ref={setPopoverContainer} className={width === "full" ? "w-full" : "w-auto"}>
         {loading ? (
           <Skeleton
             className={cn("h-8 rounded-lg", {
@@ -257,7 +258,7 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
             </PopoverTrigger>
             <PopoverContent
               data-slot="searchable-select-content"
-              portaled={false}
+              container={popoverContainer ?? undefined}
               align={align}
               side={side}
               {...(sideOffset !== undefined ? { sideOffset } : { sideOffset: 4 })}

--- a/packages/ui/src/components/select/index.tsx
+++ b/packages/ui/src/components/select/index.tsx
@@ -257,6 +257,7 @@ export function Select<V = unknown>(selectProps: SelectProps<V>) {
             </PopoverTrigger>
             <PopoverContent
               data-slot="searchable-select-content"
+              portaled={false}
               align={align}
               side={side}
               {...(sideOffset !== undefined ? { sideOffset } : { sideOffset: 4 })}


### PR DESCRIPTION
Fixes the searchable repository selector inside the Cursor connection modal. The dropdown now renders its popover content inside the modal DOM, so the dialog focus trap no longer treats the search input/options as outside interactions. Other popovers keep the existing portaled behavior by default.

Also updates the signal builder Custom script tab based on Agentation feedback:
- adds CodeMirror placeholder support in `RichTextEditor`
- shows a placeholder generated from `compileSettingsToScript` so the blank script editor displays a real evaluation script shape without seeding editable content
- removes the explanatory text under the detector tabs

Validated with browser QA:
- connected Cursor locally with the provided API key
- opened the repository selector, focused and typed in search, scrolled results, and selected `latitude-dev/latitude-llm`
- opened the signal builder Custom script tab and confirmed the generated placeholder is visible while Next remains disabled until real content is entered

Checks run:
- `pnpm --filter @repo/ui typecheck`
- `pnpm --filter @repo/ui check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`
- commit hook workspace `format` + `knip`

UI changes are visible in the Cursor integration modal and the signal builder Custom script tab; screenshots or a short recording would help reviewers.