### PR TITLE
feat(web): choose role when inviting a member

### DIFF
--- a/apps/web/src/domains/members/members.collection.ts
+++ b/apps/web/src/domains/members/members.collection.ts
@@ -60,9 +60,9 @@ export const useMembersCollection = () => {
  * Invite is not a collection mutation, so it must not use `createOptimisticAction` with an empty
  * `onMutate`: TanStack DB skips `mutationFn` when the transaction has zero pending mutations.
  */
-export async function inviteMemberMutation(email: string): Promise<void> {
+export async function inviteMemberMutation(email: string, role: "admin" | "member"): Promise<void> {
   await invite({
-    data: { email },
+    data: { email, role },
   })
   await queryClient.invalidateQueries({ queryKey: MEMBERS_QUERY_KEY })
 }

--- a/apps/web/src/domains/members/members.functions.ts
+++ b/apps/web/src/domains/members/members.functions.ts
@@ -3,11 +3,12 @@ import {
   inviteMemberUseCase,
   type ListMembersResult,
   listMembersUseCase,
+  MembershipRepository,
   removeMemberUseCase,
   transferOwnershipUseCase,
   updateMemberRoleUseCase,
 } from "@domain/organizations"
-import { InvitationId, MembershipId, UserId } from "@domain/shared"
+import { ForbiddenError, InvitationId, MembershipId, UserId } from "@domain/shared"
 import { UserRepository } from "@domain/users"
 import {
   InvitationRepositoryLive,
@@ -149,6 +150,12 @@ export const invite = createServerFn({ method: "POST" })
 
     const invitation = await Effect.runPromise(
       Effect.gen(function* () {
+        const membershipRepo = yield* MembershipRepository
+        const isAdmin = yield* membershipRepo.isAdmin(organizationId, userId)
+        if (!isAdmin) {
+          return yield* new ForbiddenError({ message: "Only organization owners and admins can invite members" })
+        }
+
         const userRepo = yield* UserRepository
         const inviter = yield* userRepo.findById(UserId(userId))
         const inviterName =

--- a/apps/web/src/domains/members/members.functions.ts
+++ b/apps/web/src/domains/members/members.functions.ts
@@ -139,6 +139,7 @@ export const invite = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       email: z.email(),
+      role: z.enum(["admin", "member"]),
     }),
   )
   .handler(async ({ data }): Promise<{ invitationId: string }> => {
@@ -156,6 +157,7 @@ export const invite = createServerFn({ method: "POST" })
         return yield* inviteMemberUseCase({
           organizationId,
           email: data.email,
+          role: data.role,
           inviterUserId: UserId(userId),
           inviterName,
           webUrl,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/members.tsx
@@ -46,13 +46,18 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
   component: MembersSettingsPage,
 })
 
+const INVITE_ROLE_OPTIONS: { label: string; value: "admin" | "member" }[] = [
+  { label: "Member", value: "member" },
+  { label: "Admin", value: "admin" },
+]
+
 function InviteMemberModal({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) {
   const { toast } = useToast()
   const form = useForm({
-    defaultValues: { email: "" },
+    defaultValues: { email: "", role: "member" as "admin" | "member" },
     onSubmit: createFormSubmitHandler(
       async (value) => {
-        await inviteMemberMutation(value.email)
+        await inviteMemberMutation(value.email, value.role)
       },
       {
         onSuccess: async () => {
@@ -88,6 +93,18 @@ function InviteMemberModal({ open, setOpen }: { open: boolean; setOpen: (open: b
                     onChange={(e) => field.handleChange(e.target.value)}
                     errors={fieldErrorsAsStrings(field.state.meta.errors)}
                     placeholder="jon@latitude.so"
+                  />
+                )}
+              </form.Field>
+              <form.Field name="role">
+                {(field) => (
+                  <Select
+                    name="role"
+                    label="Role"
+                    options={INVITE_ROLE_OPTIONS}
+                    value={field.state.value}
+                    onChange={(value) => field.handleChange(value)}
+                    errors={fieldErrorsAsStrings(field.state.meta.errors)}
                   />
                 )}
               </form.Field>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a role picker to the "Add New Member" invite modal so admins/owners can invite someone directly as an **Admin** or **Member**, instead of always defaulting to Member and having to change the role after the fact.

## Why

Previously the web invite flow only collected an email and always created the invitation with the `member` role. The only way to make someone an admin was to invite them, wait for them to accept, then use the "Change role" flow. The domain use-case (`inviteMemberUseCase`) and the public API operation already accepted an optional `role`, so this just exposes that capability in the web UI.

## Changes

- `members.tsx` — invite modal now has a **Role** `Select` (Member / Admin), defaulting to Member. Selected role is passed through on submit.
- `members.functions.ts` — the `invite` server function input now includes `role: "admin" | "member"` and forwards it to `inviteMemberUseCase`.
- `members.collection.ts` — `inviteMemberMutation(email, role)` now takes the role.

Only `admin` and `member` are selectable (matching the existing "Change role" flow); `owner` is not assignable via invite and is still rejected at the use-case level. The invite modal remains gated to admins/owners.

## Verification

- `pnpm --filter @app/web typecheck` passes.
- `pnpm biome check` on the changed files is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e21fe83-4461-4fca-a300-5edafc32cab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e21fe83-4461-4fca-a300-5edafc32cab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

