### PR TITLE
fix(monitors): give threshold monitors an open/close incident lifecycle

### DIFF
--- a/dev-docs/monitors.md
+++ b/dev-docs/monitors.md
@@ -69,7 +69,7 @@ All monitor kinds use the same target x trigger matrix:
 | Trigger | Condition | Incident lifecycle | Notification key |
 | --- | --- | --- | --- |
 | `match` | none | point event, `ended_at = started_at` | `monitor.match` |
-| `threshold` | metric threshold over the target window | point event, `ended_at = started_at` | `monitor.threshold` |
+| `threshold` | metric threshold over the target window | open/close incident; alerts once on open, closes silently after the exit dwell | `monitor.threshold` |
 | `escalating` | sustained count escalation | open/close incident | `monitor.escalating` |
 
 Supported metrics are:
@@ -138,7 +138,7 @@ Monitor evaluation inserts incidents with:
 - `severity: monitor.rule.severity`
 - `condition: null` for `match`, or the rule condition snapshot for threshold/escalating
 
-Point monitors (`match`, `threshold`) insert an event row with `endedAt = startedAt` every time the rule fires. Escalating monitors use the sustained path: one open row per monitor, closed when `EscalationEngine` exits.
+`match` monitors are point events: they insert a row with `endedAt = startedAt` every time the rule fires. `threshold` and `escalating` monitors use the sustained path: one open row per monitor while the condition holds. `threshold` opens an incident on first breach (freezing the evaluated threshold into `entrySignals` so the close-side compares against what tripped it, not a drifting baseline), then closes it once the condition has been clear for `THRESHOLD_EXIT_DWELL_MS` (`exitEligibleSince` tracks the dwell). A `threshold` incident alerts once on open (`incident.event`) and closes **silently** — no `IncidentClosed` event, so no recovery notification; closing simply re-arms a fresh alert if the breach recurs. `escalating` incidents close when `EscalationEngine` exits (and do notify on close).
 
 ## Evaluation
 
@@ -201,6 +201,6 @@ Public API/MCP surfaces follow the same contract: monitor create/update accepts 
 - Deleting a saved search cascades to active monitors with `target.type = "savedSearch"` and `target.id` matching the saved search.
 - Mute sets `muted_at`; muted monitors do not evaluate and the notification producer also skips any race-window fan-out.
 - Incidents are source keyed by `(source_type, source_id)`, not by a monitor-alert join.
-- At most one *open* incident per `(organization_id, source_type, source_id)` — enforced by a partial unique index on `incidents` where `ended_at IS NULL`. Point incidents (`ended_at = started_at`) are not open and do not contend for this slot.
+- At most one *open* incident per `(organization_id, source_type, source_id)` — enforced by a partial unique index on `incidents` where `ended_at IS NULL`. `threshold` and `escalating` incidents are open and contend for this slot; `match` point incidents (`ended_at = started_at`) are not open and do not.
 - Escalating monitors must use count series.
 - Organization/project scoping is enforced at repository and boundary layers; Postgres follows the repo's no-FK rule.

