### PR TITLE
Add ElevenLabs post-call OpenTelemetry webhook ingestion

### DIFF
--- a/apps/ingest/package.json
+++ b/apps/ingest/package.json
@@ -17,6 +17,7 @@
     "@domain/queue": "workspace:*",
     "@domain/sandboxes": "workspace:*",
     "@domain/shared": "workspace:*",
+    "@domain/elevenlabs": "workspace:*",
     "@domain/spans": "workspace:*",
     "@hono/node-server": "catalog:",
     "@hono/otel": "1.1.1",

--- a/apps/ingest/src/routes/elevenlabs-webhook.ts
+++ b/apps/ingest/src/routes/elevenlabs-webhook.ts
@@ -1,0 +1,110 @@
+import { NoCreditsRemainingError } from "@domain/billing"
+import { ingestElevenlabsWebhookUseCase } from "@domain/elevenlabs"
+import { SandboxArchivedError, SandboxQuotaExceededError } from "@domain/sandboxes"
+import { SandboxSignalsLive } from "@platform/cache-redis"
+import {
+  BillingOverrideRepositoryLive,
+  BillingUsagePeriodRepositoryLive,
+  findActiveElevenlabsWebhookEndpointByToken,
+  getEncryptionKey,
+  OrganizationRepositoryLive,
+  ProjectRepositoryLive,
+  SandboxRepositoryLive,
+  SettingsReaderLive,
+  StripeSubscriptionLookupLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { QueuePublisherLive } from "@platform/queue-bullmq"
+import { StorageDiskLive } from "@platform/storage-object"
+import { withTracing } from "@repo/observability"
+import { Cause, Effect, Exit, Layer, Option } from "effect"
+import type { Hono } from "hono"
+import {
+  getAdminPostgresClient,
+  getPostgresClient,
+  getQueuePublisher,
+  getRedisClient,
+  getStorageDisk,
+} from "../clients.ts"
+import type { IngestEnv } from "../types.ts"
+
+interface ElevenlabsWebhookRouteContext {
+  app: Hono<IngestEnv>
+}
+
+const webhookIngestionLayers = Layer.mergeAll(
+  BillingOverrideRepositoryLive,
+  BillingUsagePeriodRepositoryLive,
+  OrganizationRepositoryLive,
+  ProjectRepositoryLive,
+  SandboxRepositoryLive,
+  SettingsReaderLive,
+  StripeSubscriptionLookupLive,
+)
+
+export const registerElevenlabsWebhookRoute = ({ app }: ElevenlabsWebhookRouteContext) => {
+  app.post("/v1/webhooks/elevenlabs/:webhookToken", async (c) => {
+    const webhookToken = c.req.param("webhookToken")
+    const rawBody = await c.req.text()
+    const signature = c.req.header("ElevenLabs-Signature") ?? c.req.header("elevenlabs-signature")
+
+    const adminClient = getAdminPostgresClient()
+    const encryptionKey = await Effect.runPromise(getEncryptionKey())
+    const endpoint = await Effect.runPromise(
+      findActiveElevenlabsWebhookEndpointByToken(adminClient.db, webhookToken, new Uint8Array(encryptionKey)).pipe(
+        withTracing,
+      ),
+    )
+
+    if (!endpoint) {
+      return c.json({ error: "Webhook endpoint not found" }, 404)
+    }
+
+    const postgresClient = getPostgresClient()
+    const ingestionEffect = ingestElevenlabsWebhookUseCase({
+      endpoint,
+      signature,
+      rawBody,
+    }).pipe(
+      withPostgres(webhookIngestionLayers, postgresClient, endpoint.organizationId),
+      Effect.provide(
+        Layer.mergeAll(
+          StorageDiskLive(getStorageDisk()),
+          QueuePublisherLive(await getQueuePublisher()),
+          SandboxSignalsLive(getRedisClient()),
+        ),
+      ),
+      withTracing,
+    )
+
+    const exit = await Effect.runPromiseExit(ingestionEffect)
+
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.findErrorOption(exit.cause)
+      if (Option.isSome(failure) && (failure.value as { _tag?: string })._tag === "InvalidElevenlabsSignatureError") {
+        return c.json({ error: "Invalid signature" }, 401)
+      }
+      if (
+        Option.isSome(failure) &&
+        (failure.value as { _tag?: string })._tag === "InvalidElevenlabsWebhookPayloadError"
+      ) {
+        return c.json({ error: "Unsupported webhook payload" }, 400)
+      }
+      if (Option.isSome(failure) && failure.value instanceof NoCreditsRemainingError) {
+        const err = failure.value
+        return c.json({ error: err.httpMessage, kind: "NoCreditsRemaining" }, err.httpStatus)
+      }
+      if (Option.isSome(failure) && failure.value instanceof SandboxArchivedError) {
+        const err = failure.value
+        return c.json({ error: err.httpMessage, kind: "SandboxArchived" }, err.httpStatus)
+      }
+      if (Option.isSome(failure) && failure.value instanceof SandboxQuotaExceededError) {
+        const err = failure.value
+        return c.json({ error: err.httpMessage, kind: "SandboxQuotaExceeded" }, err.httpStatus)
+      }
+      throw new Error(Cause.pretty(exit.cause))
+    }
+
+    return c.json({ received: true, acceptedSpans: exit.value.acceptedSpans })
+  })
+}

--- a/apps/ingest/src/routes/index.ts
+++ b/apps/ingest/src/routes/index.ts
@@ -1,5 +1,6 @@
 import type { Hono } from "hono"
 import type { IngestEnv } from "../types.ts"
+import { registerElevenlabsWebhookRoute } from "./elevenlabs-webhook.ts"
 import { registerHealthRoute } from "./health.ts"
 import { registerTracesRoute } from "./traces.ts"
 
