### PR TITLE
feat(agent-dispatch): org-default + per-project override dispatch configs

### DIFF
--- a/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
+++ b/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
@@ -2,23 +2,34 @@ import { createHmac, randomBytes } from "node:crypto"
 import {
   AGENT_DISPATCH_KINDS,
   AGENT_DISPATCH_TRIGGERS,
-  type AgentDispatchConfig,
   AgentDispatchConfigRepository,
+  type AgentDispatchConfigRow,
   AgentDispatchCredentialRepository,
+  type AgentDispatchGuardrails,
   AgentDispatchIntegrationRepository,
   type AgentDispatchKind,
   AgentDispatchRepository,
   AgentDispatchTraceReader,
   agentDispatchGuardrailsSchema,
   agentDispatchKindSchema,
-  agentDispatchTargetSchema,
   buildDispatchContextFromSignal,
   buildManualDispatchIdempotencyKey,
+  checkTargetReadiness,
   connectAgentDispatchIntegrationUseCase,
+  DEFAULT_COOLDOWN_MINUTES,
+  DEFAULT_MAX_DISPATCHES_PER_DAY,
   disconnectAgentDispatchIntegrationUseCase,
+  type EffectiveAgentDispatchConfig,
   renderDispatchPrompt,
+  resetProjectDispatchOverrideUseCase,
+  resolveEffectiveConfig,
+  resolveEffectiveConfigsForProject,
+  type StoredAgentDispatchTarget,
   sendAgentDispatchUseCase,
-  upsertAgentDispatchConfigUseCase,
+  setProjectDispatchRepoUseCase,
+  storedAgentDispatchTargetSchema,
+  upsertOrgDefaultDispatchConfigUseCase,
+  upsertProjectDispatchOverrideUseCase,
 } from "@domain/agent-dispatch"
 import { IncidentMonitorReader } from "@domain/notifications"
 import { OrganizationId, ProjectId, SignalId } from "@domain/shared"
@@ -76,9 +87,21 @@ export interface AgentDispatchConfigRecord {
   readonly kind: AgentDispatchKind
   readonly enabled: boolean
   readonly triggers: readonly string[]
-  readonly target: AgentDispatchConfig["target"]
+  readonly target: StoredAgentDispatchTarget | null
   readonly promptTemplate: string | null
-  readonly guardrails: AgentDispatchConfig["guardrails"]
+  readonly guardrails: AgentDispatchGuardrails
+  readonly updatedAt: string
+}
+
+interface AgentDispatchOverrideRecord {
+  readonly id: string
+  readonly integrationId: string
+  readonly kind: AgentDispatchKind
+  readonly enabled: boolean | null
+  readonly triggers: readonly string[] | null
+  readonly target: StoredAgentDispatchTarget | null
+  readonly promptTemplate: string | null
+  readonly guardrails: AgentDispatchGuardrails | null
   readonly updatedAt: string
 }
 
@@ -248,7 +271,24 @@ async function fetchCursorRepositories(cursorApiKey: string): Promise<CursorRepo
   return parsed.success ? parsed.data.repositories : []
 }
 
-const toConfigRecord = (config: AgentDispatchConfig): AgentDispatchConfigRecord => ({
+const DEFAULT_GUARDRAILS: AgentDispatchGuardrails = {
+  maxDispatchesPerDay: DEFAULT_MAX_DISPATCHES_PER_DAY,
+  cooldownMinutes: DEFAULT_COOLDOWN_MINUTES,
+}
+
+const toConfigRecord = (config: AgentDispatchConfigRow): AgentDispatchConfigRecord => ({
+  id: config.id,
+  integrationId: config.integrationId,
+  kind: config.kind,
+  enabled: config.enabled ?? false,
+  triggers: config.triggers ?? [],
+  target: config.target,
+  promptTemplate: config.promptTemplate,
+  guardrails: config.guardrails ?? DEFAULT_GUARDRAILS,
+  updatedAt: config.updatedAt.toISOString(),
+})
+
+const toOverrideRecord = (config: AgentDispatchConfigRow): AgentDispatchOverrideRecord => ({
   id: config.id,
   integrationId: config.integrationId,
   kind: config.kind,
@@ -258,6 +298,18 @@ const toConfigRecord = (config: AgentDispatchConfig): AgentDispatchConfigRecord 
   promptTemplate: config.promptTemplate,
   guardrails: config.guardrails,
   updatedAt: config.updatedAt.toISOString(),
+})
+
+const toEffectiveRecord = (effective: EffectiveAgentDispatchConfig, updatedAt: Date): AgentDispatchConfigRecord => ({
+  id: effective.id,
+  integrationId: effective.integrationId,
+  kind: effective.kind,
+  enabled: effective.enabled,
+  triggers: effective.triggers,
+  target: effective.target,
+  promptTemplate: effective.promptTemplate,
+  guardrails: effective.guardrails,
+  updatedAt: updatedAt.toISOString(),
 })
 
 export const listAgentDispatchIntegrations = createServerFn({ method: "GET" }).handler(async () => {
@@ -298,7 +350,7 @@ export const listAgentDispatches = createServerFn({ method: "GET" })
         const signalRepository = yield* SignalRepository
         const monitorReader = yield* IncidentMonitorReader
         const dispatches = yield* dispatchRepo.listByProject(projectId)
-        const configs = yield* configRepo.listByProject(projectId)
+        const configs = yield* configRepo.listByProjectIncludingDefaults(projectId)
         const configById = new Map(configs.map((config) => [config.id, config]))
         const signalIds = dispatches
           .filter((dispatch) => dispatch.sourceType === "signal")
@@ -325,7 +377,7 @@ export const listAgentDispatches = createServerFn({ method: "GET" })
         return dispatches.map((dispatch) => {
           const config = configById.get(dispatch.configId)
           const routineUrl =
-            config?.kind === "claude_code" && "routineTriggerId" in config.target
+            config?.kind === "claude_code" && config.target && "routineTriggerId" in config.target
               ? `https://claude.ai/code/routines/${config.target.routineTriggerId}`
               : null
           const monitor = dispatch.sourceType === "monitor" ? monitorById.get(dispatch.sourceId) : undefined
@@ -433,8 +485,8 @@ export const getWebhookSecret = createServerFn({ method: "GET" })
     return { webhookSecret: credentials.webhookSecret ?? null }
   })
 
-export const getAgentDispatchConfig = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), kind: agentDispatchKindSchema }))
+export const getOrgDefaultDispatchConfig = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ kind: agentDispatchKindSchema }))
   .handler(async ({ data }) => {
     const { organizationId } = await requireSession()
     const client = getPostgresClient()
@@ -445,11 +497,46 @@ export const getAgentDispatchConfig = createServerFn({ method: "GET" })
         const configRepo = yield* AgentDispatchConfigRepository
         const integration = yield* integrationRepo.findActiveByKind(data.kind)
         if (!integration) return null
-        const config = yield* configRepo.findByProjectAndIntegration({
-          projectId: ProjectId(data.projectId),
-          integrationId: integration.id,
-        })
+        const config = yield* configRepo.findDefaultByIntegration(integration.id)
         return config ? toConfigRecord(config) : null
+      }).pipe(withPostgres(agentDispatchLayer, client, organizationId), withTracing),
+    )
+  })
+
+interface ProjectDispatchSettingsRecord {
+  readonly integrationId: string | null
+  readonly defaultConfig: AgentDispatchConfigRecord | null
+  readonly override: AgentDispatchOverrideRecord | null
+  readonly effective: AgentDispatchConfigRecord | null
+}
+
+export const getProjectDispatchSettings = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), kind: agentDispatchKindSchema }))
+  .handler(async ({ data }): Promise<ProjectDispatchSettingsRecord> => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+    const projectId = ProjectId(data.projectId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const integrationRepo = yield* AgentDispatchIntegrationRepository
+        const configRepo = yield* AgentDispatchConfigRepository
+        const integration = yield* integrationRepo.findActiveByKind(data.kind)
+        if (!integration) return { integrationId: null, defaultConfig: null, override: null, effective: null }
+        const [defaultRow, overrideRow] = yield* Effect.all([
+          configRepo.findDefaultByIntegration(integration.id),
+          configRepo.findOverrideByProjectAndIntegration({ projectId, integrationId: integration.id }),
+        ])
+        const effective = resolveEffectiveConfig({ projectId, defaultConfig: defaultRow, override: overrideRow })
+        const effectiveUpdatedAt = new Date(
+          Math.max(defaultRow?.updatedAt.getTime() ?? 0, overrideRow?.updatedAt.getTime() ?? 0),
+        )
+        return {
+          integrationId: integration.id,
+          defaultConfig: defaultRow ? toConfigRecord(defaultRow) : null,
+          override: overrideRow ? toOverrideRecord(overrideRow) : null,
+          effective: effective ? toEffectiveRecord(effective, effectiveUpdatedAt) : null,
+        }
       }).pipe(withPostgres(agentDispatchLayer, client, organizationId), withTracing),
     )
   })
@@ -459,8 +546,7 @@ export const connectCursorIntegration = createServerFn({ method: "POST" })
     z.object({
       kind: z.literal("cursor"),
       cursorApiKey: z.string().min(1),
-      projectId: z.string(),
-      repoUrl: z.string().url(),
+      repoUrl: z.string().url().optional(),
       startingRef: z.string().optional(),
     }),
   )
@@ -472,20 +558,19 @@ export const connectCursorIntegration = createServerFn({ method: "POST" })
       Effect.gen(function* () {
         const integration = yield* connectAgentDispatchIntegrationUseCase({
           kind: "cursor",
-          vendorAccountId: `cursor:${data.repoUrl}`,
+          vendorAccountId: `cursor:${organizationId}`,
           installedByUserId: userId,
           organizationId: OrganizationId(organizationId),
           cursorApiKey: data.cursorApiKey,
         })
-        const config = yield* upsertAgentDispatchConfigUseCase({
+        const config = yield* upsertOrgDefaultDispatchConfigUseCase({
           organizationId: OrganizationId(organizationId),
-          projectId: ProjectId(data.projectId),
           integrationId: integration.id,
           kind: "cursor",
           enabled: true,
           triggers: ["signal.discovered"],
           target: {
-            repoUrl: data.repoUrl,
+            ...(data.repoUrl ? { repoUrl: data.repoUrl } : {}),
             ...(data.startingRef ? { startingRef: data.startingRef } : {}),
           },
         })
@@ -500,7 +585,6 @@ export const connectClaudeIntegration = createServerFn({ method: "POST" })
       kind: z.literal("claude_code"),
       claudeRoutineToken: z.string().min(1),
       routineTriggerId: z.string().min(1),
-      projectId: z.string(),
     }),
   )
   .handler(async ({ data }) => {
@@ -516,9 +600,8 @@ export const connectClaudeIntegration = createServerFn({ method: "POST" })
           organizationId: OrganizationId(organizationId),
           claudeRoutineToken: data.claudeRoutineToken,
         })
-        yield* upsertAgentDispatchConfigUseCase({
+        yield* upsertOrgDefaultDispatchConfigUseCase({
           organizationId: OrganizationId(organizationId),
-          projectId: ProjectId(data.projectId),
           integrationId: integration.id,
           kind: "claude_code",
           enabled: true,
@@ -536,7 +619,6 @@ export const connectLinearIntegration = createServerFn({ method: "POST" })
       kind: z.literal("linear"),
       linearApiKey: z.string().min(1),
       teamId: z.string().uuid(),
-      projectId: z.string(),
     }),
   )
   .handler(async ({ data }) => {
@@ -552,9 +634,8 @@ export const connectLinearIntegration = createServerFn({ method: "POST" })
           organizationId: OrganizationId(organizationId),
           linearApiKey: data.linearApiKey,
         })
-        yield* upsertAgentDispatchConfigUseCase({
+        yield* upsertOrgDefaultDispatchConfigUseCase({
           organizationId: OrganizationId(organizationId),
-          projectId: ProjectId(data.projectId),
           integrationId: integration.id,
           kind: "linear",
           enabled: true,
@@ -571,7 +652,6 @@ export const connectWebhookIntegration = createServerFn({ method: "POST" })
     z.object({
       kind: z.literal("webhook"),
       webhookUrl: z.string().url(),
-      projectId: z.string(),
     }),
   )
   .handler(async ({ data }) => {
@@ -588,9 +668,8 @@ export const connectWebhookIntegration = createServerFn({ method: "POST" })
           organizationId: OrganizationId(organizationId),
           webhookSecret,
         })
-        yield* upsertAgentDispatchConfigUseCase({
+        yield* upsertOrgDefaultDispatchConfigUseCase({
           organizationId: OrganizationId(organizationId),
-          projectId: ProjectId(data.projectId),
           integrationId: integration.id,
           kind: "webhook",
           enabled: true,
@@ -617,25 +696,39 @@ export const disconnectAgentDispatchIntegration = createServerFn({ method: "POST
     return { disconnected: true }
   })
 
-const upsertConfigSchema = z.object({
-  projectId: z.string(),
+const orgDefaultConfigSchema = z.object({
   integrationId: z.string(),
   kind: agentDispatchKindSchema,
   enabled: z.boolean(),
-  triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)).min(1),
-  target: agentDispatchTargetSchema,
+  triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
+  target: storedAgentDispatchTargetSchema,
   promptTemplate: z.string().nullable().optional(),
   guardrails: agentDispatchGuardrailsSchema.optional(),
 })
 
+const projectOverrideSchema = z.object({
+  projectId: z.string(),
+  integrationId: z.string(),
+  kind: agentDispatchKindSchema,
+  enabled: z.boolean().nullable().optional(),
+  triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)).nullable().optional(),
+  target: storedAgentDispatchTargetSchema.nullable().optional(),
+  promptTemplate: z.string().nullable().optional(),
+  guardrails: agentDispatchGuardrailsSchema.nullable().optional(),
+})
+
 export interface SendToDestinationRecord {
-  readonly configId: string
+  readonly integrationId: string
   readonly kind: AgentDispatchKind
+  readonly configId: string | null
+  readonly ready: boolean
+  readonly missing: readonly string[]
 }
 
 type SendSignalToIntegrationResult =
   | { readonly status: "dispatched"; readonly externalUrl: string | null }
   | { readonly status: "skipped-already-dispatched" }
+  | { readonly status: "not-ready"; readonly missing: readonly string[] }
   | { readonly status: "failed"; readonly reason: string }
 
 const resolveWebAppUrl = (): string =>
@@ -682,15 +775,34 @@ export const listSendToDestinations = createServerFn({ method: "GET" })
   .inputValidator(z.object({ projectId: z.string() }))
   .handler(async ({ data }): Promise<readonly SendToDestinationRecord[]> => {
     const { organizationId } = await requireSession()
+    const projectId = ProjectId(data.projectId)
 
-    const configs = await Effect.runPromise(
+    return Effect.runPromise(
       Effect.gen(function* () {
+        const integrationRepo = yield* AgentDispatchIntegrationRepository
         const configRepo = yield* AgentDispatchConfigRepository
-        return yield* configRepo.listEnabledByProject(ProjectId(data.projectId))
-      }).pipe(withPostgres(AgentDispatchConfigRepositoryLive, getPostgresClient(), organizationId), withTracing),
-    )
+        const rows = yield* configRepo.listByProjectIncludingDefaults(projectId)
+        const effectiveByIntegration = new Map(
+          resolveEffectiveConfigsForProject(projectId, rows).map((config) => [config.integrationId, config]),
+        )
 
-    return configs.map((config) => ({ configId: config.id, kind: config.kind }))
+        const destinations: SendToDestinationRecord[] = []
+        for (const kind of AGENT_DISPATCH_KINDS) {
+          const integration = yield* integrationRepo.findActiveByKind(kind)
+          if (!integration) continue
+          const effective = effectiveByIntegration.get(integration.id)
+          const readiness = checkTargetReadiness(kind, effective?.target ?? null)
+          destinations.push({
+            integrationId: integration.id,
+            kind,
+            configId: effective?.id ?? null,
+            ready: readiness.ready,
+            missing: readiness.ready ? [] : readiness.missing,
+          })
+        }
+        return destinations
+      }).pipe(withPostgres(agentDispatchLayer, getPostgresClient(), organizationId), withTracing),
+    )
   })
 
 type GetSignalDispatchPromptResult = { readonly prompt: string } | { readonly error: string }
@@ -720,6 +832,7 @@ export const getSignalDispatchPrompt = createServerFn({ method: "GET" })
 
 const manualSendPgLayer = Layer.mergeAll(
   manualContextPgLayer,
+  AgentDispatchIntegrationRepositoryLive,
   AgentDispatchConfigRepositoryLive,
   AgentDispatchRepositoryLive,
   AgentDispatchCredentialRepositoryLive,
@@ -730,7 +843,7 @@ export const sendSignalToIntegration = createServerFn({ method: "POST" })
     z.object({
       projectId: z.string(),
       signalId: z.string(),
-      configId: z.string(),
+      kind: agentDispatchKindSchema,
       sendId: z.string().min(1),
     }),
   )
@@ -742,23 +855,35 @@ export const sendSignalToIntegration = createServerFn({ method: "POST" })
 
     return Effect.runPromise(
       Effect.gen(function* () {
+        const integrationRepo = yield* AgentDispatchIntegrationRepository
         const configRepo = yield* AgentDispatchConfigRepository
-        const config = yield* configRepo.findById(data.configId)
-        if (config.projectId !== projectId || !config.enabled) {
-          return yield* Effect.fail(new Error("This integration is not available for this project"))
+        const integration = yield* integrationRepo.findActiveByKind(data.kind)
+        if (!integration) {
+          return yield* Effect.fail(new Error("This integration is not connected"))
+        }
+        const [defaultRow, overrideRow] = yield* Effect.all([
+          configRepo.findDefaultByIntegration(integration.id),
+          configRepo.findOverrideByProjectAndIntegration({ projectId, integrationId: integration.id }),
+        ])
+        const effective = resolveEffectiveConfig({ projectId, defaultConfig: defaultRow, override: overrideRow })
+        const readiness = effective
+          ? checkTargetReadiness(data.kind, effective.target)
+          : ({ ready: false, missing: [] } as const)
+        if (!effective || !readiness.ready) {
+          return { status: "not-ready", missing: readiness.ready ? [] : readiness.missing } as const
         }
 
         const context = yield* buildManualSignalContext({ organizationId: orgId, projectId, signalId })
-        const prompt = renderDispatchPrompt({ context, template: config.promptTemplate })
+        const prompt = renderDispatchPrompt({ context, template: effective.promptTemplate })
 
         const outcome = yield* sendAgentDispatchUseCase({
-          configId: config.id,
+          configId: effective.id,
           projectId,
-          integrationId: config.integrationId,
-          kind: config.kind,
+          integrationId: effective.integrationId,
+          kind: effective.kind,
           idempotencyKey: buildManualDispatchIdempotencyKey({
-            vendor: config.kind,
-            configId: config.id,
+            vendor: effective.kind,
+            configId: effective.id,
             sourceId: data.signalId,
             sendId: data.sendId,
           }),
@@ -767,7 +892,7 @@ export const sendSignalToIntegration = createServerFn({ method: "POST" })
           sourceId: data.signalId,
           prompt,
           context,
-          target: { ...config.target, kind: config.kind },
+          target: readiness.target,
         }).pipe(
           Effect.catchTag("DispatchAdapterError", (error) =>
             Effect.succeed({ status: "failed" as const, reason: error.reason }),
@@ -793,16 +918,15 @@ export const sendSignalToIntegration = createServerFn({ method: "POST" })
     )
   })
 
-export const upsertAgentDispatchConfig = createServerFn({ method: "POST" })
-  .inputValidator((data: unknown) => upsertConfigSchema.parse(data))
+export const upsertOrgDefaultDispatchConfig = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => orgDefaultConfigSchema.parse(data))
   .handler(async ({ data }) => {
     const { organizationId } = await requireSession()
     const client = getPostgresClient()
 
     const config = await Effect.runPromise(
-      upsertAgentDispatchConfigUseCase({
+      upsertOrgDefaultDispatchConfigUseCase({
         organizationId: OrganizationId(organizationId),
-        projectId: ProjectId(data.projectId),
         integrationId: data.integrationId,
         kind: data.kind,
         enabled: data.enabled,
@@ -814,4 +938,64 @@ export const upsertAgentDispatchConfig = createServerFn({ method: "POST" })
     )
 
     return toConfigRecord(config)
+  })
+
+export const upsertProjectDispatchOverride = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => projectOverrideSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const config = await Effect.runPromise(
+      upsertProjectDispatchOverrideUseCase({
+        organizationId: OrganizationId(organizationId),
+        projectId: ProjectId(data.projectId),
+        integrationId: data.integrationId,
+        kind: data.kind,
+        ...(data.enabled !== undefined ? { enabled: data.enabled } : {}),
+        ...(data.triggers !== undefined ? { triggers: data.triggers } : {}),
+        ...(data.target !== undefined ? { target: data.target } : {}),
+        ...(data.promptTemplate !== undefined ? { promptTemplate: data.promptTemplate } : {}),
+        ...(data.guardrails !== undefined ? { guardrails: data.guardrails } : {}),
+      }).pipe(withPostgres(AgentDispatchConfigRepositoryLive, client, organizationId), withTracing),
+    )
+
+    return toOverrideRecord(config)
+  })
+
+export const resetProjectDispatchOverride = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ projectId: z.string(), integrationId: z.string() }))
+  .handler(async ({ data }) => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    await Effect.runPromise(
+      resetProjectDispatchOverrideUseCase({
+        projectId: ProjectId(data.projectId),
+        integrationId: data.integrationId,
+      }).pipe(withPostgres(AgentDispatchConfigRepositoryLive, client, organizationId), withTracing),
+    )
+    return { reset: true }
+  })
+
+export const setProjectDispatchRepo = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ projectId: z.string(), kind: z.literal("cursor"), repoUrl: z.string().url() }))
+  .handler(async ({ data }) => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const integrationRepo = yield* AgentDispatchIntegrationRepository
+        const integration = yield* integrationRepo.findActiveByKind(data.kind)
+        if (!integration) return yield* Effect.fail(new Error("Cursor is not connected"))
+        const config = yield* setProjectDispatchRepoUseCase({
+          organizationId: OrganizationId(organizationId),
+          projectId: ProjectId(data.projectId),
+          integrationId: integration.id,
+          repoUrl: data.repoUrl,
+        })
+        return toOverrideRecord(config)
+      }).pipe(withPostgres(agentDispatchLayer, client, organizationId), withTracing),
+    )
   })

