### PR TITLE
fix(traces): show the normal view (not onboarding) when a project has only old traces

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -454,9 +454,15 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     },
   ])
 
+  // Only show the "Waiting for your first trace" onboarding when the project has *never* received a
+  // trace. A project that has traces but none in the current time window falls through to the normal
+  // view (which keeps the time-filter dropdown) so the user can widen the range instead of seeing a
+  // false onboarding screen.
+  const projectNeverReceivedTraces = currentProject.firstTraceAt == null
   const hasNoTraces = totalTraceCount === 0 && !hasActiveFilters && !hasSearchQuery
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
-  const showConnectEmptyState = !hasActiveFilters && !hasSearchQuery && (isTracesCountLoading || hasNoTraces)
+  const showConnectEmptyState =
+    projectNeverReceivedTraces && !hasActiveFilters && !hasSearchQuery && (isTracesCountLoading || hasNoTraces)
 
   if (showConnectEmptyState) {
     return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -454,15 +454,15 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     },
   ])
 
-  // Only show the "Waiting for your first trace" onboarding when the project has *never* received a
-  // trace. A project that has traces but none in the current time window falls through to the normal
-  // view (which keeps the time-filter dropdown) so the user can widen the range instead of seeing a
-  // false onboarding screen.
+  // Gate on whether the project ever received a trace, not the windowed count — old-data projects
+  // fall through to the normal view (with the time filter) instead of the false onboarding.
   const projectNeverReceivedTraces = currentProject.firstTraceAt == null
-  const hasNoTraces = totalTraceCount === 0 && !hasActiveFilters && !hasSearchQuery
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
   const showConnectEmptyState =
-    projectNeverReceivedTraces && !hasActiveFilters && !hasSearchQuery && (isTracesCountLoading || hasNoTraces)
+    projectNeverReceivedTraces &&
+    !hasActiveFilters &&
+    !hasSearchQuery &&
+    (isTracesCountLoading || totalTraceCount === 0)
 
   if (showConnectEmptyState) {
     return (

--- a/packages/domain/shared/src/seeds.ts
+++ b/packages/domain/shared/src/seeds.ts
@@ -285,6 +285,15 @@ export const SEED_OWNER_EMAIL = "owner@acme.com"
 export const SEED_ADMIN_EMAIL = "admin@acme.com"
 export const SEED_PROJECT_NAME = "Support Agent"
 export const SEED_PROJECT_SLUG = "default-project"
+
+// QA fixture: a project whose traces are ALL older than the 30-day default window, so it has
+// `first_trace_at` set but zero recent spans — the exact shape that used to trip the "Waiting for
+// your first trace" onboarding. Seed it (`pnpm seed`) and open `/projects/old-traces-qa`.
+export const SEED_OLD_TRACES_QA_PROJECT_ID = ProjectId("oldtracesqaproject000001")
+export const SEED_OLD_TRACES_QA_PROJECT_NAME = "Old traces (QA)"
+export const SEED_OLD_TRACES_QA_PROJECT_SLUG = "old-traces-qa"
+export const SEED_OLD_TRACES_QA_FROM_DAYS_AGO = 45
+export const SEED_OLD_TRACES_QA_TO_DAYS_AGO = 31
 export const SEED_API_KEY_TOKEN = "lat_seed_default_api_key_token"
 
 // Dogfood projects — one per internal AI feature, mirroring

--- a/packages/platform/db-clickhouse/src/seeds/run.ts
+++ b/packages/platform/db-clickhouse/src/seeds/run.ts
@@ -7,6 +7,7 @@ import { Effect } from "effect"
 import { closeClickhouse, createClickhouseClient } from "../client.ts"
 import { allSeeders } from "./all.ts"
 import { runSeeders } from "./runner.ts"
+import { oldTracesQaSeeder } from "./spans/index.ts"
 import { truncateDataTables } from "./truncate-data-tables.ts"
 
 const nodeEnv = Effect.runSync(parseEnv("NODE_ENV", "string", "development"))
@@ -44,7 +45,9 @@ const main = async () => {
           console.log("- truncating all data tables")
           yield* truncateDataTables(client)
         }
-        yield* runSeeders(allSeeders, { client, scope: bootstrapSeedScope })
+        // `oldTracesQaSeeder` is bootstrap-only (kept out of `allSeeders` so it never runs during
+        // runtime demo-project creation, which reuses `allSeeders`).
+        yield* runSeeders([...allSeeders, oldTracesQaSeeder], { client, scope: bootstrapSeedScope })
       }),
     )
     console.log("Seed complete.")

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -62,10 +62,8 @@ export const runSpansSeed = (
     return traceIds
   })
 
