### PR TITLE
test(core): prove run cost/usage accumulates across steps end-to-end

### DIFF
--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -18,6 +18,8 @@ import {
   telemetry as realTelemetry,
   type LatitudeTelemetry,
 } from '../../telemetry'
+import { estimateCost } from '../ai/estimateCost'
+import { totalCost } from '@latitude-data/constants/costs'
 
 const mocks = {
   publish: vi.fn(),
@@ -446,6 +448,89 @@ model: gpt-4o
       })
 
       expect(foundExtraUserMessage).toBe(false)
+    })
+  })
+
+  describe('accumulated run cost/usage (basis for the sync run API response)', () => {
+    // gpt-4o, non-zero usage per step so a real cost is computed.
+    const PER_STEP_USAGE = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: 0,
+      cachedInputTokens: 0,
+    }
+
+    function mockAiWithUsage() {
+      return vi.fn(async () => {
+        const fullStream = new ReadableStream({
+          start(controller) {
+            controller.close()
+          },
+        })
+        return Result.ok({
+          type: 'text',
+          text: Promise.resolve('Fake AI generated text'),
+          providerLog: Promise.resolve({ uuid: 'fake-provider-log-uuid' }),
+          usage: Promise.resolve(PER_STEP_USAGE),
+          toolCalls: Promise.resolve([]),
+          response: Promise.resolve({ messages: [] }),
+          fullStream,
+        })
+      })
+    }
+
+    it('sums cost/usage across every step, exceeding the last-step response cost', async () => {
+      const runAiWithUsage = mockAiWithUsage()
+      // @ts-expect-error - we are mocking the function
+      aiSpy.mockImplementation(runAiWithUsage)
+
+      // dummyDoc1Content has two <step> blocks -> two provider calls.
+      const { context, workspace, document, commit, provider } =
+        await buildData({ doc1Content: dummyDoc1Content })
+
+      const result = await runDocumentAtCommit({
+        context,
+        workspace,
+        document,
+        commit,
+        parameters: {},
+        source: LogSources.API,
+        customIdentifier: 'tenant-abc',
+      }).then((r) => r.unwrap())
+
+      const lastResponse = await result.lastResponse
+      const runUsage = await result.runUsage
+      const runCost = await result.runCost
+
+      // The chain executed two steps -> ai() was called twice.
+      expect(runAiWithUsage).toHaveBeenCalledTimes(2)
+
+      // Accumulated usage is the sum of both steps.
+      expect(runUsage.promptTokens).toBe(PER_STEP_USAGE.inputTokens * 2)
+      expect(runUsage.completionTokens).toBe(PER_STEP_USAGE.outputTokens * 2)
+
+      // Cost of a single step -> this is what the API used to return
+      // (response.cost = last step only).
+      const perStepCost = estimateCost({
+        provider: provider.provider,
+        model: 'gpt-4o',
+        usage: {
+          inputTokens: PER_STEP_USAGE.inputTokens,
+          outputTokens: PER_STEP_USAGE.outputTokens,
+          promptTokens: PER_STEP_USAGE.inputTokens,
+          completionTokens: PER_STEP_USAGE.outputTokens,
+          totalTokens: PER_STEP_USAGE.totalTokens,
+          reasoningTokens: 0,
+          cachedInputTokens: 0,
+        },
+      })
+
+      // The accumulated run cost sums both steps...
+      expect(totalCost(runCost)).toBeCloseTo(perStepCost * 2)
+      // ...while the last step alone (the old response.cost) under-reports it.
+      expect(lastResponse!.cost).toBeCloseTo(perStepCost)
+      expect(totalCost(runCost)).toBeGreaterThan(lastResponse!.cost)
     })
   })
 })


### PR DESCRIPTION
## Why

Follow-up test coverage for #3914 (already merged). That PR made the sync run API return the **accumulated** `runCost`/`runUsage` instead of the last chain step's cost. Its tests assert the *handler* forwards those values, but nothing exercised the **accumulation itself** through a real chain — the mechanism the fix depends on.

## What

Adds one integration test in `runDocumentAtCommit.test.ts` that runs a real **two-step** chain (real `streamManager` + chain; only `ai()` mocked, emitting non-zero usage per step) and asserts:

- `ai()` is called once per step (two calls)
- `runUsage` sums both steps (`promptTokens`/`completionTokens` = 2× per-step)
- `totalCost(runCost)` ≈ 2× the single-step cost
- `lastResponse.cost` ≈ 1× the single-step cost — i.e. the value the API returned **before** #3914 under-reports the true run cost

This is the end-to-end demonstration of the bug #3914 fixes (last-step cost vs whole-run cost), which matters most for prompts with sub-agents / multiple steps.

## Testing

- `packages/core` `runDocumentAtCommit.test.ts`: **10 passed** (1 new).
- `pnpm tc`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)