@@ -10,4 +11,5 @@ interface RoutesContext {
 export const registerRoutes = (context: RoutesContext) => {
   registerHealthRoute(context)
   registerTracesRoute(context)
+  registerElevenlabsWebhookRoute(context)
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@better-auth/sso": "catalog:",
     "@domain/admin": "workspace:*",
     "@domain/agent-dispatch": "workspace:*",
+    "@domain/elevenlabs": "workspace:*",
     "@domain/incidents": "workspace:*",
     "@domain/annotations": "workspace:*",
     "@domain/api-keys": "workspace:*",

--- a/apps/web/src/domains/elevenlabs/elevenlabs.functions.ts
+++ b/apps/web/src/domains/elevenlabs/elevenlabs.functions.ts
@@ -1,0 +1,85 @@
+import {
+  disableElevenlabsWebhookUseCase,
+  enableElevenlabsWebhookUseCase,
+  getElevenlabsWebhookUseCase,
+} from "@domain/elevenlabs"
+import { OrganizationId, ProjectId, UserId } from "@domain/shared"
+import { ElevenlabsWebhookEndpointRepositoryLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { parseEnv } from "@platform/env"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect, Layer } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getPostgresClient } from "../../server/clients.ts"
+
+const ingestBaseUrl = () => Effect.runSync(parseEnv("LAT_INGEST_URL", "string", "http://localhost:3002"))
+
+const repositoryLayers = Layer.mergeAll(ElevenlabsWebhookEndpointRepositoryLive, ProjectRepositoryLive)
+
+interface ElevenlabsWebhookRecord {
+  readonly id: string
+  readonly webhookUrl: string
+  readonly createdAt: string
+}
+
+export const getElevenlabsWebhook = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }) => {
+    const { organizationId } = await requireSession()
+    const result = await Effect.runPromise(
+      getElevenlabsWebhookUseCase({
+        organizationId: OrganizationId(organizationId),
+        projectId: ProjectId(data.projectId),
+        ingestBaseUrl: ingestBaseUrl(),
+      }).pipe(
+        withPostgres(ElevenlabsWebhookEndpointRepositoryLive, getPostgresClient(), OrganizationId(organizationId)),
+        withTracing,
+      ),
+    )
+
+    if (!result) return null
+    return {
+      id: result.endpoint.id,
+      webhookUrl: result.webhookUrl,
+      createdAt: result.endpoint.createdAt.toISOString(),
+    } satisfies ElevenlabsWebhookRecord
+  })
+
+export const enableElevenlabsWebhook = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      signingSecret: z.string().min(8),
+    }),
+  )
+  .handler(async ({ data }) => {
+    const { organizationId, userId } = await requireSession()
+    const result = await Effect.runPromise(
+      enableElevenlabsWebhookUseCase({
+        organizationId: OrganizationId(organizationId),
+        projectId: ProjectId(data.projectId),
+        signingSecret: data.signingSecret,
+        createdByUserId: UserId(userId),
+        ingestBaseUrl: ingestBaseUrl(),
+      }).pipe(withPostgres(repositoryLayers, getPostgresClient(), OrganizationId(organizationId)), withTracing),
+    )
+
+    return {
+      id: result.endpoint.id,
+      webhookUrl: result.webhookUrl,
+      createdAt: result.endpoint.createdAt.toISOString(),
+    } satisfies ElevenlabsWebhookRecord
+  })
+
+export const disableElevenlabsWebhook = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }) => {
+    const { organizationId } = await requireSession()
+    await Effect.runPromise(
+      disableElevenlabsWebhookUseCase({
+        organizationId: OrganizationId(organizationId),
+        projectId: ProjectId(data.projectId),
+      }).pipe(withPostgres(repositoryLayers, getPostgresClient(), OrganizationId(organizationId)), withTracing),
+    )
+  })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/elevenlabs-webhook-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/elevenlabs-webhook-section.tsx
@@ -1,0 +1,121 @@
+import { Button, CopyableText, ElevenlabsIcon, FormField, Input, Modal, Text, useToast } from "@repo/ui"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useState } from "react"
+import {
+  disableElevenlabsWebhook,
+  enableElevenlabsWebhook,
+  getElevenlabsWebhook,
+} from "../../../../../../domains/elevenlabs/elevenlabs.functions.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { IntegrationCard } from "./integration-card.tsx"
+
+const QUERY_KEY = ["elevenlabs-webhook"] as const
+
+export function ElevenlabsWebhookSection({ projectId }: { readonly projectId: string }) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const [connectOpen, setConnectOpen] = useState(false)
+  const [signingSecret, setSigningSecret] = useState("")
+
+  const { data, isLoading } = useQuery({
+    queryKey: [...QUERY_KEY, projectId],
+    queryFn: () => getElevenlabsWebhook({ data: { projectId } }),
+  })
+
+  const enableMutation = useMutation({
+    mutationFn: () => enableElevenlabsWebhook({ data: { projectId, signingSecret } }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [...QUERY_KEY, projectId] })
+      setConnectOpen(false)
+      setSigningSecret("")
+      toast({ description: "ElevenLabs webhook connected" })
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    },
+  })
+
+  const disableMutation = useMutation({
+    mutationFn: () => disableElevenlabsWebhook({ data: { projectId } }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [...QUERY_KEY, projectId] })
+      toast({ description: "ElevenLabs webhook disconnected" })
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    },
+  })
+
+  return (
+    <>
+      <IntegrationCard
+        icon={ElevenlabsIcon}
+        title="ElevenLabs Agents"
+        subtitle={
+          data
+            ? "Post-call OpenTelemetry webhooks are connected for this project."
+            : "Receive post-call OpenTelemetry traces from ElevenLabs-managed agents."
+        }
+        actions={
+          isLoading ? null : data ? (
+            <div className="flex flex-row items-center gap-2">
+              <Button variant="outline" onClick={() => setConnectOpen(true)}>
+                Rotate secret
+              </Button>
+              <Button
+                variant="destructive"
+                isLoading={disableMutation.isPending}
+                onClick={() => disableMutation.mutate()}
+              >
+                Disconnect
+              </Button>
+            </div>
+          ) : (
+            <Button onClick={() => setConnectOpen(true)}>Connect</Button>
+          )
+        }
+      />
+
+      {data ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
+          <Text.H6 color="foregroundMuted">Webhook URL</Text.H6>
+          <CopyableText value={data.webhookUrl} tooltip="Copy webhook URL" />
+          <Text.H6 color="foregroundMuted" className="mt-2">
+            In ElevenLabs, create a workspace post-call webhook pointing at this URL, enable the Transcript event, and
+            set transcript format to OpenTelemetry.
+          </Text.H6>
+        </div>
+      ) : null}
+
+      <Modal open={connectOpen} onOpenChange={setConnectOpen} title="Connect ElevenLabs webhook">
+        <div className="flex flex-col gap-4">
+          <Text.H6 color="foregroundMuted">
+            Paste the signing secret from your ElevenLabs workspace webhook. Latitude verifies the ElevenLabs-Signature
+            header on every delivery.
+          </Text.H6>
+          <FormField label="Webhook signing secret">
+            <Input
+              type="password"
+              value={signingSecret}
+              onChange={(event) => setSigningSecret(event.target.value)}
+              placeholder="whsec_..."
+              autoComplete="off"
+            />
+          </FormField>
+          <div className="flex flex-row justify-end gap-2">
+            <Button variant="outline" onClick={() => setConnectOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              isLoading={enableMutation.isPending}
+              disabled={signingSecret.length < 8}
+              onClick={() => enableMutation.mutate()}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/integrations/index.tsx
@@ -16,6 +16,7 @@ import { useProjectsCollection } from "../../../../../../domains/projects/projec
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { useRouteProject } from "../../-route-data.ts"
 import { AgentDispatchSection } from "../-components/agent-dispatch-section.tsx"
+import { ElevenlabsWebhookSection } from "../-components/elevenlabs-webhook-section.tsx"
 import { IntegrationCard } from "../-components/integration-card.tsx"
 import { SettingsPage } from "../-components/settings-page.tsx"
 import { SLACK_INTEGRATION_QUERY_KEY, SlackRouteRow } from "../-components/slack-route-row.tsx"
@@ -66,7 +67,10 @@ function IntegrationsSettingsPage() {
       <div className="flex flex-col gap-3">
         <SlackIntegrationSection />
         {currentProject ? (
-          <AgentDispatchSection projectId={currentProject.id} projectSlug={currentProject.slug} />
+          <>
+            <ElevenlabsWebhookSection projectId={currentProject.id} />
+            <AgentDispatchSection projectId={currentProject.id} projectSlug={currentProject.slug} />
+          </>
         ) : null}
       </div>
     </SettingsPage>

--- a/biome.json
+++ b/biome.json
@@ -153,6 +153,7 @@
         "!apps/web/src/domains/auth/**",
         "!apps/web/src/domains/billing/**",
         "!apps/web/src/domains/destinations/**",
+        "!apps/web/src/domains/elevenlabs/**",
         "!apps/web/src/domains/feature-flags/**",
         "!apps/web/src/domains/integrations/**",
         "!apps/web/src/domains/members/**",
@@ -192,7 +193,7 @@
                   },
                   "@platform/db-postgres": {
                     "importNames": ["withPostgres"],
-                    "message": "Use withScopedPostgres (apps/web/src/server/scoped-postgres.ts): its org comes from resolveOrgScope, so under a showcase/sandbox scope it resolves the project's org, not the viewer's session org. If this domain is genuinely session- or cross-org (settings/account/org/admin/config), add it to this rule's exclude-list instead. The exclude-list holds only session- or cross-org domains that resolve the viewer's own / a cross-org id, never the project scope: admin, agent-dispatch, api-keys, auth, billing, destinations, feature-flags, integrations, members, notifications, oauth, organizations, projects, sandbox, showcase, sso, users, wrapped. `members` is the one dual domain — member management is session-org (raw withPostgres, hence excluded); its project read (`listProjectMembers`, for assignee/attribution) opts into withScopedPostgres explicitly."
+                    "message": "Use withScopedPostgres (apps/web/src/server/scoped-postgres.ts): its org comes from resolveOrgScope, so under a showcase/sandbox scope it resolves the project's org, not the viewer's session org. If this domain is genuinely session- or cross-org (settings/account/org/admin/config), add it to this rule's exclude-list instead. The exclude-list holds only session- or cross-org domains that resolve the viewer's own / a cross-org id, never the project scope: admin, agent-dispatch, api-keys, auth, billing, destinations, elevenlabs, feature-flags, integrations, members, notifications, oauth, organizations, projects, sandbox, showcase, sso, users, wrapped. `members` is the one dual domain — member management is session-org (raw withPostgres, hence excluded); its project read (`listProjectMembers`, for assignee/attribution) opts into withScopedPostgres explicitly."
                   }
                 }
               }

