### PR TITLE
fix(traces): fall back to unwindowed trace count when firstTraceAt is null

### DIFF
--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -98,17 +98,19 @@ export function useTracesCount({
   projectId,
   filters,
   searchQuery,
+  enabled = true,
 }: {
   readonly projectId: string
   readonly filters?: FilterSet
   readonly searchQuery?: string
+  readonly enabled?: boolean
 }) {
   const scope = useProjectScope()
   const { data: totalCount = 0, isLoading } = useQuery({
     queryKey: [...projectScopeKey(scope), "traces-count", projectId, filters, searchQuery],
     queryFn: () => countTracesByProject({ data: { ...projectScopeData(scope), projectId, filters, searchQuery } }),
     staleTime: 30_000,
-    enabled: projectId.length > 0,
+    enabled: enabled && projectId.length > 0,
   })
 
   return { totalCount, isLoading }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -281,7 +281,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  const { totalCount: totalTraceCount, isLoading: isTracesCountLoading } = useTracesCount({
+  const { totalCount: totalTraceCount } = useTracesCount({
     projectId: currentProject.id,
     filters: effectiveFilters,
     ...(hasSearchQuery ? { searchQuery: query } : {}),
@@ -456,13 +456,16 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
 
   // Gate on whether the project ever received a trace, not the windowed count — old-data projects
   // fall through to the normal view (with the time filter) instead of the false onboarding.
-  const projectNeverReceivedTraces = currentProject.firstTraceAt == null
+  // `firstTraceAt` is a best-effort column (only written by live ingestion), so a null value doesn't
+  // prove emptiness — backfilled/old projects can have traces with a null `firstTraceAt`. Confirm
+  // with an unwindowed total count, but only when the fast path can't already vouch for traces.
+  const { totalCount: everTraceCount } = useTracesCount({
+    projectId: currentProject.id,
+    enabled: currentProject.firstTraceAt == null,
+  })
+  const projectHasTracesEver = currentProject.firstTraceAt != null || everTraceCount > 0
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
-  const showConnectEmptyState =
-    projectNeverReceivedTraces &&
-    !hasActiveFilters &&
-    !hasSearchQuery &&
-    (isTracesCountLoading || totalTraceCount === 0)
+  const showConnectEmptyState = !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
 
   if (showConnectEmptyState) {
     return (


### PR DESCRIPTION
## Problem

Follow-up to #3961. That fix gated the **"Waiting for your first trace"** onboarding on `project.firstTraceAt` instead of the windowed trace count. It worked for the QA seed fixture (which explicitly backdates `first_trace_at` in Postgres) but **not for real projects**.

`firstTraceAt` is a **best-effort column** — it's written only by the `checkFirstTrace` worker (`apps/workers/src/workers/projects.ts`), which fires off the live-ingestion `TracesIngested` event. So it stays `null` for any project whose traces didn't flow through that path:

- **Backfilled demo/showcase projects** (e.g. "Support Agent Demo Project") whose traces were loaded straight into ClickHouse.
- Projects whose traces predate the feature (never backfilled).
- Projects where the worker silently failed (it runs under `Effect.ignore`).

For such a project whose traces are **all older than the default 30-day window**:

- `firstTraceAt == null` → reads as "never received a trace" (wrong)
- windowed `totalTraceCount === 0` → true

…so it showed the onboarding. The onboarding's own **unwindowed** poll then saw the old traces and flashed *"Your first trace just arrived"*, invalidated the caches — but on re-render `firstTraceAt` was **still** `null`, so it re-rendered the onboarding. Permanent stuck loop.

## Fix

`firstTraceAt` is the wrong ground truth. Gate on an **unwindowed total trace count** — the same reliable signal the onboarding poll already uses — and keep `firstTraceAt != null` as a fast-path so healthy projects skip the extra count query:

- `firstTraceAt != null` → has traces, normal view immediately (no count query fired; `enabled: firstTraceAt == null`).
- `firstTraceAt == null` → run the unwindowed count. `> 0` → normal view (old-data projects fall through with the time-filter dropdown). `0` → onboarding (genuinely empty — unchanged).

Added an optional `enabled` param to `useTracesCount` to support the fast-path skip.

## QA

1. Open a project with only old traces and a null `first_trace_at` (e.g. a backfilled demo project) → ✅ normal Sessions view with the time dropdown, **not** the onboarding.
2. Widen the time range → the old traces appear.
3. Regression: a project that never received a trace still shows the onboarding.
4. Regression: a healthy project with recent traces is unaffected and fires no extra count query.

## Note

This is a hotfix. The count query behind the gate (`countByProjectId`) wraps a `GROUP BY trace_id`, so it's heavier than an existence probe would be; a `SELECT 1 … LIMIT 1` `hasAnyTrace` repo method (short-circuiting on the `(organization_id, project_id, trace_id)` sort key) is the cleaner follow-up for both this gate and the onboarding poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
