### PR TITLE
feat(web): session-wide grouped Spans tab

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -89,6 +89,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
   const [activeSessionId, setActiveSessionId] = useParamState("sessionId", "")
   const [, setSelectedSpanId] = useParamState("spanId", "")
+  const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [rawFilters, setRawFilters] = useParamState("filters", "")
   const [query, setQuery] = useParamState("query", "")
   const [savedSearchSlug, setSavedSearchSlug] = useParamState("savedSearch", "")
@@ -101,8 +102,9 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
       setActiveSessionId("")
       setActiveTraceId("")
       setSelectedSpanId("")
+      setSelectedSpanTraceId("")
     },
-    [activeTab, setActiveTab, setActiveSessionId, setActiveTraceId, setSelectedSpanId],
+    [activeTab, setActiveTab, setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId],
   )
   const hasSearchQuery = query.length > 0
   const hasSemanticSearchQuery = searchHasSemanticPart(query)
@@ -335,7 +337,8 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const closeTraceDrawer = useCallback(() => {
     setActiveTraceId("")
     setSelectedSpanId("")
-  }, [setActiveTraceId, setSelectedSpanId])
+    setSelectedSpanTraceId("")
+  }, [setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
 
   const onActiveTraceChange = (traceId: string | undefined) => {
     if (!traceId) {
@@ -352,15 +355,18 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
     (sessionId: string, traceId?: string) => {
       setActiveSessionId(sessionId)
       setActiveTraceId(traceId ?? "")
+      setSelectedSpanId("")
+      setSelectedSpanTraceId("")
     },
-    [setActiveSessionId, setActiveTraceId],
+    [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId],
   )
 
   const closeSessionPanel = useCallback(() => {
     setActiveSessionId("")
     setActiveTraceId("")
     setSelectedSpanId("")
-  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId])
+    setSelectedSpanTraceId("")
+  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
 
   // Submitting a new query invalidates any open drawer context against the new result set.
   // The `savedSearch` slug is intentionally kept so the Save button can surface drift.

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer.tsx
@@ -53,6 +53,8 @@ export function SessionDetailDrawer({
   const [traceId, setTraceId] = useParamState("traceId", "")
   const [signalId, setSignalId] = useParamState("signalId", "")
   const [, setFocusAnnotationId] = useParamState("annotationId", "")
+  const [, setSelectedSpanId] = useParamState("spanId", "")
+  const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const [q] = useParamState("q", "")
   // Land on the conversation tab when arriving from an active search, so the
   // conversation tab's search-match autoscroll/highlight has something to scroll to.
@@ -111,12 +113,16 @@ export function SessionDetailDrawer({
 
   const openTrace = (nextTraceId: string, options: OpenTraceOptions = {}) => {
     const { focusAnnotationId, targetTab } = options
+    setSelectedSpanId("")
+    setSelectedSpanTraceId("")
     setFocusAnnotationId(focusAnnotationId ?? "")
     setTraceTab(targetTab ?? (focusAnnotationId ? "conversation" : "trace"))
     setTraceId(nextTraceId)
   }
 
   const openSignal = (nextSignalId: string) => {
+    setSelectedSpanId("")
+    setSelectedSpanTraceId("")
     setFocusAnnotationId("")
     setTraceId("")
     setSignalId(nextSignalId)
@@ -128,12 +134,16 @@ export function SessionDetailDrawer({
   }
 
   const backToSession = () => {
+    setSelectedSpanId("")
+    setSelectedSpanTraceId("")
     setFocusAnnotationId("")
     setTraceId("")
     setSignalId("")
   }
 
   const handleClose = () => {
+    setSelectedSpanId("")
+    setSelectedSpanTraceId("")
     setFocusAnnotationId("")
     setTraceId("")
     setSignalId("")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -286,7 +286,7 @@ export function ConversationTab({
   readonly focusMomentKind?: MomentKind | undefined
   /** Scrolls to this semantic moment when no label kind is focused. */
   readonly focusMomentId?: string | undefined
-  /** Navigates to a span in the session's single-trace Spans tab; enables the conversation's span-link affordances. */
+  /** Navigates to a span in the session Spans tab; enables the conversation's span-link affordances. */
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
 }) {
   const sessionId = session.sessionId

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -121,8 +121,10 @@ export function SessionSlot({
   }
 
   function navigateToSpan(spanId: string) {
-    if (!latestTraceId) return
-    selectSpan({ traceId: latestTraceId, spanId })
+    // Conversation span links come from session-wide span maps, so the span can
+    // belong to any trace; let SessionSpansTab resolve the trace from its spans.
+    setSelectedSpanTraceId("")
+    setSelectedSpanId(spanId)
     onActiveTabChange("spans")
   }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-slot.tsx
@@ -13,11 +13,12 @@ import type { TraceRecord } from "../../../../../../domains/traces/traces.functi
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { AddTraceToDatasetAction } from "../add-trace-to-dataset-action.tsx"
 import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
+import type { SpanTreeSelection } from "../trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx"
 import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
-import { SpansTab } from "../trace-detail-drawer/tabs/spans-tab.tsx"
 import { ConversationTab } from "./conversation-tab.tsx"
 import { MetadataTab } from "./metadata-tab.tsx"
 import { ScoresTab } from "./scores-tab.tsx"
+import { SessionSpansTab } from "./session-spans-tab.tsx"
 import { SessionStatusPill } from "./session-status-pill.tsx"
 import { SignalsTab } from "./signals-tab.tsx"
 
@@ -86,11 +87,10 @@ export function SessionSlot({
   const isSandbox = useProjectScope().kind === "sandbox"
   const scoresEnabled = !isSandbox
   const signalsEnabled = !isSandbox
-  // A single-trace session can surface its spans inline
-  const singleTrace = traces.length === 1 ? traces[0] : undefined
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
+  const [selectedSpanTraceId, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
   const { openWithErrors, openWithModel } = useSpanFilters()
-  const requestedTab: SessionTabId = activeTab === "spans" && !singleTrace ? "session" : normalizeSessionTab(activeTab)
+  const requestedTab = normalizeSessionTab(activeTab)
   // A deep-linked tab for a feature that's off (sandbox) falls back to Session.
   const effectiveActiveTab: SessionTabId =
     (requestedTab === "scores" && !scoresEnabled) || (requestedTab === "issues" && !signalsEnabled)
@@ -109,23 +109,26 @@ export function SessionSlot({
   }
 
   function navigateToSpansWithErrors() {
-    if (!singleTrace) return
     openWithErrors()
-    setSelectedSpanId("")
+    selectSpan(null)
     onActiveTabChange("spans")
   }
 
   function navigateToSpansWithModel(model: string) {
-    if (!singleTrace) return
     openWithModel(model)
-    setSelectedSpanId("")
+    selectSpan(null)
     onActiveTabChange("spans")
   }
 
   function navigateToSpan(spanId: string) {
-    if (!singleTrace) return
-    setSelectedSpanId(spanId)
+    if (!latestTraceId) return
+    selectSpan({ traceId: latestTraceId, spanId })
     onActiveTabChange("spans")
+  }
+
+  function selectSpan(selection: SpanTreeSelection | null) {
+    setSelectedSpanTraceId(selection?.traceId ?? "")
+    setSelectedSpanId(selection?.spanId ?? "")
   }
 
   // Badge counts. Both queries are shared (same key) with the tab panes, so
@@ -163,14 +166,12 @@ export function SessionSlot({
         icon: <Icon icon={MessagesSquareIcon} size="sm" />,
       },
     ]
-    if (singleTrace) {
-      all.push({
-        id: "spans",
-        label: "Spans",
-        icon: <Icon icon={ListTreeIcon} size="sm" />,
-        suffix: countSuffix(singleTrace.spanCount),
-      })
-    }
+    all.push({
+      id: "spans",
+      label: "Spans",
+      icon: <Icon icon={ListTreeIcon} size="sm" />,
+      suffix: countSuffix(session.spanCount),
+    })
     if (scoresEnabled) {
       all.push({
         id: "scores",
@@ -188,7 +189,7 @@ export function SessionSlot({
       })
     }
     return all
-  }, [scoresEnabled, signalsEnabled, scoreCount, signalCount, singleTrace])
+  }, [scoresEnabled, session.spanCount, signalsEnabled, scoreCount, signalCount])
 
   // H/L cycle the session tabs (wrapping), matching the trace drawer. Disabled
   // while a trace/issue slot is shown so they don't collide with the trace slot.
@@ -247,27 +248,19 @@ export function SessionSlot({
             )}
             <SessionStatusPill status={status} lastActivity={relativeTime(new Date(session.endTime))} />
             {session.errorCount > 0 ? (
-              singleTrace ? (
-                <button
-                  type="button"
-                  onClick={navigateToSpansWithErrors}
-                  aria-label={`View ${session.errorCount} errored spans`}
-                  className="inline-flex shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                >
-                  <Status
-                    variant="destructive"
-                    indicator={false}
-                    label={`${formatCount(session.errorCount)} ${session.errorCount === 1 ? "error" : "errors"}`}
-                    className="cursor-pointer transition-opacity hover:opacity-80"
-                  />
-                </button>
-              ) : (
+              <button
+                type="button"
+                onClick={navigateToSpansWithErrors}
+                aria-label={`View ${session.errorCount} errored spans`}
+                className="inline-flex shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
                 <Status
                   variant="destructive"
                   indicator={false}
                   label={`${formatCount(session.errorCount)} ${session.errorCount === 1 ? "error" : "errors"}`}
+                  className="cursor-pointer transition-opacity hover:opacity-80"
                 />
-              )
+              </button>
             ) : null}
             {!isSandbox && datasetTraceId ? (
               <div className="ml-auto shrink-0">
@@ -293,8 +286,8 @@ export function SessionSlot({
         {effectiveActiveTab === "session" && (
           <MetadataTab
             session={session}
-            spansNavEnabled={Boolean(singleTrace)}
-            {...(singleTrace ? { onOpenSpansWithModel: navigateToSpansWithModel } : {})}
+            spansNavEnabled
+            onOpenSpansWithModel={navigateToSpansWithModel}
             {...(filters ? { filters } : {})}
             {...(onFiltersChange ? { onFiltersChange } : {})}
           />
@@ -309,18 +302,21 @@ export function SessionSlot({
               isActive={effectiveActiveTab === "conversation"}
               focusMomentKind={focusMomentKind}
               focusMomentId={focusMomentId}
-              {...(singleTrace ? { navigateToSpan } : {})}
+              {...(latestTraceId ? { navigateToSpan } : {})}
               {...(searchQuery ? { searchQuery } : {})}
             />
           </div>
         )}
-        {singleTrace && visitedTabs.has("spans") && (
+        {visitedTabs.has("spans") && (
           <div className={effectiveActiveTab === "spans" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-            <SpansTab
+            <SessionSpansTab
               projectId={projectId}
-              traceId={singleTrace.traceId}
+              session={session}
+              traces={traces}
               selectedSpanId={selectedSpanId}
-              onSelectSpan={setSelectedSpanId}
+              selectedSpanTraceId={selectedSpanTraceId}
+              onSelectSpan={selectSpan}
+              onOpenTrace={onOpenTrace}
               isActive={effectiveActiveTab === "spans"}
             />
           </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -1,5 +1,4 @@
 import { Button, Icon, Text } from "@repo/ui"
-import { formatCount } from "@repo/utils"
 import { ArrowUpRightIcon } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
@@ -17,7 +16,6 @@ import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tr
 import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
 import {
   filterSessionSpanGroups,
-  getSessionSpanGroupName,
   getSessionTraceNumberById,
   groupSessionSpans,
   resolveSpanTraceId,
@@ -59,10 +57,6 @@ export function SessionSpansTab({
   const groups = useMemo(() => groupSessionSpans(spans ?? [], traces), [spans, traces])
   const filteredGroups = useMemo(() => filterSessionSpanGroups(groups, filters), [filters, groups])
   const traceNumberById = useMemo(() => getSessionTraceNumberById(groups), [groups])
-  const spanCountByTraceId = useMemo(
-    () => new Map(groups.map((group) => [group.traceId, group.spans.length])),
-    [groups],
-  )
   const timeRangeByTraceId = useMemo(
     () => new Map(groups.map((group) => [group.traceId, getTraceTimeRange(group.spans)])),
     [groups],
@@ -177,33 +171,26 @@ export function SessionSpansTab({
           traceId: group.traceId,
           spans: group.spans,
           timeRange: timeRangeByTraceId.get(group.traceId),
-          header: (
-            <div className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 border-b border-border bg-muted/30 px-3 py-2">
-              <div className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex min-w-0 flex-row items-center gap-1.5">
-                  <Text.H6B noWrap>Trace {traceNumberById.get(group.traceId)}</Text.H6B>
-                  <Text.H6 color="foregroundMuted" noWrap ellipsis>
-                    {getSessionSpanGroupName(group)}
-                  </Text.H6>
-                </div>
+          header: {
+            label: <Text.H6B noWrap>Trace {traceNumberById.get(group.traceId)}</Text.H6B>,
+            meta: (
+              <>
                 <Text.H6 color="foregroundMuted" noWrap>
-                  {new Date(group.startTime).toLocaleString()} ·{" "}
-                  {formatCount(spanCountByTraceId.get(group.traceId) ?? 0)}{" "}
-                  {spanCountByTraceId.get(group.traceId) === 1 ? "span" : "spans"}
+                  {new Date(group.startTime).toLocaleString()}
                 </Text.H6>
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="shrink-0"
-                onClick={() => handleOpenTrace(group.traceId)}
-              >
-                View trace
-                <Icon icon={ArrowUpRightIcon} size="xs" />
-              </Button>
-            </div>
-          ),
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => handleOpenTrace(group.traceId)}
+                >
+                  View trace
+                  <Icon icon={ArrowUpRightIcon} size="xs" />
+                </Button>
+              </>
+            ),
+          },
         }))}
         selectedSpan={selectedSpan}
         onSelectSpan={handleSelectSpan}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -1,0 +1,226 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { ArrowUpRightIcon } from "lucide-react"
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
+import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import type { OpenTraceOptions } from "../session-detail-drawer.tsx"
+import { SpanDetail } from "../trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx"
+import { SpanFiltersBar } from "../trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx"
+import {
+  GroupedSpanTree,
+  type SpanTreeSelection,
+  scrollSpanIntoView,
+} from "../trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx"
+import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+import { useSpanFilters } from "../trace-detail-drawer/tabs/spans-tab/use-span-filters.ts"
+import {
+  filterSessionSpanGroups,
+  getSessionSpanGroupName,
+  getSessionTraceNumberById,
+  groupSessionSpans,
+  resolveSpanTraceId,
+  spanSelectionKey,
+} from "./session-spans.ts"
+
+export function SessionSpansTab({
+  projectId,
+  session,
+  traces,
+  selectedSpanId,
+  selectedSpanTraceId,
+  onSelectSpan,
+  onOpenTrace,
+  isActive,
+}: {
+  readonly projectId: string
+  readonly session: SessionDetailRecord
+  readonly traces: readonly TraceRecord[]
+  readonly selectedSpanId: string
+  readonly selectedSpanTraceId: string
+  readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
+  readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
+  readonly isActive: boolean
+}) {
+  const { filters, clearFilters, toggleErrors, toggleTools, selectModel } = useSpanFilters()
+  const {
+    data: spans,
+    isLoading,
+    isError,
+  } = useSpansBySessionCollection({
+    projectId,
+    sessionId: session.sessionId,
+    startTimeFrom: session.startTime,
+    startTimeTo: session.endTime,
+  })
+  const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
+  const treeContainerRef = useRef<HTMLDivElement | null>(null)
+  const groups = useMemo(() => groupSessionSpans(spans ?? [], traces), [spans, traces])
+  const filteredGroups = useMemo(() => filterSessionSpanGroups(groups, filters), [filters, groups])
+  const traceNumberById = useMemo(() => getSessionTraceNumberById(groups), [groups])
+  const spanCountByTraceId = useMemo(
+    () => new Map(groups.map((group) => [group.traceId, group.spans.length])),
+    [groups],
+  )
+  const timeRangeByTraceId = useMemo(
+    () => new Map(groups.map((group) => [group.traceId, getTraceTimeRange(group.spans)])),
+    [groups],
+  )
+  const resolvedTraceId = selectedSpanTraceId || resolveSpanTraceId(groups, selectedSpanId).traceId || ""
+  const selectedSpan = useMemo(
+    () => (selectedSpanId && resolvedTraceId ? { traceId: resolvedTraceId, spanId: selectedSpanId } : null),
+    [resolvedTraceId, selectedSpanId],
+  )
+
+  // TODO(frontend-use-effect-policy): legacy span links only stored spanId; resolve their trace after spans load.
+  useEffect(() => {
+    if (!selectedSpanId || selectedSpanTraceId || isLoading) return
+    const resolved = resolveSpanTraceId(groups, selectedSpanId)
+    if (resolved.traceId) onSelectSpan({ traceId: resolved.traceId, spanId: selectedSpanId })
+    else if (resolved.ambiguous || groups.length > 0) onSelectSpan(null)
+  }, [groups, isLoading, onSelectSpan, selectedSpanId, selectedSpanTraceId])
+
+  // TODO(frontend-use-effect-policy): active filters can remove a URL-selected span from the rendered trees.
+  useEffect(() => {
+    if (!selectedSpan) return
+    const isVisible = filteredGroups.some(
+      (group) =>
+        group.traceId === selectedSpan.traceId && group.spans.some((span) => span.spanId === selectedSpan.spanId),
+    )
+    if (!isVisible) {
+      onSelectSpan(null)
+      setIsMinimized(false)
+    }
+  }, [filteredGroups, onSelectSpan, selectedSpan])
+
+  // TODO(frontend-use-effect-policy): external conversation/deep-link selection needs imperative scrolling after load.
+  useEffect(() => {
+    if (!selectedSpan || groups.length === 0) return
+    setIsMinimized(true)
+    requestAnimationFrame(() => {
+      scrollSpanIntoView(treeContainerRef.current, selectedSpan.spanId, selectedSpan.traceId)
+    })
+  }, [groups.length, selectedSpan])
+
+  function handleSelectSpan(selection: SpanTreeSelection | null) {
+    if (!selection || (selectedSpan && spanSelectionKey(selection) === spanSelectionKey(selectedSpan))) {
+      onSelectSpan(null)
+      setIsMinimized(false)
+      return
+    }
+    onSelectSpan(selection)
+  }
+
+  function handleOpenTrace(traceId: string) {
+    onSelectSpan(null)
+    setIsMinimized(false)
+    onOpenTrace(traceId, { targetTab: "trace" })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Text.H5 color="foregroundMuted">Loading spans...</Text.H5>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Text.H5 color="foregroundMuted">Unable to load spans</Text.H5>
+      </div>
+    )
+  }
+
+  if (!spans || spans.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Text.H5 color="foregroundMuted">No spans found</Text.H5>
+      </div>
+    )
+  }
+
+  if (filteredGroups.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <SpanFiltersBar
+          spans={spans}
+          filters={filters}
+          onToggleErrors={toggleErrors}
+          onToggleTools={toggleTools}
+          onSelectModel={selectModel}
+          onClearFilters={clearFilters}
+        />
+        <div className="flex flex-1 items-center justify-center py-6">
+          <Text.H5 color="foregroundMuted">No spans match the active filters</Text.H5>
+        </div>
+      </div>
+    )
+  }
+
+  const selectedGroup = selectedSpan ? groups.find((group) => group.traceId === selectedSpan.traceId) : undefined
+
+  return (
+    <div ref={treeContainerRef} className="flex flex-1 flex-col overflow-hidden">
+      <SpanFiltersBar
+        spans={spans}
+        filters={filters}
+        onToggleErrors={toggleErrors}
+        onToggleTools={toggleTools}
+        onSelectModel={selectModel}
+        onClearFilters={clearFilters}
+      />
+      <GroupedSpanTree
+        groups={filteredGroups.map((group) => ({
+          traceId: group.traceId,
+          spans: group.spans,
+          timeRange: timeRangeByTraceId.get(group.traceId),
+          header: (
+            <div className="flex min-h-12 shrink-0 flex-row items-center justify-between gap-3 border-b border-border bg-muted/30 px-3 py-2">
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <div className="flex min-w-0 flex-row items-center gap-1.5">
+                  <Text.H6B noWrap>Trace {traceNumberById.get(group.traceId)}</Text.H6B>
+                  <Text.H6 color="foregroundMuted" noWrap ellipsis>
+                    {getSessionSpanGroupName(group)}
+                  </Text.H6>
+                </div>
+                <Text.H6 color="foregroundMuted" noWrap>
+                  {new Date(group.startTime).toLocaleString()} ·{" "}
+                  {formatCount(spanCountByTraceId.get(group.traceId) ?? 0)}{" "}
+                  {spanCountByTraceId.get(group.traceId) === 1 ? "span" : "spans"}
+                </Text.H6>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="shrink-0"
+                onClick={() => handleOpenTrace(group.traceId)}
+              >
+                View trace
+                <Icon icon={ArrowUpRightIcon} size="xs" />
+              </Button>
+            </div>
+          ),
+        }))}
+        selectedSpan={selectedSpan}
+        onSelectSpan={handleSelectSpan}
+        isMinimized={isMinimized && selectedSpan !== null}
+        onToggleMinimized={() => setIsMinimized((current) => !current)}
+        isActive={isActive}
+      />
+      {selectedSpan && selectedGroup && (
+        <SpanDetail
+          projectId={projectId}
+          traceId={selectedSpan.traceId}
+          spanId={selectedSpan.spanId}
+          startTimeFrom={selectedGroup.startTime}
+          startTimeTo={selectedGroup.endTime}
+          onClose={() => handleSelectSpan(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest"
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
+import {
+  filterSessionSpanGroups,
+  getSessionSpanGroupName,
+  getSessionTraceNumberById,
+  groupSessionSpans,
+  resolveSpanTraceId,
+  spanSelectionKey,
+} from "./session-spans.ts"
+
+function makeSpan(
+  partial: Partial<SpanRecord> & Pick<SpanRecord, "traceId" | "spanId" | "startTime" | "endTime">,
+): SpanRecord {
+  return {
+    organizationId: "org",
+    projectId: "project",
+    parentSpanId: "",
+    simulationId: "",
+    name: partial.spanId,
+    serviceName: "",
+    kind: "internal",
+    statusCode: "ok",
+    statusMessage: "",
+    operation: "",
+    provider: "",
+    model: "",
+    toolName: "",
+    toolNames: [],
+    tokensInput: 0,
+    tokensOutput: 0,
+    costTotalMicrocents: 0,
+    timeToFirstTokenNs: 0,
+    isStreaming: false,
+    ingestedAt: partial.endTime,
+    ...partial,
+  }
+}
+
+function makeTrace(
+  partial: Partial<TraceRecord> & Pick<TraceRecord, "traceId" | "startTime" | "endTime">,
+): TraceRecord {
+  return {
+    organizationId: "org",
+    projectId: "project",
+    spanCount: 1,
+    errorCount: 0,
+    durationNs: 0,
+    timeToFirstTokenNs: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 0,
+    cacheHitRate: null,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    sessionId: "session",
+    userId: "",
+    simulationId: "",
+    tags: [],
+    metadata: {},
+    models: [],
+    providers: [],
+    serviceNames: [],
+    rootSpanId: "",
+    rootSpanName: "",
+    ...partial,
+  }
+}
+
+describe("session span groups", () => {
+  it("groups spans oldest-first and falls back to span timing when trace metadata is missing", () => {
+    const spans = [
+      makeSpan({
+        traceId: "trace-a",
+        spanId: "shared",
+        startTime: "2026-01-01T00:01:00.000Z",
+        endTime: "2026-01-01T00:01:01.000Z",
+      }),
+      makeSpan({
+        traceId: "trace-b",
+        spanId: "shared",
+        startTime: "2026-01-01T00:00:00.000Z",
+        endTime: "2026-01-01T00:00:01.000Z",
+      }),
+    ]
+    const traceA = makeTrace({
+      traceId: "trace-a",
+      startTime: "2026-01-01T00:01:00.000Z",
+      endTime: "2026-01-01T00:01:01.000Z",
+      rootSpanName: "Known trace",
+    })
+
+    const groups = groupSessionSpans(spans, [traceA])
+
+    expect(groups.map((group) => group.traceId)).toEqual(["trace-b", "trace-a"])
+    expect([...getSessionTraceNumberById(groups)]).toEqual([
+      ["trace-b", 1],
+      ["trace-a", 2],
+    ])
+    expect(groups[0]?.trace).toBeUndefined()
+    expect(groups[0]?.startTime).toBe("2026-01-01T00:00:00.000Z")
+    expect(groups[0] && getSessionSpanGroupName(groups[0])).toBe("trace-b")
+    expect(groups[1]?.trace?.rootSpanName).toBe("Known trace")
+    expect(groups[1] && getSessionSpanGroupName(groups[1])).toBe("Known trace")
+    expect(groups.map((group) => getTraceTimeRange(group.spans).totalDuration)).toEqual([1000, 1000])
+  })
+
+  it("filters each trace independently, preserves ancestors, and hides empty groups", () => {
+    const groups = groupSessionSpans(
+      [
+        makeSpan({
+          traceId: "trace-a",
+          spanId: "root",
+          startTime: "2026-01-01T00:00:00.000Z",
+          endTime: "2026-01-01T00:00:02.000Z",
+        }),
+        makeSpan({
+          traceId: "trace-a",
+          spanId: "error-child",
+          parentSpanId: "root",
+          statusCode: "error",
+          startTime: "2026-01-01T00:00:01.000Z",
+          endTime: "2026-01-01T00:00:02.000Z",
+        }),
+        makeSpan({
+          traceId: "trace-b",
+          spanId: "root",
+          startTime: "2026-01-01T00:01:00.000Z",
+          endTime: "2026-01-01T00:01:01.000Z",
+        }),
+      ],
+      [],
+    )
+
+    const filtered = filterSessionSpanGroups(groups, { errors: true, tools: false, model: "" })
+
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.traceId).toBe("trace-a")
+    expect(filtered[0]?.spans.map((span) => span.spanId)).toEqual(["root", "error-child"])
+  })
+
+  it("keeps compound selections distinct and rejects ambiguous legacy span ids", () => {
+    const groups = groupSessionSpans(
+      [
+        makeSpan({
+          traceId: "trace-a",
+          spanId: "shared",
+          startTime: "2026-01-01T00:00:00.000Z",
+          endTime: "2026-01-01T00:00:01.000Z",
+        }),
+        makeSpan({
+          traceId: "trace-b",
+          spanId: "shared",
+          startTime: "2026-01-01T00:01:00.000Z",
+          endTime: "2026-01-01T00:01:01.000Z",
+        }),
+      ],
+      [],
+    )
+
+    expect(spanSelectionKey({ traceId: "trace-a", spanId: "shared" })).not.toBe(
+      spanSelectionKey({ traceId: "trace-b", spanId: "shared" }),
+    )
+    expect(resolveSpanTraceId(groups, "shared")).toEqual({ traceId: null, ambiguous: true })
+    expect(resolveSpanTraceId(groups, "missing")).toEqual({ traceId: null, ambiguous: false })
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
@@ -4,7 +4,6 @@ import type { TraceRecord } from "../../../../../../domains/traces/traces.functi
 import { getTraceTimeRange } from "../trace-detail-drawer/tabs/spans-tab/span-tree/tree-utils.ts"
 import {
   filterSessionSpanGroups,
-  getSessionSpanGroupName,
   getSessionTraceNumberById,
   groupSessionSpans,
   resolveSpanTraceId,
@@ -105,9 +104,7 @@ describe("session span groups", () => {
     ])
     expect(groups[0]?.trace).toBeUndefined()
     expect(groups[0]?.startTime).toBe("2026-01-01T00:00:00.000Z")
-    expect(groups[0] && getSessionSpanGroupName(groups[0])).toBe("trace-b")
     expect(groups[1]?.trace?.rootSpanName).toBe("Known trace")
-    expect(groups[1] && getSessionSpanGroupName(groups[1])).toBe("Known trace")
     expect(groups.map((group) => getTraceTimeRange(group.spans).totalDuration)).toEqual([1000, 1000])
   })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
@@ -23,10 +23,6 @@ export function getSessionTraceNumberById(groups: readonly SessionSpanGroup[]): 
   return new Map(groups.map((group, index) => [group.traceId, index + 1]))
 }
 
-export function getSessionSpanGroupName(group: SessionSpanGroup): string {
-  return group.trace?.rootSpanName || group.traceId.slice(0, 7)
-}
-
 export function groupSessionSpans(
   spans: readonly SpanRecord[],
   traces: readonly TraceRecord[],

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.ts
@@ -1,0 +1,82 @@
+import type { SpanRecord } from "../../../../../../domains/spans/spans.functions.ts"
+import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
+import { filterSpansWithAncestors, type SpanFilters } from "../trace-detail-drawer/tabs/spans-tab/span-filters.ts"
+
+interface SessionSpanGroup {
+  readonly traceId: string
+  readonly trace: TraceRecord | undefined
+  readonly startTime: string
+  readonly endTime: string
+  readonly spans: readonly SpanRecord[]
+}
+
+interface SpanSelection {
+  readonly traceId: string
+  readonly spanId: string
+}
+
+export function spanSelectionKey(selection: SpanSelection): string {
+  return `${selection.traceId}:${selection.spanId}`
+}
+
+export function getSessionTraceNumberById(groups: readonly SessionSpanGroup[]): ReadonlyMap<string, number> {
+  return new Map(groups.map((group, index) => [group.traceId, index + 1]))
+}
+
+export function getSessionSpanGroupName(group: SessionSpanGroup): string {
+  return group.trace?.rootSpanName || group.traceId.slice(0, 7)
+}
+
+export function groupSessionSpans(
+  spans: readonly SpanRecord[],
+  traces: readonly TraceRecord[],
+): readonly SessionSpanGroup[] {
+  const traceById = new Map(traces.map((trace) => [trace.traceId, trace]))
+  const spansByTrace = new Map<string, SpanRecord[]>()
+
+  for (const span of spans) {
+    const traceSpans = spansByTrace.get(span.traceId)
+    if (traceSpans) traceSpans.push(span)
+    else spansByTrace.set(span.traceId, [span])
+  }
+
+  const groups: SessionSpanGroup[] = []
+  for (const [traceId, traceSpans] of spansByTrace) {
+    traceSpans.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.spanId.localeCompare(b.spanId))
+    const trace = traceById.get(traceId)
+    groups.push({
+      traceId,
+      trace,
+      startTime: trace?.startTime ?? traceSpans[0]?.startTime ?? "",
+      endTime:
+        trace?.endTime ?? traceSpans.reduce((latest, span) => (span.endTime > latest ? span.endTime : latest), ""),
+      spans: traceSpans,
+    })
+  }
+
+  groups.sort((a, b) => a.startTime.localeCompare(b.startTime) || a.traceId.localeCompare(b.traceId))
+  return groups
+}
+
+export function filterSessionSpanGroups(
+  groups: readonly SessionSpanGroup[],
+  filters: SpanFilters,
+): readonly SessionSpanGroup[] {
+  return groups.flatMap((group) => {
+    const spans = filterSpansWithAncestors(group.spans, filters)
+    return spans.length > 0 ? [{ ...group, spans }] : []
+  })
+}
+
+export function resolveSpanTraceId(
+  groups: readonly SessionSpanGroup[],
+  spanId: string,
+): { readonly traceId: string | null; readonly ambiguous: boolean } {
+  let traceId: string | null = null
+  for (const group of groups) {
+    if (!group.spans.some((span) => span.spanId === spanId)) continue
+    if (traceId !== null) return { traceId: null, ambiguous: true }
+    traceId = group.traceId
+  }
+  return { traceId, ambiguous: false }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/grouped-tree-state.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/grouped-tree-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { getAdjacentSpanSelection, spanTreeSelectionKey, toggleCollapsedSpan } from "./grouped-tree-state.ts"
+
+const visibleSelections = [
+  { traceId: "trace-a", spanId: "root" },
+  { traceId: "trace-a", spanId: "shared" },
+  { traceId: "trace-b", spanId: "shared" },
+  { traceId: "trace-b", spanId: "child" },
+]
+
+describe("grouped span tree state", () => {
+  it("navigates across trace boundaries in displayed order", () => {
+    expect(getAdjacentSpanSelection(visibleSelections, visibleSelections[1] ?? null, "next")).toEqual(
+      visibleSelections[2],
+    )
+    expect(getAdjacentSpanSelection(visibleSelections, visibleSelections[2] ?? null, "previous")).toEqual(
+      visibleSelections[1],
+    )
+    expect(getAdjacentSpanSelection(visibleSelections, null, "next")).toEqual(visibleSelections[0])
+    expect(getAdjacentSpanSelection(visibleSelections, null, "previous")).toEqual(visibleSelections[3])
+  })
+
+  it("keeps identical span ids independently selected and collapsed by trace", () => {
+    const first = visibleSelections[1]
+    const second = visibleSelections[2]
+    if (!first || !second) throw new Error("expected fixture selections")
+
+    expect(spanTreeSelectionKey(first)).not.toBe(spanTreeSelectionKey(second))
+
+    const firstCollapsed = toggleCollapsedSpan(new Set(), first)
+    const bothCollapsed = toggleCollapsedSpan(firstCollapsed, second)
+    const secondCollapsed = toggleCollapsedSpan(bothCollapsed, first)
+
+    expect(firstCollapsed).toEqual(new Set(["trace-a:shared"]))
+    expect(bothCollapsed).toEqual(new Set(["trace-a:shared", "trace-b:shared"]))
+    expect(secondCollapsed).toEqual(new Set(["trace-b:shared"]))
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/grouped-tree-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/grouped-tree-state.ts
@@ -1,0 +1,31 @@
+export interface SpanTreeSelection {
+  readonly traceId: string
+  readonly spanId: string
+}
+
+export function spanTreeSelectionKey({ traceId, spanId }: SpanTreeSelection): string {
+  return `${traceId}:${spanId}`
+}
+
+export function getAdjacentSpanSelection(
+  visibleSelections: readonly SpanTreeSelection[],
+  selectedSpan: SpanTreeSelection | null,
+  direction: "next" | "previous",
+): SpanTreeSelection | undefined {
+  const selectedIndex = selectedSpan
+    ? visibleSelections.findIndex((selection) => spanTreeSelectionKey(selection) === spanTreeSelectionKey(selectedSpan))
+    : direction === "next"
+      ? -1
+      : visibleSelections.length
+
+  if (direction === "next") return visibleSelections[selectedIndex + 1] ?? visibleSelections[0]
+  return visibleSelections[selectedIndex - 1]
+}
+
+export function toggleCollapsedSpan(collapsed: ReadonlySet<string>, selection: SpanTreeSelection): Set<string> {
+  const key = spanTreeSelectionKey(selection)
+  const next = new Set(collapsed)
+  if (next.has(key)) next.delete(key)
+  else next.add(key)
+  return next
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -1,6 +1,13 @@
 import { cn, Text, Tooltip } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { ChevronsDownUpIcon, ChevronsUpDownIcon, MaximizeIcon, MinimizeIcon } from "lucide-react"
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  MaximizeIcon,
+  MinimizeIcon,
+} from "lucide-react"
 import { type ReactNode, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../../../components/hotkey-badge.tsx"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
@@ -24,11 +31,16 @@ import { useWaterfallCursor, WaterfallCursorOverlay } from "./waterfall.tsx"
 
 export type { SpanTreeSelection } from "./grouped-tree-state.ts"
 
+export interface SpanTreeGroupHeader {
+  readonly label: ReactNode
+  readonly meta: ReactNode
+}
+
 export interface SpanTreeGroup {
   readonly traceId: string
   readonly spans: readonly SpanRecord[]
   readonly timeRange?: TraceTimeRange | undefined
-  readonly header?: ReactNode
+  readonly header?: SpanTreeGroupHeader
 }
 
 function collectCollapsibleIds(roots: ReturnType<typeof buildSpanTree>): Set<string> {
@@ -46,6 +58,124 @@ function collectCollapsibleIds(roots: ReturnType<typeof buildSpanTree>): Set<str
   return ids
 }
 
+function TreeAxisHeader({
+  treeWidth,
+  timeRange,
+  hasCollapsible,
+  isAllCollapsed,
+  onToggleAll,
+  selectedSpan,
+  isMinimized,
+  onToggleMinimized,
+}: {
+  readonly treeWidth: number
+  readonly timeRange: TraceTimeRange
+  readonly hasCollapsible: boolean
+  readonly isAllCollapsed: boolean
+  readonly onToggleAll: () => void
+  readonly selectedSpan: SpanTreeSelection | null
+  readonly isMinimized: boolean
+  readonly onToggleMinimized: () => void
+}) {
+  return (
+    <div
+      className="sticky top-0 z-30 flex shrink-0 flex-row items-center border-b border-border bg-background"
+      style={{ height: ROW_HEIGHT }}
+    >
+      <div className="flex shrink-0 flex-row items-center gap-1 px-2" style={{ width: treeWidth }}>
+        <Tooltip side="bottom" trigger={<Text.H6 color="foregroundMuted">Span</Text.H6>}>
+          Navigate <HotkeyBadge hotkey="J" /> <HotkeyBadge hotkey="K" /> · Deselect <HotkeyBadge hotkey="Escape" />
+        </Tooltip>
+        {hasCollapsible && (
+          <Tooltip
+            asChild
+            side="bottom"
+            trigger={
+              <button
+                type="button"
+                className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
+                onClick={onToggleAll}
+              >
+                {isAllCollapsed ? (
+                  <ChevronsUpDownIcon className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronsDownUpIcon className="h-3.5 w-3.5" />
+                )}
+              </button>
+            }
+          >
+            {isAllCollapsed ? "Expand all" : "Collapse all"} <HotkeyBadge hotkey="E" />
+          </Tooltip>
+        )}
+        {selectedSpan && (
+          <Tooltip
+            asChild
+            side="bottom"
+            trigger={
+              <button
+                type="button"
+                className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
+                onClick={onToggleMinimized}
+              >
+                {isMinimized ? <MaximizeIcon className="h-3.5 w-3.5" /> : <MinimizeIcon className="h-3.5 w-3.5" />}
+              </button>
+            }
+          >
+            {isMinimized ? "Expand tree" : "Minimize tree"}
+          </Tooltip>
+        )}
+      </div>
+      <div className="w-px shrink-0 self-stretch bg-border" />
+      <div
+        className="flex min-w-0 flex-1 flex-row items-center justify-between"
+        style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
+      >
+        <Text.H6 color="foregroundMuted">0ms</Text.H6>
+        <Text.H6 color="foregroundMuted">{formatDuration(timeRange.totalDuration)}</Text.H6>
+      </div>
+    </div>
+  )
+}
+
+function TraceSectionHeader({
+  treeWidth,
+  isCollapsed,
+  onToggleCollapsed,
+  label,
+  meta,
+}: {
+  readonly treeWidth: number
+  readonly isCollapsed: boolean
+  readonly onToggleCollapsed: () => void
+  readonly label: ReactNode
+  readonly meta: ReactNode
+}) {
+  return (
+    <div className="flex shrink-0 flex-row items-center border-y border-border bg-muted" style={{ height: ROW_HEIGHT }}>
+      <button
+        type="button"
+        className="flex h-full min-w-0 shrink-0 flex-row items-center gap-1 px-2 text-left transition-colors hover:bg-muted-foreground/10"
+        style={{ width: treeWidth }}
+        onClick={onToggleCollapsed}
+      >
+        {isCollapsed ? (
+          <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        {label}
+      </button>
+      <div className="w-px shrink-0 self-stretch bg-border" />
+      <div
+        className="flex min-w-0 flex-1 flex-row items-center justify-between gap-2"
+        style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
+      >
+        {meta}
+      </div>
+    </div>
+  )
+}
+
 function SpanTreeGroupRows({
   group,
   visibleNodes,
@@ -55,12 +185,6 @@ function SpanTreeGroupRows({
   onSelectSpan,
   treeWidth,
   timeRange,
-  showControls,
-  hasCollapsible,
-  isAllCollapsed,
-  onToggleAll,
-  isMinimized,
-  onToggleMinimized,
 }: {
   readonly group: SpanTreeGroup
   readonly visibleNodes: ReturnType<typeof flattenTree>
@@ -70,12 +194,6 @@ function SpanTreeGroupRows({
   readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
   readonly treeWidth: number
   readonly timeRange: TraceTimeRange
-  readonly showControls: boolean
-  readonly hasCollapsible: boolean
-  readonly isAllCollapsed: boolean
-  readonly onToggleAll: () => void
-  readonly isMinimized: boolean
-  readonly onToggleMinimized: () => void
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const { cursorX, cursorTimeLabel, onMouseMove, onMouseLeave } = useWaterfallCursor({
@@ -87,64 +205,6 @@ function SpanTreeGroupRows({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: passive mouse tracking for waterfall cursor
     <div ref={containerRef} className="relative flex flex-col" onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
-      <div className="flex shrink-0 flex-row items-center border-b border-border" style={{ height: ROW_HEIGHT }}>
-        <div className="flex shrink-0 flex-row items-center gap-1 px-2" style={{ width: treeWidth }}>
-          {showControls ? (
-            <Tooltip side="bottom" trigger={<Text.H6 color="foregroundMuted">Span</Text.H6>}>
-              Navigate <HotkeyBadge hotkey="J" /> <HotkeyBadge hotkey="K" /> · Deselect <HotkeyBadge hotkey="Escape" />
-            </Tooltip>
-          ) : (
-            <Text.H6 color="foregroundMuted">Span</Text.H6>
-          )}
-          {showControls && hasCollapsible && (
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <button
-                  type="button"
-                  className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
-                  onClick={onToggleAll}
-                >
-                  {isAllCollapsed ? (
-                    <ChevronsUpDownIcon className="h-3.5 w-3.5" />
-                  ) : (
-                    <ChevronsDownUpIcon className="h-3.5 w-3.5" />
-                  )}
-                </button>
-              }
-            >
-              {isAllCollapsed ? "Expand all" : "Collapse all"} <HotkeyBadge hotkey="E" />
-            </Tooltip>
-          )}
-          {showControls && selectedSpan && (
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <button
-                  type="button"
-                  className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
-                  onClick={onToggleMinimized}
-                >
-                  {isMinimized ? <MaximizeIcon className="h-3.5 w-3.5" /> : <MinimizeIcon className="h-3.5 w-3.5" />}
-                </button>
-              }
-            >
-              {isMinimized ? "Expand tree" : "Minimize tree"}
-            </Tooltip>
-          )}
-        </div>
-        <div className="w-px shrink-0 self-stretch bg-border" />
-        <div
-          className="flex min-w-0 flex-1 flex-row items-center justify-between"
-          style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
-        >
-          <Text.H6 color="foregroundMuted">0ms</Text.H6>
-          <Text.H6 color="foregroundMuted">{formatDuration(timeRange.totalDuration)}</Text.H6>
-        </div>
-      </div>
-
       {visibleNodes.map((flatNode) => {
         const spanId = flatNode.node.span.spanId
         const selection = { traceId: group.traceId, spanId }
@@ -185,6 +245,7 @@ export function GroupedSpanTree({
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  const [collapsedTraces, setCollapsedTraces] = useState<Set<string>>(new Set())
   const { treeWidth, isDragging, onPointerDown, onKeyDown } = useResizablePanel({ containerRef })
   const resolvedTreeWidth = treeWidth ?? MIN_TREE_WIDTH
 
@@ -208,8 +269,28 @@ export function GroupedSpanTree({
     [collapsed, groups],
   )
 
+  const sharedDuration = useMemo(
+    () => preparedGroups.reduce((max, { timeRange }) => Math.max(max, timeRange.totalDuration), 0),
+    [preparedGroups],
+  )
+  const axisTimeRange: TraceTimeRange = { minTime: 0, maxTime: sharedDuration, totalDuration: sharedDuration }
+  const renderGroups = useMemo(
+    () =>
+      preparedGroups.map((prepared) => ({
+        ...prepared,
+        rowTimeRange: {
+          minTime: prepared.timeRange.minTime,
+          maxTime: prepared.timeRange.minTime + sharedDuration,
+          totalDuration: sharedDuration,
+        } satisfies TraceTimeRange,
+      })),
+    [preparedGroups, sharedDuration],
+  )
+
   const visibleSelections = preparedGroups.flatMap(({ group, visibleNodes }) =>
-    visibleNodes.map(({ node }) => ({ traceId: group.traceId, spanId: node.span.spanId })),
+    collapsedTraces.has(group.traceId)
+      ? []
+      : visibleNodes.map(({ node }) => ({ traceId: group.traceId, spanId: node.span.spanId })),
   )
   const collapsibleSelections = preparedGroups.flatMap(({ group, collapsibleIds }) =>
     [...collapsibleIds].map((spanId) => spanTreeSelectionKey({ traceId: group.traceId, spanId })),
@@ -222,6 +303,15 @@ export function GroupedSpanTree({
 
   function toggleAll() {
     setCollapsed(isAllCollapsed ? new Set() : new Set(collapsibleSelections))
+  }
+
+  function toggleTrace(traceId: string) {
+    setCollapsedTraces((current) => {
+      const next = new Set(current)
+      if (next.has(traceId)) next.delete(traceId)
+      else next.add(traceId)
+      return next
+    })
   }
 
   useHotkeys([
@@ -263,27 +353,44 @@ export function GroupedSpanTree({
       style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
     >
       <div className="flex flex-1 flex-col overflow-y-auto">
-        {preparedGroups.map(({ group, visibleNodes, collapsed: groupCollapsed, timeRange }, index) => (
-          <div key={group.traceId} className="flex shrink-0 flex-col">
-            {group.header}
-            <SpanTreeGroupRows
-              group={group}
-              visibleNodes={visibleNodes}
-              collapsed={groupCollapsed}
-              selectedSpan={selectedSpan}
-              onToggle={(spanId) => toggle({ traceId: group.traceId, spanId })}
-              onSelectSpan={onSelectSpan}
-              treeWidth={resolvedTreeWidth}
-              timeRange={timeRange}
-              showControls={index === 0}
-              hasCollapsible={collapsibleSelections.length > 0}
-              isAllCollapsed={isAllCollapsed}
-              onToggleAll={toggleAll}
-              isMinimized={isMinimized}
-              onToggleMinimized={onToggleMinimized}
-            />
-          </div>
-        ))}
+        <TreeAxisHeader
+          treeWidth={resolvedTreeWidth}
+          timeRange={axisTimeRange}
+          hasCollapsible={collapsibleSelections.length > 0}
+          isAllCollapsed={isAllCollapsed}
+          onToggleAll={toggleAll}
+          selectedSpan={selectedSpan}
+          isMinimized={isMinimized}
+          onToggleMinimized={onToggleMinimized}
+        />
+        {renderGroups.map(({ group, visibleNodes, collapsed: groupCollapsed, rowTimeRange }) => {
+          const isTraceCollapsed = collapsedTraces.has(group.traceId)
+          return (
+            <div key={group.traceId} className="flex shrink-0 flex-col">
+              {group.header && (
+                <TraceSectionHeader
+                  treeWidth={resolvedTreeWidth}
+                  isCollapsed={isTraceCollapsed}
+                  onToggleCollapsed={() => toggleTrace(group.traceId)}
+                  label={group.header.label}
+                  meta={group.header.meta}
+                />
+              )}
+              {!isTraceCollapsed && (
+                <SpanTreeGroupRows
+                  group={group}
+                  visibleNodes={visibleNodes}
+                  collapsed={groupCollapsed}
+                  selectedSpan={selectedSpan}
+                  onToggle={(spanId) => toggle({ traceId: group.traceId, spanId })}
+                  onSelectSpan={onSelectSpan}
+                  treeWidth={resolvedTreeWidth}
+                  timeRange={rowTimeRange}
+                />
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
@@ -296,7 +403,7 @@ export function GroupedSpanTree({
         aria-valuemax={containerRef.current ? containerRef.current.offsetWidth - MIN_WATERFALL_WIDTH : 9999}
         tabIndex={0}
         className={cn(
-          "absolute bottom-0 top-0 z-10 w-px cursor-col-resize touch-none",
+          "absolute bottom-0 top-0 z-40 w-px cursor-col-resize touch-none",
           "transition-colors hover:bg-primary",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
           "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -8,7 +8,7 @@ import {
   MaximizeIcon,
   MinimizeIcon,
 } from "lucide-react"
-import { type ReactNode, useMemo, useRef, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../../../components/hotkey-badge.tsx"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
 import {
@@ -296,6 +296,19 @@ export function GroupedSpanTree({
     [...collapsibleIds].map((spanId) => spanTreeSelectionKey({ traceId: group.traceId, spanId })),
   )
   const isAllCollapsed = collapsibleSelections.length > 0 && collapsibleSelections.every((key) => collapsed.has(key))
+
+  // TODO(frontend-use-effect-policy): a span selected from outside (deep link,
+  // conversation) may target a collapsed trace; expand it so its row renders,
+  // scrolls into view, and stays reachable by J/K.
+  useEffect(() => {
+    if (!selectedSpan) return
+    setCollapsedTraces((current) => {
+      if (!current.has(selectedSpan.traceId)) return current
+      const next = new Set(current)
+      next.delete(selectedSpan.traceId)
+      return next
+    })
+  }, [selectedSpan])
 
   function toggle(selection: SpanTreeSelection) {
     setCollapsed((current) => toggleCollapsedSpan(current, selection))

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -1,9 +1,15 @@
 import { cn, Text, Tooltip } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { ChevronsDownUpIcon, ChevronsUpDownIcon, MaximizeIcon, MinimizeIcon } from "lucide-react"
-import { useCallback, useMemo, useRef, useState } from "react"
+import { type ReactNode, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../../../components/hotkey-badge.tsx"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
+import {
+  getAdjacentSpanSelection,
+  type SpanTreeSelection,
+  spanTreeSelectionKey,
+  toggleCollapsedSpan,
+} from "./grouped-tree-state.ts"
 import {
   MIN_TREE_WIDTH,
   MIN_WATERFALL_WIDTH,
@@ -12,9 +18,297 @@ import {
   WATERFALL_H_INSET_PX,
 } from "./helpers.ts"
 import { TreeRow } from "./tree-row.tsx"
-import { buildSpanTree, flattenTree, formatDuration, getTraceTimeRange } from "./tree-utils.ts"
+import { buildSpanTree, flattenTree, formatDuration, getTraceTimeRange, type TraceTimeRange } from "./tree-utils.ts"
 import { useResizablePanel } from "./use-resizable-panel.ts"
 import { useWaterfallCursor, WaterfallCursorOverlay } from "./waterfall.tsx"
+
+export type { SpanTreeSelection } from "./grouped-tree-state.ts"
+
+export interface SpanTreeGroup {
+  readonly traceId: string
+  readonly spans: readonly SpanRecord[]
+  readonly timeRange?: TraceTimeRange | undefined
+  readonly header?: ReactNode
+}
+
+function collectCollapsibleIds(roots: ReturnType<typeof buildSpanTree>): Set<string> {
+  const ids = new Set<string>()
+  const visited = new Set<string>()
+
+  function collect(node: (typeof roots)[number]) {
+    if (visited.has(node.span.spanId)) return
+    visited.add(node.span.spanId)
+    if (node.children.length > 0) ids.add(node.span.spanId)
+    for (const child of node.children) collect(child)
+  }
+
+  for (const root of roots) collect(root)
+  return ids
+}
+
+function SpanTreeGroupRows({
+  group,
+  visibleNodes,
+  collapsed,
+  selectedSpan,
+  onToggle,
+  onSelectSpan,
+  treeWidth,
+  timeRange,
+  showControls,
+  hasCollapsible,
+  isAllCollapsed,
+  onToggleAll,
+  isMinimized,
+  onToggleMinimized,
+}: {
+  readonly group: SpanTreeGroup
+  readonly visibleNodes: ReturnType<typeof flattenTree>
+  readonly collapsed: ReadonlySet<string>
+  readonly selectedSpan: SpanTreeSelection | null
+  readonly onToggle: (spanId: string) => void
+  readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
+  readonly treeWidth: number
+  readonly timeRange: TraceTimeRange
+  readonly showControls: boolean
+  readonly hasCollapsible: boolean
+  readonly isAllCollapsed: boolean
+  readonly onToggleAll: () => void
+  readonly isMinimized: boolean
+  readonly onToggleMinimized: () => void
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const { cursorX, cursorTimeLabel, onMouseMove, onMouseLeave } = useWaterfallCursor({
+    containerRef,
+    treeWidth,
+    timeRange,
+  })
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: passive mouse tracking for waterfall cursor
+    <div ref={containerRef} className="relative flex flex-col" onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <div className="flex shrink-0 flex-row items-center border-b border-border" style={{ height: ROW_HEIGHT }}>
+        <div className="flex shrink-0 flex-row items-center gap-1 px-2" style={{ width: treeWidth }}>
+          {showControls ? (
+            <Tooltip side="bottom" trigger={<Text.H6 color="foregroundMuted">Span</Text.H6>}>
+              Navigate <HotkeyBadge hotkey="J" /> <HotkeyBadge hotkey="K" /> · Deselect <HotkeyBadge hotkey="Escape" />
+            </Tooltip>
+          ) : (
+            <Text.H6 color="foregroundMuted">Span</Text.H6>
+          )}
+          {showControls && hasCollapsible && (
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
+                  onClick={onToggleAll}
+                >
+                  {isAllCollapsed ? (
+                    <ChevronsUpDownIcon className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronsDownUpIcon className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              }
+            >
+              {isAllCollapsed ? "Expand all" : "Collapse all"} <HotkeyBadge hotkey="E" />
+            </Tooltip>
+          )}
+          {showControls && selectedSpan && (
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
+                  onClick={onToggleMinimized}
+                >
+                  {isMinimized ? <MaximizeIcon className="h-3.5 w-3.5" /> : <MinimizeIcon className="h-3.5 w-3.5" />}
+                </button>
+              }
+            >
+              {isMinimized ? "Expand tree" : "Minimize tree"}
+            </Tooltip>
+          )}
+        </div>
+        <div className="w-px shrink-0 self-stretch bg-border" />
+        <div
+          className="flex min-w-0 flex-1 flex-row items-center justify-between"
+          style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
+        >
+          <Text.H6 color="foregroundMuted">0ms</Text.H6>
+          <Text.H6 color="foregroundMuted">{formatDuration(timeRange.totalDuration)}</Text.H6>
+        </div>
+      </div>
+
+      {visibleNodes.map((flatNode) => {
+        const spanId = flatNode.node.span.spanId
+        const selection = { traceId: group.traceId, spanId }
+        return (
+          <TreeRow
+            key={spanTreeSelectionKey(selection)}
+            traceId={group.traceId}
+            flatNode={flatNode}
+            isExpanded={!collapsed.has(spanId)}
+            isSelected={selectedSpan ? spanTreeSelectionKey(selectedSpan) === spanTreeSelectionKey(selection) : false}
+            onToggle={onToggle}
+            onSelect={(nextSpanId) => onSelectSpan({ traceId: group.traceId, spanId: nextSpanId })}
+            treeWidth={treeWidth}
+            timeRange={timeRange}
+          />
+        )
+      })}
+
+      <WaterfallCursorOverlay treeWidth={treeWidth} cursorX={cursorX} cursorTimeLabel={cursorTimeLabel} />
+    </div>
+  )
+}
+
+export function GroupedSpanTree({
+  groups,
+  selectedSpan,
+  onSelectSpan,
+  isMinimized,
+  onToggleMinimized,
+  isActive,
+}: {
+  readonly groups: readonly SpanTreeGroup[]
+  readonly selectedSpan: SpanTreeSelection | null
+  readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
+  readonly isMinimized: boolean
+  readonly onToggleMinimized: () => void
+  readonly isActive: boolean
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  const { treeWidth, isDragging, onPointerDown, onKeyDown } = useResizablePanel({ containerRef })
+  const resolvedTreeWidth = treeWidth ?? MIN_TREE_WIDTH
+
+  const preparedGroups = useMemo(
+    () =>
+      groups.map((group) => {
+        const roots = buildSpanTree(group.spans)
+        const groupCollapsed = new Set(
+          [...collapsed]
+            .filter((key) => key.startsWith(`${group.traceId}:`))
+            .map((key) => key.slice(group.traceId.length + 1)),
+        )
+        return {
+          group,
+          collapsed: groupCollapsed,
+          visibleNodes: flattenTree(roots, groupCollapsed),
+          collapsibleIds: collectCollapsibleIds(roots),
+          timeRange: group.timeRange ?? getTraceTimeRange(group.spans),
+        }
+      }),
+    [collapsed, groups],
+  )
+
+  const visibleSelections = preparedGroups.flatMap(({ group, visibleNodes }) =>
+    visibleNodes.map(({ node }) => ({ traceId: group.traceId, spanId: node.span.spanId })),
+  )
+  const collapsibleSelections = preparedGroups.flatMap(({ group, collapsibleIds }) =>
+    [...collapsibleIds].map((spanId) => spanTreeSelectionKey({ traceId: group.traceId, spanId })),
+  )
+  const isAllCollapsed = collapsibleSelections.length > 0 && collapsibleSelections.every((key) => collapsed.has(key))
+
+  function toggle(selection: SpanTreeSelection) {
+    setCollapsed((current) => toggleCollapsedSpan(current, selection))
+  }
+
+  function toggleAll() {
+    setCollapsed(isAllCollapsed ? new Set() : new Set(collapsibleSelections))
+  }
+
+  useHotkeys([
+    {
+      hotkey: "J",
+      callback: () => {
+        const next = getAdjacentSpanSelection(visibleSelections, selectedSpan, "next")
+        if (next) onSelectSpan(next)
+      },
+      options: { enabled: isActive },
+    },
+    {
+      hotkey: "K",
+      callback: () => {
+        const previous = getAdjacentSpanSelection(visibleSelections, selectedSpan, "previous")
+        if (previous) onSelectSpan(previous)
+      },
+      options: { enabled: isActive },
+    },
+    {
+      hotkey: "E",
+      callback: toggleAll,
+      options: { enabled: isActive },
+    },
+    {
+      hotkey: "Escape",
+      callback: () => onSelectSpan(null),
+      options: { enabled: isActive && selectedSpan !== null, ignoreInputs: true },
+    },
+  ])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative flex flex-col overflow-hidden",
+        isMinimized ? "shrink-0 border-b border-border" : "flex-1",
+      )}
+      style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
+    >
+      <div className="flex flex-1 flex-col overflow-y-auto">
+        {preparedGroups.map(({ group, visibleNodes, collapsed: groupCollapsed, timeRange }, index) => (
+          <div key={group.traceId} className="flex shrink-0 flex-col">
+            {group.header}
+            <SpanTreeGroupRows
+              group={group}
+              visibleNodes={visibleNodes}
+              collapsed={groupCollapsed}
+              selectedSpan={selectedSpan}
+              onToggle={(spanId) => toggle({ traceId: group.traceId, spanId })}
+              onSelectSpan={onSelectSpan}
+              treeWidth={resolvedTreeWidth}
+              timeRange={timeRange}
+              showControls={index === 0}
+              hasCollapsible={collapsibleSelections.length > 0}
+              isAllCollapsed={isAllCollapsed}
+              onToggleAll={toggleAll}
+              isMinimized={isMinimized}
+              onToggleMinimized={onToggleMinimized}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize span tree panel"
+        aria-valuenow={resolvedTreeWidth}
+        aria-valuemin={MIN_TREE_WIDTH}
+        aria-valuemax={containerRef.current ? containerRef.current.offsetWidth - MIN_WATERFALL_WIDTH : 9999}
+        tabIndex={0}
+        className={cn(
+          "absolute bottom-0 top-0 z-10 w-px cursor-col-resize touch-none",
+          "transition-colors hover:bg-primary",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+          "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
+          { "bg-primary": isDragging, "bg-border": !isDragging },
+        )}
+        style={{ left: resolvedTreeWidth }}
+        onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
+      />
+    </div>
+  )
+}
 
 export function SpanTree({
   spans,
@@ -31,200 +325,24 @@ export function SpanTree({
   readonly onToggleMinimized: () => void
   readonly isActive: boolean
 }) {
-  const containerRef = useRef<HTMLDivElement | null>(null)
-  const scrollRef = useRef<HTMLDivElement | null>(null)
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
-  const { treeWidth, isDragging, onPointerDown, onKeyDown } = useResizablePanel({ containerRef })
-
-  const roots = useMemo(() => buildSpanTree(spans), [spans])
-  const timeRange = useMemo(() => getTraceTimeRange(spans), [spans])
-  const visibleNodes = useMemo(() => flattenTree(roots, collapsed), [roots, collapsed])
-
-  const collapsibleIds = useMemo(() => {
-    const ids = new Set<string>()
-    const visited = new Set<string>()
-    function collect(node: { span: { spanId: string }; children: readonly unknown[] }) {
-      // Cycle detection: skip if already visited
-      if (visited.has(node.span.spanId)) return
-      visited.add(node.span.spanId)
-      if (node.children.length > 0) ids.add(node.span.spanId)
-      for (const child of node.children) collect(child as typeof node)
-    }
-    for (const root of roots) collect(root)
-    return ids
-  }, [roots])
-
-  const isAllCollapsed = collapsibleIds.size > 0 && collapsibleIds.size === collapsed.size
-
-  const resolvedTreeWidth = treeWidth ?? MIN_TREE_WIDTH
-  const { cursorX, cursorTimeLabel, onMouseMove, onMouseLeave } = useWaterfallCursor({
-    containerRef,
-    treeWidth: resolvedTreeWidth,
-    timeRange,
-  })
-
-  const toggle = useCallback((spanId: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev)
-      if (next.has(spanId)) next.delete(spanId)
-      else next.add(spanId)
-      return next
-    })
-  }, [])
-
-  const toggleAll = useCallback(() => {
-    setCollapsed((prev) => (prev.size === collapsibleIds.size ? new Set() : new Set(collapsibleIds)))
-  }, [collapsibleIds])
-
-  // J/K/E/Escape hotkeys — only active when this tab is visible
-  useHotkeys([
-    {
-      hotkey: "J",
-      callback: () => {
-        const idx = selectedSpanId ? visibleNodes.findIndex((n) => n.node.span.spanId === selectedSpanId) : -1
-        const next = visibleNodes[idx + 1] ?? visibleNodes[0]
-        if (next) onSelectSpan(next.node.span.spanId)
-      },
-      options: { enabled: isActive },
-    },
-    {
-      hotkey: "K",
-      callback: () => {
-        const idx = selectedSpanId
-          ? visibleNodes.findIndex((n) => n.node.span.spanId === selectedSpanId)
-          : visibleNodes.length
-        const prev = visibleNodes[idx - 1]
-        if (prev) onSelectSpan(prev.node.span.spanId)
-      },
-      options: { enabled: isActive },
-    },
-    {
-      hotkey: "E",
-      callback: toggleAll,
-      options: { enabled: isActive },
-    },
-    {
-      hotkey: "Escape",
-      callback: () => onSelectSpan(""),
-      options: { enabled: isActive && selectedSpanId !== "", ignoreInputs: true },
-    },
-  ])
-
+  const traceId = spans[0]?.traceId ?? ""
+  const selectedSpan = selectedSpanId ? { traceId, spanId: selectedSpanId } : null
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: passive mouse tracking for waterfall cursor
-    <div
-      ref={containerRef}
-      className={cn(
-        "relative flex flex-col overflow-hidden",
-        isMinimized ? "shrink-0 border-b border-border" : "flex-1",
-      )}
-      style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
-      onMouseMove={onMouseMove}
-      onMouseLeave={onMouseLeave}
-    >
-      {/* Header */}
-      <div className="flex flex-row items-center shrink-0 border-b border-border" style={{ height: ROW_HEIGHT }}>
-        <div className="flex flex-row items-center gap-1 shrink-0 px-2" style={{ width: resolvedTreeWidth }}>
-          <Tooltip side="bottom" trigger={<Text.H6 color="foregroundMuted">Span</Text.H6>}>
-            Navigate <HotkeyBadge hotkey="J" /> <HotkeyBadge hotkey="K" /> · Deselect <HotkeyBadge hotkey="Escape" />
-          </Tooltip>
-          {collapsibleIds.size > 0 && (
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <button
-                  type="button"
-                  className="shrink-0 p-0.5 rounded hover:bg-muted text-muted-foreground transition-colors"
-                  onClick={toggleAll}
-                >
-                  {isAllCollapsed ? (
-                    <ChevronsUpDownIcon className="w-3.5 h-3.5" />
-                  ) : (
-                    <ChevronsDownUpIcon className="w-3.5 h-3.5" />
-                  )}
-                </button>
-              }
-            >
-              {isAllCollapsed ? "Expand all" : "Collapse all"} <HotkeyBadge hotkey="E" />
-            </Tooltip>
-          )}
-          {selectedSpanId !== "" && (
-            <Tooltip
-              asChild
-              side="bottom"
-              trigger={
-                <button
-                  type="button"
-                  className="shrink-0 p-0.5 rounded hover:bg-muted text-muted-foreground transition-colors"
-                  onClick={onToggleMinimized}
-                >
-                  {isMinimized ? <MaximizeIcon className="w-3.5 h-3.5" /> : <MinimizeIcon className="w-3.5 h-3.5" />}
-                </button>
-              }
-            >
-              {isMinimized ? "Expand tree" : "Minimize tree"}
-            </Tooltip>
-          )}
-        </div>
-        <div className="shrink-0 w-px self-stretch bg-border" />
-        <div
-          className="flex-1 flex flex-row items-center justify-between min-w-0"
-          style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
-        >
-          <Text.H6 color="foregroundMuted">0ms</Text.H6>
-          <Text.H6 color="foregroundMuted">{formatDuration(timeRange.totalDuration)}</Text.H6>
-        </div>
-      </div>
-
-      {/* Rows */}
-      <div ref={scrollRef} className="flex flex-col overflow-y-auto flex-1">
-        {visibleNodes.map((flatNode) => (
-          <TreeRow
-            key={flatNode.node.span.spanId}
-            flatNode={flatNode}
-            isExpanded={!collapsed.has(flatNode.node.span.spanId)}
-            isSelected={selectedSpanId === flatNode.node.span.spanId}
-            onToggle={toggle}
-            onSelect={onSelectSpan}
-            treeWidth={resolvedTreeWidth}
-            timeRange={timeRange}
-          />
-        ))}
-      </div>
-
-      {/* Waterfall time cursor */}
-      <WaterfallCursorOverlay treeWidth={resolvedTreeWidth} cursorX={cursorX} cursorTimeLabel={cursorTimeLabel} />
-
-      {/* Resize handle */}
-      {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
-      <div
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize span tree panel"
-        aria-valuenow={resolvedTreeWidth}
-        aria-valuemin={MIN_TREE_WIDTH}
-        aria-valuemax={containerRef.current ? containerRef.current.offsetWidth - MIN_WATERFALL_WIDTH : 9999}
-        tabIndex={0}
-        className={cn(
-          "absolute top-0 bottom-0 w-px cursor-col-resize z-10 touch-none",
-          "hover:bg-primary transition-colors",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
-          "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
-          isDragging ? "bg-primary" : "bg-border",
-        )}
-        style={{ left: resolvedTreeWidth }}
-        onPointerDown={onPointerDown}
-        onKeyDown={onKeyDown}
-      />
-    </div>
+    <GroupedSpanTree
+      groups={[{ traceId, spans }]}
+      selectedSpan={selectedSpan}
+      onSelectSpan={(selection) => onSelectSpan(selection?.spanId ?? "")}
+      isMinimized={isMinimized}
+      onToggleMinimized={onToggleMinimized}
+      isActive={isActive}
+    />
   )
 }
 
-export function scrollSpanIntoView(containerEl: HTMLElement | null, spanId: string) {
+export function scrollSpanIntoView(containerEl: HTMLElement | null, spanId: string, traceId?: string) {
   if (!containerEl) return
-  const row = containerEl.querySelector(`[data-span-id="${spanId}"]`)
-  if (row) {
-    row.scrollIntoView({ block: "nearest", behavior: "smooth" })
-  }
+  const row = [...containerEl.querySelectorAll<HTMLElement>("[data-span-id]")].find(
+    (element) => element.dataset.spanId === spanId && (traceId === undefined || element.dataset.traceId === traceId),
+  )
+  row?.scrollIntoView({ block: "nearest", behavior: "smooth" })
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -34,6 +34,7 @@ function TreeConnectors({
 }
 
 export const TreeRow = memo(function TreeRow({
+  traceId,
   flatNode,
   isExpanded,
   isSelected,
@@ -42,6 +43,7 @@ export const TreeRow = memo(function TreeRow({
   treeWidth,
   timeRange,
 }: {
+  readonly traceId: string
   readonly flatNode: FlattenedNode
   readonly isExpanded: boolean
   readonly isSelected: boolean
@@ -59,6 +61,7 @@ export const TreeRow = memo(function TreeRow({
     <div
       role="button"
       tabIndex={0}
+      data-trace-id={traceId}
       data-span-id={node.span.spanId}
       className={cn(
         "flex flex-row items-center shrink-0 cursor-pointer transition-colors",

--- a/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/sandbox/$sandboxOrgId/projects/$projectSlug.tsx
@@ -85,6 +85,7 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
   const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
   const [activeSessionId, setActiveSessionId] = useParamState("sessionId", "")
   const [, setSelectedSpanId] = useParamState("spanId", "")
+  const [, setSelectedSpanTraceId] = useParamState("spanTraceId", "")
 
   const tabDefaultSorting = activeTab === "sessions" ? DEFAULT_SESSION_SORTING : DEFAULT_TRACE_SORTING
   const [sortBy, setSortBy] = useParamState("sortBy", tabDefaultSorting.column)
@@ -138,7 +139,8 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
   const closeTraceDrawer = useCallback(() => {
     setActiveTraceId("")
     setSelectedSpanId("")
-  }, [setActiveTraceId, setSelectedSpanId])
+    setSelectedSpanTraceId("")
+  }, [setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
 
   const onActiveTraceChange = (traceId: string | undefined) => {
     if (!traceId) {
@@ -154,15 +156,18 @@ function SandboxTracesContent({ sandboxOrgId, projectSlug }: { sandboxOrgId: str
     (sessionId: string, traceId?: string) => {
       setActiveSessionId(sessionId)
       setActiveTraceId(traceId ?? "")
+      setSelectedSpanId("")
+      setSelectedSpanTraceId("")
     },
-    [setActiveSessionId, setActiveTraceId],
+    [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId],
   )
 
   const closeSessionPanel = useCallback(() => {
     setActiveSessionId("")
     setActiveTraceId("")
     setSelectedSpanId("")
-  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId])
+    setSelectedSpanTraceId("")
+  }, [setActiveSessionId, setActiveTraceId, setSelectedSpanId, setSelectedSpanTraceId])
 
   // Next/prev trace navigation off the loaded list (Traces tab drawer).
   const navigateTrace = useCallback(

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -981,6 +981,53 @@ describe("SpanRepository", () => {
 
       expect(tools.map((t) => t.name)).toEqual(["orphan_tool"])
     })
+
+    it("keeps identical tool span ids from different traces while deduping re-ingestion within each trace", async () => {
+      const DEDUP_SESSION = SessionId("tool-dedup-session")
+      const traceA = TraceId("55555555555555555555555555555555")
+      const traceB = TraceId("66666666666666666666666666666666")
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            session_id: DEDUP_SESSION,
+            trace_id: traceA,
+            span_id: "eeee111111111111",
+            operation: "execute_tool",
+            tool_name: "shared_older",
+            start_time: "2026-03-01 00:04:00.000000000",
+            end_time: "2026-03-01 00:04:00.100000000",
+            ingested_at: "2026-03-01 00:04:00.000",
+          }),
+          makeSpanRow({
+            session_id: DEDUP_SESSION,
+            trace_id: traceA,
+            span_id: "eeee111111111111",
+            operation: "execute_tool",
+            tool_name: "shared_newer",
+            start_time: "2026-03-01 00:04:00.000000000",
+            end_time: "2026-03-01 00:04:00.100000000",
+            ingested_at: "2026-03-01 00:04:01.000",
+          }),
+          makeSpanRow({
+            session_id: DEDUP_SESSION,
+            trace_id: traceB,
+            span_id: "eeee111111111111",
+            operation: "execute_tool",
+            tool_name: "trace_b_tool",
+            start_time: "2026-03-01 00:05:00.000000000",
+            end_time: "2026-03-01 00:05:00.100000000",
+            ingested_at: "2026-03-01 00:05:00.000",
+          }),
+        ]),
+      )
+
+      const tools = await runCh(
+        repo.listToolSpansBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: DEDUP_SESSION }),
+      )
+
+      expect(tools.map((t) => t.name)).toEqual(["shared_newer", "trace_b_tool"])
+      expect(tools.map((t) => t.traceId)).toEqual([traceA, traceB])
+    })
   })
 
   describe("findBySpanId", () => {

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -230,6 +230,43 @@ describe("SpanRepository", () => {
       expect(detail.attrString).toEqual({ "ai.prompt": "huge-blob" })
     })
 
+    it("keeps identical span ids from different traces while deduping re-ingestion within each trace", async () => {
+      const otherTrace = TraceId("12121212121212121212121212121212")
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_ID,
+            span_id: "abababababababab",
+            name: "trace-a-older",
+            ingested_at: "2026-01-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: TRACE_ID,
+            span_id: "abababababababab",
+            name: "trace-a-newer",
+            ingested_at: "2026-01-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            session_id: SESSION_ID,
+            trace_id: otherTrace,
+            span_id: "abababababababab",
+            name: "trace-b",
+            start_time: "2026-01-01 00:00:02.000000000",
+            end_time: "2026-01-01 00:00:03.000000000",
+          }),
+        ]),
+      )
+
+      const spans = await runCh(
+        repo.listBySessionId({ organizationId: ORG_ID, projectId: PROJECT_ID, sessionId: SESSION_ID }),
+      )
+
+      expect(spans.map((span) => span.name)).toEqual(["trace-a-newer", "trace-b"])
+      expect(spans.map((span) => span.traceId)).toEqual([TRACE_ID, otherTrace])
+    })
+
     it("matches orphan single-trace sessions keyed by trace id", async () => {
       await insertListFixture()
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -644,8 +644,8 @@ export const SpanRepositoryLive = Layer.effect(
                         AND project_id = {projectId:String}
                         AND ${membership.clause}
                         AND operation = 'execute_tool'
-                      ORDER BY span_id, ingested_at DESC
-                      LIMIT 1 BY span_id
+                      ORDER BY trace_id, span_id, ingested_at DESC
+                      LIMIT 1 BY trace_id, span_id
                     )
                     ORDER BY start_time ASC`,
               query_params: {

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -587,7 +587,7 @@ export const SpanRepositoryLive = Layer.effect(
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Same `LIMIT 1 BY span_id` dedupe as listByTraceId. The attr maps
+              // Dedupe by trace + span because OpenTelemetry span ids are trace-scoped. The attr maps
               // come back as empty literals: a session is unbounded in span count
               // and `attr_string` alone can hold the full conversation per span
               // (Vercel AI SDK `ai.prompt*`), so reading them here has OOMed the
@@ -602,8 +602,8 @@ export const SpanRepositoryLive = Layer.effect(
                         AND ${membership.clause}
                         ${startFromClause}
                         ${startToClause}
-                      ORDER BY span_id, ingested_at DESC
-                      LIMIT 1 BY span_id
+                      ORDER BY trace_id, span_id, ingested_at DESC
+                      LIMIT 1 BY trace_id, span_id
                     )
                     ORDER BY start_time ASC`,
               query_params: {


### PR DESCRIPTION
## What this does

Adds a **Spans** tab to the Session Detail Drawer for every session, not just sessions built from a single trace. The tab shows all spans across all of the session's traces in one tree, grouped by trace, with each trace rendered as its own zero-based waterfall so per-trace timing stays readable.

Previously the Spans tab was gated to `singleTrace` sessions: it reused the Trace drawer's `SpanTree`, which accepts exactly one `traceId`, so it vanished the moment a session picked up a second trace. Multi-trace deep links to `sessionTab=spans` were even redirected back to the Session tab. This lifts that restriction and treats the session view as a first-class multi-trace tree.


https://github.com/user-attachments/assets/d3d4f0ce-f45f-4c82-b330-290e923cddd0



## How it looks

- One shared tree header (span/waterfall split) scaled to the **longest trace's duration**, so every trace's bars share a single time scale.
- Under it, each trace is a collapsible section with a compact single-line header: collapse toggle + `Trace N` on the left, trace start time + a `View trace` link on the right, mirroring the span/time split. A border band separates sections.
- Traces render oldest-first, following session chronology; each waterfall starts at its own `0ms`.

## Notable changes

- **Shared tree is now multi-trace aware.** `SpanTree` gained a `GroupedSpanTree` mode with compound `{ traceId, spanId }` selection, cross-trace J/K/E keyboard navigation from a single controller (no more duelling hotkey instances), and per-trace collapse/scroll/resize state. Span-scoped state that keyed on `spanId` alone now keys on the trace/span pair, since span IDs are only unique within a trace.
- **New session-spans module** (`session-spans.ts`): grouping, per-trace filtering with ancestor preservation, trace numbering, and compound selection keys. Spans themselves are authoritative for grouping; trace metadata (capped at 500 traces upstream) is decoration only.
- **URL state** gained a `spanTraceId` param alongside `spanId`, with legacy-link resolution — an old `spanId`-only link resolves its trace after spans load, and falls back to clearing selection if ambiguous.
- **ClickHouse dedup fix.** `listBySessionId` deduplicated with `LIMIT 1 BY span_id`, which can collide across traces in a session. Changed to `LIMIT 1 BY (trace_id, span_id)`. The frontend collection already used the composite key.
- Explicit loading / error / empty / no-match-filters states for the session tab.

## Scope cut

Rendering is not virtualized. Session span counts are unbounded and a large session will render many rows; trace-level collapsing is the only mitigation here. Virtualization is a deliberate follow-up — the server-side query was already hardened for large sessions, so this is a client-render concern, not a data one.

## Tests

Added unit tests for grouping/filtering, compound selection and keyboard order, collapse identity, and a ClickHouse repository test for `(trace_id, span_id)` dedup. Web suite (574 tests) and focused ClickHouse tests pass; web build and workspace typechecks pass.