--- a/docs/telemetry/frameworks/elevenlabs.mdx
+++ b/docs/telemetry/frameworks/elevenlabs.mdx
@@ -34,7 +34,52 @@ The way in is ElevenLabs' [**Custom LLM**](https://elevenlabs.io/docs/eleven-age
 
 ---
 
-## Steps
+## ElevenLabs-managed agents (post-call OpenTelemetry)
+
+If your agent uses an **ElevenLabs-managed LLM** (not Custom LLM), the LLM calls never leave ElevenLabs' infrastructure. Latitude still receives the full conversation when ElevenLabs exports **post-call OpenTelemetry traces** to a webhook you configure.
+
+ElevenLabs sends `post_call_transcription_otel` webhooks with an `otlp_traces` payload (OTLP JSON). Latitude verifies the `ElevenLabs-Signature` header and ingests those spans into your project.
+
+<Steps>
+
+  <Step title="Enable the webhook in Latitude">
+    In your Latitude project, open **Settings → Integrations → ElevenLabs Agents** and click **Connect**. Paste the **signing secret** from your ElevenLabs workspace webhook. Copy the **Webhook URL** Latitude shows you.
+  </Step>
+
+  <Step title="Create a workspace webhook in ElevenLabs">
+    In the [ElevenAgents dashboard](https://elevenlabs.io/app/agents), create a workspace webhook with the Latitude URL and authentication enabled. Save the signing secret — you need the same value in Latitude.
+  </Step>
+
+  <Step title="Attach the webhook to your agent">
+    Open your agent settings, assign the webhook as the **post-call webhook**, enable the **Transcript** event, and set **transcript format** to **OpenTelemetry**.
+
+    See ElevenLabs' [OpenTelemetry traces guide](https://elevenlabs.io/docs/eleven-agents/customization/opentelemetry-traces#post-call-webhook) for CLI/API examples (`transcript_format: "opentelemetry"`).
+  </Step>
+
+  <Step title="Finish a conversation">
+    After a call completes and analysis finishes, ElevenLabs POSTs the OTLP trace to Latitude. Conversations appear grouped by `elevenlabs.conversation_id` with user/agent transcript spans and tool calls.
+  </Step>
+
+</Steps>
+
+### What you get
+
+| Span | Visible in Latitude |
+| --- | --- |
+| `elevenlabs.conversation` | Session root for the call |
+| `elevenlabs.recv.user_transcript` | User speech (text) |
+| `elevenlabs.recv.agent_response` | Agent reply (text) |
+| `elevenlabs.tool.*` | Tool executions |
+
+STT and TTS still run inside ElevenLabs; the webhook export covers the conversation transcript and tool timeline, not raw audio.
+
+---
+
+## Custom LLM proxy
+
+<Note>
+  Use **post-call OpenTelemetry webhooks** (above) for ElevenLabs-managed LLMs. Use the **Custom LLM** path below when you route the LLM through infrastructure you control and want per-turn token usage from your provider.
+</Note>
 
 <Steps>
 
@@ -244,10 +289,4 @@ Once connected, traces appear automatically in Latitude:
 2. Each agent turn shows the LLM call with its input/output conversation
 3. Token usage and latency are aggregated at every level
 
-<Note>
-  ElevenLabs-managed LLMs (where you don't bring your own endpoint) cannot be
-  traced this way — the calls never leave ElevenLabs' infrastructure. For those
-  agents, conversation transcripts are available via ElevenLabs'
-  [post-call webhooks](https://elevenlabs.io/docs/eleven-agents/workflows/post-call-webhooks)
-  and Conversations API.
-</Note>
+For ElevenLabs-managed agents without Custom LLM, use **Settings → Integrations → ElevenLabs Agents** to connect post-call OpenTelemetry webhooks instead.

--- a/packages/domain/elevenlabs/package.json
+++ b/packages/domain/elevenlabs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@domain/elevenlabs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@domain/organizations": "workspace:*",
+    "@domain/projects": "workspace:*",
+    "@domain/shared": "workspace:*",
+    "@domain/spans": "workspace:*",
+    "@platform/elevenlabs": "workspace:*",
+    "effect": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/vitest-config": "workspace:*",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/domain/elevenlabs/src/entities/webhook-endpoint.ts
+++ b/packages/domain/elevenlabs/src/entities/webhook-endpoint.ts
@@ -1,0 +1,30 @@
+import {
+  type ElevenlabsWebhookEndpointId,
+  elevenlabsWebhookEndpointIdSchema,
+  organizationIdSchema,
+  type ProjectId,
+  projectIdSchema,
+  userIdSchema,
+} from "@domain/shared"
+import { z } from "zod"
+
+export const elevenlabsWebhookEndpointSchema = z.object({
+  id: elevenlabsWebhookEndpointIdSchema,
+  organizationId: organizationIdSchema,
+  projectId: projectIdSchema,
+  webhookToken: z.string().min(1),
+  signingSecret: z.string().min(1),
+  createdByUserId: userIdSchema,
+  revokedAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+
+export type ElevenlabsWebhookEndpoint = z.infer<typeof elevenlabsWebhookEndpointSchema>
+
+export interface ElevenlabsWebhookEndpointPublic {
+  readonly id: ElevenlabsWebhookEndpointId
+  readonly projectId: ProjectId
+  readonly webhookToken: string
+  readonly createdAt: Date
+}

--- a/packages/domain/elevenlabs/src/errors.ts
+++ b/packages/domain/elevenlabs/src/errors.ts
@@ -1,0 +1,10 @@
+import { Data } from "effect"
+
+export class ElevenlabsWebhookNotFoundError extends Data.TaggedError("ElevenlabsWebhookNotFoundError")<{
+  readonly webhookToken?: string
+  readonly projectId?: string
+}> {}
+
+export class InvalidElevenlabsWebhookPayloadError extends Data.TaggedError("InvalidElevenlabsWebhookPayloadError")<{
+  readonly reason: "type" | "otlp"
+}> {}

--- a/packages/domain/elevenlabs/src/index.ts
+++ b/packages/domain/elevenlabs/src/index.ts
@@ -1,0 +1,24 @@
+export type {
+  ElevenlabsWebhookEndpoint,
+  ElevenlabsWebhookEndpointPublic,
+} from "./entities/webhook-endpoint.ts"
+export { elevenlabsWebhookEndpointSchema } from "./entities/webhook-endpoint.ts"
+export {
+  ElevenlabsWebhookNotFoundError,
+  InvalidElevenlabsWebhookPayloadError,
+} from "./errors.ts"
+export {
+  ElevenlabsWebhookEndpointRepository,
+  type ElevenlabsWebhookEndpointRepositoryShape,
+} from "./ports/webhook-endpoint-repository.ts"
+export {
+  type IngestElevenlabsWebhookInput,
+  ingestElevenlabsWebhookUseCase,
+} from "./use-cases/ingest-elevenlabs-webhook.ts"
+export {
+  disableElevenlabsWebhookUseCase,
+  type EnableElevenlabsWebhookInput,
+  type EnableElevenlabsWebhookResult,
+  enableElevenlabsWebhookUseCase,
+  getElevenlabsWebhookUseCase,
+} from "./use-cases/manage-elevenlabs-webhook.ts"

--- a/packages/domain/elevenlabs/src/ports/webhook-endpoint-repository.ts
+++ b/packages/domain/elevenlabs/src/ports/webhook-endpoint-repository.ts
@@ -1,0 +1,25 @@
+import type { ElevenlabsWebhookEndpointId, ProjectId, RepositoryError, SqlClient } from "@domain/shared"
+import { Context, type Effect } from "effect"
+import type { ElevenlabsWebhookEndpoint } from "../entities/webhook-endpoint.ts"
+
+export interface ElevenlabsWebhookEndpointRepositoryShape {
+  readonly findActiveByProjectId: (
+    projectId: ProjectId,
+  ) => Effect.Effect<ElevenlabsWebhookEndpoint | null, RepositoryError, SqlClient>
+
+  readonly findActiveByWebhookToken: (
+    webhookToken: string,
+  ) => Effect.Effect<ElevenlabsWebhookEndpoint | null, RepositoryError, SqlClient>
+
+  readonly save: (endpoint: ElevenlabsWebhookEndpoint) => Effect.Effect<void, RepositoryError, SqlClient>
+
+  readonly softRevokeById: (
+    id: ElevenlabsWebhookEndpointId,
+    revokedAt: Date,
+  ) => Effect.Effect<void, RepositoryError, SqlClient>
+}
+
+export class ElevenlabsWebhookEndpointRepository extends Context.Service<
+  ElevenlabsWebhookEndpointRepository,
+  ElevenlabsWebhookEndpointRepositoryShape
+>()("@domain/elevenlabs/ElevenlabsWebhookEndpointRepository") {}

--- a/packages/domain/elevenlabs/src/use-cases/ingest-elevenlabs-webhook.ts
+++ b/packages/domain/elevenlabs/src/use-cases/ingest-elevenlabs-webhook.ts
@@ -1,0 +1,87 @@
+import { isSandbox, OrganizationRepository } from "@domain/organizations"
+import { ProjectRepository } from "@domain/projects"
+import { OrganizationId, type ProjectId } from "@domain/shared"
+import { ingestSpansWithBillingUseCase } from "@domain/spans"
+import type { OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpSpan } from "@domain/spans/otlp"
+import { parseElevenlabsOtelWebhookEvent, verifyElevenlabsSignature } from "@platform/elevenlabs"
+import { Effect } from "effect"
+import type { ElevenlabsWebhookEndpoint } from "../entities/webhook-endpoint.ts"
+import { InvalidElevenlabsWebhookPayloadError } from "../errors.ts"
+
+export interface IngestElevenlabsWebhookInput {
+  readonly endpoint: ElevenlabsWebhookEndpoint
+  readonly signature: string | null | undefined
+  readonly rawBody: string
+}
+
+export const ingestElevenlabsWebhookUseCase = Effect.fn("elevenlabs.ingestWebhook")(function* (
+  input: IngestElevenlabsWebhookInput,
+) {
+  yield* verifyElevenlabsSignature({
+    signingSecret: input.endpoint.signingSecret,
+    signature: input.signature,
+    body: input.rawBody,
+  })
+
+  const event = parseElevenlabsOtelWebhookEvent(input.rawBody)
+  if (!event) {
+    return yield* Effect.fail(new InvalidElevenlabsWebhookPayloadError({ reason: "otlp" }))
+  }
+
+  const projectRepo = yield* ProjectRepository
+  const project = yield* projectRepo.findById(input.endpoint.projectId as ProjectId)
+
+  const organizationRepo = yield* OrganizationRepository
+  const organization = yield* organizationRepo.findById(OrganizationId(input.endpoint.organizationId))
+
+  const enrichContext = {
+    projectSlug: project.slug,
+    conversationId: event.data.conversation_id,
+    ...(event.data.agent_id ? { agentId: event.data.agent_id } : {}),
+  }
+
+  const otlp = enrichOtlpTraces(event.data.otlp_traces, enrichContext)
+
+  const payload = new TextEncoder().encode(JSON.stringify(otlp))
+  const result = yield* ingestSpansWithBillingUseCase({
+    organizationId: OrganizationId(input.endpoint.organizationId),
+    apiKeyId: `elevenlabs-webhook:${input.endpoint.id}`,
+    payload,
+    contentType: "application/json",
+    isSandbox: isSandbox(organization),
+    defaultProjectSlug: project.slug,
+  })
+
+  return { acceptedSpans: result.acceptedSpans }
+})
+
+const enrichOtlpTraces = (
+  request: OtlpExportTraceServiceRequest,
+  context: { readonly projectSlug: string; readonly conversationId: string; readonly agentId?: string },
+): OtlpExportTraceServiceRequest => ({
+  resourceSpans: (request.resourceSpans ?? []).map((resourceSpans) => ({
+    ...resourceSpans,
+    resource: {
+      ...resourceSpans.resource,
+      attributes: appendAttributes(resourceSpans.resource?.attributes ?? [], [
+        { key: "latitude.project", value: { stringValue: context.projectSlug } },
+        { key: "elevenlabs.conversation_id", value: { stringValue: context.conversationId } },
+        ...(context.agentId ? [{ key: "elevenlabs.agent_id" as const, value: { stringValue: context.agentId } }] : []),
+      ]),
+    },
+    scopeSpans: (resourceSpans.scopeSpans ?? []).map((scopeSpans) => ({
+      ...scopeSpans,
+      spans: (scopeSpans.spans ?? []).map((span: OtlpSpan) => ({
+        ...span,
+        attributes: appendAttributes(span.attributes ?? [], [
+          { key: "gen_ai.conversation.id", value: { stringValue: context.conversationId } },
+        ]),
+      })),
+    })),
+  })),
+})
+
+const appendAttributes = (existing: readonly OtlpKeyValue[], extra: readonly OtlpKeyValue[]): OtlpKeyValue[] => {
+  const keys = new Set(existing.map((attr) => attr.key))
+  return [...existing, ...extra.filter((attr) => !keys.has(attr.key))]
+}

--- a/packages/domain/elevenlabs/src/use-cases/manage-elevenlabs-webhook.ts
+++ b/packages/domain/elevenlabs/src/use-cases/manage-elevenlabs-webhook.ts
@@ -1,0 +1,97 @@
+import { randomBytes } from "node:crypto"
+import { ProjectRepository } from "@domain/projects"
+import { generateId, type OrganizationId, type ProjectId, SqlClient, type UserId } from "@domain/shared"
+import { Effect } from "effect"
+import type { ElevenlabsWebhookEndpoint, ElevenlabsWebhookEndpointPublic } from "../entities/webhook-endpoint.ts"
+import { ElevenlabsWebhookNotFoundError } from "../errors.ts"
+import { ElevenlabsWebhookEndpointRepository } from "../ports/webhook-endpoint-repository.ts"
+
+export interface EnableElevenlabsWebhookInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly signingSecret: string
+  readonly createdByUserId: UserId
+}
+
+export interface EnableElevenlabsWebhookResult {
+  readonly endpoint: ElevenlabsWebhookEndpointPublic
+  readonly webhookUrl: string
+}
+
+export const enableElevenlabsWebhookUseCase = Effect.fn("elevenlabs.enableWebhook")(function* (
+  input: EnableElevenlabsWebhookInput & { readonly ingestBaseUrl: string },
+) {
+  const projectRepo = yield* ProjectRepository
+  const project = yield* projectRepo.findById(input.projectId)
+  if (project.organizationId !== input.organizationId) {
+    return yield* Effect.fail(new ElevenlabsWebhookNotFoundError({ projectId: input.projectId }))
+  }
+
+  const sqlClient = yield* SqlClient
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* ElevenlabsWebhookEndpointRepository
+      const existing = yield* repo.findActiveByProjectId(input.projectId)
+      if (existing) {
+        yield* repo.softRevokeById(existing.id, new Date())
+      }
+
+      const now = new Date()
+      const endpoint: ElevenlabsWebhookEndpoint = {
+        id: generateId<"ElevenlabsWebhookEndpointId">(),
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        webhookToken: randomBytes(24).toString("hex"),
+        signingSecret: input.signingSecret,
+        createdByUserId: input.createdByUserId,
+        revokedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      yield* repo.save(endpoint)
+
+      const baseUrl = input.ingestBaseUrl.replace(/\/$/, "")
+      return {
+        endpoint: {
+          id: endpoint.id,
+          projectId: endpoint.projectId,
+          webhookToken: endpoint.webhookToken,
+          createdAt: endpoint.createdAt,
+        },
+        webhookUrl: `${baseUrl}/v1/webhooks/elevenlabs/${endpoint.webhookToken}`,
+      } satisfies EnableElevenlabsWebhookResult
+    }),
+  )
+})
+
+export const disableElevenlabsWebhookUseCase = Effect.fn("elevenlabs.disableWebhook")(function* (input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+}) {
+  const repo = yield* ElevenlabsWebhookEndpointRepository
+  const existing = yield* repo.findActiveByProjectId(input.projectId)
+  if (!existing || existing.organizationId !== input.organizationId) return
+  yield* repo.softRevokeById(existing.id, new Date())
+})
+
+export const getElevenlabsWebhookUseCase = Effect.fn("elevenlabs.getWebhook")(function* (input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly ingestBaseUrl: string
+}) {
+  const repo = yield* ElevenlabsWebhookEndpointRepository
+  const existing = yield* repo.findActiveByProjectId(input.projectId)
+  if (!existing || existing.organizationId !== input.organizationId) return null
+
+  const baseUrl = input.ingestBaseUrl.replace(/\/$/, "")
+  return {
+    endpoint: {
+      id: existing.id,
+      projectId: existing.projectId,
+      webhookToken: existing.webhookToken,
+      createdAt: existing.createdAt,
+    },
+    webhookUrl: `${baseUrl}/v1/webhooks/elevenlabs/${existing.webhookToken}`,
+  }
+})

