### PR TITLE
fix(datasets): show imported rows after creation

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
@@ -7,6 +7,7 @@ import { useDatasetsList } from "../../../../../domains/datasets/datasets.collec
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
+import { useRouteProject } from "../-route-data.ts"
 
 /**
  * Generic "add the current selection to a dataset" modal. It owns only the
@@ -45,6 +46,7 @@ export function AddToDatasetModal({
   const [submitting, setSubmitting] = useState(false)
   const { toast } = useToast()
   const navigate = useNavigate()
+  const project = useRouteProject()
   const { data: datasets } = useDatasetsList(projectId)
 
   const datasetOptions = useMemo<SelectOption<string>[]>(
@@ -75,12 +77,21 @@ export function AddToDatasetModal({
           title: "Dataset created",
           description: `"${newDatasetName.trim()}" created with ${result.rowCount} row${result.rowCount === 1 ? "" : "s"}.`,
         })
-        getQueryClient().invalidateQueries({ queryKey: ["datasets", projectId] })
+        const queryClient = getQueryClient()
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["datasets", projectId] }),
+          queryClient.invalidateQueries({ queryKey: ["dataset", result.datasetId] }),
+          queryClient.invalidateQueries({ queryKey: ["datasetRows", result.datasetId] }),
+        ])
+        queryClient.setQueryData(["datasetRowCount", result.datasetId], {
+          rows: [],
+          total: result.rowCount,
+        })
         onSuccess()
         onOpenChange(false)
         navigate({
           to: "/projects/$projectSlug/datasets/$datasetId",
-          params: { projectId, datasetId: result.datasetId },
+          params: { projectSlug: project.slug, datasetId: result.datasetId },
         })
       } else {
         if (!selectedDatasetId) return
@@ -89,9 +100,12 @@ export function AddToDatasetModal({
           title: `${itemLabelTitle} added to dataset`,
           description: `${result.rowCount} row${result.rowCount === 1 ? "" : "s"} added (version ${result.version}).`,
         })
-        getQueryClient().invalidateQueries({ queryKey: ["datasets", projectId] })
-        getQueryClient().invalidateQueries({ queryKey: ["datasetRows", selectedDatasetId] })
-        getQueryClient().invalidateQueries({ queryKey: ["datasetRowCount", selectedDatasetId] })
+        const queryClient = getQueryClient()
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["datasets", projectId] }),
+          queryClient.invalidateQueries({ queryKey: ["datasetRows", selectedDatasetId] }),
+          queryClient.invalidateQueries({ queryKey: ["datasetRowCount", selectedDatasetId] }),
+        ])
         onSuccess()
         onOpenChange(false)
       }
@@ -117,6 +131,7 @@ export function AddToDatasetModal({
     navigate,
     onSuccess,
     onOpenChange,
+    project.slug,
   ])
 
   const exceedsLimit = selectedCount > MAX_TRACES_PER_DATASET_IMPORT

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
@@ -221,6 +221,10 @@ export const DatasetRowRepositoryLive = Layer.effect(
                 table: "dataset_rows",
                 values: batch,
                 format: "JSONEachRow",
+                clickhouse_settings: {
+                  async_insert: 1,
+                  wait_for_async_insert: 1,
+                },
               })
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Rows imported during dataset creation now appear on the dataset detail page immediately after redirect. Dataset row inserts wait for ClickHouse to acknowledge the write, and the create flow seeds the row-count cache before navigation. The modal also refreshes related dataset queries and passes the project slug expected by the destination route.

## Related issue (if applicable)

N/A

## How was this tested?

- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @platform/db-clickhouse check`
- `pnpm --filter @platform/db-clickhouse typecheck`
- `pnpm exec vitest run src/repositories/dataset-row-repository.test.ts` from `packages/platform/db-clickhouse` using Node 25: 22 tests passed

## Checklist

- [x] Lint, type-checking, and focused tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4731e37-9b15-465e-a9e2-9b21e2b00153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4731e37-9b15-465e-a9e2-9b21e2b00153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