--- a/packages/domain/incidents/src/entities/incident.ts
+++ b/packages/domain/incidents/src/entities/incident.ts
@@ -54,9 +54,10 @@ export const entrySignalsSnapshotSchema = z.object({
 export type EntrySignalsSnapshot = z.infer<typeof entrySignalsSnapshotSchema>
 
 /**
- * Entry snapshot for a `savedSearch.escalating` incident: the threshold frozen at
- * open time so the close-side compares against it rather than re-resolving a
- * drifting baseline. `baselineCount` + `baseline` are multiplier-mode only.
+ * Entry snapshot for a monitor `threshold` incident: the evaluated threshold frozen at
+ * open time so the close-side compares against it rather than re-resolving a drifting
+ * multiplier/seasonal baseline (which could auto-close a live breach). `baselineCount` +
+ * `baseline` are multiplier-mode only.
  */
 export const savedSearchEntrySignalsSchema = z.object({
   evaluatedThreshold: z.number(),

--- a/packages/domain/monitors/src/constants.ts
+++ b/packages/domain/monitors/src/constants.ts
@@ -13,6 +13,13 @@ export const SAVED_SEARCH_CURRENT_WINDOW_MS = 5 * 60 * 1000
  */
 export const SAVED_SEARCH_MONITORS_THROTTLE_MS = 5 * 60 * 1000
 
+/**
+ * How long a `threshold` monitor's condition must stay clear before its open incident
+ * closes — hysteresis so a metric oscillating around the threshold doesn't flap open/closed.
+ * Independent of the escalation engine's dwell so threshold behaviour can be tuned alone.
+ */
+export const THRESHOLD_EXIT_DWELL_MS = 30 * 60 * 1000
+
 /** Per-project `checkSavedSearchMonitors` dedupe key, shared by trace-end + the sweep so the two triggers coalesce into one throttled check stream. */
 export const savedSearchMonitorsCheckDedupeKey = ({
   organizationId,

--- a/packages/domain/monitors/src/use-cases/check-monitors.test.ts
+++ b/packages/domain/monitors/src/use-cases/check-monitors.test.ts
@@ -58,6 +58,40 @@ const monitor = ({ id, rule, ...edits }: Partial<Monitor> & Pick<Monitor, "id" |
   ...edits,
 })
 
+const thresholdMonitorId = MonitorId(cuid("m-thr"))
+const thresholdCondition = {
+  trigger: "threshold" as const,
+  metric: { kind: "count" as const },
+  threshold: { mode: "absolute" as const, value: 2 },
+  direction: "above" as const,
+}
+const thresholdMonitor = () =>
+  monitor({
+    id: thresholdMonitorId,
+    rule: {
+      trigger: "threshold",
+      config: { metric: { kind: "count" }, condition: thresholdCondition },
+      severity: "high",
+    },
+  })
+const openThresholdIncident = (overrides: Partial<Incident> = {}): Incident => ({
+  id: AlertIncidentId(cuid("ai-thr")),
+  organizationId,
+  projectId,
+  sourceType: "monitor",
+  sourceId: thresholdMonitorId,
+  severity: "high",
+  startedAt: new Date("2026-06-23T11:00:00.000Z"),
+  endedAt: null,
+  createdAt: new Date("2026-06-23T11:00:00.000Z"),
+  entrySignals: { evaluatedThreshold: 2 },
+  exitEligibleSince: null,
+  condition: thresholdCondition,
+  ...overrides,
+})
+// Two count-metric matches inside the current [now-5m, now) window ⇒ value 2 ⇒ meets `>= 2`.
+const twoMatches = [new Date("2026-06-23T11:57:00.000Z"), new Date("2026-06-23T11:58:00.000Z")]
+
 const layersFor = (
   monitors: readonly Monitor[],
   matches: readonly Date[],
@@ -192,25 +226,10 @@ describe("checkMonitorsUseCase", () => {
     })
   })
 
-  it("creates a point incident for a threshold monitor that breaches", async () => {
+  it("opens an incident for a threshold monitor that breaches and freezes the threshold", async () => {
     const firstMatch = new Date("2026-06-23T11:57:30.000Z")
-    const condition = {
-      trigger: "threshold" as const,
-      metric: { kind: "count" as const },
-      threshold: { mode: "absolute" as const, value: 2 },
-      direction: "above" as const,
-    }
-    const { incidents, layer } = layersFor(
-      [
-        monitor({
-          id: MonitorId(cuid("m2")),
-          rule: {
-            trigger: "threshold",
-            config: { metric: { kind: "count" }, condition },
-            severity: "high",
-          },
-        }),
-      ],
+    const { events, incidents, layer } = layersFor(
+      [thresholdMonitor()],
       [firstMatch, new Date("2026-06-23T11:58:30.000Z")],
     )
 
@@ -220,12 +239,81 @@ describe("checkMonitorsUseCase", () => {
     expect(incidents).toHaveLength(1)
     expect(incidents[0]).toMatchObject({
       sourceType: "monitor",
-      sourceId: MonitorId(cuid("m2")),
+      sourceId: thresholdMonitorId,
       severity: "high",
       startedAt: firstMatch,
-      endedAt: firstMatch,
-      condition,
+      endedAt: null,
+      exitEligibleSince: null,
+      entrySignals: { evaluatedThreshold: 2 },
+      condition: thresholdCondition,
     })
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IncidentCreated",
+      payload: { sourceType: "monitor", sourceId: thresholdMonitorId },
+    })
+  })
+
+  it("does not re-open or re-notify while a threshold incident is open", async () => {
+    const { events, incidents, layer } = layersFor([thresholdMonitor()], twoMatches, undefined, undefined, [
+      openThresholdIncident(),
+    ])
+
+    const result = await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(result).toEqual({ checked: 1, evaluatable: 1, evaluated: 1, failed: 0 })
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({ endedAt: null, exitEligibleSince: null })
+    expect(events).toHaveLength(0)
+  })
+
+  it("starts the exit dwell when a threshold condition clears", async () => {
+    const { events, incidents, layer } = layersFor([thresholdMonitor()], [], undefined, undefined, [
+      openThresholdIncident(),
+    ])
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(incidents).toHaveLength(1)
+    expect(incidents[0]).toMatchObject({ endedAt: null, exitEligibleSince: now })
+    expect(events).toHaveLength(0)
+  })
+
+  it("holds a threshold incident open during the exit dwell", async () => {
+    const exitEligibleSince = new Date("2026-06-23T11:45:00.000Z") // 15 min before now
+    const { events, incidents, layer } = layersFor([thresholdMonitor()], [], undefined, undefined, [
+      openThresholdIncident({ exitEligibleSince }),
+    ])
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(incidents[0]).toMatchObject({ endedAt: null, exitEligibleSince })
+    expect(events).toHaveLength(0)
+  })
+
+  it("closes a threshold incident silently after the exit dwell elapses", async () => {
+    const exitEligibleSince = new Date("2026-06-23T11:29:00.000Z") // 31 min before now
+    const { events, incidents, layer } = layersFor([thresholdMonitor()], [], undefined, undefined, [
+      openThresholdIncident({ exitEligibleSince }),
+    ])
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    // Closed at the moment it cleared, and silently — no IncidentClosed event, so no recovery email.
+    expect(incidents[0]).toMatchObject({ endedAt: exitEligibleSince })
+    expect(events).toHaveLength(0)
+  })
+
+  it("resets the exit dwell when a threshold breach resumes", async () => {
+    const exitEligibleSince = new Date("2026-06-23T11:45:00.000Z")
+    const { events, incidents, layer } = layersFor([thresholdMonitor()], twoMatches, undefined, undefined, [
+      openThresholdIncident({ exitEligibleSince }),
+    ])
+
+    await Effect.runPromise(checkMonitorsUseCase({ projectId }).pipe(Effect.provide(layer)))
+
+    expect(incidents[0]).toMatchObject({ endedAt: null, exitEligibleSince: null })
+    expect(events).toHaveLength(0)
   })
 
   it("opens an escalating monitor incident through the sustained state machine", async () => {

--- a/packages/domain/monitors/src/use-cases/check-monitors.ts
+++ b/packages/domain/monitors/src/use-cases/check-monitors.ts
@@ -1,9 +1,11 @@
 import { OutboxEventWriter } from "@domain/events"
 import {
   IncidentRepository,
+  isSavedSearchEntrySignals,
   isSignalEscalationEntrySignals,
   MIN_SEASONAL_SAMPLES,
   makeEscalationEngine,
+  type SavedSearchEntrySignals,
   SeriesReader,
   seasonalAnomalyThreshold,
 } from "@domain/incidents"
@@ -25,7 +27,7 @@ import {
 } from "@domain/shared"
 import { SEASONAL_HISTORY_WEEKS } from "@domain/signals"
 import { Effect } from "effect"
-import { SAVED_SEARCH_CURRENT_WINDOW_MS } from "../constants.ts"
+import { SAVED_SEARCH_CURRENT_WINDOW_MS, THRESHOLD_EXIT_DWELL_MS } from "../constants.ts"
 import type { Monitor } from "../entities/monitor.ts"
 import { monitorConfigCondition } from "../entities/monitor.ts"
 import type { MetricSeriesReaderShape, MetricSeriesTarget } from "../ports/metric-series-reader.ts"
@@ -154,41 +156,49 @@ const resolveMonitorTargets = (monitors: readonly Monitor[]) =>
     return resolved.filter((entry): entry is ResolvedMonitorTarget => entry !== null)
   })
 
-const evaluatePointMonitor = (
+type ThresholdCondition = Extract<AlertIncidentCondition, { trigger: "threshold" }>
+
+const thresholdMetricTarget = (target: MetricSeriesTarget, condition: ThresholdCondition): MetricSeriesTarget => ({
+  ...target,
+  metric: condition.metric,
+})
+
+const evaluateMatchPoint = (
   monitor: Monitor,
   target: MetricSeriesTarget,
-  condition: AlertIncidentCondition | null,
   metricReader: MetricSeriesReaderShape,
   now: Date,
 ) =>
   Effect.gen(function* () {
     const from = new Date(now.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS)
-    if (monitor.rule.trigger === "match") {
-      const matchTarget = { ...target, metric: { kind: "count" as const } }
-      const value = yield* metricReader.valueInWindow({
-        organizationId: monitor.organizationId,
-        projectId: monitor.projectId,
-        target: matchTarget,
-        from,
-        to: now,
-      })
-      if (value <= 0) return null
-      const firstEventAt = yield* metricReader.firstEventAt({
-        organizationId: monitor.organizationId,
-        projectId: monitor.projectId,
-        target: matchTarget,
-        from,
-        to: now,
-      })
-      return {
-        startedAt: firstEventAt ?? now,
-        condition,
-      }
-    }
+    const matchTarget = { ...target, metric: { kind: "count" as const } }
+    const value = yield* metricReader.valueInWindow({
+      organizationId: monitor.organizationId,
+      projectId: monitor.projectId,
+      target: matchTarget,
+      from,
+      to: now,
+    })
+    if (value <= 0) return null
+    const firstEventAt = yield* metricReader.firstEventAt({
+      organizationId: monitor.organizationId,
+      projectId: monitor.projectId,
+      target: matchTarget,
+      from,
+      to: now,
+    })
+    return { startedAt: firstEventAt ?? now }
+  })
 
-    if (condition?.trigger !== "threshold") return null
-
-    const metricTarget = { ...target, metric: condition.metric }
+const computeThresholdValue = (
+  monitor: Monitor,
+  target: MetricSeriesTarget,
+  condition: ThresholdCondition,
+  metricReader: MetricSeriesReaderShape,
+  now: Date,
+) =>
+  Effect.gen(function* () {
+    const metricTarget = thresholdMetricTarget(target, condition)
     const valueIn = (windowFrom: Date, windowTo: Date) =>
       metricReader.valueInWindow({
         organizationId: monitor.organizationId,
@@ -197,28 +207,54 @@ const evaluatePointMonitor = (
         from: windowFrom,
         to: windowTo,
       })
-    const value = yield* valueIn(from, now)
     const threshold = condition.threshold
     const direction = condition.direction ?? "above"
-    let thresholdValue: number
-    if (threshold.mode === "absolute") {
-      thresholdValue = threshold.value
-    } else if (threshold.mode === "multiplier") {
+    if (threshold.mode === "absolute") return threshold.value
+    if (threshold.mode === "multiplier") {
       const baseline = baselineWindow(threshold.baseline, now)
       const baselineValue = yield* valueIn(baseline.from, baseline.to)
       const scale = metricIsAccumulating(metricTarget.metric) ? SAVED_SEARCH_CURRENT_WINDOW_MS / baseline.lengthMs : 1
-      thresholdValue = threshold.factor * baselineValue * scale
-    } else {
-      const historical = yield* Effect.all(
-        Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
-          const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
-          return valueIn(new Date(historyTo.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS), historyTo)
-        }),
-        { concurrency: "unbounded" },
-      )
-      thresholdValue = seasonalThreshold(historical, threshold, direction)
+      return threshold.factor * baselineValue * scale
     }
+    const historical = yield* Effect.all(
+      Array.from({ length: SEASONAL_HISTORY_WEEKS }, (_unused, index) => {
+        const historyTo = new Date(now.getTime() - (index + 1) * WEEK_MS)
+        return valueIn(new Date(historyTo.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS), historyTo)
+      }),
+      { concurrency: "unbounded" },
+    )
+    return seasonalThreshold(historical, threshold, direction)
+  })
 
+/**
+ * Evaluate a threshold condition over the current window. Without `frozenThreshold` the
+ * live threshold is computed (the open decision); passing an open incident's frozen entry
+ * threshold re-checks it against what tripped it, so a drifting multiplier/seasonal baseline
+ * can't silently close a real breach.
+ */
+const evaluateThreshold = (
+  monitor: Monitor,
+  target: MetricSeriesTarget,
+  condition: ThresholdCondition,
+  metricReader: MetricSeriesReaderShape,
+  now: Date,
+  frozenThreshold?: number,
+) =>
+  Effect.gen(function* () {
+    const metricTarget = thresholdMetricTarget(target, condition)
+    const from = new Date(now.getTime() - SAVED_SEARCH_CURRENT_WINDOW_MS)
+    const value = yield* metricReader.valueInWindow({
+      organizationId: monitor.organizationId,
+      projectId: monitor.projectId,
+      target: metricTarget,
+      from,
+      to: now,
+    })
+    const thresholdValue =
+      frozenThreshold !== undefined
+        ? frozenThreshold
+        : yield* computeThresholdValue(monitor, target, condition, metricReader, now)
+    const direction = condition.direction ?? "above"
     let isMet = isThresholdMet(value, thresholdValue, direction)
     const firstEventAt = isMet
       ? yield* metricReader.firstEventAt({
@@ -229,12 +265,9 @@ const evaluatePointMonitor = (
           to: now,
         })
       : null
-    if (isMet && direction === "below" && threshold.mode === "absolute" && firstEventAt === null) isMet = false
-    if (!isMet) return null
-    return {
-      startedAt: firstEventAt ?? now,
-      condition,
-    }
+    if (isMet && direction === "below" && condition.threshold.mode === "absolute" && firstEventAt === null)
+      isMet = false
+    return { met: isMet, startedAt: firstEventAt ?? now, thresholdValue }
   })
 
 export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
@@ -251,10 +284,9 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
     let failed = 0
     const evaluatable = active.filter(monitorCanEvaluate)
 
-    const checkPointMonitor = (monitor: Monitor, target: MetricSeriesTarget) =>
+    const checkMatchMonitor = (monitor: Monitor, target: MetricSeriesTarget) =>
       Effect.gen(function* () {
-        const condition = monitorConfigCondition(monitor.rule.config)
-        const point = yield* evaluatePointMonitor(monitor, target, condition, metricReader, now)
+        const point = yield* evaluateMatchPoint(monitor, target, metricReader, now)
         if (point === null) return
         yield* sqlClient.transaction(
           Effect.gen(function* () {
@@ -271,7 +303,7 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
               createdAt,
               entrySignals: null,
               exitEligibleSince: null,
-              condition: point.condition,
+              condition: null,
             }
             yield* incidentRepository.insert(incident)
             yield* outboxEventWriter.write({
@@ -289,6 +321,80 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
             })
           }),
         )
+      })
+
+    const checkThresholdMonitor = (monitor: Monitor, target: MetricSeriesTarget) =>
+      Effect.gen(function* () {
+        const condition = monitorConfigCondition(monitor.rule.config)
+        if (condition?.trigger !== "threshold") return
+        const openIncident = yield* incidentRepository.findOpen({ sourceType: "monitor", sourceId: monitor.id })
+
+        if (openIncident === null) {
+          const breach = yield* evaluateThreshold(monitor, target, condition, metricReader, now)
+          if (!breach.met) return
+          yield* sqlClient.transaction(
+            Effect.gen(function* () {
+              const createdAt = new Date()
+              const incident = {
+                id: AlertIncidentId(generateId()),
+                organizationId: monitor.organizationId,
+                projectId: monitor.projectId,
+                sourceType: "monitor" as const,
+                sourceId: monitor.id,
+                severity: monitor.rule.severity,
+                startedAt: breach.startedAt,
+                endedAt: null,
+                createdAt,
+                entrySignals: { evaluatedThreshold: breach.thresholdValue } satisfies SavedSearchEntrySignals,
+                exitEligibleSince: null,
+                condition,
+              }
+              yield* incidentRepository.insert(incident)
+              yield* outboxEventWriter.write({
+                eventName: "IncidentCreated",
+                aggregateType: "alert_incident",
+                aggregateId: incident.id,
+                organizationId: incident.organizationId,
+                payload: {
+                  organizationId: incident.organizationId,
+                  projectId: incident.projectId,
+                  alertIncidentId: incident.id,
+                  sourceType: "monitor",
+                  sourceId: monitor.id,
+                },
+              })
+            }),
+          )
+          return
+        }
+
+        // An open incident exists: re-check against the FROZEN entry threshold so a
+        // drifting baseline can't auto-close a live breach. A single open incident per
+        // episode (the partial unique index) means one alert, not one per sweep.
+        const frozenThreshold = isSavedSearchEntrySignals(openIncident.entrySignals)
+          ? openIncident.entrySignals.evaluatedThreshold
+          : undefined
+        const breach = yield* evaluateThreshold(monitor, target, condition, metricReader, now, frozenThreshold)
+
+        if (breach.met) {
+          if (openIncident.exitEligibleSince !== null) {
+            yield* incidentRepository.updateExitDwell({ id: openIncident.id, exitEligibleSince: null })
+          }
+          return
+        }
+        if (openIncident.exitEligibleSince === null) {
+          yield* incidentRepository.updateExitDwell({ id: openIncident.id, exitEligibleSince: now })
+          return
+        }
+        if (now.getTime() - openIncident.exitEligibleSince.getTime() >= THRESHOLD_EXIT_DWELL_MS) {
+          // Silent close: no IncidentClosed event, so no recovery notification. `ended_at`
+          // is the moment it cleared, and closing re-arms a fresh alert on recurrence.
+          yield* incidentRepository.closeOpen({
+            sourceType: "monitor",
+            sourceId: monitor.id,
+            endedAt: openIncident.exitEligibleSince,
+          })
+        }
       })
 
     const checkEscalatingMonitor = (monitor: Monitor, target: MetricSeriesTarget) =>
@@ -407,8 +513,12 @@ export const checkMonitorsUseCase = (input: CheckMonitorsInput) =>
         const resolved = yield* resolveMonitorTargets([monitor])
         const entry = resolved[0]
         if (entry === undefined) return false
-        if (monitor.rule.trigger === "match" || monitor.rule.trigger === "threshold") {
-          yield* checkPointMonitor(entry.monitor, entry.target)
+        if (monitor.rule.trigger === "match") {
+          yield* checkMatchMonitor(entry.monitor, entry.target)
+          return true
+        }
+        if (monitor.rule.trigger === "threshold") {
+          yield* checkThresholdMonitor(entry.monitor, entry.target)
           return true
         }
         if (monitorCanUseSeasonalEngine(monitor)) {

--- a/packages/domain/monitors/src/use-cases/update-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor.test.ts
@@ -286,4 +286,54 @@ describe("updateMonitorUseCase", () => {
       payload: { alertIncidentId: incidentId, reason: "resolved", sourceType: "monitor", sourceId: monitorId },
     })
   })
+
+  it("closes an open threshold incident when the condition changes", async () => {
+    const incidentId = AlertIncidentId("i".repeat(24))
+    const incidentRepo = createIncidentRepo(incidentId)
+    const outbox = createOutbox()
+    const thresholdRule = {
+      trigger: "threshold" as const,
+      severity: "high" as const,
+      config: {
+        metric: { kind: "count" as const },
+        condition: {
+          trigger: "threshold" as const,
+          metric: { kind: "count" as const },
+          threshold: { mode: "absolute" as const, value: 2 },
+          direction: "above" as const,
+        },
+      },
+    }
+    const { repo } = createFakeMonitorRepository([makeMonitor({ rule: thresholdRule })])
+
+    await run(
+      updateMonitorUseCase({
+        id: monitorId,
+        rule: {
+          trigger: "threshold",
+          severity: "high",
+          config: {
+            metric: { kind: "count" },
+            condition: {
+              trigger: "threshold",
+              metric: { kind: "count" },
+              threshold: { mode: "absolute", value: 5 },
+              direction: "above",
+            },
+          },
+        },
+      }),
+      repo,
+      incidentRepo.repo,
+      outbox.writer,
+    )
+
+    expect(incidentRepo.closeOpenCalls).toMatchObject([{ sourceType: "monitor", sourceId: monitorId }])
+    // reason "resolved" is silent in the IncidentClosed handler → no recovery email on a reconfigure.
+    expect(outbox.events[0]).toMatchObject({
+      eventName: "IncidentClosed",
+      aggregateId: incidentId,
+      payload: { alertIncidentId: incidentId, reason: "resolved" },
+    })
+  })
 })

--- a/packages/domain/monitors/src/use-cases/update-monitor.ts
+++ b/packages/domain/monitors/src/use-cases/update-monitor.ts
@@ -164,8 +164,12 @@ export const updateMonitorUseCase = (
           rule: nextRule,
           updatedAt: now,
         }
+        // `escalating` and `threshold` are the triggers that open a sustained incident; a target/rule
+        // edit must evict the stale open row so the next sweep can't reuse it (or leave it dangling if
+        // the trigger switched to point-based `match`). `IncidentClosed` with `reason: "resolved"` is
+        // silent for both, so no recovery email fires — the incident was reconfigured, not recovered.
         const closesOpenIncident =
-          monitor.rule.trigger === "escalating" &&
+          (monitor.rule.trigger === "escalating" || monitor.rule.trigger === "threshold") &&
           (JSON.stringify(monitor.target) !== JSON.stringify(nextTarget) ||
             monitor.rule.trigger !== nextRule.trigger ||
             JSON.stringify(monitor.rule.config) !== JSON.stringify(nextRule.config))

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
@@ -256,12 +256,15 @@ describe("requestIncidentNotificationsUseCase", () => {
     })
   })
 
-  it("fans out monitor threshold incidents and applies the monitor threshold gate", async () => {
+  it("fans out monitor threshold incidents as one-shot events and applies the monitor threshold gate", async () => {
+    // Threshold incidents are now sustained (open, endedAt=null) but still alert once with the
+    // one-shot `incident.event` kind, not `incident.opened` — no recovery email on close.
     const incident = makeIncident({
       sourceType: "monitor",
       sourceId: monitorId,
       severity: "medium",
-      endedAt: startedAt,
+      endedAt: null,
+      entrySignals: { evaluatedThreshold: 10 },
       condition: thresholdCondition,
     })
 
@@ -274,6 +277,8 @@ describe("requestIncidentNotificationsUseCase", () => {
 
     expect(allowed.status).toBe("ok")
     if (allowed.status !== "ok") throw new Error("expected ok")
+    expect(allowed.requests[0]?.kind).toBe("incident.event")
+    expect(allowed.requests[0]?.idempotencyKey).toBe(`incident.event:${incident.id}`)
     expect(allowed.requests[0]?.payload).toMatchObject({
       incidentKind: "monitor.threshold" satisfies IncidentNotificationKey,
       condition: thresholdCondition,

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
@@ -120,6 +120,10 @@ const TAGS_LOOKBACK_DAYS = 30
 
 const resolveKind = (incident: Incident, transition: IncidentTransition): IncidentNotificationKind => {
   if (transition === "closed") return "incident.closed"
+  // Monitor threshold incidents are sustained (open, `endedAt = null`) for dedup + tracking,
+  // but alert once on open with no recovery email — the same one-shot copy as a point event.
+  // So they emit `incident.event` despite being open; the close is silent (no IncidentClosed).
+  if (incident.sourceType === "monitor" && incident.condition?.trigger === "threshold") return "incident.event"
   // "created" — the incident is freshly inserted. `endedAt = startedAt`
   // means an eventful kind that collapsed
   // to a point in time; otherwise it's the open side of a sustained


### PR DESCRIPTION
## what

`threshold` monitors now open a single incident per breach episode and close it once the condition clears, instead of firing a fresh point incident on every evaluation. `match` monitors are unchanged.

## why

A `threshold` monitor (`avg cost`, direction `below`, `1.2×` a 7-day baseline) sent a user 7-9 identical "Monitor threshold: a monitored target" emails in one day — one every ~5-20 min until they muted it.

Root cause: for `threshold` (and `match`) monitors, `checkMonitorsUseCase` used the point path, which unconditionally inserts a new incident (`ended_at = started_at`) and emits `IncidentCreated` on every sweep the condition holds. There's no open-incident dedup, and the notification idempotency key is `incident.event:${alertIncidentId}` — a new id each cycle, so nothing collapses. A `below`/`multiplier` condition is satisfied almost continuously for a stable metric, so it re-fired on nearly every 5-min sweep.

## how

`checkThresholdMonitor` replaces the threshold branch of the old point path with the open/close state machine the `escalating` path already uses:

- **Open** on first breach: insert one incident with `ended_at = null` (protected by the existing `incidents_open_source_idx` partial unique index — one open incident per source) and emit `IncidentCreated`. The evaluated threshold is **frozen** onto `entry_signals` (the previously dormant `savedSearchEntrySignals` shape, `{ evaluatedThreshold }`).
- **Dedup while open**: subsequent sweeps re-check the current value against the *frozen* threshold (so a drifting multiplier/seasonal baseline can't auto-close a live breach). Still breaching → no new incident, no email.
- **Close** after a 30-min exit dwell (`exit_eligible_since` + new `THRESHOLD_EXIT_DWELL_MS`): the condition must stay clear for the dwell before the incident closes; a re-breach in the window resets the timer. Hysteresis, no separate entry/exit bands.

Notification behavior is deliberately unchanged for the reader: a threshold incident still alerts **once** with the same one-shot `incident.event` email (identical subject/body). This required decoupling the notification kind from `ended_at` — `resolveKind` now returns `incident.event` for an open monitor-threshold incident rather than `incident.opened`. The **close is silent**: no `IncidentClosed` event is emitted (it's notification-only), so there's no recovery email. Closing only re-arms a fresh alert if the breach recurs.

The net user-visible change is that duplicates stop.

## decisions / scope

- **No recovery email** and no new email types — the smallest behavioral delta for a bugfix. Silent close = simply not writing the `IncidentClosed` outbox event.
- **Permanently-open incidents are intended** ("active since N" tracking) — no max-duration timeout, unlike the escalating engine's 72h backstop.
- `ended_at` on close is set to when the condition cleared (`exit_eligible_since`), not the dwell-confirmation time.
- **`match` is untouched** for now — an event-stream trigger where open/close changes meaning more than it does for threshold.
- **No migration**: the schema already had nullable `ended_at`, `entry_signals`, `exit_eligible_since`, and the one-open-per-source index. No existing open threshold incidents to backfill. The web incident chart already renders `ended_at = null` as an ongoing range.

## testing

- `@domain/monitors` (50 pass): threshold open+freeze, dedup-while-open, dwell start/hold, silent close, dwell reset; `match` and `escalating` cases unchanged.
- `@domain/notifications` (36 pass): open threshold incident on `created` resolves to `incident.event` with a stable idempotency key.
- Typecheck clean across `@domain/{monitors,notifications,incidents}`, `@app/{workers,web,api}`.