--- a/packages/domain/elevenlabs/tsconfig.json
+++ b/packages/domain/elevenlabs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/domain/elevenlabs/vitest.config.ts
+++ b/packages/domain/elevenlabs/vitest.config.ts
@@ -1,0 +1,3 @@
+import base from "@repo/vitest-config"
+
+export default base

--- a/packages/domain/shared/src/id.ts
+++ b/packages/domain/shared/src/id.ts
@@ -66,6 +66,7 @@ export type TaxonomyLineageId = Id<"TaxonomyLineageId">
 // Integration-related IDs
 export type SlackIntegrationId = Id<"SlackIntegrationId">
 export type SlackDeliveryId = Id<"SlackDeliveryId">
+export type ElevenlabsWebhookEndpointId = Id<"ElevenlabsWebhookEndpointId">
 
 // Data-destination IDs
 export type DestinationId = Id<"DestinationId">
@@ -106,6 +107,8 @@ export const TaxonomyClusterId = (value: string): TaxonomyClusterId => value as 
 export const TaxonomyRunId = (value: string): TaxonomyRunId => value as TaxonomyRunId
 export const TaxonomyLineageId = (value: string): TaxonomyLineageId => value as TaxonomyLineageId
 export const SlackIntegrationId = (value: string): SlackIntegrationId => value as SlackIntegrationId
