### PR TITLE
feat(web): cross-trace span links in the session Conversation tab

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/conversation-tab.tsx
@@ -402,6 +402,11 @@ export function ConversationTab({
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
       timeline={timeline}
       focusMessageIndex={focusMessageIndex}
+      sessionSpanScope={{
+        sessionId,
+        sessionStartTime: session.startTime,
+        sessionEndTime: session.endTime,
+      }}
       {...(navigateToSpan ? { navigateToSpan } : {})}
       {...(labelsByMessageIndex.size > 0 ? { messageTrailingSlot } : {})}
       {...(searchQuery ? { searchQuery } : {})}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -17,7 +17,10 @@ import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useRef
 import type { GenAIMessage } from "rosetta-ai"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { useAuthSession } from "../../../../../../../domains/sessions/session.collection.ts"
-import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
+import {
+  useConversationSpanMaps,
+  useSessionConversationSpanMaps,
+} from "../../../../../../../domains/spans/spans.collection.ts"
 import {
   useTraceConversationMessages,
   useTraceSearchHighlights,
@@ -94,6 +97,7 @@ function ConversationContent({
   traceDetail,
   messages,
   navigateToSpan,
+  sessionSpanScope,
   projectId,
   isActive,
   annotationsEnabled,
@@ -113,6 +117,15 @@ function ConversationContent({
   readonly traceDetail: TraceDetailRecord
   readonly messages: readonly GenAIMessage[]
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
+  /** When set, message/tool-call navigation links resolve against ALL session spans
+   *  (not just this trace); annotations still anchor to this trace. */
+  readonly sessionSpanScope?:
+    | {
+        readonly sessionId: string
+        readonly sessionStartTime: string
+        readonly sessionEndTime: string
+      }
+    | undefined
   readonly projectId: string
   readonly isActive: boolean
   /** Off under a sandbox scope — hides the inline annotate affordances and skips annotation fetches. */
@@ -145,8 +158,20 @@ function ConversationContent({
     traceId: traceDetail.traceId,
     startTime: traceDetail.startTime,
     allMessages: messages,
-    enabled: messages.length > 0 && (annotationsEnabled || navigateToSpan !== undefined),
+    enabled: messages.length > 0 && (annotationsEnabled || (navigateToSpan !== undefined && sessionSpanScope == null)),
   })
+
+  const { data: sessionSpanMaps } = useSessionConversationSpanMaps({
+    projectId,
+    sessionId: sessionSpanScope?.sessionId ?? "",
+    latestTraceId: traceDetail.traceId,
+    sessionStartTime: sessionSpanScope?.sessionStartTime ?? "",
+    sessionEndTime: sessionSpanScope?.sessionEndTime ?? "",
+    allMessages: messages,
+    enabled: sessionSpanScope != null && messages.length > 0 && navigateToSpan !== undefined,
+  })
+
+  const navSpanMaps = sessionSpanScope ? sessionSpanMaps : spanMaps
 
   const band = useViewportBand({ scrollRef, timeline: timeline ?? null, isActive })
 
@@ -467,16 +492,19 @@ function ConversationContent({
   }
 
   const messageActions =
-    navigateToSpan && spanMaps && Object.keys(spanMaps.messageSpanMap).length > 0
+    navigateToSpan && navSpanMaps && Object.keys(navSpanMaps.messageSpanMap).length > 0
       ? new Map(
-          Object.entries(spanMaps.messageSpanMap).map(([idx, spanId]) => [Number(idx), () => navigateToSpan(spanId)]),
+          Object.entries(navSpanMaps.messageSpanMap).map(([idx, spanId]) => [
+            Number(idx),
+            () => navigateToSpan(spanId),
+          ]),
         )
       : undefined
 
   const toolCallActions =
-    navigateToSpan && spanMaps && Object.keys(spanMaps.toolCallSpanMap).length > 0
+    navigateToSpan && navSpanMaps && Object.keys(navSpanMaps.toolCallSpanMap).length > 0
       ? new Map(
-          Object.entries(spanMaps.toolCallSpanMap).map(([toolCallId, spanId]) => [
+          Object.entries(navSpanMaps.toolCallSpanMap).map(([toolCallId, spanId]) => [
             toolCallId,
             () => navigateToSpan(spanId),
           ]),
@@ -628,6 +656,7 @@ export function ConversationTab({
   traceDetail,
   isDetailLoading,
   navigateToSpan,
+  sessionSpanScope,
   projectId,
   isActive,
   annotationsEnabled = true,
@@ -643,6 +672,15 @@ export function ConversationTab({
   readonly isDetailLoading: boolean
   /** Optional callback to navigate to a span. If not provided, message/tool call actions are hidden. */
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
+  /** When set, message/tool-call navigation links resolve against ALL session spans
+   *  (not just this trace); annotations still anchor to this trace. */
+  readonly sessionSpanScope?:
+    | {
+        readonly sessionId: string
+        readonly sessionStartTime: string
+        readonly sessionEndTime: string
+      }
+    | undefined
   readonly projectId: string
   readonly isActive: boolean
   /** Off under a sandbox scope — hides inline annotate affordances and skips annotation fetches. Defaults on. */
@@ -690,6 +728,7 @@ export function ConversationTab({
       traceDetail={traceDetail}
       messages={conversation.messages}
       navigateToSpan={navigateToSpan}
+      sessionSpanScope={sessionSpanScope}
       projectId={projectId}
       scrollContainerRef={scrollContainerRef}
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}


### PR DESCRIPTION
## What this does

The session Conversation tab renders the latest trace's conversation, but because an agent re-sends its full history each turn, that view contains messages and tool-calls produced in *earlier* traces too. Those elements only got a jump-to-span link if their span lived in the latest trace — a tool-call run five traces back showed as history with no link.

This wires the session Conversation tab's navigation links to a **session-wide** span map, so links now appear for spans generated in any trace of the session. Clicking one opens that exact span in its trace's section of the Spans tab (auto-expanding the collapsed section and scrolling into view), using the trace-resolution mechanism already shipped with the session Spans tab.

## How

The shared `TraceConversationTab` gets an optional `sessionSpanScope`. When set, its message/tool-call navigation actions build from `useSessionConversationSpanMaps` (session-wide, message-bearing spans) instead of the trace-scoped `useConversationSpanMaps`. This is the same session-wide map the timeline minimap already consumes and reuses its query key, so there's no new fetch, no backend change, and no matcher change.

Annotations deliberately stay on the trace-scoped map: an annotation writes `spanId` paired with `traceId = latest trace`, so a cross-trace `spanId` there would corrupt the anchor. The trace-scoped fetch is now skipped when only session-wide navigation is needed.

The session Conversation tab passes the scope (`sessionId`, `startTime`, `endTime`, all already in scope). The single-trace trace drawer passes no scope, so its behavior is unchanged.

## Caveats

- Trace is resolved by scanning session spans for the `spanId`, relying on globally-unique OTel span IDs (existing merged mechanism).
- Assistant-message→span matching is fingerprint-based over the session-wide span set — the same map the timeline minimap already uses, so link accuracy is consistent with what ships today.

## Testing

`pnpm --filter @app/web typecheck`, `test` (574 passing), and `build` all green. No test asserts the message/tool action wiring and this component has no co-located tests, so behavioral verification is manual.
