### PR TITLE
fix(web): show skeletons while session empty states resolve

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -465,13 +465,14 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   // `firstTraceAt` is a best-effort column (only written by live ingestion), so a null value doesn't
   // prove emptiness — backfilled/old projects can have traces with a null `firstTraceAt`. Confirm
   // with an unwindowed total count, but only when the fast path can't already vouch for traces.
-  const { totalCount: everTraceCount } = useTracesCount({
+  const { totalCount: everTraceCount, isLoading: everTraceCountLoading } = useTracesCount({
     projectId: currentProject.id,
     enabled: currentProject.firstTraceAt == null,
   })
   const projectHasTracesEver = currentProject.firstTraceAt != null || everTraceCount > 0
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
-  const showConnectEmptyState = !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
+  const showConnectEmptyState =
+    !everTraceCountLoading && !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
 
   if (showConnectEmptyState) {
     return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -471,8 +471,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   })
   const projectHasTracesEver = currentProject.firstTraceAt != null || everTraceCount > 0
   const orgHasConnectedProjects = allProjects.some((p) => p.id !== currentProject.id && p.firstTraceAt != null)
-  const showConnectEmptyState =
-    !everTraceCountLoading && !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
+  const showConnectEmptyState = !everTraceCountLoading && !projectHasTracesEver && !hasActiveFilters && !hasSearchQuery
 
   if (showConnectEmptyState) {
     return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -708,7 +708,7 @@ export function SessionsView({
         <InfiniteTable
           {...listingLayoutIntrinsicScroll.infiniteTable}
           data={tableData}
-          isLoading={isLoading}
+          isLoading={isLoading || isOrphanFragmentCountLoading}
           columns={columns}
           getRowKey={getRowKey}
           onRowClick={onRowClick}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Keeps the sessions and traces explorer in its loading state until the project trace count has resolved, preventing the connect-traces blank slate from flashing for populated projects. It also keeps the sessions table skeleton visible while checking whether an empty result contains hidden orphan-fragment sessions.

## Related issue (if applicable)

N/A

## How was this tested?

- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web test` (59 files, 574 tests)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df28c20a-b76b-4ae4-adea-057e90710dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df28c20a-b76b-4ae4-adea-057e90710dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