+export const ElevenlabsWebhookEndpointId = (value: string): ElevenlabsWebhookEndpointId =>
+  value as ElevenlabsWebhookEndpointId
 export const SlackDeliveryId = (value: string): SlackDeliveryId => value as SlackDeliveryId
 export const DestinationId = (value: string): DestinationId => value as DestinationId
 export const DestinationSyncRunId = (value: string): DestinationSyncRunId => value as DestinationSyncRunId
@@ -143,6 +146,7 @@ export const taxonomyClusterIdSchema = cuidSchema.transform(TaxonomyClusterId)
 export const taxonomyRunIdSchema = cuidSchema.transform(TaxonomyRunId)
 export const taxonomyLineageIdSchema = cuidSchema.transform(TaxonomyLineageId)
 export const slackIntegrationIdSchema = cuidSchema.transform(SlackIntegrationId)
+export const elevenlabsWebhookEndpointIdSchema = cuidSchema.transform(ElevenlabsWebhookEndpointId)
 export const slackDeliveryIdSchema = cuidSchema.transform(SlackDeliveryId)
 export const destinationIdSchema = cuidSchema.transform(DestinationId)
 export const destinationSyncRunIdSchema = cuidSchema.transform(DestinationSyncRunId)

--- a/packages/domain/spans/src/otlp.ts
+++ b/packages/domain/spans/src/otlp.ts
@@ -6,4 +6,4 @@
 export { decodeOtlpProtobuf } from "./otlp/proto.ts"
 export type { TransformContext } from "./otlp/transform.ts"
 export { transformOtlpToSpans } from "./otlp/transform.ts"
-export type { OtlpExportTraceServiceRequest } from "./otlp/types.ts"
+export type { OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpSpan } from "./otlp/types.ts"

--- a/packages/domain/spans/src/otlp/content/elevenlabs.ts
+++ b/packages/domain/spans/src/otlp/content/elevenlabs.ts
@@ -1,0 +1,23 @@
+import type { GenAIMessage } from "rosetta-ai"
+import { stringAttr } from "../attributes.ts"
+import type { OtlpKeyValue } from "../types.ts"
+import type { ParsedContent } from "./index.ts"
+
+export function parseElevenlabs(attrs: readonly OtlpKeyValue[]): ParsedContent {
+  const userText = stringAttr(attrs, "elevenlabs.user.text")
+  const agentText = stringAttr(attrs, "elevenlabs.agent.text")
+
+  const inputMessages: GenAIMessage[] = userText
+    ? ([{ role: "user", parts: [{ type: "text", content: userText }] }] as GenAIMessage[])
+    : []
+  const outputMessages: GenAIMessage[] = agentText
+    ? ([{ role: "assistant", parts: [{ type: "text", content: agentText }] }] as GenAIMessage[])
+    : []
+
+  return {
+    inputMessages,
+    outputMessages,
+    systemInstructions: [],
+    toolDefinitions: [],
+  }
+}

--- a/packages/domain/spans/src/otlp/content/index.ts
+++ b/packages/domain/spans/src/otlp/content/index.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from "../../entities/span.ts"
 import { stringAttr } from "../attributes.ts"
 import type { OtlpKeyValue } from "../types.ts"
 import { parseClaudeCode } from "./claude-code.ts"
+import { parseElevenlabs } from "./elevenlabs.ts"
 import { parseFlue } from "./flue.ts"
 import { parseGenAICurrent } from "./genai.ts"
 import { parseGenAIDeprecated } from "./genai_deprecated.ts"
