### PR TITLE
fix(observability): suppress expected 4xx errors in Effect spans

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -19,6 +19,7 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@repo/utils": "workspace:*",
     "@effect/opentelemetry": "catalog:",
     "@latitude-data/telemetry": "workspace:*",
     "@opentelemetry/api": "1.9.1",

--- a/packages/observability/src/effect-tracer-client-errors.test.ts
+++ b/packages/observability/src/effect-tracer-client-errors.test.ts
@@ -1,0 +1,40 @@
+import { isHttpError } from "@repo/utils"
+import * as Exit from "effect/Exit"
+import { describe, expect, it } from "vitest"
+import { exitHasOnlyExpectedClientErrors } from "./effect-tracer-client-errors.ts"
+
+const clientError = {
+  _tag: "BadRequestError",
+  httpStatus: 400,
+  httpMessage: "bad request",
+}
+
+const serverError = {
+  _tag: "RepositoryError",
+  httpStatus: 500,
+  httpMessage: "internal server error",
+}
+
+describe("exitHasOnlyExpectedClientErrors", () => {
+  it("returns true for a single 4xx HttpError", () => {
+    expect(exitHasOnlyExpectedClientErrors(Exit.fail(clientError))).toBe(true)
+  })
+
+  it("returns false for a 5xx HttpError", () => {
+    expect(exitHasOnlyExpectedClientErrors(Exit.fail(serverError))).toBe(false)
+  })
+
+  it("returns false for success exits", () => {
+    expect(exitHasOnlyExpectedClientErrors(Exit.succeed("ok"))).toBe(false)
+  })
+
+  it("returns false for plain errors without http metadata", () => {
+    expect(exitHasOnlyExpectedClientErrors(Exit.fail(new Error("boom")))).toBe(false)
+  })
+})
+
+describe("isHttpError", () => {
+  it("recognizes domain-style HttpErrors", () => {
+    expect(isHttpError(clientError)).toBe(true)
+  })
+})

--- a/packages/observability/src/effect-tracer-client-errors.ts
+++ b/packages/observability/src/effect-tracer-client-errors.ts
@@ -1,0 +1,17 @@
+import { isHttpError } from "@repo/utils"
+import * as Cause from "effect/Cause"
+import type * as Exit from "effect/Exit"
+
+const isExpectedClientHttpError = (error: unknown): boolean =>
+  isHttpError(error) && error.httpStatus >= 400 && error.httpStatus < 500
+
+const failErrorsFromExit = (exit: Exit.Exit<unknown, unknown>): unknown[] => {
+  if (exit._tag !== "Failure") return []
+  return exit.cause.reasons.flatMap((reason) => (reason._tag === "Fail" ? [reason.error] : []))
+}
+
+export const exitHasOnlyExpectedClientErrors = (exit: Exit.Exit<unknown, unknown>): boolean => {
+  if (exit._tag !== "Failure" || Cause.hasInterruptsOnly(exit.cause)) return false
+  const errors = failErrorsFromExit(exit)
+  return errors.length > 0 && errors.every(isExpectedClientHttpError)
+}

--- a/packages/observability/src/effect-tracer.test.ts
+++ b/packages/observability/src/effect-tracer.test.ts
@@ -1,40 +1,58 @@
 import type { TracerProvider } from "@opentelemetry/api"
-import { context, trace } from "@opentelemetry/api"
+import { context, SpanStatusCode, trace } from "@opentelemetry/api"
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
 import { Effect } from "effect"
-import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import type { Exit } from "effect/Exit"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
 import { withTracing } from "./effect-tracer.ts"
