### PR TITLE
Fix Cursor agent dispatch

### DIFF
--- a/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
+++ b/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
@@ -444,7 +444,7 @@ export const connectCursorIntegration = createServerFn({ method: "POST" })
           organizationId: OrganizationId(organizationId),
           cursorApiKey: data.cursorApiKey,
         })
-        yield* upsertAgentDispatchConfigUseCase({
+        const config = yield* upsertAgentDispatchConfigUseCase({
           organizationId: OrganizationId(organizationId),
           projectId: ProjectId(data.projectId),
           integrationId: integration.id,
@@ -456,7 +456,7 @@ export const connectCursorIntegration = createServerFn({ method: "POST" })
             ...(data.startingRef ? { startingRef: data.startingRef } : {}),
           },
         })
-        return { integrationId: integration.id }
+        return { integrationId: integration.id, config: toConfigRecord(config) }
       }).pipe(withPostgres(agentDispatchLayer, client, organizationId), withTracing),
     )
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -862,7 +862,7 @@ function ConnectAgentDispatchModal({
           const parsed = z
             .object({ cursorApiKey: z.string().min(1), repoUrl: z.string().url(), startingRef: z.string().optional() })
             .parse(values)
-          await connectCursorIntegration({
+          const result = await connectCursorIntegration({
             data: {
               kind: "cursor",
               cursorApiKey: parsed.cursorApiKey,
@@ -871,6 +871,7 @@ function ConnectAgentDispatchModal({
               ...(parsed.startingRef ? { startingRef: parsed.startingRef } : {}),
             },
           })
+          queryClient.setQueryData(["agent-dispatch-config", projectId, kind], result.config)
         } else if (kind === "claude_code") {
           const parsed = z
             .object({
@@ -1409,7 +1410,7 @@ function AgentDispatchHistorySection({
         const errorDetail = getDispatchErrorDetail(dispatch)
 
         return (
-          <div className="flex min-w-0 items-start gap-1">
+          <div className="flex min-w-0 items-end gap-2">
             <div className="flex min-w-0 flex-col gap-1">
               <Badge variant={statusVariant} size="small" className="w-fit capitalize">
                 {dispatch.status}
@@ -1421,11 +1422,11 @@ function AgentDispatchHistorySection({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="h-7 w-7 shrink-0 p-0"
+                className="h-7 w-7 shrink-0 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
                 aria-label="View error details"
                 onClick={() => setErrorDetailModal({ title: errorTitle ?? "Error details", detail: errorDetail })}
               >
-                <FileText className="h-4 w-4" />
+                <Icon icon={FileText} size="sm" />
               </Button>
             ) : null}
           </div>

--- a/packages/platform/agent-dispatch/src/adapters/cursor-adapter.test.ts
+++ b/packages/platform/agent-dispatch/src/adapters/cursor-adapter.test.ts
@@ -2,19 +2,20 @@ import { describe, expect, it, vi } from "vitest"
 import { createCursorAdapter } from "./cursor-adapter.ts"
 
 describe("createCursorAdapter", () => {
-  it("posts agent mode payload and maps 409 to success", async () => {
-    const calls: { body: string; auth: string }[] = []
+  it("posts v1 agent payload with a deterministic Cursor agent id", async () => {
+    const calls: { url: string; body: string; auth: string }[] = []
     vi.stubGlobal(
       "fetch",
       vi.fn(async (_url: string, init?: RequestInit) => {
         calls.push({
+          url: _url,
           body: init?.body as string,
           auth: new Headers(init?.headers).get("Authorization") ?? "",
         })
         return new Response(
           JSON.stringify({
-            id: "bc_abc123",
-            target: { url: "https://cursor.com/agents?id=bc_abc123" },
+            agent: { id: "bc-abc123", url: "https://cursor.com/agents/bc-abc123" },
+            run: { id: "run-abc123" },
           }),
           { status: 200 },
         )
@@ -44,16 +45,59 @@ describe("createCursorAdapter", () => {
     )
 
     expect(result.status).toBe("accepted")
-    expect(result.externalAgentId).toBe("bc_abc123")
-    expect(result.deepLinkUrl).toBe("https://cursor.com/agents?id=bc_abc123")
+    expect(result.externalAgentId).toBe("bc-abc123")
+    expect(result.externalRunId).toBe("run-abc123")
+    expect(result.deepLinkUrl).toBe("https://cursor.com/agents/bc-abc123")
     const payload = calls[0] ?? {}
-    expect(JSON.parse(payload.body)).toMatchObject({
-      agentId: "cursor:incident.opened:src1",
+    expect(payload.url).toBe("https://api.cursor.com/v1/agents")
+    const body = JSON.parse(payload.body)
+    expect(body.agentId).toMatch(/^bc-[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    expect(body).toEqual({
+      agentId: body.agentId,
       prompt: { text: "fix it" },
-      source: { repository: "https://github.com/acme/app", ref: "main" },
-      target: { autoCreatePr: true },
+      repos: [{ url: "https://github.com/acme/app", startingRef: "main" }],
+      autoCreatePR: true,
     })
     expect(payload.auth.startsWith("Basic ")).toBe(true)
+
+    vi.unstubAllGlobals()
+  })
+
+  it("maps Cursor agent id conflicts to the deterministic agent", async () => {
+    let sentAgentId = ""
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        sentAgentId = JSON.parse(init?.body as string).agentId
+        return new Response(JSON.stringify({ error: "agent_id_conflict" }), { status: 409 })
+      }),
+    )
+
+    const adapter = createCursorAdapter()
+    const { Effect } = await import("effect")
+    const result = await Effect.runPromise(
+      adapter.dispatch({
+        idempotencyKey: "cursor:incident.opened:src1",
+        prompt: "fix it",
+        context: {
+          trigger: "incident.opened",
+          organizationName: "Acme",
+          projectName: "App",
+          projectSlug: "app",
+          deepLinkUrl: "https://example.com",
+        },
+        config: {
+          kind: "cursor",
+          repoUrl: "https://github.com/acme/app",
+          startingRef: "main",
+        },
+        credential: { cursorApiKey: "key123" },
+      }),
+    )
+
+    expect(result.status).toBe("accepted")
+    expect(result.externalAgentId).toBe(sentAgentId)
+    expect(result.deepLinkUrl).toBe(`https://cursor.com/agents/${sentAgentId}`)
 
     vi.unstubAllGlobals()
   })

--- a/packages/platform/agent-dispatch/src/adapters/cursor-adapter.ts
+++ b/packages/platform/agent-dispatch/src/adapters/cursor-adapter.ts
@@ -1,6 +1,15 @@
+import { createHash } from "node:crypto"
 import type { AgentDispatchAdapter } from "@domain/agent-dispatch"
 import { DispatchAdapterError } from "@domain/agent-dispatch"
 import { Effect } from "effect"
+
+const buildCursorAgentId = (idempotencyKey: string): string => {
+  const bytes = createHash("sha256").update(idempotencyKey).digest().subarray(0, 16)
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80
+  const hex = bytes.toString("hex")
+  return `bc-${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
 
 export const createCursorAdapter = (): AgentDispatchAdapter => ({
   kind: "cursor",
@@ -21,21 +30,17 @@ export const createCursorAdapter = (): AgentDispatchAdapter => ({
         startingRef?: string
         autoCreatePR?: boolean
       }
+      const agentId = buildCursorAgentId(idempotencyKey)
       const body = {
-        agentId: idempotencyKey,
+        agentId,
         prompt: { text: prompt },
-        source: {
-          repository: target.repoUrl,
-          ...(target.startingRef ? { ref: target.startingRef } : {}),
-        },
-        target: {
-          autoCreatePr: target.autoCreatePR ?? true,
-        },
+        repos: [{ url: target.repoUrl, ...(target.startingRef ? { startingRef: target.startingRef } : {}) }],
+        autoCreatePR: target.autoCreatePR ?? true,
       }
 
       const response = yield* Effect.tryPromise({
         try: () =>
-          fetch("https://api.cursor.com/v0/agents", {
+          fetch("https://api.cursor.com/v1/agents", {
             method: "POST",
             headers: {
               Authorization: `Basic ${btoa(`${apiKey}:`)}`,
@@ -60,13 +65,13 @@ export const createCursorAdapter = (): AgentDispatchAdapter => ({
             ? { externalAgentId: responseBody.id }
             : responseBody.agent?.id !== undefined
               ? { externalAgentId: responseBody.agent.id }
-              : {}),
+              : { externalAgentId: agentId }),
           ...(responseBody.run?.id !== undefined ? { externalRunId: responseBody.run.id } : {}),
           ...(responseBody.target?.url !== undefined
             ? { deepLinkUrl: responseBody.target.url }
             : responseBody.agent?.url !== undefined
               ? { deepLinkUrl: responseBody.agent.url }
-              : {}),
+              : { deepLinkUrl: `https://cursor.com/agents/${agentId}` }),
         }
       }
 


### PR DESCRIPTION
Fixes Cursor agent dispatch after Cursor started rejecting the legacy v0 create payload with an `agentId` field.

The Cursor adapter now uses the current `/v1/agents` create API and converts Latitude's idempotency key into a deterministic `bc-<uuid>` `agentId`, which keeps retry behavior idempotent while matching Cursor's accepted schema. `409 agent_id_conflict` is treated as an accepted dispatch for the deterministic agent.

Also fixes two UI issues in agent dispatch settings:

- The Cursor connect flow now returns the config created during connect and seeds the config query cache with it, so the selected repository and branch are immediately visible in Manage without needing a second save.
- The dispatch history error-details action is aligned with the error text and uses destructive styling.

Validation:

- `pnpm --filter @platform/agent-dispatch test -- src/adapters/cursor-adapter.test.ts`
- `pnpm --filter @platform/agent-dispatch typecheck`
- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- Manual QA confirmed the local app flow looks good.

UI change included: attach a screenshot or short screen recording of the dispatch history status cell if useful for reviewer context.