### PR TITLE
fix(dates): default the time filter to All time across all screens (drop the hidden 30-day window)

### DIFF
--- a/apps/web/src/domains/projects/use-analytics-time-window.test.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyAnalyticsBrushSelect,
+  applyAnalyticsTimeChange,
+  isAllTimeRead,
+  resolveAnalyticsListRange,
+  resolveAnalyticsTrendRange,
+} from "./use-analytics-time-window.ts"
+
+const DAY = 24 * 60 * 60 * 1000
+const now = Date.UTC(2026, 6, 10, 12, 0, 0)
+const iso = (ms: number) => new Date(ms).toISOString()
+const RANGE_30D = 30 * 24 * 60 * 60
+
+describe("isAllTimeRead", () => {
+  it("true when no lower bound is picked", () => {
+    expect(isAllTimeRead("")).toBe(true)
+  })
+  it("false when a range is picked", () => {
+    expect(isAllTimeRead(iso(now))).toBe(false)
+  })
+})
+
+describe("resolveAnalyticsListRange", () => {
+  it("default (no params) → unbounded All time", () => {
+    const r = resolveAnalyticsListRange({ timeFrom: "", timeTo: "", nowMs: now })
+    expect(r).toEqual({ toIso: iso(now) })
+    expect(r.fromIso).toBeUndefined()
+  })
+
+  it("All time with a concrete lower bound uses it (screens whose endpoints require one)", () => {
+    const first = iso(now - 200 * DAY)
+    const r = resolveAnalyticsListRange({ timeFrom: "", timeTo: "", nowMs: now, allTimeLowerBoundIso: first })
+    expect(r).toEqual({ fromIso: first, toIso: iso(now) })
+  })
+
+  it("explicit range is used verbatim", () => {
+    const from = iso(now - 5 * DAY)
+    const to = iso(now - 1 * DAY)
+    const r = resolveAnalyticsListRange({ timeFrom: from, timeTo: to, nowMs: now })
+    expect(r).toEqual({ fromIso: from, toIso: to })
+  })
+
+  it("falls back safely on unparseable URL dates instead of throwing", () => {
+    // Bad upper bound → now; bad lower bound → drop to All time. Both branches must stay valid ISO.
+    expect(resolveAnalyticsListRange({ timeFrom: "", timeTo: "not-a-date", nowMs: now })).toEqual({ toIso: iso(now) })
+    expect(resolveAnalyticsListRange({ timeFrom: "nope", timeTo: "", nowMs: now })).toEqual({ toIso: iso(now) })
+    const first = iso(now - 200 * DAY)
+    expect(
+      resolveAnalyticsListRange({ timeFrom: "bad", timeTo: "bad", nowMs: now, allTimeLowerBoundIso: first }),
+    ).toEqual({ fromIso: first, toIso: iso(now) })
+  })
+})
+
+describe("resolveAnalyticsTrendRange", () => {
+  it("bounded range ≤ maxSpan is used verbatim", () => {
+    const from = iso(now - 10 * DAY)
+    const to = iso(now - 2 * DAY)
+    const r = resolveAnalyticsTrendRange({
+      listRange: { fromIso: from, toIso: to },
+      isAllTime: false,
+      maxSpanSeconds: RANGE_30D,
+      nowMs: now,
+    })
+    expect(r).toEqual({ fromIso: from, toIso: to })
+  })
+
+  it("clamps a > maxSpan bounded range to the most recent maxSpan of it", () => {
+    const from = iso(now - 90 * DAY)
+    const to = iso(now - 5 * DAY)
+    const r = resolveAnalyticsTrendRange({
+      listRange: { fromIso: from, toIso: to },
+      isAllTime: false,
+      maxSpanSeconds: RANGE_30D,
+      nowMs: now,
+    })
+    expect(r).toEqual({ fromIso: iso(now - 35 * DAY), toIso: to })
+  })
+
+  it("All time without latest activity → last maxSpan ending now", () => {
+    const r = resolveAnalyticsTrendRange({
+      listRange: { toIso: iso(now) },
+      isAllTime: true,
+      maxSpanSeconds: RANGE_30D,
+      nowMs: now,
+    })
+    expect(r).toEqual({ fromIso: iso(now - 30 * DAY), toIso: iso(now) })
+  })
+
+  it("All time anchors to latest activity — even with a concrete list lower bound", () => {
+    const last = iso(now - 40 * DAY)
+    const r = resolveAnalyticsTrendRange({
+      listRange: { fromIso: iso(now - 200 * DAY), toIso: iso(now) },
+      isAllTime: true,
+      lastActivityIso: last,
+      maxSpanSeconds: RANGE_30D,
+      nowMs: now,
+    })
+    expect(r).toEqual({ fromIso: iso(now - 70 * DAY), toIso: last })
+  })
+})
+
+describe("applyAnalyticsTimeChange", () => {
+  it("bounded selection sets both params", () => {
+    const from = iso(now - 3 * DAY)
+    const to = iso(now)
+    expect(applyAnalyticsTimeChange(from, to)).toEqual([from, to])
+  })
+
+  it("empty selection (clear) returns to All time (empty params)", () => {
+    expect(applyAnalyticsTimeChange()).toEqual(["", ""])
+  })
+})
+
+describe("applyAnalyticsBrushSelect", () => {
+  it("brush selection sets both params", () => {
+    const range = { from: iso(now - 2 * DAY), to: iso(now) }
+    expect(applyAnalyticsBrushSelect(range)).toEqual([range.from, range.to])
+  })
+
+  it("clearing the brush returns to All time (empty params)", () => {
+    expect(applyAnalyticsBrushSelect(null)).toEqual(["", ""])
+  })
+})