@@ -75,6 +76,10 @@ const PARSERS: readonly ContentParser[] = [
   {
     canHandle: (attrs) => hasKey(attrs, "flue.turn.input") || hasKey(attrs, "flue.turn.output"),
     parse: parseFlue,
+  },
+  {
+    canHandle: (attrs) => hasKey(attrs, "elevenlabs.user.text") || hasKey(attrs, "elevenlabs.agent.text"),
+    parse: parseElevenlabs,
   },
   {
     canHandle: (attrs) => hasKey(attrs, "user_prompt"), // Claude Code

--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -76,12 +76,22 @@ function anthropicProviderFromClaudeCodeSpanName(spanName: string): string | und
   return "anthropic"
 }
 
+function elevenlabsProviderFromSpan(scopeName: string, spanName: string): string | undefined {
+  if (scopeName === "elevenlabs.convai" || spanName.startsWith("elevenlabs.")) return "elevenlabs"
+  return undefined
+}
+
 /**
  * Resolves telemetry provider from span attributes, with a fallback for Agent SDK
  * span names (`claude_code.llm_request`) when `span.type` is absent.
  */
-export function resolveProvider(spanAttrs: readonly OtlpKeyValue[], spanName: string): string {
-  return first(providerCandidates, spanAttrs) ?? anthropicProviderFromClaudeCodeSpanName(spanName) ?? ""
+export function resolveProvider(spanAttrs: readonly OtlpKeyValue[], spanName: string, scopeName = ""): string {
+  return (
+    first(providerCandidates, spanAttrs) ??
+    anthropicProviderFromClaudeCodeSpanName(spanName) ??
+    elevenlabsProviderFromSpan(scopeName, spanName) ??
+    ""
+  )
 }
 
 export const modelCandidates: Candidate<string>[] = [
@@ -120,6 +130,7 @@ export const sessionIdCandidates = [
   fromString("wandb.thread_id"), // W&B Weave
   fromString("ai.telemetry.metadata.threadId"), // Opik (via Vercel AI SDK metadata)
   fromString("gen_ai.conversation.id"), // GenAI semconv
+  fromString("elevenlabs.conversation_id"), // ElevenLabs Agents OTEL export
   fromString("eve.turn.id"), // Eve framework (per-turn thread fallback)
 ]
 

--- a/packages/domain/spans/src/otlp/resolvers/index.ts
+++ b/packages/domain/spans/src/otlp/resolvers/index.ts
@@ -43,7 +43,7 @@ export function resolveAttributes({
   spanName = "",
   scopeName = "",
 }: ResolveAttributesInput): ResolvedAttributes {
-  const provider = resolveProvider(spanAttrs, spanName)
+  const provider = resolveProvider(spanAttrs, spanName, scopeName)
   const model = first(modelCandidates, spanAttrs) ?? ""
   const operation = resolveOperation(spanAttrs, spanName, scopeName)
 

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -74,6 +74,13 @@ const OPENCLAW_SPAN_OPERATION: Record<string, Operation> = {
   "openclaw.tool.execution": "execute_tool",
 }
 
+const ELEVENLABS_SCOPE = "elevenlabs.convai"
+const ELEVENLABS_SPAN_OPERATION: Record<string, Operation> = {
+  "elevenlabs.conversation": "invoke_agent",
+  "elevenlabs.recv.user_transcript": "chat",
+  "elevenlabs.recv.agent_response": "chat",
+}
+
 const CLAUDE_CODE_NATIVE_SPAN_PREFIX = "claude_code."
 
 /**
@@ -111,6 +118,13 @@ export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: s
   if (scopeName === OPENCLAW_TELEMETRY_SCOPE) {
     const mapped = OPENCLAW_SPAN_OPERATION[spanName]
     if (mapped) return mapped
+  }
+  if (scopeName === ELEVENLABS_SCOPE || spanName.startsWith("elevenlabs.")) {
+    const mapped = ELEVENLABS_SPAN_OPERATION[spanName]
+    if (mapped) return mapped
+    if (spanName.startsWith("elevenlabs.tool.")) return "execute_tool"
+    if (spanName.startsWith("elevenlabs.event.user_transcript")) return "chat"
+    if (spanName.startsWith("elevenlabs.event.agent_response")) return "chat"
   }
   return first(operationCandidates, spanAttrs) ?? operationFromClaudeCodeNativeSpanName(spanName) ?? "unspecified"
 }

--- a/packages/platform/db-postgres/drizzle/20260709100000_elevenlabs-webhook-endpoints/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260709100000_elevenlabs-webhook-endpoints/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "latitude"."elevenlabs_webhook_endpoints" (
+	"id" varchar(24) PRIMARY KEY,
+	"organization_id" varchar(24) NOT NULL,
+	"project_id" varchar(24) NOT NULL,
+	"webhook_token" varchar(64) NOT NULL,
+	"signing_secret" text NOT NULL,
+	"created_by_user_id" varchar(24) NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "latitude"."elevenlabs_webhook_endpoints" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX "elevenlabs_webhook_endpoints_organization_id_idx" ON "latitude"."elevenlabs_webhook_endpoints" ("organization_id");
+--> statement-breakpoint
+CREATE INDEX "elevenlabs_webhook_endpoints_project_id_idx" ON "latitude"."elevenlabs_webhook_endpoints" ("project_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "elevenlabs_webhook_endpoints_active_project_idx" ON "latitude"."elevenlabs_webhook_endpoints" ("project_id") WHERE "revoked_at" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "elevenlabs_webhook_endpoints_active_token_idx" ON "latitude"."elevenlabs_webhook_endpoints" ("webhook_token") WHERE "revoked_at" IS NULL;
+--> statement-breakpoint
+CREATE POLICY "elevenlabs_webhook_endpoints_organization_policy" ON "latitude"."elevenlabs_webhook_endpoints" AS PERMISSIVE FOR ALL TO public USING (organization_id = get_current_organization_id()) WITH CHECK (organization_id = get_current_organization_id());

--- a/packages/platform/db-postgres/package.json
+++ b/packages/platform/db-postgres/package.json
@@ -34,6 +34,7 @@
     "@better-auth/stripe": "catalog:",
     "@domain/admin": "workspace:*",
     "@domain/agent-dispatch": "workspace:*",
+    "@domain/elevenlabs": "workspace:*",
     "@domain/ai": "workspace:*",
     "@domain/incidents": "workspace:*",
     "@domain/api-keys": "workspace:*",

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -14,6 +14,7 @@ export {
   type StripePlanConfig,
   type User,
 } from "./create-better-auth.ts"
+export { decryptField, encryptField, getEncryptionKey } from "./encryption-key.ts"
 export { healthcheckPostgres } from "./health.ts"
 // Outbox consumer for reliable event publishing
 export {
@@ -42,6 +43,10 @@ export { DatasetRepositoryLive } from "./repositories/dataset-repository.ts"
 export { DestinationRepositoryLive } from "./repositories/destination-repository.ts"
 export { DestinationSourceStateRepositoryLive } from "./repositories/destination-source-state-repository.ts"
 export { DestinationSyncRunRepositoryLive } from "./repositories/destination-sync-run-repository.ts"
+export {
+  ElevenlabsWebhookEndpointRepositoryLive,
+  findActiveElevenlabsWebhookEndpointByToken,
+} from "./repositories/elevenlabs-webhook-endpoint-repository.ts"
 // Repository implementations
 export { EvaluationAlignmentExamplesRepositoryLive } from "./repositories/evaluation-alignment-examples-repository.ts"
 export { EvaluationRepositoryLive } from "./repositories/evaluation-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/elevenlabs-webhook-endpoint-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/elevenlabs-webhook-endpoint-repository.ts
@@ -1,0 +1,165 @@
+import {
+  type ElevenlabsWebhookEndpoint,
+  ElevenlabsWebhookEndpointRepository,
+  elevenlabsWebhookEndpointSchema,
+} from "@domain/elevenlabs"
+import {
+  ElevenlabsWebhookEndpointId,
+  OrganizationId,
+  ProjectId,
+  type RepositoryError,
+  SqlClient,
+  type SqlClientShape,
+  toRepositoryError,
+  UserId,
+} from "@domain/shared"
+import { and, eq, isNull } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import type { Operator, PostgresDb } from "../client.ts"
+import { decryptField, encryptField, getEncryptionKey } from "../encryption-key.ts"
+import { elevenlabsWebhookEndpoints } from "../schema/elevenlabs-webhook-endpoints.ts"
+
+const toDomain = (
+  row: typeof elevenlabsWebhookEndpoints.$inferSelect,
+  signingSecret: string,
+): ElevenlabsWebhookEndpoint =>
+  elevenlabsWebhookEndpointSchema.parse({
+    id: ElevenlabsWebhookEndpointId(row.id),
+    organizationId: OrganizationId(row.organizationId),
+    projectId: ProjectId(row.projectId),
+    webhookToken: row.webhookToken,
+    signingSecret,
+    createdByUserId: UserId(row.createdByUserId),
+    revokedAt: row.revokedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  })
+
+export const findActiveElevenlabsWebhookEndpointByToken = (
+  db: PostgresDb,
+  webhookToken: string,
+  encryptionKey: Uint8Array,
+): Effect.Effect<ElevenlabsWebhookEndpoint | null, RepositoryError> =>
+  Effect.gen(function* () {
+    const rows = yield* Effect.tryPromise({
+      try: () =>
+        db
+          .select()
+          .from(elevenlabsWebhookEndpoints)
+          .where(
+            and(
+              eq(elevenlabsWebhookEndpoints.webhookToken, webhookToken),
+              isNull(elevenlabsWebhookEndpoints.revokedAt),
+            ),
+          )
+          .limit(1),
+      catch: (cause) => toRepositoryError(cause, "findActiveElevenlabsWebhookEndpointByToken"),
+    })
+
+    const row = rows[0]
+    if (!row) return null
+    const signingSecret = yield* decryptField(row.signingSecret, encryptionKey, "decryptElevenlabsWebhookSecret")
+    return toDomain(row, signingSecret)
+  })
+
+export const ElevenlabsWebhookEndpointRepositoryLive = Layer.effect(
+  ElevenlabsWebhookEndpointRepository,
+  Effect.gen(function* () {
+    const encryptionKey = yield* getEncryptionKey()
+
+    const decryptSecret = (value: string) => decryptField(value, encryptionKey, "decryptElevenlabsWebhookSecret")
+    const encryptSecret = (value: string) => encryptField(value, encryptionKey, "encryptElevenlabsWebhookSecret")
+
+    return {
+      findActiveByProjectId: (projectId: ProjectId) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const rows = yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .select()
+                .from(elevenlabsWebhookEndpoints)
+                .where(
+                  and(
+                    eq(elevenlabsWebhookEndpoints.projectId, projectId),
+                    eq(elevenlabsWebhookEndpoints.organizationId, organizationId),
+                    isNull(elevenlabsWebhookEndpoints.revokedAt),
+                  ),
+                )
+                .limit(1),
+            )
+            .pipe(Effect.mapError((e) => toRepositoryError(e, "findActiveElevenlabsWebhookEndpointByProject")))
+
+          const row = rows[0]
+          if (!row) return null
+          const signingSecret = yield* decryptSecret(row.signingSecret)
+          return toDomain(row, signingSecret)
+        }),
+
+      findActiveByWebhookToken: (webhookToken: string) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const rows = yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .select()
+                .from(elevenlabsWebhookEndpoints)
+                .where(
+                  and(
+                    eq(elevenlabsWebhookEndpoints.webhookToken, webhookToken),
+                    eq(elevenlabsWebhookEndpoints.organizationId, organizationId),
+                    isNull(elevenlabsWebhookEndpoints.revokedAt),
+                  ),
+                )
+                .limit(1),
+            )
+            .pipe(Effect.mapError((e) => toRepositoryError(e, "findActiveElevenlabsWebhookEndpointByToken")))
+
+          const row = rows[0]
+          if (!row) return null
+          const signingSecret = yield* decryptSecret(row.signingSecret)
+          return toDomain(row, signingSecret)
+        }),
+
+      save: (endpoint: ElevenlabsWebhookEndpoint) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const encryptedSecret = yield* encryptSecret(endpoint.signingSecret)
+          yield* sqlClient
+            .query((db, organizationId) =>
+              db.insert(elevenlabsWebhookEndpoints).values({
+                id: endpoint.id,
+                organizationId,
+                projectId: endpoint.projectId,
+                webhookToken: endpoint.webhookToken,
+                signingSecret: encryptedSecret,
+                createdByUserId: endpoint.createdByUserId,
+                revokedAt: endpoint.revokedAt,
+                createdAt: endpoint.createdAt,
+                updatedAt: endpoint.updatedAt,
+              }),
+            )
+            .pipe(Effect.mapError((e) => toRepositoryError(e, "saveElevenlabsWebhookEndpoint")))
+        }),
+
+      softRevokeById: (id: ElevenlabsWebhookEndpointId, revokedAt: Date) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .update(elevenlabsWebhookEndpoints)
+                .set({ revokedAt, updatedAt: revokedAt })
+                .where(
+                  and(
+                    eq(elevenlabsWebhookEndpoints.id, id),
+                    eq(elevenlabsWebhookEndpoints.organizationId, organizationId),
+                    isNull(elevenlabsWebhookEndpoints.revokedAt),
+                  ),
+                ),
+            )
+            .pipe(Effect.mapError((e) => toRepositoryError(e, "revokeElevenlabsWebhookEndpoint")))
+        }),
+    }
+  }),
+)

--- a/packages/platform/db-postgres/src/schema/elevenlabs-webhook-endpoints.ts
+++ b/packages/platform/db-postgres/src/schema/elevenlabs-webhook-endpoints.ts
@@ -1,0 +1,24 @@
+import { sql } from "drizzle-orm"
+import { index, text, uniqueIndex, varchar } from "drizzle-orm/pg-core"
+import { cuid, latitudeSchema, organizationRLSPolicy, timestamps, tzTimestamp } from "../schemaHelpers.ts"
+
+export const elevenlabsWebhookEndpoints = latitudeSchema.table(
+  "elevenlabs_webhook_endpoints",
+  {
+    id: cuid("id").primaryKey(),
+    organizationId: cuid("organization_id").notNull(),
+    projectId: cuid("project_id").notNull(),
+    webhookToken: varchar("webhook_token", { length: 64 }).notNull(),
+    signingSecret: text("signing_secret").notNull(),
+    createdByUserId: cuid("created_by_user_id").notNull(),
+    revokedAt: tzTimestamp("revoked_at"),
+    ...timestamps(),
+  },
+  (t) => [
+    organizationRLSPolicy("elevenlabs_webhook_endpoints"),
+    index("elevenlabs_webhook_endpoints_organization_id_idx").on(t.organizationId),
+    index("elevenlabs_webhook_endpoints_project_id_idx").on(t.projectId),
+    uniqueIndex("elevenlabs_webhook_endpoints_active_project_idx").on(t.projectId).where(sql`${t.revokedAt} IS NULL`),
+    uniqueIndex("elevenlabs_webhook_endpoints_active_token_idx").on(t.webhookToken).where(sql`${t.revokedAt} IS NULL`),
+  ],
+)

--- a/packages/platform/elevenlabs/package.json
+++ b/packages/platform/elevenlabs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@platform/elevenlabs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@domain/spans": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/vitest-config": "workspace:*",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/platform/elevenlabs/src/errors.ts
+++ b/packages/platform/elevenlabs/src/errors.ts
@@ -1,0 +1,5 @@
+import { Data } from "effect"
+
+export class InvalidElevenlabsSignatureError extends Data.TaggedError("InvalidElevenlabsSignatureError")<{
+  readonly reason: "format" | "stale" | "mismatch"
+}> {}

--- a/packages/platform/elevenlabs/src/index.ts
+++ b/packages/platform/elevenlabs/src/index.ts
@@ -1,0 +1,7 @@
+export { InvalidElevenlabsSignatureError } from "./errors.ts"
+export {
+  ELEVENLABS_OTEL_WEBHOOK_TYPE,
+  type ElevenlabsOtelWebhookEvent,
+  parseElevenlabsOtelWebhookEvent,
+} from "./payload.ts"
+export { verifyElevenlabsSignature } from "./signature.ts"

--- a/packages/platform/elevenlabs/src/payload.ts
+++ b/packages/platform/elevenlabs/src/payload.ts
@@ -1,0 +1,24 @@
+import type { OtlpExportTraceServiceRequest } from "@domain/spans/otlp"
+
+export const ELEVENLABS_OTEL_WEBHOOK_TYPE = "post_call_transcription_otel" as const
+
+export interface ElevenlabsOtelWebhookEvent {
+  readonly type: typeof ELEVENLABS_OTEL_WEBHOOK_TYPE
+  readonly event_timestamp?: number
+  readonly data: {
+    readonly conversation_id: string
+    readonly agent_id?: string
+    readonly otlp_traces: OtlpExportTraceServiceRequest
+  }
+}
+
+export const parseElevenlabsOtelWebhookEvent = (rawBody: string): ElevenlabsOtelWebhookEvent | null => {
+  try {
+    const parsed = JSON.parse(rawBody) as ElevenlabsOtelWebhookEvent
+    if (parsed.type !== ELEVENLABS_OTEL_WEBHOOK_TYPE) return null
+    if (!parsed.data?.otlp_traces?.resourceSpans) return null
+    return parsed
+  } catch {
+    return null
+  }
+}

--- a/packages/platform/elevenlabs/src/signature.test.ts
+++ b/packages/platform/elevenlabs/src/signature.test.ts
@@ -1,0 +1,70 @@
+import { Cause, Effect, Exit } from "effect"
+import { describe, expect, it } from "vitest"
+import type { InvalidElevenlabsSignatureError } from "./errors.ts"
+import { verifyElevenlabsSignature } from "./signature.ts"
+
+const signingSecret = "test-webhook-secret"
+const body = JSON.stringify({ type: "post_call_transcription_otel", data: { conversation_id: "conv_1" } })
+const timestamp = "1700000000"
+
+const sign = async (secret: string, ts: string, rawBody: string): Promise<string> => {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, [
+    "sign",
+  ])
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(`${ts}.${rawBody}`))
+  const digest = Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `t=${ts},v0=${digest}`
+}
+
+const failure = async (
+  effect: Effect.Effect<void, InvalidElevenlabsSignatureError>,
+): Promise<InvalidElevenlabsSignatureError> => {
+  const exit = await Effect.runPromiseExit(effect)
+  if (Exit.isSuccess(exit)) throw new Error("Expected failure")
+  const failReason = exit.cause.reasons.find(Cause.isFailReason)
+  if (!failReason) throw new Error("Expected typed failure")
+  return failReason.error
+}
+
+describe("verifyElevenlabsSignature", () => {
+  it("accepts a valid signature", async () => {
+    const signature = await sign(signingSecret, timestamp, body)
+    await Effect.runPromise(
+      verifyElevenlabsSignature({
+        signingSecret,
+        signature,
+        body,
+        nowSeconds: Number(timestamp),
+      }),
+    )
+  })
+
+  it("rejects a tampered body", async () => {
+    const signature = await sign(signingSecret, timestamp, body)
+    const err = await failure(
+      verifyElevenlabsSignature({
+        signingSecret,
+        signature,
+        body: `${body} `,
+        nowSeconds: Number(timestamp),
+      }),
+    )
+    expect(err.reason).toBe("mismatch")
+  })
+
+  it("rejects stale timestamps", async () => {
+    const signature = await sign(signingSecret, timestamp, body)
+    const err = await failure(
+      verifyElevenlabsSignature({
+        signingSecret,
+        signature,
+        body,
+        nowSeconds: Number(timestamp) + 6 * 60,
+      }),
+    )
+    expect(err.reason).toBe("stale")
+  })
+})

--- a/packages/platform/elevenlabs/src/signature.ts
+++ b/packages/platform/elevenlabs/src/signature.ts
@@ -1,0 +1,74 @@
+import { Effect } from "effect"
+import { InvalidElevenlabsSignatureError } from "./errors.ts"
+
+const REPLAY_WINDOW_SECONDS = 5 * 60
+
+const computeHmacHex = (secret: string, message: string): Effect.Effect<string, never> =>
+  Effect.promise(async () => {
+    const encoder = new TextEncoder()
+    const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, [
+      "sign",
+    ])
+    const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message))
+    return Array.from(new Uint8Array(signature))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+  })
+
+const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}
+
+const parseSignatureHeader = (signature: string): { readonly timestamp: string; readonly digest: string } | null => {
+  let timestamp: string | undefined
+  let digest: string | undefined
+
+  for (const part of signature.split(",")) {
+    const trimmed = part.trim()
+    if (trimmed.startsWith("t=")) {
+      timestamp = trimmed.slice(2)
+    } else if (trimmed.startsWith("v0=")) {
+      digest = trimmed.slice(3)
+    }
+  }
+
+  if (!timestamp || !digest) return null
+  return { timestamp, digest }
+}
+
+export const verifyElevenlabsSignature = (input: {
+  readonly signingSecret: string
+  readonly signature: string | null | undefined
+  readonly body: string
+  readonly nowSeconds?: number
+}): Effect.Effect<void, InvalidElevenlabsSignatureError> =>
+  Effect.gen(function* () {
+    if (!input.signature) {
+      return yield* Effect.fail(new InvalidElevenlabsSignatureError({ reason: "format" }))
+    }
+
+    const parsed = parseSignatureHeader(input.signature)
+    if (!parsed) {
+      return yield* Effect.fail(new InvalidElevenlabsSignatureError({ reason: "format" }))
+    }
+
+    const timestampSeconds = Number(parsed.timestamp)
+    if (!Number.isFinite(timestampSeconds)) {
+      return yield* Effect.fail(new InvalidElevenlabsSignatureError({ reason: "format" }))
+    }
+
+    const nowSeconds = input.nowSeconds ?? Math.floor(Date.now() / 1000)
+    if (Math.abs(nowSeconds - timestampSeconds) > REPLAY_WINDOW_SECONDS) {
+      return yield* Effect.fail(new InvalidElevenlabsSignatureError({ reason: "stale" }))
+    }
+
+    const expected = yield* computeHmacHex(input.signingSecret, `${parsed.timestamp}.${input.body}`)
+    if (!constantTimeEqual(expected, parsed.digest)) {
+      return yield* Effect.fail(new InvalidElevenlabsSignatureError({ reason: "mismatch" }))
+    }
+  })

--- a/packages/platform/elevenlabs/tsconfig.json
+++ b/packages/platform/elevenlabs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/platform/elevenlabs/vitest.config.ts
+++ b/packages/platform/elevenlabs/vitest.config.ts
@@ -1,0 +1,3 @@
+import base from "@repo/vitest-config"
+
+export default base

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/design-system:
     dependencies:
@@ -336,6 +336,9 @@ importers:
       '@domain/billing':
         specifier: workspace:*
         version: link:../../packages/domain/billing
+      '@domain/elevenlabs':
+        specifier: workspace:*
+        version: link:../../packages/domain/elevenlabs
       '@domain/queue':
         specifier: workspace:*
         version: link:../../packages/domain/queue
@@ -363,6 +366,9 @@ importers:
       '@platform/db-postgres':
         specifier: workspace:*
         version: link:../../packages/platform/db-postgres
+      '@platform/elevenlabs':
+        specifier: workspace:*
+        version: link:../../packages/platform/elevenlabs
       '@platform/env':
         specifier: workspace:*
         version: link:../../packages/platform/env
@@ -390,7 +396,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/web:
     dependencies:
@@ -424,6 +430,9 @@ importers:
       '@domain/destinations':
         specifier: workspace:*
         version: link:../../packages/domain/destinations
+      '@domain/elevenlabs':
+        specifier: workspace:*
+        version: link:../../packages/domain/elevenlabs
       '@domain/evaluations':
         specifier: workspace:*
         version: link:../../packages/domain/evaluations
@@ -1252,6 +1261,37 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/domain/elevenlabs:
+    dependencies:
+      '@domain/organizations':
+        specifier: workspace:*
+        version: link:../organizations
+      '@domain/projects':
+        specifier: workspace:*
+        version: link:../projects
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@domain/spans':
+        specifier: workspace:*
+        version: link:../spans
+      '@platform/elevenlabs':
+        specifier: workspace:*
+        version: link:../../platform/elevenlabs
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.57
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@repo/vitest-config':
+        specifier: workspace:*
+        version: link:../../vitest-config
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -2418,6 +2458,9 @@ importers:
       '@domain/destinations':
         specifier: workspace:*
         version: link:../../domain/destinations
+      '@domain/elevenlabs':
+        specifier: workspace:*
+        version: link:../../domain/elevenlabs
       '@domain/evaluations':
         specifier: workspace:*
         version: link:../../domain/evaluations
@@ -2536,6 +2579,22 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+
+  packages/platform/elevenlabs:
+    dependencies:
+      '@domain/spans':
+        specifier: workspace:*
+        version: link:../../domain/spans
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.57
+    devDependencies:
+      '@repo/vitest-config':
+        specifier: workspace:*
+        version: link:../../vitest-config
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ElevenLabs Agents can export completed conversations as OTLP JSON via `post_call_transcription_otel` post-call webhooks. This PR adds a native Latitude path for that flow: operators connect a per-project webhook in Settings, point ElevenLabs at the generated ingest URL, and conversation traces land in the project without running a Custom LLM proxy.

## What changed

**Ingest (`POST /v1/webhooks/elevenlabs/:token`)**
- Looks up the project webhook endpoint by URL token (admin DB lookup, no API key).
- Verifies `ElevenLabs-Signature` (`t=…,v0=…` over `{timestamp}.{body}`).
- Accepts only `post_call_transcription_otel` payloads, extracts `data.otlp_traces`, enriches spans with `latitude.project` and `gen_ai.conversation.id`, and runs the normal span ingestion + billing pipeline.

**Configuration**
- New `elevenlabs_webhook_endpoints` table (one active endpoint per project; signing secret encrypted at rest).
- Settings → Integrations → **ElevenLabs Agents**: connect signing secret, copy webhook URL, rotate or disconnect.

**Span parsing**
- Maps `elevenlabs.convai` span names to operations (`conversation` → invoke_agent, transcript spans → chat, `elevenlabs.tool.*` → execute_tool).
- Parses `elevenlabs.user.text` / `elevenlabs.agent.text` into message content.
- Uses `elevenlabs.conversation_id` for session grouping.

**Docs**
- `docs/telemetry/frameworks/elevenlabs.mdx` now documents the managed-agent webhook path alongside the existing Custom LLM proxy guide.

## Setup flow

1. Latitude: Settings → Integrations → ElevenLabs Agents → Connect (paste ElevenLabs webhook signing secret).
2. ElevenLabs: create workspace post-call webhook with the Latitude URL; enable Transcript + OpenTelemetry format on the agent.
3. After each call, ElevenLabs POSTs OTLP JSON; Latitude returns `200` with `{ received: true, acceptedSpans }`.

## Testing

- `@platform/elevenlabs`: signature verification unit tests
- Typecheck: `@platform/elevenlabs`, `@domain/elevenlabs`, `@platform/db-postgres`, `@app/ingest`, `@app/web`

## Follow-ups (out of scope)

- Live monitoring WebSocket ingest (`events_format=opentelemetry`)
- On-demand backfill via ElevenLabs GET conversation `format=opentelemetry`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-547ba384-589f-4482-891e-ac16c8690d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-547ba384-589f-4482-891e-ac16c8690d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

