### PR TITLE
docs: document manual signal creation and align Issues terminology to Signals

### DIFF
--- a/.agents/skills/humanizer/SKILL.md
+++ b/.agents/skills/humanizer/SKILL.md
@@ -1,0 +1,622 @@
+---
+name: humanizer
+version: 2.8.2
+description: |
+  Remove signs of AI-generated writing from text. Use when editing or reviewing
+  text to make it sound more natural and human-written. Based on Wikipedia's
+  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
+  inflated symbolism, promotional language, superficial -ing analyses, vague
+  attributions, em dash overuse, rule of three, AI vocabulary words, passive
+  voice, negative parallelisms, and filler phrases.
+license: MIT
+compatibility: any-agent
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below.
+2. **Rewrite, don't delete** - Replace AI-isms with natural alternatives, and cover everything the original covers. If the original has five paragraphs, the rewrite has five paragraphs.
+3. **Preserve meaning** - Keep the core message intact.
+4. **Match the voice** - Fit the intended tone (formal, casual, technical). Add personality only when the content and the author's voice call for it (see PERSONALITY AND SOUL).
+
+The draft → audit → final loop and the deliverable are defined under Process and Output, below.
+
+
+## Voice Calibration (Optional)
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. **Read the sample first.** Note:
+   - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
+   - Word choice level (casual? academic? somewhere between?)
+   - How they start paragraphs (jump right in? Set context first?)
+   - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
+   - Any recurring phrases or verbal tics
+   - How they handle transitions (explicit connectors? Just start the next point?)
+
+2. **Match their voice in the rewrite.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+
+3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+
+### How to provide a sample
+- Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
+- File: "Humanize this text. Use my writing style from [file path] as a reference."
+
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain *is* the correct human voice; don't inject opinions or first person there.
+
+### Signs of soulless writing (even if technically "clean"):
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+### Before (clean but soulless):
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+
+### 9. Negative Parallelisms and Tailing Negations
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+
+### 13. Passive Voice and Subjectless Fragments
+
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+
+## STYLE PATTERNS
+
+### 14. Em Dashes (and En Dashes): Cut Them
+
+**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (` — `) and double hyphens (` -- `) used the same way.
+
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
+
+Before returning the final rewrite, scan it for `—` and `–`. Any hit means the draft isn't done.
+
+
+### 15. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+
+### 16. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+
+### 17. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+
+### 18. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+
+### 19. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+
+**Before:**
+> He said “the project is on track” but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., Want me to...?, Want me to give examples?, Should I continue?, let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+
+### 21. Knowledge-Cutoff Disclaimers and Speculative Gap-Filling
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
+
+**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph *about* not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
+
+**Before (cutoff disclaimer):**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+**Before (speculative gap-fill):**
+> Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
+
+**After:**
+> Her early life is not documented in the available sources. (Or omit the section.)
+
+
+### 22. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+
+### 24. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+
+### 25. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+> The company plans to open two more locations next year.
+
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+
+**Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
+
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
+
+**After:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
+
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+
+### 30. Diff-Anchored Writing
+
+**Problem:** Documentation or comments written as if narrating a change rather than describing the thing as it is. Unless the document is inherently version-scoped (changelogs, release notes, migration guides), it should read coherently without knowing what changed in the last commit.
+
+**Before:**
+> This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
+
+**After:**
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+
+### 31. Manufactured Punchlines and Staccato Drama
+
+**Problem:** LLMs often make every sentence land like a quotable closer, then stack short declarative fragments to manufacture drama. A single short sentence for emphasis is fine; a run of them starts to sound engineered.
+
+**Before:**
+> Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
+
+**After:**
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+
+
+### 32. Aphorism Formulas
+
+**Words to watch:** X is the Y of Z, X becomes a trap, X is not a tool but a mirror, the language of, the currency of, the architecture of
+
+**Problem:** LLMs turn ordinary claims into reusable aphorisms that sound profound without adding precision. Replace the formula with the concrete claim it is gesturing at.
+
+**Before:**
+> Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
+
+**After:**
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
+
+
+### 33. Conversational Rhetorical Openers
+
+**Phrases to watch:** Honestly?, Look, Here's the thing, The thing is, Let's be honest, Real talk, when used as standalone hooks or fake-candid pauses before an ordinary point.
+
+**Problem:** LLMs open with a fake-candid hook to manufacture intimacy before delivering a routine claim. The tell is the theatrical pause-and-reveal: a one-word question or aside, then the "real" answer. A person being honest usually just says the thing.
+
+**Before:**
+> Is it worth the price? Honestly? It depends on how often you'll use it.
+
+**After:**
+> Whether it's worth the price depends on how often you'll use it.
+
+
+## DETECTION GUIDANCE
+
+### What NOT to flag (false positives)
+
+A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are *not* reliable indicators on their own:
+
+- **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
+- **Mixed casual and formal registers.** This often signals a person in a technical field, a young writer, or someone with neurodivergent prose habits — not a chatbot.
+- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic vocabulary.** AI overuses *specific* fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
+- **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
+- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
+- **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
+- **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
+- **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
+- **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+- **Secondhand text.** Do not rewrite watched phrases inside quotations, titles, proper names, or examples where the phrase is being discussed rather than used.
+
+When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
+
+
+### Signs of human writing (preserve these)
+
+When you see these, lean toward leaving the prose alone — they are evidence of a real person writing, and over-editing will destroy what makes the piece sound human:
+
+- **Specific, unusual, hard-to-fabricate detail.** A real address. A weird quote. The phrase "the lawyer who used to work upstairs from my dentist." LLMs round off specifics; humans hoard them.
+- **Mixed feelings and unresolved tension.** "I think this is mostly good, but it bothers me, and I can't fully explain why." LLMs default to clean takes.
+- **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
+- **First-person editorial choices the writer can defend.** If the writer can explain *why* they made a particular cut or used a particular word, that's a strong human signal.
+- **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
+- **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
+- **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
+
+
+---
+
+## Process and Output
+
+1. Read the input carefully and identify every instance of the patterns above.
+2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
+3. Ask: **"What makes the below so obviously AI generated?"** Answer briefly with any remaining tells.
+4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+
+Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes.
+
+
+## Full Example
+
+**Before (AI-sounding):**
+> I recently spent five unforgettable days in Lisbon, and let me tell you — this city completely stole my heart. From the moment I arrived, I knew I was somewhere truly special.
+>
+> Nestled along the banks of the Tagus River, Lisbon stands as a vibrant testament to Portugal's enduring spirit, where rich history and modern energy intertwine at every turn. Yes, the famous hills are challenging — my legs certainly felt it! — but every climb rewards you with breathtaking, panoramic views that make it all worthwhile.
+>
+> No trip would be complete without riding the iconic Tram 28, winding through the city's most historic neighborhoods. And the food? Simply divine. The original pastéis de nata at Pastéis de Belém are a beloved national treasure, and savoring one still warm was a moment I will never forget.
+>
+> But what truly makes Lisbon special isn't just the sights — it's the feeling. Wander a few steps off the main squares and you'll discover a quieter, more authentic side: sun-drenched alleys, charming tiled facades, and friendly locals going about their daily lives, inviting you to slow down and savor every moment.
+>
+> Of course, the must-see São Jorge Castle offers stunning views over the rooftops below. The queues can be long, but the experience is absolutely worth it for any history buff or curious traveler.
+>
+> Would I go back? Absolutely. Lisbon isn't just a place to visit — it's a place to fall in love with, again and again. If you're dreaming of your next getaway, this is one destination that promises memories to last a lifetime. ✨
+
+**Draft rewrite:**
+> I spent five days in Lisbon last October and I am still a little split on it. The city is beautiful, but it is also more tiring than I expected.
+>
+> The hills are not a detail. My hotel was in Alfama, which looked great in photos and meant I had to climb a long staircase every time I wanted coffee. By the second day I was planning walks around which direction went downhill.
+>
+> I rode Tram 28 because everyone says to ride Tram 28. It was crowded, slow, and mostly full of people filming the same corners. The pastries were better. I had a warm custard tart in Graça that was worth the hype.
+>
+> The part I liked most was away from the main squares: laundry, tile, open windows, and people watching football in small cafes. The castle view was good, but the line was too long for what it was.
+>
+> I would go back, but in spring and with better shoes.
+
+**What makes the below so obviously AI generated?**
+- The draft is too compressed compared with the original; it drops texture instead of rewriting it.
+- Some sentences still explain the point too cleanly ("The city is beautiful, but...").
+- The closer is flat and generic rather than a real ending in the same voice.
+
+**Now make it not obviously AI generated.**
+> I spent five days in Lisbon last October and still have mixed feelings about it. Beautiful, yes. Also harder on the knees than anyone warned me.
+>
+> The hills are the whole story and somehow never make the brochures. My hotel was up in Alfama, which photographs beautifully and translates, in practice, to climbing what felt like a six-story staircase every time I wanted coffee. By the second day my calves had opinions. I started planning each walk around which way was downhill, which is a strange way to see a city but probably an honest one.
+>
+> Everyone says to ride Tram 28, so I did, wedged against a stranger's backpack for forty minutes while three tour groups filmed the same corner. I would walk the route next time, or go before breakfast. The custard tarts, though, earn the fuss. I had one at a plain little place in Graça, still warm, and for about thirty seconds I understood why people build trips around pastry.
+>
+> What I did not expect was how quiet the city gets away from the main squares. Two blocks uphill from any plaza it turns into laundry lines, chipped tile, open windows, and old men watching football with the sound turned up. That is the Lisbon I keep thinking about, not the castle.
+>
+> The castle is fine. The view is great, the queue is long, and I spent more time shuffling toward the entrance than looking at anything once I got inside. If I had only two days, I would trade it for an afternoon of getting lost.
+>
+> I would go back, but in spring and with better shoes. Lisbon does not bend over backward to make things easy for you. I think I liked that, even when my legs disagreed.
+
+**Changes made:** Kept the first-person travel recap and roughly the same level of detail, but removed the chatbot framing, significance inflation, promotional language, forced enthusiasm, em dashes, rule-of-three cadence, generic upbeat conclusion, and emoji. Rebuilt the piece around concrete friction, mixed feelings, uneven rhythm, and specific scenes.
+
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ At a glance: **`apps/*`** own HTTP boundaries (validation, authz, routing to use
 
 Detailed policies, command examples, and code samples live under **`.agents/skills/<skill-name>/SKILL.md`**. Load narrow skills instead of memorizing the entire monorepo at once.
 
-**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **27** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
+**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **28** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
 
 ## Skill glossary
 
@@ -50,6 +50,7 @@ Detailed policies, command examples, and code samples live under **`.agents/skil
 | **Environment configuration** | [.agents/skills/env-configuration/SKILL.md](.agents/skills/env-configuration/SKILL.md) | **`LAT_*` / `VITE_LAT_*`**, `.env.example`, **`parseEnv` / `parseEnvOptional`** |
 | **Fix Datadog issues** | [.agents/skills/fix-datadog-issues/SKILL.md](.agents/skills/fix-datadog-issues/SKILL.md) | Finding, triaging, and fixing production errors from **Datadog Error Tracking** (`plugin:datadog:mcp`); picking which issue to work (occurrence/trend/recency, v2-only, prod-only), root-causing in code, reproducing with tests, commenting on the issue, and opening a PR to `development` |
 | **GitHub issues** | [.agents/skills/gh-issue/SKILL.md](.agents/skills/gh-issue/SKILL.md) | Creating clear, actionable GitHub issues for bugs, features, and improvements, optimized for LLM/actionability |
+| **Humanizer** | [.agents/skills/humanizer/SKILL.md](.agents/skills/humanizer/SKILL.md) | Editing or reviewing prose (docs, PR and commit copy) to remove AI-writing tells such as em dashes, rule of three, promotional language, and filler, so it reads naturally |
 | **Managing maintenance windows** | [.agents/skills/managing-maintenance-windows/SKILL.md](.agents/skills/managing-maintenance-windows/SKILL.md) | Enabling, disabling, verifying, or preparing production maintenance mode, which redirects **`console.latitude.so`** to the Better Stack status page with the Pulumi `enableWebMaintenanceRedirect` switch |
 | **Mintlify docs preview** | [.agents/skills/mintlify-preview/SKILL.md](.agents/skills/mintlify-preview/SKILL.md) | Running the public **Mintlify** docs site (`docs/`) locally for live preview (`mint dev`); **Node <25 (nvm v22) requirement**, keeping the CLI current, non-default port, page-path mapping |
 | **Notifications** | [.agents/skills/notifications/SKILL.md](.agents/skills/notifications/SKILL.md) | Adding a notification **kind**, **group**, or **channel**; in-app + email delivery; `NOTIFICATION_KIND_META` / `NOTIFICATION_GROUPS`; per-user prefs (`users.notification_preferences`); project-level gates (`projects.settings.notifications`); idempotency + cascade-on-`ProjectDeleted` |

--- a/docs/annotations/flaggers.mdx
+++ b/docs/annotations/flaggers.mdx
@@ -57,7 +57,7 @@ Each project starts with flaggers for common reliability and safety categories:
 
 ## How flaggers appear in Latitude
 
-When a flagger matches a trace, Latitude adds an annotation to that trace. You can review it from the trace detail view, see it in score analytics, and use it as signal for issues and evaluations.
+When a flagger matches a trace, Latitude adds an annotation to that trace. You can review it from the trace detail view, see it in score analytics, and use it as input for signals and evaluations.
 
 Flaggers are especially useful for patterns that are easy to miss in manual review, such as low-volume safety failures, recurring frustration, or behavior that appears only across long sessions.
 
@@ -86,7 +86,7 @@ These surfaces complement each other: flaggers create automatic signal, search s
 
 ## Related
 
-- [Annotations Overview](./overview): How annotations connect to scores, issues, and evaluations
+- [Annotations Overview](./overview): How annotations connect to scores, signals, and evaluations
 - [Inline Annotations](./inline-annotations): Leave human feedback on traces
 - [Search](../search/overview): Investigate patterns that flaggers do not cover
-- [Issues](../signals/overview): How annotations become trackable failure patterns
+- [Signals](../signals/overview): How annotations become trackable failure patterns

--- a/docs/annotations/guides/annotate-effectively.mdx
+++ b/docs/annotations/guides/annotate-effectively.mdx
@@ -23,7 +23,7 @@ The single biggest predictor of annotation value is consistency.
 
 ## Write specific feedback
 
-Latitude adds conversation context to short feedback automatically, but your verdict and wording still shape how issues group and how evaluations get built.
+Latitude adds conversation context to short feedback automatically, but your verdict and wording still shape how signals group and how evaluations get built.
 
 | Less useful | More useful |
 | --- | --- |
@@ -35,7 +35,7 @@ A few rules of thumb:
 
 - **Say what happened, not just pass/fail.** One short sentence about what the agent did is enough.
 - **Note what set it off.** What in the user's message or earlier turns led to the problem? That helps similar cases group together.
-- **Skip boilerplate and fluff.** No need for "annotation:" prefixes or "this trace shows…". Treat it like a Slack note to a teammate. Padding waste time and reduces automatic issue detection accuracy.
+- **Skip boilerplate and fluff.** No need for "annotation:" prefixes or "this trace shows…". Treat it like a Slack note to a teammate. Padding waste time and reduces automatic signal detection accuracy.
 - **Don't pad obvious passes.** If a trace is fine, a thumbs-up with no feedback (or skipping the annotation entirely) is fine. On a thumbs-down, empty feedback won't help you find or fix issues later.
 
 ## Pick the right scope
@@ -49,7 +49,7 @@ Every annotation can be **conversation-level**, **message-level**, or **text-ran
 <Note>
   Don't over-narrow. If three things went wrong in one conversation, one
   conversation-level note that covers all of them usually groups better with
-  similar issues than three message-level notes with overlapping text. Still be
+  similar signals than three message-level notes with overlapping text. Still be
   specific in what you write.
 </Note>
 
@@ -74,16 +74,16 @@ Flagger annotations feed [signal discovery](../../signals/overview) and [alignme
 
 ## When to link a signal manually
 
-You can let Latitude pick the issue for an annotation, or link it yourself. Usually, let Latitude decide.
+You can let Latitude pick the signal for an annotation, or link it yourself. Usually, let Latitude decide.
 
-- **Automatic linking** keeps issues tidy. Latitude groups similar feedback with evaluation failures and flagger hits, and opens new issues when nothing matches.
-- **Link manually** when you're sure it's the same bug as an existing issue.
+- **Automatic linking** keeps signals tidy. Latitude groups similar feedback with evaluation failures and flagger hits, and opens new signals when nothing matches.
+- **Link manually** when you're sure it's the same bug as an existing signal.
 
 ## Revisit after prompts, product, or model changes
 
 Annotations age. The product changes, the model changes, the prompts change.
 
-- **Re-review after a fix.** When an issue is resolved, annotate a few recent matches of its watch evaluation to confirm the fix held.
+- **Re-review after a fix.** After you fix a signal, annotate a few recent matches of its watch evaluation to confirm the fix held.
 - **Watch alignment.** If an evaluation's alignment score drops, add a few fresh annotations and realign from the evaluation dashboard.
 - **Prune stale saved searches.** If reopening one turns up no recent matches, the traces may be gone or the query needs updating.
 

--- a/docs/annotations/inline-annotations.md
+++ b/docs/annotations/inline-annotations.md
@@ -5,7 +5,7 @@ description: Annotate any trace directly from its detail view
 
 # Inline Annotations
 
-Inline annotations are the main way to leave human feedback on a trace. Any trace you can open has an annotation panel, whether you reached it from the Traces page, Issues, or a saved search.
+Inline annotations are the main way to leave human feedback on a trace. Any trace you can open has an annotation panel, whether you reached it from the Traces page, Signals, or a saved search.
 
 ## How Inline Annotations Work
 
@@ -18,7 +18,7 @@ When viewing a trace:
    - **Message-level**: annotate one message.
    - **Text-range**: anchor feedback to selected text inside a message.
 4. Add a thumbs-up or thumbs-down verdict and feedback.
-5. Optionally link the annotation to an issue.
+5. Optionally link the annotation to a signal.
 
 Annotations save as drafts while you edit. Once finalized, they feed analytics, signal discovery, and evaluation alignment alongside annotations from [flaggers](./flaggers) and the [API](../scores/api).
 
@@ -39,15 +39,15 @@ Use inline annotations for:
 
 - Systematic review of a trace cohort
 - Ad-hoc spot checks while browsing traces
-- Issue investigation
+- Signal investigation
 - Team review and coaching
 - Extra context on traces that already have scores or flagger annotations
 
 If you want detection without human review for a fixed set of known failure categories, use [flaggers](./flaggers).
 
-## Inline Annotations and Issues
+## Inline Annotations and Signals
 
-When creating an inline annotation, you can leave issue assignment automatic or link the annotation to an existing signal. After the annotation is finalized, failed annotations enter signal discovery automatically.
+When creating an inline annotation, you can leave signal assignment automatic or link the annotation to an existing signal. After the annotation is finalized, failed annotations enter signal discovery automatically.
 
 ## Persisted Highlights
 
@@ -58,4 +58,4 @@ Message-level and text-range annotations leave highlights in the conversation vi
 - [Annotations Overview](./overview): How the annotation system works
 - [Flaggers](./flaggers): Automatic annotators for common failure categories
 - [Search](../search/overview): Find traces to annotate
-- [Issues](../signals/overview): How annotations connect to issue tracking
+- [Signals](../signals/overview): How annotations connect to signal tracking

--- a/docs/annotations/overview.md
+++ b/docs/annotations/overview.md
@@ -19,7 +19,7 @@ Annotations can come from:
 
 ## How to Annotate
 
-Every annotation has a **verdict**, **feedback**, and an optional **issue link**.
+Every annotation has a **verdict**, **feedback**, and an optional **signal link**.
 
 1. **Choose a scope**: conversation, message, or text range.
 2. **Give a verdict**: thumbs up for good behavior, thumbs down when something went wrong.
@@ -30,7 +30,7 @@ Human annotations save as drafts while you edit. Once finalized, they become par
 
 ## Where to Annotate
 
-Open any trace detail view—from Traces, Search, Issues, or Sessions—and use the annotation panel on the right. For batch review, start with a [saved search](../search/saved-searches), then work through the matching traces one at a time.
+Open any trace detail view—from Traces, Search, Signals, or Sessions—and use the annotation panel on the right. For batch review, start with a [saved search](../search/saved-searches), then work through the matching traces one at a time.
 
 If you want automatic coverage for known failure categories, use [flaggers](./flaggers). If you are building your own feedback UI, submit annotations through the [Annotations API](../scores/api).
 
@@ -39,7 +39,7 @@ If you want automatic coverage for known failure categories, use [flaggers](./fl
 Annotations are the foundation of Latitude's reliability loop. They help you:
 
 - **Calibrate evaluations** by comparing automated scores with human judgment. See [Alignment](../evaluations/alignment).
-- **Validate issues** by confirming whether discovered failure patterns are real problems.
+- **Validate signals** by confirming whether discovered failure patterns are real problems.
 - **Capture qualitative feedback** that explains why something was good or bad.
 
 ## How Annotations Connect to Other Features
@@ -47,7 +47,7 @@ Annotations are the foundation of Latitude's reliability loop. They help you:
 | Feature | Relationship |
 | --- | --- |
 | **[Scores](../scores/overview)** | Each finalized annotation becomes a score for analytics and dashboards. |
-| **[Issues](../signals/overview)** | Failed annotations can cluster into trackable issues. |
+| **[Signals](../signals/overview)** | Failed annotations can cluster into trackable signals. |
 | **[Evaluations](../evaluations/overview)** | Annotations provide ground truth for measuring evaluation accuracy. |
 | **[Search](../search/overview)** | Search and saved searches help you find trace cohorts to review. |
 | **[Flaggers](./flaggers)** | Flaggers create automatic annotations for common failure categories. |

--- a/docs/deployment/cluster.mdx
+++ b/docs/deployment/cluster.mdx
@@ -120,9 +120,9 @@ The stack boots and core observability (ingest + trace viewing) works **without 
 
 | Capability | Providers | Feature |
 | --- | --- | --- |
-| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, issue summarization, taxonomy naming, AI generation |
-| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/issue search, search highlights, issue clustering |
-| Reranking | Voyage AI (default) or Amazon Bedrock | Issue-discovery candidate matching |
+| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, signal summarization, taxonomy naming, AI generation |
+| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/signal search, search highlights, signal clustering |
+| Reranking | Voyage AI (default) or Amazon Bedrock | Signal-discovery candidate matching |
 
 Every provider and model is selectable per feature through environment variables — see the [AI configuration reference](/deployment/configuration#ai).
 

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -86,13 +86,13 @@ Available `<SETTING>`:
 
 ### Embeddings
 
-Embeddings are configured globally through `LAT_AI_EMBEDDING_PROVIDER` and `LAT_AI_EMBEDDING_MODEL`. It defaults to `voyage` / `voyage-4-large`, and powers semantic trace/issue search, search highlights, and issue clustering. Without a working embeddings provider, search falls back to lexical.
+Embeddings are configured globally through `LAT_AI_EMBEDDING_PROVIDER` and `LAT_AI_EMBEDDING_MODEL`. It defaults to `voyage` / `voyage-4-large`, and powers semantic trace/signal search, search highlights, and signal clustering. Without a working embeddings provider, search falls back to lexical.
 
 <Warning>
   The embedding model is a **one-time choice — pick it at install time and keep it**.
 </Warning>
 
-Once an embedding model is used on a live deployment, changing it is a difficult task. Different models produce incompatible vector spaces and existing data is never re-embedded, so switching breaks semantic search, issue matching, and clustering.
+Once an embedding model is used on a live deployment, changing it is a difficult task. Different models produce incompatible vector spaces and existing data is never re-embedded, so switching breaks semantic search, signal matching, and clustering.
 
 The model must also **emit 2048-dimensional vectors** — the dimension is fixed by the database schema and is not configurable.
 

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -16,7 +16,7 @@ Latitude is [MIT-licensed](https://github.com/latitude-dev/latitude-llm/blob/dev
 Why most teams choose Cloud:
 
 - **Zero ops.** No servers, databases, queues, or object stores to run, patch, scale, or back up — we handle all of it.
-- **Every AI feature on by default.** Semantic search, flaggers, evaluations, and issue clustering work out of the box — no proprietary AI provider accounts or keys to manage.
+- **Every AI feature on by default.** Semantic search, flaggers, evaluations, and signal clustering work out of the box — no proprietary AI provider accounts or keys to manage.
 - **Always current.** New features and fixes the moment they ship, with zero-downtime upgrades and no migrations to run yourself.
 - **Scales with you.** Trace spikes, retention, and growth are handled automatically — no capacity planning.
 - **Enterprise-grade security & compliance.** SOC 2, ISO 27001, and GDPR, with managed backups and high availability. See [Security & Compliance](/security/data-protection).

--- a/docs/deployment/single-host.mdx
+++ b/docs/deployment/single-host.mdx
@@ -99,9 +99,9 @@ The stack boots and core observability (ingest + trace viewing) works **without 
 
 | Capability | Providers | Feature |
 | --- | --- | --- |
-| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, issue summarization, taxonomy naming, AI generation |
-| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/issue search, search highlights, issue clustering |
-| Reranking | Voyage AI (default) or Amazon Bedrock | Issue-discovery candidate matching |
+| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, signal summarization, taxonomy naming, AI generation |
+| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/signal search, search highlights, signal clustering |
+| Reranking | Voyage AI (default) or Amazon Bedrock | Signal-discovery candidate matching |
 
 Every provider and model is selectable per feature through environment variables — see the [AI configuration reference](/deployment/configuration#ai).
 

--- a/docs/development/setup.mdx
+++ b/docs/development/setup.mdx
@@ -77,7 +77,7 @@ Core observability (trace ingest and viewing) works out of the box. AI-dependent
     pnpm seed
     ```
 
-    Optionally create a sample organization, with a default project, a handful of users, an API key, and realistic sample telemetry across Postgres and ClickHouse — enough to sign in and exercise traces, search, issues, and evaluations immediately.
+    Optionally create a sample organization, with a default project, a handful of users, an API key, and realistic sample telemetry across Postgres and ClickHouse — enough to sign in and exercise traces, search, signals, and evaluations immediately.
   </Step>
 
   <Step title="Start the services">
@@ -163,9 +163,9 @@ The stack boots and core observability (ingest + trace viewing) works **without 
 
 | Capability | Providers | Feature |
 | --- | --- | --- |
-| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, issue summarization, taxonomy naming, AI generation |
-| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/issue search, search highlights, issue clustering |
-| Reranking | Voyage AI (default) or Amazon Bedrock | Issue-discovery candidate matching |
+| Generation | Amazon Bedrock (default), Anthropic, OpenAI, Google, or any OpenAI-compatible endpoint | Flaggers, evaluations, signal summarization, taxonomy naming, AI generation |
+| Embeddings | Voyage AI (default), OpenAI, Google, or any OpenAI-compatible endpoint | Semantic trace/signal search, search highlights, signal clustering |
+| Reranking | Voyage AI (default) or Amazon Bedrock | Signal-discovery candidate matching |
 
 Every provider and model is selectable per feature through environment variables — see the [AI configuration reference](/deployment/configuration#ai).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -211,6 +211,7 @@
         "group": "Understand",
         "pages": [
           "signals/overview",
+          "signals/create",
           "signals/management",
           "search/behaviours",
           {
@@ -227,6 +228,8 @@
             "group": "Evaluations",
             "pages": [
               "evaluations/overview",
+              "evaluations/detection-methods",
+              "evaluations/custom-scripts",
               "evaluations/triggers",
               "evaluations/alignment"
             ]

--- a/docs/evaluations/alignment.md
+++ b/docs/evaluations/alignment.md
@@ -1,61 +1,61 @@
 ---
-title: Evaluation Alignment
-description: Measure how well your automated evaluations agree with human judgment
+title: Evaluation alignment
+description: Measure how well your automated evaluations agree with human judgment.
 ---
 
-# Evaluation Alignment
+# Evaluation alignment
 
-Alignment measures how closely evaluations match human judgment. It answers: **Can you trust this monitor to represent the signal your team cares about?**
+Alignment measures how closely an evaluation matches human judgment. It answers one question: can you trust this detector to represent the behavior your team cares about?
 
-## Why Alignment Matters
+## Why alignment matters
 
-Evaluations are useful only when they agree with the way your team reviews real traces. Without alignment tracking:
+An evaluation is useful only when it agrees with the way your team reviews real traffic. Without alignment tracking:
 
 - You may not notice that an evaluation is too strict or too lenient.
-- You may miss drift as your agent, users, or product behavior changes.
-- You may keep monitoring a signal with outdated examples.
+- You may miss drift as your agent, users, or product change.
+- You may keep scoring a behavior against outdated examples.
 
-Alignment helps Latitude keep evaluations calibrated over time.
+Alignment helps Latitude keep generated evaluations calibrated over time.
 
-## How Alignment Works
+## How alignment works
 
-Alignment is computed when an evaluation and a human annotation score the same trace. Latitude compares their verdicts and uses the result as feedback for the monitor.
+Alignment is computed when an evaluation and a human annotation score the same trace. Latitude compares their verdicts and uses the result as feedback for the detector. The point is not to display a metric; it is to keep the evaluation close to the latest human-reviewed examples.
 
-The goal is not just to display a metric; it is to keep the evaluation close to the latest human-reviewed examples of the signal.
+## Viewing alignment
 
-## Viewing Alignment
+Each evaluation detail page shows alignment when enough human-reviewed traces are available. Use it to see whether the evaluation still matches reviewer expectations and where it may be drifting.
 
-Each evaluation detail page shows alignment information when enough human-reviewed traces are available. Use it to see whether the evaluation still matches reviewer expectations and where it may be drifting.
+## Alignment and generated evaluations
 
-## Alignment and Evaluation Generation
+When Latitude generates an evaluation from a signal:
 
-When you generate an evaluation from a signal:
+1. It collects examples from annotations, signal-linked scores, and trace context.
+2. It builds a detector for the behavior.
+3. The detector is compared against known examples.
+4. The detector is attached to the signal.
 
-1. Latitude collects examples from annotations, signal-linked scores, and trace context.
-2. Latitude creates a monitor for the signal pattern.
-3. The evaluation is compared against known examples.
-4. The monitor is attached to the signal.
+A detector can start from a small amount of evidence. As more annotations and scores arrive, Latitude has more to work with, and it can realign the detector as new annotations, flagger matches, evaluation results, and custom scores come in. This keeps the detector matched to the behavior as production traffic evolves.
 
-A monitor can start from a small amount of evidence. As more annotations and scores arrive, Latitude has more signal to improve it.
+## Manually defined detectors
 
-## Automatic Realignment
+A detector you write when you [create a signal](../signals/create) works differently. It runs exactly as you defined it and is not automatically realigned to annotations. That is deliberate: it does what you specified, and nothing changes it behind your back.
 
-Once an evaluation exists, Latitude can realign it as new annotations, flagger matches, evaluation results, and custom scores arrive. This keeps the monitor matched to the signal as production traffic evolves.
+If a detector you defined turns out too strict or too lenient, edit it. Adjust the conditions, rewrite the judge criteria, change a threshold in a script, and preview the change against recent sessions before saving. See [Detection methods](./detection-methods).
 
-## Improving Alignment
+## Improving alignment
 
-When an evaluation appears misaligned:
+When a generated evaluation looks misaligned:
 
 1. Review traces where the evaluation and human review disagree.
 2. Add annotations with specific feedback.
-3. Confirm the signal contains representative examples of the behavior you want to track.
-4. Let the new signal improve future realignment.
+3. Confirm the signal has representative examples of the behavior.
+4. Let the new evidence improve the next realignment.
 
-This process keeps automated monitoring grounded in human judgment.
+This keeps automated scoring grounded in human judgment.
 
-## Next Steps
+## Next steps
 
-- [Annotations](../annotations/overview): How human review produces alignment signal
-- [Flaggers](../annotations/flaggers): Automatic annotators that contribute signal
-- [Search](../search/overview): Build cohorts of traces to annotate
-- [Signals](../signals/overview): How failed evaluations become trackable signals
+- [Annotations](../annotations/overview): how human review produces alignment signal
+- [Flaggers](../annotations/flaggers): automatic annotators that contribute signal
+- [Detection methods](./detection-methods): the three ways to define a detector
+- [Signals](../signals/overview): how evaluation matches become tracked signals

--- a/docs/evaluations/custom-scripts.mdx
+++ b/docs/evaluations/custom-scripts.mdx
@@ -1,0 +1,195 @@
+---
+title: Custom scripts
+description: Write a JavaScript detector that reads a session and decides whether a behavior is present.
+---
+
+A custom script is a detector you write by hand in JavaScript. It reads one session and returns a score saying how strongly a behavior is present. Reach for it when a [set of conditions](./detection-methods#set-of-conditions) is too rigid and an [LLM judge](./detection-methods#llm-as-judge) is too loose, or when you need logic that combines several checks.
+
+Conditions and LLM judges compile down to the same kind of script, so a custom script can express anything they can, plus whatever else you write.
+
+<Note>
+Most signals don't need a custom script. Start with conditions or a judge, and drop to a script when you hit their limits.
+</Note>
+
+## The shape of a script
+
+Your code runs as the body of an async function, so you can use `await` at the top level. It must `return` a score built with `Score`, `Passed`, or `Failed`.
+
+```js
+// Match sessions where the assistant said it couldn't help.
+const messages = session.conversation
+const lastReply = messages.length ? messages[messages.length - 1].content : ''
+return lastReply.includes("I can't help") ? Passed() : Failed()
+```
+
+`Passed()` and `Failed()` are shorthand for a full match (`1`) and no match (`0`). Use `Score(value, feedback)` when you want a strength in between, or a note explaining the verdict.
+
+## Returning a verdict
+
+A script returns a strength between `0` and `1`, not a pass or fail. Latitude compares that strength against a threshold (0.5 by default): at or above it, the behavior counts as present and the session joins the signal.
+
+| Helper | Returns | Use for |
+| --- | --- | --- |
+| `Score(value, feedback?)` | `value`, from 0 to 1 | A graded strength, optionally with a reason |
+| `Passed(value?, feedback?)` | `value` if given, otherwise `1` | A clear match |
+| `Failed(value?, feedback?)` | `value` if given, otherwise `0` | A clear non-match |
+
+`feedback` is optional free text. Latitude stores it on the score and uses it when it groups and displays matches, so a short reason pays off later.
+
+<Warning>
+`passed = true` means the behavior is present, not that the session was good. A signal tracks a behavior, and a matching session is one that exhibits it. A signal for "made-up information" passes when the model hallucinated.
+</Warning>
+
+## The session object
+
+Every script receives one global, `session`: a read-only snapshot of the conversation being checked. It is frozen, so you can read it but not change it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | The session id |
+| `userId` | `string` | The end user's id, empty if none was sent |
+| `startTime`, `endTime` | `string` | ISO 8601 timestamps |
+| `duration` | `number` | Total wall-clock time, in nanoseconds |
+| `timeToFirstToken` | `number` | Time to the first token, in nanoseconds |
+| `traceCount`, `spanCount`, `errorCount` | `number` | Counts across the session |
+| `cost` | `object` | `{ input, output, total }`, in microcents |
+| `tokens` | `object` | `{ input, output, total, cacheRead, cacheCreate, reasoning }` |
+| `tags` | `string[]` | Tags on the session |
+| `metadata` | `object` | The string metadata your app sent |
+| `conversation` | `array` | The transcript, each entry `{ role, content }` |
+| `traces` | `array` | Per-trace breakdown (see below) |
+
+Numbers are in raw units: durations are nanoseconds, costs are microcents (one US cent is 1,000,000 microcents), and token counts are integers. Most scripts read `conversation`, `tags`, `metadata`, and the tool data rather than the cost and token fields.
+
+### Messages
+
+`session.conversation` is the deduplicated transcript for the whole session. Each entry is `{ role, content }`.
+
+```js
+const userTurns = session.conversation.filter((m) => m.role === 'user').length
+return Score(userTurns > 5 ? 1 : 0, `${userTurns} user turns`)
+```
+
+Interpolating the array into a string renders it as `[role] content` lines, one per message, which is handy for prompts:
+
+```js
+const transcript = `${session.conversation}`
+// [user] where is my order?
+// [assistant] let me check that for you...
+```
+
+### Traces and tools
+
+`session.traces` breaks the session down by trace. Each trace carries its own rollups plus the models, providers, finish reasons, and tool calls it used.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id`, `name`, `status` | `string` | Trace id, name, and status (`ok`, `error`, or `unset`) |
+| `errorCount`, `spanCount` | `number` | Counts within the trace |
+| `duration`, `timeToFirstToken` | `number` | Nanoseconds |
+| `cost`, `tokens` | `object` | Same shape as the session totals |
+| `models`, `providers`, `finishReasons` | `string[]` | What the trace used |
+| `tools` | `array` | Tool calls in the trace (see below) |
+
+Each tool call has this shape:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The tool's name |
+| `input`, `output` | `string` | The call's arguments and result, possibly truncated for large payloads |
+| `error` | `boolean` | `true` if the call failed |
+| `duration` | `number` | Nanoseconds |
+
+```js
+// Match sessions where any tool call failed.
+const failed = session.traces.some((t) => t.tools.some((tool) => tool.error))
+return failed ? Passed() : Failed()
+```
+
+## Built-in functions
+
+Alongside the score helpers, a few functions are always available, and two more appear only when your script calls them.
+
+### semanticSimilarity(query)
+
+Returns the highest cosine similarity between `query` and any message in the session, from `0` to `1` (0 when the session has no messages). It is async.
+
+```js
+const score = await semanticSimilarity('the user is angry or frustrated')
+return score >= 0.55 ? Passed(score) : Failed(score)
+```
+
+Latitude reuses the message embeddings computed when the session was ingested and embeds only your query, so this stays cheap. As a starting point, about 0.4 is broad, 0.55 is balanced, and 0.7 is strict. A session that hasn't been embedded yet is scored once its embeddings are ready.
+
+### llm(prompt, options)
+
+Sends a prompt to an LLM and returns a structured object matching `schema`. Latitude manages the model and the system prompt. `schema` is required and must be built with `z` (below). It is async.
+
+```js
+const result = await llm(
+  `Did the assistant promise a refund in this conversation?\n${session.conversation}`,
+  { schema: z.object({ promised: z.boolean(), quote: z.string() }) },
+)
+return result.promised ? Passed(1, result.quote) : Failed()
+```
+
+### z
+
+A schema builder for shaping `llm()` output and `parse()` input. It mirrors a subset of Zod: `z.string()`, `z.number()`, `z.boolean()`, `z.literal()`, `z.enum()`, `z.array()`, `z.object()`, and `z.union()`, with `.optional()`, `.nullable()`, `.describe()`, `.min()`, `.max()`, and `.int()`.
+
+### parse(value, schema)
+
+Validates a value against a `z` schema and returns it, or throws if it doesn't match. Useful for checking JSON your agent produced.
+
+```js
+const messages = session.conversation
+const output = messages.length ? messages[messages.length - 1].content : ''
+try {
+  parse(JSON.parse(output), z.object({ answer: z.string(), confidence: z.number() }))
+  return Failed(0, 'output matched the expected schema')
+} catch {
+  return Passed(1, 'output was missing or malformed')
+}
+```
+
+<Note>
+Call `llm` and `semanticSimilarity` by name in your source. Latitude reads those names to allocate the right resources and to make the functions available, so building the call dynamically won't work.
+</Note>
+
+### What isn't available
+
+The sandbox is deliberately small. There is no network access, no `fetch`, no timers, no `Date.now` or `Math.random`, and no Node or browser APIs. The only import allowed is `zod`. A script's verdict depends only on the session and any `llm()` call, which keeps results reproducible.
+
+## Where scripts run and their limits
+
+Detectors run in the background, never inside your app's request path. When a session finishes, Latitude runs the matching detectors on it. A preview runs the same way, over recent sessions, on demand.
+
+Latitude picks a resource budget from what your script uses:
+
+| The script | Time budget |
+| --- | --- |
+| Uses neither `llm()` nor `semanticSimilarity()` | about 1 second |
+| Calls `semanticSimilarity()` | about 15 seconds |
+| Calls `llm()` | about 120 seconds |
+
+Every script gets 64 MiB of memory. These limits are enforced automatically and are generous for typical detectors.
+
+Errors are handled at two points:
+
+- Invalid JavaScript is caught when you save, so a script that won't compile can't be stored.
+- A script that throws at runtime, or exceeds its time or memory budget, scores that session as `errored`. Errored sessions show up in the preview. A detector that errors often is flagged as unhealthy.
+
+LLM and embedding calls cost money, so use the sampling control in the [Scope step](../signals/create#scope) to check a slice of traffic rather than every session.
+
+## Editing and detaching
+
+If you build a detector with conditions or an LLM judge, the Custom script tab shows the exact script Latitude compiled from your settings, read-only. Choose "Edit as custom script" to take it over by hand. This clears the conditions or criteria form and switches the detector to your script.
+
+It is a one-way move. Once the script is the source of truth, the settings form is gone. Switching between the conditions and judge tabs before you detach keeps both drafts, so detach only when you're ready to hand-write.
+
+## Related pages
+
+- [Detection methods](./detection-methods): conditions and LLM judges, the other two ways to define a detector
+- [Create a signal](../signals/create): the full creation flow
+- [Scores](../scores/overview): what a detector produces when it matches
+- [Sessions](../observability/sessions): what a session is

--- a/docs/evaluations/detection-methods.mdx
+++ b/docs/evaluations/detection-methods.mdx
@@ -1,0 +1,92 @@
+---
+title: Detection methods
+description: The three ways an evaluation decides whether a session matches a signal: a set of conditions, an LLM judge, or a custom script.
+---
+
+When you create a signal, you define how Latitude decides whether a session belongs to it. That check is the signal's evaluation, and you can build it three ways.
+
+| Method | How it decides | Cost | Good for |
+| --- | --- | --- | --- |
+| [Set of conditions](#set-of-conditions) | Deterministic checks on facts about the session | Free, instant | Concrete facts: a phrase, a failed tool, latency over a limit |
+| [LLM as judge](#llm-as-judge) | An LLM reads each session and decides | One LLM call per checked session | Fuzzy behavior: tone, frustration, made-up answers |
+| [Custom script](#custom-script) | JavaScript you write | Depends on the script | Logic the other two can't express |
+
+All three produce the same kind of detector, and a signal has one active detector at a time. You can switch methods while you build or edit a signal.
+
+## Set of conditions
+
+A set of conditions checks concrete facts about a session. Each condition is a small deterministic test. Conditions are free and run instantly, so this is the method to start with.
+
+Add up to 10 conditions and choose how they combine:
+
+- **All**: every condition must hold (AND).
+- **Any**: at least one condition must hold (OR).
+
+The match selector appears once you have two or more conditions. A single condition just has to hold.
+
+### Condition types
+
+| Condition | What it checks | Options |
+| --- | --- | --- |
+| Text match | A message contains, doesn't contain, matches, or doesn't match text or a regex | Where; operator; value; case sensitive |
+| Semantic similarity | A message is semantically close to a query | Query; sensitivity, or a custom threshold |
+| Empty output | The assistant produced no output | None |
+| Output length | The assistant output's length compared to a value | Characters or words; operator; value |
+| JSON output | The assistant output is valid or invalid JSON | Valid or invalid |
+| Metric | A session or trace metric compared to a value | Metric; aggregation; operator; value |
+| Tool used | A specific tool was called | Tool name |
+| Tool failed | A tool call ended with an error status | Tool name (optional; empty means any tool) |
+| Tool call count | How many tool calls happened | Operator; value |
+| Error | The trace or session ended in an error state | None |
+| Finish reason | The model's finish reason, such as stop, length, or tool_calls | Value |
+
+A few details are worth knowing:
+
+- **Where** (for text match) picks which messages to look at: the last assistant message, any assistant message, any user message, any tool message, or the whole conversation.
+- **Comparison operators** read as "greater than", "at least", "less than", and "at most".
+- **Metric** works in display units: duration in milliseconds, cost in dollars. The available metrics are duration, cost, total or input or output tokens, error count, trace count, and span count. Aggregation decides whether a metric is summed across the session or compared per trace.
+- **Tool failed** and **Error** look at the error status of a tool call or trace, not at the content of a tool's output. A tool that returns the word "error" in an otherwise normal result does not count as failed.
+- **Semantic similarity** compares messages to a query using the embeddings Latitude already computed for the session. It is the one condition that isn't instant, because it works on embeddings.
+
+### Semantic similarity sensitivity
+
+The sensitivity presets map to a similarity threshold:
+
+| Preset | Threshold |
+| --- | --- |
+| Broad | 0.40 |
+| Balanced | 0.55 |
+| Strict | 0.70 |
+
+Broad matches loosely and catches more. Strict matches only close paraphrases. Start with Balanced and adjust from the preview, or set an exact threshold and operator under Advanced.
+
+## LLM as judge
+
+An LLM judge reads each matching session and decides whether the behavior is present, with a short reason. You describe the behavior in plain language in the "A session matches when..." field:
+
+> the user got frustrated, repeating themselves, complaining, or giving up before getting a useful answer
+
+Use a judge for behavior that is hard to pin to a fixed rule: tone, frustration, whether the answer actually resolved the request, or whether the model made something up. Latitude writes the prompt and manages the model, so you only supply the criteria.
+
+Each check sends a session to an LLM, which costs money and takes longer than a condition. On high traffic, lower the sampling rate in the [Scope step](../signals/create#scope) so a judge checks a representative slice instead of every session.
+
+## Custom script
+
+A custom script is JavaScript you write that reads a session and returns a score. It can express anything conditions and judges can, plus logic they can't, such as combining several checks or inspecting tool arguments.
+
+The [Custom scripts](./custom-scripts) page documents the full API: the `session` object, the built-in functions, and the limits scripts run under.
+
+## Choosing a method
+
+- If the behavior is a concrete fact you can name, use a set of conditions. It is free, fast, and easy to reason about.
+- If the behavior is fuzzy or semantic, use an LLM judge.
+- If you need logic the builder can't express, write a custom script.
+
+You aren't locked in. Editing a signal lets you switch methods, and the Custom script tab always shows the script your conditions or criteria compiled to, so you can start simple and take over by hand later.
+
+## Related pages
+
+- [Create a signal](../signals/create): where you pick a method and scope the detector
+- [Custom scripts](./custom-scripts): the full scripting reference
+- [Triggers](./triggers): scope and sampling for a detector
+- [Evaluations overview](./overview): how detectors fit the wider evaluation model

--- a/docs/evaluations/overview.md
+++ b/docs/evaluations/overview.md
@@ -1,63 +1,63 @@
 ---
-title: Evaluations Overview
-description: Understand how evaluations monitor your agent's quality over time
+title: Evaluations overview
+description: Understand how evaluations score traffic to monitor your agent's quality over time.
 ---
 
-# Evaluations Overview
+# Evaluations overview
 
-Evaluations are automated monitors that score incoming traces. They track known signal patterns, catch regressions, and show whether a production problem is getting better or worse.
+An evaluation is an automated detector that scores sessions as they arrive. It watches for one behavior or quality criterion, runs on completed traffic, and produces a [score](../scores/overview) each time it checks a session. Those scores feed the same analytics, signal, and alignment workflows as annotations and flaggers.
 
-Latitude can use different strategies depending on the signal. Some monitors check structural signals, while others use LLM judgment for behavior that requires semantic understanding. For signal-generated evaluations, Latitude chooses the strategy from the available examples and feedback.
+Every signal is backed by an evaluation. When a signal's evaluation matches a session, that session joins the signal.
 
-## What Is an Evaluation
+## What an evaluation has
 
-An evaluation defines a quality check for traces. Each evaluation has:
+- A name and description: the behavior being detected.
+- A detection method: how it decides whether a session matches. See [Detection methods](./detection-methods).
+- A trigger: which sessions it runs on, and at what sampling rate. See [Triggers](./triggers).
 
-- **A name**: The signal or behavior being monitored
-- **A description**: What the evaluation is trying to detect
-- **A detection strategy**: How Latitude decides whether a trace matches the signal
-- **A trigger configuration**: Which traces to monitor and at what sample rate
+## How an evaluation runs
 
-Most evaluations are created from signals. When you generate an evaluation from a signal, Latitude uses the signal description, example traces, annotations, and scores to build the monitor.
+1. A session completes in your project.
+2. Latitude checks it against each active evaluation's scope and sampling.
+3. Matching evaluations score the session.
+4. Each returns a pass or fail verdict with feedback, stored as a score.
+5. A passing score adds the session to the evaluation's signal.
 
-## How Evaluations Work
+`passed = true` means the behavior is present, not that the session was good. A signal for a bad behavior passes when that behavior happens.
 
-1. A trace completes in your project.
-2. Latitude checks whether it matches each active evaluation's trigger configuration.
-3. Matching evaluations analyze the trace.
-4. Each evaluation returns a pass/fail verdict with feedback.
-5. Latitude creates a score attached to the trace.
-6. Failed scores feed back into [signal discovery](../signals/overview).
+## Where evaluations come from
 
-## Evaluation Strategies
+An evaluation can be created two ways.
 
-Clear structural failures, such as tool errors or empty responses, can often be monitored directly. Semantic behavior, such as relevance, refusal quality, or whether an answer resolved the user's request, may need LLM judgment.
+### Generated from a signal
 
-You do not need to choose the strategy manually for signal-generated evaluations. Latitude builds a monitor from the signal's traces and scores.
+When Latitude discovers a signal, or when you choose to monitor one, it can generate an evaluation from the signal's description, example traces, annotations, and scores. You don't pick the method. Latitude builds a detector from the evidence and keeps it aligned to human judgment over time.
 
-## Realignment
+### Defined by you
 
-Evaluations improve as more evidence arrives. New annotations, flagger matches, evaluation results, and custom scores help Latitude keep monitors calibrated to recent examples and human judgment. See [Alignment](./alignment).
+When you [create a signal](../signals/create) yourself, you define its evaluation directly. You choose one of three [detection methods](./detection-methods):
 
-## Creating Evaluations
+- Set of conditions: deterministic checks, free and instant.
+- LLM as judge: describe the behavior and let an LLM decide.
+- Custom script: JavaScript for anything the other two can't express.
 
-### From Signals
+A detector you define runs exactly as written. It is not automatically realigned to annotations the way a generated one is. See [Alignment](./alignment).
 
-Generate an evaluation from an [signal](../signals/overview) to monitor that failure pattern on future traces.
+## Choosing a detection method
 
-### From Known Requirements
+Clear structural failures, such as tool errors, empty responses, or latency over a limit, are a good fit for a set of conditions. Semantic behavior, such as relevance, tone, or whether an answer resolved the request, usually needs an LLM judge. When neither fits, a custom script gives you full control. See [Detection methods](./detection-methods) for the full catalog.
 
-You can also create evaluations for behaviors you already know you want to enforce, such as answer completeness, policy compliance, formatting requirements, or task success.
+## Evaluation lifecycle
 
-## Evaluation Lifecycle
+- Active: scoring matching sessions in real time.
+- Paused: sampling set to `0`, configuration preserved.
+- Archived: read-only and no longer scoring new sessions.
+- Deleted: removed from management views, while historical results stay in analytics.
 
-- **Active**: Monitoring matching traces in real time
-- **Paused**: Temporarily disabled by setting sampling to `0`; configuration is preserved
-- **Archived**: Read-only and no longer monitoring new traces
-- **Deleted**: Removed from management views while historical results remain represented in analytics
+## Next steps
 
-## Next Steps
-
-- [Triggers](./triggers): Configure which traces an evaluation monitors
-- [Alignment](./alignment): Understand how evaluations stay calibrated to human judgment
-- [Signals](../signals/overview): How evaluation failures become trackable signals
+- [Detection methods](./detection-methods): the three ways an evaluation decides
+- [Custom scripts](./custom-scripts): the scripting reference
+- [Triggers](./triggers): scope and sampling
+- [Alignment](./alignment): how evaluations stay calibrated to human judgment
+- [Signals](../signals/overview): how evaluation matches become tracked signals

--- a/docs/evaluations/triggers.md
+++ b/docs/evaluations/triggers.md
@@ -1,86 +1,45 @@
 ---
-title: Evaluation Triggers
-description: Configure which traces an evaluation runs against and when
+title: Evaluation triggers
+description: Configure which sessions an evaluation runs on, and how many.
 ---
 
-# Evaluation Triggers
+# Evaluation triggers
 
-Every evaluation has a **trigger configuration** that determines which traces it evaluates. Triggers control monitoring scope without changing the evaluation's detection strategy.
+An evaluation's trigger decides which sessions it runs on and how many of them. It controls monitoring scope and cost without changing how the evaluation decides a match.
 
-## How Triggers Work
+## Scope: which sessions to check
 
-When a trace completes, Latitude checks it against each active evaluation's trigger configuration:
+By default an evaluation runs on every session in your project. Narrow it with filters. When you [create a signal](../signals/create), the Scope step offers these dimensions:
 
-1. **Filter**: Does the trace match the evaluation's filter criteria?
-2. **Sampling**: Should this matching trace be evaluated?
-3. **Turn**: Is this the right turn in the session?
+- Tags
+- Services
+- Models
+- Providers
+- Metadata (any `metadata.*` key your app sends)
 
-If a trace passes all checks, the evaluation runs. Otherwise, it skips that trace.
+With filters set, only matching sessions run through the evaluation, and everything else is skipped. An empty filter means every session.
 
-Triggers use the same **shared filter system** as trace views and saved searches.
+Scope uses the same shared filter system as trace views and [saved searches](../search/saved-searches), so a filter you build for search translates directly to an evaluation's scope. You can also open the builder pre-scoped from a search, using "Create signal from this search."
 
-## Trigger Fields
+## Sampling: how many to check
 
-### Filter
+Sampling is the percentage of matching sessions the evaluation actually runs on, from 0 to 100.
 
-Select which traces the evaluation monitors using any combination of shared filters:
+- It defaults to 10 percent for a new signal.
+- Setting it to 0 pauses the evaluation. The configuration is kept, but no sessions are checked.
+- A [set of conditions](./detection-methods#set-of-conditions) is free and instant, so 100 percent is usually fine. An LLM judge, or a script that calls an LLM, costs money and time per check, so a lower rate keeps costs down while still catching the pattern on a high-traffic project.
 
-- **Status**: Errors or successful traces
-- **Models**: Specific models
-- **Providers**: Specific providers
-- **Tags**: Specific tags
-- **Cost**: Above or below a cost threshold
-- **Duration**: Above or below a duration threshold
-- **Custom metadata**: Any `metadata.*` fields your application sends
+## Timing
 
-An empty filter means "match all traces."
+Latitude runs an evaluation as sessions complete, so it acts on finished work rather than partial executions. The exact turn it runs on, and any debouncing for multi-turn sessions, are handled for you. You set the scope and the sampling rate, and Latitude manages the rest.
 
-### Sampling
+## Scope, search, and annotations
 
-The percentage of matching traces that the evaluation runs against, from 0 to 100. Sampling controls cost and processing time while preserving coverage.
+Scope and sampling control automated monitoring. [Search](../search/overview) and [annotations](../annotations/overview) cover human review: use search to inspect relevant sessions, then annotate the ones that need human judgment for alignment or discovery. [Flaggers](../annotations/flaggers) add automatic signal for a fixed list of common categories.
 
-- Setting sampling to `0` effectively pauses the evaluation.
-- New evaluations generated from issues default to `10%` sampling.
+## Next steps
 
-### Turn
-
-Controls which trace or turn the evaluation runs on:
-
-- **`every`**: Run on every completed trace (the default)
-- **`first`**: Run only on the first trace or turn in a session
-- **`last`**: Run only on the last trace or turn in a session
-
-Use this when an evaluation only makes sense at the start or end of a conversation.
-
-## Trigger Examples
-
-**Monitor all production traces for jailbreak attempts:**
-
-- Filter: metadata `environment` = "production"
-- Sampling: 100%
-- Turn: every
-
-**Spot-check expensive traces for quality:**
-
-- Filter: cost > $0.50
-- Sampling: 25%
-- Turn: every
-
-**Evaluate only the last turn of each session:**
-
-- Filter: empty
-- Sampling: 10%
-- Turn: last
-
-## Triggers, Search, and Annotations
-
-Triggers scope automated monitoring. Search and annotations cover human review: use search to inspect relevant traces, then add annotations when you need human judgment for alignment or signal discovery.
-
-[Flaggers](../annotations/flaggers) provide automatic signal for a fixed list of common categories.
-
-## Next Steps
-
-- [Alignment](./alignment): How human annotations calibrate evaluations
-- [Evaluations Overview](./overview): How evaluations work
-- [Annotations](../annotations/overview): The human side of the feedback loop
-- [Search](../search/overview): Build cohorts of traces to review
+- [Detection methods](./detection-methods): how an evaluation decides a match
+- [Alignment](./alignment): how human annotations calibrate evaluations
+- [Evaluations overview](./overview): how evaluations work
+- [Search](../search/overview): build cohorts of sessions to review

--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -18,7 +18,7 @@ Project
 ├─ Understand
 │  ├─ Search and Behaviours over traces
 │  ├─ Scores attached to traces
-│  └─ Signals grouped from failed scores
+│  └─ Signals grouped from failed scores, or defined by you
 └─ Refine
    ├─ Evaluations that score live traffic
    └─ Monitors that alert on signals, searches, or raw traffic
@@ -113,7 +113,7 @@ Failed, eligible scores are the primary input for signal discovery. Scores also 
 
 ## Signals
 
-A **signal** is a recurring failure pattern Latitude tracks. Instead of leaving failures as isolated examples, Latitude groups similar failed scores into named signals with example traces, trends, affected users, lifecycle states, and linked evaluations.
+A **signal** is a recurring failure pattern Latitude tracks. Instead of leaving failures as isolated examples, Latitude groups similar failed scores into named signals with example traces, trends, affected users, lifecycle states, and linked evaluations. You can also define a signal yourself when you already know the behavior to track. See [Create a signal](../signals/create).
 
 Signals created from negative human annotations are also called **issues**; the word is still used in that narrower context.
 
@@ -125,7 +125,7 @@ Signals help teams:
 - generate evaluations that monitor the same failure mode on future traces
 - catch regressions after a fix ships
 
-Signal states include **new**, **escalating**, **resolved**, **regressed**, and **ignored**. A signal can have multiple states at once, such as new and escalating.
+Signal states are **new**, **escalating**, and **ongoing**. A signal can have more than one at once, such as new and escalating.
 
 ## Evaluations
 
@@ -152,7 +152,7 @@ A **monitor** watches a target, such as a signal, a saved search, a tool, or you
 3. Related spans form completed **traces**, and related traces group into **sessions**.
 4. **Search** and **Behaviours** help you find the traces and topics that matter; **Users** and **Tools** break the same activity down by end user and by tool.
 5. Annotations, flaggers, **evaluations**, and custom checks create **scores** on traces.
-6. Failed scores cluster into **signals** you can triage, monitor, and fix. Signals from negative annotations are called issues.
+6. Failed scores cluster into **signals** you can triage, monitor, and fix, and you can also define a signal yourself. Signals from negative annotations are called issues.
 7. **Monitors** watch signals (and searches, tools, or raw traffic) and open incidents that alert you when something needs attention.
 
 ## Next steps

--- a/docs/getting-started/mcp.mdx
+++ b/docs/getting-started/mcp.mdx
@@ -9,7 +9,7 @@ The **Latitude MCP** is a remote, OAuth-authenticated, streamable HTTP [Model Co
 
 It is the portal that AI agents — Claude, Cursor, Codex, Gemini, Zed, OpenCode, and others — can use to read and manage your Latitude workspace.
 
-The MCP exposes everything you can do in the Latitude UI as tools — managing projects, members, keys, traces, annotations, scores, searches, issues, datasets, and more.
+The MCP exposes everything you can do in the Latitude UI as tools — managing projects, members, keys, traces, annotations, scores, searches, signals, datasets, and more.
 
 Tools are **dynamically generated** from the Latitude API, so the catalog automatically stays in sync with the platform. For the live list of tools, their descriptions, and their input/output schemas, you can check the [API reference](https://api.latitude.so/docs)
 

--- a/docs/getting-started/quick-start-dev.md
+++ b/docs/getting-started/quick-start-dev.md
@@ -14,7 +14,7 @@ This guide walks you through connecting an existing AI agent to Latitude. By the
 
 ## Step 1: Create a Project
 
-After signing in, create a new project from the dashboard. Projects are the main boundary for all reliability features: issues, evaluations, flaggers, and saved searches are all scoped to a project.
+After signing in, create a new project from the dashboard. Projects are the main boundary for all reliability features: signals, evaluations, flaggers, and saved searches are all scoped to a project.
 
 Give your project a descriptive name that matches the agent or feature you're monitoring.
 
@@ -45,7 +45,7 @@ Scores come from three sources:
 2. **Annotations**: human review verdicts from your team
 3. **Custom**: scores you submit from your own code via the API
 
-Your project starts with default [flaggers](../annotations/flaggers) that automatically annotate traces for common problems like jailbreaking, refusals, frustration, and tool call errors. Flagger annotations are written directly on matching traces and feed straight into signal discovery, so you'll see issues forming from your live traffic without configuring anything.
+Your project starts with default [flaggers](../annotations/flaggers) that automatically annotate traces for common problems like jailbreaking, refusals, frustration, and tool call errors. Flagger annotations are written directly on matching traces and feed straight into signal discovery, so you'll see signals forming from your live traffic without configuring anything.
 
 ## Step 5: Explore with Search and Annotate
 
@@ -68,4 +68,4 @@ Your annotations feed into signal discovery and evaluation alignment alongside t
 - [Annotations](../annotations/overview): Build human review workflows
 - [Flaggers](../annotations/flaggers): Automatic annotators for common failure categories
 - [Evaluations](../evaluations/overview): Set up automated monitoring
-- [Issues](../signals/overview): Understand how failure patterns are discovered
+- [Signals](../signals/overview): Understand how failure patterns are discovered

--- a/docs/getting-started/quick-start-pm.md
+++ b/docs/getting-started/quick-start-pm.md
@@ -5,7 +5,7 @@ description: Get started with Latitude through the web UI. No coding required
 
 # No-Code Quick Start
 
-This guide walks you through the Latitude web interface. You'll learn how to navigate the product, review agent interactions, annotate conversations, and understand issues, all without writing code.
+This guide walks you through the Latitude web interface. You'll learn how to navigate the product, review agent interactions, annotate conversations, and understand signals, all without writing code.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ When you open a project, you'll see the main navigation with these sections:
 
 - **Search**: Find traces by meaning, and bookmark useful searches for later
 - **Traces**: Every interaction your agent has had, shown as a timeline
-- **Issues**: Failure patterns discovered from your agent's interactions
+- **Signals**: Failure patterns discovered from your agent's interactions
 - **Datasets**: Saved trace collections for offline analysis
 - **Settings**: Project configuration, including flaggers
 
@@ -62,37 +62,37 @@ When a flagger matches, it writes an annotation directly on the trace. That anno
 
 ## Reviewing Traces
 
-To leave human feedback on a trace, open it from any list (Search, Traces, an issue's logs) and use the annotation panel on the right:
+To leave human feedback on a trace, open it from any list (Search, Traces, a signal's logs) and use the annotation panel on the right:
 
 - Click anywhere in the conversation to create a message-level annotation, or use the button for a conversation-level one.
 - Mark it as positive (thumbs up) or negative (thumbs down).
 - Write feedback describing what you observed.
-- Optionally link it to an existing issue, or leave issue assignment automatic.
+- Optionally link it to an existing signal, or leave the assignment automatic.
 
 A typical review session combines saved searches and inline annotations: open the saved search you're responsible for, click the first trace, annotate, move on. The saved search's Annotated count goes up as you work.
 
-## Understanding Issues
+## Understanding Signals
 
-The **Issues** page shows failure patterns your agent is experiencing. Issues are discovered automatically when failed scores share similar feedback.
+The **Signals** page shows failure patterns your agent is experiencing. Signals are discovered automatically when failed scores share similar feedback, and you can also [create one yourself](../signals/create).
 
-Each issue has:
+Each signal has:
 
 - **A name and description** summarizing the failure pattern
-- **A lifecycle state**: New, Escalating, Resolved, Regressed, or Ignored
-- **Linked evaluations** that monitor for this issue on live traffic
-- **Occurrence trends** showing how often the issue appears
+- **A lifecycle state**: New, Escalating, or Ongoing
+- **Linked evaluations** that monitor for this signal on live traffic
+- **Occurrence trends** showing how often the signal appears
 
 You can:
 
-- **Generate an evaluation** from an issue to start automated monitoring
-- **Resolve** an issue when you believe it's fixed (with an option to keep monitoring for regressions)
-- **Ignore** an issue that isn't worth tracking
+- **Generate an evaluation** from a signal to monitor it on live traffic
+- **Assign** a signal and set its **priority** to triage it
+- **Mute** a signal that isn't worth acting on, which moves it to the Archived tab and stops its notifications
 
 ## Understanding Evaluations
 
 The **Evaluations** page shows automated monitors that score your agent's interactions in real time.
 
-Evaluations are typically generated from issues. When you click "Generate Evaluation" on an issue, Latitude creates a monitor that watches for that failure pattern on live traffic.
+Evaluations are often generated from signals. When you choose Generate an evaluation on a signal, Latitude builds a monitor that watches for that pattern on live traffic. You can also define a signal's evaluation yourself when you create the signal.
 
 Each evaluation shows:
 
@@ -109,7 +109,7 @@ Scores are the fundamental unit of measurement in Latitude. Every score has:
 - **Feedback** text describing the verdict
 - A **source**: evaluation, annotation (human review), or custom
 
-Scores appear throughout the product: on traces, in evaluation dashboards, and in issue details.
+Scores appear throughout the product: on traces, in evaluation dashboards, and in signal details.
 
 ## What's Next
 
@@ -118,5 +118,5 @@ Scores appear throughout the product: on traces, in evaluation dashboards, and i
 - [Flaggers](../annotations/flaggers): Built-in automatic annotators for common failures
 - [Scores](../scores/overview): Deep dive into how scores work
 - [Annotations](../annotations/overview): Human review workflows
-- [Issues](../signals/overview): Learn about issue lifecycle and management
+- [Signals](../signals/overview): Learn about signal lifecycle and management
 - [Evaluations](../evaluations/overview): Understand automated monitoring

--- a/docs/monitors/overview.mdx
+++ b/docs/monitors/overview.mdx
@@ -5,7 +5,7 @@ description: Watch your signals and saved searches, and get alerted when somethi
 
 # Monitors
 
-A **monitor** watches your production traffic and opens an **incident** when a condition you care about is met. Each monitor has one **alert**, which watches a single signal with its own condition and severity. When the alert fires, Latitude records an incident and sends you a notification through your existing notification channels.
+A **monitor** watches your production traffic and opens an **incident** when a condition you care about is met. Each monitor has one **alert**, which watches a single signal or saved search with its own condition and severity. When the alert fires, Latitude records an incident and sends you a notification through your existing notification channels.
 
 Monitors live on the **Monitors** page of each project. Open it from the project sidebar.
 
@@ -40,7 +40,7 @@ Click any row to open its details panel, where you can see the alert, the full i
 Every project comes with three monitors that watch the signal lifecycle. Each one notifies you about a different moment:
 
 - **Signal discovered**: fires each time a brand-new signal is detected in your traffic.
-- **Signal regressed**: fires each time a signal you had resolved is detected again.
+- **Signal regressed**: fires when a signal that had gone quiet starts being detected again, so a problem you thought was behind you doesn't slip back unnoticed.
 - **Signal escalating**: fires when an ongoing signal is being detected _more than expected_ for this time of day and week. This is the one monitor with a tunable knob: its **sensitivity** (a value from 1 to 6) controls how large a deviation from the normal pattern is needed before it fires. Open the monitor and edit the alert to change it.
 
 System monitors **can't be deleted**: they're part of how Latitude keeps you informed about signals. If you don't want to be notified by one, **mute** it (see [Mute](#mute) below).

--- a/docs/observability/features/environments.mdx
+++ b/docs/observability/features/environments.mdx
@@ -83,7 +83,7 @@ With environment context, you can:
 - filter traces to production traffic
 - search only staging or preview traces
 - save searches for production failure modes
-- scope issue monitoring to a specific environment
+- scope signal monitoring to a specific environment
 - compare whether a behaviour appears in one environment or across all environments
 
 ## Related

--- a/docs/observability/features/metadata.mdx
+++ b/docs/observability/features/metadata.mdx
@@ -71,7 +71,7 @@ Metadata appears on traces and in filters, so you can review cohorts such as:
 - production traces for one account
 - failed traces for a specific feature flag
 - expensive traces from one region
-- issue examples from a specific plan tier
+- signal examples from a specific plan tier
 
 Metadata filters use dot notation, such as `metadata.environment = production`.
 

--- a/docs/observability/features/releases-versioning.mdx
+++ b/docs/observability/features/releases-versioning.mdx
@@ -5,7 +5,7 @@ description: Track agent versions, deployment ids, and rollout cohorts with tags
 
 # Releases and versioning
 
-Add release and version context through tags or metadata to investigate whether a behaviour started after a deploy, compare canary and stable traffic, or filter issue examples to one agent version.
+Add release and version context through tags or metadata to investigate whether a behaviour started after a deploy, compare canary and stable traffic, or filter signal examples to one agent version.
 
 Use:
 
@@ -82,13 +82,13 @@ With version context, you can:
 
 - search for behaviours introduced by a release
 - filter traces by prompt version or deployment id
-- compare issue examples before and after a rollout
+- compare signal examples before and after a rollout
 - scope saved searches to canary traffic
-- monitor whether a resolved issue regressed in a new version
+- monitor whether a signal you fixed comes back in a new version
 
 ## Related
 
 - [Tags](./tags): Track rollout labels
 - [Metadata](./metadata): Track exact release fields
 - [Search](../../search/overview): Discover version-specific behaviours
-- [Issues](../../signals/overview): Track failure modes across releases
+- [Signals](../../signals/overview): Track failure modes across releases

--- a/docs/observability/features/sampling.mdx
+++ b/docs/observability/features/sampling.mdx
@@ -25,10 +25,10 @@ A sampling rate of `0%` pauses the evaluation.
 
 Flaggers can sample how aggressively Latitude runs additional automated checks for a category. This balances detection coverage with processing volume.
 
-Flagger sampling does not remove traces from search, filtering, or manual issue investigation.
+Flagger sampling does not remove traces from search, filtering, or manual signal investigation.
 
 ## Related
 
 - [Search](../../search/overview): Search across all searchable traces
-- [Evaluations](../../evaluations/overview): Monitor issue patterns on incoming traces
+- [Evaluations](../../evaluations/overview): Monitor signal patterns on incoming traces
 - [Flaggers](../../annotations/flaggers): Automatic detection for common failure categories

--- a/docs/observability/features/sandbox.mdx
+++ b/docs/observability/features/sandbox.mdx
@@ -29,7 +29,7 @@ The production monitoring layer is **not** available in a sandbox. The following
 
 - Semantic and saved searches
 - Monitors and alerts
-- Issue detection and clustering
+- Signal detection and clustering
 - Evaluations, annotations, and flaggers
 - Outbound notifications (email, Slack, webhooks) — a sandbox never reaches an external channel, so your experiments can't page teammates or hit customer alert channels
 

--- a/docs/observability/features/tags.mdx
+++ b/docs/observability/features/tags.mdx
@@ -61,7 +61,7 @@ Use tags to:
 - narrow semantic or exact-text searches
 - save reusable search cohorts
 - scope evaluation monitoring
-- compare issue patterns across environments, agents, or features
+- compare signal patterns across environments, agents, or features
 
 ## Tags vs metadata
 

--- a/docs/observability/features/trace-urls.mdx
+++ b/docs/observability/features/trace-urls.mdx
@@ -7,7 +7,7 @@ description: Open and share specific traces from the Latitude web app.
 
 When you open a trace in the Latitude web app, the selected trace is reflected in the page URL. Share that URL with teammates who have access to the same organization and project.
 
-Trace URLs point teammates to an exact production interaction from a search result, saved search, issue, or trace list.
+Trace URLs point teammates to an exact production interaction from a search result, saved search, signal, or trace list.
 
 ## Open a trace URL
 
@@ -16,7 +16,7 @@ You can open a trace from:
 - the Traces page
 - Search results
 - Saved searches
-- Issue logs
+- Signal logs
 - Session rows
 
 After opening the trace, copy the browser URL and share it with someone who has project access.

--- a/docs/observability/guides/group-traces-by-project.mdx
+++ b/docs/observability/guides/group-traces-by-project.mdx
@@ -1,11 +1,11 @@
 ---
 title: Group traces by project
-description: Keep issue detection scoped to the right agent by routing traces into separate Latitude projects.
+description: Keep signal detection scoped to the right agent by routing traces into separate Latitude projects.
 ---
 
 # Group traces by project
 
-Latitude runs issue detection across all traces inside a project. That is the right default when one project represents one agent, application, or product surface.
+Latitude runs signal detection across all traces inside a project. That is the right default when one project represents one agent, application, or product surface.
 
 If the same workspace receives traces from multiple unrelated agents, their failure modes can mix together. For example, a customer-support agent and a code-review agent should usually not share signal discovery, because frustration, tool failures, refusals, or hallucinations mean different things in each context.
 
@@ -19,9 +19,9 @@ Use separate projects when agents have different:
 - users, workflows, or product surfaces
 - quality standards or failure definitions
 - owners or triage workflows
-- issue detection and evaluation needs
+- signal detection and evaluation needs
 
-Keep traces in the same project when they belong to the same agent experience and should share signal discovery, search, scores, evaluations, and issue trends.
+Keep traces in the same project when they belong to the same agent experience and should share signal discovery, search, scores, evaluations, and signal trends.
 
 ## How Latitude resolves the project
 

--- a/docs/observability/overview.md
+++ b/docs/observability/overview.md
@@ -14,7 +14,7 @@ For the complete product vocabulary, see [Core Concepts](../getting-started/conc
 Latitude uses three telemetry levels:
 
 - **Spans**: individual operations such as LLM calls, tool invocations, retrieval steps, HTTP requests, or custom work.
-- **Traces**: complete interactions composed of one or more spans. Traces are the main unit for debugging, search, annotations, scores, evaluations, and issues.
+- **Traces**: complete interactions composed of one or more spans. Traces are the main unit for debugging, search, annotations, scores, evaluations, and signals.
 - **Sessions**: optional groups of related traces, usually a multi-turn conversation or workflow identified by a stable session id.
 
 ```text
@@ -38,7 +38,7 @@ Observability views help you answer questions such as:
 - Which model, provider, tool, or service was involved?
 - Where did latency, cost, or errors come from?
 - Which user, session, release, environment, tags, or metadata are attached?
-- What annotations, scores, or issue signals are connected to this trace?
+- What annotations, scores, or signals are connected to this trace?
 
 ## Trace completion
 
@@ -49,7 +49,7 @@ Once a trace is complete, Latitude can:
 - make the conversation available in [Search](../search/overview)
 - run matching [Evaluations](../evaluations/overview)
 - apply enabled [Flaggers](../annotations/flaggers)
-- update related [Scores](../scores/overview) and [Issues](../signals/overview)
+- update related [Scores](../scores/overview) and [Signals](../signals/overview)
 
 ## Next steps
 

--- a/docs/observability/sessions.mdx
+++ b/docs/observability/sessions.mdx
@@ -80,13 +80,13 @@ The sessions view shows one row per session, with columns for:
 - span count
 - error and annotation indicators
 
-Expand a row to see the traces inside the session, or click it to open a detail panel with the full conversation, the span tree, annotations, and any linked issues.
+Expand a row to see the traces inside the session, or click it to open a detail panel with the full conversation, the span tree, annotations, and any linked signals.
 
 Each trace within a session keeps its own metrics, so you can identify which turn had high latency, high cost, errors, or unusual behaviour.
 
 ## Sessions in search and review
 
-Sessions are an aggregation on top of traces. Search, annotations, scores, and issues still operate primarily on traces.
+Sessions are an aggregation on top of traces. Search, annotations, scores, and signals still operate primarily on traces.
 
 You can:
 

--- a/docs/observability/traces.mdx
+++ b/docs/observability/traces.mdx
@@ -5,7 +5,7 @@ description: Understand the trace model, lifecycle, and how to work with traces 
 
 # Traces
 
-A trace represents one complete interaction between a user and your agent. It's the primary unit that Latitude's reliability features operate on: evaluations, annotations, and issues all reference traces.
+A trace represents one complete interaction between a user and your agent. It's the primary unit that Latitude's reliability features operate on: evaluations, annotations, and signals all reference traces.
 
 <Frame>
   <img src="/images/traces/traces-overview.png" alt="Traces page showing a list of traces with metadata" />
@@ -42,7 +42,7 @@ Once a trace is complete, Latitude can:
 - make it available in [Search](../search/overview)
 - run matching [Evaluations](../evaluations/overview)
 - apply enabled [Flaggers](../annotations/flaggers)
-- connect resulting [Scores](../scores/overview) to [Issues](../signals/overview)
+- connect resulting [Scores](../scores/overview) to [Signals](../signals/overview)
 
 ## Viewing Traces
 

--- a/docs/observability/users.mdx
+++ b/docs/observability/users.mdx
@@ -64,10 +64,10 @@ Use the time range, column selector, and search controls to focus on a subset of
 
 ## User detail
 
-Open a user to see their lifetime profile: traces, sessions, errored sessions, cost, tokens, average trace duration, and active days, alongside a 30-day activity chart. The page also surfaces the [issues](../signals/overview) affecting this user and the behaviours they triggered, so you can connect one user's complaints to known problems.
+Open a user to see their lifetime profile: traces, sessions, errored sessions, cost, tokens, average trace duration, and active days, alongside a 30-day activity chart. The page also surfaces the [signals](../signals/overview) affecting this user and the behaviours they triggered, so you can connect one user's complaints to known problems.
 
 <Frame>
-  <img src="/images/observability/user-detail.png" alt="User detail page with lifetime stats, activity chart, issues, and behaviours" />
+  <img src="/images/observability/user-detail.png" alt="User detail page with lifetime stats, activity chart, signals, and behaviours" />
 </Frame>
 
 Further down, usage breakdowns show which models, providers, and tools this user's traces relied on, followed by their sessions. Toggle the error view to focus on the sessions that failed.

--- a/docs/scores/analytics.md
+++ b/docs/scores/analytics.md
@@ -5,7 +5,7 @@ description: Visualize score trends and quality metrics across your project
 
 # Score Analytics
 
-Score analytics show quality trends across your project: whether quality is improving, which evaluations catch the most failures, and when issues occur.
+Score analytics show quality trends across your project: whether quality is improving, which evaluations catch the most failures, and when signals occur.
 
 ## Project-Level Dashboard
 
@@ -28,13 +28,13 @@ Each evaluation has its own analytics page with:
 
 Use evaluation analytics to spot regressions, improvements after a fix, or drift from human judgment.
 
-## Issue-Level Analytics
+## Signal-Level Analytics
 
-Each issue tracks:
+Each signal tracks:
 
-- **Occurrence count**: How many times the issue has been detected
-- **Lifecycle state**: Whether the issue is new, escalating, resolved, or regressed
-- **Resolution history**: When it was resolved and whether it has returned
+- **Occurrence count**: How many times the signal has been detected
+- **Lifecycle state**: Whether the signal is new, escalating, or ongoing
+- **Affected users**: The share of users the signal has impacted
 
 ## Score-Aware Trace Filtering
 
@@ -42,10 +42,10 @@ Traces and sessions can be filtered by score-derived properties:
 
 - **Score state**: Failing scores, passing scores, or draft annotations
 - **Value thresholds**: Scores below a quality threshold
-- **Issue linkage**: Traces associated with a specific issue
+- **Signal linkage**: Traces associated with a specific signal
 - **Score source**: A specific evaluation, annotation source, or custom source
 
-This bridges observability and reliability: you can move from a failed evaluation or issue directly to the underlying conversations.
+This bridges observability and reliability: you can move from a failed evaluation or signal directly to the underlying conversations.
 
 ## Filtering Analytics
 
@@ -55,4 +55,4 @@ Analytics dashboards use the same [filter system](../observability/filters) as t
 
 - [Scores Overview](./overview): How the score model works
 - [Evaluations](../evaluations/overview): How automated evaluations produce scores
-- [Issues](../signals/overview): How failure patterns are discovered from scores
+- [Signals](../signals/overview): How failure patterns are discovered from scores

--- a/docs/scores/api.md
+++ b/docs/scores/api.md
@@ -71,13 +71,13 @@ Annotations support the same fields as custom scores, plus optional anchor field
 | `value` | number | Yes | Normalized score between 0 and 1 |
 | `passed` | boolean | Yes | Pass/fail verdict |
 | `feedback` | string | Yes | The reviewer's feedback text |
-| `issueId` | string | No | Link to an existing issue |
+| `signalId` | string | No | Link to an existing signal |
 
 ## How Scores Feed the System
 
 Once submitted, custom scores and annotations flow through the same reliability pipeline as internally generated scores:
 
-1. **Issue discovery**: Failed scores automatically enter the discovery pipeline, where Latitude clusters similar failures into issues
+1. **Signal discovery**: Failed scores automatically enter the discovery pipeline, where Latitude clusters similar failures into signals
 2. **Analytics**: Finalized scores appear in time-series dashboards
 3. **Alignment**: Annotation scores are compared against evaluation scores for the same traces to compute alignment metrics
 
@@ -87,4 +87,4 @@ Custom scores and annotations are first-class citizens. They appear alongside ev
 
 - [Scores Overview](./overview): How the score model works
 - [Annotations](../annotations/overview): How the annotation workflow works
-- [Issues](../signals/overview): How failed scores become trackable issues
+- [Signals](../signals/overview): How failed scores become trackable signals

--- a/docs/scores/overview.md
+++ b/docs/scores/overview.md
@@ -5,7 +5,7 @@ description: Understand how scores work as the universal measurement unit in Lat
 
 # Scores
 
-Scores are Latitude's common measurement unit. Every verdict on an agent interaction—from an evaluation, annotation, flagger, or your own code—is stored as a score. Issues, evaluation dashboards, annotation workflows, and analytics all build on this model.
+Scores are Latitude's common measurement unit. Every verdict on an agent interaction—from an evaluation, annotation, flagger, or your own code—is stored as a score. Signals, evaluation dashboards, annotation workflows, and analytics all build on this model.
 
 ## What Is a Score
 
@@ -20,7 +20,7 @@ A score is a verdict attached to a trace. Every score has:
 
 Scores can also carry resource fields such as duration, token count, and cost.
 
-A score is always associated with a **trace**. It can also be associated with a **span**, **session**, or **issue**.
+A score is always associated with a **trace**. It can also be associated with a **span**, **session**, or **signal**.
 
 ## Score Sources
 
@@ -46,8 +46,8 @@ Once finalized, a score becomes part of Latitude's reliability workflows.
 
 Finalized scores feed into:
 
-1. **Signal discovery**: Failed scores can become named, trackable [issues](../signals/overview).
-2. **Evaluation generation**: Issues can generate monitors that produce more scores on live traffic.
+1. **Signal discovery**: Failed scores can become named, trackable [signals](../signals/overview).
+2. **Evaluation generation**: Signals can generate monitors that produce more scores on live traffic.
 3. **Alignment**: Annotation scores are compared with evaluation scores on the same traces.
 4. **Analytics**: Score dashboards show quality trends across your project.
 
@@ -55,6 +55,6 @@ Finalized scores feed into:
 
 - [Annotations](../annotations/overview): How human reviewers create scores
 - [Evaluations](../evaluations/overview): How automated monitors create scores
-- [Issues](../signals/overview): How failed scores become trackable failure patterns
+- [Signals](../signals/overview): How failed scores become trackable failure patterns
 - [Analytics](./analytics): Visualize score trends
 - [Scores API](./api): Submit custom scores programmatically

--- a/docs/search/overview.mdx
+++ b/docs/search/overview.mdx
@@ -87,19 +87,19 @@ Search is the discovery layer for behaviours Latitude should track. A typical wo
 1. Search for a user or agent behaviour you care about.
 2. Open representative traces.
 3. Annotate traces that show a real failure mode.
-4. Latitude turns failed annotations and related scores into [issues](../signals/overview).
-5. Generate evaluations from important issues to monitor them automatically on incoming traces.
+4. Latitude turns failed annotations and related scores into [signals](../signals/overview).
+5. Generate evaluations from important signals to monitor them automatically on incoming traces.
 
 | Feature | Relationship |
 | --- | --- |
 | **[Saved searches](./saved-searches)** | Revisit useful behavioural cohorts |
 | **[Inline annotations](../annotations/inline-annotations)** | Label traces from search as good or bad behaviour |
-| **[Issues](../signals/overview)** | Turn failed annotations and scores into trackable production issues |
+| **[Signals](../signals/overview)** | Turn failed annotations and scores into trackable production signals |
 | **[Flaggers](../annotations/flaggers)** | Automatically detect common categories; use search for product-specific patterns |
 
 ## Next steps
 
 - [Saved Searches](./saved-searches): Save behavioural cohorts for repeated review
 - [Inline Annotations](../annotations/inline-annotations): Label traces you find through search
-- [Issues](../signals/overview): Track recurring failure modes
+- [Signals](../signals/overview): Track recurring failure modes
 - [Filters](../observability/filters): Narrow searches with trace metadata

--- a/docs/security/compliance/iso-27001.mdx
+++ b/docs/security/compliance/iso-27001.mdx
@@ -35,7 +35,7 @@ Latitude's audit work covers areas such as:
 
 ## AWS eu-central-1 operating boundary
 
-Hosted Latitude stores and processes customer data and runs Latitude-managed inference in AWS eu-central-1 in Frankfurt, Germany. This boundary applies to product data such as traces, spans, sessions, annotations, scores, issues, evaluations, and search indexes.
+Hosted Latitude stores and processes customer data and runs Latitude-managed inference in AWS eu-central-1 in Frankfurt, Germany. This boundary applies to product data such as traces, spans, sessions, annotations, scores, signals, evaluations, and search indexes.
 
 See [Data protection](../data-protection) for more detail.
 

--- a/docs/security/compliance/soc2.mdx
+++ b/docs/security/compliance/soc2.mdx
@@ -25,7 +25,7 @@ Relevant control areas include:
 - tenant isolation across organizations and projects
 - operational monitoring and incident handling
 - change management for product and infrastructure updates
-- data protection for traces, sessions, scores, issues, and evaluations
+- data protection for traces, sessions, scores, signals, and evaluations
 - vendor and infrastructure risk management
 
 ## Data processing boundary

--- a/docs/security/data-protection.mdx
+++ b/docs/security/data-protection.mdx
@@ -7,14 +7,14 @@ description: How Latitude keeps hosted customer data and Latitude-managed infere
 
 Hosted Latitude is designed for teams that need AI observability while keeping production agent data within a defined European region. It stores and processes customer data and runs Latitude-managed inference in AWS eu-central-1 in Frankfurt, Germany.
 
-This covers data Latitude receives or creates while operating the platform, including traces, spans, sessions, annotations, scores, issues, evaluations, search indexes, and related metadata.
+This covers data Latitude receives or creates while operating the platform, including traces, spans, sessions, annotations, scores, signals, evaluations, search indexes, and related metadata.
 
 ## European data and inference boundary
 
 Latitude-managed inference includes the internal model calls that power product workflows such as:
 
 - signal discovery and clustering
-- issue names and descriptions
+- signal names and descriptions
 - flagger review for supported failure categories
 - evaluation generation and alignment workflows
 - search, scoring, and reliability analysis
@@ -26,8 +26,8 @@ Your application can call any model provider you choose. This boundary applies o
 Latitude scopes data by organization and project:
 
 - **Organizations** are the top-level access boundary.
-- **Projects** scope traces, search, scores, issues, evaluations, and related workflows.
-- Issue detection runs within a project, so teams can keep unrelated agents separate by routing them to separate projects.
+- **Projects** scope traces, search, scores, signals, evaluations, and related workflows.
+- Signal detection runs within a project, so teams can keep unrelated agents separate by routing them to separate projects.
 
 See [Group traces by project](../observability/guides/group-traces-by-project) for recommended project scoping patterns.
 

--- a/docs/security/pii-redaction.mdx
+++ b/docs/security/pii-redaction.mdx
@@ -73,7 +73,7 @@ latitude = Latitude(
 Latitude's internal systems are designed to avoid unnecessary sensitive-data exposure:
 
 - Internal AI workflows receive only the trace context needed for the task.
-- Product workflows prefer summaries, derived labels, scores, and issue examples over raw payloads.
+- Product workflows prefer summaries, derived labels, scores, and signal examples over raw payloads.
 - Sensitive implementation details and omitted payloads are not exposed in generated customer-facing explanations.
 - Latitude-managed inference stays within the hosted data boundary described in [Data protection](./data-protection).
 

--- a/docs/signals/create.mdx
+++ b/docs/signals/create.mdx
@@ -1,0 +1,87 @@
+---
+title: Create a signal
+description: Define a signal yourself when you already know the behavior you want to track, using the New signal builder.
+---
+
+Signals usually come from [discovery](./overview): Latitude groups similar failed scores into named patterns without you defining them first. You can also create a signal yourself when you already know the behavior you want to track. This page covers that path.
+
+Discovery finds what you didn't know to look for. Creating a signal manually tracks what you already know matters: a specific failure mode, a policy you need to enforce, or a behavior you want measured from day one.
+
+## When to create one manually
+
+- You already know a failure mode and want it tracked and counted from now on.
+- You want to enforce a known requirement, such as a format, a policy, or task success.
+- The behavior is specific enough that you can describe it or write a rule for it.
+
+If you are exploring rather than tracking something specific, start with [Search](../search/overview) and [Behaviours](../search/behaviours) instead, and let discovery surface patterns.
+
+## Open the builder
+
+On the Signals page, select **New signal**. The builder opens on a short intro with two ways forward:
+
+- **Generate signal**: describe the behavior and let Latitude build the whole signal.
+- **Configure manually**: build it yourself step by step.
+
+{/* TODO: add screenshot of the New signal builder intro (describe-first screen). */}
+
+Both paths end the same way: a signal with a detector that checks every new matching session and adds the ones that exhibit the behavior. That detector is an [evaluation](../evaluations/overview).
+
+## Describe it and let Latitude build it
+
+In the "What do you want to track?" field, describe the behavior in plain language. For example:
+
+> Sessions where the ticket-cancellation tool fails and the user gets frustrated.
+
+Select **Generate signal**. Latitude reads your description, drafts a detector, chooses a scope and sampling rate, tests it against recent sessions, names it, and creates it. When it finishes, you land on the new signal's detail page, where you can review it and edit anything.
+
+This is a good starting point even when you plan to adjust the result. You can reopen the builder from the signal to change the detector, scope, or sampling. AI generation is rate limited, so if you generate several in a row you may need to wait before the next one.
+
+## Configure it manually
+
+Choosing **Configure manually** runs a four-step builder.
+
+<Steps>
+  <Step title="Evaluation">
+    Pick how Latitude decides whether a session matches, using one of three [detection methods](../evaluations/detection-methods): a set of conditions, an LLM judge, or a custom script. This check runs automatically on every new matching session, and a session that passes joins the signal.
+  </Step>
+  <Step title="Scope">
+    Choose which sessions get checked and how many of them. See [Scope](#scope) below.
+  </Step>
+  <Step title="Test">
+    Try the detector on recent sessions before saving. See [Test](#test) below.
+  </Step>
+  <Step title="Details">
+    Give the signal a **name** and a **description**. Both are required. The name shows up in the signals list, so pick something your team will recognize.
+  </Step>
+</Steps>
+
+### Scope
+
+By default a detector runs on every session in your project. Narrow it with filters on **Tags**, **Services**, **Models**, **Providers**, or **Metadata**. With filters set, only matching sessions run through the detector and everything else is ignored.
+
+The sampling slider controls how many of those sessions get checked, from 0 to 100 percent. It defaults to 10 percent.
+
+- A set of conditions is free and instant, so checking 100 percent is usually fine.
+- An LLM judge or a script that calls an LLM costs money and time per check. On high traffic, sampling a slice still catches the pattern for much less.
+- Setting sampling to 0 pauses the signal: no sessions are checked.
+
+See [Triggers](../evaluations/triggers) for more on scope and sampling.
+
+### Test
+
+The Test step runs your detector against recent sessions from your project and shows how it scored each one. Nothing is saved. Each session gets a verdict: **match**, **no match**, **skipped** (for example, not embedded yet), or **errored**. If the verdicts look off, go back, adjust the detector or scope, and run the preview again.
+
+## After you create a signal
+
+A new signal starts empty and collects matches from new sessions onward. It does not scan your history.
+
+From there it behaves like any signal. It appears in your Signals list, its occurrences and trends build up as matching sessions arrive, and you can triage, mute, monitor, or delete it from its detail page. See [Signal management](./management).
+
+You can edit the detector, scope, and sampling of a signal you created at any time, and switch detection methods freely. Edits apply going forward. A detector you define runs exactly as you wrote it. Unlike a detector Latitude generates from a discovered signal, it is not automatically realigned to human annotations, so it keeps doing what you specified. See [Alignment](../evaluations/alignment).
+
+## Related pages
+
+- [Detection methods](../evaluations/detection-methods): the three ways to define a detector
+- [Custom scripts](../evaluations/custom-scripts): the scripting reference
+- [Signals overview](./overview): how discovery finds signals for you
+- [Signal management](./management): triage, monitor, mute, and manage signals

--- a/docs/signals/management.md
+++ b/docs/signals/management.md
@@ -1,81 +1,82 @@
 ---
-title: Signal Management
-description: Workflows for triaging, investigating, and resolving signals
+title: Signal management
+description: Triage signals, monitor them with evaluations, mute noise, and keep your signal list focused.
 ---
 
-# Signal Management
+# Signal management
 
-After Latitude discovers a signal, use the signal detail view to decide whether to investigate, monitor, resolve, or ignore it.
+Once a signal exists, whether Latitude [discovered](./overview) it or you [created](./create) it, you work with it from its detail page. This page covers its states and the actions you can take.
 
-## Triage Workflow
+## Signal states
 
-When a new signal appears:
+A signal's status is one of three states:
 
-1. **Review the description** to understand the discovered failure pattern.
-2. **Open example traces** to see the conversations where it occurred.
-3. **Assess severity**: safety risk, quality degradation, or minor edge case.
-4. **Choose an action**:
-   - Generate an evaluation for ongoing monitoring.
-   - Resolve it if the problem is already fixed.
-   - Ignore it if it is noise or too rare to track.
+- New: discovered or created in the last 7 days.
+- Escalating: occurrences are rising faster than the normal pattern for this time of week. Escalation is detected automatically and surfaced by the Signal escalating [monitor](../monitors/overview).
+- Ongoing: the steady state, once a signal is neither new nor escalating.
 
-## Investigating a Signal
+A signal can be both New and Escalating at once. Separately, a signal with an active evaluation shows an Evaluated marker.
 
-For signals that need deeper investigation, review several example traces and ask:
+The Signals page has two tabs, Active and Archived. Muting a signal moves it to Archived.
 
-- What user inputs trigger the signal?
+## Triage
+
+When a signal appears:
+
+1. Read its description to understand the pattern.
+2. Open example sessions to see where it happened.
+3. Judge how much it matters: a safety risk, a quality problem, or a rare edge case.
+4. Act on it: assign an owner, set a priority, start monitoring, mute it, or delete it.
+
+Assign a signal to an org member and set its priority (Urgent, High, Medium, Low, or none) so the right person picks up the right thing first. You can filter the list by assignee.
+
+## Monitor a signal
+
+Monitoring attaches an evaluation that scores new sessions for the same behavior. For a discovered signal, open it and choose Generate an evaluation: Latitude builds a detector from the signal's examples, annotations, and scores, then keeps it aligned to human judgment. A signal you created already has the detector you defined.
+
+From the signal you can:
+
+- Change the sampling rate to trade coverage for cost.
+- Realign a generated evaluation after adding annotations.
+- Remove the evaluation to stop scoring new sessions.
+
+Unmute a signal before you generate an evaluation for it.
+
+See [Evaluations](../evaluations/overview) for how detectors work, and [Create a signal](./create) to define one yourself.
+
+## Investigate
+
+For a signal worth digging into, review several example sessions and ask:
+
+- What user inputs lead to it?
 - Is the agent consistently wrong, or is the failure intermittent?
 - Are there shared patterns in context, tools, retrieval, model, or prompt behavior?
-- If evaluations are linked, are they too strict, too lenient, or drifting from human review?
+- If an evaluation is attached, is it too strict, too lenient, or drifting from human review?
 
-## Resolving Signals
+## Mute noise
 
-When the underlying problem is fixed:
+Mute a signal that isn't worth acting on. Muting stops its notifications and moves it to the Archived tab, though new occurrences still register. Unmute to bring it back to the active list. Use muting for noise, not for problems you have already fixed.
 
-1. Open the signal detail page.
-2. Click **Resolve**.
-3. Choose whether to keep monitoring.
+## Delete a signal you created
 
-The **keep monitoring** toggle controls linked evaluations:
+A signal you created can be renamed or deleted from its detail page. Deleting also archives its evaluation and can't be undone. Existing scores stay in analytics. Discovered signals can't be deleted; mute them instead.
 
-- **Enabled**: Linked evaluations stay active and can move the signal to **Regressed** if the failure returns.
-- **Disabled**: Linked evaluations are archived when the signal resolves.
+## Catching regressions
 
-The default comes from project settings, or from the organization setting if the project has no override. You can change it for each resolve action.
+After you ship a fix, keep an evaluation on the signal so Latitude keeps scoring new sessions. If the behavior comes back, the evaluation scores it again. The Signal regressed [monitor](../monitors/overview) notifies you when a signal that had settled down starts being detected again, so you don't have to watch for it by hand.
 
-## Working with Regressed Signals
-
-A regressed signal is a previously resolved problem that has returned. Treat it as high priority:
-
-1. Review the new occurrence traces and confirm they match the original failure pattern.
-2. Compare them with the original fix and resolution notes.
-3. Fix the cause and resolve the signal again.
-
-Regression can mean the first fix was incomplete, a later change reintroduced the problem, or the agent drifted after model or prompt updates.
-
-You don't have to watch for regressions by hand: the **Signal regressed** system [monitor](../monitors/overview) notifies you automatically whenever a resolved signal is detected again.
-
-## Ignoring Signals
-
-Ignoring is different from resolving:
-
-- Ignoring immediately archives all linked evaluations, regardless of the keep-monitoring setting.
-- Ignored signals are hidden from default views but can be restored later.
-- Use ignore for noise, not for problems that have been fixed.
-
-## Keeping Signals Manageable
+## Keep signals manageable
 
 As your project matures:
 
-- Resolve fixed signals instead of leaving them open.
-- Keep monitoring enabled when regressions matter.
-- Ignore irrelevant signals so real problems stay visible.
-- Keep signal descriptions clear enough for future teammates.
-- Link meaningful signals to evaluations when you need ongoing coverage.
+- Assign and prioritize signals so the important ones stand out.
+- Monitor the signals you need ongoing coverage for.
+- Mute noise so real problems stay visible.
+- Keep descriptions clear enough for the next teammate to understand.
 
-## Next Steps
+## Next steps
 
-- [Signals Overview](./overview): How signals are discovered
-- [Monitors](../monitors/overview): Get notified when signals are discovered, regress, or escalate
-- [Evaluations](../evaluations/overview): Generate monitors from signals
-- [Annotations](../annotations/overview): Leave human feedback on signal traces
+- [Signals overview](./overview): how discovery finds signals
+- [Create a signal](./create): define one yourself
+- [Monitors](../monitors/overview): get notified when signals are discovered, escalate, or regress
+- [Evaluations](../evaluations/overview): monitor a signal on live traffic

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -5,9 +5,13 @@ description: Understand how Latitude turns annotations, scores, evaluations, and
 
 # Signal discovery
 
-Signals are recurring failure patterns in your agent's production traffic. Latitude groups failed scores into signals, then gives each signal a name, examples, trends, and a lifecycle your team can act on.
+Signals are recurring behavior patterns in your agent's production traffic, usually failures. Latitude discovers most of them for you by grouping similar failed scores, and gives each signal a name, examples, trends, and a lifecycle your team can act on.
 
-The loop is simple: **find bad behavior, explain it, monitor it, fix it, and catch regressions**.
+The loop is the same whether a signal is discovered or defined: find the behavior, explain it, monitor it, fix it, and watch for it coming back.
+
+<Note>
+  Most signals are discovered for you. You can also [create one yourself](./create) when you already know the behavior to track: a specific failure, a policy to enforce, or a check you want from day one.
+</Note>
 
 ## How signal discovery works
 
@@ -79,7 +83,7 @@ Use the **Active / Inactive** tabs to switch between current signals and resolve
 
 Click any signal to open its detail page:
 
-{/* TODO: re-capture signal-detail.png — this is now the full signal page, not the old drawer. */}
+{/* TODO: re-capture signal-detail.png (now the full signal page, not the old drawer). */}
 
 <Frame>
   <img
@@ -92,34 +96,39 @@ The signal page shows the signal description, lifecycle state, impact (affected 
 
 ## Signal lifecycle
 
+A signal's status is one of three states, shown as a chip on the signal:
+
 | State | Meaning |
 | --- | --- |
-| **New** | Newly discovered |
-| **Escalating** | Occurrences are increasing compared to the recent baseline |
-| **Resolved** | Marked fixed or inactive |
-| **Regressed** | New occurrences appeared after the signal was resolved |
-| **Ignored** | Hidden from the active workflow because it is not worth tracking |
+| New | Discovered or created within the last 7 days |
+| Escalating | Occurrences are rising faster than the normal pattern for this time of week |
+| Ongoing | The steady state, once a signal is neither new nor escalating |
 
-An signal can be in multiple states at once. For example, a newly discovered signal can also be escalating.
+A signal can hold more than one state at once. A signal created this week that is also spiking shows as both New and Escalating.
+
+Two more markers appear alongside the state:
+
+- Evaluated: the signal has an active evaluation checking new sessions. See [Evaluations](../evaluations/overview).
+- Archived: the signal has been muted and moved out of the active list. See [Signal management](./management).
 
 ## Common workflows
 
-### Investigate traces
+### Investigate sessions
 
-Use the signal's example traces to understand common user intents, missing context, tool failures, retrieval problems, prompt gaps, or model behavior that needs to change.
+Use the signal's example sessions to understand common user intents, missing context, tool failures, retrieval problems, prompt gaps, or model behavior that needs to change.
 
 ### Generate an evaluation
 
-Click **Generate Evaluation** to create an automated monitor for the signal. The evaluation runs on future traces and helps track whether the signal is still happening.
+Choose Generate an evaluation to attach an automated detector to the signal. It scores new sessions and tracks whether the behavior is still happening. See [Signal management](./management).
 
-### Resolve or ignore
+### Triage and mute
 
-- **Resolve** when the underlying problem is fixed. Keep monitoring enabled if you want Latitude to catch regressions.
-- **Ignore** when the signal is noise or not worth tracking. Ignored signals leave the active workflow.
+Assign an owner and a priority so the right person picks it up. Mute a signal that isn't worth acting on: muting stops its notifications and moves it to the Archived tab. For a signal you created that you no longer need, delete it.
 
 ## Related pages
 
-- [Signal Management](./management): Triage, investigate, resolve, and ignore signals
+- [Create a signal](./create): Define a signal yourself
+- [Signal management](./management): Triage, monitor, mute, and manage signals
 - [Monitors](../monitors/overview): Get notified when signals are discovered, regress, or escalate
 - [Annotations](../annotations/overview): Leave human feedback on traces
 - [Flaggers](../annotations/flaggers): Detect common failure categories automatically

--- a/docs/telemetry/start-tracing.mdx
+++ b/docs/telemetry/start-tracing.mdx
@@ -45,4 +45,4 @@ For other languages, use the [OpenTelemetry exporter](../telemetry/otel-exporter
 
 - Explore traces in [Observability](../observability/overview)
 - Add provider-specific instrumentation from the Observability sidebar
-- Learn how traces become [scores](../scores/overview), [issues](../signals/overview), and [evaluations](../evaluations/overview)
+- Learn how traces become [scores](../scores/overview), [signals](../signals/overview), and [evaluations](../evaluations/overview)


### PR DESCRIPTION
## what this changes

Documents the New Signal builder (manual signal creation), which had no docs, and corrects pages that no longer matched the shipped product.

New pages:

- `signals/create` — the builder flow: describe-first AI generation vs. the manual wizard (Evaluation → Scope → Test → Details), when to define a signal instead of letting discovery find it, and what happens after creation (collects forward, editable, sampling 0 pauses).
- `evaluations/detection-methods` — the three ways a detector decides a match: a set of conditions (with the full 11-condition catalog), an LLM judge, and a custom script.
- `evaluations/custom-scripts` — the script API: the `session` object, the built-in verbs (`Score`/`Passed`/`Failed`, `semanticSimilarity`, `llm`, `parse`, `z`), the strength-vs-threshold return contract, the execution lanes and limits, and error handling.

Updated:

- `evaluations/overview`, `triggers`, `alignment` — the two ways an evaluation comes to exist (generated from a signal, or defined by you), and that a detector you define runs as written and is not auto-realigned to annotations.
- `signals/overview`, `signals/management`, `getting-started/concepts`, `quick-start-pm` — corrected the lifecycle to what ships. States are `new`/`escalating`/`ongoing`; the actions are mute/unmute (the Archived tab), monitor via Generate an evaluation, triage (assignee and priority), and delete. The previous New/Escalating/Resolved/Regressed/Ignored lifecycle and the Resolve/Ignore/keep-monitoring workflow describe behavior that isn't in the product.
- `monitors/overview` — the "Signal regressed" system monitor no longer claims a signal was "resolved" first (there is no Resolve action); it now describes re-detection after a signal goes quiet.

## terminology: Issues → Signals

The feature is called Signals, but ~30 docs still said "Issues." Renamed the feature references across scores, annotations, observability, search, security, deployment, and telemetry. The annotations API field in `scores/api.md` was documented as `issueId`; the shipped field is `signalId`, so that's corrected too.

Kept "issue" where it's correct: GitHub issues (contributing and upstream links), Linear issues (agent-dispatch/linear), generic "problem/bug" usages, the `ISSUE_DETAILS_GENERATOR` env var, and the intentional narrower sense ("a signal from a negative annotation is also called an issue") in concepts and how-to-use.

## scope notes

- Prose I authored or rewrote follows the docs voice. I did not restyle pre-existing em dashes in files that only got a one-word terminology swap (deployment, sandbox, and similar keep their existing style).
- Pre-existing and left as-is: three relative links in `observability/features/sandbox.mdx` (lines 79-81) resolve one directory too shallow. Unrelated to this change.
- `signals/create` has a screenshot placeholder (`{/* TODO */}`) for the builder intro; a real capture of the builder would help readers.

## validation

`docs.json` is valid JSON, internal doc links resolve (except the three pre-existing sandbox.mdx ones above), cross-page anchors resolve, and the new MDX compiles with no stray braces or tags.
