### PR TITLE
Improve signal dispatch prompt fallback

### DIFF
--- a/packages/domain/agent-dispatch/src/helpers/render-prompt.test.ts
+++ b/packages/domain/agent-dispatch/src/helpers/render-prompt.test.ts
@@ -42,6 +42,9 @@ describe("renderDispatchPrompt", () => {
     expect(prompt).not.toContain("Severity:")
     expect(prompt).not.toContain("Tags:")
     expect(prompt).toContain("If Latitude MCP tools are available")
+    expect(prompt).toContain("suggest installing the Latitude MCP server")
+    expect(prompt).toContain("do not make speculative code changes")
+    expect(prompt).toContain("Do not mute or resolve the signal")
   })
 
   it("includes sample conversation excerpts", () => {

--- a/packages/domain/agent-dispatch/src/helpers/render-prompt.ts
+++ b/packages/domain/agent-dispatch/src/helpers/render-prompt.ts
@@ -93,9 +93,11 @@ const renderDefaultPrompt = (context: AgentDispatchContext): string => {
 
   lines.push(
     "",
-    "If Latitude MCP tools are available in your environment, use them to inspect the signal and additional member traces. If they are not available, use the Latitude URL, trace IDs, and excerpts above as your starting evidence.",
+    "If Latitude MCP tools are available in your environment, use them to inspect the signal and additional member traces. If they are not available, use the Latitude URL, trace IDs, and excerpts above as your starting evidence, and suggest installing the Latitude MCP server to improve future signal root-cause debugging.",
     "",
     "Identify the most likely root cause in this repository, implement the smallest correct fix, add a regression test if applicable, and open a PR describing the signal and the fix.",
+    "",
+    "If you cannot determine a concrete repo-level root cause, do not make speculative code changes and do not open a PR. Instead, return a concise investigation summary with the evidence reviewed, the best-supported explanation, remaining hypotheses, and the next data needed to confirm the cause.",
     "",
     "Do not mute or resolve the signal — a human verifies after deploy.",
   )


### PR DESCRIPTION
Updates the default signal dispatch prompt so Cursor agents do not open PRs or make speculative changes when they cannot determine a concrete repo-level root cause. The prompt now asks for an investigation summary in that case and suggests installing the Latitude MCP server when it is unavailable, while still allowing the agent to use the existing URL, trace IDs, and excerpts as fallback evidence.\n\nTested with `pnpm --filter @domain/agent-dispatch test`.