### PR TITLE
perf(flaggers): normalize instruction-extractor cache key and raise verbatim threshold

### DIFF
--- a/packages/domain/flaggers/src/constants.ts
+++ b/packages/domain/flaggers/src/constants.ts
@@ -34,6 +34,8 @@ export const FLAGGER_DEFAULT_ANNOTATOR_MODEL = {
   maxTokens: 2048,
 } as const
 
+export const FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS = 6_000
+
 export const FLAGGER_DRAFT_DEFAULTS = {
   passed: false,
   value: 0,

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -21,7 +21,11 @@ import { createFakeTraceRepository } from "@domain/spans/testing"
 import { Cause, Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { FLAGGER_DEFAULT_CLASSIFIER_MODEL, FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL } from "../constants.ts"
+import {
+  FLAGGER_DEFAULT_CLASSIFIER_MODEL,
+  FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL,
+  FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS,
+} from "../constants.ts"
 import type { Flagger } from "../entities/flagger.ts"
 import { FlaggerRepository } from "../ports/flagger-repository.ts"
 import { createFakeFlaggerRepository } from "../testing/fake-flagger-repository.ts"
@@ -332,6 +336,48 @@ describe("runFlaggerUseCase", () => {
     expect(calls.generate).toHaveLength(0)
   })
 
+  it("keeps mid-size inspected system prompts verbatim without invoking the instruction extractor", async () => {
+    const midSizeSystemPrompt =
+      `You are a mid-size billing support assistant. ${"Follow the escalation policy and cite the relevant policy section. ".repeat(35)}`.trim()
+    expect(midSizeSystemPrompt.length).toBeGreaterThan(1200)
+    expect(midSizeSystemPrompt.length).toBeLessThanOrEqual(FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS)
+
+    const systemInstructions = [
+      { type: "text", content: midSizeSystemPrompt },
+    ] satisfies TraceDetail["systemInstructions"]
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        if (input.system.includes("You extract agent context")) {
+          return Effect.die("Instruction extractor must not run for mid-size verbatim prompts")
+        }
+        return Effect.succeed({ object: { matched: false } as T, tokens: 20, duration: 90_000_000 })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      classifyTraceForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        traceId: INPUT.traceId,
+        flaggerSlug: "laziness",
+        trace: makeTraceDetail(
+          [
+            { role: "user", parts: [{ type: "text", content: "Create the dashboard." }] },
+            { role: "assistant", parts: [{ type: "text", content: "Here is the dashboard." }] },
+          ],
+          [],
+          systemInstructions,
+        ),
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, defaultCacheLayer))),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate.filter((call) => call.system?.includes("You extract agent context"))).toHaveLength(0)
+    expect(calls.generate[0].prompt).toContain("EVALUATED AGENT SYSTEM PROMPT:")
+    expect(calls.generate[0].prompt).toContain(midSizeSystemPrompt)
+  })
+
   it("extracts context for long inspected system prompts before classification", async () => {
     const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(400)}`
     const systemInstructions = [{ type: "text", content: longSystemPrompt }] satisfies TraceDetail["systemInstructions"]
@@ -557,6 +603,53 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     const extractorCalls = calls.generate.filter((call) => call.system?.includes("You extract agent context"))
     expect(extractorCalls).toHaveLength(1)
     expect(calls.generate).toHaveLength(3)
+  })
+
+  it("sends the raw un-normalized system prompt to the instruction extractor even though the cache key is normalized", async () => {
+    const uuid = "123e4567-e89b-12d3-a456-426614174000"
+    const timestamp = "2026-07-08T12:34:56.789Z"
+    const longSystemPrompt = `You are a dashboard design assistant handling request ${uuid} at ${timestamp}. ${"Detailed rubric. ".repeat(400)}`
+    const systemInstructions = [{ type: "text", content: longSystemPrompt }] satisfies TraceDetail["systemInstructions"]
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        if (input.system.includes("You extract agent context")) {
+          return Effect.succeed({
+            object: {
+              understood: true,
+              agentContext: "This agent is a dashboard design assistant that should create dashboard designs.",
+            } as T,
+            tokens: 20,
+            duration: 90_000_000,
+          })
+        }
+
+        return Effect.succeed({ object: { matched: false } as T, tokens: 20, duration: 90_000_000 })
+      },
+    })
+
+    const result = await Effect.runPromise(
+      classifyTraceForFlaggerUseCase({
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        traceId: INPUT.traceId,
+        flaggerSlug: "laziness",
+        trace: makeTraceDetail(
+          [
+            { role: "user", parts: [{ type: "text", content: "Create the dashboard." }] },
+            { role: "assistant", parts: [{ type: "text", content: "Here is the dashboard." }] },
+          ],
+          [],
+          systemInstructions,
+        ),
+      }).pipe(Effect.provide(Layer.mergeAll(aiLayer, defaultCacheLayer))),
+    )
+
+    expect(result).toEqual({ matched: false })
+    const extractorCall = calls.generate.find((call) => call.system?.includes("You extract agent context"))
+    expect(extractorCall?.prompt).toContain(uuid)
+    expect(extractorCall?.prompt).toContain(timestamp)
+    expect(normalizeSystemPromptForCacheKey(longSystemPrompt)).not.toContain(uuid)
   })
 
   it("stamps the LLM call with the no-reflag tag when the trace is itself flagger-generated", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -25,7 +25,12 @@ import { FLAGGER_DEFAULT_CLASSIFIER_MODEL, FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR
 import type { Flagger } from "../entities/flagger.ts"
 import { FlaggerRepository } from "../ports/flagger-repository.ts"
 import { createFakeFlaggerRepository } from "../testing/fake-flagger-repository.ts"
-import { classifyTraceForFlaggerUseCase, type RunFlaggerInput, runFlaggerUseCase } from "./run-flagger.ts"
+import {
+  classifyTraceForFlaggerUseCase,
+  normalizeSystemPromptForCacheKey,
+  type RunFlaggerInput,
+  runFlaggerUseCase,
+} from "./run-flagger.ts"
 
 const INPUT: RunFlaggerInput = {
   organizationId: "a".repeat(24),
@@ -150,6 +155,36 @@ function createMemoryCacheLayer(initialEntries: ReadonlyMap<string, string> = ne
     }),
   }
 }
+
+describe("normalizeSystemPromptForCacheKey", () => {
+  it("normalizes volatile dates, uuids, ids, and emails to the same placeholders", () => {
+    const promptA =
+      "You are a support agent for org 123e4567-e89b-12d3-a456-426614174000. Request received at 2026-07-08T12:34:56.789Z from user 4009876543210987, contact jane.doe@example.com."
+    const promptB =
+      "You are a support agent for org 550e8400-e29b-41d4-a716-446655440000. Request received at 2026-07-09 01:02:03 from user 1122334455667788, contact john.smith@example.org."
+
+    expect(normalizeSystemPromptForCacheKey(promptA)).toBe(normalizeSystemPromptForCacheKey(promptB))
+  })
+
+  it("keeps materially different prompts distinct", () => {
+    const promptA = "You are a support agent that answers billing questions."
+    const promptB = "You are a support agent that answers shipping questions."
+
+    expect(normalizeSystemPromptForCacheKey(promptA)).not.toBe(normalizeSystemPromptForCacheKey(promptB))
+  })
+
+  it("collapses whitespace runs, including newlines, into single spaces and trims", () => {
+    const prompt = "  You are a support agent.\n\n\tAlways be polite.  \n"
+
+    expect(normalizeSystemPromptForCacheKey(prompt)).toBe("You are a support agent. Always be polite.")
+  })
+
+  it("replaces short digit runs with <num> and long hex-looking runs with <hex>", () => {
+    const prompt = "Ticket 4821 assigned to case a1b2c3d4e5f60718."
+
+    expect(normalizeSystemPromptForCacheKey(prompt)).toBe("Ticket <num> assigned to case <hex>.")
+  })
+})
 
 describe("runFlaggerUseCase", () => {
   it("uses the LLM flagger for jailbreaking with suspicious snippets prompt", async () => {
@@ -298,7 +333,7 @@ describe("runFlaggerUseCase", () => {
   })
 
   it("extracts context for long inspected system prompts before classification", async () => {
-    const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(120)}`
+    const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(400)}`
     const systemInstructions = [{ type: "text", content: longSystemPrompt }] satisfies TraceDetail["systemInstructions"]
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>(input: GenerateInput<T>) => {
@@ -393,7 +428,7 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
 
   it("skips long inspected system prompts when the extractor cannot understand the agent", async () => {
     const systemInstructions = [
-      { type: "text", content: `Disconnected examples only. ${"example ".repeat(300)}` },
+      { type: "text", content: `Disconnected examples only. ${"example ".repeat(800)}` },
     ] satisfies TraceDetail["systemInstructions"]
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
@@ -430,8 +465,8 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
   })
 
   it("uses cached long-prompt extraction results", async () => {
-    const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(120)}`
-    const cacheKey = `org:${INPUT.organizationId}:flaggers:inspected-agent-context:v1:sha256:${createHash("sha256").update(longSystemPrompt.trim()).digest("hex")}`
+    const longSystemPrompt = `You are a dashboard design assistant. ${"Detailed rubric. ".repeat(400)}`
+    const cacheKey = `org:${INPUT.organizationId}:flaggers:inspected-agent-context:v2:sha256:${createHash("sha256").update(normalizeSystemPromptForCacheKey(longSystemPrompt)).digest("hex")}`
     const cache = createMemoryCacheLayer(
       new Map([
         [
@@ -467,6 +502,61 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(result).toEqual({ matched: false })
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].prompt).toContain("This cached agent designs dashboards.")
+  })
+
+  it("reuses the instruction extraction across traces whose system prompts differ only by volatile ids/timestamps", async () => {
+    const buildSystemPrompt = (timestamp: string, uuid: string) =>
+      `You are a dashboard design assistant handling request ${uuid} at ${timestamp}. ${"Detailed rubric. ".repeat(400)}`
+
+    const promptA = buildSystemPrompt("2026-07-08T12:34:56.789Z", "123e4567-e89b-12d3-a456-426614174000")
+    const promptB = buildSystemPrompt("2026-07-09 01:02:03", "550e8400-e29b-41d4-a716-446655440000")
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>(input: GenerateInput<T>) => {
+        if (input.system.includes("You extract agent context")) {
+          return Effect.succeed({
+            object: {
+              understood: true,
+              agentContext: "This agent is a dashboard design assistant that should create dashboard designs.",
+            } as T,
+            tokens: 20,
+            duration: 90_000_000,
+          })
+        }
+
+        return Effect.succeed({ object: { matched: false } as T, tokens: 20, duration: 90_000_000 })
+      },
+    })
+
+    const cache = createMemoryCacheLayer()
+
+    const classify = (systemPrompt: string) =>
+      Effect.runPromise(
+        classifyTraceForFlaggerUseCase({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          traceId: INPUT.traceId,
+          flaggerSlug: "laziness",
+          trace: makeTraceDetail(
+            [
+              { role: "user", parts: [{ type: "text", content: "Create the dashboard." }] },
+              { role: "assistant", parts: [{ type: "text", content: "Here is the dashboard." }] },
+            ],
+            [],
+            [{ type: "text", content: systemPrompt }],
+          ),
+        }).pipe(Effect.provide(Layer.mergeAll(aiLayer, cache.layer))),
+      )
+
+    const resultA = await classify(promptA)
+    const resultB = await classify(promptB)
+
+    expect(resultA).toEqual({ matched: false })
+    expect(resultB).toEqual({ matched: false })
+
+    const extractorCalls = calls.generate.filter((call) => call.system?.includes("You extract agent context"))
+    expect(extractorCalls).toHaveLength(1)
+    expect(calls.generate).toHaveLength(3)
   })
 
   it("stamps the LLM call with the no-reflag tag when the trace is itself flagger-generated", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -21,7 +21,11 @@ import { type TraceDetail, TraceRepository } from "@domain/spans"
 import { hash } from "@repo/utils"
 import { Effect, Option } from "effect"
 import { z } from "zod"
-import { FLAGGER_DEFAULT_CLASSIFIER_MODEL, FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL } from "../constants.ts"
+import {
+  FLAGGER_DEFAULT_CLASSIFIER_MODEL,
+  FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL,
+  FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS,
+} from "../constants.ts"
 import { getFlaggerStrategy, hasFlaggerStrategy, isLlmCapableStrategy } from "../flagger-strategies/index.ts"
 import { isRecord, iterMessageParts } from "../flagger-strategies/shared.ts"
 import type { FlaggerSlug, FlaggerStrategy } from "../flagger-strategies/types.ts"
@@ -145,10 +149,9 @@ const annotationReviewOutputSchema = z.object({
   reason: z.string().optional(),
 })
 
-const INSPECTED_AGENT_VERBATIM_MAX_CHARS = 1_200
 const INSPECTED_AGENT_EXTRACTED_TRUE_TTL_SECONDS = 30 * 24 * 60 * 60
 const INSPECTED_AGENT_EXTRACTED_FALSE_TTL_SECONDS = 24 * 60 * 60
-const INSPECTED_AGENT_CONTEXT_CACHE_VERSION = 1
+const INSPECTED_AGENT_CONTEXT_CACHE_VERSION = 2
 const INSPECTED_AGENT_CONTEXT_CACHE_PREFIX = `flaggers:inspected-agent-context:v${INSPECTED_AGENT_CONTEXT_CACHE_VERSION}:sha256:`
 const FALLBACK_SYSTEM_PROMPT_CHARS = 600
 
@@ -204,11 +207,35 @@ type InspectedAgentContext =
   | { readonly available: true; readonly text: string }
   | { readonly available: false; readonly reason: string }
 
-const buildCacheKey = (organizationId: string, systemPrompt: string): Effect.Effect<string, never> =>
-  hash(systemPrompt).pipe(
+const UUID_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi
+const ISO_DATETIME_PATTERN = /\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?/g
+const TIME_PATTERN = /\b\d{1,2}:\d{2}(?::\d{2})?\b/g
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g
+const HEX_RUN_PATTERN = /\b[0-9a-f]{16,}\b/gi
+const DIGIT_RUN_PATTERN = /\d{4,}/g
+
+export function normalizeSystemPromptForCacheKey(systemPrompt: string): string {
+  return systemPrompt
+    .replace(UUID_PATTERN, "<uuid>")
+    .replace(ISO_DATETIME_PATTERN, "<datetime>")
+    .replace(TIME_PATTERN, "<time>")
+    .replace(EMAIL_PATTERN, "<email>")
+    .replace(HEX_RUN_PATTERN, "<hex>")
+    .replace(DIGIT_RUN_PATTERN, "<num>")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+const buildCacheKey = (organizationId: string, systemPrompt: string): Effect.Effect<string, never> => {
+  const normalizedSystemPrompt = normalizeSystemPromptForCacheKey(systemPrompt)
+
+  return hash(normalizedSystemPrompt).pipe(
     Effect.map((digest) => `org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}${digest}`),
-    Effect.catch(() => Effect.succeed(`org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}${systemPrompt}`)),
+    Effect.catch(() =>
+      Effect.succeed(`org:${organizationId}:${INSPECTED_AGENT_CONTEXT_CACHE_PREFIX}${normalizedSystemPrompt}`),
+    ),
   )
+}
 
 function parseCachedExtraction(value: string): InstructionExtractorOutput | null {
   try {
@@ -355,7 +382,7 @@ function getInspectedAgentContext(input: {
     return Effect.succeed({ available: false, reason: "missing inspected agent system prompt" })
   }
 
-  if (systemPrompt.length <= INSPECTED_AGENT_VERBATIM_MAX_CHARS) {
+  if (systemPrompt.length <= FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS) {
     return Effect.succeed({ available: true, text: renderShortSystemPromptContext(systemPrompt) })
   }
 


### PR DESCRIPTION
## What does this PR do?

Cuts the cost of the flagger instruction extractor (the LLM that summarizes long inspected-agent system prompts before classification).

The extractor result was cached in Redis keyed by an exact `sha256` of the **raw** system prompt. Customer system prompts embed volatile per-call content (timestamps, UUIDs, user ids, emails), so every trace produced a new hash, every lookup missed, and the extractor re-read the full prompt on every trace — despite a 30-day TTL meant to amortize it.

Changes:

- **Normalize the prompt before hashing** — `normalizeSystemPromptForCacheKey` replaces UUIDs, ISO datetimes, times, emails, long hex runs, and digit runs with stable placeholders and collapses whitespace, so per-call drift maps to the same cache key. The extractor LLM still receives the raw, un-normalized prompt; normalization only affects key derivation.
- **Bump the cache key version to v2** since the key semantics changed.
- **Raise the verbatim threshold from 1,200 to 6,000 chars** (`FLAGGER_INSPECTED_AGENT_VERBATIM_MAX_CHARS`, moved to `constants.ts`) — mid-size prompts now go verbatim to the classifier, skipping the extractor roundtrip entirely; the extractor only runs for genuinely large prompts.

A follow-up PR stacks similarity-based (SimHash) cache reuse on top, for prompts whose prose itself drifts.

## Related issue (if applicable)

Closes #

## How was this tested?

- New unit tests for `normalizeSystemPromptForCacheKey` (volatile-content equivalence, materially different prompts staying distinct, whitespace collapsing, hex vs digit placeholders).
- New integration test proving two traces whose system prompts differ only by timestamp/UUID share a single extractor call (cache hit on the second).
- Existing cache tests updated to the v2 key format; long-prompt fixtures grown past the new 6,000-char threshold so they still exercise the extractor path.
- `pnpm --filter @domain/flaggers test` → 241 passed, 2 skipped (pre-existing gated regression suites); `pnpm --filter @domain/flaggers typecheck` clean.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Mgw9ns6S1mWgyde7s5PpP

---
_Generated by [Claude Code](https://claude.ai/code/session_019Mgw9ns6S1mWgyde7s5PpP)_