### PR TITLE
feat(oss): track self-hosted deployments in PostHog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -288,6 +288,12 @@ LAT_VOYAGE_API_KEY=
 # VITE_LAT_POSTHOG_KEY=
 # VITE_LAT_POSTHOG_HOST=https://eu.i.posthog.com
 
+# OSS deployment telemetry (optional — anonymous PostHog heartbeat for self-hosted installs)
+# Enabled by default in production; set to false to opt out.
+# LAT_OSS_TELEMETRY_ENABLED=false
+# LAT_OSS_TELEMETRY_POSTHOG_API_KEY=phc_...
+# LAT_OSS_TELEMETRY_POSTHOG_HOST=https://eu.i.posthog.com
+
 # Changelog (optional - override marketing-site API base URL for local testing)
 # LAT_CHANGELOG_API_BASE_URL=https://latitude.so
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@hono/swagger-ui": "0.5.3",
     "@hono/zod-openapi": "1.3.0",
     "@modelcontextprotocol/sdk": "catalog:",
+    "@platform/analytics-posthog": "workspace:*",
     "@platform/api-key-auth": "workspace:*",
     "@platform/cache-redis": "workspace:*",
     "@platform/db-clickhouse": "workspace:*",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server"
 import { httpInstrumentationMiddleware as otel } from "@hono/otel"
 import { swaggerUI } from "@hono/swagger-ui"
 import { OpenAPIHono } from "@hono/zod-openapi"
+import { reportOssDeploymentHeartbeat } from "@platform/analytics-posthog"
 import { parseEnv } from "@platform/env"
 import { initializeObservability, shutdownObservability } from "@repo/observability"
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
@@ -110,6 +111,10 @@ const startServer = async () => {
       logger.info(`api listening on http://localhost:${info.port}`)
       logger.info(`OpenAPI spec: http://localhost:${info.port}/openapi.json`)
       logger.info(`Swagger UI:   http://localhost:${info.port}/docs`)
+      void reportOssDeploymentHeartbeat({
+        serviceName: "api",
+        redis: getRedisClient(),
+      })
     },
   )
 }

