### PR TITLE
ci(v1): re-enable deployment migrations via SSH proxy

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -260,8 +260,29 @@ jobs:
             S3_BUCKET=${{ vars.STATIC_ASSETS_S3_BUCKET }}
             STATIC_ASSETS_HOST=${{ vars.STATIC_ASSETS_HOST }}
             NEXT_PUBLIC_STATIC_ASSETS_URL=${{ env.NEXT_PUBLIC_STATIC_ASSETS_URL }}
+  run-migrations:
+    needs: [build-and-push-private, acceptance-tests]
+    uses: ./.github/workflows/run-migrations.yml
+    with:
+      workflow_call: true
+    secrets:
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_USERNAME: ${{ secrets.DB_USERNAME }}
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      CLICKHOUSE_MIGRATION_URL: ${{ secrets.CLICKHOUSE_MIGRATION_URL }}
+      CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+      CLICKHOUSE_DB: ${{ secrets.CLICKHOUSE_DB }}
+      CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+      CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+      CLICKHOUSE_MIGRATION_SSL: ${{ secrets.CLICKHOUSE_MIGRATION_SSL }}
+
   deploy-bluegreen:
-    needs: [build-and-push-private]
+    needs: [run-migrations, build-and-push-private]
     uses: ./.github/workflows/deploy-bluegreen.yml
     permissions:
       id-token: write
@@ -273,7 +294,7 @@ jobs:
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
   deploy-rolling:
-    needs: [build-and-push-private]
+    needs: [run-migrations, build-and-push-private]
     uses: ./.github/workflows/deploy-rolling.yml
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Restores the `run-migrations` job in `build-and-push.yml`, which was disabled in `a9078712e` when the SSH proxy was unreachable
- Deploy jobs (`deploy-bluegreen`, `deploy-rolling`) again wait for migrations to complete before proceeding

## Context
The `latitude-llm-ec2` bastion (`18.153.210.140`) in the legacy VPC now has SSH ingress restored and verified connectivity to `latitude-llm-db3c0513e`.

## Test plan
- [ ] Verify GitHub secrets are set: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_NAME`
- [ ] Merge and push to `latitude-v1`; confirm `run-migrations` succeeds in CI before deploy jobs run
- [ ] Confirm SSH tunnel connects and `pnpm db:migrate` completes without errors


Made with [Cursor](https://cursor.com)