### PR TITLE
Enrich signal discovery notifications

### DIFF
--- a/packages/domain/email/src/templates/notifications/signal-discovered/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/notifications/signal-discovered/EmailTemplate.tsx
@@ -1,0 +1,84 @@
+import { Section } from "@react-email/components"
+// @ts-expect-error TS6133 - React required at runtime for JSX in workers
+// biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
+import React from "react"
+import { ContainerLayout } from "../../../components/ContainerLayout.tsx"
+import { EmailButton } from "../../../components/EmailButton.tsx"
+import { EmailFooter } from "../../../components/EmailFooter.tsx"
+import { EmailText } from "../../../components/EmailText.tsx"
+import { emailDesignTokens } from "../../../tokens/design-system.ts"
+import {
+  EmailMetadataTable,
+  formatScope,
+  SectionHeader,
+  SignalIdFooter,
+  SignalTimestamp,
+} from "../-incident-components.tsx"
+
+interface SignalDiscoveredEmailProps {
+  readonly signalId: string
+  readonly signalName: string
+  readonly description: string | undefined
+  readonly signalUrl: string | undefined
+  readonly notificationCreatedAt: Date
+  readonly organizationName: string
+  readonly projectName: string | undefined
+  readonly webAppUrl: string
+}
+
+export function SignalDiscoveredEmail({
+  signalId,
+  signalName,
+  description,
+  signalUrl,
+  notificationCreatedAt,
+  organizationName,
+  projectName,
+  webAppUrl,
+}: SignalDiscoveredEmailProps) {
+  const scope = formatScope(organizationName, projectName)
+
+  return (
+    <ContainerLayout
+      previewText={`Signal discovered: ${signalName}`}
+      footer={<EmailFooter unsubscribe={{ webAppUrl, group: "incidents" }} />}
+    >
+      <EmailText variant="heading" className={emailDesignTokens.spacing.headingGap}>
+        New signal discovered
+      </EmailText>
+      <EmailText variant="body">{`Latitude discovered this signal in ${scope}.`}</EmailText>
+
+      <SectionHeader label="Signal" />
+      <EmailText variant="heading">{signalName}</EmailText>
+      {description ? (
+        <EmailText variant="bodySmall" className="text-muted-foreground">
+          {description}
+        </EmailText>
+      ) : null}
+
+      <SignalTimestamp timestamp={notificationCreatedAt} />
+
+      <EmailMetadataTable rows={[{ label: "Project", value: scope }]} />
+
+      <SignalIdFooter signalId={signalId} />
+
+      {signalUrl ? (
+        <Section className={emailDesignTokens.spacing.buttonTop}>
+          <EmailButton href={signalUrl} label="View signal" />
+        </Section>
+      ) : null}
+    </ContainerLayout>
+  )
+}
+
+SignalDiscoveredEmail.PreviewProps = {
+  signalId: "dds0rt8sqgpuku4u4wabze9r",
+  signalName: "Long-running sessions (2x average)",
+  description:
+    "Sessions whose duration is at least twice a reasonable baseline average. The project shows many sessions with zero-recorded duration; this threshold targets the outliers that record meaningful time.",
+  signalUrl: "https://console.latitude.so/projects/sample-project/signals/preview-signal",
+  notificationCreatedAt: new Date("2026-03-18T10:05:00Z"),
+  organizationName: "Acme Inc.",
+  projectName: "Flaggers",
+  webAppUrl: "http://localhost:3000",
+} satisfies SignalDiscoveredEmailProps

--- a/packages/domain/email/src/templates/notifications/signal-discovered/index.tsx
+++ b/packages/domain/email/src/templates/notifications/signal-discovered/index.tsx
@@ -1,7 +1,12 @@
 import { SignalId } from "@domain/shared"
 import { SignalRepository } from "@domain/signals"
 import { Effect } from "effect"