-// QA fixture: spans for the `old-traces-qa` project, all older than the 30-day default window, so
-// the project has data but nothing recent. Idempotent — no-ops if the project already has spans.
-// Bootstrap-only (wired into `ch:seed`'s run.ts, NOT `spanSeeders`/`allSeeders`) so it never runs
-// during runtime demo-project creation and stays out of the `spanTraceSlots` demo catalog.
+// QA fixture: idempotent spans for `old-traces-qa`, all older than the 30-day window. Bootstrap-only —
+// kept out of spanSeeders/allSeeders so it never runs during demo-project creation or the spanTraceSlots catalog.
 export const oldTracesQaSeeder: Seeder = {
   name: "spans/old-traces-qa",
   run: (ctx: SeedContext) =>

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -64,7 +64,9 @@ export const runSpansSeed = (
 
 // QA fixture: spans for the `old-traces-qa` project, all older than the 30-day default window, so
 // the project has data but nothing recent. Idempotent — no-ops if the project already has spans.
-const oldTracesQaSeeder: Seeder = {
+// Bootstrap-only (wired into `ch:seed`'s run.ts, NOT `spanSeeders`/`allSeeders`) so it never runs
+// during runtime demo-project creation and stays out of the `spanTraceSlots` demo catalog.
+export const oldTracesQaSeeder: Seeder = {
   name: "spans/old-traces-qa",
   run: (ctx: SeedContext) =>
     Effect.gen(function* () {
@@ -90,7 +92,7 @@ const oldTracesQaSeeder: Seeder = {
     }),
 }
 
-export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders, oldTracesQaSeeder]
+export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders]
 
 /**
  * Catalog of every deterministic trace the demo seed writes, as

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -1,10 +1,22 @@
-import { type SeedScope, TraceId } from "@domain/shared/seeding"
+import {
+  SEED_API_KEY_ID,
+  SEED_OLD_TRACES_QA_FROM_DAYS_AGO,
+  SEED_OLD_TRACES_QA_PROJECT_ID,
+  SEED_OLD_TRACES_QA_TO_DAYS_AGO,
+  SEED_ORG_ID,
+  type SeedScope,
+  TraceId,
+} from "@domain/shared/seeding"
 import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
+import { isSentinelPresent } from "../idempotency.ts"
 import type { SeedContext, Seeder, TraceSlot } from "../types.ts"
 import { fixedTraceSeeders, fixedTraceSlots } from "./fixed-traces.ts"
 import { generateAllSpans, type SpanRow, type TraceConfig } from "./generator.ts"
 import { orphanFragmentSeeders, orphanFragmentTraceSlots } from "./orphan-fragments.ts"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const OLD_TRACES_QA_TRACE_COUNT = 150
 
 const TRACE_COUNT = 2000
 const BATCH_SIZE = 500
@@ -50,7 +62,35 @@ export const runSpansSeed = (
     return traceIds
   })
 
-export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders]
+// QA fixture: spans for the `old-traces-qa` project, all older than the 30-day default window, so
+// the project has data but nothing recent. Idempotent — no-ops if the project already has spans.
+const oldTracesQaSeeder: Seeder = {
+  name: "spans/old-traces-qa",
+  run: (ctx: SeedContext) =>
+    Effect.gen(function* () {
+      const alreadySeeded = yield* isSentinelPresent(ctx.client, "spans", "project_id = {projectId:String}", {
+        projectId: SEED_OLD_TRACES_QA_PROJECT_ID,
+      })
+      if (alreadySeeded) {
+        if (!ctx.quiet) console.log("  -> spans/old-traces-qa: already seeded, skipping")
+        return
+      }
+      const now = Date.now()
+      yield* runSpansSeed(ctx, {
+        organizationId: SEED_ORG_ID,
+        projectId: SEED_OLD_TRACES_QA_PROJECT_ID,
+        apiKeyId: SEED_API_KEY_ID,
+        traceCount: OLD_TRACES_QA_TRACE_COUNT,
+        timeWindow: {
+          from: new Date(now - SEED_OLD_TRACES_QA_FROM_DAYS_AGO * DAY_MS),
+          to: new Date(now - SEED_OLD_TRACES_QA_TO_DAYS_AGO * DAY_MS),
+        },
+        quiet: ctx.quiet ?? false,
+      })
+    }),
+}
+
+export const spanSeeders: Seeder[] = [...fixedTraceSeeders, ...orphanFragmentSeeders, oldTracesQaSeeder]
 
 /**
  * Catalog of every deterministic trace the demo seed writes, as

--- a/packages/platform/db-postgres/src/seeds/projects/index.ts
+++ b/packages/platform/db-postgres/src/seeds/projects/index.ts
@@ -22,6 +22,10 @@ import {
   SEED_LATITUDE_TAXONOMY_PROJECT_ID,
   SEED_LATITUDE_TAXONOMY_PROJECT_NAME,
   SEED_LATITUDE_TAXONOMY_PROJECT_SLUG,
+  SEED_OLD_TRACES_QA_FROM_DAYS_AGO,
+  SEED_OLD_TRACES_QA_PROJECT_ID,
+  SEED_OLD_TRACES_QA_PROJECT_NAME,
+  SEED_OLD_TRACES_QA_PROJECT_SLUG,
   SEED_ORG_ID,
   SEED_PROJECT_ID,
   SEED_PROJECT_NAME,
@@ -105,4 +109,24 @@ const seedLatitudeDogfoodProjects: Seeder = {
     }),
 }
 
-export const projectSeeders: readonly Seeder[] = [seedProjects, seedLatitudeDogfoodProjects]
+// QA fixture project with `first_trace_at` backdated so it reads as "has ever had traces" while its
+// ClickHouse spans (seeded separately) all predate the default window. See `SEED_OLD_TRACES_QA_*`.
+const seedOldTracesQaProject: Seeder = {
+  name: "projects/old-traces-qa",
+  run: (ctx: SeedContext) =>
+    Effect.gen(function* () {
+      const project = createProject({
+        id: SEED_OLD_TRACES_QA_PROJECT_ID,
+        organizationId: SEED_ORG_ID,
+        name: SEED_OLD_TRACES_QA_PROJECT_NAME,
+        slug: SEED_OLD_TRACES_QA_PROJECT_SLUG,
+        firstTraceAt: new Date(Date.now() - SEED_OLD_TRACES_QA_FROM_DAYS_AGO * 24 * 60 * 60 * 1000),
+      })
+      yield* ctx.repositories.project.save(project)
+      console.log(
+        `  -> project: ${project.name} (${project.slug}) [first_trace_at ~${SEED_OLD_TRACES_QA_FROM_DAYS_AGO}d ago]`,
+      )
+    }),
+}
+
+export const projectSeeders: readonly Seeder[] = [seedProjects, seedLatitudeDogfoodProjects, seedOldTracesQaProject]

--- a/packages/platform/db-postgres/src/seeds/projects/index.ts
+++ b/packages/platform/db-postgres/src/seeds/projects/index.ts
@@ -109,8 +109,7 @@ const seedLatitudeDogfoodProjects: Seeder = {
     }),
 }
 
-// QA fixture project with `first_trace_at` backdated so it reads as "has ever had traces" while its
-// ClickHouse spans (seeded separately) all predate the default window. See `SEED_OLD_TRACES_QA_*`.
+// QA fixture: project with a backdated first_trace_at; its ClickHouse spans (seeded separately) all predate the default window.
 const seedOldTracesQaProject: Seeder = {
   name: "projects/old-traces-qa",
   run: (ctx: SeedContext) =>


### PR DESCRIPTION
## Problem

Sessions/Traces gated the **"Waiting for your first trace"** onboarding on the *windowed* trace count. A project whose traces all predate the default 30-day window read as empty and fell into the onboarding screen — even though it has data — and the onboarding screen hides the toolbar, so there was no way to widen the range.

## Fix (quick, minimal)

Gate the onboarding on **`project.firstTraceAt`** (has the project *ever* received a trace) instead of the windowed count:

- **Never received a trace** → still shows "Waiting for your first trace" (unchanged).
- **Has traces but none in the window** → falls through to the normal Sessions/Traces view, which keeps the **time-filter dropdown** visible so the user can widen the range and find their data.
- The `totalTraceCount === 0` guard remains, so a brand-new project whose first trace just landed is unaffected while `firstTraceAt` briefly lags.

Applies to both tabs (shared gate). This is the minimal version — no clear-to-All-time / auto-widen / histogram changes (those live in the larger #3955).

## QA fixture (reusable, in `pnpm seed`)

Adds an **"Old traces (QA)"** seeded project (`/projects/old-traces-qa`) whose data is all 45→31 days old: `first_trace_at` set (~45d ago) in Postgres, ~150 traces in ClickHouse, **zero in the last 30 days** — the exact repro shape. Runs as part of `pnpm seed` (idempotent), so it's reusable for QA of this fix and the larger one.

- `SEED_OLD_TRACES_QA_*` constants
- PG seeder: project with backdated `firstTraceAt`
- CH seeder: `runSpansSeed` with a backdated `timeWindow`

## QA

1. `pnpm seed` (already applies the fixture; safe/idempotent).
2. Open `/projects/old-traces-qa` → ✅ normal Sessions view with the time dropdown, **not** "Waiting for your first trace".
3. Open the time dropdown → pick a **custom calendar range starting ~46 days ago** → the ~150 old traces appear. (Presets only reach "Last month"/30d, which is empty by design here.)
4. Regression: a project that never received a trace still shows the onboarding.

Typecheck + knip + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)