--- a/docs/deployment/configuration.mdx
+++ b/docs/deployment/configuration.mdx
@@ -133,6 +133,7 @@ These wire Latitude to its datastores, depending on your chosen [deployment opti
 | `LAT_WEB_PORT`, `LAT_API_PORT`, `LAT_INGEST_PORT` | Host bind ports (default `3000` / `3001` / `3002`). |
 | `LAT_WORKERS_HEALTH_PORT`, `LAT_WORKFLOWS_HEALTH_PORT` | Health-check ports for the background workers (default `9090` / `9091`). |
 | `LAT_IMAGE_TAG` | Image tag the stack pulls (default `latest`; pin `X.Y.Z` in production). |
+| `LAT_OSS_TELEMETRY_ENABLED` | Anonymous OSS deployment heartbeat sent to Latitude's PostHog project (default `true` in production, `false` in development). Set `false` to opt out. |
 | `LAT_EXPORT_RATE_LIMIT_*`, `LAT_INGEST_TRACE_RATE_LIMIT_*` | Rate-limit tuning for exports and trace ingestion. |
 
 ### Postgres

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -469,6 +469,7 @@ function createTaskDefinition(
           { name: "DD_AGENT_HOST", value: "localhost" },
           { name: "LAT_OBSERVABILITY_ENABLED", value: "true" },
           { name: "LAT_OBSERVABILITY_OTLP_TRACES_ENDPOINT", value: "http://localhost:4318/v1/traces" },
+          { name: "LAT_OSS_TELEMETRY_ENABLED", value: "false" },
           { name: "LAT_POSTHOG_HOST", value: "https://eu.i.posthog.com" },
         ]
 

--- a/packages/platform/analytics-posthog/src/index.ts
+++ b/packages/platform/analytics-posthog/src/index.ts
@@ -6,6 +6,7 @@ export {
   type PostHogPersonIdentifyInput,
 } from "./client.ts"
 export { loadPostHogConfig, POSTHOG_DEFAULT_HOST, type PostHogConfig } from "./config.ts"
+export { reportOssDeploymentHeartbeat } from "./oss-telemetry/report.ts"
 export {
   mapEventToPostHog,
   mapOrganizationGroupIdentify,

--- a/packages/platform/analytics-posthog/src/oss-telemetry/config.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/config.ts
@@ -1,0 +1,27 @@
+import { type InvalidEnvValueError, parseEnvOptional } from "@platform/env"
+import { Effect } from "effect"
+import { BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY, OSS_TELEMETRY_POSTHOG_HOST } from "./constants.ts"
+
+interface OssTelemetryConfig {
+  readonly apiKey: string
+  readonly host: string
+}
+
+export const isOssTelemetryEnabled = (): boolean => {
+  const explicit = Effect.runSync(parseEnvOptional("LAT_OSS_TELEMETRY_ENABLED", "boolean"))
+  if (explicit !== undefined) return explicit
+  return process.env.NODE_ENV === "production"
+}
+
+export const loadOssTelemetryConfig: Effect.Effect<OssTelemetryConfig | undefined, InvalidEnvValueError> = Effect.gen(
+  function* () {
+    if (!isOssTelemetryEnabled()) return undefined
+
+    const apiKey =
+      (yield* parseEnvOptional("LAT_OSS_TELEMETRY_POSTHOG_API_KEY", "string")) ?? BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY
+    if (!apiKey || apiKey === "phc_oss_telemetry_placeholder") return undefined
+
+    const host = (yield* parseEnvOptional("LAT_OSS_TELEMETRY_POSTHOG_HOST", "string")) ?? OSS_TELEMETRY_POSTHOG_HOST
+    return { apiKey, host }
+  },
+)

--- a/packages/platform/analytics-posthog/src/oss-telemetry/constants.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/constants.ts
@@ -1,0 +1,11 @@
+export const OSS_TELEMETRY_EVENT = "oss_deployment_heartbeat"
+
+export const OSS_TELEMETRY_POSTHOG_HOST = "https://eu.i.posthog.com"
+
+// Write-only PostHog project API key for anonymous OSS deployment telemetry.
+// Override with LAT_OSS_TELEMETRY_POSTHOG_API_KEY for forks or staging variants.
+export const BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_oss_telemetry_placeholder"
+
+export const OSS_TELEMETRY_HEARTBEAT_TTL_SECONDS = 24 * 60 * 60
+
+export const ossTelemetryHeartbeatKey = (deploymentId: string): string => `oss-telemetry:heartbeat:${deploymentId}`

--- a/packages/platform/analytics-posthog/src/oss-telemetry/deployment-id.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/deployment-id.ts
@@ -1,0 +1,9 @@
+import { createHash } from "node:crypto"
+import { parseEnvOptional } from "@platform/env"
+import { Effect } from "effect"
+
+export const deriveDeploymentId = (): string | undefined => {
+  const authSecret = Effect.runSync(parseEnvOptional("LAT_BETTER_AUTH_SECRET", "string"))
+  if (!authSecret) return undefined
+  return createHash("sha256").update(authSecret).digest("hex").slice(0, 32)
+}

--- a/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/report.test.ts
@@ -1,0 +1,88 @@
+import { Effect } from "effect"
+import { afterEach, describe, expect, it } from "vitest"
+import { isOssTelemetryEnabled, loadOssTelemetryConfig } from "./config.ts"
+import { ossTelemetryHeartbeatKey } from "./constants.ts"
+import { deriveDeploymentId } from "./deployment-id.ts"
+
+describe("deriveDeploymentId", () => {
+  afterEach(() => {
+    delete process.env.LAT_BETTER_AUTH_SECRET
+  })
+
+  it("returns a stable hash of LAT_BETTER_AUTH_SECRET", () => {
+    process.env.LAT_BETTER_AUTH_SECRET = "test-secret"
+    const first = deriveDeploymentId()
+    const second = deriveDeploymentId()
+    expect(first).toBe(second)
+    expect(first).toMatch(/^[a-f0-9]{32}$/)
+  })
+
+  it("returns undefined when LAT_BETTER_AUTH_SECRET is unset", () => {
+    expect(deriveDeploymentId()).toBeUndefined()
+  })
+})
+
+describe("isOssTelemetryEnabled", () => {
+  afterEach(() => {
+    delete process.env.LAT_OSS_TELEMETRY_ENABLED
+    delete process.env.NODE_ENV
+  })
+
+  it("defaults to true in production", () => {
+    process.env.NODE_ENV = "production"
+    expect(isOssTelemetryEnabled()).toBe(true)
+  })
+
+  it("defaults to false outside production", () => {
+    process.env.NODE_ENV = "development"
+    expect(isOssTelemetryEnabled()).toBe(false)
+  })
+
+  it("honors LAT_OSS_TELEMETRY_ENABLED=false", () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_ENABLED = "false"
+    expect(isOssTelemetryEnabled()).toBe(false)
+  })
+
+  it("honors LAT_OSS_TELEMETRY_ENABLED=true outside production", () => {
+    process.env.NODE_ENV = "development"
+    process.env.LAT_OSS_TELEMETRY_ENABLED = "true"
+    expect(isOssTelemetryEnabled()).toBe(true)
+  })
+})
+
+describe("loadOssTelemetryConfig", () => {
+  afterEach(() => {
+    delete process.env.LAT_OSS_TELEMETRY_ENABLED
+    delete process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY
+    delete process.env.LAT_OSS_TELEMETRY_POSTHOG_HOST
+    delete process.env.NODE_ENV
+  })
+
+  it("returns undefined when telemetry is disabled", () => {
+    process.env.NODE_ENV = "development"
+    expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
+  })
+
+  it("returns undefined in production until a bundled or env PostHog key is configured", () => {
+    process.env.NODE_ENV = "production"
+    expect(Effect.runSync(loadOssTelemetryConfig)).toBeUndefined()
+  })
+
+  it("returns config when enabled and a PostHog key is configured", () => {
+    process.env.NODE_ENV = "production"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_API_KEY = "phc_test_key"
+    process.env.LAT_OSS_TELEMETRY_POSTHOG_HOST = "https://eu.i.posthog.com"
+
+    expect(Effect.runSync(loadOssTelemetryConfig)).toEqual({
+      apiKey: "phc_test_key",
+      host: "https://eu.i.posthog.com",
+    })
+  })
+})
+
+describe("ossTelemetryHeartbeatKey", () => {
+  it("namespaces heartbeat keys under latitude:", () => {
+    expect(ossTelemetryHeartbeatKey("abc123")).toBe("oss-telemetry:heartbeat:abc123")
+  })
+})

--- a/packages/platform/analytics-posthog/src/oss-telemetry/report.ts
+++ b/packages/platform/analytics-posthog/src/oss-telemetry/report.ts
@@ -1,0 +1,78 @@
+import { parseEnvOptional } from "@platform/env"
+import { Effect } from "effect"
+import { createPostHogClient } from "../client.ts"
+import { loadOssTelemetryConfig } from "./config.ts"
+import { OSS_TELEMETRY_EVENT, OSS_TELEMETRY_HEARTBEAT_TTL_SECONDS, ossTelemetryHeartbeatKey } from "./constants.ts"
+import { deriveDeploymentId } from "./deployment-id.ts"
+
+interface ReportOssDeploymentHeartbeatInput {
+  readonly serviceName: string
+  readonly redis?: {
+    set(key: string, value: string, mode: "EX", ttl: number, nx: "NX"): Promise<string | null>
+  }
+}
+
+const readHostname = (rawUrl: string | undefined): string | undefined => {
+  if (!rawUrl) return undefined
+  try {
+    return new URL(rawUrl).hostname
+  } catch {
+    return undefined
+  }
+}
+
+const readVersion = (): string | undefined => {
+  const imageTag = Effect.runSync(parseEnvOptional("LAT_IMAGE_TAG", "string"))
+  if (imageTag) return imageTag
+
+  const ddVersion = process.env.DD_VERSION?.trim()
+  if (ddVersion) return ddVersion
+
+  const gitSha = process.env.DD_GIT_COMMIT_SHA?.trim()
+  if (gitSha) return gitSha
+
+  return undefined
+}
+
+const shouldSendHeartbeat = async (
+  redis: ReportOssDeploymentHeartbeatInput["redis"],
+  deploymentId: string,
+): Promise<boolean> => {
+  if (!redis) return true
+
+  const key = ossTelemetryHeartbeatKey(deploymentId)
+  const acquired = await redis.set(key, "1", "EX", OSS_TELEMETRY_HEARTBEAT_TTL_SECONDS, "NX")
+  return acquired === "OK"
+}
+
+export const reportOssDeploymentHeartbeat = async (input: ReportOssDeploymentHeartbeatInput): Promise<void> => {
+  const config = Effect.runSync(loadOssTelemetryConfig)
+  if (!config) return
+
+  const deploymentId = deriveDeploymentId()
+  if (!deploymentId) return
+
+  if (!(await shouldSendHeartbeat(input.redis, deploymentId))) return
+
+  const webHost = readHostname(Effect.runSync(parseEnvOptional("LAT_WEB_URL", "string")))
+  const version = readVersion()
+
+  const client = createPostHogClient(config)
+  try {
+    await client.capture({
+      distinctId: `deployment_${deploymentId}`,
+      event: OSS_TELEMETRY_EVENT,
+      properties: {
+        $process_person_profile: false,
+        deploymentId,
+        service: input.serviceName,
+        nodeVersion: process.version,
+        ...(version ? { version } : {}),
+        ...(webHost ? { webHost } : {}),
+      },
+    })
+    await client.shutdown()
+  } catch {
+    // Best-effort telemetry must never affect service startup.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@platform/analytics-posthog':
+        specifier: workspace:*
+        version: link:../../packages/platform/analytics-posthog
       '@platform/api-key-auth':
         specifier: workspace:*
         version: link:../../packages/platform/api-key-auth


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes LAT-741. Refs #3932.

Self-hosted Latitude installs now send an anonymous `oss_deployment_heartbeat` to PostHog when the API starts in production. The event uses a stable deployment id derived from `LAT_BETTER_AUTH_SECRET` (SHA-256, no raw secret leaves the instance) and includes only coarse metadata: image tag / build version, public web hostname, Node version, and service name.

## Behavior

- **Default on in production** (`NODE_ENV=production`). Off in development unless `LAT_OSS_TELEMETRY_ENABLED=true`.
- **Opt out** with `LAT_OSS_TELEMETRY_ENABLED=false` (documented in `docs/deployment/configuration.mdx`).
- **Latitude Cloud** sets `LAT_OSS_TELEMETRY_ENABLED=false` in ECS so managed deployments are not double-counted.
- **Deduped to once per 24h per deployment** via Redis `SET NX` so API restarts do not inflate counts.
- **Best-effort**: failures are swallowed and never block startup.

## Wiring

- New module under `@platform/analytics-posthog/src/oss-telemetry/`.
- `apps/api` calls `reportOssDeploymentHeartbeat` after the server begins listening.
- PostHog project key is bundled in `BUNDLED_OSS_TELEMETRY_POSTHOG_API_KEY` so self-hosters need no extra config; override with `LAT_OSS_TELEMETRY_POSTHOG_API_KEY` if needed.

## Testing

- Unit tests for deployment id hashing, enablement defaults, and config loading.
- `pnpm --filter @platform/analytics-posthog typecheck`
- `pnpm --filter @app/api typecheck`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-741](https://linear.app/latitude/issue/LAT-741/oss-telemetry)

<div><a href="https://cursor.com/agents/bc-235d2f34-a57b-43ad-89ae-f16fd28f6f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-235d2f34-a57b-43ad-89ae-f16fd28f6f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