+// @ts-expect-error TS6133 - React required at runtime for JSX in workers
+// biome-ignore lint/correctness/noUnusedImports: React required at runtime for JSX in workers
+import React from "react"
+import { renderEmail } from "../../../utils/render.ts"
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
+import { SignalDiscoveredEmail } from "./EmailTemplate.tsx"
 
 const loadError = (cause: unknown) => ({
   _tag: "RenderNotificationEmailError" as const,
@@ -14,14 +19,6 @@ const buildSignalUrl = (ctx: NotificationEmailRenderContext, signalId: string): 
   return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signalId)}`
 }
 
-const escapeHtml = (value: string): string =>
-  value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;")
-
 export const signalDiscoveredRenderer: NotificationEmailRenderer<"signal.discovered"> = (payload, ctx) =>
   Effect.gen(function* () {
     const signals = yield* SignalRepository
@@ -30,20 +27,35 @@ export const signalDiscoveredRenderer: NotificationEmailRenderer<"signal.discove
       Effect.catchTag("RepositoryError", (cause) => Effect.fail(loadError(cause))),
     )
 
-    const signalName = signal?.name ?? "A new signal"
+    const signalName = signal?.name ?? "a signal"
     const signalUrl = buildSignalUrl(ctx, payload.signalId)
-    const subject = `[Latitude] ${signalName} was discovered`
-    const projectText = ctx.project ? ` in ${ctx.project.name}` : ""
-    const html = [
-      `<p>Latitude discovered a new signal${escapeHtml(projectText)}.</p>`,
-      `<p><strong>${escapeHtml(signalName)}</strong></p>`,
-      signal?.description ? `<p>${escapeHtml(signal.description)}</p>` : "",
-      signalUrl ? `<p><a href="${escapeHtml(signalUrl)}">Open signal</a></p>` : "",
-    ].join("")
+    const subject = `Signal discovered: ${signalName}`
+    const html = yield* Effect.tryPromise({
+      try: () =>
+        renderEmail(
+          <SignalDiscoveredEmail
+            signalId={payload.signalId}
+            signalName={signalName}
+            description={signal?.description ?? undefined}
+            signalUrl={signalUrl}
+            notificationCreatedAt={ctx.notificationCreatedAt}
+            organizationName={ctx.organization.name}
+            projectName={ctx.project?.name}
+            webAppUrl={ctx.webAppUrl}
+          />,
+        ),
+      catch: (cause) => ({
+        _tag: "RenderNotificationEmailError" as const,
+        message: "Failed to render signal.discovered email",
+        cause,
+      }),
+    })
 
     return {
       html,
       subject,
-      text: `${signalName} was discovered${projectText}.${signalUrl ? `\n\n${signalUrl}` : ""}\n\n- Latitude`,
+      text: `${subject}.${signalUrl ? `\n\n${signalUrl}` : ""}\n\n— Latitude`,
     }
   })
+
+export default SignalDiscoveredEmail

--- a/packages/domain/integrations/src/templates/notifications/signal-discovered.ts
+++ b/packages/domain/integrations/src/templates/notifications/signal-discovered.ts
@@ -1,9 +1,30 @@
+import { SignalId } from "@domain/shared"
+import { SignalRepository } from "@domain/signals"
 import { Effect } from "effect"
-import { sectionMarkdown } from "./blocks.ts"
+import { actionsLink, contextLine, projectOrOrgContext, sectionMarkdown } from "./blocks.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
-export const signalDiscoveredRenderer: SlackNotificationRenderer<"signal.discovered"> = (_payload, ctx) =>
-  Effect.succeed({
-    text: `A new signal was discovered in ${ctx.project?.name ?? ctx.organization.name}.`,
-    blocks: [sectionMarkdown(`A new signal was discovered in ${ctx.project?.name ?? ctx.organization.name}.`)],
+export const signalDiscoveredRenderer: SlackNotificationRenderer<"signal.discovered"> = (payload, ctx) =>
+  Effect.gen(function* () {
+    const signals = yield* SignalRepository
+    const signal = yield* signals.findById(SignalId(payload.signalId)).pipe(
+      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+      Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
+    )
+
+    const projectName = ctx.project?.name ?? ctx.organization.name
+    const signalName = signal?.name ?? "A new signal"
+    const signalUrl = ctx.project
+      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.signalId)}`
+      : ctx.webAppUrl
+
+    return {
+      text: `${signalName} was discovered in ${projectName}.`,
+      blocks: [
+        sectionMarkdown(`A new signal was discovered: *<${signalUrl}|${signalName}>*.`),
+        ...(signal?.description ? [sectionMarkdown(signal.description)] : []),
+        contextLine(`signal · ${projectOrOrgContext(ctx.organization, ctx.project)}`),
+        actionsLink("View signal", signalUrl),
+      ],
+    }
   })

