### PR TITLE
Route signal notifications to assignees

### DIFF
--- a/apps/workers/src/workers/notifications.ts
+++ b/apps/workers/src/workers/notifications.ts
@@ -74,6 +74,7 @@ interface ProducerRequest {
   /** One per-recipient notification ID (all share the same idempotencyKey).
    *  The first one is passed to Slack jobs for chart URL generation. */
   readonly notificationId: string
+  readonly slackEligible?: boolean
 }
 
 const fanOutSlackRoutes = (
@@ -83,6 +84,7 @@ const fanOutSlackRoutes = (
   Effect.gen(function* () {
     if (requests.length === 0) return
     const first = requests[0]!
+    if (first.slackEligible === false) return
 
     const repo = yield* SlackIntegrationRepository
     const integration = yield* repo.findActiveByOrganizationId().pipe(Effect.orElseSucceed(() => null))

--- a/dev-docs/notifications.md
+++ b/dev-docs/notifications.md
@@ -33,7 +33,10 @@ notifications:request-{incident,wrapped-report,signal-assigned}-notifications
         endedAt > startedAt → incident.closed)
      – gate (incidents only): projectSettings.notifications.incidents[incidentNotificationKey]
      – mute gate (incidents only): skip muted monitor or muted signal sources
-     – resolveRecipients (today: all org members)
+     – signal-related notifications target the signal assignee when present;
+       unassigned signals and non-signal notifications use the existing
+       project-member fan-out
+     – assignee-targeted signal notifications do not fan out to shared Slack routes
      – signal-assigned: single recipient (the new assignee); router +
        producer both skip cleared assignments and self-assignments
      – snapshot trend window (signal-sourced sustained kinds: 14d ending at the

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.test.ts
@@ -195,6 +195,7 @@ describe("requestIncidentNotificationsUseCase", () => {
     if (result.status !== "ok") throw new Error("expected ok")
     expect(result.requests).toHaveLength(2)
     expect(result.requests[0]?.kind).toBe("incident.opened")
+    expect(result.requests[0]?.slackEligible).toBe(true)
     expect(result.requests[0]?.idempotencyKey).toBe(`incident.opened:${incident.id}`)
     expect(result.requests[0]?.payload).toMatchObject({
       alertIncidentId: incident.id,
@@ -204,6 +205,23 @@ describe("requestIncidentNotificationsUseCase", () => {
       severity: "high",
       condition: escalatingCondition,
     })
+  })
+
+  it("sends signal escalation incidents only to the assignee when assigned", async () => {
+    const incident = makeIncident()
+    const assigneeId = UserId(cuid("u2"))
+    const result = await Effect.runPromise(
+      requestIncidentNotificationsUseCase({
+        alertIncidentId: incident.id,
+        transition: "created",
+      }).pipe(Effect.provide(makeLayer({ incident, signal: makeSignal({ assigneeId }) }))),
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") throw new Error("expected ok")
+    expect(result.requests).toHaveLength(1)
+    expect(result.requests[0]?.userId).toBe(assigneeId)
+    expect(result.requests[0]?.slackEligible).toBe(false)
   })
 
   it("skips signal incidents when the signal is muted", async () => {

--- a/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-incident-notifications.ts
@@ -68,6 +68,7 @@ export interface IncidentNotificationRequest {
   readonly notificationId: NotificationId
   /** Project anchor for cascade-delete on `ProjectDeleted`. */
   readonly projectId: ProjectId
+  readonly slackEligible: boolean
 }
 
 export type RequestIncidentNotificationsResult =
@@ -543,11 +544,17 @@ export const requestIncidentNotificationsUseCase = (input: RequestIncidentNotifi
       { concurrency: "unbounded" },
     )
 
-    const recipients = yield* resolveRecipients({
-      organizationId: incident.organizationId,
-      projectId: incident.projectId,
-      kind: incidentNotificationKey,
-    })
+    const hasSignalAssignee = Boolean(signal?.assigneeId)
+    let recipients: readonly UserId[]
+    if (signal?.assigneeId) {
+      recipients = [UserId(signal.assigneeId)]
+    } else {
+      recipients = yield* resolveRecipients({
+        organizationId: incident.organizationId,
+        projectId: incident.projectId,
+        kind: incidentNotificationKey,
+      })
+    }
 
     if (recipients.length === 0) {
       return { status: "skipped", reason: "no-recipients" } as const
@@ -586,6 +593,7 @@ export const requestIncidentNotificationsUseCase = (input: RequestIncidentNotifi
       payload,
       notificationId: NotificationId(generateId()),
       projectId: incident.projectId,
+      slackEligible: !hasSignalAssignee,
     }))
 
     return { status: "ok", requests } as const

--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.test.ts
@@ -72,7 +72,7 @@ const input = {
 }
 
 describe("requestSignalDiscoveredNotificationsUseCase", () => {
-  it("fans out one discovery request per org member", async () => {
+  it("fans out one discovery request per org member when unassigned", async () => {
     const result = await Effect.runPromise(
       requestSignalDiscoveredNotificationsUseCase(input).pipe(Effect.provide(makeLayer({ signal: makeSignal() }))),
     )
@@ -85,8 +85,24 @@ describe("requestSignalDiscoveredNotificationsUseCase", () => {
     if (!first) throw new Error("expected a request")
     expect(first.kind).toBe("signal.discovered")
     expect(first.projectId).toBe(projectId)
+    expect(first.slackEligible).toBe(true)
     expect(first.idempotencyKey).toBe(`signal.discovered:${signalId}`)
     expect(first.payload).toEqual({ signalId, discoveredAt })
+  })
+
+  it("sends discovery requests only to the assignee when assigned", async () => {
+    const assigneeId = UserId(cuid("u2"))
+    const result = await Effect.runPromise(
+      requestSignalDiscoveredNotificationsUseCase(input).pipe(
+        Effect.provide(makeLayer({ signal: makeSignal({ assigneeId }) })),
+      ),
+    )
+
+    expect(result.status).toBe("ok")
+    if (result.status !== "ok") throw new Error("expected ok")
+    expect(result.requests).toHaveLength(1)
+    expect(result.requests[0]?.userId).toBe(assigneeId)
+    expect(result.requests[0]?.slackEligible).toBe(false)
   })
 
   it("skips when the signal is missing", async () => {

--- a/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
+++ b/packages/domain/notifications/src/use-cases/request-signal-discovered-notifications.ts
@@ -30,6 +30,7 @@ export interface SignalDiscoveredNotificationRequest {
   readonly payload: SignalDiscoveredPayload
   readonly notificationId: NotificationId
   readonly projectId: ProjectId
+  readonly slackEligible: boolean
 }
 
 export type RequestSignalDiscoveredNotificationsResult =
@@ -55,11 +56,17 @@ export const requestSignalDiscoveredNotificationsUseCase = (input: RequestSignal
       return { status: "skipped", reason: "user-origin-signal" } as const
     }
 
-    const recipients = yield* resolveRecipients({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      kind: "signal.discovered",
-    })
+    const hasSignalAssignee = Boolean(signal.assigneeId)
+    let recipients: readonly UserId[]
+    if (signal.assigneeId) {
+      recipients = [UserId(signal.assigneeId)]
+    } else {
+      recipients = yield* resolveRecipients({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        kind: "signal.discovered",
+      })
+    }
     if (recipients.length === 0) {
       return { status: "skipped", reason: "no-recipients" } as const
     }
@@ -78,6 +85,7 @@ export const requestSignalDiscoveredNotificationsUseCase = (input: RequestSignal
         payload,
         notificationId: NotificationId(generateId()),
         projectId: input.projectId,
+        slackEligible: !hasSignalAssignee,
       }),
     )
 


### PR DESCRIPTION
Signal discovery and escalation notifications now target the signal assignee when one is set. Unassigned signals keep the existing project-member fan-out.

Assignee-targeted notifications also skip shared Slack routes so they remain private to the assigned user.

Tests cover assigned and unassigned recipient selection for discovery and escalation notifications.

## Verification

- `pnpm --filter @domain/notifications test -- request-incident-notifications.test.ts request-signal-discovered-notifications.test.ts`
- `pnpm --filter @domain/notifications typecheck`
- `pnpm --filter @app/workers typecheck`
- commit hooks: workspace format and knip