### PR TITLE
Fix members role modal page freeze

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
@@ -435,7 +435,7 @@ function MembersTable({
               <TableCell>
                 <div className="flex items-center gap-2">
                   {(member.role === "owner" && isOwner) || canChangeRole(member) ? (
-                    <DropdownMenuRoot>
+                    <DropdownMenuRoot modal={false}>
                       <DropdownMenuTrigger asChild>
                         <div className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 transition-colors hover:bg-muted">
                           <Text.H5 color="foregroundMuted">{toTitle(member.role)}</Text.H5>


### PR DESCRIPTION
## What

- Set the members role dropdown to non-modal before it opens the transfer ownership or change-role dialog.
- Prevents Radix dropdown modal state from leaving the page interaction lock active after the dialog closes.

## Why

Opening a dialog from a modal dropdown can leave the document unable to receive pointer interactions after the dialog closes. This made buttons and navigation items stop responding after using the transfer ownership/change role flow.

## Verification

- `corepack pnpm --filter @app/web check` passed.
- `corepack pnpm --filter @app/web typecheck` blocked by existing unresolved `@latitude-data/telemetry` imports from shared packages.
- `corepack pnpm --filter @app/web test` ran 381 passing tests, then failed in 16 suites on the same unresolved `@latitude-data/telemetry` package resolution.

## Notes

The local environment has Node v22.22.0 while the repo asks for Node >=25; `mise`/other Node version managers were not available in this session.