### PR TITLE
fix(annotations): guard GenAI message formatting against missing parts

### DIFF
--- a/packages/domain/ai/src/formatAi.test.ts
+++ b/packages/domain/ai/src/formatAi.test.ts
@@ -1,4 +1,4 @@
-import type { GenAIPart } from "rosetta-ai"
+import type { GenAIMessage, GenAIPart } from "rosetta-ai"
 import { describe, expect, it } from "vitest"
 import { formatGenAIConversation, formatGenAIMessage, formatGenAIPart } from "./formatAi.ts"
 
@@ -51,6 +51,14 @@ describe("formatGenAIMessage", () => {
         ],
       }),
     ).toBe("a\nb")
+  })
+
+  it("returns an empty string when parts is missing", () => {
+    expect(formatGenAIMessage({ role: "user" } as GenAIMessage)).toBe("")
+  })
+
+  it("returns an empty string when parts is not an array", () => {
+    expect(formatGenAIMessage({ role: "user", parts: null } as unknown as GenAIMessage)).toBe("")
   })
 })
 

--- a/packages/domain/ai/src/formatAi.ts
+++ b/packages/domain/ai/src/formatAi.ts
@@ -57,7 +57,7 @@ function formatLooseGenAIPart(part: GenAIPart): string {
 
 /** Concatenates all parts of a GenAI message */
 export function formatGenAIMessage(message: GenAIMessage): string {
-  return message.parts
+  return (message.parts ?? [])
     .map((p) => formatGenAIPart(p))
     .join("\n")
     .trim()

--- a/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
+++ b/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts
@@ -55,6 +55,16 @@ describe("resolveAnnotationAnchorText", () => {
     ).toBeUndefined()
   })
 
+  it("returns undefined instead of throwing when the message is missing parts", () => {
+    const malformed: GenAIMessage[] = [{ role: "system" } as GenAIMessage]
+    expect(resolveAnnotationAnchorText(malformed, { messageIndex: 0, partIndex: 0 })).toBeUndefined()
+  })
+
+  it("returns an empty string instead of throwing when joining parts of a message missing parts", () => {
+    const malformed: GenAIMessage[] = [{ role: "system" } as GenAIMessage]
+    expect(resolveAnnotationAnchorText(malformed, { messageIndex: 0 })).toBe("")
+  })
+
   it("slices against prettified JSON when textFormat is 'pretty-json'", () => {
     const raw = '[{"id":"rel-2026-17"},{"id":"rel-2026-18"}]'
     const prettified = JSON.stringify(JSON.parse(raw), null, 2)

--- a/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts
+++ b/packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts
@@ -2,9 +2,9 @@ import type { AnnotationAnchor } from "@domain/scores"
 import { formatPartText } from "@repo/utils"
 import type { GenAIMessage } from "rosetta-ai"
 
-function joinTextParts(parts: GenAIMessage["parts"]): string {
+function joinTextParts(parts: GenAIMessage["parts"] | undefined): string {
   let out = ""
-  for (const part of parts) {
+  for (const part of parts ?? []) {
     if (part.type === "text" && typeof part.content === "string") {
       out += part.content
     }
@@ -39,7 +39,7 @@ export function resolveAnnotationAnchorText(
 
   let text: string
   if (anchor.partIndex !== undefined) {
-    const part = message.parts[anchor.partIndex]
+    const part = message.parts?.[anchor.partIndex]
     if (!part) {
       return undefined
     }

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.test.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.test.ts
@@ -303,4 +303,10 @@ describe("formatGenAIMessagesForEnrichmentPrompt", () => {
     expect(out).toContain("[message 1] role=assistant")
     expect(out).toContain("\n\n---\n\n")
   })
+
+  it("does not crash on a message missing parts (malformed ClickHouse payload)", () => {
+    const out = formatGenAIMessagesForEnrichmentPrompt([{ role: "system" } as GenAIMessage])
+    expect(out).toContain("[message 0] role=system")
+    expect(out).toContain("<no plain text in this message>")
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a production `TypeError` crashing annotation-publication enrichment:
[Datadog issue `b20aa0b2-7c6c-11f1-bbab-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/b20aa0b2-7c6c-11f1-bbab-da7ad0900005) — `workflows` service, `TypeError: Cannot read properties of undefined (reading 'map')` at `formatAi.ts:61`, 16 occurrences starting 2026-07-10.

**Root cause:** `TraceRepository.parseMessages`/`parseSystem` parse ClickHouse-stored `GenAIMessage` JSON with no shape validation — `genAIMessageSchema` (`packages/domain/spans/src/entities/trace.ts:59`) only checks that the value is a non-null object, not that it has a `parts` array. `formatGenAIMessage` (`packages/domain/ai/src/formatAi.ts:59-64`) and `resolveAnnotationAnchorText` (`packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts`) both assumed `message.parts` always exists, so a message reaching either function without `parts` throws.

This is one instance of a broader, already-known constraint: several sibling consumers of `GenAIMessage.parts` already guard against exactly this (`build-trace-search-document.ts`: `(message.parts ?? [])`, `compute-trace-search-highlights.ts`: `if (!message?.parts) return`, the flaggers' shared `iterMessageParts` helper: `Array.isArray(parts) ? parts : []`, `conversation-intelligence/normalization.ts`: `if (!Array.isArray(m.parts)) return ""`). `formatAi.ts` and `resolve-annotation-anchor-text.ts` were the two remaining call sites that didn't.

## Fix

- `packages/domain/ai/src/formatAi.ts`: `formatGenAIMessage` now does `(message.parts ?? [])` before mapping, matching the established pattern. This also fixes `formatGenAIConversation`, which delegates to it.
- `packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.ts`: guards the two direct `.parts` accesses (`joinTextParts` and the indexed `partIndex` lookup) the same way.

Both call sites are reachable from `enrichAnnotationForPublicationUseCase` (the Temporal activity in the stack trace), so the crash is fixed at both places it can occur for the same malformed-message input, not just the one that happened to be observed.

## Tests

Added regression tests that reproduce the exact crash with a message missing `parts` and confirmed they fail without the fix (`TypeError: Cannot read properties of undefined (reading 'map')` / `parts is not iterable`) and pass with it:
- `packages/domain/ai/src/formatAi.test.ts`: `formatGenAIMessage` with missing/non-array `parts`.
- `packages/domain/annotations/src/helpers/resolve-annotation-anchor-text.test.ts`: `resolveAnnotationAnchorText` with a message missing `parts`, both the `partIndex`-set and join-all-parts branches.
- `packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.test.ts`: `formatGenAIMessagesForEnrichmentPrompt` (the actual function in the observed stack trace) with a message missing `parts`.

`pnpm --filter @domain/ai test`, `pnpm --filter @domain/annotations test`, and `pnpm --filter @domain/ai typecheck` / `pnpm --filter @domain/annotations typecheck` (via `tsgo`) all pass. `pnpm exec biome check` on changed files is clean.

## Verification

After deploy, occurrences of Datadog issue `b20aa0b2-7c6c-11f1-bbab-da7ad0900005` should stop (it was a single-day burst on 2026-07-10 and hasn't recurred since, so absence of new occurrences alongside the added regression coverage is the confirmation here). Locally: `pnpm --filter @domain/ai test`, `pnpm --filter @domain/annotations test`.

## Other Datadog issues surveyed, not fixed

Per the standing Datadog-triage routine, the rest of this week's top production error-tracking issues were reviewed and are **not** being fixed in this PR — most were already triaged with a comment on the issue by a prior run:
- `ingest` `ECONNRESET`/`aborted` (9001 occurrences) — infra/transient (client abort mid-request).
- `workflows` `AI_NoOutputGeneratedError`/`NoOutputGeneratedError`/`AIError` "No output generated" (~17k occurrences combined) — **already triaged as Class D** (expected/handled; callers already degrade gracefully; span is marked `status:error` before the caller's recovery logic runs). See the existing comment on issue `89794698-599a-11f1-85db-da7ad0900005`.
- `web` `Error` "Description is required"/"Instructions are required" (92 occurrences) — **already triaged as Class C** (TanStack Start `createServerFn` validator returns HTTP 200 on validation failure; cross-cutting framework-boundary fix, out of scope for a minimal PR). See the existing comment on issue `41c254a4-3eea-11f1-a146-da7ad0900005`.
- Remaining issues (ClickHouse memory-limit errors, model context-length/schema-validation errors, `NotFoundError`s, etc.) were low-volume, infra/upstream-model related, or otherwise not a code bug per the triage criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013udyDwWPepVTF7t56mabu6

---
_Generated by [Claude Code](https://claude.ai/code/session_013udyDwWPepVTF7t56mabu6)_