### PR TITLE
fix(clickhouse): reduce trace detail memory usage

### DIFF
--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -85,6 +85,12 @@ export interface TraceRepositoryShape {
     readonly traceId: TraceId
   }): Effect.Effect<TraceDetail, NotFoundError | RepositoryError, ChSqlClient>
 
+  findSummaryByTraceId(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceId: TraceId
+  }): Effect.Effect<Trace, NotFoundError | RepositoryError, ChSqlClient>
+
   findMetadataByTraceId(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -21,6 +21,7 @@ export const createFakeTraceRepository = (overrides?: Partial<TraceRepositorySha
     aggregateMetricsByProjectId: () => Effect.succeed(emptyTraceMetrics()),
     histogramByProjectId: () => Effect.succeed([]),
     findByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
+    findSummaryByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
     findMetadataByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
     findConversationChunk: () =>
       Effect.succeed({ messages: [], offset: 0, limit: 0, totalMessages: 0, hasMore: false, payloadBytes: 0 }),

--- a/packages/domain/spans/src/use-cases/load-trace-for-trace-end.ts
+++ b/packages/domain/spans/src/use-cases/load-trace-for-trace-end.ts
@@ -1,7 +1,7 @@
 import { type ChSqlClient, OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
 import { Effect } from "effect"
 
-import type { TraceDetail } from "../entities/trace.ts"
+import type { Trace } from "../entities/trace.ts"
 import { TraceRepository } from "../ports/trace-repository.ts"
 
 export type LoadTraceForTraceEndSkipped = {
@@ -12,7 +12,7 @@ export type LoadTraceForTraceEndSkipped = {
 
 export type LoadTraceForTraceEndFound = {
   readonly kind: "found"
-  readonly traceDetail: TraceDetail
+  readonly traceDetail: Trace
 }
 
 export type LoadTraceForTraceEndResult = LoadTraceForTraceEndSkipped | LoadTraceForTraceEndFound
@@ -28,7 +28,7 @@ export const loadTraceForTraceEndUseCase = (input: {
 
     const traceRepository = yield* TraceRepository
     const detail = yield* traceRepository
-      .findByTraceId({
+      .findSummaryByTraceId({
         organizationId: OrganizationId(input.organizationId),
         projectId: ProjectId(input.projectId),
         traceId: TraceId(input.traceId),

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -533,6 +533,31 @@ describe("TraceRepository", () => {
         }
       }
     })
+
+    it("loads conversation chunks with the same message assembly as trace detail", async () => {
+      const [detail, chunk] = await Promise.all([
+        runCh(
+          repo.findByTraceId({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            traceId: TraceId(SEED_ANNOTATION_DEMO_TRACE_ID),
+          }),
+        ),
+        runCh(
+          repo.findConversationChunk({
+            organizationId: ORG_ID,
+            projectId: PROJECT_ID,
+            traceId: TraceId(SEED_ANNOTATION_DEMO_TRACE_ID),
+            offset: 0,
+            limit: 100,
+          }),
+        ),
+      ])
+
+      expect(chunk.messages).toEqual(detail.allMessages)
+      expect(chunk.totalMessages).toBe(detail.allMessages.length)
+      expect(chunk.hasMore).toBe(false)
+    })
   })
 
   describe("listMatchingFilterIdsByTraceId", () => {

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -479,6 +479,24 @@ describe("TraceRepository", () => {
     })
   })
 
+  describe("findSummaryByTraceId", () => {
+    it("loads trace orchestration fields without conversation content", async () => {
+      const summary = await runCh(
+        repo.findSummaryByTraceId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TraceId(SEED_ANNOTATION_DEMO_TRACE_ID),
+        }),
+      )
+
+      expect(summary.traceId).toBe(SEED_ANNOTATION_DEMO_TRACE_ID)
+      expect(summary.projectId).toBe(PROJECT_ID)
+      expect(summary.startTime).toBeInstanceOf(Date)
+      expect(summary.rootSpanName).toBeTypeOf("string")
+      expect("outputMessages" in summary).toBe(false)
+    })
+  })
+
   describe("findByTraceId", () => {
     it("prepends system instructions as first message in allMessages", async () => {
       const detail = await runCh(

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -15,6 +15,7 @@ import {
   SessionId,
   SimulationId,
   SpanId,
+  type TraceId,
   OrganizationId as toOrganizationId,
   ProjectId as toProjectId,
   toRepositoryError,

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -88,18 +88,12 @@ export const LIST_SELECT = `
   argMinIfMerge(root_span_name) AS root_span_name
 `
 
-const DETAIL_SELECT = `${LIST_SELECT},
-  argMinIfMerge(input_messages)        AS input_messages,
-  argMaxIfMerge(last_input_messages)   AS last_input_messages,
-  argMaxIfMerge(output_messages)       AS output_messages,
-  argMinIfMerge(system_instructions)   AS system_instructions
-`
-
-// Trace-panel detail WITHOUT last_input_messages (huge in long traces; the full convo loads via chunks).
-const METADATA_DETAIL_SELECT = `${LIST_SELECT},
-  argMinIfMerge(input_messages)        AS input_messages,
-  argMaxIfMerge(output_messages)       AS output_messages,
-  argMinIfMerge(system_instructions)   AS system_instructions
+const SPAN_MESSAGES_SELECT = `
+  trace_id,
+  argMinIf(input_messages, start_time, input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS first_input_messages,
+  argMaxIf(input_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
+  argMaxIf(output_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS final_output_messages,
+  argMinIf(system_instructions, start_time, system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS first_system_instructions
 `
 
 type TraceListRow = {
@@ -136,17 +130,12 @@ type TraceListRow = {
   root_span_name: string
 }
 
-type TraceDetailRow = TraceListRow & {
-  input_messages: string
+type SpanMessagesRow = {
+  trace_id: string
+  first_input_messages: string
   last_input_messages: string
-  output_messages: string
-  system_instructions: string
-}
-
-type TraceMetadataDetailRow = TraceListRow & {
-  input_messages: string
-  output_messages: string
-  system_instructions: string
+  final_output_messages: string
+  first_system_instructions: string
 }
 
 type TraceConversationChunkRow = {
@@ -339,29 +328,39 @@ const toTraceMetrics = (row: TraceMetricsRow | undefined): TraceMetrics => {
   }
 }
 
-const toDomainTraceDetail = (row: TraceDetailRow): TraceDetail => {
-  const systemInstructions = parseSystem(row.system_instructions)
-  const lastInput = parseMessages(row.last_input_messages)
-  const output = parseMessages(row.output_messages)
+const EMPTY_MESSAGES_ROW: Omit<SpanMessagesRow, "trace_id"> = {
+  first_input_messages: "",
+  last_input_messages: "",
+  final_output_messages: "",
+  first_system_instructions: "",
+}
+
+const toDomainTraceDetail = (summary: Trace, messages: Omit<SpanMessagesRow, "trace_id">): TraceDetail => {
+  const systemInstructions = parseSystem(messages.first_system_instructions)
+  const lastInput = parseMessages(messages.last_input_messages)
+  const output = parseMessages(messages.final_output_messages)
 
   // Prepend system instructions as a system message at index 0
   const systemMessage: GenAIMessage | null =
     systemInstructions.length > 0 ? { role: "system", parts: systemInstructions } : null
 
   return {
-    ...toBaseFields(row),
+    ...summary,
     systemInstructions,
-    inputMessages: parseMessages(row.input_messages),
+    inputMessages: parseMessages(messages.first_input_messages),
     outputMessages: output,
     allMessages: systemMessage ? [systemMessage, ...lastInput, ...output] : [...lastInput, ...output],
   }
 }
 
-const toDomainTraceMetadataDetail = (row: TraceMetadataDetailRow): TraceMetadataDetail => ({
-  ...toBaseFields(row),
-  systemInstructions: parseSystem(row.system_instructions),
-  inputMessages: parseMessages(row.input_messages),
-  outputMessages: parseMessages(row.output_messages),
+const toDomainTraceMetadataDetail = (
+  summary: Trace,
+  messages: Omit<SpanMessagesRow, "trace_id">,
+): TraceMetadataDetail => ({
+  ...summary,
+  systemInstructions: parseSystem(messages.first_system_instructions),
+  inputMessages: parseMessages(messages.first_input_messages),
+  outputMessages: parseMessages(messages.final_output_messages),
 })
 
 interface SortColumn {
@@ -880,34 +879,74 @@ export const TraceRepositoryLive = Layer.effect(
           )
       })
 
-    const listByTraceIds: TraceRepositoryShape["listByTraceIds"] = ({ organizationId, projectId, traceIds }) =>
+    const listSummariesByTraceIds = (input: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly traceIds: readonly TraceId[]
+    }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
-        if (traceIds.length === 0) return []
+        if (input.traceIds.length === 0) return []
 
-        return yield* chSqlClient
-          .query(async (client) => {
-            const result = await client.query({
-              query: `SELECT ${DETAIL_SELECT}
+        return yield* chSqlClient.query(async (client) => {
+          const result = await client.query({
+            query: `SELECT ${LIST_SELECT}
                     FROM traces
                     WHERE organization_id = {organizationId:String}
                       AND project_id = {projectId:String}
                       AND trace_id IN ({traceIds:Array(String)})
                     GROUP BY organization_id, project_id, trace_id`,
-              query_params: {
-                organizationId: organizationId as string,
-                projectId: projectId as string,
-                traceIds: Array.from(traceIds) as string[],
-              },
-              format: "JSONEachRow",
-            })
-            return result.json<TraceDetailRow>()
+            query_params: {
+              organizationId: input.organizationId as string,
+              projectId: input.projectId as string,
+              traceIds: Array.from(input.traceIds) as string[],
+            },
+            format: "JSONEachRow",
           })
-          .pipe(
-            Effect.map((rows) => rows.map(toDomainTraceDetail)),
-            Effect.mapError((error) => toRepositoryError(error, "listByTraceIds")),
-          )
+          return result.json<TraceListRow>()
+        })
+      }).pipe(Effect.map((rows) => rows.map(toBaseFields)))
+
+    const listSpanMessagesByTraceIds = (input: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly traceIds: readonly TraceId[]
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        if (input.traceIds.length === 0) return []
+
+        return yield* chSqlClient.query(async (client) => {
+          const result = await client.query({
+            query: `SELECT ${SPAN_MESSAGES_SELECT}
+                    FROM spans
+                    WHERE organization_id = {organizationId:String}
+                      AND project_id = {projectId:String}
+                      AND trace_id IN ({traceIds:Array(String)})
+                    GROUP BY trace_id`,
+            query_params: {
+              organizationId: input.organizationId as string,
+              projectId: input.projectId as string,
+              traceIds: Array.from(input.traceIds) as string[],
+            },
+            format: "JSONEachRow",
+          })
+          return result.json<SpanMessagesRow>()
+        })
       })
+
+    const listByTraceIds: TraceRepositoryShape["listByTraceIds"] = (input) =>
+      Effect.gen(function* () {
+        const [summaries, messageRows] = yield* Effect.all(
+          [listSummariesByTraceIds(input), listSpanMessagesByTraceIds(input)],
+          { concurrency: "unbounded" },
+        )
+        const messagesByTraceId = new Map(messageRows.map((row) => [normalizeCHString(row.trace_id), row] as const))
+
+        return summaries.map((summary) =>
+          toDomainTraceDetail(summary, messagesByTraceId.get(summary.traceId) ?? EMPTY_MESSAGES_ROW),
+        )
+      }).pipe(Effect.mapError((error) => toRepositoryError(error, "listByTraceIds")))
 
     const matchesFiltersByTraceId: TraceRepositoryShape["matchesFiltersByTraceId"] = ({
       organizationId,
@@ -1432,75 +1471,54 @@ export const TraceRepositoryLive = Layer.effect(
             )
         }),
 
+      findSummaryByTraceId: ({ organizationId, projectId, traceId }) =>
+        listSummariesByTraceIds({ organizationId, projectId, traceIds: [traceId] }).pipe(
+          Effect.flatMap((rows) => {
+            const first = rows[0]
+            return first
+              ? Effect.succeed(first)
+              : Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
+          }),
+          Effect.mapError((error) =>
+            isNotFoundError(error) ? error : toRepositoryError(error, "findSummaryByTraceId"),
+          ),
+        ),
+
       findByTraceId: ({ organizationId, projectId, traceId }) =>
         Effect.gen(function* () {
-          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
-          return yield* chSqlClient
-            .query(async (client) => {
-              const result = await client.query({
-                query: `SELECT ${DETAIL_SELECT}
-                      FROM traces
-                      WHERE organization_id = {organizationId:String}
-                        AND project_id = {projectId:String}
-                        AND trace_id = {traceId:FixedString(32)}
-                      GROUP BY organization_id, project_id, trace_id
-                      LIMIT 1`,
-                query_params: {
-                  organizationId: organizationId as string,
-                  projectId: projectId as string,
-                  traceId,
-                },
-                format: "JSONEachRow",
-              })
-              return result.json<TraceDetailRow>()
-            })
-            .pipe(
-              Effect.flatMap((rows) => {
-                const first = rows[0]
-                if (!first) {
-                  return Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
-                }
-                return Effect.succeed(toDomainTraceDetail(first))
-              }),
-              Effect.mapError((error) => (isNotFoundError(error) ? error : toRepositoryError(error, "findByTraceId"))),
-            )
-        }),
+          const [summaries, messageRows] = yield* Effect.all(
+            [
+              listSummariesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
+              listSpanMessagesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
+            ],
+            { concurrency: "unbounded" },
+          )
+          const summary = summaries[0]
+          if (!summary) return yield* Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
+
+          return toDomainTraceDetail(summary, messageRows[0] ?? EMPTY_MESSAGES_ROW)
+        }).pipe(
+          Effect.mapError((error) => (isNotFoundError(error) ? error : toRepositoryError(error, "findByTraceId"))),
+        ),
 
       findMetadataByTraceId: ({ organizationId, projectId, traceId }) =>
         Effect.gen(function* () {
-          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
-          return yield* chSqlClient
-            .query(async (client) => {
-              const result = await client.query({
-                query: `SELECT ${METADATA_DETAIL_SELECT}
-                      FROM traces
-                      WHERE organization_id = {organizationId:String}
-                        AND project_id = {projectId:String}
-                        AND trace_id = {traceId:FixedString(32)}
-                      GROUP BY organization_id, project_id, trace_id
-                      LIMIT 1`,
-                query_params: {
-                  organizationId: organizationId as string,
-                  projectId: projectId as string,
-                  traceId,
-                },
-                format: "JSONEachRow",
-              })
-              return result.json<TraceMetadataDetailRow>()
-            })
-            .pipe(
-              Effect.flatMap((rows) => {
-                const first = rows[0]
-                if (!first) {
-                  return Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
-                }
-                return Effect.succeed(toDomainTraceMetadataDetail(first))
-              }),
-              Effect.mapError((error) =>
-                isNotFoundError(error) ? error : toRepositoryError(error, "findMetadataByTraceId"),
-              ),
-            )
-        }),
+          const [summaries, messageRows] = yield* Effect.all(
+            [
+              listSummariesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
+              listSpanMessagesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
+            ],
+            { concurrency: "unbounded" },
+          )
+          const summary = summaries[0]
+          if (!summary) return yield* Effect.fail(new NotFoundError({ entity: "Trace", id: traceId as string }))
+
+          return toDomainTraceMetadataDetail(summary, messageRows[0] ?? EMPTY_MESSAGES_ROW)
+        }).pipe(
+          Effect.mapError((error) =>
+            isNotFoundError(error) ? error : toRepositoryError(error, "findMetadataByTraceId"),
+          ),
+        ),
 
       findConversationChunk: ({ organizationId, projectId, traceId, offset, limit }) =>
         Effect.gen(function* () {
@@ -1524,14 +1542,14 @@ export const TraceRepositoryLive = Layer.effect(
                           ) AS all_messages
                           FROM (
                             SELECT
-                              argMinIfMerge(system_instructions) AS system_instructions_json,
-                              argMaxIfMerge(last_input_messages) AS last_input_messages_json,
-                              argMaxIfMerge(output_messages) AS output_messages_json
-                            FROM traces
+                              argMinIf(system_instructions, start_time, system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions_json,
+                              argMaxIf(input_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages_json,
+                              argMaxIf(output_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages_json
+                            FROM spans
                             WHERE organization_id = {organizationId:String}
                               AND project_id = {projectId:String}
                               AND trace_id = {traceId:FixedString(32)}
-                            GROUP BY organization_id, project_id, trace_id
+                            GROUP BY trace_id
                             LIMIT 1
                           )
                         )`,

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -89,12 +89,23 @@ export const LIST_SELECT = `
   argMinIfMerge(root_span_name) AS root_span_name
 `
 
+const MESSAGE_OPERATION_FILTER = "operation IN ('chat', 'text_completion', 'generate_content')"
+const SYSTEM_INSTRUCTION_OPERATION_FILTER =
+  "operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')"
+
 const SPAN_MESSAGES_SELECT = `
   trace_id,
-  argMinIf(input_messages, start_time, input_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS first_input_messages,
-  argMaxIf(input_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages,
-  argMaxIf(output_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS final_output_messages,
-  argMinIf(system_instructions, start_time, system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS first_system_instructions
+  argMinIf(input_messages, start_time, input_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS first_input_messages,
+  argMaxIf(input_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages,
+  argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
+  argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS first_system_instructions
+`
+
+const SPAN_METADATA_MESSAGES_SELECT = `
+  trace_id,
+  argMinIf(input_messages, start_time, input_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS first_input_messages,
+  argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS final_output_messages,
+  argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS first_system_instructions
 `
 
 type TraceListRow = {
@@ -138,6 +149,8 @@ type SpanMessagesRow = {
   final_output_messages: string
   first_system_instructions: string
 }
+
+type SpanMetadataMessagesRow = Omit<SpanMessagesRow, "last_input_messages">
 
 type TraceConversationChunkRow = {
   total_messages: string | number
@@ -356,7 +369,7 @@ const toDomainTraceDetail = (summary: Trace, messages: Omit<SpanMessagesRow, "tr
 
 const toDomainTraceMetadataDetail = (
   summary: Trace,
-  messages: Omit<SpanMessagesRow, "trace_id">,
+  messages: Omit<SpanMetadataMessagesRow, "trace_id">,
 ): TraceMetadataDetail => ({
   ...summary,
   systemInstructions: parseSystem(messages.first_system_instructions),
@@ -936,6 +949,34 @@ export const TraceRepositoryLive = Layer.effect(
         })
       })
 
+    const listSpanMetadataMessagesByTraceIds = (input: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly traceIds: readonly TraceId[]
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        if (input.traceIds.length === 0) return []
+
+        return yield* chSqlClient.query(async (client) => {
+          const result = await client.query({
+            query: `SELECT ${SPAN_METADATA_MESSAGES_SELECT}
+                    FROM spans
+                    WHERE organization_id = {organizationId:String}
+                      AND project_id = {projectId:String}
+                      AND trace_id IN ({traceIds:Array(String)})
+                    GROUP BY trace_id`,
+            query_params: {
+              organizationId: input.organizationId as string,
+              projectId: input.projectId as string,
+              traceIds: Array.from(input.traceIds) as string[],
+            },
+            format: "JSONEachRow",
+          })
+          return result.json<SpanMetadataMessagesRow>()
+        })
+      })
+
     const listByTraceIds: TraceRepositoryShape["listByTraceIds"] = (input) =>
       Effect.gen(function* () {
         const [summaries, messageRows] = yield* Effect.all(
@@ -1507,7 +1548,7 @@ export const TraceRepositoryLive = Layer.effect(
           const [summaries, messageRows] = yield* Effect.all(
             [
               listSummariesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
-              listSpanMessagesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
+              listSpanMetadataMessagesByTraceIds({ organizationId, projectId, traceIds: [traceId] }),
             ],
             { concurrency: "unbounded" },
           )
@@ -1543,9 +1584,9 @@ export const TraceRepositoryLive = Layer.effect(
                           ) AS all_messages
                           FROM (
                             SELECT
-                              argMinIf(system_instructions, start_time, system_instructions != '' AND operation IN ('chat', 'text_completion', 'generate_content', 'invoke_agent')) AS system_instructions_json,
-                              argMaxIf(input_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS last_input_messages_json,
-                              argMaxIf(output_messages, end_time, output_messages != '' AND operation IN ('chat', 'text_completion', 'generate_content')) AS output_messages_json
+                              argMinIf(system_instructions, start_time, system_instructions != '' AND ${SYSTEM_INSTRUCTION_OPERATION_FILTER}) AS system_instructions_json,
+                              argMaxIf(input_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS last_input_messages_json,
+                              argMaxIf(output_messages, end_time, output_messages != '' AND ${MESSAGE_OPERATION_FILTER}) AS output_messages_json
                             FROM spans
                             WHERE organization_id = {organizationId:String}
                               AND project_id = {projectId:String}


### PR DESCRIPTION
## What changed

- add a summary-only trace lookup for trace-end orchestration and signal matching
- resolve trace message fields from source `spans` rows instead of finalizing wide `argMinIf`/`argMaxIf` aggregate states from `traces`
- apply the spans-backed message path to point lookups, batched detail reads, metadata reads, and conversation chunks
- preserve the materialized view's operation filters when reconstructing input, output, and system messages

## Why

Production ClickHouse periodically reaches its replica memory ceiling while worker fan-out runs concurrent trace-detail lookups. A full lookup can consume roughly 690 MiB because ClickHouse must deserialize message aggregate states from every matching active part. Bursts reached 23 detail queries per second and caused OvercommitTracker to cancel reads at the 18 GiB server limit.

Reading message candidates from `spans` bounds aggregation by the spans in the requested trace. Callers that only need orchestration fields no longer read conversation content.

Datadog issue: https://app.datadoghq.eu/error-tracking/issue/c70cdfb2-74fa-11f1-b700-da7ad0900005

## Verification

- `pnpm --filter @domain/spans typecheck`
- Biome checks for all changed files
- `git diff --check`
- production query-log analysis confirmed the failing query shape, concurrency bursts, and per-query memory profile

The ClickHouse repository test suite is currently blocked during module loading by an unrelated missing `@domain/monitors` workspace resolution. The commit hook's formatting pass succeeded; its workspace `knip` step was blocked by the existing `@tanstack/react-start/plugin/vite` package-export mismatch.