--- a/apps/web/src/domains/projects/use-analytics-time-window.ts
+++ b/apps/web/src/domains/projects/use-analytics-time-window.ts
@@ -1,0 +1,177 @@
+import { useMountEffect } from "@repo/ui"
+import { useCallback, useMemo } from "react"
+import { useParamState } from "../../lib/hooks/useParamState.ts"
+import { defaultProjectTimeWindowSeconds } from "./default-time-window.ts"
+
+/**
+ * Shared time-window logic for the analytics screens (Tools, Signals, Users) that store the range as
+ * two URL params (`<prefix>TimeFrom` / `<prefix>TimeTo`) and feed a `{ fromIso, toIso }` range into
+ * their queries. The default is "All time": untouched params mean no lower bound (a picked range
+ * lives in the params, and clearing returns to All time). Screens whose endpoints require a concrete
+ * lower bound pass `allTimeLowerBoundIso` (the project's earliest activity). The trend/histogram
+ * range is clamped and anchored to the latest activity so All time never triggers an unbounded scan.
+ */
+
+/** List/aggregation range. `fromIso` omitted == unbounded lower bound ("All time"). */
+interface AnalyticsListRange {
+  readonly fromIso?: string
+  readonly toIso: string
+}
+
+/** Trend/histogram range — always bounded (clamped + anchored). */
+interface AnalyticsTrendRange {
+  readonly fromIso: string
+  readonly toIso: string
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in use-analytics-time-window.test.ts)
+// ---------------------------------------------------------------------------
+
+/** No lower bound picked — reads are "All time". */
+export function isAllTimeRead(timeFrom: string): boolean {
+  return timeFrom === ""
+}
+
+/**
+ * The list range: the picked range, else "All time" (default). "All time" drops the lower bound
+ * unless `allTimeLowerBoundIso` is given — screens whose endpoints require a concrete lower bound
+ * pass the project's earliest activity, which captures all data without an unbounded scan param.
+ */
+export function resolveAnalyticsListRange(input: {
+  readonly timeFrom: string
+  readonly timeTo: string
+  readonly nowMs: number
+  readonly allTimeLowerBoundIso?: string | null | undefined
+}): AnalyticsListRange {
+  const { timeFrom, timeTo, nowMs, allTimeLowerBoundIso } = input
+  // Bounds come from the URL and may be unparseable (hand-crafted); guard so `new Date(NaN).toISOString()`
+  // can never throw. A bad upper bound falls back to `now`; a bad lower bound falls through to All time.
+  const toMs = timeTo ? Date.parse(timeTo) : nowMs
+  const toIso = new Date(Number.isFinite(toMs) ? toMs : nowMs).toISOString()
+  if (timeFrom) {
+    const fromMs = Date.parse(timeFrom)
+    if (Number.isFinite(fromMs)) return { fromIso: new Date(fromMs).toISOString(), toIso }
+  }
+  return allTimeLowerBoundIso ? { fromIso: allTimeLowerBoundIso, toIso } : { toIso }
+}
+
+/**
+ * Clamps the trend/histogram window to `maxSpanSeconds`, anchored to the end. When All time, anchors
+ * to `lastActivityIso` (latest data) so the chart isn't a blank "last N days from now".
+ */
+export function resolveAnalyticsTrendRange(input: {
+  readonly listRange: AnalyticsListRange
+  readonly isAllTime: boolean
+  readonly lastActivityIso?: string | null | undefined
+  readonly maxSpanSeconds: number
+  readonly nowMs: number
+}): AnalyticsTrendRange {
+  const { listRange, isAllTime, lastActivityIso, maxSpanSeconds, nowMs } = input
+  const maxSpanMs = maxSpanSeconds * 1000
+  const anchorMs = isAllTime && lastActivityIso ? Date.parse(lastActivityIso) : Date.parse(listRange.toIso)
+  const endMs = Number.isFinite(anchorMs) ? anchorMs : nowMs
+  const desiredStartMs = !isAllTime && listRange.fromIso ? Date.parse(listRange.fromIso) : endMs - maxSpanMs
+  const startMs = Math.max(desiredStartMs, endMs - maxSpanMs)
+  return { fromIso: new Date(startMs).toISOString(), toIso: new Date(endMs).toISOString() }
+}
+
+/** Time-picker change → next `[timeFrom, timeTo]`. An empty selection clears back to "All time". */
+export function applyAnalyticsTimeChange(from?: string, to?: string): readonly [string, string] {
+  if (!from && !to) return ["", ""]
+  return [from ?? "", to ?? ""]
+}
+
+/** Histogram brush selection → next `[timeFrom, timeTo]`. Clearing the brush (`null`) returns to All time. */
+export function applyAnalyticsBrushSelect(range: { from: string; to: string } | null): readonly [string, string] {
+  if (!range) return ["", ""]
+  return [range.from, range.to]
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+interface UseAnalyticsTimeWindowInput {
+  readonly project: { readonly isShowcase: boolean }
+  readonly fromKey: string
+  readonly toKey: string
+  /** Latest activity ISO, used to anchor the trend when All time. */
+  readonly lastActivityIso?: string | null
+  /** Concrete lower bound for "All time" when the screen's endpoint needs one (e.g. `firstTraceAt`). */
+  readonly allTimeLowerBoundIso?: string | null
+  readonly trendMaxSpanSeconds?: number
+}
+
+interface AnalyticsTimeWindow {
+  readonly timeFrom: string
+  readonly timeTo: string
+  readonly isAllTime: boolean
+  /** A real user-picked bounded range (not the All-time default). */
+  readonly hasExplicitRange: boolean
+  readonly listRange: AnalyticsListRange
+  readonly trendRange: AnalyticsTrendRange
+  readonly pickerStartFrom: string | undefined
+  readonly pickerStartTo: string | undefined
+  readonly onTimeChange: (from?: string, to?: string) => void
+  readonly onBrushSelect: (range: { from: string; to: string } | null) => void
+}
+
+export function useAnalyticsTimeWindow({
+  project,
+  fromKey,
+  toKey,
+  lastActivityIso,
+  allTimeLowerBoundIso,
+  trendMaxSpanSeconds,
+}: UseAnalyticsTimeWindowInput): AnalyticsTimeWindow {
+  const [timeFrom, setTimeFrom] = useParamState(fromKey, "")
+  const [timeTo, setTimeTo] = useParamState(toKey, "")
+  const maxSpanSeconds = trendMaxSpanSeconds ?? defaultProjectTimeWindowSeconds(project)
+  const isAllTime = isAllTimeRead(timeFrom)
+
+  useMountEffect(() => {
+    if (!project.isShowcase || timeFrom !== "" || timeTo !== "") return
+    setTimeFrom(new Date(Date.now() - defaultProjectTimeWindowSeconds(project) * 1000).toISOString())
+  })
+
+  const { listRange, trendRange } = useMemo(() => {
+    const nowMs = Date.now()
+    const list = resolveAnalyticsListRange({ timeFrom, timeTo, nowMs, allTimeLowerBoundIso })
+    return {
+      listRange: list,
+      trendRange: resolveAnalyticsTrendRange({ listRange: list, isAllTime, lastActivityIso, maxSpanSeconds, nowMs }),
+    }
+  }, [timeFrom, timeTo, isAllTime, lastActivityIso, allTimeLowerBoundIso, maxSpanSeconds])
+
+  const onTimeChange = useCallback(
+    (from?: string, to?: string) => {
+      const [nextFrom, nextTo] = applyAnalyticsTimeChange(from, to)
+      setTimeFrom(nextFrom)
+      setTimeTo(nextTo)
+    },
+    [setTimeFrom, setTimeTo],
+  )
+
+  const onBrushSelect = useCallback(
+    (range: { from: string; to: string } | null) => {
+      const [nextFrom, nextTo] = applyAnalyticsBrushSelect(range)
+      setTimeFrom(nextFrom)
+      setTimeTo(nextTo)
+    },
+    [setTimeFrom, setTimeTo],
+  )
+
+  return {
+    timeFrom,
+    timeTo,
+    isAllTime,
+    hasExplicitRange: !isAllTime,
+    listRange,
+    trendRange,
+    pickerStartFrom: isAllTime ? undefined : timeFrom,
+    pickerStartTo: isAllTime ? undefined : timeTo || undefined,
+    onTimeChange,
+    onBrushSelect,
+  }
+}

--- a/apps/web/src/domains/signals/signals.collection.ts
+++ b/apps/web/src/domains/signals/signals.collection.ts
@@ -92,6 +92,7 @@ interface SignalsKeyInput {
   readonly sorting: SignalsSorting
   readonly searchQuery: string | undefined
   readonly timeRange: SignalsTimeRange | undefined
+  readonly histogramMaxSpanDays: number | undefined
 }
 
 const getSignalsQueryKey = (input: SignalsKeyInput) =>
@@ -152,6 +153,7 @@ const buildListSignalsRequest = (input: SignalsKeyInput, offset: number) => ({
   ...(input.assigneeIds?.length ? { assigneeIds: [...input.assigneeIds] } : {}),
   ...(input.searchQuery ? { searchQuery: input.searchQuery } : {}),
   ...(input.timeRange?.fromIso || input.timeRange?.toIso ? { timeRange: input.timeRange } : {}),
+  ...(input.histogramMaxSpanDays ? { histogramMaxSpanDays: input.histogramMaxSpanDays } : {}),
 })
 
 export function useSignals(input: {
@@ -161,6 +163,7 @@ export function useSignals(input: {
   readonly sorting?: SignalsSorting
   readonly searchQuery?: string
   readonly timeRange?: SignalsTimeRange
+  readonly histogramMaxSpanDays?: number
   readonly limit?: number
   readonly enabled?: boolean
 }) {
@@ -175,6 +178,7 @@ export function useSignals(input: {
     sorting,
     searchQuery: normalizedSearchQuery,
     timeRange: input.timeRange,
+    histogramMaxSpanDays: input.histogramMaxSpanDays,
   }
 
   const queryKey = useMemo(

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -108,6 +108,7 @@ const listSignalsInputSchema = z.object({
       toIso: z.iso.datetime().optional(),
     })
     .optional(),
+  histogramMaxSpanDays: z.number().int().positive().optional(),
 })
 
 const toSignalsBucketRecord = (bucket: { readonly bucket: string; readonly count: number }) => ({
@@ -401,6 +402,7 @@ const runSignalsList = async (
         ...(data.assigneeIds?.length ? { assigneeIds: data.assigneeIds } : {}),
         ...(data.sort ? { sort: data.sort } : {}),
         ...(timeRange ? { timeRange } : {}),
+        ...(data.histogramMaxSpanDays ? { histogramMaxSpanDays: data.histogramMaxSpanDays } : {}),
         ...(directMatch
           ? { signalIds: [directMatch.id] }
           : search

--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -13,6 +13,8 @@ import { useMemo } from "react"
 import { projectScopeData, projectScopeKey, useProjectScope } from "../projects/project-scope.tsx"
 import {
   countTracesByProject,
+  getProjectFirstTraceAt,
+  getProjectLastTraceAt,
   getSessionMomentIntelligence,
   getTraceCohortSummary,
   getTraceConversationChunk,
@@ -114,6 +116,57 @@ export function useTracesCount({
   })
 
   return { totalCount, isLoading }
+}
+
+/**
+ * Latest trace `start_time` (ISO) matching `filters`, or null. Used to anchor the histogram to
+ * real activity when the list is showing "All time" but recent activity is empty.
+ */
+export function useProjectLastTraceAt({
+  projectId,
+  filters,
+  searchQuery,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly filters?: FilterSet
+  readonly searchQuery?: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  const { data = null } = useQuery({
+    queryKey: [...projectScopeKey(scope), "traces-last-at", projectId, filters, searchQuery],
+    queryFn: () =>
+      getProjectLastTraceAt({
+        data: { ...projectScopeData(scope), projectId, filters, ...(searchQuery ? { searchQuery } : {}) },
+      }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+
+  return { lastTraceAt: data }
+}
+
+/**
+ * Earliest trace `start_time` (ISO) for the whole project, or null. The concrete "All time" lower
+ * bound for analytics screens whose endpoints require one (robust, unlike `project.firstTraceAt`).
+ */
+export function useProjectFirstTraceAt({
+  projectId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  const { data = null } = useQuery({
+    queryKey: [...projectScopeKey(scope), "traces-first-at", projectId],
+    queryFn: () => getProjectFirstTraceAt({ data: { ...projectScopeData(scope), projectId } }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+
+  return { firstTraceAt: data }
 }
 
 export function useTraceMetrics({

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -255,6 +255,52 @@ export const countTracesByProject = createServerFn({ method: "GET" })
     )
   })
 
+export const getProjectLastTraceAt = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      filters: filterSetSchema.optional(),
+      searchQuery: z.string().max(500).optional(),
+    }),
+  )
+  .handler(async ({ data, context }): Promise<string | null> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        const lastAt = yield* repo.findLastTraceAt({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          ...(data.filters ? { filters: data.filters } : {}),
+          ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
+        })
+        return lastAt ? lastAt.toISOString() : null
+      }).pipe(
+        withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId),
+        withAi(AIEmbedLive, getRedisClient()),
+        withTracing,
+      ),
+    )
+  })
+
+export const getProjectFirstTraceAt = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data, context }): Promise<string | null> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        const firstAt = yield* repo.findFirstTraceAt({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+        })
+        return firstAt ? firstAt.toISOString() : null
+      }).pipe(withScopedClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
 export const getTraceMetricsByProject = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -18,6 +18,8 @@ interface TraceAggregationsPanelProps {
   readonly mode: "traces" | "sessions"
   /** Called when user selects a time range via brush on the histogram. */
   readonly onTimeRangeSelect?: (range: { from: string; to: string } | null) => void
+  /** Overrides the histogram window (independent of `filters`) — used to anchor an "All time" list to recent activity. */
+  readonly histogramRangeOverride?: { readonly rangeStartIso: string; readonly rangeEndIso: string }
 }
 
 export function TraceAggregationsPanel({
@@ -26,6 +28,7 @@ export function TraceAggregationsPanel({
   filters,
   mode,
   onTimeRangeSelect,
+  histogramRangeOverride,
 }: TraceAggregationsPanelProps) {
   const [collapsed, setCollapsed] = useState(false)
   const [selectedMetric, setSelectedMetric] = useParamState("histogramMetric", DEFAULT_HISTOGRAM_METRIC, {
@@ -63,37 +66,39 @@ export function TraceAggregationsPanel({
           onMetricSelect={onMetricSelect}
           onCollapse={() => setCollapsed(true)}
         />
-        <div className="relative">
-          {incidentsFlagEnabled ? (
-            <div className="absolute right-2 top-2 z-10">
-              <Tooltip
-                asChild
-                trigger={
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowIncidents((prev) => !prev)}
-                    aria-pressed={showIncidents}
+        <Histogram
+          projectId={projectId}
+          projectSlug={projectSlug}
+          filters={filters}
+          mode={mode}
+          metric={selectedMetric}
+          showIncidents={incidentsFlagEnabled && showIncidents}
+          onRangeSelect={onTimeRangeSelect}
+          isAllTime={!!histogramRangeOverride}
+          {...(histogramRangeOverride ? { rangeOverride: histogramRangeOverride } : {})}
+          {...(incidentsFlagEnabled
+            ? {
+                headerActions: (
+                  <Tooltip
+                    asChild
+                    trigger={
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setShowIncidents((prev) => !prev)}
+                        aria-pressed={showIncidents}
+                      >
+                        <Icon icon={showIncidents ? ShieldAlertIcon : ShieldOffIcon} size="sm" />
+                        Incidents
+                      </Button>
+                    }
                   >
-                    <Icon icon={showIncidents ? ShieldAlertIcon : ShieldOffIcon} size="sm" />
-                    Incidents
-                  </Button>
-                }
-              >
-                Overlay incidents on the timeline
-              </Tooltip>
-            </div>
-          ) : null}
-          <Histogram
-            projectId={projectId}
-            projectSlug={projectSlug}
-            filters={filters}
-            mode={mode}
-            metric={selectedMetric}
-            showIncidents={incidentsFlagEnabled && showIncidents}
-            onRangeSelect={onTimeRangeSelect}
-          />
-        </div>
+                    Overlay incidents on the timeline
+                  </Tooltip>
+                ),
+              }
+            : {})}
+        />
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -1,7 +1,7 @@
 import type { FilterSet } from "@domain/shared"
 import { denseTraceTimeHistogramBuckets, type TraceHistogramMetric } from "@domain/spans"
 import { BarChart, HistogramSkeleton, Text } from "@repo/ui"
-import { useCallback, useMemo } from "react"
+import { type ReactNode, useCallback, useMemo } from "react"
 
 import { useProjectAlertIncidentsInRange } from "../../../../../../domains/alerts/alerts.collection.ts"
 import { IncidentMarkerPopover } from "../../../../../../domains/alerts/incident-marker-popover.tsx"
@@ -9,6 +9,7 @@ import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-
 import { useIncidentBucketHoverPopover } from "../../../../../../domains/alerts/use-incident-bucket-hover-popover.ts"
 import { useSessionTimeHistogram } from "../../../../../../domains/sessions/sessions.collection.ts"
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
+import { ChartHeader } from "../chart-header.tsx"
 import { HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
 
 function formatBucketAxisLabel(iso: string): string {
@@ -29,6 +30,12 @@ interface HistogramProps {
   readonly metric: TraceHistogramMetric
   readonly showIncidents: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
+  /** Forces the histogram window (independent of `filters`) — anchors an "All time" list to recent activity. */
+  readonly rangeOverride?: { readonly rangeStartIso: string; readonly rangeEndIso: string }
+  /** All time (no lower bound) — flags the header copy that the chart is a recent, anchored slice. */
+  readonly isAllTime?: boolean
+  /** Right-aligned header controls (e.g. the Incidents overlay toggle). */
+  readonly headerActions?: ReactNode
 }
 
 export function Histogram({
@@ -39,15 +46,20 @@ export function Histogram({
   metric,
   showIncidents,
   onRangeSelect,
+  rangeOverride,
+  isAllTime,
+  headerActions,
 }: HistogramProps) {
   const isSessionsMode = mode === "sessions"
   const traceHistogram = useTraceTimeHistogram({
     projectId: isSessionsMode ? "" : projectId,
     filters,
+    ...(rangeOverride ?? {}),
   })
   const sessionHistogram = useSessionTimeHistogram({
     projectId: isSessionsMode ? projectId : "",
     filters,
+    ...(rangeOverride ?? {}),
   })
   const {
     data: sparseBuckets,
@@ -161,26 +173,34 @@ export function Histogram({
   }
 
   return (
-    <div className="px-4 py-3">
-      <BarChart
-        data={chartData}
-        height={160}
-        showYAxis={false}
-        ariaLabel={`${definition.label} by time bucket`}
-        formatTooltip={formatTooltip}
-        onSelect={onRangeSelect ? handleSelect : undefined}
-        {...(overlay ? { overlay } : {})}
-        {...(showIncidents ? { onBucketAxisPointerChange: handleBucketAxisPointerChange } : {})}
+    <>
+      <ChartHeader
+        fromIso={rangeStartIso}
+        toIso={rangeEndIso}
+        isAllTime={isAllTime ?? false}
+        {...(headerActions ? { actions: headerActions } : {})}
       />
-      <IncidentMarkerPopover
-        open={popover !== null}
-        anchor={popover?.anchor ?? null}
-        incidents={popoverIncidents}
-        projectSlug={projectSlug}
-        onOpenChange={onPopoverOpenChange}
-        onContentMouseEnter={onContentMouseEnter}
-        onContentMouseLeave={onContentMouseLeave}
-      />
-    </div>
+      <div className="px-4 py-3">
+        <BarChart
+          data={chartData}
+          height={160}
+          showYAxis={false}
+          ariaLabel={`${definition.label} by time bucket`}
+          formatTooltip={formatTooltip}
+          onSelect={onRangeSelect ? handleSelect : undefined}
+          {...(overlay ? { overlay } : {})}
+          {...(showIncidents ? { onBucketAxisPointerChange: handleBucketAxisPointerChange } : {})}
+        />
+        <IncidentMarkerPopover
+          open={popover !== null}
+          anchor={popover?.anchor ?? null}
+          incidents={popoverIncidents}
+          projectSlug={projectSlug}
+          onOpenChange={onPopoverOpenChange}
+          onContentMouseEnter={onContentMouseEnter}
+          onContentMouseLeave={onContentMouseLeave}
+        />
+      </div>
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/chart-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/chart-header.tsx
@@ -1,0 +1,52 @@
+import { Icon, Text, Tooltip } from "@repo/ui"
+import { formatChartWindowCaption } from "@repo/utils"
+import { ClockIcon, InfoIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+interface ChartHeaderProps {
+  /** Chart title, e.g. "Tool calls over time". Omit when a sibling control (e.g. a metric selector) already labels the chart. */
+  readonly title?: string
+  readonly fromIso: string
+  readonly toIso: string
+  /** The All-time default charts a bounded, latest-activity-anchored slice — flag it so the copy explains the window. */
+  readonly isAllTime: boolean
+  /** Right-aligned controls (e.g. the Incidents overlay toggle). */
+  readonly actions?: ReactNode
+}
+
+/**
+ * Header shown above a time-series chart: an optional title plus the rendered time window. Under the
+ * All-time default the chart is a recent, latest-activity-anchored slice while the totals/list cover
+ * the full range — the subtitle + tooltip make that explicit so the window isn't read as "all time".
+ */
+export function ChartHeader({ title, fromIso, toIso, isAllTime, actions }: ChartHeaderProps) {
+  const window = formatChartWindowCaption(fromIso, toIso)
+  if (!window && !title && !actions) return null
+
+  return (
+    <div className="flex items-start justify-between gap-2 px-4 pt-3">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        {title ? <Text.H6 color="foreground">{title}</Text.H6> : null}
+        {window ? (
+          <div className="flex items-center gap-1">
+            <Icon icon={ClockIcon} size="sm" color="foregroundMuted" />
+            <Text.H6 color="foregroundMuted">{isAllTime ? `Recent activity · ${window}` : window}</Text.H6>
+            {isAllTime ? (
+              <Tooltip
+                asChild
+                trigger={
+                  <span className="inline-flex cursor-default">
+                    <Icon icon={InfoIcon} size="sm" color="foregroundMuted" />
+                  </span>
+                }
+              >
+                Chart shows recent activity anchored to your latest data. Totals and the list cover all time.
+              </Tooltip>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -24,11 +24,9 @@ import {
   createDatasetFromTracesFunction,
 } from "../../../../../domains/datasets/datasets.functions.ts"
 import { useMonitors } from "../../../../../domains/monitors/monitors.collection.ts"
-import { defaultProjectTimeWindowSeconds } from "../../../../../domains/projects/default-time-window.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { useSavedSearchBySlug } from "../../../../../domains/saved-searches/saved-searches.collection.ts"
 import type { SavedSearchRecord } from "../../../../../domains/saved-searches/saved-searches.functions.ts"
-import { withSessionDefaults } from "../../../../../domains/sessions/sessions.collection.ts"
 import { useTracesCount } from "../../../../../domains/traces/traces.collection.ts"
 import { enqueueTracesExport } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
@@ -61,15 +59,10 @@ import {
 import { useTableColumnSettings } from "./table-column-settings.ts"
 import { TimeFilterDropdown } from "./time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./trace-detail-drawer.tsx"
-import {
-  DEFAULT_SEARCH_SORTING,
-  DEFAULT_TRACE_SORTING,
-  getTimeFilterValue,
-  parseFilters,
-  serializeFilters,
-} from "./trace-page-state.ts"
+import { DEFAULT_SEARCH_SORTING, DEFAULT_TRACE_SORTING, parseFilters, serializeFilters } from "./trace-page-state.ts"
 import { TracesEmptyOnboarding } from "./traces-empty-onboarding.tsx"
 import { TracesView } from "./traces-view.tsx"
+import { useProjectTimeWindow } from "./use-project-time-window.ts"
 
 export type ExplorerMode = "traces" | "sessions"
 
@@ -221,24 +214,23 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const traceIdsRef = useRef<string[]>([])
 
   const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
-  const defaultSessionRangeSeconds = defaultProjectTimeWindowSeconds(currentProject)
-  // Sessions and Traces share the same default window when the user hasn't picked
-  // a range (open-ended `gte` so the dropdown shows the "Last month"/"Last 2 weeks"
-  // preset). Applied in both modes so Traces isn't stuck on "All time".
-  const filtersWithDefaultTime = useMemo(() => {
-    if (filters.startTime) return filters
-    const fromMs = Date.now() - defaultSessionRangeSeconds * 1000
-    return {
-      ...filters,
-      startTime: [{ op: "gte" as const, value: new Date(fromMs).toISOString() }],
-    }
-  }, [filters, defaultSessionRangeSeconds])
-  // Data reads use the default-windowed set; `withSessionDefaults` (orphan-fragment
-  // hiding via `hasLlmActivity`) is session-only, so it's layered on in that mode.
-  const effectiveFilters = useMemo(
-    () => (isSessions ? withSessionDefaults(filtersWithDefaultTime) : filtersWithDefaultTime),
-    [filtersWithDefaultTime, isSessions],
-  )
+  // Sessions/Traces date filter: default is "All time"; a picked range lives in `filters.startTime`,
+  // and the histogram stays clamped (anchored to latest activity when All time). See the hook.
+  const {
+    filtersWithDefaultTime,
+    effectiveFilters,
+    timeFrom,
+    timeTo,
+    histogramRangeOverride,
+    onTimeFilterChange,
+    onTimeRangeSelect,
+  } = useProjectTimeWindow({
+    project: currentProject,
+    filters,
+    setRawFilters,
+    isSessions,
+    ...(hasSearchQuery ? { searchQuery: query } : {}),
+  })
   const traceColumnSettings = useTableColumnSettings<TraceColumnId>({
     storageKey: "projects.traces.columns.v1",
     columns: TRACE_COLUMN_OPTIONS,
@@ -251,10 +243,10 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     storageKey: "projects.sessions.columns.v3",
     columns: getSessionColumnOptions(hasSearchQuery),
   })
-  const hasActiveFilters = Object.keys(filters).length > 0
+  // A cleared time filter persists as `startTime: []` (explicit "All time"); an empty
+  // condition array is not a user-applied filter, so ignore empties here.
+  const hasActiveFilters = Object.values(filters).some((conds) => conds.length > 0)
   const hasSelectedSavedSearch = savedSearchSlug.length > 0
-  const timeFrom = getTimeFilterValue(filtersWithDefaultTime, "gte")
-  const timeTo = getTimeFilterValue(filtersWithDefaultTime, "lte")
   const sessionsMonitorTarget = useMemo<MonitorTarget>(
     () => ({
       type: "session",
@@ -283,7 +275,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  const { totalCount: totalTraceCount } = useTracesCount({
+  const { totalCount: totalTraceCount, isLoading: isTracesCountLoading } = useTracesCount({
     projectId: currentProject.id,
     filters: effectiveFilters,
     ...(hasSearchQuery ? { searchQuery: query } : {}),
@@ -305,22 +297,6 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const onShowAllSessions = useCallback(() => {
     setRawFilters(serializeFilters({ ...filters, hasLlmActivity: [{ op: "eq", value: false as const }] }) ?? "")
   }, [filters, setRawFilters])
-
-  const onTimeRangeSelect = useCallback((range: { from: string; to: string } | null) => {
-    setRawFilters((prev) => {
-      const current = parseFilters(prev || undefined)
-      const next = { ...current }
-      if (range) {
-        next.startTime = [
-          { op: "gte" as const, value: range.from },
-          { op: "lte" as const, value: range.to },
-        ]
-      } else {
-        delete next.startTime
-      }
-      return serializeFilters(next) ?? ""
-    })
-  }, [])
 
   // "Clear all" resets the whole search bar: filters, query, and the selected saved search.
   // Also drop an explicit sort so a `relevance` sort doesn't linger in the header after
@@ -460,18 +436,11 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     },
   ])
 
-  // Gate on whether the project ever received a trace, not the windowed count — old-data projects
-  // fall through to the normal view (with the time filter) instead of the false onboarding.
-  // `firstTraceAt` is a best-effort column (only written by live ingestion), so a null value doesn't
-  // prove emptiness — backfilled/old projects can have traces with a null `firstTraceAt`. Confirm
-  // with an unwindowed total count, but only when the fast path can't already vouch for traces.
-  const { totalCount: everTraceCount } = useTracesCount({
-    projectId: currentProject.id,
-    enabled: currentProject.firstTraceAt == null,
-  })
-  const projectHasTracesEver = currentProject.firstTraceAt != null || everTraceCount > 0
+  // Reads default to All time, so `totalTraceCount` is the unwindowed count — `=== 0` (once loaded)
+  // means the project has no traces at all, a robust "empty project" signal. `firstTraceAt` is
+  // best-effort (null on backfilled/old-data projects), so it must not gate the onboarding.
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
-  const showConnectEmptyState = !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
+  const showConnectEmptyState = !isTracesCountLoading && totalTraceCount === 0 && !hasActiveFilters && !hasSearchQuery
 
   if (showConnectEmptyState) {
     return (
@@ -479,7 +448,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
         <TracesEmptyOnboarding
           projectId={currentProject.id}
           projectSlug={currentProject.slug}
-          orgHasConnectedProjects={orgHasConnectedProjects || currentProject.firstTraceAt != null}
+          orgHasConnectedProjects={orgHasConnectedProjects}
         />
       </Layout>
     )
@@ -510,19 +479,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
             <TimeFilterDropdown
               {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
               {...(timeTo ? { startTimeTo: timeTo } : {})}
-              onChange={(from, to) => {
-                const next = { ...filters }
-                if (from || to) {
-                  const conditions = [
-                    ...(from ? [{ op: "gte" as const, value: from }] : []),
-                    ...(to ? [{ op: "lte" as const, value: to }] : []),
-                  ]
-                  next.startTime = conditions
-                } else {
-                  delete next.startTime
-                }
-                setRawFilters(serializeFilters(next) ?? "")
-              }}
+              onChange={onTimeFilterChange}
             />
             {isSessions ? (
               <ColumnsSelector
@@ -670,6 +627,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
           filters={filtersWithDefaultTime}
           mode={activeTab}
           onTimeRangeSelect={onTimeRangeSelect}
+          {...(histogramRangeOverride ? { histogramRangeOverride } : {})}
         />
       </div>
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/time-filter-dropdown.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/time-filter-dropdown.tsx
@@ -22,11 +22,17 @@ function buildPresetRange(seconds: number): DateRange {
 }
 
 function buildPickerRange(startTimeFrom?: string, startTimeTo?: string): DateRange | undefined {
-  if (!startTimeFrom && !startTimeTo) return undefined
+  // Bounds come from the URL and may be unparseable (hand-crafted). Drop invalid dates so an
+  // `Invalid Date` never reaches the picker, where `date-fns` `format()` would throw a RangeError.
+  const from = startTimeFrom ? new Date(startTimeFrom) : undefined
+  const to = startTimeTo ? new Date(startTimeTo) : undefined
+  const validFrom = from && Number.isFinite(from.getTime()) ? from : undefined
+  const validTo = to && Number.isFinite(to.getTime()) ? to : undefined
+  if (!validFrom && !validTo) return undefined
 
   return {
-    ...(startTimeFrom ? { from: new Date(startTimeFrom) } : {}),
-    ...(startTimeTo ? { to: new Date(startTimeTo) } : {}),
+    ...(validFrom ? { from: validFrom } : {}),
+    ...(validTo ? { to: validTo } : {}),
   }
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-project-time-window.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-project-time-window.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyTimeFilterChange,
+  applyTimeRangeSelect,
+  computeHistogramRangeOverride,
+  isAllTimeRead,
+} from "./use-project-time-window.ts"
+
+const DAY = 24 * 60 * 60 * 1000
+const now = Date.UTC(2026, 6, 10, 12, 0, 0)
+const iso = (ms: number) => new Date(ms).toISOString()
+const RANGE_30D = 30 * 24 * 60 * 60
+
+describe("isAllTimeRead", () => {
+  it("true when there is no lower bound", () => {
+    expect(isAllTimeRead({})).toBe(true)
+    expect(isAllTimeRead({ status: [{ op: "eq", value: "error" }] })).toBe(true)
+    expect(isAllTimeRead({ startTime: [{ op: "lte", value: iso(now) }] })).toBe(true)
+  })
+
+  it("false when a lower bound (gte) is set", () => {
+    expect(isAllTimeRead({ startTime: [{ op: "gte", value: iso(now - 5 * DAY) }] })).toBe(false)
+  })
+})
+
+describe("applyTimeFilterChange", () => {
+  it("sets gte + lte for a bounded range", () => {
+    const from = iso(now - 5 * DAY)
+    const to = iso(now)
+    expect(applyTimeFilterChange({}, from, to).startTime).toEqual([
+      { op: "gte", value: from },
+      { op: "lte", value: to },
+    ])
+  })
+
+  it("sets only gte when there is no upper bound", () => {
+    const from = iso(now - 5 * DAY)
+    expect(applyTimeFilterChange({}, from, undefined).startTime).toEqual([{ op: "gte", value: from }])
+  })
+
+  it("clears back to All time (drops startTime) when both bounds are absent", () => {
+    const result = applyTimeFilterChange({ startTime: [{ op: "gte", value: iso(now) }] })
+    expect("startTime" in result).toBe(false)
+  })
+
+  it("preserves non-time filters", () => {
+    const result = applyTimeFilterChange({ status: [{ op: "eq", value: "error" }] }, iso(now - 1 * DAY), undefined)
+    expect(result.status).toEqual([{ op: "eq", value: "error" }])
+  })
+})
+
+describe("applyTimeRangeSelect", () => {
+  it("sets gte + lte from a brush selection", () => {
+    const range = { from: iso(now - 2 * DAY), to: iso(now) }
+    expect(applyTimeRangeSelect({}, range).startTime).toEqual([
+      { op: "gte", value: range.from },
+      { op: "lte", value: range.to },
+    ])
+  })
+
+  it("clearing the brush returns to All time (drops startTime)", () => {
+    const result = applyTimeRangeSelect({ startTime: [{ op: "gte", value: iso(now) }] }, null)
+    expect("startTime" in result).toBe(false)
+  })
+})
+
+describe("computeHistogramRangeOverride", () => {
+  it("returns undefined when not All time", () => {
+    expect(computeHistogramRangeOverride(false, iso(now), RANGE_30D)).toBeUndefined()
+  })
+
+  it("returns undefined when there is no latest activity", () => {
+    expect(computeHistogramRangeOverride(true, null, RANGE_30D)).toBeUndefined()
+  })
+
+  it("anchors a span ending at the latest activity", () => {
+    const last = iso(now - 40 * DAY)
+    expect(computeHistogramRangeOverride(true, last, RANGE_30D)).toEqual({
+      rangeStartIso: iso(now - 70 * DAY),
+      rangeEndIso: last,
+    })
+  })
+
+  it("returns undefined for an unparseable timestamp", () => {
+    expect(computeHistogramRangeOverride(true, "not-a-date", RANGE_30D)).toBeUndefined()
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-project-time-window.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/use-project-time-window.ts
@@ -1,0 +1,154 @@
+import type { FilterSet } from "@domain/shared"
+import { useMountEffect } from "@repo/ui"
+import { useCallback, useMemo } from "react"
+import { defaultProjectTimeWindowSeconds } from "../../../../../domains/projects/default-time-window.ts"
+import { withSessionDefaults } from "../../../../../domains/sessions/sessions.collection.ts"
+import { useProjectLastTraceAt } from "../../../../../domains/traces/traces.collection.ts"
+import { getTimeFilterValue, parseFilters, serializeFilters } from "./trace-page-state.ts"
+
+interface HistogramRange {
+  readonly rangeStartIso: string
+  readonly rangeEndIso: string
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in use-project-time-window.test.ts)
+// ---------------------------------------------------------------------------
+
+/** No lower bound on the time filter — reads are "All time". */
+export function isAllTimeRead(filters: FilterSet): boolean {
+  return getTimeFilterValue(filters, "gte") === undefined
+}
+
+/** Time-picker change → next filters. An empty selection clears the range back to "All time". */
+export function applyTimeFilterChange(filters: FilterSet, from?: string, to?: string): FilterSet {
+  const next = { ...filters }
+  if (from || to) {
+    next.startTime = [
+      ...(from ? [{ op: "gte" as const, value: from }] : []),
+      ...(to ? [{ op: "lte" as const, value: to }] : []),
+    ]
+  } else {
+    delete next.startTime
+  }
+  return next
+}
+
+/** Histogram brush selection → next filters. Clearing the brush (`null`) returns to "All time". */
+export function applyTimeRangeSelect(filters: FilterSet, range: { from: string; to: string } | null): FilterSet {
+  const next = { ...filters }
+  if (range) {
+    next.startTime = [
+      { op: "gte", value: range.from },
+      { op: "lte", value: range.to },
+    ]
+  } else {
+    delete next.startTime
+  }
+  return next
+}
+
+/**
+ * Anchors the histogram to the latest activity when reads are unbounded ("All time"), so it charts a
+ * real window ending at the most recent trace instead of an empty "last N days from now".
+ */
+export function computeHistogramRangeOverride(
+  allTime: boolean,
+  lastTraceAt: string | null | undefined,
+  spanSeconds: number,
+): HistogramRange | undefined {
+  if (!allTime || !lastTraceAt) return undefined
+  const endMs = Date.parse(lastTraceAt)
+  if (!Number.isFinite(endMs)) return undefined
+  return {
+    rangeStartIso: new Date(endMs - spanSeconds * 1000).toISOString(),
+    rangeEndIso: new Date(endMs).toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+interface UseProjectTimeWindowInput {
+  readonly project: { readonly id: string; readonly isShowcase: boolean }
+  readonly filters: FilterSet
+  readonly setRawFilters: (updater: (prev: string) => string) => void
+  readonly isSessions: boolean
+  readonly searchQuery?: string
+}
+
+interface ProjectTimeWindow {
+  /** Read filters — the user's picked range, or unbounded ("All time") by default. */
+  readonly filtersWithDefaultTime: FilterSet
+  /** `filtersWithDefaultTime` plus session-only orphan-fragment hiding when in sessions mode. */
+  readonly effectiveFilters: FilterSet
+  readonly timeFrom: string | undefined
+  readonly timeTo: string | undefined
+  readonly histogramRangeOverride: HistogramRange | undefined
+  readonly onTimeFilterChange: (from?: string, to?: string) => void
+  readonly onTimeRangeSelect: (range: { from: string; to: string } | null) => void
+}
+
+/**
+ * Owns the Sessions/Traces time window. The default is "All time" (no lower bound) — a picked range
+ * lives in `filters.startTime`, and clearing it returns to All time. The histogram is clamped to a
+ * bounded span (anchored to the latest activity when All time) so an unbounded list never triggers an
+ * unbounded per-bucket scan.
+ */
+export function useProjectTimeWindow({
+  project,
+  filters,
+  setRawFilters,
+  isSessions,
+  searchQuery,
+}: UseProjectTimeWindowInput): ProjectTimeWindow {
+  const histogramSpanSeconds = defaultProjectTimeWindowSeconds(project)
+  const allTime = isAllTimeRead(filters)
+
+  const effectiveFilters = useMemo(() => (isSessions ? withSessionDefaults(filters) : filters), [filters, isSessions])
+
+  // Fetch the anchor whenever reads are All time; the query returns null when the project has no
+  // data (a robust signal, unlike the best-effort `firstTraceAt` flag). Forward `searchQuery` so the
+  // anchor matches the searched list scope (and its query key invalidates when the search changes).
+  const { lastTraceAt } = useProjectLastTraceAt({
+    projectId: project.id,
+    filters,
+    enabled: allTime,
+    ...(searchQuery ? { searchQuery } : {}),
+  })
+
+  const histogramRangeOverride = useMemo(
+    () => computeHistogramRangeOverride(allTime, lastTraceAt, histogramSpanSeconds),
+    [allTime, lastTraceAt, histogramSpanSeconds],
+  )
+
+  const onTimeFilterChange = useCallback(
+    (from?: string, to?: string) => {
+      setRawFilters((prev) => serializeFilters(applyTimeFilterChange(parseFilters(prev || undefined), from, to)) ?? "")
+    },
+    [setRawFilters],
+  )
+
+  const onTimeRangeSelect = useCallback(
+    (range: { from: string; to: string } | null) => {
+      setRawFilters((prev) => serializeFilters(applyTimeRangeSelect(parseFilters(prev || undefined), range)) ?? "")
+    },
+    [setRawFilters],
+  )
+
+  useMountEffect(() => {
+    if (!project.isShowcase || !allTime) return
+    onTimeFilterChange(new Date(Date.now() - histogramSpanSeconds * 1000).toISOString())
+  })
+
+  return {
+    filtersWithDefaultTime: filters,
+    effectiveFilters,
+    timeFrom: getTimeFilterValue(filters, "gte"),
+    timeTo: getTimeFilterValue(filters, "lte"),
+    histogramRangeOverride,
+    onTimeFilterChange,
+    onTimeRangeSelect,
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -2,6 +2,7 @@ import { Button, Icon, Text } from "@repo/ui"
 import { createFileRoute } from "@tanstack/react-router"
 import { ExternalLinkIcon, Loader2Icon, TagsIcon } from "lucide-react"
 import { useMemo } from "react"
+import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
 import { type BehaviourSegment, useProjectBehaviours } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
 import type {
   BehaviourMomentRangeRecord,
@@ -77,21 +78,20 @@ function BehavioursPageContent() {
       value === "all" || value === "new_this_week" || value === "spiking" || value === "high_escalation",
   })
   const [behaviourPathParam, setBehaviourPathParam] = useParamState("behaviourPath", "", { history: "push" })
-  const [timeFrom, setTimeFrom] = useParamState("behaviourTimeFrom", "")
-  const [timeTo, setTimeTo] = useParamState("behaviourTimeTo", "")
+  const tw = useAnalyticsTimeWindow({ project, fromKey: "behaviourTimeFrom", toKey: "behaviourTimeTo" })
   const [momentMetric, setMomentMetric] = useParamState("behaviourMomentMetric", "")
   const [momentTurnFrom, setMomentTurnFrom] = useParamState("behaviourMomentTurnFrom", "")
   const [momentTurnTo, setMomentTurnTo] = useParamState("behaviourMomentTurnTo", "")
   const [momentTurnMax, setMomentTurnMax] = useParamState("behaviourMomentTurnMax", "")
   const timeRange = useMemo(
     () =>
-      timeFrom || timeTo
-        ? {
-            ...(timeFrom ? { fromIso: timeFrom } : {}),
-            ...(timeTo ? { toIso: timeTo } : {}),
-          }
-        : undefined,
-    [timeFrom, timeTo],
+      tw.isAllTime
+        ? undefined
+        : {
+            ...(tw.listRange.fromIso ? { fromIso: tw.listRange.fromIso } : {}),
+            toIso: tw.listRange.toIso,
+          },
+    [tw.isAllTime, tw.listRange],
   )
   const isDemoProject = project.settings.isSample || isDemoProjectName(project.name)
   const { data, isLoading } = useProjectBehaviours({
@@ -181,12 +181,9 @@ function BehavioursPageContent() {
           behaviourPath={behaviourPath}
           timeFilter={
             <TimeFilterDropdown
-              {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
-              {...(timeTo ? { startTimeTo: timeTo } : {})}
-              onChange={(from, to) => {
-                setTimeFrom(from ?? "")
-                setTimeTo(to ?? "")
-              }}
+              {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+              {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+              onChange={tw.onTimeChange}
             />
           }
           timeRange={timeRange}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-analytics-panel.tsx
@@ -8,6 +8,7 @@ import { buildIncidentMarkers } from "../../../../../../domains/alerts/incident-
 import { useIncidentBucketHoverPopover } from "../../../../../../domains/alerts/use-incident-bucket-hover-popover.ts"
 import { useShowIncidentsOverlay } from "../../../../../../domains/alerts/use-show-incidents-overlay.ts"
 import type { SignalsListResultRecord } from "../../../../../../domains/signals/signals.functions.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
 import { formatHistogramBucketLabel, formatHistogramBucketTooltipLabel } from "./signal-formatters.ts"
 
 const COUNT_CARDS = [
@@ -47,12 +48,14 @@ export function SignalsAnalyticsPanel({
   projectSlug,
   analytics,
   isLoading,
+  isAllTime,
   onRangeSelect,
 }: {
   readonly projectId: string
   readonly projectSlug: string
   readonly analytics: SignalsListResultRecord["analytics"]
   readonly isLoading: boolean
+  readonly isAllTime: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }) {
   const [collapsed, setCollapsed] = useState(false)
@@ -215,26 +218,34 @@ export function SignalsAnalyticsPanel({
           </div>
         ) : (
           <>
-            {incidentsFlagEnabled ? (
-              <div className="flex items-center justify-end gap-2 px-4 -mb-1">
-                <Tooltip
-                  asChild
-                  trigger={
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setShowIncidents((prev) => !prev)}
-                      aria-pressed={showIncidents}
-                    >
-                      <Icon icon={showIncidents ? ShieldAlertIcon : ShieldOffIcon} size="sm" />
-                      Incidents
-                    </Button>
+            <ChartHeader
+              title="Occurrences over time"
+              fromIso={incidentRange?.fromIso ?? ""}
+              toIso={incidentRange?.toIso ?? ""}
+              isAllTime={isAllTime}
+              {...(incidentsFlagEnabled
+                ? {
+                    actions: (
+                      <Tooltip
+                        asChild
+                        trigger={
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setShowIncidents((prev) => !prev)}
+                            aria-pressed={showIncidents}
+                          >
+                            <Icon icon={showIncidents ? ShieldAlertIcon : ShieldOffIcon} size="sm" />
+                            Incidents
+                          </Button>
+                        }
+                      >
+                        Overlay incidents on the timeline
+                      </Tooltip>
+                    ),
                   }
-                >
-                  Overlay incidents on the timeline
-                </Tooltip>
-              </div>
-            ) : null}
+                : {})}
+            />
             <div className="px-4 py-3">
               <BarChart
                 data={histogramBarChartData}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/index.tsx
@@ -15,8 +15,9 @@ import {
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, redirect, useParams } from "@tanstack/react-router"
 import { useProjectFlaggers } from "../../../../../domains/flaggers/flaggers.collection.ts"
-import { defaultProjectTimeWindowSeconds } from "../../../../../domains/projects/default-time-window.ts"
+import { defaultProjectTimeWindowDays } from "../../../../../domains/projects/default-time-window.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
+import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
 
 function SignalsBreadcrumb() {
@@ -147,8 +148,11 @@ function SignalsPage() {
   const [lifecycleGroup, setLifecycleGroup] = useParamState("signalsLifecycle", "active", {
     validate: (value): value is "active" | "archived" => value === "active" || value === "archived",
   })
-  const [timeFrom, setTimeFrom] = useParamState("signalsTimeFrom", "")
-  const [timeTo, setTimeTo] = useParamState("signalsTimeTo", "")
+  const tw = useAnalyticsTimeWindow({
+    project,
+    fromKey: "signalsTimeFrom",
+    toKey: "signalsTimeTo",
+  })
   const [assigneesParam, setAssigneesParam] = useParamState("signalsAssignees", "")
   const [searchQuery, setSearchQuery] = useParamState("signalsSearch", "")
   const [searchInput, setSearchInput] = useValueWithDefault(searchQuery)
@@ -194,18 +198,9 @@ function SignalsPage() {
     [searchInput, searchQuery, setSearchQuery],
   )
 
-  const timeRange = useMemo(() => {
-    const toMs = timeTo ? Date.parse(timeTo) : Date.now()
-    const fromMs = timeFrom ? Date.parse(timeFrom) : toMs - defaultProjectTimeWindowSeconds(project) * 1000
-    return {
-      fromIso: new Date(fromMs).toISOString(),
-      toIso: new Date(toMs).toISOString(),
-    }
-  }, [timeFrom, timeTo, project])
-
   useEffect(() => {
     setFocusedSignalId(undefined)
-  }, [lifecycleGroup, searchQuery, rawSorting, assigneesParam, timeFrom, timeTo])
+  }, [lifecycleGroup, searchQuery, rawSorting, assigneesParam, tw.timeFrom, tw.timeTo])
 
   const assigneeIds = useMemo(() => parseAssignees(assigneesParam), [assigneesParam])
   const setAssigneeIds = useCallback(
@@ -231,7 +226,8 @@ function SignalsPage() {
     sorting,
     ...(assigneeIds.length > 0 ? { assigneeIds } : {}),
     ...(searchQuery ? { searchQuery } : {}),
-    ...(timeRange ? { timeRange } : {}),
+    timeRange: tw.listRange,
+    histogramMaxSpanDays: defaultProjectTimeWindowDays(project),
   })
 
   // While a filter/sort change is in flight we hide the (now stale) previous
@@ -266,7 +262,7 @@ function SignalsPage() {
           },
           ...(assigneeIds.length > 0 ? { assigneeIds: [...assigneeIds] } : {}),
           ...(searchQuery ? { searchQuery } : {}),
-          ...(timeRange ? { timeRange } : {}),
+          timeRange: tw.listRange,
         },
       })
       toast({
@@ -283,7 +279,7 @@ function SignalsPage() {
     } finally {
       setExporting(false)
     }
-  }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
+  }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, tw.listRange])
 
   const handleBulkMute = useCallback(async () => {
     const bulkSelection = selection.bulkSelection
@@ -303,7 +299,7 @@ function SignalsPage() {
           },
           ...(assigneeIds.length > 0 ? { assigneeIds: [...assigneeIds] } : {}),
           ...(searchQuery ? { searchQuery } : {}),
-          ...(timeRange ? { timeRange } : {}),
+          timeRange: tw.listRange,
         },
       })
       const changedCount = result.items.filter((item) => item.changed).length
@@ -327,10 +323,10 @@ function SignalsPage() {
     } finally {
       setBulkActionLoading(false)
     }
-  }, [archived, lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
+  }, [archived, lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, tw.listRange])
 
   const hasActiveFilters =
-    lifecycleGroup !== "active" || searchQuery !== "" || Boolean(timeFrom || timeTo) || assigneeIds.length > 0
+    lifecycleGroup !== "active" || searchQuery !== "" || tw.hasExplicitRange || assigneeIds.length > 0
   // Derived from the un-substituted data so a placeholder reload (which forces
   // `issues` to []) does not falsely trigger the empty state.
   const hasNoSignals = !hasAnySignals && !hasActiveFilters
@@ -372,12 +368,9 @@ function SignalsPage() {
           <Layout.ActionsRow>
             <Layout.ActionRowItem>
               <TimeFilterDropdown
-                startTimeFrom={timeFrom || timeRange.fromIso}
-                {...(timeTo ? { startTimeTo: timeTo } : {})}
-                onChange={(from, to) => {
-                  setTimeFrom(from ?? "")
-                  setTimeTo(to ?? "")
-                }}
+                {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+                {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+                onChange={tw.onTimeChange}
               />
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
@@ -435,10 +428,8 @@ function SignalsPage() {
             projectSlug={project.slug}
             analytics={analytics}
             isLoading={isAnalyticsLoading}
-            onRangeSelect={(range) => {
-              setTimeFrom(range?.from ?? "")
-              setTimeTo(range?.to ?? "")
-            }}
+            isAllTime={tw.isAllTime}
+            onRangeSelect={tw.onBrushSelect}
           />
         </div>
         <SignalsView

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/-components/tools-analytics-panel.tsx
@@ -4,6 +4,7 @@ import { formatCount } from "@repo/utils"
 import { BarChart2, ChevronDown, ChevronUp } from "lucide-react"
 import { useMemo, useState } from "react"
 import type { ToolsAnalyticsRecord } from "../../../../../../domains/tools/tools.functions.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
 import { formatBucketLabel, formatPercent, getToolStatuses } from "./tool-formatters.ts"
 
 const OK_CALLS_COLOR = "hsl(217 91% 60%)"
@@ -44,11 +45,17 @@ export function ToolsAnalyticsPanel({
   analytics,
   histogram,
   bucketSeconds,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
   isLoading,
 }: {
   readonly analytics: ToolsAnalyticsRecord | undefined
   readonly histogram: readonly ToolCallHistogramBucket[]
   readonly bucketSeconds: number
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
   readonly isLoading: boolean
 }) {
   const [collapsed, setCollapsed] = useState(false)
@@ -177,15 +184,18 @@ export function ToolsAnalyticsPanel({
             <Text.H6 color="foregroundMuted">No tool calls in this time window</Text.H6>
           </div>
         ) : (
-          <div className="px-4 py-3">
-            <Chart
-              categories={categories}
-              series={series}
-              height={160}
-              xAxisLabelFontSize={10}
-              ariaLabel="Tool calls over time"
-            />
-          </div>
+          <>
+            <ChartHeader title="Tool calls over time" fromIso={rangeFromIso} toIso={rangeToIso} isAllTime={isAllTime} />
+            <div className="px-4 py-3">
+              <Chart
+                categories={categories}
+                series={series}
+                height={160}
+                xAxisLabelFontSize={10}
+                ariaLabel="Tool calls over time"
+              />
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/tools/index.tsx
@@ -3,8 +3,9 @@ import { createFileRoute } from "@tanstack/react-router"
 import { CircleSlashIcon, LayoutGridIcon, SearchIcon, TriangleAlertIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { allToolsMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
-import { defaultProjectTimeWindowSeconds } from "../../../../../domains/projects/default-time-window.ts"
+import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
 import { useProjectTools, useToolCallHistogram } from "../../../../../domains/tools/tools.collection.ts"
+import { useProjectFirstTraceAt, useProjectLastTraceAt } from "../../../../../domains/traces/traces.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -69,8 +70,15 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/tool
 
 function ToolsPageContent() {
   const project = useRouteProject()
-  const [timeFrom, setTimeFrom] = useParamState("toolsTimeFrom", "")
-  const [timeTo, setTimeTo] = useParamState("toolsTimeTo", "")
+  const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
+  const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
+  const tw = useAnalyticsTimeWindow({
+    project,
+    fromKey: "toolsTimeFrom",
+    toKey: "toolsTimeTo",
+    allTimeLowerBoundIso: firstTraceAt,
+    lastActivityIso: lastTraceAt,
+  })
   const [searchQuery, setSearchQuery] = useParamState("toolsSearch", "")
   const [searchInput, setSearchInput] = useValueWithDefault(searchQuery)
   const [statusTab, setStatusTab] = useParamState("toolsStatus", "all", {
@@ -98,26 +106,30 @@ function ToolsPageContent() {
     [searchInput],
   )
 
-  // Recomputed only when the URL params change, so query keys stay stable
-  // across re-renders.
-  const range = useMemo(() => {
-    const toMs = timeTo ? Date.parse(timeTo) : Date.now()
-    const fromMs = timeFrom ? Date.parse(timeFrom) : toMs - defaultProjectTimeWindowSeconds(project) * 1000
-    return {
-      fromIso: new Date(fromMs).toISOString(),
-      toIso: new Date(toMs).toISOString(),
-    }
-  }, [timeFrom, timeTo, project])
+  // Tools' queries require a concrete lower bound, so "All time" resolves to the project's earliest
+  // activity (falling back to the default window when the project has no traces yet).
+  const range = useMemo(
+    () => ({ fromIso: tw.listRange.fromIso ?? tw.trendRange.fromIso, toIso: tw.listRange.toIso }),
+    [tw.listRange, tw.trendRange],
+  )
   const trendBucketSeconds = useMemo(
     () => pickToolTrendBucketSeconds(Date.parse(range.toIso) - Date.parse(range.fromIso)),
     [range],
+  )
+  // The histogram clamps to the anchored window (≤ project window, latest-activity anchored when All
+  // time) so it stays consistent with the Traces/Users charts and never scans the full history per
+  // bucket; the list/counts above keep the full `range`. Explicit ranges are shown in full.
+  const histogramRange = useMemo(() => (tw.isAllTime ? tw.trendRange : range), [tw.isAllTime, tw.trendRange, range])
+  const histogramBucketSeconds = useMemo(
+    () => pickToolTrendBucketSeconds(Date.parse(histogramRange.toIso) - Date.parse(histogramRange.fromIso)),
+    [histogramRange],
   )
 
   const { data: analytics, isLoading } = useProjectTools({ projectId: project.id, range, trendBucketSeconds })
   const { data: histogram = [], isLoading: histogramLoading } = useToolCallHistogram({
     projectId: project.id,
-    range,
-    bucketSeconds: trendBucketSeconds,
+    range: histogramRange,
+    bucketSeconds: histogramBucketSeconds,
   })
 
   const visibleTools = useMemo(() => {
@@ -139,9 +151,11 @@ function ToolsPageContent() {
 
   useEffect(() => {
     setFocusedToolName(undefined)
-  }, [searchQuery, statusTab, rawSorting, timeFrom, timeTo])
+  }, [searchQuery, statusTab, rawSorting, tw.timeFrom, tw.timeTo])
 
   const hasAnyTools = (analytics?.tools.length ?? 0) > 0
+  // `hasAnyTools` is over the All-time default, so no tools here means the project has never had a
+  // tool call — a robust empty-state signal (not the best-effort `firstTraceAt`).
   const showEmptyState = !isLoading && !hasAnyTools && !searchQuery && statusTab === "all"
   const hasOnlyDefinedTools = !isLoading && hasAnyTools && (analytics?.totals.tracesWithToolCalls ?? 0) === 0
 
@@ -151,12 +165,9 @@ function ToolsPageContent() {
         <Layout.ActionsRow>
           <Layout.ActionRowItem>
             <TimeFilterDropdown
-              startTimeFrom={timeFrom || range.fromIso}
-              startTimeTo={timeTo || undefined}
-              onChange={(from, to) => {
-                setTimeFrom(from ?? "")
-                setTimeTo(to ?? "")
-              }}
+              {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+              {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+              onChange={tw.onTimeChange}
             />
             <Tabs
               variant="bordered"
@@ -213,7 +224,10 @@ function ToolsPageContent() {
             <ToolsAnalyticsPanel
               analytics={analytics}
               histogram={histogram}
-              bucketSeconds={trendBucketSeconds}
+              bucketSeconds={histogramBucketSeconds}
+              rangeFromIso={histogramRange.fromIso}
+              rangeToIso={histogramRange.toIso}
+              isAllTime={tw.isAllTime}
               isLoading={isLoading || histogramLoading}
             />
           </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/-components/users-analytics-panel.tsx
@@ -3,6 +3,7 @@ import { formatCount } from "@repo/utils"
 import { ChevronDown, ChevronUp, UsersRoundIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import type { UsersOverviewRecord } from "../../../../../../domains/end-users/end-users.functions.ts"
+import { ChartHeader } from "../../-components/chart-header.tsx"
 import { formatBucketLabel } from "./user-formatters.ts"
 
 const OK_SESSIONS_COLOR = "hsl(217 91% 60%)"
@@ -50,10 +51,16 @@ function formatCoverage(identified: number, total: number): string {
 export function UsersAnalyticsPanel({
   overview,
   isLoading,
+  rangeFromIso,
+  rangeToIso,
+  isAllTime,
   onRangeSelect,
 }: {
   readonly overview: UsersOverviewRecord | undefined
   readonly isLoading: boolean
+  readonly rangeFromIso: string
+  readonly rangeToIso: string
+  readonly isAllTime: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }) {
   const [collapsed, setCollapsed] = useState(false)
@@ -185,16 +192,24 @@ export function UsersAnalyticsPanel({
             <Text.H6 color="foregroundMuted">No user sessions in this time window</Text.H6>
           </div>
         ) : (
-          <div className="px-4 py-3">
-            <Chart
-              categories={categories}
-              series={series}
-              height={160}
-              xAxisLabelFontSize={10}
-              ariaLabel="User sessions over time"
-              {...(onRangeSelect ? { onSelect: handleSelect } : {})}
+          <>
+            <ChartHeader
+              title="User sessions over time"
+              fromIso={rangeFromIso}
+              toIso={rangeToIso}
+              isAllTime={isAllTime}
             />
-          </div>
+            <div className="px-4 py-3">
+              <Chart
+                categories={categories}
+                series={series}
+                height={160}
+                xAxisLabelFontSize={10}
+                ariaLabel="User sessions over time"
+                {...(onRangeSelect ? { onSelect: handleSelect } : {})}
+              />
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/index.tsx
@@ -4,7 +4,8 @@ import { ExternalLinkIcon, SearchIcon, UsersRoundIcon } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useProjectUsers, useUsersOverview } from "../../../../../domains/end-users/end-users.collection.ts"
 import { allUsersMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
-import { defaultProjectTimeWindowSeconds } from "../../../../../domains/projects/default-time-window.ts"
+import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
+import { useProjectFirstTraceAt, useProjectLastTraceAt } from "../../../../../domains/traces/traces.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useDebounce } from "../../../../../lib/hooks/useDebounce.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -24,6 +25,8 @@ import {
 
 const DEFAULT_SORTING: UsersTableSorting = { column: "lastSeen", direction: "desc" }
 const USER_SEARCH_DEBOUNCE_MS = 300
+// Server caps `trendBucketSeconds` at 31 days; clamp so an all-time span never exceeds it.
+const USER_TREND_BUCKET_MAX_SECONDS = 31 * 24 * 60 * 60
 const SORT_PARAM_PATTERN = /^(lastSeen|firstSeen|sessions|errors|tokens|cost|costAvg|costMedian):(asc|desc)$/
 
 function serializeSorting(sorting: UsersTableSorting): string {
@@ -70,8 +73,15 @@ function UsersEmptyState() {
 
 function UsersPage() {
   const project = useRouteProject()
-  const [timeFrom, setTimeFrom] = useParamState("usersTimeFrom", "")
-  const [timeTo, setTimeTo] = useParamState("usersTimeTo", "")
+  const { firstTraceAt } = useProjectFirstTraceAt({ projectId: project.id })
+  const { lastTraceAt } = useProjectLastTraceAt({ projectId: project.id })
+  const tw = useAnalyticsTimeWindow({
+    project,
+    fromKey: "usersTimeFrom",
+    toKey: "usersTimeTo",
+    allTimeLowerBoundIso: firstTraceAt,
+    lastActivityIso: lastTraceAt,
+  })
   const [searchQuery, setSearchQuery] = useParamState("usersSearch", "")
   const [searchInput, setSearchInput] = useValueWithDefault(searchQuery)
   const [rawSorting, setRawSorting] = useParamState("usersSort", serializeSorting(DEFAULT_SORTING), {
@@ -96,24 +106,24 @@ function UsersPage() {
     columns: USERS_COLUMN_OPTIONS,
   })
 
-  // Recomputed only when the URL params change, so query keys stay stable
-  // across re-renders. Default window comes from `defaultProjectTimeWindowSeconds`.
-  const range = useMemo(() => {
-    const toMs = timeTo ? Date.parse(timeTo) : Date.now()
-    const fromMs = timeFrom ? Date.parse(timeFrom) : toMs - defaultProjectTimeWindowSeconds(project) * 1000
-    return {
-      fromIso: new Date(fromMs).toISOString(),
-      toIso: new Date(toMs).toISOString(),
-    }
-  }, [timeFrom, timeTo, project])
+  // The list uses a concrete range ("All time" → [firstTraceAt, now]); its per-user activity
+  // sparklines are bucketed over it, so the bucket is capped at the server's 31-day max.
+  const range = useMemo(
+    () => ({ fromIso: tw.listRange.fromIso ?? tw.trendRange.fromIso, toIso: tw.listRange.toIso }),
+    [tw.listRange, tw.trendRange],
+  )
   const trendBucketSeconds = useMemo(
-    () => pickUserTrendBucketSeconds(Date.parse(range.toIso) - Date.parse(range.fromIso)),
+    () =>
+      Math.min(
+        pickUserTrendBucketSeconds(Date.parse(range.toIso) - Date.parse(range.fromIso)),
+        USER_TREND_BUCKET_MAX_SECONDS,
+      ),
     [range],
   )
 
   useEffect(() => {
     setFocusedUserId(undefined)
-  }, [searchQuery, rawSorting, timeFrom, timeTo])
+  }, [searchQuery, rawSorting, tw.timeFrom, tw.timeTo])
 
   const {
     data: users,
@@ -130,14 +140,19 @@ function UsersPage() {
     ...(searchQuery ? { searchQuery } : {}),
   })
 
+  // The overview's per-day/hour bucketing would blow up over an all-time span, so All time uses the
+  // clamped, latest-activity-anchored trend range; an explicit/default range is shown as-is.
+  const overviewRange = useMemo(() => (tw.isAllTime ? tw.trendRange : range), [tw.isAllTime, tw.trendRange, range])
   const { data: overview, isLoading: overviewLoading } = useUsersOverview({
     projectId: project.id,
-    timeRange: range,
+    timeRange: overviewRange,
   })
 
   const showSkeletons = isLoading
 
-  const hasActiveFilters = searchQuery !== "" || Boolean(timeFrom || timeTo)
+  const hasActiveFilters = searchQuery !== "" || tw.hasExplicitRange
+  // `totalCount` is over the All-time default, so 0 means the project has no users at all — a robust
+  // empty-state signal (not the best-effort `firstTraceAt`).
   const showEmptyState = !showSkeletons && totalCount === 0 && !hasActiveFilters
 
   if (showEmptyState) {
@@ -157,12 +172,9 @@ function UsersPage() {
           <Layout.ActionsRow>
             <Layout.ActionRowItem>
               <TimeFilterDropdown
-                startTimeFrom={timeFrom || range.fromIso}
-                {...(timeTo ? { startTimeTo: timeTo } : {})}
-                onChange={(from, to) => {
-                  setTimeFrom(from ?? "")
-                  setTimeTo(to ?? "")
-                }}
+                {...(tw.pickerStartFrom ? { startTimeFrom: tw.pickerStartFrom } : {})}
+                {...(tw.pickerStartTo ? { startTimeTo: tw.pickerStartTo } : {})}
+                onChange={tw.onTimeChange}
               />
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
@@ -189,10 +201,10 @@ function UsersPage() {
           <UsersAnalyticsPanel
             overview={overview}
             isLoading={overviewLoading}
-            onRangeSelect={(selected) => {
-              setTimeFrom(selected?.from ?? "")
-              setTimeTo(selected?.to ?? "")
-            }}
+            rangeFromIso={overviewRange.fromIso}
+            rangeToIso={overviewRange.toIso}
+            isAllTime={tw.isAllTime}
+            onRangeSelect={tw.onBrushSelect}
           />
         </div>
         <UsersView

--- a/packages/domain/signals/src/use-cases/list-signals.test.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.test.ts
@@ -715,11 +715,12 @@ describe("listSignalsUseCase", () => {
     expect(result.items[0]?.trend).toHaveLength(14)
     expect(listBySignalIdsCalls).toEqual([[activeSignal.id]])
     expect(histogramInputs[0]?.signalIds).toEqual([activeSignal.id, regressedSignal.id, archivedSignal.id])
-    expect(histogramInputs[0]?.from.toISOString()).toBe("2026-04-04T00:00:00.000Z")
-    expect(histogramInputs[0]?.to.toISOString()).toBe("2026-04-10T23:59:59.999Z")
+    // All-time window anchors to the latest occurrence (2026-04-09), not today (2026-04-10).
+    expect(histogramInputs[0]?.from.toISOString()).toBe("2026-04-03T00:00:00.000Z")
+    expect(histogramInputs[0]?.to.toISOString()).toBe("2026-04-09T23:59:59.999Z")
     expect(trendInputs[0]?.signalIds).toEqual([activeSignal.id])
-    expect(trendInputs[0]?.from.toISOString()).toBe("2026-03-28T00:00:00.000Z")
-    expect(trendInputs[0]?.to.toISOString()).toBe("2026-04-10T23:59:59.999Z")
+    expect(trendInputs[0]?.from.toISOString()).toBe("2026-03-27T00:00:00.000Z")
+    expect(trendInputs[0]?.to.toISOString()).toBe("2026-04-09T23:59:59.999Z")
   })
 
   it("attaches per-issue tag aggregates to the visible page", async () => {
@@ -992,6 +993,73 @@ describe("listSignalsUseCase", () => {
       for (const [index, bucket] of histogram.entries()) {
         expect(Date.parse(bucket.bucket)).toBe(firstMs + index * widthMs)
       }
+    })
+
+    it("anchors the All-time histogram and trend to the latest activity when data predates today", async () => {
+      const now = new Date("2026-04-10T12:00:00.000Z")
+      const issue = makeSignal({ id: SignalId("o".repeat(24)), name: "Old-data issue" })
+      // Latest occurrence is three weeks before today: the window must end here, not at `now`.
+      const latestOccurrence = new Date("2026-03-20T00:00:00.000Z")
+
+      const { repository: signalRepository } = createFakeSignalRepository([issue])
+      const { repository: evaluationRepository } = createEvaluationRepository()
+      const histogramInputs: Array<{ from: Date; to: Date }> = []
+      const trendInputs: Array<{ from: Date; to: Date }> = []
+      const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
+        listSignalWindowMetrics: () =>
+          Effect.succeed([
+            makeWindowMetric({
+              signalId: issue.id,
+              occurrences: 4,
+              firstSeenAt: new Date("2026-03-01T00:00:00.000Z"),
+              lastSeenAt: latestOccurrence,
+            }),
+          ]),
+        aggregateBySignals: aggregateOccurrences([
+          makeOccurrence({
+            signalId: issue.id,
+            totalOccurrences: 4,
+            recentOccurrences: 4,
+            baselineAvgOccurrences: 1,
+            firstSeenAt: new Date("2026-03-01T00:00:00.000Z"),
+            lastSeenAt: latestOccurrence,
+          }),
+        ]),
+        histogramBySignals: ({ timeRange }) =>
+          Effect.sync(() => {
+            histogramInputs.push({ from: timeRange.from ?? new Date(0), to: timeRange.to ?? new Date(0) })
+            return []
+          }),
+        trendBySignals: ({ timeRange }) =>
+          Effect.sync(() => {
+            trendInputs.push({ from: timeRange.from ?? new Date(0), to: timeRange.to ?? new Date(0) })
+            return []
+          }),
+      })
+      createSignalSearch([])
+      sessionCount = 4
+
+      await Effect.runPromise(
+        listSignalsUseCase({ organizationId, projectId, now }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              Layer.succeed(SignalRepository, signalRepository),
+              Layer.succeed(EvaluationRepository, evaluationRepository),
+              Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+              Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+              Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+              provideSessionRepository,
+            ),
+          ),
+        ),
+      )
+
+      // Histogram: last 7 days ending at the latest occurrence (2026-03-20), not today.
+      expect(histogramInputs[0]?.from.toISOString()).toBe("2026-03-14T00:00:00.000Z")
+      expect(histogramInputs[0]?.to.toISOString()).toBe("2026-03-20T23:59:59.999Z")
+      // Trend: 14 days ending at the latest occurrence.
+      expect(trendInputs[0]?.from.toISOString()).toBe("2026-03-07T00:00:00.000Z")
+      expect(trendInputs[0]?.to.toISOString()).toBe("2026-03-20T23:59:59.999Z")
     })
   })
 

--- a/packages/domain/signals/src/use-cases/list-signals.ts
+++ b/packages/domain/signals/src/use-cases/list-signals.ts
@@ -84,6 +84,13 @@ const listSignalsInputSchema = z.object({
     }),
   limit: z.number().int().min(1).max(200).default(50),
   offset: z.number().int().min(0).default(0),
+  /**
+   * Max span (days) of the All-time occurrences histogram, anchored to the latest activity so a
+   * bounded, latest-activity window is charted instead of an unbounded per-bucket scan. Defaults to
+   * the legacy 6-day window; the web app passes the project's default time window (30d / 14d showcase)
+   * to keep it consistent with the Traces/Tools/Users charts. Explicit ranges are always shown in full.
+   */
+  histogramMaxSpanDays: z.number().int().positive().default(6),
   includeAnalytics: z.boolean().default(true),
   includeItems: z.boolean().default(true),
   now: z.date().optional(),
@@ -175,9 +182,26 @@ const toUtcDayStart = (value: Date): Date =>
 const toUtcDayEnd = (value: Date): Date =>
   new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 23, 59, 59, 999))
 
+/**
+ * End of the default (All-time) chart window. Anchored to the latest activity so the histogram/trend
+ * shows the most recent real data instead of a blank "last N days from now" when a project's activity
+ * predates today. Capped at the upper bound (a user-selected `to`, else `now`) so it never runs past
+ * the selected/current time, and falls back to that cap when there is no activity to anchor to.
+ */
+const resolveAnchoredWindowEnd = (input: {
+  readonly to: Date | undefined
+  readonly now: Date
+  readonly latestActivityAt: Date | undefined
+}): Date => {
+  const cap = input.to ?? input.now
+  return input.latestActivityAt && input.latestActivityAt.getTime() < cap.getTime() ? input.latestActivityAt : cap
+}
+
 const resolveHistogramTimeRange = (input: {
   readonly timeRange: z.infer<typeof signalsTimeRangeSchema> | undefined
   readonly now: Date
+  readonly latestActivityAt?: Date
+  readonly maxSpanDays: number
 }): { readonly from: Date; readonly to: Date } => {
   if (input.timeRange?.from && input.timeRange?.to) {
     return {
@@ -193,9 +217,11 @@ const resolveHistogramTimeRange = (input: {
     }
   }
 
-  const end = toUtcDayEnd(input.timeRange?.to ?? input.now)
+  const end = toUtcDayEnd(
+    resolveAnchoredWindowEnd({ to: input.timeRange?.to, now: input.now, latestActivityAt: input.latestActivityAt }),
+  )
   const start = new Date(end)
-  start.setUTCDate(start.getUTCDate() - 6)
+  start.setUTCDate(start.getUTCDate() - input.maxSpanDays)
   start.setUTCHours(0, 0, 0, 0)
 
   return {
@@ -207,8 +233,13 @@ const resolveHistogramTimeRange = (input: {
 const resolveTrendTimeRange = (input: {
   readonly timeRange: z.infer<typeof signalsTimeRangeSchema> | undefined
   readonly now: Date
+  readonly latestActivityAt?: Date
 }): { readonly from: Date; readonly to: Date } => {
-  const end = toUtcDayEnd(input.timeRange?.to ?? input.timeRange?.from ?? input.now)
+  const end = toUtcDayEnd(
+    input.timeRange?.from
+      ? (input.timeRange.to ?? input.timeRange.from)
+      : resolveAnchoredWindowEnd({ to: input.timeRange?.to, now: input.now, latestActivityAt: input.latestActivityAt }),
+  )
   const start = new Date(end)
   start.setUTCDate(start.getUTCDate() - 13)
   start.setUTCHours(0, 0, 0, 0)
@@ -517,6 +548,7 @@ export const listSignalsUseCase = (
         const histogramTimeRange = resolveHistogramTimeRange({
           timeRange: parsed.timeRange,
           now,
+          maxSpanDays: parsed.histogramMaxSpanDays,
         })
         const histogramBucketSeconds = pickTraceHistogramBucketSeconds(
           histogramTimeRange.from.getTime(),
@@ -557,6 +589,7 @@ export const listSignalsUseCase = (
       const histogramTimeRange = resolveHistogramTimeRange({
         timeRange: parsed.timeRange,
         now,
+        maxSpanDays: parsed.histogramMaxSpanDays,
       })
       const histogramBucketSeconds = pickTraceHistogramBucketSeconds(
         histogramTimeRange.from.getTime(),
@@ -698,6 +731,12 @@ export const listSignalsUseCase = (
     ])
 
     const windowMetricsBySignalId = new Map(windowMetrics.map((metric) => [metric.signalId, metric] as const))
+    // Latest occurrence across the (list-window) metrics — anchors the All-time histogram/trend so
+    // they chart the most recent real activity instead of a blank "last N days from now".
+    const latestActivityAt = windowMetrics.reduce<Date | undefined>(
+      (latest, metric) => (!latest || metric.lastSeenAt.getTime() > latest.getTime() ? metric.lastSeenAt : latest),
+      undefined,
+    )
     const createdInWindowSet = new Set<SignalId>(createdInWindowIds)
     // A created-in-window signal still has to match an active search, so it
     // only joins the candidate set through the search hits — never as a bare id.
@@ -716,6 +755,8 @@ export const listSignalsUseCase = (
     const histogramTimeRange = resolveHistogramTimeRange({
       timeRange: parsed.timeRange,
       now,
+      maxSpanDays: parsed.histogramMaxSpanDays,
+      ...(latestActivityAt ? { latestActivityAt } : {}),
     })
     // Pick a "nice" bucket width adaptively so a 6-day default window lands at ~3h–4h bars while
     // longer user-selected ranges step up to 6h, 12h, 1d, etc. Same helper the Traces histogram
@@ -828,6 +869,7 @@ export const listSignalsUseCase = (
     const trendTimeRange = resolveTrendTimeRange({
       timeRange: parsed.timeRange,
       now,
+      ...(latestActivityAt ? { latestActivityAt } : {}),
     })
     const trendScaffold = buildBucketScaffold(trendTimeRange)
     const tagsTimeRange = resolveTagsTimeRange({ timeRange: selectedTimeRange, now })

--- a/packages/domain/spans/src/helpers.test.ts
+++ b/packages/domain/spans/src/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,
   pickTraceHistogramBucketSeconds,
+  resolveTraceHistogramRangeIso,
 } from "./helpers.ts"
 import { emptyTraceTimeHistogramBucket } from "./ports/trace-repository.ts"
 
@@ -12,6 +13,87 @@ describe("alignUnixSecondsToHistogramBucket", () => {
     const t = Date.UTC(2024, 5, 1, 10, 0, 0) / 1000
     expect(alignUnixSecondsToHistogramBucket(t + 90, bs)).toBe(t)
     expect(alignUnixSecondsToHistogramBucket(t, bs)).toBe(t)
+  })
+})
+
+describe("resolveTraceHistogramRangeIso", () => {
+  const DAY = 24 * 60 * 60 * 1000
+  const now = Date.UTC(2026, 6, 9, 12, 0, 0)
+  const iso = (ms: number) => new Date(ms).toISOString()
+
+  it("unbounded ('All time'): last 7 days ending now", () => {
+    const r = resolveTraceHistogramRangeIso({}, now)
+    expect(r).toEqual({ rangeStartIso: iso(now - 7 * DAY), rangeEndIso: iso(now) })
+  })
+
+  it("empty startTime array (cleared to All time): same as unbounded", () => {
+    const r = resolveTraceHistogramRangeIso({ startTime: [] }, now)
+    expect(r).toEqual({ rangeStartIso: iso(now - 7 * DAY), rangeEndIso: iso(now) })
+  })
+
+  it("range ≤ 30 days is used verbatim", () => {
+    const gte = iso(now - 10 * DAY)
+    const lte = iso(now - 3 * DAY)
+    const r = resolveTraceHistogramRangeIso(
+      {
+        startTime: [
+          { op: "gte", value: gte },
+          { op: "lte", value: lte },
+        ],
+      },
+      now,
+    )
+    expect(r).toEqual({ rangeStartIso: gte, rangeEndIso: lte })
+  })
+
+  it("clamps a > 30 day range to the most recent 30 days of it", () => {
+    const gte = iso(now - 90 * DAY)
+    const lte = iso(now - 5 * DAY)
+    const r = resolveTraceHistogramRangeIso(
+      {
+        startTime: [
+          { op: "gte", value: gte },
+          { op: "lte", value: lte },
+        ],
+      },
+      now,
+    )
+    expect(r).toEqual({ rangeStartIso: iso(now - 35 * DAY), rangeEndIso: lte })
+  })
+
+  it("open-ended gte older than 30 days clamps to last 30 days ending now", () => {
+    const gte = iso(now - 90 * DAY)
+    const r = resolveTraceHistogramRangeIso({ startTime: [{ op: "gte", value: gte }] }, now)
+    expect(r).toEqual({ rangeStartIso: iso(now - 30 * DAY), rangeEndIso: iso(now) })
+  })
+
+  it("falls back safely on unparseable URL dates instead of throwing", () => {
+    const r = resolveTraceHistogramRangeIso(
+      {
+        startTime: [
+          { op: "gte", value: "not-a-date" },
+          { op: "lte", value: "also-bad" },
+        ],
+      },
+      now,
+    )
+    // Bad `lte` → end = now; bad `gte` → start = end - 7d default. Both valid ISO, no RangeError.
+    expect(r).toEqual({ rangeStartIso: iso(now - 7 * DAY), rangeEndIso: iso(now) })
+  })
+
+  it("clamps start ≤ end when the range is inverted (gte after lte)", () => {
+    const gte = iso(now - 2 * DAY)
+    const lte = iso(now - 5 * DAY)
+    const r = resolveTraceHistogramRangeIso(
+      {
+        startTime: [
+          { op: "gte", value: gte },
+          { op: "lte", value: lte },
+        ],
+      },
+      now,
+    )
+    expect(r).toEqual({ rangeStartIso: lte, rangeEndIso: lte })
   })
 })
 

--- a/packages/domain/spans/src/helpers.ts
+++ b/packages/domain/spans/src/helpers.ts
@@ -4,6 +4,13 @@ import { emptyTraceTimeHistogramBucket, type TraceTimeHistogramBucket } from "./
 
 const DEFAULT_RANGE_MS = 7 * 24 * 60 * 60 * 1000
 
+/**
+ * Hard cap on the histogram's time span. The list and aggregations honor an unbounded
+ * ("All time") selection, but the histogram is a per-bucket scan whose cost grows with
+ * the span, so it never charts more than this window — anchored to the selection's end.
+ */
+const MAX_HISTOGRAM_SPAN_MS = 30 * 24 * 60 * 60 * 1000
+
 /** Rough target bar count; actual count depends on the chosen nice bucket width. */
 const TARGET_HISTOGRAM_BUCKET_COUNT = 50
 
@@ -59,39 +66,27 @@ export function parseStartTimeBoundsFromFilters(filters: FilterSet): { gte?: str
 }
 
 /**
- * Resolves the histogram time window (ISO strings, UTC).
- * When no `startTime` filter exists, uses the last 7 days ending at `nowMs`.
- * When only `lte` is set, uses a 7-day window ending at `lte`.
+ * Resolves the histogram time window (ISO strings, UTC), anchored to the selection's end.
+ * When no `startTime` `gte` is set (unbounded / "All time"), starts {@link DEFAULT_RANGE_MS}
+ * before the end. The span is always clamped to {@link MAX_HISTOGRAM_SPAN_MS} so an unbounded
+ * or very wide list selection never turns into an unbounded per-bucket scan.
  */
 export function resolveTraceHistogramRangeIso(
   filters: FilterSet,
   nowMs: number,
 ): { readonly rangeStartIso: string; readonly rangeEndIso: string } {
   const { gte, lte } = parseStartTimeBoundsFromFilters(filters)
-  const nowIso = new Date(nowMs).toISOString()
+  // Bounds come from the URL and may be unparseable (hand-crafted); fall back to the defaults so
+  // `new Date(NaN).toISOString()` can never throw. Clamp start ≤ end for a safe (degenerate) window.
+  const parsedEndMs = lte ? new Date(lte).getTime() : nowMs
+  const endMs = Number.isFinite(parsedEndMs) ? parsedEndMs : nowMs
+  const parsedStartMs = gte ? new Date(gte).getTime() : endMs - DEFAULT_RANGE_MS
+  const desiredStartMs = Number.isFinite(parsedStartMs) ? parsedStartMs : endMs - DEFAULT_RANGE_MS
+  const startMs = Math.min(Math.max(desiredStartMs, endMs - MAX_HISTOGRAM_SPAN_MS), endMs)
 
-  if (!gte && !lte) {
-    return {
-      rangeStartIso: new Date(nowMs - DEFAULT_RANGE_MS).toISOString(),
-      rangeEndIso: nowIso,
-    }
-  }
-  if (gte && lte) {
-    return { rangeStartIso: gte, rangeEndIso: lte }
-  }
-  if (gte) {
-    return { rangeStartIso: gte, rangeEndIso: nowIso }
-  }
-  if (lte) {
-    const lteMs = new Date(lte).getTime()
-    return {
-      rangeStartIso: new Date(lteMs - DEFAULT_RANGE_MS).toISOString(),
-      rangeEndIso: lte,
-    }
-  }
   return {
-    rangeStartIso: new Date(nowMs - DEFAULT_RANGE_MS).toISOString(),
-    rangeEndIso: nowIso,
+    rangeStartIso: new Date(startMs).toISOString(),
+    rangeEndIso: new Date(endMs).toISOString(),
   }
 }
 

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -51,6 +51,12 @@ export interface TraceRepositoryShape {
     readonly searchQuery?: string
   }): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
 
+  /** Earliest `start_time` across all of a project's traces (unfiltered) — the "All time" lower bound. */
+  findFirstTraceAt(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+  }): Effect.Effect<Date | null, RepositoryError, ChSqlClient>
+
   /**
    * Count of traces matching the same filter + search semantics as `countByProjectId` that have at
    * least one `source = 'annotation'` score linked. The shared `searchQuery` path requires AI

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -17,6 +17,7 @@ export const createFakeTraceRepository = (overrides?: Partial<TraceRepositorySha
     listByProjectId: () => Effect.succeed({ items: [], hasMore: false }),
     countByProjectId: () => Effect.succeed(0),
     findLastTraceAt: () => Effect.succeed(null),
+    findFirstTraceAt: () => Effect.succeed(null),
     countAnnotatedByProjectId: () => Effect.succeed(0),
     aggregateMetricsByProjectId: () => Effect.succeed(emptyTraceMetrics()),
     histogramByProjectId: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -1101,6 +1101,45 @@ export const TraceRepositoryLive = Layer.effect(
           const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
           const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
 
+          const mapLastAt = (rows: ReadonlyArray<{ last_at: string | null }>) => {
+            const raw = rows[0]?.last_at ?? null
+            if (!raw) return null
+            const parsedDate = new Date(raw.includes(" ") ? `${raw.replace(" ", "T")}Z` : raw)
+            return Number.isNaN(parsedDate.getTime()) ? null : parsedDate
+          }
+
+          const parsedSearch = searchQuery ? parseSearchQuery(searchQuery) : undefined
+          const hasSearch = Boolean(parsedSearch && isActiveSearch(parsedSearch))
+
+          // Fast path — no filters, no search (the dominant All-time histogram-anchor call). A trace's
+          // `start_time` is `min(min_start_time)`, so the latest trace start is `max` over a minimal
+          // grouped subquery. Avoids projecting the full, expensive `LIST_SELECT` per trace.
+          if (havingClauses.length === 0 && whereClauses.length === 0 && !hasSearch) {
+            return yield* chSqlClient
+              .query(async (client) => {
+                const result = await client.query({
+                  query: `SELECT toString(maxOrNull(trace_start)) AS last_at
+                          FROM (
+                            SELECT min(min_start_time) AS trace_start
+                            FROM traces
+                            WHERE organization_id = {organizationId:String}
+                              AND project_id = {projectId:String}
+                            GROUP BY organization_id, project_id, trace_id
+                          )`,
+                  query_params: {
+                    organizationId: organizationId as string,
+                    projectId: projectId as string,
+                  },
+                  format: "JSONEachRow",
+                })
+                return result.json<{ last_at: string | null }>()
+              })
+              .pipe(
+                Effect.map(mapLastAt),
+                Effect.mapError((error) => toRepositoryError(error, "findLastTraceAt")),
+              )
+          }
+
           const runQuery = (
             extraJoinCondition: string,
             extraParams: Record<string, unknown>,
@@ -1109,7 +1148,7 @@ export const TraceRepositoryLive = Layer.effect(
             chSqlClient
               .query(async (client) => {
                 const result = await client.query({
-                  query: `SELECT toString(max(start_time)) AS last_at
+                  query: `SELECT toString(maxOrNull(start_time)) AS last_at
                         FROM (
                           SELECT ${LIST_SELECT}
                           FROM traces
@@ -1132,18 +1171,12 @@ export const TraceRepositoryLive = Layer.effect(
                 return result.json<{ last_at: string | null }>()
               })
               .pipe(
-                Effect.map((rows) => {
-                  const raw = rows[0]?.last_at ?? null
-                  if (!raw) return null
-                  const parsed = new Date(raw.includes(" ") ? `${raw.replace(" ", "T")}Z` : raw)
-                  return Number.isNaN(parsed.getTime()) ? null : parsed
-                }),
+                Effect.map(mapLastAt),
                 Effect.mapError((error) => toRepositoryError(error, "findLastTraceAt")),
               )
 
-          const parsed = searchQuery ? parseSearchQuery(searchQuery) : undefined
-          if (parsed && isActiveSearch(parsed)) {
-            const plan = yield* planSearch(parsed)
+          if (parsedSearch && isActiveSearch(parsedSearch)) {
+            const plan = yield* planSearch(parsedSearch)
             return yield* runQuery(
               `AND trace_id IN (SELECT trace_id FROM (${plan.subquery}))`,
               plan.params,
@@ -1152,6 +1185,38 @@ export const TraceRepositoryLive = Layer.effect(
           }
 
           return yield* runQuery("", {})
+        }),
+
+      // Earliest activity is the global min of the raw start column — no per-trace GROUP BY or
+      // LIST_SELECT needed (min-of-per-trace-min == global min). `minOrNull` yields null (not epoch)
+      // for a project with no rows.
+      findFirstTraceAt: ({ organizationId, projectId }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT toString(minOrNull(min_start_time)) AS first_at
+                        FROM traces
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<{ first_at: string | null }>()
+            })
+            .pipe(
+              Effect.map((rows) => {
+                const raw = rows[0]?.first_at ?? null
+                if (!raw) return null
+                const parsed = new Date(raw.includes(" ") ? `${raw.replace(" ", "T")}Z` : raw)
+                return Number.isNaN(parsed.getTime()) ? null : parsed
+              }),
+              Effect.mapError((error) => toRepositoryError(error, "findFirstTraceAt")),
+            )
         }),
 
       countAnnotatedByProjectId: ({ organizationId, projectId, filters, searchQuery }) =>

--- a/packages/utils/src/format.test.ts
+++ b/packages/utils/src/format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   cacheHitRate,
   formatBytes,
+  formatChartWindowCaption,
   formatCount,
   formatDuration,
   formatPercentage,
@@ -10,6 +11,29 @@ import {
   normalizeCHString,
   parseCHDate,
 } from "./format.ts"
+
+describe("formatChartWindowCaption", () => {
+  it("omits the start year when both ends share a year and always shows the end year", () => {
+    // Midday UTC keeps the calendar day stable across the runner's timezone.
+    const result = formatChartWindowCaption("2026-06-25T12:00:00.000Z", "2026-07-01T12:00:00.000Z")
+    expect(result).toContain("–")
+    expect(result).toMatch(/, 2026$/)
+    const [start] = result.split(" – ")
+    expect(start).not.toContain("2026")
+  })
+
+  it("shows both years when the window crosses a year boundary", () => {
+    const result = formatChartWindowCaption("2025-12-28T12:00:00.000Z", "2026-01-03T12:00:00.000Z")
+    const [start, end] = result.split(" – ")
+    expect(start).toContain("2025")
+    expect(end).toContain("2026")
+  })
+
+  it("returns an empty string for unparseable input", () => {
+    expect(formatChartWindowCaption("nope", "2026-07-01T00:00:00.000Z")).toBe("")
+    expect(formatChartWindowCaption("2026-07-01T00:00:00.000Z", "")).toBe("")
+  })
+})
 
 describe("formatBytes", () => {
   it("formats whole bytes without decimals", () => {

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -250,3 +250,23 @@ export function safeStringifyJson(value: unknown, fallback = ""): string {
 export function stableStringify(value: unknown): string {
   return stringify(value)
 }
+
+/**
+ * Human caption for a chart's rendered time window, e.g. `"Jun 25 – Jul 1, 2026"`. Shown under
+ * histograms so a bounded window (e.g. the All-time charts, which render a recent slice anchored to
+ * the latest activity) reads clearly instead of being mistaken for the full selected scope. The year
+ * is omitted from the start when both ends fall in the same year. Returns `""` for unparseable input.
+ */
+export function formatChartWindowCaption(fromIso: string, toIso: string): string {
+  const from = new Date(fromIso)
+  const to = new Date(toIso)
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return ""
+  const sameYear = from.getFullYear() === to.getFullYear()
+  const fromLabel = from.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    ...(sameYear ? {} : { year: "numeric" }),
+  })
+  const toLabel = to.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+  return `${fromLabel} – ${toLabel}`
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
 export {
   cacheHitRate,
   formatBytes,
+  formatChartWindowCaption,
   formatCount,
   formatDuration,
   formatPercentage,


### PR DESCRIPTION
## Problem

The date range picker defaulted to a hidden **"Last month" (30-day) window**, which was the root of a cluster of bugs across every time-filtered screen (Sessions, Traces, Tools, Signals, Users):

- **"Clear dates" did nothing** — clearing dropped back to the re-injected default, so there was no way to reach "All time".
- **False onboarding / empty states** — a project whose data predates 30 days read as empty and showed "Waiting for your first trace" (or "no tools / no users"), hiding the time filter needed to widen the range.

## Approach: default to "All time"

Rather than paper over the hidden window with sentinels + auto-widen, this **removes the default window** — the default is now **All time** on all five screens. That collapses the whole problem:

- A picked range lives in the URL; **clearing simply returns to All time** (no sentinel, no re-injection).
- Nothing is hidden by age, so **empty states gate on real all-time data**, not a window.
- No auto-widen / count-probe / latch machinery needed.

The one cost of All-time-by-default — unbounded scans — is contained: the **list is paginated**, `count()` is cheap, and the **histogram/trend is clamped to ≤30 days anchored to the latest activity**, so it never becomes an unbounded per-bucket scan.

## Robust empty-state signal (no `project.firstTraceAt`)

`project.first_trace_at` is **best-effort** (a worker sets it on first ingest) and is `null` on many projects that do have data — it broke the earlier quick fix (#3961) in production. This PR does **not** rely on it for any gating:

- **Onboarding / empty states** gate on the **all-time count** (`totalTraceCount === 0`, `hasAnyTools`, `totalCount === 0`) — which under the All-time default reflects real data. Signals already used the time-independent `hasAnySignals`.
- **Tools/Users** need a concrete lower bound for "All time" (their endpoints require one); it's derived from ClickHouse **`min(start_time)`** via a new lean `getProjectFirstTraceAt` (no `LIST_SELECT`/`GROUP BY`), not the flag. Sessions/Traces/Signals go truly unbounded.

## What's in the PR

- **Sessions/Traces** (`useProjectTimeWindow`): default All time; clear → All time; onboarding on all-time count; histogram clamped + anchored to latest activity (new `getProjectLastTraceAt` = `max(start_time)`).
- **Tools/Signals/Users** (shared `useAnalyticsTimeWindow`): default All time; clear → All time; empty-states on all-time counts; trend clamped + anchored; Tools/Users use `getProjectFirstTraceAt` as the concrete All-time lower bound.
- **Thin ClickHouse reads**: `findFirstTraceAt` / `findLastTraceAt` exposed as web server fns (no public API/SDK surface).
- Behaviours is unchanged — it already had no default window.

Supersedes the quick fix **#3961** (onboarding gate, shipped in v0.3.45) — this removes its `firstTraceAt` dependency and extends the fix to all five screens.

## Tests

- `use-project-time-window.test.ts` (Sessions/Traces) + `use-analytics-time-window.test.ts` (Tools/Signals/Users) — pure helpers for range resolution, All-time detection, the clamp/anchor, and the clear/brush handlers.
- `helpers.test.ts` — the shared histogram span clamp.
- Typecheck (web + spans + db-clickhouse), all hook suites + the 876-case spans suite, knip, and Biome are clean.

## QA

The QA fixture from #3961 is in `main`: **`/projects/old-traces-qa`** — a project whose spans are all 45→31 days old (nothing in the last 30 days), from `pnpm seed`.

- **Sessions / Traces / Tools / Users** → open `/projects/old-traces-qa`: default is All time, so the old data shows immediately; the histogram/trend charts the last ~30 days of actual activity (not a blank "last 30 days from now"). Clearing dates stays on All time; picking a range then clearing returns to All time.
- **Signals** → open the **default project** (`/projects/default-project`): its ~128 signals all show under All time. (The QA fixture has no signals — spans only.)
- **Empty project** (a genuinely new one) → still shows the "Waiting for your first trace" onboarding.
- Robustness spot-check: a project with data but `first_trace_at = null` must **not** show onboarding and must show all its data under All time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
