### PR TITLE
fix(flaggers): reduce long-running session spikes from instruction extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -218,7 +218,7 @@ LAT_VOYAGE_API_KEY=
 # Feature keys and their built-in defaults:
 #   ISSUE_DETAILS_GENERATOR  amazon-bedrock / minimax.minimax-m2.5 / reasoning high
 #   FLAGGER_CLASSIFIER       amazon-bedrock / anthropic.claude-haiku-4-5-20251001-v1:0 / temperature 0, maxTokens 2048
-#   FLAGGER_EXTRACTOR        amazon-bedrock / minimax.minimax-m2.5 / temperature 0, maxTokens 512
+#   FLAGGER_EXTRACTOR        amazon-bedrock / anthropic.claude-haiku-4-5-20251001-v1:0 / temperature 0, maxTokens 512
 #   FLAGGER_ANNOTATOR        amazon-bedrock / minimax.minimax-m2.5 / temperature 0.2, maxTokens 2048
 #   ANNOTATION_ENRICHER      amazon-bedrock / minimax.minimax-m2.5 / reasoning medium
 #   EVALUATION_JUDGE         amazon-bedrock / minimax.minimax-m2.5 / reasoning low

--- a/packages/domain/flaggers/src/constants.ts
+++ b/packages/domain/flaggers/src/constants.ts
@@ -22,7 +22,7 @@ export const FLAGGER_DEFAULT_CLASSIFIER_MODEL = {
 
 export const FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL = {
   provider: "amazon-bedrock",
-  model: "minimax.minimax-m2.5",
+  model: "anthropic.claude-haiku-4-5-20251001-v1:0",
   temperature: 0,
   maxTokens: 512,
 } as const

--- a/packages/domain/spans/src/otlp/transform.test.ts
+++ b/packages/domain/spans/src/otlp/transform.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { normalizeParentSpanId } from "./transform.ts"
+
+describe("normalizeParentSpanId", () => {
+  it("maps OTEL's all-zero root parent id to an empty string", () => {
+    expect(normalizeParentSpanId("0000000000000000")).toBe("")
+  })
+
+  it("keeps empty and non-root parent ids unchanged", () => {
+    expect(normalizeParentSpanId("")).toBe("")
+    expect(normalizeParentSpanId(undefined)).toBe("")
+    expect(normalizeParentSpanId("abcd1234abcd1234")).toBe("abcd1234abcd1234")
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -30,6 +30,13 @@ function nanosToDate(nanos: string | undefined): Date {
   return new Date(ms)
 }
 
+const OTEL_ROOT_PARENT_SPAN_ID = "0000000000000000"
+
+export function normalizeParentSpanId(parentSpanId: string | undefined): string {
+  const id = parentSpanId ?? ""
+  return id === OTEL_ROOT_PARENT_SPAN_ID ? "" : id
+}
+
 function resolveAnyValue(
   value: OtlpAnyValue | undefined,
 ): { type: "string" | "int" | "float" | "bool"; value: string | number | boolean } | null {
@@ -175,7 +182,7 @@ function transformSpan({
     userEmail: resolved.userEmail,
     traceId: TraceId(span.traceId.replace(/-/g, "")),
     spanId: SpanId(span.spanId),
-    parentSpanId: span.parentSpanId ?? "",
+    parentSpanId: normalizeParentSpanId(span.parentSpanId),
     apiKeyId: context.apiKeyId,
     simulationId: SimulationId(""),
     startTime: nanosToDate(span.startTimeUnixNano),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigates the **Long-running sessions (2x average)** signal (`nd4wn7usf8jx3ri20osx8kfd`) in the `latitude-flaggers` project.

Latitude analytics show ~2,000 sessions above ~12s active duration (project avg ~5.9s). Traces behind the spikes are overwhelmingly `flagger:extract-instructions` workflow runs: cold-path instruction extraction via `minimax.minimax-m2.5` taking 15–26s per trace, which rolls up into session `duration_ns` when the capture root span is present.

A related cache-miss problem (volatile system prompts hashing to unique keys on every trace) was fixed earlier today in #3926. This PR addresses the remaining slow path and a small ingest consistency issue.

## Root cause

1. **Cold instruction extractor latency** — When an inspected agent's system prompt exceeds the verbatim threshold and is not yet cached, `getInspectedAgentContext` runs `flagger.extract-instructions`. The default model was `minimax.minimax-m2.5`, which consistently took 15–26s in production traces while classification on Haiku completed in ~1s.
2. **Zero-duration sessions (context)** — ~17% of sessions report `duration_ns = 0`, often when the capture root span is missing from ingest but child spans remain. OTEL exporters sometimes emit the root parent id as `0000000000000000`; traces MV root detection only treated `''` as root.

## Changes

- Switch `FLAGGER_DEFAULT_INSTRUCTION_EXTRACTOR_MODEL` to Haiku (`anthropic.claude-haiku-4-5-20251001-v1:0`), matching the classifier. Cache hits are unchanged; cache misses should drop from ~20s to low seconds.
- Normalize `0000000000000000` parent span ids to `''` at OTLP ingest so root-span detection is consistent with sessions MV semantics.
- Regression test for parent span id normalization.

## Testing

- `pnpm --filter @domain/flaggers test -- run-flagger.test.ts` (243 passed)
- `pnpm --filter @domain/spans exec vitest run src/otlp/transform.test.ts` (2 passed)

## Signal follow-up

Do **not** mute or resolve the signal — verify occurrence rate drops after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a20607cd-6100-5ccb-86c3-f7b2719e0ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a20607cd-6100-5ccb-86c3-f7b2719e0ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

