### PR TITLE
fix(web): validate signalId as a CUID in signals server functions

### DIFF
--- a/apps/web/src/domains/signals/signals.functions.test.ts
+++ b/apps/web/src/domains/signals/signals.functions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { signalTracesInputSchema } from "./signals.functions.ts"
+
+const VALID_SIGNAL_ID = "ssssssssssssssssssssssss"
+
+describe("signalTracesInputSchema", () => {
+  it("accepts a well-formed CUID signalId", () => {
+    const result = signalTracesInputSchema.safeParse({
+      projectId: "ssssssssssssssssssssssss",
+      signalId: VALID_SIGNAL_ID,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a signalId that is not a CUID", () => {
+    const result = signalTracesInputSchema.safeParse({
+      projectId: "ssssssssssssssssssssssss",
+      signalId: "structured-output-json-parse-failure",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects an empty signalId", () => {
+    const result = signalTracesInputSchema.safeParse({
+      projectId: "ssssssssssssssssssssssss",
+      signalId: "",
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -22,6 +22,7 @@ import {
   resolveSettings,
   SettingsReader,
   SignalId,
+  signalIdSchema,
 } from "@domain/shared"
 import {
   type ApplySignalLifecycleCommandResult,
@@ -169,7 +170,7 @@ export type SignalsListResultRecord = ReturnType<typeof toSignalsListResultRecor
 
 const signalRowMetricsInputSchema = z.object({
   projectId: z.string(),
-  signalIds: z.array(z.string()).min(1).max(100),
+  signalIds: z.array(signalIdSchema).min(1).max(100),
   timeRange: z
     .object({
       fromIso: z.iso.datetime().optional(),
@@ -190,7 +191,7 @@ export interface SignalRowMetricsRecord {
 
 const signalInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
 })
 
 const toSignalSummaryRecord = (issue: Signal) => ({
@@ -208,19 +209,19 @@ export type SignalSummaryRecord = ReturnType<typeof toSignalSummaryRecord>
 
 const signalDetailInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
 })
 
-const signalTracesInputSchema = z.object({
+export const signalTracesInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   limit: z.number().int().min(1).max(100).optional(),
   offset: z.number().int().min(0).optional(),
 })
 
 const signalImpactInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
 })
 
 export interface SignalImpactRecord {
@@ -238,7 +239,7 @@ export interface SignalImpactRecord {
 
 const updateSignalTriageInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   // `undefined` (key omitted) leaves the field unchanged; `null` clears it; a value sets it.
   assigneeId: z.string().nullable().optional(),
   priority: signalPrioritySchema.nullable().optional(),
@@ -254,18 +255,18 @@ const signalDimensionSchema = z.enum([
 
 const signalDimensionsInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   dimension: signalDimensionSchema,
 })
 
 const signalOccurrencesInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
 })
 
 const relatedSignalsInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
 })
 
 // Cap on how many pinpointed example occurrences the carousel loads. Examples
@@ -324,7 +325,7 @@ export type SignalDetailRecord = ReturnType<typeof toSignalDetailRecord>
 
 const signalLifecycleActionInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   command: signalLifecycleCommandSchema,
   keepMonitoring: z.boolean().optional(),
 })
@@ -846,7 +847,7 @@ export const listSignalSessions = createServerFn({ method: "GET" })
   })
 
 export const countSignalSessions = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), signalId: z.string() }))
+  .inputValidator(z.object({ projectId: z.string(), signalId: signalIdSchema }))
   .handler(async ({ data }): Promise<number> => {
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
@@ -1370,7 +1371,7 @@ export const createSignal = createServerFn({ method: "POST" })
 
 const updateSignalInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   name: z.string().min(1).optional(),
   description: z.string().min(1).optional(),
   filters: filterSetSchema.nullable().optional(),
@@ -1403,7 +1404,7 @@ export const updateSignal = createServerFn({ method: "POST" })
 
 const updateSignalEvaluationInputSchema = z.object({
   projectId: z.string(),
-  signalId: z.string(),
+  signalId: signalIdSchema,
   evaluation: evaluationDraftSchema,
   sampling: z.number().int().min(0).max(100).optional(),
 })
@@ -1437,7 +1438,7 @@ export const updateSignalEvaluation = createServerFn({ method: "POST" })
     },
   )
 
-const deleteSignalInputSchema = z.object({ projectId: z.string(), signalId: z.string() })
+const deleteSignalInputSchema = z.object({ projectId: z.string(), signalId: signalIdSchema })
 
 /** Soft-deletes a signal and archives its evaluation. */
 export const deleteSignal = createServerFn({ method: "POST" })


### PR DESCRIPTION
## What does this PR do?

Fixes a production crash surfaced in Datadog Error Tracking: [`596d8076-7a0c-11f1-8afa-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/596d8076-7a0c-11f1-8afa-da7ad0900005) — `RepositoryError: Too large value for FixedString(24): value structured-output-json-parse-failure cannot be parsed as FixedString(24) for query parameter 'signalId'` in `web` (`GET`, `listSignalSessions`).

**Root cause:** every input schema in `apps/web/src/domains/signals/signals.functions.ts` (~13 of them) validated `signalId`/`signalIds` as a bare `z.string()`, then cast it through the unchecked `SignalId()` helper (`(value: string): SignalId => value as SignalId` — a type-cast, not a validator) before passing it straight into `ScoreAnalyticsRepository`/`ScoreRepository` calls. Several of those repository methods (`listSessionsBySignal`, `countSessionsBySignal`, `listTracesBySignal`, `countTracesBySignal`, `trendBySignal`) query ClickHouse columns typed `FixedString(24)`. Any malformed `signalId` — e.g. a stale/bad deep-link query param — skipped the `signalIdSchema` (CUID) validation already used everywhere else in the domain layer (`packages/domain/signals/src/use-cases/{update-signal,delete-signal,apply-signal-lifecycle-command,list-signals}.ts`) and reached the ClickHouse driver raw, throwing an unhandled `RepositoryError` instead of a clean 400.

This wasn't a one-off: the same unchecked `z.string()` → `SignalId()` pattern appeared at every sibling call site in the file (`getSignalRowMetrics`, `listSignalSessions`, `countSignalSessions`, `getSignalImpact`, `getSignalDimensions`, `getRelatedSignals`, `getSignalOccurrences`, `updateSignalTriage`, `applySignalLifecycleAction`, `updateSignal`, `updateSignalEvaluation`, `deleteSignal`), so the fix replaces `z.string()`/`z.array(z.string())` with the existing `signalIdSchema`/`z.array(signalIdSchema)` (`cuidSchema.transform(SignalId)`) across all of them, matching the convention already established in the domain layer. No behavior changes for well-formed IDs; malformed ones now fail fast with a validation error at the server-function boundary instead of a raw infra exception downstream.

## Related issue (if applicable)

Datadog Error Tracking issue: https://app.datadoghq.eu/error-tracking/issue/596d8076-7a0c-11f1-8afa-da7ad0900005 (first seen 2026-07-07, low volume so far — new regression, not yet an open GitHub issue)

Closes #

## How was this tested?

- Added `apps/web/src/domains/signals/signals.functions.test.ts`, exercising `signalTracesInputSchema` (used by the crashing `listSignalSessions` function): accepts a well-formed CUID, rejects the exact malformed value from the Datadog error (`structured-output-json-parse-failure`) and an empty string.
- Confirmed the new tests **fail** against the pre-fix schema (temporarily reverted `signalId` to `z.string()`) and **pass** with the fix restored.
- `pnpm --filter web typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.
- `pnpm --filter web exec vitest run src/domains/signals` — all 13 tests pass, no regressions in the existing signals test suite.

**Verification in production:** after deploy, occurrences of Datadog issue `596d8076-7a0c-11f1-8afa-da7ad0900005` should stop; any future malformed `signalId` will surface as a clean 400 validation error rather than an unhandled `RepositoryError`.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01AmwWE7kpvpNYbbmRzEJVDd)_