--- a/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
+++ b/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
@@ -791,6 +791,9 @@ export const listSendToDestinations = createServerFn({ method: "GET" })
           const integration = yield* integrationRepo.findActiveByKind(kind)
           if (!integration) continue
           const effective = effectiveByIntegration.get(integration.id)
+          // Manual send-to is gated on the credential + a complete target, not `enabled`;
+          // `enabled` only governs automatic dispatch, so a disabled integration is still
+          // manually sendable.
           const readiness = checkTargetReadiness(kind, effective?.target ?? null)
           destinations.push({
             integrationId: integration.id,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -1,4 +1,8 @@
-import { AGENT_DISPATCH_TRIGGERS } from "@domain/agent-dispatch"
+import {
+  AGENT_DISPATCH_TRIGGERS,
+  type AgentDispatchTrigger,
+  type StoredAgentDispatchTarget,
+} from "@domain/agent-dispatch"
 import {
   Badge,
   Button,
@@ -24,7 +28,7 @@ import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { BookOpen, Copy, ExternalLink, FileText, type LucideProps, Plus, Webhook } from "lucide-react"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 import { z } from "zod"
 import {
   type AgentDispatchConfigRecord,
@@ -35,7 +39,7 @@ import {
   connectLinearIntegration,
   connectWebhookIntegration,
   disconnectAgentDispatchIntegration,
-  getAgentDispatchConfig,
+  getOrgDefaultDispatchConfig,
   getWebhookSecret,
   listAgentDispatches,
   listAgentDispatchIntegrations,
@@ -45,7 +49,7 @@ import {
   listLinearTeams,
   listLinearTeamsForApiKey,
   sendToDestinationsQueryKey,
-  upsertAgentDispatchConfig,
+  upsertOrgDefaultDispatchConfig,
 } from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../../lib/form-server-action.ts"
@@ -54,6 +58,17 @@ import { maskSensitiveValue } from "../../../../../../lib/mask-sensitive-value.t
 import { IntegrationCard } from "./integration-card.tsx"
 
 export const AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY = ["agent-dispatch-integrations"] as const
+
+export const orgDefaultConfigQueryKey = (kind: string) => ["agent-dispatch-config-default", kind] as const
+
+export const projectDispatchSettingsQueryKey = (projectId: string, kind: string) =>
+  ["agent-dispatch-project-settings", projectId, kind] as const
+
+export interface DispatchConfigFormValues {
+  readonly triggers: readonly AgentDispatchTrigger[]
+  readonly target: StoredAgentDispatchTarget
+  readonly guardrails: { readonly maxDispatchesPerDay: number; readonly cooldownMinutes: number }
+}
 
 export const AGENT_DISPATCH_KIND_LABELS = {
   cursor: "Cursor",
@@ -273,7 +288,7 @@ function AgentDispatchKindCard({
     mutationFn: () => disconnectAgentDispatchIntegration({ data: { integrationId: integration!.id } }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY })
-      await queryClient.invalidateQueries({ queryKey: ["agent-dispatch-config", projectId, kind] })
+      await queryClient.invalidateQueries({ queryKey: orgDefaultConfigQueryKey(kind) })
       await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
       toast({ description: `${KIND_LABELS[kind]} disconnected` })
     },
@@ -390,8 +405,22 @@ export function AgentDispatchIntegrationDetails({
         </div>
         <IntegrationDocsButton kind={kind} />
       </div>
+      <div className="flex max-w-3xl flex-col gap-1">
+        <Text.H5 display="block" weight="semibold">
+          Default settings
+        </Text.H5>
+        <Text.H6 display="block" color="foregroundMuted">
+          These defaults apply to every project in your organization.{" "}
+          <Link
+            to="/projects/$projectSlug/settings/signals"
+            params={{ projectSlug }}
+            className="font-semibold text-foreground hover:underline"
+          >
+            Configure for this project only →
+          </Link>
+        </Text.H6>
+      </div>
       <AgentDispatchConfigForm
-        projectId={projectId}
         kind={kind}
         integrationId={integration.id}
         vendorAccountId={integration.vendorAccountId}
@@ -403,13 +432,11 @@ export function AgentDispatchIntegrationDetails({
 }
 
 function AgentDispatchConfigForm({
-  projectId,
   kind,
   integrationId,
   vendorAccountId,
   webhookSecret,
 }: {
-  readonly projectId: string
   readonly kind: AgentDispatchKindKey
   readonly integrationId: string
   readonly vendorAccountId: string
@@ -418,8 +445,8 @@ function AgentDispatchConfigForm({
   const queryClient = useQueryClient()
   const { toast } = useToast()
   const { data: config, isLoading } = useQuery({
-    queryKey: ["agent-dispatch-config", projectId, kind],
-    queryFn: () => getAgentDispatchConfig({ data: { projectId, kind } }),
+    queryKey: orgDefaultConfigQueryKey(kind),
+    queryFn: () => getOrgDefaultDispatchConfig({ data: { kind } }),
   })
 
   if (isLoading) return null
@@ -427,37 +454,50 @@ function AgentDispatchConfigForm({
   return (
     <AgentDispatchConfigFormInner
       key={config ? `${config.id}:${config.updatedAt}` : "new"}
-      projectId={projectId}
       kind={kind}
       integrationId={integrationId}
       vendorAccountId={vendorAccountId}
       initial={config ?? null}
       webhookSecret={webhookSecret}
-      onSaved={async () => {
-        await queryClient.invalidateQueries({ queryKey: ["agent-dispatch-config", projectId, kind] })
-        await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
-        toast({ description: "Dispatch settings saved" })
+      onSubmit={async (values) => {
+        await upsertOrgDefaultDispatchConfig({
+          data: {
+            integrationId,
+            kind,
+            enabled: values.triggers.length > 0,
+            triggers: values.triggers,
+            target: values.target,
+            guardrails: values.guardrails,
+          },
+        })
+        await queryClient.invalidateQueries({ queryKey: orgDefaultConfigQueryKey(kind) })
+        await queryClient.invalidateQueries({ queryKey: ["send-to-destinations"] })
+        toast({ description: "Default settings saved" })
       }}
     />
   )
 }
 
-function AgentDispatchConfigFormInner({
-  projectId,
+export function AgentDispatchConfigFormInner({
   kind,
   integrationId,
   vendorAccountId,
   initial,
   webhookSecret,
-  onSaved,
+  readOnly = false,
+  submitLabel = "Save settings",
+  extraActions,
+  onSubmit,
 }: {
-  readonly projectId: string
   readonly kind: AgentDispatchKindKey
   readonly integrationId: string
   readonly vendorAccountId: string
   readonly initial: AgentDispatchConfigRecord | null
   readonly webhookSecret: string | null
-  readonly onSaved: () => Promise<void>
+  readonly readOnly?: boolean
+  readonly submitLabel?: string
+  readonly extraActions?: ReactNode
+  readonly onSubmit: (values: DispatchConfigFormValues) => Promise<void>
 }) {
   const target = initial?.target
   const visibleTriggers = ACTIVE_DISPATCH_TRIGGERS.filter((trigger) => {
@@ -534,112 +574,37 @@ function AgentDispatchConfigFormInner({
     },
     onSubmit: createFormSubmitHandler(
       async (values: Record<string, unknown>) => {
+        const common = z
+          .object({
+            triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
+            maxDispatchesPerDay: z.coerce.number().int().positive(),
+            cooldownMinutes: z.coerce.number().int().nonnegative(),
+          })
+          .parse(values)
+        const guardrails = {
+          maxDispatchesPerDay: common.maxDispatchesPerDay,
+          cooldownMinutes: common.cooldownMinutes,
+        }
+        let target: StoredAgentDispatchTarget
         if (kind === "cursor") {
           const parsed = z
-            .object({
-              enabled: z.boolean(),
-              triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
-              maxDispatchesPerDay: z.coerce.number().int().positive(),
-              cooldownMinutes: z.coerce.number().int().nonnegative(),
-              repoUrl: z.string().url(),
-              startingRef: z.string().optional(),
-            })
+            .object({ repoUrl: z.string().url().or(z.literal("")), startingRef: z.string().optional() })
             .parse(values)
-          await upsertAgentDispatchConfig({
-            data: {
-              projectId,
-              integrationId,
-              kind,
-              enabled: parsed.triggers.length > 0,
-              triggers: parsed.triggers,
-              target: {
-                repoUrl: parsed.repoUrl,
-                ...(parsed.startingRef ? { startingRef: parsed.startingRef } : {}),
-              },
-              guardrails: {
-                maxDispatchesPerDay: parsed.maxDispatchesPerDay,
-                cooldownMinutes: parsed.cooldownMinutes,
-              },
-            },
-          })
+          target = {
+            ...(parsed.repoUrl ? { repoUrl: parsed.repoUrl } : {}),
+            ...(parsed.startingRef ? { startingRef: parsed.startingRef } : {}),
+          }
         } else if (kind === "claude_code") {
-          const parsed = z
-            .object({
-              enabled: z.boolean(),
-              triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
-              maxDispatchesPerDay: z.coerce.number().int().positive(),
-              cooldownMinutes: z.coerce.number().int().nonnegative(),
-              routineTriggerId: z.string().min(1),
-            })
-            .parse(values)
-          await upsertAgentDispatchConfig({
-            data: {
-              projectId,
-              integrationId,
-              kind,
-              enabled: parsed.triggers.length > 0,
-              triggers: parsed.triggers,
-              target: { routineTriggerId: parsed.routineTriggerId },
-              guardrails: {
-                maxDispatchesPerDay: parsed.maxDispatchesPerDay,
-                cooldownMinutes: parsed.cooldownMinutes,
-              },
-            },
-          })
+          const parsed = z.object({ routineTriggerId: z.string().min(1) }).parse(values)
+          target = { routineTriggerId: parsed.routineTriggerId }
         } else if (kind === "linear") {
-          const parsed = z
-            .object({
-              enabled: z.boolean(),
-              triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
-              maxDispatchesPerDay: z.coerce.number().int().positive(),
-              cooldownMinutes: z.coerce.number().int().nonnegative(),
-              teamId: z.string().uuid(),
-              assigneeId: z.string().optional(),
-            })
-            .parse(values)
-          await upsertAgentDispatchConfig({
-            data: {
-              projectId,
-              integrationId,
-              kind,
-              enabled: parsed.triggers.length > 0,
-              triggers: parsed.triggers,
-              target: {
-                teamId: parsed.teamId,
-                ...(parsed.assigneeId ? { assigneeId: parsed.assigneeId } : {}),
-              },
-              guardrails: {
-                maxDispatchesPerDay: parsed.maxDispatchesPerDay,
-                cooldownMinutes: parsed.cooldownMinutes,
-              },
-            },
-          })
+          const parsed = z.object({ teamId: z.string().uuid(), assigneeId: z.string().optional() }).parse(values)
+          target = { teamId: parsed.teamId, ...(parsed.assigneeId ? { assigneeId: parsed.assigneeId } : {}) }
         } else {
-          const parsed = z
-            .object({
-              enabled: z.boolean(),
-              triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
-              maxDispatchesPerDay: z.coerce.number().int().positive(),
-              cooldownMinutes: z.coerce.number().int().nonnegative(),
-              webhookUrl: z.string().url(),
-            })
-            .parse(values)
-          await upsertAgentDispatchConfig({
-            data: {
-              projectId,
-              integrationId,
-              kind,
-              enabled: parsed.triggers.length > 0,
-              triggers: parsed.triggers,
-              target: { webhookUrl: parsed.webhookUrl },
-              guardrails: {
-                maxDispatchesPerDay: parsed.maxDispatchesPerDay,
-                cooldownMinutes: parsed.cooldownMinutes,
-              },
-            },
-          })
+          const parsed = z.object({ webhookUrl: z.string().url() }).parse(values)
+          target = { webhookUrl: parsed.webhookUrl }
         }
-        await onSaved()
+        await onSubmit({ triggers: common.triggers, target, guardrails })
       },
       { resetOnSuccess: false },
     ),
@@ -662,6 +627,7 @@ function AgentDispatchConfigFormInner({
               return (
                 <div key={trigger} className="flex flex-row items-start gap-3">
                   <Checkbox
+                    disabled={readOnly}
                     checked={field.state.value.includes(trigger)}
                     onCheckedChange={(checked) => {
                       field.handleChange(
@@ -695,7 +661,7 @@ function AgentDispatchConfigFormInner({
                   placeholder={cursorRepositoriesLoading ? "Loading repositories" : "Select a repository"}
                   searchable
                   loading={cursorRepositoriesLoading}
-                  disabled={cursorRepositoriesLoading}
+                  disabled={readOnly || cursorRepositoriesLoading}
                   options={cursorRepositoryOptions}
                   value={field.state.value}
                   onChange={(value) => field.handleChange(String(value))}
@@ -705,7 +671,7 @@ function AgentDispatchConfigFormInner({
                 <Input
                   label="Repository URL"
                   placeholder="https://github.com/acme/app"
-                  disabled={cursorRepositoriesLoading}
+                  disabled={readOnly || cursorRepositoriesLoading}
                   value={field.state.value}
                   onChange={(event) => field.handleChange(event.target.value)}
                   errors={fieldErrorsAsStrings(field.state.meta.errors)}
@@ -719,6 +685,7 @@ function AgentDispatchConfigFormInner({
                 label="Branch"
                 placeholder="main"
                 className="h-9"
+                disabled={readOnly}
                 value={field.state.value}
                 onChange={(event) => field.handleChange(event.target.value)}
                 errors={fieldErrorsAsStrings(field.state.meta.errors)}
@@ -734,6 +701,7 @@ function AgentDispatchConfigFormInner({
             {(field) => (
               <Input
                 label="Routine trigger ID"
+                disabled={readOnly}
                 value={field.state.value}
                 onChange={(event) => field.handleChange(event.target.value)}
                 errors={fieldErrorsAsStrings(field.state.meta.errors)}
@@ -753,7 +721,7 @@ function AgentDispatchConfigFormInner({
                 placeholder={linearTeamsLoading ? "Loading Linear teams" : "Select a Linear team"}
                 searchable
                 loading={linearTeamsLoading}
-                disabled={linearTeamsLoading}
+                disabled={readOnly || linearTeamsLoading}
                 options={linearTeamOptions}
                 value={field.state.value}
                 onChange={(value) => field.handleChange(String(value))}
@@ -771,7 +739,7 @@ function AgentDispatchConfigFormInner({
                 searchable
                 removable
                 loading={linearMembersLoading}
-                disabled={linearMembersLoading}
+                disabled={readOnly || linearMembersLoading}
                 options={linearMemberOptions}
                 value={field.state.value}
                 onChange={(value) => field.handleChange(String(value))}
@@ -796,6 +764,7 @@ function AgentDispatchConfigFormInner({
             {(field) => (
               <Input
                 label="Webhook URL"
+                disabled={readOnly}
                 value={String(field.state.value)}
                 onChange={(event) => field.handleChange(event.target.value)}
                 errors={fieldErrorsAsStrings(field.state.meta.errors)}
@@ -805,17 +774,24 @@ function AgentDispatchConfigFormInner({
         </div>
       ) : null}
 
-      <form.Subscribe selector={(state) => ({ isDirty: state.isDirty, isSubmitting: state.isSubmitting })}>
-        {({ isDirty, isSubmitting }) =>
-          isDirty ? (
-            <div className="max-w-3xl">
-              <Button type="submit" isLoading={isSubmitting}>
-                Save settings
-              </Button>
+      {readOnly ? (
+        extraActions ? (
+          <div className="flex max-w-3xl flex-row gap-2">{extraActions}</div>
+        ) : null
+      ) : (
+        <form.Subscribe selector={(state) => ({ isDirty: state.isDirty, isSubmitting: state.isSubmitting })}>
+          {({ isDirty, isSubmitting }) => (
+            <div className="flex max-w-3xl flex-row gap-2">
+              {isDirty ? (
+                <Button type="submit" isLoading={isSubmitting}>
+                  {submitLabel}
+                </Button>
+              ) : null}
+              {extraActions}
             </div>
-          ) : null
-        }
-      </form.Subscribe>
+          )}
+        </form.Subscribe>
+      )}
     </form>
   )
 }
@@ -866,18 +842,20 @@ function ConnectAgentDispatchModal({
       ) => {
         if (kind === "cursor") {
           const parsed = z
-            .object({ cursorApiKey: z.string().min(1), repoUrl: z.string().url(), startingRef: z.string().optional() })
+            .object({
+              cursorApiKey: z.string().min(1),
+              repoUrl: z.string().url().or(z.literal("")),
+              startingRef: z.string().optional(),
+            })
             .parse(values)
-          const result = await connectCursorIntegration({
+          await connectCursorIntegration({
             data: {
               kind: "cursor",
               cursorApiKey: parsed.cursorApiKey,
-              projectId,
-              repoUrl: parsed.repoUrl,
+              ...(parsed.repoUrl ? { repoUrl: parsed.repoUrl } : {}),
               ...(parsed.startingRef ? { startingRef: parsed.startingRef } : {}),
             },
           })
-          queryClient.setQueryData(["agent-dispatch-config", projectId, kind], result.config)
         } else if (kind === "claude_code") {
           const parsed = z
             .object({
@@ -896,29 +874,28 @@ function ConnectAgentDispatchModal({
               kind: "claude_code",
               claudeRoutineToken: parsed.claudeRoutineToken,
               routineTriggerId: extractClaudeRoutineTriggerId(parsed.routineUrl)!,
-              projectId,
             },
           })
         } else if (kind === "linear") {
           const parsed = z.object({ linearApiKey: z.string().min(1), teamId: z.string().uuid() }).parse(values)
           await connectLinearIntegration({
-            data: { kind: "linear", linearApiKey: parsed.linearApiKey, teamId: parsed.teamId, projectId },
+            data: { kind: "linear", linearApiKey: parsed.linearApiKey, teamId: parsed.teamId },
           })
         } else {
           const parsed = z.object({ webhookUrl: z.string().url() }).parse(values)
           const result = await connectWebhookIntegration({
-            data: { kind: "webhook", webhookUrl: parsed.webhookUrl, projectId },
+            data: { kind: "webhook", webhookUrl: parsed.webhookUrl },
           })
           setWebhookSecret(result.webhookSecret)
           onWebhookSecret(result.webhookSecret)
           await queryClient.invalidateQueries({ queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY })
-          await queryClient.invalidateQueries({ queryKey: ["agent-dispatch-config", projectId, kind] })
+          await queryClient.invalidateQueries({ queryKey: orgDefaultConfigQueryKey(kind) })
           await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
           toast({ description: `${KIND_LABELS[kind]} connected` })
           return
         }
         await queryClient.invalidateQueries({ queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY })
-        await queryClient.invalidateQueries({ queryKey: ["agent-dispatch-config", projectId, kind] })
+        await queryClient.invalidateQueries({ queryKey: orgDefaultConfigQueryKey(kind) })
         await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
         toast({ description: `${KIND_LABELS[kind]} connected` })
         onClose()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
@@ -107,12 +107,21 @@ function ProjectDispatchKindSection({
         extraActions={
           showForm ? (
             hasOverride ? (
-              <Button variant="outline" onClick={() => resetMutation.mutate()} isLoading={resetMutation.isPending}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => resetMutation.mutate()}
+                isLoading={resetMutation.isPending}
+              >
                 Reset to organization defaults
               </Button>
-            ) : null
+            ) : (
+              <Button type="button" variant="outline" onClick={() => setEditing(false)}>
+                Cancel
+              </Button>
+            )
           ) : (
-            <Button variant="outline" onClick={() => setEditing(true)}>
+            <Button type="button" variant="outline" onClick={() => setEditing(true)}>
               Override for this project
             </Button>
           )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/project-dispatch-overrides.tsx
@@ -1,0 +1,140 @@
+import { Button, Icon, Skeleton, Text, useToast } from "@repo/ui"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useState } from "react"
+import {
+  type AgentDispatchIntegrationRecord,
+  getProjectDispatchSettings,
+  listAgentDispatchIntegrations,
+  resetProjectDispatchOverride,
+  sendToDestinationsQueryKey,
+  upsertProjectDispatchOverride,
+} from "../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+import {
+  AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  AgentDispatchConfigFormInner,
+  type AgentDispatchKindKey,
+  projectDispatchSettingsQueryKey,
+} from "./agent-dispatch-section.tsx"
+
+export function ProjectDispatchOverrides({ projectId }: { readonly projectId: string }) {
+  const { data: integrations = [], isLoading } = useQuery({
+    queryKey: AGENT_DISPATCH_INTEGRATIONS_QUERY_KEY,
+    queryFn: () => listAgentDispatchIntegrations(),
+  })
+
+  if (isLoading) return <Skeleton className="h-32 w-full" />
+  if (integrations.length === 0) return null
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <Text.H5 display="block" weight="semibold">
+          Cloud agents
+        </Text.H5>
+        <Text.H6 display="block" color="foregroundMuted">
+          Override the organization dispatch defaults for this project.
+        </Text.H6>
+      </div>
+      {integrations.map((integration: AgentDispatchIntegrationRecord) => (
+        <ProjectDispatchKindSection
+          key={integration.kind}
+          projectId={projectId}
+          kind={integration.kind}
+          integration={integration}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ProjectDispatchKindSection({
+  projectId,
+  kind,
+  integration,
+}: {
+  readonly projectId: string
+  readonly kind: AgentDispatchKindKey
+  readonly integration: AgentDispatchIntegrationRecord
+}) {
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+  const [editing, setEditing] = useState(false)
+  const { data: settings, isLoading } = useQuery({
+    queryKey: projectDispatchSettingsQueryKey(projectId, kind),
+    queryFn: () => getProjectDispatchSettings({ data: { projectId, kind } }),
+  })
+
+  const resetMutation = useMutation({
+    mutationFn: () => resetProjectDispatchOverride({ data: { projectId, integrationId: integration.id } }),
+    onSuccess: async () => {
+      setEditing(false)
+      await queryClient.invalidateQueries({ queryKey: projectDispatchSettingsQueryKey(projectId, kind) })
+      await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
+      toast({ description: `${AGENT_DISPATCH_KIND_LABELS[kind]} reset to organization defaults` })
+    },
+    onError: (error) => toast({ variant: "destructive", description: toUserMessage(error) }),
+  })
+
+  if (isLoading) return <Skeleton className="h-32 w-full" />
+
+  const hasOverride = settings?.override != null
+  const initial = settings?.effective ?? null
+  const showForm = hasOverride || editing
+
+  return (
+    <section id={kind} className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-4">
+      <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row items-center gap-2">
+          <Icon icon={AGENT_DISPATCH_KIND_ICONS[kind]} size="sm" />
+          <Text.H5 weight="semibold">{AGENT_DISPATCH_KIND_LABELS[kind]}</Text.H5>
+        </div>
+        <Text.H6 color="foregroundMuted">
+          {hasOverride ? "Customized for this project" : "Using organization defaults"}
+        </Text.H6>
+      </div>
+      <AgentDispatchConfigFormInner
+        key={`${kind}:${hasOverride ? "override" : "default"}:${settings?.effective?.updatedAt ?? "new"}`}
+        kind={kind}
+        integrationId={integration.id}
+        vendorAccountId={integration.vendorAccountId}
+        initial={initial}
+        webhookSecret={null}
+        readOnly={!showForm}
+        submitLabel={hasOverride ? "Save override" : "Save for this project"}
+        extraActions={
+          showForm ? (
+            hasOverride ? (
+              <Button variant="outline" onClick={() => resetMutation.mutate()} isLoading={resetMutation.isPending}>
+                Reset to organization defaults
+              </Button>
+            ) : null
+          ) : (
+            <Button variant="outline" onClick={() => setEditing(true)}>
+              Override for this project
+            </Button>
+          )
+        }
+        onSubmit={async (values) => {
+          await upsertProjectDispatchOverride({
+            data: {
+              projectId,
+              integrationId: integration.id,
+              kind,
+              enabled: values.triggers.length > 0,
+              triggers: values.triggers,
+              target: values.target,
+              guardrails: values.guardrails,
+            },
+          })
+          setEditing(false)
+          await queryClient.invalidateQueries({ queryKey: projectDispatchSettingsQueryKey(projectId, kind) })
+          await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
+          toast({ description: `${AGENT_DISPATCH_KIND_LABELS[kind]} settings saved for this project` })
+        }}
+      />
+    </section>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/signals.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/signals.tsx
@@ -5,6 +5,7 @@ import { useState } from "react"
 import { updateProjectMutation, useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useRouteProject } from "../-route-data.ts"
+import { ProjectDispatchOverrides } from "./-components/project-dispatch-overrides.tsx"
 import { SettingsPage } from "./-components/settings-page.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings/signals")({
@@ -60,6 +61,7 @@ function ProjectSignalsSettingsPage() {
           />
         </div>
       </div>
+      <ProjectDispatchOverrides projectId={currentProject.id} />
     </SettingsPage>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalId/-components/signal-send-to.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalId/-components/signal-send-to.tsx
@@ -10,27 +10,32 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Icon,
+  Input,
   Modal,
+  Select,
   Skeleton,
   Text,
   ToastAction,
   useToast,
 } from "@repo/ui"
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Clipboard, Loader2, Plus, Sparkles } from "lucide-react"
 import { useState } from "react"
 import {
   getSignalDispatchPrompt,
+  listCursorRepositories,
   listSendToDestinations,
   type SendToDestinationRecord,
   sendSignalToIntegration,
   sendToDestinationsQueryKey,
+  setProjectDispatchRepo,
 } from "../../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
 import { toUserMessage } from "../../../../../../../lib/errors.ts"
 import {
   AGENT_DISPATCH_KIND_ICONS,
   AGENT_DISPATCH_KIND_LABELS,
+  projectDispatchSettingsQueryKey,
 } from "../../../settings/-components/agent-dispatch-section.tsx"
 
 const MCP_DOCS_URL = "https://docs.latitude.so/getting-started/mcp"
@@ -71,6 +76,7 @@ export function SignalSendTo({
 }) {
   const { toast } = useToast()
   const [promptModalOpen, setPromptModalOpen] = useState(false)
+  const [cursorRepoModal, setCursorRepoModal] = useState<SendToDestinationRecord | null>(null)
 
   const { data: destinations, isLoading: destinationsLoading } = useQuery({
     queryKey: sendToDestinationsQueryKey(projectId),
@@ -80,7 +86,7 @@ export function SignalSendTo({
   const sendMutation = useMutation({
     mutationFn: (destination: SendToDestinationRecord) =>
       sendSignalToIntegration({
-        data: { projectId, signalId, configId: destination.configId, sendId: crypto.randomUUID() },
+        data: { projectId, signalId, kind: destination.kind, sendId: crypto.randomUUID() },
       }),
     onSuccess: (result, destination) => {
       const label = AGENT_DISPATCH_KIND_LABELS[destination.kind]
@@ -103,6 +109,11 @@ export function SignalSendTo({
         toast({
           description: dispatchToastDescription(`Already sent to ${label}.`, projectSlug, destination.kind),
         })
+      } else if (result.status === "not-ready") {
+        toast({
+          variant: "destructive",
+          description: dispatchToastDescription(`Finish setting up ${label} first.`, projectSlug, destination.kind),
+        })
       } else {
         toast({
           variant: "destructive",
@@ -121,7 +132,7 @@ export function SignalSendTo({
       }),
   })
 
-  const sendingConfigId = sendMutation.isPending ? sendMutation.variables?.configId : undefined
+  const sendingKind = sendMutation.isPending ? sendMutation.variables?.kind : undefined
 
   const hasCloudDestinations = (destinations?.length ?? 0) > 0
 
@@ -146,28 +157,39 @@ export function SignalSendTo({
                 <Text.H5 color="foregroundMuted">Loading integrations…</Text.H5>
               </DropdownMenuItem>
             ) : hasCloudDestinations ? (
-              destinations?.map((destination) => (
-                <DropdownMenuItem
-                  key={destination.configId}
-                  disabled={sendMutation.isPending}
-                  className="cursor-pointer items-center gap-2"
-                  onSelect={() => {
-                    if (sendMutation.isPending) return
-                    sendMutation.mutate(destination)
-                  }}
-                >
-                  {sendingConfigId === destination.configId ? (
-                    <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" aria-hidden />
-                  ) : (
-                    <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
-                  )}
-                  <Text.H5>
-                    {sendingConfigId === destination.configId
-                      ? "Sending…"
-                      : AGENT_DISPATCH_KIND_LABELS[destination.kind]}
-                  </Text.H5>
-                </DropdownMenuItem>
-              ))
+              destinations?.map((destination) =>
+                !destination.ready && destination.kind !== "cursor" ? (
+                  <DropdownMenuItem key={destination.kind} asChild className="cursor-pointer items-center gap-2">
+                    <Link to="/projects/$projectSlug/settings/signals" params={{ projectSlug }} hash={destination.kind}>
+                      <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
+                      <Text.H5>{`Finish setting up ${AGENT_DISPATCH_KIND_LABELS[destination.kind]}`}</Text.H5>
+                    </Link>
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem
+                    key={destination.kind}
+                    disabled={sendMutation.isPending}
+                    className="cursor-pointer items-center gap-2"
+                    onSelect={() => {
+                      if (sendMutation.isPending) return
+                      if (!destination.ready) {
+                        setCursorRepoModal(destination)
+                        return
+                      }
+                      sendMutation.mutate(destination)
+                    }}
+                  >
+                    {sendingKind === destination.kind ? (
+                      <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" aria-hidden />
+                    ) : (
+                      <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
+                    )}
+                    <Text.H5>
+                      {sendingKind === destination.kind ? "Sending…" : AGENT_DISPATCH_KIND_LABELS[destination.kind]}
+                    </Text.H5>
+                  </DropdownMenuItem>
+                ),
+              )
             ) : (
               <DropdownMenuItem asChild className="cursor-pointer items-center gap-2">
                 <Link to="/projects/$projectSlug/settings/integrations" params={{ projectSlug }}>
@@ -188,7 +210,95 @@ export function SignalSendTo({
       {promptModalOpen ? (
         <CopyPromptModal projectId={projectId} signalId={signalId} onClose={() => setPromptModalOpen(false)} />
       ) : null}
+      {cursorRepoModal ? (
+        <SendToCursorRepoModal
+          projectId={projectId}
+          integrationId={cursorRepoModal.integrationId}
+          onClose={() => setCursorRepoModal(null)}
+          onSaved={(destination) => {
+            setCursorRepoModal(null)
+            sendMutation.mutate(destination)
+          }}
+          destination={cursorRepoModal}
+        />
+      ) : null}
     </>
+  )
+}
+
+function SendToCursorRepoModal({
+  projectId,
+  integrationId,
+  destination,
+  onClose,
+  onSaved,
+}: {
+  readonly projectId: string
+  readonly integrationId: string
+  readonly destination: SendToDestinationRecord
+  readonly onClose: () => void
+  readonly onSaved: (destination: SendToDestinationRecord) => void
+}) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const [repoUrl, setRepoUrl] = useState("")
+
+  const { data: repositories = [], isLoading } = useQuery({
+    queryKey: ["cursor-repositories", integrationId],
+    queryFn: () => listCursorRepositories({ data: { integrationId } }),
+  })
+  const repositoryOptions = repositories.map((repo) => ({
+    label: `${repo.owner}/${repo.name}`,
+    value: repo.repository,
+  }))
+
+  const saveMutation = useMutation({
+    mutationFn: () => setProjectDispatchRepo({ data: { projectId, kind: "cursor", repoUrl } }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: sendToDestinationsQueryKey(projectId) })
+      await queryClient.invalidateQueries({ queryKey: projectDispatchSettingsQueryKey(projectId, "cursor") })
+      onSaved({ ...destination, ready: true, missing: [] })
+    },
+    onError: (error) => toast({ variant: "destructive", description: toUserMessage(error) }),
+  })
+
+  return (
+    <Modal
+      open
+      dismissible
+      onOpenChange={(next) => (!next ? onClose() : undefined)}
+      title="Choose a repository"
+      description="Cursor needs a repository for this project before it can dispatch. This is saved for future sends."
+      footer={
+        <>
+          <CloseTrigger />
+          <Button onClick={() => saveMutation.mutate()} isLoading={saveMutation.isPending} disabled={!repoUrl}>
+            Save and send
+          </Button>
+        </>
+      }
+    >
+      {repositoryOptions.length > 0 ? (
+        <Select
+          name="repoUrl"
+          label="Repository"
+          placeholder={isLoading ? "Loading repositories" : "Select a repository"}
+          searchable
+          loading={isLoading}
+          disabled={isLoading}
+          options={repositoryOptions}
+          value={repoUrl}
+          onChange={(value) => setRepoUrl(String(value))}
+        />
+      ) : (
+        <Input
+          label="Repository URL"
+          placeholder="https://github.com/acme/app"
+          value={repoUrl}
+          onChange={(event) => setRepoUrl(event.target.value)}
+        />
+      )}
+    </Modal>
   )
 }
 

--- a/apps/workers/src/workers/agent-dispatch.ts
+++ b/apps/workers/src/workers/agent-dispatch.ts
@@ -7,6 +7,7 @@ import {
   agentDispatchContextSchema,
   DISPATCH_ERROR_CATEGORIES,
   type DispatchErrorCategory,
+  parseResolvedDispatchTarget,
   requestAgentDispatchUseCase,
   sendAgentDispatchUseCase,
 } from "@domain/agent-dispatch"
@@ -127,7 +128,7 @@ export const createAgentDispatchWorker = ({
                   sourceId: request.sourceId,
                   prompt: request.prompt,
                   context: request.context as Record<string, unknown>,
-                  target: {},
+                  target: request.target as Record<string, unknown>,
                 },
                 {
                   dedupeKey: `agent-dispatch:send:${request.idempotencyKey}`,
@@ -160,9 +161,18 @@ export const createAgentDispatchWorker = ({
         const projectId = ProjectId(payload.projectId)
 
         return Effect.gen(function* () {
-          const configRepo = yield* AgentDispatchConfigRepository
-          const config = yield* configRepo.findById(payload.configId)
           const context = agentDispatchContextSchema.parse(payload.context)
+          // In-flight jobs published before targets rode the payload carry {};
+          // fall back to deriving from the (pre-migration, full) config row.
+          let target = parseResolvedDispatchTarget({ ...payload.target, kind: payload.kind })
+          if (target === null) {
+            const configRepo = yield* AgentDispatchConfigRepository
+            const config = yield* configRepo.findById(payload.configId)
+            target = parseResolvedDispatchTarget({ ...config.target, kind: config.kind })
+          }
+          if (target === null) {
+            return yield* Effect.fail(new Error(`agent-dispatch.send unresolvable target configId=${payload.configId}`))
+          }
 
           const outcome = yield* sendAgentDispatchUseCase({
             configId: payload.configId,
@@ -175,7 +185,7 @@ export const createAgentDispatchWorker = ({
             sourceId: payload.sourceId,
             prompt: payload.prompt,
             context,
-            target: { ...config.target, kind: config.kind },
+            target,
           }).pipe(
             Effect.catchTag("DispatchAdapterError", (error) => {
               if (error.reason === "rate_limited" || error.reason === "transport") {

--- a/packages/domain/agent-dispatch/src/entities/agent-dispatch-config.ts
+++ b/packages/domain/agent-dispatch/src/entities/agent-dispatch-config.ts
@@ -45,7 +45,10 @@ export type AgentDispatchTarget = z.infer<typeof agentDispatchTargetSchema>
 
 export const storedCursorDispatchTargetSchema = cursorDispatchTargetSchema.partial({ repoUrl: true })
 
-// The fully-optional cursor shape must stay last or it would swallow the other kinds.
+// storedCursorDispatchTargetSchema has every field optional, so it matches `{}` and
+// any object — it MUST stay last, and no other all-optional kind may precede it, or
+// zod's union would match cursor first and mis-parse. e.g. a `{ teamId }` linear target
+// placed after cursor would resolve as an empty cursor target instead.
 export const storedAgentDispatchTargetSchema = z.union([
   claudeDispatchTargetSchema,
   linearDispatchTargetSchema,

--- a/packages/domain/agent-dispatch/src/entities/agent-dispatch-config.ts
+++ b/packages/domain/agent-dispatch/src/entities/agent-dispatch-config.ts
@@ -1,6 +1,8 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
 import { cuidSchema, organizationIdSchema, projectIdSchema } from "@domain/shared"
 import { z } from "zod"
 import { AGENT_DISPATCH_KINDS, AGENT_DISPATCH_TRIGGERS } from "../constants.ts"
+import type { AgentDispatchTrigger } from "./agent-dispatch-context.ts"
 
 export const agentDispatchKindSchema = z.enum(AGENT_DISPATCH_KINDS)
 export type AgentDispatchKind = z.infer<typeof agentDispatchKindSchema>
@@ -41,21 +43,55 @@ export const agentDispatchTargetSchema = z.union([
 
 export type AgentDispatchTarget = z.infer<typeof agentDispatchTargetSchema>
 
-export const agentDispatchConfigSchema = z.object({
+export const storedCursorDispatchTargetSchema = cursorDispatchTargetSchema.partial({ repoUrl: true })
+
+// The fully-optional cursor shape must stay last or it would swallow the other kinds.
+export const storedAgentDispatchTargetSchema = z.union([
+  claudeDispatchTargetSchema,
+  linearDispatchTargetSchema,
+  webhookDispatchTargetSchema,
+  storedCursorDispatchTargetSchema,
+])
+
+export type StoredAgentDispatchTarget = z.infer<typeof storedAgentDispatchTargetSchema>
+
+/**
+ * A stored config row. `projectId === null` marks the org-wide default for the
+ * integration; rows with a project are per-project overrides where each
+ * nullable field means "inherit from the default" and a non-null field
+ * replaces the default's value wholly. `promptTemplate` cannot distinguish
+ * "inherit" from "clear" — an empty string is the escape hatch to disable a
+ * default template.
+ */
+export const agentDispatchConfigRowSchema = z.object({
   id: cuidSchema,
   organizationId: organizationIdSchema,
-  projectId: projectIdSchema,
+  projectId: projectIdSchema.nullable(),
   integrationId: cuidSchema,
   kind: agentDispatchKindSchema,
-  enabled: z.boolean(),
-  triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)),
-  target: agentDispatchTargetSchema,
+  enabled: z.boolean().nullable(),
+  triggers: z.array(z.enum(AGENT_DISPATCH_TRIGGERS)).nullable(),
+  target: storedAgentDispatchTargetSchema.nullable(),
   promptTemplate: z.string().nullable(),
-  guardrails: agentDispatchGuardrailsSchema,
+  guardrails: agentDispatchGuardrailsSchema.nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 })
 
-export type AgentDispatchConfig = z.infer<typeof agentDispatchConfigSchema>
+export type AgentDispatchConfigRow = z.infer<typeof agentDispatchConfigRowSchema>
+
+/** A default and its project override merged for one resolving project. */
+export interface EffectiveAgentDispatchConfig {
+  readonly id: string
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly integrationId: string
+  readonly kind: AgentDispatchKind
+  readonly enabled: boolean
+  readonly triggers: readonly AgentDispatchTrigger[]
+  readonly target: StoredAgentDispatchTarget | null
+  readonly promptTemplate: string | null
+  readonly guardrails: AgentDispatchGuardrails
+}
 
 export type ResolvedDispatchTarget = AgentDispatchTarget & { readonly kind: AgentDispatchKind }

--- a/packages/domain/agent-dispatch/src/helpers/resolve-effective-config.test.ts
+++ b/packages/domain/agent-dispatch/src/helpers/resolve-effective-config.test.ts
@@ -1,0 +1,141 @@
+import { OrganizationId, ProjectId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import type { AgentDispatchConfigRow } from "../entities/agent-dispatch-config.ts"
+import {
+  checkTargetReadiness,
+  resolveEffectiveConfig,
+  resolveEffectiveConfigsForProject,
+} from "./resolve-effective-config.ts"
+
+const ORG = OrganizationId("o".padEnd(24, "0"))
+const PROJECT = ProjectId("p".padEnd(24, "0"))
+const now = new Date("2026-07-09T00:00:00.000Z")
+
+const row = (overrides: Partial<AgentDispatchConfigRow>): AgentDispatchConfigRow => ({
+  id: "id".padEnd(24, "0"),
+  organizationId: ORG,
+  projectId: null,
+  integrationId: "int".padEnd(24, "0"),
+  kind: "webhook",
+  enabled: true,
+  triggers: ["signal.discovered"],
+  target: { webhookUrl: "https://example.com/hook" },
+  promptTemplate: null,
+  guardrails: { maxDispatchesPerDay: 5, cooldownMinutes: 30 },
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+})
+
+describe("resolveEffectiveConfig", () => {
+  it("returns null when both default and override are null", () => {
+    expect(resolveEffectiveConfig({ projectId: PROJECT, defaultConfig: null, override: null })).toBeNull()
+  })
+
+  it("uses the default when there is no override, resolving projectId to the caller", () => {
+    const effective = resolveEffectiveConfig({
+      projectId: PROJECT,
+      defaultConfig: row({ projectId: null }),
+      override: null,
+    })
+    expect(effective?.projectId).toBe(PROJECT)
+    expect(effective?.enabled).toBe(true)
+    expect(effective?.target).toEqual({ webhookUrl: "https://example.com/hook" })
+  })
+
+  it("lets a non-null override field win wholly", () => {
+    const effective = resolveEffectiveConfig({
+      projectId: PROJECT,
+      defaultConfig: row({ projectId: null }),
+      override: row({
+        id: "ovr".padEnd(24, "0"),
+        projectId: PROJECT,
+        enabled: false,
+        triggers: null,
+        target: { webhookUrl: "https://project.example.com/hook" },
+        guardrails: null,
+      }),
+    })
+    expect(effective?.id).toBe("ovr".padEnd(24, "0"))
+    expect(effective?.enabled).toBe(false)
+    expect(effective?.triggers).toEqual(["signal.discovered"])
+    expect(effective?.target).toEqual({ webhookUrl: "https://project.example.com/hook" })
+    expect(effective?.guardrails).toEqual({ maxDispatchesPerDay: 5, cooldownMinutes: 30 })
+  })
+
+  it("resolves an override-only row (legacy full row with no default)", () => {
+    const effective = resolveEffectiveConfig({
+      projectId: PROJECT,
+      defaultConfig: null,
+      override: row({ id: "ovr".padEnd(24, "0"), projectId: PROJECT }),
+    })
+    expect(effective?.id).toBe("ovr".padEnd(24, "0"))
+    expect(effective?.enabled).toBe(true)
+  })
+
+  it("falls back to defaults for a row with all-null overridable fields", () => {
+    const effective = resolveEffectiveConfig({
+      projectId: PROJECT,
+      defaultConfig: null,
+      override: row({
+        id: "ovr".padEnd(24, "0"),
+        projectId: PROJECT,
+        enabled: null,
+        triggers: null,
+        target: null,
+        guardrails: null,
+      }),
+    })
+    expect(effective?.enabled).toBe(false)
+    expect(effective?.triggers).toEqual([])
+    expect(effective?.target).toBeNull()
+    expect(effective?.guardrails).toEqual({ maxDispatchesPerDay: 10, cooldownMinutes: 60 })
+  })
+})
+
+describe("resolveEffectiveConfigsForProject", () => {
+  it("groups by integration and ignores other projects' overrides", () => {
+    const other = ProjectId("x".padEnd(24, "0"))
+    const configs = resolveEffectiveConfigsForProject(PROJECT, [
+      row({ id: "d".padEnd(24, "0"), projectId: null }),
+      row({ id: "mine".padEnd(24, "0"), projectId: PROJECT, target: { webhookUrl: "https://mine.example.com/hook" } }),
+      row({
+        id: "theirs".padEnd(24, "0"),
+        projectId: other,
+        target: { webhookUrl: "https://theirs.example.com/hook" },
+      }),
+    ])
+    expect(configs).toHaveLength(1)
+    expect(configs[0]?.id).toBe("mine".padEnd(24, "0"))
+    expect(configs[0]?.target).toEqual({ webhookUrl: "https://mine.example.com/hook" })
+  })
+})
+
+describe("checkTargetReadiness", () => {
+  it("reports the missing repo for a cursor target without a repoUrl", () => {
+    const result = checkTargetReadiness("cursor", { startingRef: "main" })
+    expect(result.ready).toBe(false)
+    if (result.ready) return
+    expect(result.missing).toEqual(["repoUrl"])
+  })
+
+  it("reports missing fields for a null target", () => {
+    const result = checkTargetReadiness("cursor", null)
+    expect(result.ready).toBe(false)
+    if (result.ready) return
+    expect(result.missing).toContain("repoUrl")
+  })
+
+  it("passes a complete cursor target and stamps the kind", () => {
+    const result = checkTargetReadiness("cursor", { repoUrl: "https://github.com/acme/app" })
+    expect(result.ready).toBe(true)
+    if (!result.ready) return
+    expect(result.target).toEqual({ repoUrl: "https://github.com/acme/app", kind: "cursor" })
+  })
+
+  it("passes complete targets for the other kinds", () => {
+    expect(checkTargetReadiness("claude_code", { routineTriggerId: "trig_1" }).ready).toBe(true)
+    expect(checkTargetReadiness("linear", { teamId: "team-1" }).ready).toBe(true)
+    expect(checkTargetReadiness("webhook", { webhookUrl: "https://example.com/hook" }).ready).toBe(true)
+  })
+})

--- a/packages/domain/agent-dispatch/src/helpers/resolve-effective-config.ts
+++ b/packages/domain/agent-dispatch/src/helpers/resolve-effective-config.ts
@@ -1,0 +1,92 @@
+import type { ProjectId } from "@domain/shared"
+import type { z } from "zod"
+import { DEFAULT_COOLDOWN_MINUTES, DEFAULT_MAX_DISPATCHES_PER_DAY } from "../constants.ts"
+import {
+  type AgentDispatchConfigRow,
+  type AgentDispatchKind,
+  type AgentDispatchTarget,
+  agentDispatchKindSchema,
+  claudeDispatchTargetSchema,
+  cursorDispatchTargetSchema,
+  type EffectiveAgentDispatchConfig,
+  linearDispatchTargetSchema,
+  type ResolvedDispatchTarget,
+  type StoredAgentDispatchTarget,
+  webhookDispatchTargetSchema,
+} from "../entities/agent-dispatch-config.ts"
+
+const FULL_TARGET_SCHEMAS: Record<AgentDispatchKind, z.ZodType<AgentDispatchTarget>> = {
+  cursor: cursorDispatchTargetSchema,
+  claude_code: claudeDispatchTargetSchema,
+  linear: linearDispatchTargetSchema,
+  webhook: webhookDispatchTargetSchema,
+}
+
+export interface ResolveEffectiveConfigInput {
+  readonly projectId: ProjectId
+  readonly defaultConfig: AgentDispatchConfigRow | null
+  readonly override: AgentDispatchConfigRow | null
+}
+
+export function resolveEffectiveConfig(input: ResolveEffectiveConfigInput): EffectiveAgentDispatchConfig | null {
+  const base = input.override ?? input.defaultConfig
+  if (!base) return null
+  return {
+    id: base.id,
+    organizationId: base.organizationId,
+    projectId: input.projectId,
+    integrationId: base.integrationId,
+    kind: base.kind,
+    enabled: input.override?.enabled ?? input.defaultConfig?.enabled ?? false,
+    triggers: input.override?.triggers ?? input.defaultConfig?.triggers ?? [],
+    target: input.override?.target ?? input.defaultConfig?.target ?? null,
+    promptTemplate: input.override?.promptTemplate ?? input.defaultConfig?.promptTemplate ?? null,
+    guardrails: input.override?.guardrails ??
+      input.defaultConfig?.guardrails ?? {
+        maxDispatchesPerDay: DEFAULT_MAX_DISPATCHES_PER_DAY,
+        cooldownMinutes: DEFAULT_COOLDOWN_MINUTES,
+      },
+  }
+}
+
+export function resolveEffectiveConfigsForProject(
+  projectId: ProjectId,
+  rows: readonly AgentDispatchConfigRow[],
+): readonly EffectiveAgentDispatchConfig[] {
+  const byIntegration = new Map<
+    string,
+    { defaultConfig: AgentDispatchConfigRow | null; override: AgentDispatchConfigRow | null }
+  >()
+  for (const row of rows) {
+    const group = byIntegration.get(row.integrationId) ?? { defaultConfig: null, override: null }
+    if (row.projectId === null) group.defaultConfig = row
+    else if (row.projectId === projectId) group.override = row
+    byIntegration.set(row.integrationId, group)
+  }
+  return [...byIntegration.values()]
+    .map((group) => resolveEffectiveConfig({ projectId, ...group }))
+    .filter((config) => config !== null)
+}
+
+export type TargetReadiness =
+  | { readonly ready: true; readonly target: ResolvedDispatchTarget }
+  | { readonly ready: false; readonly missing: readonly string[] }
+
+export function checkTargetReadiness(
+  kind: AgentDispatchKind,
+  target: StoredAgentDispatchTarget | null,
+): TargetReadiness {
+  const result = FULL_TARGET_SCHEMAS[kind].safeParse(target ?? {})
+  if (result.success) return { ready: true, target: { ...result.data, kind } }
+  const missing = [...new Set(result.error.issues.map((issue) => issue.path.join(".")))]
+  return { ready: false, missing }
+}
+
+export function parseResolvedDispatchTarget(value: unknown): ResolvedDispatchTarget | null {
+  if (typeof value !== "object" || value === null || !("kind" in value)) return null
+  const kind = agentDispatchKindSchema.safeParse(value.kind)
+  if (!kind.success) return null
+  const target = FULL_TARGET_SCHEMAS[kind.data].safeParse(value)
+  if (!target.success) return null
+  return { ...target.data, kind: kind.data }
+}

--- a/packages/domain/agent-dispatch/src/index.ts
+++ b/packages/domain/agent-dispatch/src/index.ts
@@ -13,20 +13,24 @@ export {
   dispatchErrorCategorySchema,
 } from "./entities/agent-dispatch.ts"
 export type {
-  AgentDispatchConfig,
+  AgentDispatchConfigRow,
   AgentDispatchGuardrails,
   AgentDispatchKind,
   AgentDispatchTarget,
+  EffectiveAgentDispatchConfig,
   ResolvedDispatchTarget,
+  StoredAgentDispatchTarget,
 } from "./entities/agent-dispatch-config.ts"
 export {
-  agentDispatchConfigSchema,
+  agentDispatchConfigRowSchema,
   agentDispatchGuardrailsSchema,
   agentDispatchKindSchema,
   agentDispatchTargetSchema,
   claudeDispatchTargetSchema,
   cursorDispatchTargetSchema,
   linearDispatchTargetSchema,
+  storedAgentDispatchTargetSchema,
+  storedCursorDispatchTargetSchema,
   webhookDispatchTargetSchema,
 } from "./entities/agent-dispatch-config.ts"
 export type { AgentDispatchContext, AgentDispatchTrigger } from "./entities/agent-dispatch-context.ts"
@@ -39,6 +43,13 @@ export {
 export { buildDispatchContextFromSignal } from "./helpers/build-dispatch-context.ts"
 export { buildDispatchIdempotencyKey, buildManualDispatchIdempotencyKey } from "./helpers/idempotency-key.ts"
 export { defaultDispatchPromptTemplate, renderDispatchPrompt } from "./helpers/render-prompt.ts"
+export type { ResolveEffectiveConfigInput, TargetReadiness } from "./helpers/resolve-effective-config.ts"
+export {
+  checkTargetReadiness,
+  parseResolvedDispatchTarget,
+  resolveEffectiveConfig,
+  resolveEffectiveConfigsForProject,
+} from "./helpers/resolve-effective-config.ts"
 export type { AgentDispatchAdapter, DecryptedCredential, DispatchResult } from "./ports/agent-dispatch-adapter.ts"
 export { AgentDispatchAdapters } from "./ports/agent-dispatch-adapter.ts"
 export type {
@@ -66,7 +77,11 @@ export type {
   RequestAgentDispatchResult,
 } from "./use-cases/request-agent-dispatch.ts"
 export { requestAgentDispatchUseCase } from "./use-cases/request-agent-dispatch.ts"
+export { resetProjectDispatchOverrideUseCase } from "./use-cases/reset-project-dispatch-override.ts"
 export type { SendAgentDispatchInput, SendAgentDispatchOutcome } from "./use-cases/send-agent-dispatch.ts"
 export { sendAgentDispatchUseCase } from "./use-cases/send-agent-dispatch.ts"
-export type { UpsertAgentDispatchConfigInput } from "./use-cases/upsert-agent-dispatch-config.ts"
-export { upsertAgentDispatchConfigUseCase } from "./use-cases/upsert-agent-dispatch-config.ts"
+export { setProjectDispatchRepoUseCase } from "./use-cases/set-project-dispatch-repo.ts"
+export type { UpsertOrgDefaultDispatchConfigInput } from "./use-cases/upsert-org-default-dispatch-config.ts"
+export { upsertOrgDefaultDispatchConfigUseCase } from "./use-cases/upsert-org-default-dispatch-config.ts"
+export type { UpsertProjectDispatchOverrideInput } from "./use-cases/upsert-project-dispatch-override.ts"
+export { upsertProjectDispatchOverrideUseCase } from "./use-cases/upsert-project-dispatch-override.ts"

--- a/packages/domain/agent-dispatch/src/ports/repositories.ts
+++ b/packages/domain/agent-dispatch/src/ports/repositories.ts
@@ -9,29 +9,32 @@ import type {
 } from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { AgentDispatch } from "../entities/agent-dispatch.ts"
-import type { AgentDispatchConfig, AgentDispatchKind } from "../entities/agent-dispatch-config.ts"
+import type { AgentDispatchConfigRow, AgentDispatchKind } from "../entities/agent-dispatch-config.ts"
 import type { AgentDispatchTrigger } from "../entities/agent-dispatch-context.ts"
 import type { AgentDispatchIntegrationConflictError } from "../errors.ts"
 
 export interface AgentDispatchConfigRepositoryShape {
-  readonly listEnabledByProject: (
+  readonly listByProjectIncludingDefaults: (
     projectId: ProjectId,
-  ) => Effect.Effect<readonly AgentDispatchConfig[], RepositoryError, SqlClient>
-  readonly listByProject: (
-    projectId: ProjectId,
-  ) => Effect.Effect<readonly AgentDispatchConfig[], RepositoryError, SqlClient>
-  readonly findByProjectAndIntegration: (input: {
+  ) => Effect.Effect<readonly AgentDispatchConfigRow[], RepositoryError, SqlClient>
+  readonly findDefaultByIntegration: (
+    integrationId: string,
+  ) => Effect.Effect<AgentDispatchConfigRow | null, RepositoryError, SqlClient>
+  readonly findOverrideByProjectAndIntegration: (input: {
     readonly projectId: ProjectId
     readonly integrationId: string
-  }) => Effect.Effect<AgentDispatchConfig | null, RepositoryError, SqlClient>
-  readonly listByOrganization: () => Effect.Effect<readonly AgentDispatchConfig[], RepositoryError, SqlClient>
-  readonly findById: (id: string) => Effect.Effect<AgentDispatchConfig, RepositoryError, SqlClient>
-  readonly upsert: (config: AgentDispatchConfig) => Effect.Effect<AgentDispatchConfig, RepositoryError, SqlClient>
+  }) => Effect.Effect<AgentDispatchConfigRow | null, RepositoryError, SqlClient>
+  readonly findById: (id: string) => Effect.Effect<AgentDispatchConfigRow, RepositoryError, SqlClient>
+  readonly upsert: (config: AgentDispatchConfigRow) => Effect.Effect<AgentDispatchConfigRow, RepositoryError, SqlClient>
   readonly delete: (id: string) => Effect.Effect<void, RepositoryError, SqlClient>
   readonly deleteByIntegrationId: (integrationId: string) => Effect.Effect<void, RepositoryError, SqlClient>
-  readonly countDispatchesInLast24h: (configId: string) => Effect.Effect<number, RepositoryError, SqlClient>
+  readonly countDispatchesInLast24h: (input: {
+    readonly configId: string
+    readonly projectId: ProjectId
+  }) => Effect.Effect<number, RepositoryError, SqlClient>
   readonly hasRecentDispatchForSource: (input: {
     readonly configId: string
+    readonly projectId: ProjectId
     readonly sourceId: string
     readonly cooldownMinutes: number
   }) => Effect.Effect<boolean, RepositoryError, SqlClient>

--- a/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.test.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.test.ts
@@ -13,7 +13,7 @@ import { type Signal, SignalRepository } from "@domain/signals"
 import { createFakeSignalRepository } from "@domain/signals/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
-import type { AgentDispatchConfig } from "../entities/agent-dispatch-config.ts"
+import type { AgentDispatchConfigRow } from "../entities/agent-dispatch-config.ts"
 import { AgentDispatchConfigRepository, AgentDispatchTraceReader } from "../ports/repositories.ts"
 import { requestAgentDispatchUseCase } from "./request-agent-dispatch.ts"
 
@@ -54,7 +54,7 @@ const makeSignal = (overrides: Partial<Signal> = {}): Signal => ({
 
 const incidentId = AlertIncidentId(cuid("a"))
 
-const makeConfig = (overrides: Partial<AgentDispatchConfig> = {}): AgentDispatchConfig => ({
+const makeConfig = (overrides: Partial<AgentDispatchConfigRow> = {}): AgentDispatchConfigRow => ({
   id: configId,
   organizationId: orgId,
   projectId,
@@ -96,7 +96,12 @@ const makeIncident = (overrides: Partial<Incident> = {}): Incident => ({
   ...overrides,
 })
 
-const makeLayer = (opts: { signal: Signal; configs?: readonly AgentDispatchConfig[]; incident?: Incident | null }) => {
+const makeLayer = (opts: {
+  signal: Signal
+  configs?: readonly AgentDispatchConfigRow[]
+  incident?: Incident | null
+  guardrailCalls?: Array<{ configId: string; projectId: string }>
+}) => {
   const organization = createOrganization({ id: orgId, name: "Acme", slug: "acme" })
   const project = createProject({ id: projectId, organizationId: orgId, name: "Demo", slug: "demo" })
   const { repository: organizationRepository, organizations } = createFakeOrganizationRepository()
@@ -108,10 +113,14 @@ const makeLayer = (opts: { signal: Signal; configs?: readonly AgentDispatchConfi
   const configs = opts.configs ?? [makeConfig()]
 
   const configRepository: (typeof AgentDispatchConfigRepository)["Service"] = {
-    listEnabledByProject: () => Effect.succeed(configs),
-    listByProject: () => Effect.succeed(configs),
-    findByProjectAndIntegration: () => Effect.succeed(configs[0] ?? null),
-    listByOrganization: () => Effect.succeed(configs),
+    listByProjectIncludingDefaults: (forProjectId) =>
+      Effect.succeed(configs.filter((row) => row.projectId === null || row.projectId === forProjectId)),
+    findDefaultByIntegration: (forIntegrationId) =>
+      Effect.succeed(configs.find((row) => row.projectId === null && row.integrationId === forIntegrationId) ?? null),
+    findOverrideByProjectAndIntegration: (query) =>
+      Effect.succeed(
+        configs.find((row) => row.projectId === query.projectId && row.integrationId === query.integrationId) ?? null,
+      ),
     findById: (id) => {
       const config = configs.find((row) => row.id === id)
       return config ? Effect.succeed(config) : Effect.die(new Error("config not found"))
@@ -119,7 +128,10 @@ const makeLayer = (opts: { signal: Signal; configs?: readonly AgentDispatchConfi
     upsert: (config) => Effect.succeed(config),
     delete: () => Effect.void,
     deleteByIntegrationId: () => Effect.void,
-    countDispatchesInLast24h: () => Effect.succeed(0),
+    countDispatchesInLast24h: (query) => {
+      opts.guardrailCalls?.push(query)
+      return Effect.succeed(0)
+    },
     hasRecentDispatchForSource: () => Effect.succeed(false),
   }
 
@@ -193,6 +205,96 @@ describe("requestAgentDispatchUseCase", () => {
     expect(result.requests).toHaveLength(1)
     expect(result.requests[0]?.trigger).toBe("signal.discovered")
     expect(result.requests[0]?.sourceId).toBe(signalId)
+    expect(result.requests[0]?.target).toEqual({ webhookUrl: "https://example.com/hook", kind: "webhook" })
+  })
+
+  it("inherits an enabled org default when the project has no override", async () => {
+    const guardrailCalls: Array<{ configId: string; projectId: string }> = []
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase(input).pipe(
+        Effect.provide(
+          makeLayer({
+            signal: makeSignal({ origin: "system" }),
+            configs: [makeConfig({ projectId: null })],
+            guardrailCalls,
+          }),
+        ),
+      ),
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") return
+    expect(result.requests).toHaveLength(1)
+    expect(result.requests[0]?.projectId).toBe(projectId)
+    expect(result.requests[0]?.configId).toBe(configId)
+    expect(guardrailCalls).toEqual([{ configId, projectId }])
+  })
+
+  it("suppresses an enabled default when the project override disables it", async () => {
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase(input).pipe(
+        Effect.provide(
+          makeLayer({
+            signal: makeSignal({ origin: "system" }),
+            configs: [
+              makeConfig({ projectId: null }),
+              makeConfig({
+                id: cuid("c2"),
+                enabled: false,
+                triggers: null,
+                target: null,
+                guardrails: null,
+              }),
+            ],
+          }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "no-config" })
+  })
+
+  it("merges override fields over default fields per top-level field", async () => {
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase(input).pipe(
+        Effect.provide(
+          makeLayer({
+            signal: makeSignal({ origin: "system" }),
+            configs: [
+              makeConfig({ projectId: null }),
+              makeConfig({
+                id: cuid("c2"),
+                enabled: null,
+                triggers: null,
+                target: { webhookUrl: "https://project.example.com/hook" },
+                guardrails: null,
+              }),
+            ],
+          }),
+        ),
+      ),
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") return
+    expect(result.requests).toHaveLength(1)
+    expect(result.requests[0]?.configId).toBe(cuid("c2"))
+    expect(result.requests[0]?.target).toEqual({ webhookUrl: "https://project.example.com/hook", kind: "webhook" })
+  })
+
+  it("skips configs whose effective target is incomplete", async () => {
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase(input).pipe(
+        Effect.provide(
+          makeLayer({
+            signal: makeSignal({ origin: "system" }),
+            configs: [makeConfig({ projectId: null, kind: "cursor", target: { startingRef: "main" } })],
+          }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "no-matching-config" })
   })
 
   it("dispatches incident.opened for user-origin signals on escalation", async () => {

--- a/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts
@@ -4,7 +4,11 @@ import { isSandbox, OrganizationRepository } from "@domain/organizations"
 import { AlertIncidentId, type OrganizationId, type ProjectId, SignalId, type SqlClient } from "@domain/shared"
 import { SignalRepository } from "@domain/signals"
 import { Effect } from "effect"
-import type { AgentDispatchConfig } from "../entities/agent-dispatch-config.ts"
+import type {
+  AgentDispatchKind,
+  EffectiveAgentDispatchConfig,
+  ResolvedDispatchTarget,
+} from "../entities/agent-dispatch-config.ts"
 import type { AgentDispatchContext, AgentDispatchTrigger } from "../entities/agent-dispatch-context.ts"
 import {
   buildDispatchContextFromIncident,
@@ -15,6 +19,7 @@ import {
 } from "../helpers/build-dispatch-context.ts"
 import { buildDispatchIdempotencyKey } from "../helpers/idempotency-key.ts"
 import { renderDispatchPrompt } from "../helpers/render-prompt.ts"
+import { checkTargetReadiness, resolveEffectiveConfigsForProject } from "../helpers/resolve-effective-config.ts"
 import { AgentDispatchConfigRepository } from "../ports/repositories.ts"
 
 export type AgentDispatchRequestSource =
@@ -31,24 +36,25 @@ export interface AgentDispatchSendRequest {
   readonly projectId: ProjectId
   readonly configId: string
   readonly integrationId: string
-  readonly kind: AgentDispatchConfig["kind"]
+  readonly kind: AgentDispatchKind
   readonly idempotencyKey: string
   readonly trigger: AgentDispatchTrigger
   readonly sourceType: "signal" | "monitor"
   readonly sourceId: string
   readonly prompt: string
   readonly context: AgentDispatchContext
+  readonly target: ResolvedDispatchTarget
 }
 
 export type RequestAgentDispatchResult =
   | { readonly status: "skipped"; readonly reason: string }
   | { readonly status: "ok"; readonly requests: readonly AgentDispatchSendRequest[] }
 
-const passesTriggerGate = (config: AgentDispatchConfig, trigger: AgentDispatchTrigger): boolean =>
+const passesTriggerGate = (config: EffectiveAgentDispatchConfig, trigger: AgentDispatchTrigger): boolean =>
   config.triggers.includes(trigger)
 
 const passesGuardrails = (
-  config: AgentDispatchConfig,
+  config: EffectiveAgentDispatchConfig,
   checks: { readonly count24h: number; readonly recentForSource: boolean },
 ): string | null => {
   if (checks.count24h >= config.guardrails.maxDispatchesPerDay) return "max-dispatches-per-day"
@@ -59,7 +65,8 @@ const passesGuardrails = (
 const dispatchWindow = (date: Date): string => date.toISOString().slice(0, 10)
 
 const buildSendRequest = (input: {
-  readonly config: AgentDispatchConfig
+  readonly config: EffectiveAgentDispatchConfig
+  readonly target: ResolvedDispatchTarget
   readonly trigger: AgentDispatchTrigger
   readonly sourceType: "signal" | "monitor"
   readonly sourceId: string
@@ -85,6 +92,7 @@ const buildSendRequest = (input: {
     sourceId: input.sourceId,
     prompt: renderDispatchPrompt({ context: input.context, template: input.config.promptTemplate }),
     context: input.context,
+    target: input.target,
   }
 }
 
@@ -103,7 +111,8 @@ export const requestAgentDispatchUseCase = (input: {
       input.source.type === "signal"
         ? input.source.projectId
         : (yield* incidents.findById(AlertIncidentId(input.source.alertIncidentId))).projectId
-    const configs = yield* configRepo.listEnabledByProject(projectId)
+    const rows = yield* configRepo.listByProjectIncludingDefaults(projectId)
+    const configs = resolveEffectiveConfigsForProject(projectId, rows).filter((config) => config.enabled)
     if (configs.length === 0) return { status: "skipped", reason: "no-config" } as const
 
     if (input.source.type === "signal") {
@@ -128,11 +137,14 @@ export const requestAgentDispatchUseCase = (input: {
       const requests: AgentDispatchSendRequest[] = []
       for (const config of configs) {
         if (!passesTriggerGate(config, "signal.discovered")) continue
+        const readiness = checkTargetReadiness(config.kind, config.target)
+        if (!readiness.ready) continue
         const guardrailReason = yield* checkGuardrails(config, signal.id)
         if (guardrailReason !== null) continue
         requests.push(
           buildSendRequest({
             config,
+            target: readiness.target,
             trigger: "signal.discovered",
             sourceType: "signal",
             sourceId: signal.id,
@@ -174,11 +186,14 @@ export const requestAgentDispatchUseCase = (input: {
     const requests: AgentDispatchSendRequest[] = []
     for (const config of configs) {
       if (!passesTriggerGate(config, trigger)) continue
+      const readiness = checkTargetReadiness(config.kind, config.target)
+      if (!readiness.ready) continue
       const guardrailReason = yield* checkGuardrails(config, sourceId)
       if (guardrailReason !== null) continue
       requests.push(
         buildSendRequest({
           config,
+          target: readiness.target,
           trigger,
           sourceType,
           sourceId,
@@ -201,15 +216,16 @@ export const requestAgentDispatchUseCase = (input: {
   >
 
 const checkGuardrails = (
-  config: AgentDispatchConfig,
+  config: EffectiveAgentDispatchConfig,
   sourceId: string,
 ): Effect.Effect<string | null, unknown, AgentDispatchConfigRepository | SqlClient> =>
   Effect.gen(function* () {
     const configRepo = yield* AgentDispatchConfigRepository
     const [count24h, recentForSource] = yield* Effect.all([
-      configRepo.countDispatchesInLast24h(config.id),
+      configRepo.countDispatchesInLast24h({ configId: config.id, projectId: config.projectId }),
       configRepo.hasRecentDispatchForSource({
         configId: config.id,
+        projectId: config.projectId,
         sourceId,
         cooldownMinutes: config.guardrails.cooldownMinutes,
       }),

--- a/packages/domain/agent-dispatch/src/use-cases/reset-project-dispatch-override.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/reset-project-dispatch-override.ts
@@ -1,0 +1,17 @@
+import type { ProjectId, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { AgentDispatchConfigRepository } from "../ports/repositories.ts"
+
+export const resetProjectDispatchOverrideUseCase = (input: {
+  readonly projectId: ProjectId
+  readonly integrationId: string
+}) =>
+  Effect.gen(function* () {
+    const configRepo = yield* AgentDispatchConfigRepository
+    const existing = yield* configRepo.findOverrideByProjectAndIntegration(input)
+    if (existing) yield* configRepo.delete(existing.id)
+  }).pipe(Effect.withSpan("agentDispatch.resetProjectOverride")) as Effect.Effect<
+    void,
+    unknown,
+    AgentDispatchConfigRepository | SqlClient
+  >

--- a/packages/domain/agent-dispatch/src/use-cases/set-project-dispatch-repo.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/set-project-dispatch-repo.ts
@@ -1,0 +1,40 @@
+import type { OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { type AgentDispatchConfigRow, storedCursorDispatchTargetSchema } from "../entities/agent-dispatch-config.ts"
+import { AgentDispatchConfigRepository } from "../ports/repositories.ts"
+import { upsertProjectDispatchOverrideUseCase } from "./upsert-project-dispatch-override.ts"
+
+/**
+ * Sets the cursor repo for one project from the send-time prompt. The override
+ * target snapshots the effective target plus the repo, so the atomic
+ * whole-field override semantics still resolve a complete target afterwards.
+ */
+export const setProjectDispatchRepoUseCase = (input: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly integrationId: string
+  readonly repoUrl: string
+}) =>
+  Effect.gen(function* () {
+    const configRepo = yield* AgentDispatchConfigRepository
+    const [defaultConfig, override] = yield* Effect.all([
+      configRepo.findDefaultByIntegration(input.integrationId),
+      configRepo.findOverrideByProjectAndIntegration({
+        projectId: input.projectId,
+        integrationId: input.integrationId,
+      }),
+    ])
+    const effectiveTarget = storedCursorDispatchTargetSchema.safeParse(override?.target ?? defaultConfig?.target ?? {})
+
+    return yield* upsertProjectDispatchOverrideUseCase({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      integrationId: input.integrationId,
+      kind: "cursor",
+      target: { ...(effectiveTarget.success ? effectiveTarget.data : {}), repoUrl: input.repoUrl },
+    })
+  }).pipe(Effect.withSpan("agentDispatch.setProjectRepo")) as Effect.Effect<
+    AgentDispatchConfigRow,
+    unknown,
+    AgentDispatchConfigRepository | SqlClient
+  >

--- a/packages/domain/agent-dispatch/src/use-cases/upsert-org-default-dispatch-config.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/upsert-org-default-dispatch-config.ts
@@ -1,40 +1,36 @@
-import { generateId, type OrganizationId, type ProjectId, type SqlClient } from "@domain/shared"
+import { generateId, type OrganizationId, type SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { DEFAULT_COOLDOWN_MINUTES, DEFAULT_MAX_DISPATCHES_PER_DAY } from "../constants.ts"
 import type {
-  AgentDispatchConfig,
+  AgentDispatchConfigRow,
   AgentDispatchGuardrails,
   AgentDispatchKind,
-  AgentDispatchTarget,
+  StoredAgentDispatchTarget,
 } from "../entities/agent-dispatch-config.ts"
 import type { AgentDispatchTrigger } from "../entities/agent-dispatch-context.ts"
 import { AgentDispatchConfigRepository } from "../ports/repositories.ts"
 
-export interface UpsertAgentDispatchConfigInput {
+export interface UpsertOrgDefaultDispatchConfigInput {
   readonly organizationId: OrganizationId
-  readonly projectId: ProjectId
   readonly integrationId: string
   readonly kind: AgentDispatchKind
   readonly enabled: boolean
   readonly triggers: readonly AgentDispatchTrigger[]
-  readonly target: AgentDispatchTarget
+  readonly target: StoredAgentDispatchTarget
   readonly promptTemplate?: string | null
   readonly guardrails?: AgentDispatchGuardrails
 }
 
-export const upsertAgentDispatchConfigUseCase = (input: UpsertAgentDispatchConfigInput) =>
+export const upsertOrgDefaultDispatchConfigUseCase = (input: UpsertOrgDefaultDispatchConfigInput) =>
   Effect.gen(function* () {
     const configRepo = yield* AgentDispatchConfigRepository
-    const existing = yield* configRepo.findByProjectAndIntegration({
-      projectId: input.projectId,
-      integrationId: input.integrationId,
-    })
+    const existing = yield* configRepo.findDefaultByIntegration(input.integrationId)
 
     const now = new Date()
-    const config: AgentDispatchConfig = {
+    const config: AgentDispatchConfigRow = {
       id: existing?.id ?? generateId(),
       organizationId: input.organizationId,
-      projectId: input.projectId,
+      projectId: null,
       integrationId: input.integrationId,
       kind: input.kind,
       enabled: input.enabled,
@@ -51,8 +47,8 @@ export const upsertAgentDispatchConfigUseCase = (input: UpsertAgentDispatchConfi
     }
 
     return yield* configRepo.upsert(config)
-  }).pipe(Effect.withSpan("agentDispatch.upsertConfig")) as Effect.Effect<
-    AgentDispatchConfig,
+  }).pipe(Effect.withSpan("agentDispatch.upsertOrgDefaultConfig")) as Effect.Effect<
+    AgentDispatchConfigRow,
     unknown,
     AgentDispatchConfigRepository | SqlClient
   >

--- a/packages/domain/agent-dispatch/src/use-cases/upsert-project-dispatch-override.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/upsert-project-dispatch-override.ts
@@ -1,0 +1,55 @@
+import { generateId, type OrganizationId, type ProjectId, type SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type {
+  AgentDispatchConfigRow,
+  AgentDispatchGuardrails,
+  AgentDispatchKind,
+  StoredAgentDispatchTarget,
+} from "../entities/agent-dispatch-config.ts"
+import type { AgentDispatchTrigger } from "../entities/agent-dispatch-context.ts"
+import { AgentDispatchConfigRepository } from "../ports/repositories.ts"
+
+/** Overridable fields: undefined keeps the stored value, null sets "inherit". */
+export interface UpsertProjectDispatchOverrideInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly integrationId: string
+  readonly kind: AgentDispatchKind
+  readonly enabled?: boolean | null
+  readonly triggers?: readonly AgentDispatchTrigger[] | null
+  readonly target?: StoredAgentDispatchTarget | null
+  readonly promptTemplate?: string | null
+  readonly guardrails?: AgentDispatchGuardrails | null
+}
+
+export const upsertProjectDispatchOverrideUseCase = (input: UpsertProjectDispatchOverrideInput) =>
+  Effect.gen(function* () {
+    const configRepo = yield* AgentDispatchConfigRepository
+    const existing = yield* configRepo.findOverrideByProjectAndIntegration({
+      projectId: input.projectId,
+      integrationId: input.integrationId,
+    })
+
+    const now = new Date()
+    const config: AgentDispatchConfigRow = {
+      id: existing?.id ?? generateId(),
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      integrationId: input.integrationId,
+      kind: input.kind,
+      enabled: input.enabled !== undefined ? input.enabled : (existing?.enabled ?? null),
+      triggers:
+        input.triggers !== undefined ? (input.triggers ? [...input.triggers] : null) : (existing?.triggers ?? null),
+      target: input.target !== undefined ? input.target : (existing?.target ?? null),
+      promptTemplate: input.promptTemplate !== undefined ? input.promptTemplate : (existing?.promptTemplate ?? null),
+      guardrails: input.guardrails !== undefined ? input.guardrails : (existing?.guardrails ?? null),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    }
+
+    return yield* configRepo.upsert(config)
+  }).pipe(Effect.withSpan("agentDispatch.upsertProjectOverride")) as Effect.Effect<
+    AgentDispatchConfigRow,
+    unknown,
+    AgentDispatchConfigRepository | SqlClient
+  >

--- a/packages/platform/db-postgres/drizzle/.migration-lock
+++ b/packages/platform/db-postgres/drizzle/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-07-06T12:38:19.250Z
-# Hash: bc2343ba-cc34-4d4a-86d2-d2334863c4ca
+# Generated: 2026-07-09T11:27:30.004Z
+# Hash: c711f38d-48eb-4a1e-9405-705cb5ac7a34
 # Do not manually edit this file.

--- a/packages/platform/db-postgres/drizzle/20260709112729_agent-dispatch-config-org-defaults/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260709112729_agent-dispatch-config-org-defaults/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "project_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "enabled" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "enabled" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "triggers" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "target" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "latitude"."agent_dispatch_configs" ALTER COLUMN "guardrails" DROP NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_dispatch_configs_default_uq" ON "latitude"."agent_dispatch_configs" ("integration_id") WHERE "project_id" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_dispatch_configs_project_integration_uq" ON "latitude"."agent_dispatch_configs" ("project_id","integration_id") WHERE "project_id" IS NOT NULL;

--- a/packages/platform/db-postgres/drizzle/20260709112729_agent-dispatch-config-org-defaults/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260709112729_agent-dispatch-config-org-defaults/snapshot.json
@@ -1,0 +1,11909 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "1204ab60-23be-40d9-bb0e-bea460333689",
+  "prevIds": [
+    "bff8bd5d-cd82-407e-a67d-94be5d9d7b0c"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatch_configs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatch_credentials",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "agent_dispatches",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "incidents",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queue_items",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_access_tokens",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "oauth_applications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_consents",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "sso_providers",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "subscriptions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_overrides",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_usage_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "billing_usage_periods",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "datasets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "dataset_versions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destination_sources",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destination_sync_runs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "destinations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "evaluations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "flaggers",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "integrations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "monitors",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "notifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_claims",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "projects",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "sandboxes",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "saved_searches",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "scores",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "showcase",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "signals",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "simulations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "slack_deliveries",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "slack_integration_details",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_cluster_lineage",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_clusters",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "taxonomy_runs",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "wrapped_reports",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "triggers",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "prompt_template",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "guardrails",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cursor_api_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claude_routine_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "linear_api_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "webhook_secret",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatched_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_agent_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_run_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_url",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_category",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error_detail",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "severity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "condition",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entry_signals",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "exit_eligible_since",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "review_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignees",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "completed_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_secret",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "redirect_urls",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "disabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consent_given",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_org_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issuer",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "oidc_config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "saml_config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "domain_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "enforced",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'incomplete'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seats",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_interval",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_schedule_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "job_title",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "phone_number",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_preferences",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "included_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "retention_days",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "happened_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan_slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "included_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consumed_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "overage_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "reported_overage_credits",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "overage_amount_mills",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "columns",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "current_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_inserted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_deleted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'api'",
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destination_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'enabled'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "watermark",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "watermark_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "coverage_start_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backfill_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "backfill_progress_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_run_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consecutive_empty_runs",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "destination_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'live'",
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "spans_read",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "events_sent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "events_dropped",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credentials",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "consecutive_failures",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_failure_message",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "signal_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "alignment",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aligned_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "enabled_for_all",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enabled_by_admin_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "10",
+      "generated": null,
+      "identity": null,
+      "name": "sampling",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vendor_account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "installed_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "installed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revoked_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "config",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "severity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "muted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seen_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "emailed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "published",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "occurred_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_trace_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "linked_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(20)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_activity_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "query",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filter_set",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "span_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "simulation_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "signal_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "feedback",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "tokens",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "drafted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "annotator_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "current_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "next_project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "next_state",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "uuid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'system'",
+      "generated": null,
+      "identity": null,
+      "name": "origin",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filters",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignee_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "priority",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "vector(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid_embedding",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "tsvector",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "\n          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||\n          setweight(to_tsvector('english', coalesce(description, '')), 'B')\n        ",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "search_document",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "muted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evaluations",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "claimed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "posted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message_ts",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "integration_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "team_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "app_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bot_token_scopes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reconnect_required_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "routes",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "run_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "transition_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "from_cluster_ids",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "to_cluster_ids",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "similarity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parent_cluster_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "depth",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "path",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "split_link_threshold",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(80)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(280)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "vector(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid_embedding",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "tsvector",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "\n          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||\n          setweight(to_tsvector('english', coalesce(description, '')), 'B')\n        ",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "search_document",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observation_count",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "merged_into_cluster_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_observed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_observed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_scanned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_available",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "observations_sampled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'day_stratified_hash_round_robin'",
+      "generated": null,
+      "identity": null,
+      "name": "sample_strategy",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1500",
+      "generated": null,
+      "identity": null,
+      "name": "sample_cap",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "noise_scanned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_born",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_merged",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "clusters_deprecated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'claude_code'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "owner_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_integration_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"project_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_default_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"project_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatch_configs_project_integration_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "agent_dispatches_config_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_project_started_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_source_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "ended_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "incidents_open_source_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "completed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queue_items_queue_progress_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queues_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "inviter_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_inviterId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "client_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthAccessTokens_clientId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthAccessTokens_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthApplications_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthApplications_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "client_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthConsents_clientId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauthConsents_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "parent_org_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_parent_org_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"expires_at\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_expires_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "active_organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_activeOrganizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_organizationId_unique_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_domain_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ssoProviders_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "subscriptions_reference_status_period_end_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "billing_period_start",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_period_idempotency_key_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "happened_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_org_happened_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_events_idempotency_key_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_start",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "period_end",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "billing_usage_periods_org_period_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "dataset_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_dataset_id_version_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "last_run_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destination_sources_last_run_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "destination_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destination_sync_runs_destination_id_started_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "finished_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "brin",
+      "concurrently": false,
+      "name": "destination_sync_runs_finished_at_brin_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destinations_project_id_kind_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "destinations_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "archived_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_signal_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"deleted_at\" IS NULL AND \"archived_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_active_detector_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"deleted_at\" IS NULL AND \"archived_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_active_detector_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "flaggers_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_active_organization_kind_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vendor_account_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"revoked_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_active_kind_vendor_account_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vendor_account_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "integrations_kind_vendor_account_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "monitors_project_slug_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "monitors_org_project_active_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "\"config\"->'filterSet'",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "deleted_at IS NULL",
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "monitors_config_filter_set_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"seen_at\" is null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_user_org_unread_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_idempotency_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"project_id\" is not null",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "notifications_org_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "token_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_claims_token_hash_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_claims_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_workspace_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "aggregate_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_aggregate_type_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "linked_project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_linked_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_activity_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sandboxes_status_last_activity_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sandboxes_created_by_user_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_source_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"source_type\" = 'evaluation' AND \"drafted_at\" IS NULL AND \"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_canonical_evaluation_trace_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "signal_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"signal_id\" IS NOT NULL AND \"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_signal_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_trace_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"session_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_session_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "span_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"span_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_span_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL AND \"errored\" = false AND \"passed\" = false AND \"signal_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_signal_discovery_work_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_draft_finalization_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "muted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "signals_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "search_document",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "signals_search_document_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"deleted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "signals_unique_slug_per_project_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "simulations_project_created_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "idempotency_key",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "channel_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_deliveries_claim_uq",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "integration_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_deliveries_integration_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "slack_integration_details_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_cluster_lineage_project_created_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "state",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "last_observed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_clusters_project_state_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "search_document",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gin",
+      "concurrently": false,
+      "name": "taxonomy_clusters_search_document_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "taxonomy_runs_project_started_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "wrapped_reports_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "wrapped_reports_type_project_recent_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "oauth_applications",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_client_id_oauth_applications_client_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_access_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_access_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_applications_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_applications_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "oauth_applications",
+      "columnsTo": [
+        "client_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_client_id_oauth_applications_client_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_consents_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "oauth_consents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sso_providers_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sso_providers_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "columns": [
+        "id",
+        "billing_period_start"
+      ],
+      "nameExplicit": false,
+      "name": "billing_usage_events_pkey",
+      "entityType": "pks",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "columns": [
+        "destination_id",
+        "source"
+      ],
+      "nameExplicit": false,
+      "name": "destination_source_cursors_pkey",
+      "entityType": "pks",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatch_configs_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "integration_id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatch_credentials_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "agent_dispatches_pkey",
+      "schema": "latitude",
+      "table": "agent_dispatches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "incidents_pkey",
+      "schema": "latitude",
+      "table": "incidents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queue_items_pkey",
+      "schema": "latitude",
+      "table": "annotation_queue_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queues_pkey",
+      "schema": "latitude",
+      "table": "annotation_queues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "latitude",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "latitude",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "latitude",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_access_tokens_pkey",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_applications_pkey",
+      "schema": "latitude",
+      "table": "oauth_applications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_consents_pkey",
+      "schema": "latitude",
+      "table": "oauth_consents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sso_providers_pkey",
+      "schema": "latitude",
+      "table": "sso_providers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "subscriptions_pkey",
+      "schema": "latitude",
+      "table": "subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "latitude",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "billing_overrides_pkey",
+      "schema": "latitude",
+      "table": "billing_overrides",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "billing_usage_periods_pkey",
+      "schema": "latitude",
+      "table": "billing_usage_periods",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "datasets_pkey",
+      "schema": "latitude",
+      "table": "datasets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dataset_versions_pkey",
+      "schema": "latitude",
+      "table": "dataset_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "destination_sync_runs_pkey",
+      "schema": "latitude",
+      "table": "destination_sync_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "destinations_pkey",
+      "schema": "latitude",
+      "table": "destinations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "evaluations_pkey",
+      "schema": "latitude",
+      "table": "evaluations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "identifier"
+      ],
+      "nameExplicit": false,
+      "name": "feature_flags_pkey",
+      "schema": "latitude",
+      "table": "feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_feature_flags_pkey",
+      "schema": "latitude",
+      "table": "organization_feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "flaggers_pkey",
+      "schema": "latitude",
+      "table": "flaggers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "integrations_pkey",
+      "schema": "latitude",
+      "table": "integrations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "monitors_pkey",
+      "schema": "latitude",
+      "table": "monitors",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "notifications_pkey",
+      "schema": "latitude",
+      "table": "notifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_claims_pkey",
+      "schema": "latitude",
+      "table": "organization_claims",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_events_pkey",
+      "schema": "latitude",
+      "table": "outbox_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pkey",
+      "schema": "latitude",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sandboxes_pkey",
+      "schema": "latitude",
+      "table": "sandboxes",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "saved_searches_pkey",
+      "schema": "latitude",
+      "table": "saved_searches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "scores_pkey",
+      "schema": "latitude",
+      "table": "scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "showcase_pkey",
+      "schema": "latitude",
+      "table": "showcase",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "signals_pkey",
+      "schema": "latitude",
+      "table": "signals",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "simulations_pkey",
+      "schema": "latitude",
+      "table": "simulations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "slack_deliveries_pkey",
+      "schema": "latitude",
+      "table": "slack_deliveries",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "integration_id"
+      ],
+      "nameExplicit": false,
+      "name": "slack_integration_details_pkey",
+      "schema": "latitude",
+      "table": "slack_integration_details",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_cluster_lineage_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_clusters_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_clusters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "taxonomy_runs_pkey",
+      "schema": "latitude",
+      "table": "taxonomy_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "wrapped_reports_pkey",
+      "schema": "latitude",
+      "table": "wrapped_reports",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "queue_id",
+        "trace_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "annotation_queue_items_unique_trace_per_queue_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "identifier"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_feature_flags_unique_org_identifier_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug"
+      ],
+      "nullsNotDistinct": true,
+      "name": "flaggers_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "projects_unique_slug_per_organization_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "saved_searches_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_token_hash_key",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "access_token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_access_tokens_access_token_key",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "refresh_token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_access_tokens_refresh_token_key",
+      "schema": "latitude",
+      "table": "oauth_access_tokens",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "client_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_applications_client_id_key",
+      "schema": "latitude",
+      "table": "oauth_applications",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "provider_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sso_providers_provider_id_key",
+      "schema": "latitude",
+      "table": "sso_providers",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "billing_overrides_organization_id_key",
+      "schema": "latitude",
+      "table": "billing_overrides",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sandboxes_organization_id_key",
+      "schema": "latitude",
+      "table": "sandboxes",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uuid"
+      ],
+      "nullsNotDistinct": false,
+      "name": "signals_uuid_key",
+      "schema": "latitude",
+      "table": "signals",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"id\" = 1",
+      "name": "showcase_singleton_check",
+      "entityType": "checks",
+      "schema": "latitude",
+      "table": "showcase"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatch_configs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatch_configs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatch_credentials_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatch_credentials"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "agent_dispatches_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "agent_dispatches"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "incidents_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "incidents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queue_items_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "api_keys_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "invitations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "members_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "oauth_applications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "oauth_applications"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "sso_providers_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "sso_providers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "reference_id = get_current_organization_id()",
+      "withCheck": "reference_id = get_current_organization_id()",
+      "name": "subscriptions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_overrides_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_overrides"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_usage_events_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_usage_events"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "billing_usage_periods_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "billing_usage_periods"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "datasets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "dataset_versions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destination_sources_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destination_sources"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destination_sync_runs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destination_sync_runs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "destinations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "destinations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "evaluations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "organization_feature_flags_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "flaggers_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "integrations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "integrations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "monitors_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "monitors"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "notifications_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "notifications"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "organization_claims_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "organization_claims"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "projects_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "sandboxes_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "sandboxes"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "saved_searches_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "scores_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "signals_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "signals"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "simulations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "slack_deliveries_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "slack_deliveries"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "slack_integration_details_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "slack_integration_details"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_cluster_lineage_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_cluster_lineage"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_clusters_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_clusters"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "taxonomy_runs_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "taxonomy_runs"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "wrapped_reports_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "wrapped_reports"
+    }
+  ],
+  "renames": []
+}

--- a/packages/platform/db-postgres/src/repositories/agent-dispatch-config-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/agent-dispatch-config-repository.test.ts
@@ -1,0 +1,167 @@
+import { AgentDispatchConfigRepository, type AgentDispatchConfigRow } from "@domain/agent-dispatch"
+import { generateId, OrganizationId, ProjectId, type SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { afterEach, describe, expect, it } from "vitest"
+import { agentDispatchConfigs } from "../schema/agent-dispatch-configs.ts"
+import { agentDispatches } from "../schema/agent-dispatches.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { AgentDispatchConfigRepositoryLive } from "./agent-dispatch-config-repository.ts"
+
+const ORG = OrganizationId("a".repeat(24))
+const PROJECT_A = ProjectId("b".repeat(24))
+const PROJECT_B = ProjectId("c".repeat(24))
+const INTEGRATION = generateId()
+
+const pg = setupTestPostgres()
+
+const run = <A, E>(effect: Effect.Effect<A, E, AgentDispatchConfigRepository | SqlClient>) =>
+  Effect.runPromise(effect.pipe(withPostgres(AgentDispatchConfigRepositoryLive, pg.adminPostgresClient, ORG)))
+
+const now = new Date("2026-07-09T00:00:00.000Z")
+
+const row = (overrides: Partial<AgentDispatchConfigRow>): AgentDispatchConfigRow => ({
+  id: generateId(),
+  organizationId: ORG,
+  projectId: null,
+  integrationId: INTEGRATION,
+  kind: "webhook",
+  enabled: true,
+  triggers: ["signal.discovered"],
+  target: { webhookUrl: "https://example.com/hook" },
+  promptTemplate: null,
+  guardrails: { maxDispatchesPerDay: 5, cooldownMinutes: 30 },
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+})
+
+afterEach(async () => {
+  await pg.db.delete(agentDispatches)
+  await pg.db.delete(agentDispatchConfigs)
+})
+
+describe("AgentDispatchConfigRepositoryLive", () => {
+  it("round-trips a default row with null overridable fields", async () => {
+    const created = await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        return yield* repo.upsert(row({ enabled: null, triggers: null, target: null, guardrails: null }))
+      }),
+    )
+    expect(created.projectId).toBeNull()
+
+    const found = await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        return yield* repo.findDefaultByIntegration(INTEGRATION)
+      }),
+    )
+    expect(found?.enabled).toBeNull()
+    expect(found?.triggers).toBeNull()
+    expect(found?.target).toBeNull()
+    expect(found?.guardrails).toBeNull()
+  })
+
+  it("enforces one default per integration", async () => {
+    await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        yield* repo.upsert(row({}))
+      }),
+    )
+    await expect(
+      run(
+        Effect.gen(function* () {
+          const repo = yield* AgentDispatchConfigRepository
+          yield* repo.upsert(row({}))
+        }),
+      ),
+    ).rejects.toThrow()
+  })
+
+  it("enforces one override per project and integration", async () => {
+    await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        yield* repo.upsert(row({ projectId: PROJECT_A }))
+      }),
+    )
+    await expect(
+      run(
+        Effect.gen(function* () {
+          const repo = yield* AgentDispatchConfigRepository
+          yield* repo.upsert(row({ projectId: PROJECT_A }))
+        }),
+      ),
+    ).rejects.toThrow()
+  })
+
+  it("returns defaults plus the project's own override, not other projects' overrides", async () => {
+    await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        yield* repo.upsert(row({ id: generateId(), projectId: null }))
+        yield* repo.upsert(row({ id: generateId(), projectId: PROJECT_A }))
+        yield* repo.upsert(row({ id: generateId(), projectId: PROJECT_B }))
+      }),
+    )
+    const rows = await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        return yield* repo.listByProjectIncludingDefaults(PROJECT_A)
+      }),
+    )
+    const projectIds = rows.map((r) => r.projectId)
+    expect(rows).toHaveLength(2)
+    expect(projectIds).toContain(null)
+    expect(projectIds).toContain(PROJECT_A)
+    expect(projectIds).not.toContain(PROJECT_B)
+  })
+
+  it("counts dispatches per project so a shared config's budget does not bleed across projects", async () => {
+    const configId = generateId()
+    await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        yield* repo.upsert(row({ id: configId, projectId: null }))
+      }),
+    )
+    await pg.db.insert(agentDispatches).values([
+      {
+        id: generateId(),
+        organizationId: ORG,
+        projectId: PROJECT_A,
+        configId,
+        idempotencyKey: generateId(),
+        trigger: "signal.discovered",
+        sourceType: "signal",
+        sourceId: "sig-a",
+        status: "dispatched",
+      },
+      {
+        id: generateId(),
+        organizationId: ORG,
+        projectId: PROJECT_B,
+        configId,
+        idempotencyKey: generateId(),
+        trigger: "signal.discovered",
+        sourceType: "signal",
+        sourceId: "sig-b",
+        status: "dispatched",
+      },
+    ])
+
+    const [countA, countB] = await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchConfigRepository
+        return yield* Effect.all([
+          repo.countDispatchesInLast24h({ configId, projectId: PROJECT_A }),
+          repo.countDispatchesInLast24h({ configId, projectId: PROJECT_B }),
+        ])
+      }),
+    )
+    expect(countA).toBe(1)
+    expect(countB).toBe(1)
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/agent-dispatch-config-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/agent-dispatch-config-repository.ts
@@ -1,4 +1,8 @@
-import { type AgentDispatchConfig, AgentDispatchConfigRepository, type AgentDispatchKind } from "@domain/agent-dispatch"
+import {
+  AgentDispatchConfigRepository,
+  type AgentDispatchConfigRow,
+  type AgentDispatchKind,
+} from "@domain/agent-dispatch"
 import {
   generateId,
   OrganizationId,
@@ -7,21 +11,21 @@ import {
   type SqlClientShape,
   toRepositoryError,
 } from "@domain/shared"
-import { and, eq, gte, inArray, sql } from "drizzle-orm"
+import { and, eq, gte, inArray, isNull, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { agentDispatchConfigs } from "../schema/agent-dispatch-configs.ts"
 import { agentDispatches } from "../schema/agent-dispatches.ts"
 
-const toDomainConfig = (row: typeof agentDispatchConfigs.$inferSelect): AgentDispatchConfig => ({
+const toDomainConfig = (row: typeof agentDispatchConfigs.$inferSelect): AgentDispatchConfigRow => ({
   id: row.id,
   organizationId: OrganizationId(row.organizationId),
-  projectId: ProjectId(row.projectId),
+  projectId: row.projectId === null ? null : ProjectId(row.projectId),
   integrationId: row.integrationId,
   kind: row.kind as AgentDispatchKind,
   enabled: row.enabled,
-  triggers: row.triggers as AgentDispatchConfig["triggers"],
-  target: row.target as AgentDispatchConfig["target"],
+  triggers: row.triggers as AgentDispatchConfigRow["triggers"],
+  target: row.target as AgentDispatchConfigRow["target"],
   promptTemplate: row.promptTemplate,
   guardrails: row.guardrails,
   createdAt: row.createdAt,
@@ -29,7 +33,7 @@ const toDomainConfig = (row: typeof agentDispatchConfigs.$inferSelect): AgentDis
 })
 
 export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConfigRepository, {
-  listEnabledByProject: (projectId) =>
+  listByProjectIncludingDefaults: (projectId) =>
     Effect.gen(function* () {
       const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
       const rows = yield* sqlClient
@@ -39,17 +43,16 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
             .from(agentDispatchConfigs)
             .where(
               and(
-                eq(agentDispatchConfigs.projectId, projectId),
                 eq(agentDispatchConfigs.organizationId, organizationId),
-                eq(agentDispatchConfigs.enabled, true),
+                or(isNull(agentDispatchConfigs.projectId), eq(agentDispatchConfigs.projectId, projectId)),
               ),
             ),
         )
-        .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatchConfigs")))
+        .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatchConfigsIncludingDefaults")))
       return rows.map(toDomainConfig)
     }),
 
-  listByProject: (projectId) =>
+  findDefaultByIntegration: (integrationId) =>
     Effect.gen(function* () {
       const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
       const rows = yield* sqlClient
@@ -59,16 +62,18 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
             .from(agentDispatchConfigs)
             .where(
               and(
-                eq(agentDispatchConfigs.projectId, projectId),
+                isNull(agentDispatchConfigs.projectId),
+                eq(agentDispatchConfigs.integrationId, integrationId),
                 eq(agentDispatchConfigs.organizationId, organizationId),
               ),
-            ),
+            )
+            .limit(1),
         )
-        .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatchConfigsByProject")))
-      return rows.map(toDomainConfig)
+        .pipe(Effect.mapError((e) => toRepositoryError(e, "findDefaultAgentDispatchConfig")))
+      return rows[0] ? toDomainConfig(rows[0]) : null
     }),
 
-  findByProjectAndIntegration: ({ projectId, integrationId }) =>
+  findOverrideByProjectAndIntegration: ({ projectId, integrationId }) =>
     Effect.gen(function* () {
       const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
       const rows = yield* sqlClient
@@ -85,19 +90,8 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
             )
             .limit(1),
         )
-        .pipe(Effect.mapError((e) => toRepositoryError(e, "findAgentDispatchConfigByProjectIntegration")))
+        .pipe(Effect.mapError((e) => toRepositoryError(e, "findAgentDispatchConfigOverride")))
       return rows[0] ? toDomainConfig(rows[0]) : null
-    }),
-
-  listByOrganization: () =>
-    Effect.gen(function* () {
-      const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
-      const rows = yield* sqlClient
-        .query((db, organizationId) =>
-          db.select().from(agentDispatchConfigs).where(eq(agentDispatchConfigs.organizationId, organizationId)),
-        )
-        .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatchConfigsByOrg")))
-      return rows.map(toDomainConfig)
     }),
 
   findById: (id) =>
@@ -131,8 +125,8 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
               integrationId: config.integrationId,
               kind: config.kind,
               enabled: config.enabled,
-              triggers: [...config.triggers],
-              target: config.target as Record<string, unknown>,
+              triggers: config.triggers ? [...config.triggers] : null,
+              target: config.target as Record<string, unknown> | null,
               promptTemplate: config.promptTemplate,
               guardrails: config.guardrails,
             })
@@ -140,8 +134,8 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
               target: agentDispatchConfigs.id,
               set: {
                 enabled: config.enabled,
-                triggers: [...config.triggers],
-                target: config.target as Record<string, unknown>,
+                triggers: config.triggers ? [...config.triggers] : null,
+                target: config.target as Record<string, unknown> | null,
                 promptTemplate: config.promptTemplate,
                 guardrails: config.guardrails,
                 updatedAt: new Date(),
@@ -184,7 +178,7 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
         .pipe(Effect.mapError((e) => toRepositoryError(e, "deleteAgentDispatchConfigsByIntegration")))
     }),
 
-  countDispatchesInLast24h: (configId) =>
+  countDispatchesInLast24h: ({ configId, projectId }) =>
     Effect.gen(function* () {
       const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
       const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
@@ -196,6 +190,7 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
             .where(
               and(
                 eq(agentDispatches.configId, configId),
+                eq(agentDispatches.projectId, projectId),
                 eq(agentDispatches.organizationId, organizationId),
                 gte(agentDispatches.claimedAt, since),
                 inArray(agentDispatches.status, ["claimed", "dispatched"]),
@@ -206,7 +201,7 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
       return rows[0]?.count ?? 0
     }),
 
-  hasRecentDispatchForSource: ({ configId, sourceId, cooldownMinutes }) =>
+  hasRecentDispatchForSource: ({ configId, projectId, sourceId, cooldownMinutes }) =>
     Effect.gen(function* () {
       if (cooldownMinutes <= 0) return false
       const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
@@ -219,6 +214,7 @@ export const AgentDispatchConfigRepositoryLive = Layer.succeed(AgentDispatchConf
             .where(
               and(
                 eq(agentDispatches.configId, configId),
+                eq(agentDispatches.projectId, projectId),
                 eq(agentDispatches.sourceId, sourceId),
                 eq(agentDispatches.organizationId, organizationId),
                 gte(agentDispatches.claimedAt, since),

--- a/packages/platform/db-postgres/src/schema/agent-dispatch-configs.ts
+++ b/packages/platform/db-postgres/src/schema/agent-dispatch-configs.ts
@@ -1,24 +1,39 @@
-import { boolean, index, jsonb, text } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+import { boolean, index, jsonb, text, uniqueIndex } from "drizzle-orm/pg-core"
 import { cuid, latitudeSchema, organizationRLSPolicy, timestamps } from "../schemaHelpers.ts"
 
+/**
+ * Dispatch behavior for a connected agent integration.
+ *
+ * Two row shapes share this table, keyed by `project_id`:
+ * - `project_id IS NULL` — the organization-wide default for the integration
+ *   (at most one per `integration_id`).
+ * - `project_id` set — a per-project override; each overridable field
+ *   (`enabled`, `triggers`, `target`, `guardrails`, `prompt_template`) is
+ *   NULL to inherit from the default or non-NULL to replace it wholly.
+ */
 export const agentDispatchConfigs = latitudeSchema.table(
   "agent_dispatch_configs",
   {
     id: cuid("id").primaryKey(),
     organizationId: cuid("organization_id").notNull(),
-    projectId: cuid("project_id").notNull(),
+    projectId: cuid("project_id"),
     integrationId: cuid("integration_id").notNull(),
     kind: text("kind").notNull(),
-    enabled: boolean("enabled").notNull().default(false),
-    triggers: jsonb("triggers").$type<readonly string[]>().notNull(),
-    target: jsonb("target").$type<Record<string, unknown>>().notNull(),
+    enabled: boolean("enabled"),
+    triggers: jsonb("triggers").$type<readonly string[]>(),
+    target: jsonb("target").$type<Record<string, unknown>>(),
     promptTemplate: text("prompt_template"),
-    guardrails: jsonb("guardrails").$type<{ maxDispatchesPerDay: number; cooldownMinutes: number }>().notNull(),
+    guardrails: jsonb("guardrails").$type<{ maxDispatchesPerDay: number; cooldownMinutes: number }>(),
     ...timestamps(),
   },
   (t) => [
     organizationRLSPolicy("agent_dispatch_configs"),
     index("agent_dispatch_configs_project_idx").on(t.projectId),
     index("agent_dispatch_configs_integration_idx").on(t.integrationId),
+    uniqueIndex("agent_dispatch_configs_default_uq").on(t.integrationId).where(sql`${t.projectId} IS NULL`),
+    uniqueIndex("agent_dispatch_configs_project_integration_uq")
+      .on(t.projectId, t.integrationId)
+      .where(sql`${t.projectId} IS NOT NULL`),
   ],
 )


### PR DESCRIPTION
## what this does

Turns agent-dispatch config into an **org-level default plus sparse per-project overrides**, so connecting a cloud-agent integration (Cursor / Claude Code / Linear / Webhook) makes it available across the whole organization instead of only the project you happened to connect it in.

## why

Connecting an integration created exactly one dispatch config row, scoped to the project you were in at the time. The integration *credential* is org-wide, but "Send to agent" and auto-dispatch are driven by that per-project config row — so Cursor showed up only in the project where it was first wired up (reported as "Cursor only appears in the flaggers project"). Every other project fell through to "Set up cloud agents".

## the model

`agent_dispatch_configs.project_id` is now nullable:

- **`project_id IS NULL`** — the organization-wide default for that integration (at most one per integration).
- **`project_id` set** — a per-project override. Each overridable field (`enabled`, `triggers`, `target`, `guardrails`, `prompt_template`) is `NULL` to inherit the default or non-`NULL` to replace it wholly. Resolution is `effective = { ...default, ...override }`, field-atomic.

Two partial unique indexes enforce it: one default per integration, one override per `(project, integration)`.

New domain helper `resolveEffectiveConfig` does the merge; `checkTargetReadiness` validates the merged target against the full per-kind schema and reports which fields are missing.

## behavior

- **Send-to is credential-gated.** Every connected kind appears in every project's dropdown. A cursor default without a repo is a legitimate state (multi-repo orgs), so clicking "Send to Cursor" on a project with no repo opens a one-field repo prompt that saves a project override and then dispatches — subsequent sends skip the prompt. Non-cursor kinds that are somehow incomplete deep-link to the project's Signals settings.
- **Auto-dispatch inherits defaults.** A project with no override auto-dispatches from the org default when the effective config is enabled, its trigger matches, and its target is complete. Guardrail counting is scoped by `(configId, projectId)` so projects sharing one default row don't share one daily budget.
- **Settings split by scope.** Org defaults are edited on the Integrations page (Organization group); per-project overrides live on the project Signals settings page (Project group) with inherit / "override for this project" / "reset to organization defaults". The connect flow no longer takes a `projectId`, and the cursor repo is optional at connect time.

## notable decisions

- **No data migration.** Existing rows keep all their fields and behave as full overrides. Orgs with an existing credential simply have no default row yet; send-to still works everywhere via credential gating plus the repo prompt.
- **`prompt_template` can't express "inherit vs. clear"** on an override (`NULL` means inherit). Accepted per the field-atomic model; an empty string is the escape hatch.
- **Worker carries the resolved target in the send payload** instead of re-deriving it from the config row, with a `findById` fallback so jobs published by the old worker during a rolling deploy still resolve. That fallback can be removed a release later.
- Cursor's `vendor_account_id` moves from `cursor:<repoUrl>` to `cursor:<orgId>` now that the repo is optional at connect.

## tested

- Unit: `resolveEffectiveConfig` merge matrix + `checkTargetReadiness` per kind; `requestAgentDispatchUseCase` inheritance, override-disable, incomplete-target skip, and per-project guardrail calls.
- PGlite integration (real migration + indexes): null-field round-trip, both unique constraints, per-project isolation of `listByProjectIncludingDefaults`, and non-bleeding per-project dispatch counts.
- Typecheck + biome + knip clean across `@domain/agent-dispatch`, `@platform/db-postgres`, `@app/workers`, `@app/web`.

## pre-deploy note

The new `agent_dispatch_configs_project_integration_uq` index build fails if production has duplicate `(project_id, integration_id)` rows. The find-then-upsert path makes duplicates unlikely, but confirm before deploying.