### PR TITLE
refactor(operations): restore getApiKey as a tool

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -14177,6 +14177,93 @@
       }
     },
     {
+      "name": "getApiKey",
+      "title": "Get API key",
+      "description": "Returns a single API key including the full unmasked `token`. Useful for retrieving a stored token by id without rotating it.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "apiKeyId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "API-key identifier."
+          }
+        },
+        "required": [
+          "apiKeyId"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable API-key identifier."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this API key."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "token": {
+            "type": "string",
+            "description": "The full API key token. Returned by create / get / update — store it securely; treat it as a password."
+          },
+          "lastUsedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "token",
+          "lastUsedAt",
+          "deletedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      }
+    },
+    {
       "name": "updateApiKey",
       "title": "Update API key",
       "description": "Renames an API key. The token itself is immutable — use create + revoke if you need a new value.",

--- a/packages/operations/src/operations/api-keys.ts
+++ b/packages/operations/src/operations/api-keys.ts
@@ -188,9 +188,6 @@ const getApiKey = apiKeyEndpoint({
     request: { params: ApiKeyIdParamsSchema },
     responses: typedResponses({ status: 200, schema: ResponseSchema, description: "API key" }),
   }),
-  // Returns the full unmasked token — keep it off MCP and every in-process agent
-  // toolset (HTTP/SDK/CLI only) so a secret can't land in an agent's context.
-  tool: false,
   access: "read-only",
   rateLimitTier: "low",
   execute: (input, ctx) =>

--- a/packages/operations/src/toolsets/read-only.test.ts
+++ b/packages/operations/src/toolsets/read-only.test.ts
@@ -14,7 +14,5 @@ describe("readOnlyToolset", () => {
     const names = readOnlyToolset.tools.map((t) => t.name)
     expect(names).toContain("listTools")
     expect(names).not.toContain("createSignal")
-    // Returns an unmasked API-key token; must stay out of the default agent surface.
-    expect(names).not.toContain("getApiKey")
   })
 })


### PR DESCRIPTION
Restores `getApiKey` as an MCP tool and an in-process read-only toolset operation, reverting the `tool: false` opt-out added in #3934.

## context

The operations migration (#3934) converted `getApiKey` to execute-form. During review it was marked `tool: false` because it returns the full unmasked `token` — that removed it from MCP and kept it out of `readOnlyToolset`. Removing it from MCP was a surface change from the pre-migration state, where `getApiKey` had always been an MCP tool. This brings it back: it's an MCP tool again and, as an execute-form read-only operation, is now also included in `readOnlyToolset`.

## security note

`getApiKey` returns the unmasked API-key token. Over MCP and in the in-process read-only agent toolset, that token lands in tool output — and therefore in the agent's context, logs, and replay history. Reaching the operation still requires org-level auth. This is a deliberate decision to keep the operation available to agents; the masked `listApiKeys` remains the safer listing surface.

## surface

- `mcp.json`: `getApiKey` re-added
- `openapi.json`, TS SDK, Python SDK, CLI: unchanged
- `read-only.test` drops the `not.toContain("getApiKey")` guard added in #3934
