### PR TITLE
fix(signals): show freshly created signals with zero occurrences

### DIFF
--- a/packages/domain/signals/src/ports/signal-repository.ts
+++ b/packages/domain/signals/src/ports/signal-repository.ts
@@ -164,6 +164,20 @@ export interface SignalRepositoryShape {
   listTableRows(
     input: ListSignalTableRowsRepositoryInput,
   ): Effect.Effect<SignalTableRowsPage, RepositoryError, SqlClient>
+  /**
+   * Ids of non-deleted signals created within the window. The analytics path
+   * seeds its candidate set from ClickHouse activity metrics, which never
+   * include zero-occurrence signals; feeding these ids in keeps the counts,
+   * public API list, and export consistent with the table (which lists a
+   * signal that fired in OR was created in the window).
+   */
+  listIdsCreatedInTimeRange(input: {
+    readonly projectId: ProjectId
+    readonly timeRange: {
+      readonly from?: Date
+      readonly to?: Date
+    }
+  }): Effect.Effect<readonly SignalId[], RepositoryError, SqlClient>
 }
 
 export class SignalRepository extends Context.Service<SignalRepository, SignalRepositoryShape>()(

--- a/packages/domain/signals/src/testing/fake-signal-repository.ts
+++ b/packages/domain/signals/src/testing/fake-signal-repository.ts
@@ -171,8 +171,11 @@ export const createFakeSignalRepository = (
             if (lifecycleGroup === "active" && archived) return false
             if (lifecycleGroup === "archived" && !archived) return false
             if (assigneeIds?.length && !assigneeIds.includes(issue.assigneeId ?? "unassigned")) return false
-            if (timeRange?.from && issue.updatedAt < timeRange.from) return false
-            if (timeRange?.to && issue.updatedAt > timeRange.to) return false
+            if (timeRange?.from || timeRange?.to) {
+              const inWindow = (date: Date) =>
+                (!timeRange.from || date >= timeRange.from) && (!timeRange.to || date <= timeRange.to)
+              if (!inWindow(issue.updatedAt) && !inWindow(issue.createdAt)) return false
+            }
             if (
               query &&
               !issue.name.toLowerCase().includes(query) &&

--- a/packages/domain/signals/src/testing/fake-signal-repository.ts
+++ b/packages/domain/signals/src/testing/fake-signal-repository.ts
@@ -203,6 +203,18 @@ export const createFakeSignalRepository = (
         }
       }),
 
+    listIdsCreatedInTimeRange: ({ projectId, timeRange }) =>
+      Effect.sync(() =>
+        [...issues.values()]
+          .filter((issue) => issue.projectId === projectId && issue.deletedAt === null)
+          .filter(
+            (issue) =>
+              (!timeRange.from || issue.createdAt >= timeRange.from) &&
+              (!timeRange.to || issue.createdAt <= timeRange.to),
+          )
+          .map((issue) => issue.id),
+      ),
+
     ...overrides,
   }
 

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -492,6 +492,76 @@ describe("listSignalsUseCase", () => {
     expect(result.hasAnySignals).toBe(true)
   })
 