--- a/packages/domain/integrations/src/templates/notifications/types.ts
+++ b/packages/domain/integrations/src/templates/notifications/types.ts
@@ -82,7 +82,7 @@ export type SlackRenderDepsByKind = {
   readonly "wrapped.report": never
   readonly "custom.message": never
   readonly "issue.assigned": never
-  readonly "signal.discovered": never
+  readonly "signal.discovered": SignalRepository | SqlClient
   readonly "destination.quarantined": never
 }
 

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
@@ -4,11 +4,13 @@ import {
   NotFoundError,
   OrganizationId,
   ProjectId,
+  SignalId,
   SlackIntegrationId,
   SqlClient,
   type SqlClientShape,
 } from "@domain/shared"
-import { SignalRepository } from "@domain/signals"
+import { type Signal, SignalRepository } from "@domain/signals"
+import { createFakeSignalRepository } from "@domain/signals/testing"
 import { UserRepository } from "@domain/users"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -43,6 +45,7 @@ const NoopSavedSearchRepository = Layer.succeed(SavedSearchRepository, {
 const ORG = OrganizationId("o".repeat(24))
 const PROJECT = ProjectId("p".repeat(24))
 const INTEGRATION = SlackIntegrationId("i".repeat(24))
+const SIGNAL = SignalId("s".repeat(24))
 
 // Org-repo layer for the test-mode guard the use case now resolves up
 // front. `parentOrgId` decides sandbox-ness: null = live, set = sandbox.
@@ -86,6 +89,33 @@ const customMessagePayload = {
   title: "Heads up",
   content: "Please reboot",
   link: "https://docs.example.com",
+}
+
+const makeSignal = (): Signal => {
+  const now = new Date("2026-06-17T10:00:00.000Z")
+  return {
+    id: SIGNAL,
+    organizationId: ORG,
+    projectId: PROJECT,
+    slug: "bad-json-output",
+    name: "Bad JSON output",
+    description: "The model returns malformed JSON.",
+    source: "annotation",
+    origin: "system",
+    assigneeId: null,
+    priority: null,
+    centroid: {
+      base: [1, 0],
+      mass: 1,
+      model: "test",
+      decay: 1,
+      weights: { annotation: 1, custom: 0, evaluation: 0 },
+    },
+    clusteredAt: now,
+    mutedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  }
 }
 
 const fakeMessenger = (): SlackMessenger & { calls: Array<unknown> } => {
@@ -136,6 +166,58 @@ describe("dispatchSlackNotificationUseCase", () => {
 
     expect(outcome.status).toBe("delivered")
     expect(messenger.calls).toHaveLength(1)
+  })
+
+  it("renders discovered signal details with a deep link", async () => {
+    const messenger = fakeMessenger()
+    const layer = InMemorySlackDeliveryRepositoryLive()
+    const { repository } = createFakeSignalRepository([makeSignal()])
+
+    const outcome = await Effect.runPromise(
+      dispatchSlackNotificationUseCase({
+        integrationId: INTEGRATION,
+        botToken: "xoxb-test",
+        channelId: "C123",
+        kind: "signal.discovered",
+        payload: { signalId: SIGNAL, discoveredAt: "2026-06-17T10:00:00.000Z" },
+        idempotencyKey: `signal.discovered:${SIGNAL}`,
+        context: ctx,
+        messenger,
+      }).pipe(
+        Effect.provide(layer),
+        Effect.provide(Layer.succeed(SignalRepository, repository)),
+        Effect.provide(NoopSavedSearchRepository),
+        Effect.provide(NoopUserRepository),
+        Effect.provide(NoopSqlClient),
+        Effect.provide(LiveOrg),
+      ),
+    )
+
+    expect(outcome.status).toBe("delivered")
+    expect(messenger.calls).toHaveLength(1)
+    expect(messenger.calls[0]).toMatchObject({
+      text: "Bad JSON output was discovered in Frontend.",
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          text: expect.objectContaining({
+            text: "A new signal was discovered: *<https://app.example.com/projects/frontend/signals/ssssssssssssssssssssssss|Bad JSON output>*.",
+          }),
+        }),
+        expect.objectContaining({
+          text: expect.objectContaining({ text: "The model returns malformed JSON." }),
+        }),
+        expect.objectContaining({
+          elements: expect.arrayContaining([expect.objectContaining({ text: "signal · Project *Frontend* · Acme" })]),
+        }),
+        expect.objectContaining({
+          elements: expect.arrayContaining([
+            expect.objectContaining({
+              url: "https://app.example.com/projects/frontend/signals/ssssssssssssssssssssssss",
+            }),
+          ]),
+        }),
+      ]),
+    })
   })
 
   it("short-circuits on second dispatch with the same idempotency + channel", async () => {

--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
@@ -96,4 +96,16 @@ describe("requestSignalDiscoveredNotificationsUseCase", () => {
 
     expect(result).toEqual({ status: "skipped", reason: "signal-not-found" })
   })
+
+  it("skips user-origin signals", async () => {
+    const result = await Effect.runPromise(
+      requestSignalDiscoveredNotificationsUseCase(input).pipe(
+        Effect.provide(
+          makeLayer({ signal: makeSignal({ origin: "user", source: "custom", centroid: null, clusteredAt: null }) }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "user-origin-signal" })
+  })
 })

--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
@@ -33,7 +33,7 @@ export interface SignalDiscoveredNotificationRequest {
 }
 
 export type RequestSignalDiscoveredNotificationsResult =
-  | { readonly status: "skipped"; readonly reason: "signal-not-found" | "no-recipients" }
+  | { readonly status: "skipped"; readonly reason: "signal-not-found" | "user-origin-signal" | "no-recipients" }
   | { readonly status: "ok"; readonly requests: readonly SignalDiscoveredNotificationRequest[] }
 
 export type RequestSignalDiscoveredNotificationsError = RepositoryError
@@ -49,6 +49,10 @@ export const requestSignalDiscoveredNotificationsUseCase = (input: RequestSignal
     if (signal === null || signal.projectId !== input.projectId) {
       yield* Effect.annotateCurrentSpan("skipped", "signal-not-found")
       return { status: "skipped", reason: "signal-not-found" } as const
+    }
+    if (signal.origin === "user") {
+      yield* Effect.annotateCurrentSpan("skipped", "user-origin-signal")
+      return { status: "skipped", reason: "user-origin-signal" } as const
     }
 
     const recipients = yield* resolveRecipients({


### PR DESCRIPTION
Signal discovery notifications were too sparse compared with the incident escalation notifications. This updates both delivery surfaces so a newly discovered signal includes the signal name, description, project context, and a direct link back to the signal.

The email renderer now uses the shared React Email notification layout instead of hand-built HTML, with the same section header, metadata table, timestamp, signal id footer, unsubscribe footer, and CTA button used by the other signal/incident emails. The Slack renderer now resolves the signal before posting and includes the signal details plus a "View signal" action.

The producer now skips user-origin signals for `signal.discovered` notifications, matching the signal-discovery trigger behavior so manually created signals do not fan out as newly discovered system signals.

Validation:
- `pnpm --filter @domain/email check`
- `pnpm --filter @domain/email typecheck`
- `pnpm --filter @domain/integrations check`
- `pnpm --filter @domain/integrations typecheck`
- `pnpm --filter @domain/integrations test -- dispatch-slack-notification.test.ts`
- `pnpm --filter @domain/notifications check`
- `pnpm --filter @domain/notifications typecheck`
- `pnpm --filter @domain/notifications test -- request-signal-discovered-notifications.test.ts`
- commit hook: `turbo format` and `knip`
