### PR TITLE
fix(gateway): return accumulated run cost/usage in sync run API response

### DIFF
--- a/apps/gateway/src/presenters/runPresenter.ts
+++ b/apps/gateway/src/presenters/runPresenter.ts
@@ -7,13 +7,28 @@ import {
   StreamType,
 } from '@latitude-data/constants'
 import { LatitudeError } from '@latitude-data/constants/errors'
+import { CostBreakdown, totalCost } from '@latitude-data/constants/costs'
 import { Result, TypedResult } from '@latitude-data/core/lib/Result'
 
+/**
+ * Builds the synchronous run API response.
+ *
+ * When available, `cost` and `usage` are taken from the accumulated run totals
+ * (`runCost` / `runUsage`), which include every step and sub-agent LLM call in
+ * the run. This matches what the Traces tab reports. The last step's
+ * `response.cost` / `response.usage` only reflect the final completion and
+ * under-report runs that use sub-prompts, so they are used only as a fallback
+ * (e.g. when attaching to a background run, where the totals are not available).
+ */
 export function runPresenter({
   response,
+  runCost,
+  runUsage,
   source,
 }: {
   response: ChainStepResponse<StreamType>
+  runCost?: CostBreakdown
+  runUsage?: ChainStepResponse<StreamType>['usage']
   source?: PromptSource
 }): TypedResult<RunSyncAPIResponse<AssertedStreamType>, LatitudeError> {
   const conversation = response.input
@@ -36,7 +51,7 @@ export function runPresenter({
     uuid: uuid!,
     conversation: conversation!,
     response: {
-      cost: response.cost,
+      cost: runCost ? totalCost(runCost) : response.cost,
       input: response.input,
       model: response.model,
       object: type === 'object' ? response.object : undefined,
@@ -45,7 +60,7 @@ export function runPresenter({
       streamType: type,
       text: response.text,
       toolCalls: type === 'text' ? response.toolCalls : [],
-      usage: response.usage!,
+      usage: runUsage ?? response.usage!,
     },
     source,
   })

--- a/apps/gateway/src/routes/api/v3/conversations/chat/chat.handler.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/chat/chat.handler.ts
@@ -78,9 +78,15 @@ export const chatHandler: AppRouteHandler<ChatRoute> = async (c) => {
   if (error) throw error
 
   const response = (await result.response)!
+  const [runUsage, runCost] = await Promise.all([
+    result.runUsage,
+    result.runCost,
+  ])
 
   const body = runPresenter({
     response,
+    runCost,
+    runUsage,
     source: undefined,
   }).unwrap()
 

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.test.ts
@@ -26,7 +26,11 @@ import { Project } from '@latitude-data/core/schema/models/types/Project'
 import { ProviderApiKey } from '@latitude-data/core/schema/models/types/ProviderApiKey'
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
 import { generateUUIDIdentifier } from '@latitude-data/core/lib/generateUUID'
-import { estimateCost } from '@latitude-data/core/services/ai/estimateCost/index'
+import {
+  estimateCost,
+  estimateCostBreakdown,
+} from '@latitude-data/core/services/ai/estimateCost/index'
+import { totalCost } from '@latitude-data/constants/costs'
 import { Providers } from '@latitude-data/constants'
 
 const MODEL = 'gpt-4o'
@@ -841,6 +845,113 @@ describe('POST /run', () => {
           model: MODEL,
           provider: Providers.OpenAI,
           cost: expectedCost,
+        },
+        source: {
+          commitUuid: commit.uuid,
+          documentUuid: expect.any(String),
+        },
+      })
+    })
+
+    it('returns accumulated run cost and usage (all steps + sub-agents), not the last step', async () => {
+      const documentLogUuid = generateUUIDIdentifier()
+
+      // The final chain step only reflects the last completion...
+      const lastStepUsage = {
+        promptTokens: 4,
+        completionTokens: 6,
+        totalTokens: 10,
+        inputTokens: 4,
+        outputTokens: 6,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      }
+      const lastStepCost = estimateCost({
+        provider: provider.provider,
+        model: MODEL,
+        usage: lastStepUsage,
+      })
+
+      // ...while the run totals sum every step and sub-agent LLM call.
+      const runUsage = {
+        promptTokens: 12,
+        completionTokens: 18,
+        totalTokens: 30,
+        inputTokens: 12,
+        outputTokens: 18,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      }
+      const runCost = estimateCostBreakdown({
+        provider: provider.provider,
+        model: MODEL,
+        usage: runUsage,
+      })
+      const expectedRunCost = totalCost(runCost)
+
+      // Guard: the fix only matters if the accumulated total differs from the
+      // last step. If these were equal the test would pass trivially.
+      expect(expectedRunCost).toBeGreaterThan(lastStepCost)
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            event: StreamEventTypes.Latitude,
+            data: { type: ChainEventTypes.ChainCompleted },
+          })
+          controller.close()
+        },
+      })
+
+      mocks.resolveAbTestRouting.mockResolvedValue({
+        abTest: null,
+        effectiveCommit: commit,
+        effectiveDocument: document,
+        effectiveSource: LogSources.API,
+      })
+
+      mocks.runForegroundDocument.mockReturnValue(
+        Promise.resolve({
+          stream,
+          error: Promise.resolve(undefined),
+          getFinalResponse: async () => ({
+            response: {
+              streamType: 'text',
+              text: 'Hello',
+              toolCalls: [],
+              usage: lastStepUsage,
+              documentLogUuid,
+              input: responseMessages,
+              model: MODEL,
+              provider: Providers.OpenAI,
+              cost: lastStepCost,
+            },
+            provider,
+            runUsage,
+            runCost,
+          }),
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body,
+        headers,
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        uuid: documentLogUuid,
+        conversation: responseMessages,
+        response: {
+          streamType: 'text',
+          usage: runUsage,
+          text: 'Hello',
+          toolCalls: [],
+          input: responseMessages,
+          model: MODEL,
+          provider: Providers.OpenAI,
+          cost: expectedRunCost,
         },
         source: {
           commitUuid: commit.uuid,

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.ts
@@ -290,6 +290,8 @@ async function handleForegroundRun({
 
   const body = runPresenter({
     response: finalResponse.response!,
+    runCost: finalResponse.runCost,
+    runUsage: finalResponse.runUsage,
     source: {
       documentUuid: document.documentUuid,
       commitUuid: commit.uuid,

--- a/packages/core/src/services/commits/foregroundRun.test.ts
+++ b/packages/core/src/services/commits/foregroundRun.test.ts
@@ -74,6 +74,12 @@ describe('runForegroundDocument', () => {
           id: provider.id,
           name: provider.name,
         }),
+        runUsage: Promise.resolve({
+          promptTokens: 12,
+          completionTokens: 18,
+          totalTokens: 30,
+        }),
+        runCost: Promise.resolve({ 'openai/gpt-4o': { cost: 123 } }),
       }) as any,
     )
 
@@ -229,6 +235,27 @@ describe('runForegroundDocument', () => {
           name: provider.name,
         }),
       )
+    })
+
+    it('should return accumulated run usage and cost', async () => {
+      const result = await runForegroundDocument({
+        workspace,
+        document,
+        commit,
+        project,
+        parameters: {},
+        source: LogSources.API,
+        tools: [],
+      })
+
+      const finalResponse = await result.getFinalResponse()
+
+      expect(finalResponse.runUsage).toEqual({
+        promptTokens: 12,
+        completionTokens: 18,
+        totalTokens: 30,
+      })
+      expect(finalResponse.runCost).toEqual({ 'openai/gpt-4o': { cost: 123 } })
     })
 
     it('should throw error if stream error occurs', async () => {

--- a/packages/core/src/services/commits/foregroundRun.ts
+++ b/packages/core/src/services/commits/foregroundRun.ts
@@ -33,6 +33,8 @@ export type RunForegroundDocumentResult = {
   getFinalResponse: () => Promise<{
     response: Awaited<RunResult['lastResponse']>
     provider: Awaited<RunResult['provider']>
+    runUsage: Awaited<RunResult['runUsage']>
+    runCost: Awaited<RunResult['runCost']>
   }>
 }
 
@@ -120,7 +122,12 @@ export async function runForegroundDocument(
         throw new LatitudeError('Provider not found in stream result')
       }
 
-      return { response, provider }
+      const [runUsage, runCost] = await Promise.all([
+        result.runUsage,
+        result.runCost,
+      ])
+
+      return { response, provider, runUsage, runCost }
     },
   }
 }


### PR DESCRIPTION
## Problem

The synchronous **run** and **chat** API responses report `cost` and `usage` from the **last chain step only** (`response.cost` / `response.usage`).

For prompts that fan out into multiple steps or **sub-agents (sub-prompts)**, this under-reports the true cost of the run — it only reflects the final completion. Meanwhile the **Traces** tab sums *every* completion span in the trace, so the two numbers don't match. A customer trying to build per-tenant cost accounting from the API response (pairing their `customIdentifier` with the returned cost) gets values much lower than reality.

## Root cause

- `runPresenter` returns `response.cost` / `response.usage`, which is a single `ChainStepResponse` — the last step (`runPresenter.ts`).
- The `StreamManager` already tracks the correct accumulated totals: `runCost` / `runUsage` (all steps + all sub-agent LLM calls). The **background run job already uses these** (`backgroundRunJob.ts`) — only the sync/foreground path was left on the last-step values.

## Fix

- **`foregroundRun`**: `getFinalResponse()` now also resolves and returns `runUsage` / `runCost`.
- **run + chat handlers**: pass the run totals into `runPresenter` (chat gets them from `addMessages`, which already exposes them).
- **`runPresenter`**: prefer `runCost` (summed via `totalCost`) / `runUsage`, falling back to the last-step values when they're not available (e.g. `attach.handler`, which only has the `ChainCompleted` event data from a background run's stream).

Single-call prompts are unaffected (`runCost === last step cost`); only multi-step / sub-agent runs change — which is the bug. This makes the sync API cost/usage match the Traces tab and be usable for per-run / per-tenant billing.

## Known follow-up (out of scope)

`attach.handler` (attaching to a **background** run) still falls back to the last-step values, because the accumulated totals aren't carried in the `ChainCompleted` event stream. Fully fixing that path requires propagating `runCost`/`runUsage` through the event contract — left as a follow-up. Foreground `run` (the reported customer case) is fully fixed.

## Testing

- `pnpm tc` — passes across all packages
- `apps/gateway` `run.handler.test.ts` (25) + `conversations` chat/attach tests (22) — pass
- `packages/core` `foregroundRun.test.ts` (6) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)