+  it("includes a signal created in the selected window with zero occurrences in the analytics counts and items", async () => {
+    const now = new Date("2026-04-10T00:00:00.000Z")
+    const timeRange = { from: new Date("2026-03-11T00:00:00.000Z"), to: now }
+    const activeSignal = makeSignal({
+      id: SignalId("aaaaaaaaaaaaaaaaaaaaaaaa"),
+      priority: "high",
+      createdAt: new Date("2026-03-20T08:00:00.000Z"),
+      updatedAt: new Date("2026-03-20T08:00:00.000Z"),
+      clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
+    })
+    // A freshly created user signal with no scores yet: no ClickHouse window
+    // metric, but its createdAt falls in the window, so it must still surface in
+    // the analytics path that drives the counts, public API list, and export.
+    const freshSignal = makeSignal({
+      id: SignalId("ffffffffffffffffffffffff"),
+      origin: "user",
+      source: "custom",
+      priority: "urgent",
+      centroid: null,
+      clusteredAt: null,
+      createdAt: new Date("2026-04-09T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-09T08:00:00.000Z"),
+    })
+
+    const { repository: signalRepository } = createFakeSignalRepository([activeSignal, freshSignal])
+    const { repository: evaluationRepository } = createEvaluationRepository()
+    const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
+      listSignalWindowMetrics: () =>
+        Effect.succeed([
+          makeWindowMetric({
+            signalId: activeSignal.id,
+            occurrences: 5,
+            firstSeenAt: new Date("2026-04-01T00:00:00.000Z"),
+            lastSeenAt: new Date("2026-04-05T00:00:00.000Z"),
+          }),
+        ]),
+      aggregateBySignals: aggregateOccurrences([
+        makeOccurrence({
+          signalId: activeSignal.id,
+          totalOccurrences: 5,
+          firstSeenAt: new Date("2026-04-01T00:00:00.000Z"),
+          lastSeenAt: new Date("2026-04-05T00:00:00.000Z"),
+        }),
+      ]),
+    })
+
+    const result = await Effect.runPromise(
+      listSignalsUseCase({ organizationId, projectId, now, timeRange }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(SignalRepository, signalRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+            Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+            provideSessionRepository,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.totalCount).toBe(2)
+    // Priority-grouped: urgent (fresh) before high (active).
+    expect(result.items.map((issue) => issue.id)).toEqual([freshSignal.id, activeSignal.id])
+    const fresh = result.items.find((issue) => issue.id === freshSignal.id)
+    expect(fresh?.occurrences).toBe(0)
+    expect(result.priorityCounts.urgent).toBe(1)
+    expect(result.priorityCounts.high).toBe(1)
+  })
+
   it("keeps analytics independent from the lifecycle tab and hydrates only visible signal ids", async () => {
     const now = new Date("2026-04-10T12:00:00.000Z")
     const activeSignal = makeSignal({

--- a/packages/domain/signals/src/use-cases/list-signals.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.ts
@@ -658,6 +658,16 @@ export const listSignalsUseCase = (
         })
       : Effect.succeed([] satisfies readonly SignalSearchCandidate[])
 
+    // ClickHouse window metrics never surface zero-occurrence signals, so a
+    // signal created in the window is invisible to the analytics path (counts,
+    // public API list, export) even though the table now lists it. Pull those
+    // ids from Postgres and fold them into the candidate set below.
+    const createdInWindowEffect = selectedTimeRange
+      ? signalRepository
+          .listIdsCreatedInTimeRange({ projectId: parsed.projectId, timeRange: selectedTimeRange })
+          .pipe(Effect.withSpan("issues.listSignals.listIdsCreatedInTimeRange"))
+      : Effect.succeed([] satisfies readonly SignalId[])
+
     // The denominator for `affectedSessionsPercent` must be counted against
     // `sessions.start_time` (not `scores.created_at`) so the percentage stays
     // consistent with what the web table shows. Async scoring can produce
@@ -681,14 +691,21 @@ export const listSignalsUseCase = (
       })
       .pipe(Effect.withSpan("issues.listSignals.countByProjectId"))
 
-    const [windowMetrics, searchCandidates] = yield* Effect.all([windowMetricsEffect, searchCandidatesEffect])
+    const [windowMetrics, searchCandidates, createdInWindowIds] = yield* Effect.all([
+      windowMetricsEffect,
+      searchCandidatesEffect,
+      createdInWindowEffect,
+    ])
 
     const windowMetricsBySignalId = new Map(windowMetrics.map((metric) => [metric.signalId, metric] as const))
+    const createdInWindowSet = new Set<SignalId>(createdInWindowIds)
+    // A created-in-window signal still has to match an active search, so it
+    // only joins the candidate set through the search hits — never as a bare id.
     const baseCandidateIds = parsed.search
       ? searchCandidates
           .map((candidate) => candidate.signalId)
-          .filter((signalId) => windowMetricsBySignalId.has(signalId))
-      : windowMetrics.map((metric) => metric.signalId)
+          .filter((signalId) => windowMetricsBySignalId.has(signalId) || createdInWindowSet.has(signalId))
+      : Array.from(new Set<SignalId>([...windowMetrics.map((metric) => metric.signalId), ...createdInWindowIds]))
     // When the caller passed an explicit `signalIds` filter, include those
     // issues in the candidate set even if they had no activity in the
     // window — they get synthesized zero `windowMetric` rows below so the
@@ -743,7 +760,10 @@ export const listSignalsUseCase = (
     const searchScoresBySignalId = new Map(
       searchCandidates.map((candidate) => [candidate.signalId, candidate.score] as const),
     )
-    const forceIncludeSignalIds = parsed.signalIds ? new Set<string>(parsed.signalIds) : null
+    const forceIncludeSignalIds =
+      parsed.signalIds || createdInWindowIds.length > 0
+        ? new Set<string>([...(parsed.signalIds ?? []), ...createdInWindowIds])
+        : null
     const canonicalSignals = yield* signalRepository
       .findByIds({
         projectId: parsed.projectId,
@@ -756,10 +776,10 @@ export const listSignalsUseCase = (
     const analyticsCandidates = canonicalSignals
       .map((issue) => {
         const windowMetric = windowMetricsBySignalId.get(issue.id) ?? null
-        // Signals without window metrics are normally filtered out — but when
-        // the caller passed `signalIds`, force-include them with a synthesized
-        // zero-activity metric so a point-lookup over a known issue id still
-        // returns a stable analytics shape.
+        // Signals without window metrics are normally filtered out. Force-include
+        // those the caller pinned via `signalIds` or that were created in the
+        // window, synthesizing a zero-activity metric so the analytics shape
+        // stays stable and zero-occurrence signals still surface.
         if (!windowMetric && !forceIncludeSignalIds?.has(issue.id)) {
           return null
         }

--- a/packages/platform/db-postgres/src/repositories/signal-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/signal-repository.test.ts
@@ -1,0 +1,117 @@
+import { OrganizationId, ProjectId, SignalId, type SqlClient } from "@domain/shared"
+import { SignalRepository } from "@domain/signals"
+import { Effect } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { signals } from "../schema/signals.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { SignalRepositoryLive } from "./signal-repository.ts"
+
+const ORG_ID = OrganizationId("org-signal-repo-test".padEnd(24, "x").slice(0, 24))
+const PROJECT_ID = ProjectId("proj-signal-repo-test".padEnd(24, "x").slice(0, 24))
+
+const WINDOW_FROM = new Date("2026-03-01T00:00:00.000Z")
+const WINDOW_TO = new Date("2026-04-01T00:00:00.000Z")
+
+const pg = setupTestPostgres()
+
+const run = <A, E>(effect: Effect.Effect<A, E, SignalRepository | SqlClient>) =>
+  Effect.runPromise(effect.pipe(withPostgres(SignalRepositoryLive, pg.adminPostgresClient, ORG_ID)))
+
+const seedSignal = (input: { readonly id: string; readonly slug: string; readonly createdAt: Date }) =>
+  pg.db.insert(signals).values({
+    id: input.id,
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    slug: input.slug,
+    name: input.slug,
+    description: `${input.slug} description`,
+    source: "custom",
+    origin: "user",
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  })
+
+// A signal created inside the window, and one created well before it. Neither
+// has scores, so occurrence-based membership never applies.
+const CREATED_IN_WINDOW = {
+  id: "sig-fresh".padEnd(24, "a"),
+  slug: "fresh",
+  createdAt: new Date("2026-03-15T00:00:00.000Z"),
+}
+const CREATED_BEFORE_WINDOW = {
+  id: "sig-stale".padEnd(24, "b"),
+  slug: "stale",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+}
+
+describe("SignalRepositoryLive.listTableRows zero-occurrence membership", () => {
+  beforeEach(async () => {
+    await pg.db.delete(signals)
+    await seedSignal(CREATED_IN_WINDOW)
+    await seedSignal(CREATED_BEFORE_WINDOW)
+  })
+
+  it("lists a signal created in the window even with no occurrences", async () => {
+    const page = await run(
+      Effect.gen(function* () {
+        const repo = yield* SignalRepository
+        return yield* repo.listTableRows({
+          projectId: PROJECT_ID,
+          limit: 50,
+          offset: 0,
+          timeRange: { from: WINDOW_FROM, to: WINDOW_TO },
+        })
+      }),
+    )
+
+    expect(page.items.map((issue) => issue.id)).toContain(CREATED_IN_WINDOW.id)
+    expect(page.items.map((issue) => issue.id)).not.toContain(CREATED_BEFORE_WINDOW.id)
+    expect(page.totalCount).toBe(1)
+  })
+
+  it("lists every signal when no window is applied", async () => {
+    const page = await run(
+      Effect.gen(function* () {
+        const repo = yield* SignalRepository
+        return yield* repo.listTableRows({ projectId: PROJECT_ID, limit: 50, offset: 0 })
+      }),
+    )
+
+    expect(page.totalCount).toBe(2)
+    expect(page.items.map((issue) => issue.id).sort()).toEqual([CREATED_IN_WINDOW.id, CREATED_BEFORE_WINDOW.id].sort())
+  })
+})
+
+describe("SignalRepositoryLive.listIdsCreatedInTimeRange", () => {
+  beforeEach(async () => {
+    await pg.db.delete(signals)
+    await seedSignal(CREATED_IN_WINDOW)
+    await seedSignal(CREATED_BEFORE_WINDOW)
+  })
+
+  it("returns only signals created inside the bounds", async () => {
+    const ids = await run(
+      Effect.gen(function* () {
+        const repo = yield* SignalRepository
+        return yield* repo.listIdsCreatedInTimeRange({
+          projectId: PROJECT_ID,
+          timeRange: { from: WINDOW_FROM, to: WINDOW_TO },
+        })
+      }),
+    )
+
+    expect(ids).toEqual([SignalId(CREATED_IN_WINDOW.id)])
+  })
+
+  it("returns all non-deleted signals when the range is unbounded", async () => {
+    const ids = await run(
+      Effect.gen(function* () {
+        const repo = yield* SignalRepository
+        return yield* repo.listIdsCreatedInTimeRange({ projectId: PROJECT_ID, timeRange: {} })
+      }),
+    )
+
+    expect([...ids].sort()).toEqual([SignalId(CREATED_IN_WINDOW.id), SignalId(CREATED_BEFORE_WINDOW.id)].sort())
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/signal-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/signal-repository.ts
@@ -368,6 +368,27 @@ const signalRepositoryCoreLive = Layer.effect(
             )
         }),
 
+      listIdsCreatedInTimeRange: ({ projectId, timeRange }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .select({ id: signals.id })
+                .from(signals)
+                .where(
+                  and(
+                    eq(signals.organizationId, organizationId),
+                    eq(signals.projectId, projectId),
+                    isNull(signals.deletedAt),
+                    timeRange.from ? gte(signals.createdAt, timeRange.from) : undefined,
+                    timeRange.to ? lte(signals.createdAt, timeRange.to) : undefined,
+                  ),
+                ),
+            )
+            .pipe(Effect.map((rows) => rows.map((row) => SignalId(row.id))))
+        }),
+
       findById: (id: SignalId) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/packages/platform/db-postgres/src/repositories/signal-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/signal-repository.ts
@@ -23,7 +23,23 @@ import {
   signalSchema,
   UNASSIGNED_FILTER,
 } from "@domain/signals"
-import { and, asc, count, desc, eq, getTableColumns, ilike, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm"
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  getTableColumns,
+  gte,
+  ilike,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { incidents } from "../schema/alert-incidents.ts"
@@ -239,18 +255,26 @@ const signalRepositoryCoreLive = Layer.effect(
               const search = searchQuery?.trim()
               const scoreCreatedFromClause = timeRange?.from ? sql`and ${scores.createdAt} >= ${timeRange.from}` : sql``
               const scoreCreatedToClause = timeRange?.to ? sql`and ${scores.createdAt} <= ${timeRange.to}` : sql``
-              const hasScoreActivityInTimeRange =
+              // A signal belongs in the window if it fired in it OR was created in it, so a
+              // freshly created signal appears before its first occurrence lands.
+              const activityOrCreatedInTimeRange =
                 timeRange?.from || timeRange?.to
-                  ? sql<boolean>`exists (
-                      select 1
-                      from ${scores}
-                      where ${scores.organizationId} = ${organizationId}
-                        and ${scores.projectId} = ${projectId}
-                        and ${scores.signalId} = ${signals.id}
-                        and ${scores.draftedAt} is null
-                        ${scoreCreatedFromClause}
-                        ${scoreCreatedToClause}
-                    )`
+                  ? or(
+                      sql<boolean>`exists (
+                        select 1
+                        from ${scores}
+                        where ${scores.organizationId} = ${organizationId}
+                          and ${scores.projectId} = ${projectId}
+                          and ${scores.signalId} = ${signals.id}
+                          and ${scores.draftedAt} is null
+                          ${scoreCreatedFromClause}
+                          ${scoreCreatedToClause}
+                      )`,
+                      and(
+                        timeRange?.from ? gte(signals.createdAt, timeRange.from) : undefined,
+                        timeRange?.to ? lte(signals.createdAt, timeRange.to) : undefined,
+                      ),
+                    )
                   : undefined
               const where = and(
                 eq(signals.organizationId, organizationId),
@@ -262,7 +286,7 @@ const signalRepositoryCoreLive = Layer.effect(
                     ? isNotNull(signals.mutedAt)
                     : undefined,
                 assigneeConditions,
-                hasScoreActivityInTimeRange,
+                activityOrCreatedInTimeRange,
                 search ? or(ilike(signals.name, `%${search}%`), ilike(signals.description, `%${search}%`)) : undefined,
               )
               const direction = sort?.direction === "asc" ? asc : desc


### PR DESCRIPTION
Creating a signal used to leave it invisible on the Signals page until its first occurrence landed. This fixes that.

## Cause

The Signals list is served by `listTableRows` in the Postgres signal repository. It filtered rows to signals with at least one `scores` row inside the selected time window. The page always sends a window (default: last 30 days), so a brand-new signal with zero occurrences failed the filter and disappeared until its first score arrived.

## Fix

The window filter now treats a signal as in-window if it fired in the window **or** was created in the window:

```
EXISTS(scores in window) OR (signals.created_at BETWEEN from AND to)
```

Because the default view always covers the last 30 days, a just-created signal is "created in window" and shows immediately, regardless of occurrences. Selecting an explicit range keeps working and now also surfaces signals created during that range, not only ones that fired in it.

Sorting is unchanged: a zero-occurrence signal falls back to `created_at` for its last-seen key, so it lands by creation time within its priority group.

## Scope

Touches only the list membership query. The analytics/counts panel and per-row metrics stay window-scoped as before — a zero-occurrence signal simply reads 0.

Known edge case: a signal created *before* the current window with zero occurrences still won't appear in that window (it neither fired nor was created in it); widening the range to cover its creation date surfaces it.

## Testing

Typecheck and the full `@domain/signals` suite pass. The membership predicate lives in raw SQL with no PGlite harness for this repository, so it's best confirmed manually — create a signal and verify it appears with 0 occurrences under the default range.