+
+const clientError = {
+  _tag: "BadRequestError",
+  httpStatus: 400,
+  httpMessage: "User-authored signals manage their own evaluation and cannot be monitored or realigned",
+}
+
+const serverError = {
+  _tag: "RepositoryError",
+  httpStatus: 500,
+  httpMessage: "Internal server error",
+}
 
 describe("withTracing", () => {
   let originalProvider: TracerProvider | undefined
+  let exporter: InMemorySpanExporter
+  let provider: BasicTracerProvider
+  let otelTracer: ReturnType<typeof trace.getTracer>
 
   beforeAll(() => {
     context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+    originalProvider = trace.getTracerProvider()
+
+    exporter = new InMemorySpanExporter()
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+    trace.setGlobalTracerProvider(provider)
+    otelTracer = trace.getTracer("observability-test")
   })
 
   afterEach(async () => {
+    await provider.forceFlush()
+    exporter.reset()
+  })
+
+  afterAll(() => {
     if (originalProvider) {
       trace.setGlobalTracerProvider(originalProvider)
-      originalProvider = undefined
     }
   })
 
   it("parents Effect spans to the active OTel span", async () => {
-    originalProvider = trace.getTracerProvider()
-
-    const exporter = new InMemorySpanExporter()
-    const provider = new BasicTracerProvider({
-      spanProcessors: [new SimpleSpanProcessor(exporter)],
-    })
-
-    trace.setGlobalTracerProvider(provider)
-
-    const tracer = trace.getTracer("observability-test")
     let parentSpanId: string | undefined
     let parentTraceId: string | undefined
 
-    tracer.startActiveSpan("worker.root", (span) => {
+    otelTracer.startActiveSpan("worker.root", (span) => {
       const spanContext = span.spanContext()
       parentSpanId = spanContext.spanId
       parentTraceId = spanContext.traceId
@@ -46,10 +64,44 @@ describe("withTracing", () => {
 
     await provider.forceFlush()
 
-    const childSpan = exporter.getFinishedSpans().find((span) => span.name === "effect.child")
+    const childSpan = exporter.getFinishedSpans().find((finished) => finished.name === "effect.child")
 
     expect(childSpan).toBeDefined()
     expect(childSpan?.spanContext().traceId).toBe(parentTraceId)
     expect(childSpan?.spanContext().spanId).not.toBe(parentSpanId)
+  })
+
+  it("does not mark the traced span as an error for expected 4xx HttpErrors", async () => {
+    const effect = Effect.fail(clientError).pipe(Effect.withSpan("evaluations.monitorSignal"), withTracing)
+
+    let exit: Exit<never, typeof clientError> | undefined
+    otelTracer.startActiveSpan("request", (span) => {
+      exit = Effect.runSyncExit(effect)
+      span.end()
+    })
+    expect(exit?._tag).toBe("Failure")
+
+    await provider.forceFlush()
+
+    const tracedSpan = exporter.getFinishedSpans().find((finished) => finished.name === "evaluations.monitorSignal")
+    expect(tracedSpan).toBeDefined()
+    expect(tracedSpan?.status.code).not.toBe(SpanStatusCode.ERROR)
+  })
+
+  it("marks the traced span as an error for 5xx HttpErrors", async () => {
+    const effect = Effect.fail(serverError).pipe(Effect.withSpan("evaluations.monitorSignal"), withTracing)
+
+    let exit: Exit<never, typeof serverError> | undefined
+    otelTracer.startActiveSpan("request", (span) => {
+      exit = Effect.runSyncExit(effect)
+      span.end()
+    })
+    expect(exit?._tag).toBe("Failure")
+
+    await provider.forceFlush()
+
+    const tracedSpan = exporter.getFinishedSpans().find((finished) => finished.name === "evaluations.monitorSignal")
+    expect(tracedSpan).toBeDefined()
+    expect(tracedSpan?.status.code).toBe(SpanStatusCode.ERROR)
   })
 })

--- a/packages/observability/src/effect-tracer.ts
+++ b/packages/observability/src/effect-tracer.ts
@@ -1,6 +1,8 @@
 import { Tracer as EffectOtelTracer, Resource } from "@effect/opentelemetry"
 import { trace } from "@opentelemetry/api"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Tracer } from "effect"
+import * as Exit from "effect/Exit"
+import { exitHasOnlyExpectedClientErrors } from "./effect-tracer-client-errors.ts"
 
 /**
  * Bridges Effect's Tracer to the already-running OTel TracerProvider.
@@ -13,6 +15,26 @@ import { Effect, Layer } from "effect"
  * both already set by startTracing() in otel.ts.
  */
 export const EffectOtelTracerLive = EffectOtelTracer.layerGlobal.pipe(Layer.provide(Resource.layerFromEnv()))
+
+const wrapSpan = (span: Tracer.Span): Tracer.Span => ({
+  ...span,
+  end(endTime, exit) {
+    span.end(endTime, exitHasOnlyExpectedClientErrors(exit) ? Exit.void : exit)
+  },
+})
+
+const ClientErrorSuppressingTracerLive = Layer.effect(
+  Tracer.Tracer,
+  Effect.gen(function* () {
+    const inner = yield* Tracer.Tracer
+    return Tracer.make({
+      span(options) {
+        return wrapSpan(inner.span(options))
+      },
+      ...(inner.context !== undefined ? { context: inner.context } : {}),
+    })
+  }),
+).pipe(Layer.provide(EffectOtelTracerLive))
 
 const bridgeActiveOtelSpan = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> => {
   const activeSpan = trace.getActiveSpan()
@@ -27,6 +49,10 @@ const bridgeActiveOtelSpan = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.E
 /**
  * Pipe combinator to provide the OTel tracer layer to any effect.
  *
+ * Expected 4xx `HttpError`s end traced spans as success so Datadog Error
+ * Tracking does not treat intentional client rejections as server faults. The
+ * error still propagates to callers after the span ends.
+ *
  * @example
  * ```ts
  * const result = await Effect.runPromise(
@@ -38,4 +64,7 @@ const bridgeActiveOtelSpan = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.E
  * ```
  */
 export const withTracing = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  Effect.suspend((): Effect.Effect<A, E, R> => Effect.provide(bridgeActiveOtelSpan(effect), EffectOtelTracerLive))
+  Effect.suspend(
+    (): Effect.Effect<A, E, R> =>
+      Effect.provide(bridgeActiveOtelSpan(effect), Layer.fresh(ClientErrorSuppressingTracerLive)),
+  )

--- a/packages/observability/src/effect-tracer.ts
+++ b/packages/observability/src/effect-tracer.ts
@@ -16,12 +16,17 @@ import { exitHasOnlyExpectedClientErrors } from "./effect-tracer-client-errors.t
  */
 export const EffectOtelTracerLive = EffectOtelTracer.layerGlobal.pipe(Layer.provide(Resource.layerFromEnv()))
 
-const wrapSpan = (span: Tracer.Span): Tracer.Span => ({
-  ...span,
-  end(endTime, exit) {
-    span.end(endTime, exitHasOnlyExpectedClientErrors(exit) ? Exit.void : exit)
-  },
-})
+const wrapSpan = (span: Tracer.Span): Tracer.Span =>
+  new Proxy(span, {
+    get(target, prop, receiver) {
+      if (prop === "end") {
+        return (endTime: bigint, exit: Exit.Exit<unknown, unknown>) => {
+          target.end(endTime, exitHasOnlyExpectedClientErrors(exit) ? Exit.void : exit)
+        }
+      }
+      return Reflect.get(target, prop, receiver)
+    },
+  })
 
 const ClientErrorSuppressingTracerLive = Layer.effect(
   Tracer.Tracer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1959,6 +1959,9 @@ importers:
       '@platform/env':
         specifier: workspace:*
         version: link:../platform/env
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.57


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops intentional `HttpError` 4xx responses from marking Effect spans as errors in Datadog Error Tracking.

This addresses [Datadog issue f6b0e63c-7aae-11f1-9d15-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/f6b0e63c-7aae-11f1-9d15-da7ad0900005), where `monitorSignal` correctly returned HTTP 400 for a user-authored signal but the nested `evaluations.monitorSignal` Effect span was still reported as an error.

## Root cause

The API already suppresses HTTP-level 4xx telemetry via `suppressHttpErrorTelemetry`, but operation handlers also run domain logic through `withTracing`, which creates nested Effect spans. When a use-case yields an expected `BadRequestError`, `@effect/opentelemetry` ended that inner span with `status: error`, and Datadog grouped it as a production issue even though the request was handled correctly.

## Fix

`withTracing` now provides a tracer wrapper that ends spans with a success exit when the failure is an expected client `HttpError` (`400 <= httpStatus < 500`). The error still propagates to callers and Hono still returns the correct 4xx response.

## Tests

- Unit tests for `exitHasOnlyExpectedClientErrors` (4xx vs 5xx vs non-HTTP errors)
- Integration tests confirming 4xx failures keep span status non-error while 5xx failures still mark spans as error

## Verification

After deploy, calls like `monitorSignal` on user-authored signals should continue returning HTTP 400, and occurrences of issue `f6b0e63c-7aae-11f1-9d15-da7ad0900005` should stop.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3c5f85-f669-4bc9-b91f-ca01e6ddd0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3c5f85-f669-4bc9-b91f-ca01e6ddd0dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

