### PR TITLE
Fix OAuth token validation to enforce live organization membership

### DIFF
--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
@@ -225,6 +225,25 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, N
     expect(result).toBeNull()
   })
 
+  it("returns null when the token user is not a member at initial DB lookup", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+      createMembership: false,
+    })
+
+    const redis = createFakeRedis()
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(result).toBeNull()
+  })
+
   it("returns null after the token user is removed from the bound org", async () => {
     const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
     const setup = await insertOAuthSetup(database.postgresDb, {

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
@@ -1,10 +1,11 @@
 import { generateId } from "@domain/shared"
 import type { RedisClient } from "@platform/cache-redis"
-import type { PostgresDb } from "@platform/db-postgres"
-import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { and, eq, type PostgresDb } from "@platform/db-postgres"
+import { members, oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
 import {
   closeInMemoryPostgres,
   createInMemoryPostgres,
+  createMembershipFixture,
   createOrganizationFixture,
   createUserFixture,
   type InMemoryPostgres,
@@ -50,6 +51,7 @@ interface InsertOAuthSetupOptions {
   /** Default: 5 minutes from now. */
   readonly accessTokenExpiresAt?: Date
   readonly scopes?: string
+  readonly createMembership?: boolean
 }
 
 /**
@@ -90,6 +92,16 @@ const insertOAuthSetup = async (db: PostgresDb, options: InsertOAuthSetupOptions
     userId,
     scopes: options.scopes ?? "openid profile",
   })
+
+  if (options.organizationId !== null && options.createMembership !== false) {
+    await Effect.runPromise(
+      createMembershipFixture(db, {
+        organizationId: options.organizationId,
+        userId,
+        role: "member",
+      }),
+    )
+  }
 
   return {
     accessToken,
@@ -211,6 +223,35 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, N
     )
 
     expect(result).toBeNull()
+  })
+
+  it("returns null after the token user is removed from the bound org", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+    })
+
+    const redis = createFakeRedis()
+    const beforeRemoval = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+    expect(beforeRemoval?.userId).toBe(setup.userId)
+
+    await database.postgresDb
+      .delete(members)
+      .where(and(eq(members.organizationId, organization.id), eq(members.userId, setup.userId)))
+
+    const afterRemoval = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(afterRemoval).toBeNull()
   })
 
   it("serves a cached result without calling onTokenValidated again", async () => {

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
@@ -3,8 +3,8 @@ import type { RedisClient } from "@platform/cache-redis"
 // `eq` is re-exported by `@platform/db-postgres` to keep all consumers on one
 // drizzle-orm version (peer-dep collisions cause private-property typecheck
 // errors otherwise).
-import { eq, type PostgresClient } from "@platform/db-postgres"
-import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { and, eq, type PostgresClient } from "@platform/db-postgres"
+import { members, oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
 import { hash } from "@repo/utils"
 import { Effect, Layer } from "effect"
 
@@ -182,9 +182,24 @@ const lookupByToken = (client: PostgresClient, token: string): Promise<DbRow | u
     })
     .from(oauthAccessTokens)
     .innerJoin(oauthApplications, eq(oauthApplications.clientId, oauthAccessTokens.clientId))
+    .innerJoin(
+      members,
+      and(
+        eq(members.organizationId, oauthApplications.organizationId),
+        eq(members.userId, oauthAccessTokens.userId),
+      ),
+    )
     .where(eq(oauthAccessTokens.accessToken, token))
     .limit(1)
     .then((rows) => rows[0])
+
+const hasLiveMembership = (client: PostgresClient, userId: string, organizationId: string): Promise<boolean> =>
+  client.db
+    .select({ id: members.id })
+    .from(members)
+    .where(and(eq(members.organizationId, organizationId), eq(members.userId, userId)))
+    .limit(1)
+    .then((rows) => rows.length > 0)
 
 /**
  * Parse a BA-stored `scopes` text field (space-separated per RFC 6749 §3.3)
@@ -228,6 +243,7 @@ export interface ValidateOAuthAccessTokenDeps {
  *
  * Validation rules (any one rejects the token):
  *   - row not found
+ *   - token user is no longer a member of the bound organization
  *   - `accessTokenExpiresAt < now()`
  *   - `oauth_applications.disabled = true`
  *   - `oauth_applications.organization_id IS NULL` (registered but never
@@ -264,6 +280,18 @@ export const validateOAuthAccessToken = (
         yield* invalidateCache(redis, tokenHash)
         // Fall through to the DB path so we don't return stale-expired.
       } else {
+        if (cached !== null) {
+          const isMember = yield* Effect.tryPromise({
+            try: () => hasLiveMembership(adminClient, cached.userId, cached.organizationId),
+            catch: () => false,
+          }).pipe(Effect.orDie)
+          if (!isMember) {
+            yield* invalidateCache(redis, tokenHash)
+            yield* cache(redis, tokenHash, null, INVALID_TOKEN_TTL_SECONDS)
+            yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+            return null
+          }
+        }
         yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
         return cached
       }

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
@@ -247,6 +247,9 @@ export interface ValidateOAuthAccessTokenDeps {
  *     consent-bound to an org — the `/auth/consent` step never happened or
  *     was abandoned)
  *
+ * On cache hits, membership is re-verified live so revocation takes effect on
+ * the next request rather than waiting for cache TTL (~300 s) to expire.
+ *
  * The DB query uses the admin Postgres connection (RLS-bypass) because
  * `oauth_applications` has RLS scoped by `organization_id` and the org id
  * is exactly what we're trying to discover from the token.
@@ -278,6 +281,7 @@ export const validateOAuthAccessToken = (
         // Fall through to the DB path so we don't return stale-expired.
       } else {
         if (cached !== null) {
+          // catch → error channel; Effect.orDie makes DB errors defects, not a silent false fallback.
           const isMember = yield* Effect.tryPromise({
             try: () => hasLiveMembership(adminClient, cached.userId, cached.organizationId),
             catch: () => false,

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
@@ -184,10 +184,7 @@ const lookupByToken = (client: PostgresClient, token: string): Promise<DbRow | u
     .innerJoin(oauthApplications, eq(oauthApplications.clientId, oauthAccessTokens.clientId))
     .innerJoin(
       members,
-      and(
-        eq(members.organizationId, oauthApplications.organizationId),
-        eq(members.userId, oauthAccessTokens.userId),
-      ),
+      and(eq(members.organizationId, oauthApplications.organizationId), eq(members.userId, oauthAccessTokens.userId)),
     )
     .where(eq(oauthAccessTokens.accessToken, token))
     .limit(1)


### PR DESCRIPTION
## Summary
Previously, an OAuth access token issued to a user who was subsequently removed from their organization would continue to pass validation until the Redis cache entry expired (up to 5 minutes). This PR closes that window with two complementary changes:

1. **INNER JOIN members in lookupByToken** - on initial DB lookup, any token whose user is no longer a member of the bound organization returns no row and is immediately rejected, caching a null for 5 seconds.
2. **Live membership re-check on every cache hit** - after a valid result is retrieved from cache, hasLiveMembership is called against Postgres before returning it. If the user has been removed since the cache was populated, the cache entry is invalidated, a null is written in its place, and the request is rejected. This limits the effective revocation window to a single DB query rather than the full ~300 s TTL.