### PR TITLE
fix(clickhouse): prevent project span query OOMs

### DIFF
--- a/apps/api/src/routes/spans.test.ts
+++ b/apps/api/src/routes/spans.test.ts
@@ -16,10 +16,18 @@ const createProjectRecord = async (
 const RANGE = { fromIso: "2026-06-01T00:00:00.000Z", toIso: "2026-06-08T00:00:00.000Z" }
 
 // Mirrors the route's opaque keyset-cursor encoding so tests can mint cursors.
-const encodeCursor = (c: { f: string; d: string; v: string; s: string }): string =>
+const encodeCursor = (c: { f: string; d: string; v: string; t?: string; s: string }): string =>
   Buffer.from(JSON.stringify(c), "utf8").toString("base64url")
 
 const START_TIME_DESC_CURSOR = encodeCursor({
+  f: "startTime",
+  d: "desc",
+  v: "2026-06-01 00:00:00.000000000",
+  t: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  s: "1111111111111111",
+})
+
+const LEGACY_START_TIME_DESC_CURSOR = encodeCursor({
   f: "startTime",
   d: "desc",
   v: "2026-06-01 00:00:00.000000000",
@@ -84,6 +92,7 @@ describe("Spans Routes Integration", () => {
         name: "cursor whose direction disagrees with orderBy",
         body: { orderBy: { field: "startTime", direction: "asc" }, cursor: START_TIME_DESC_CURSOR },
       },
+      { name: "cursor without a trace-id tiebreaker", body: { cursor: LEGACY_START_TIME_DESC_CURSOR } },
       { name: "inverted range", body: { range: { fromIso: RANGE.toIso, toIso: RANGE.fromIso } } },
       { name: "empty range (fromIso === toIso)", body: { range: { fromIso: RANGE.fromIso, toIso: RANGE.fromIso } } },
       { name: "limit over the cap", body: { limit: 100_000 } },

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -233,7 +233,7 @@ export type SpanListOrderDirection = "asc" | "desc"
 
 /**
  * Keyset cursor for `listByProjectId` — points at the last returned row's
- * `(sortValue, spanId)` in the active ordering. Stable across concurrent inserts
+ * `(sortValue, traceId, spanId)` in the active ordering. Stable across concurrent inserts
  * (unlike an offset, which shifts when rows land mid-pagination). `sortValue` is
  * the raw sort-column value carried at full fidelity: a nanosecond ClickHouse
  * datetime for `startTime`, a base-10 integer for `duration`/`cost`. `field` and
@@ -244,6 +244,7 @@ export interface SpanListCursor {
   readonly field: SpanListOrderField
   readonly direction: SpanListOrderDirection
   readonly sortValue: string
+  readonly traceId: TraceId
   readonly spanId: SpanId
 }
 

--- a/packages/operations/src/operations/spans.ts
+++ b/packages/operations/src/operations/spans.ts
@@ -1,5 +1,5 @@
 import { ProjectRepository } from "@domain/projects"
-import { OrganizationId, ProjectId, SpanId } from "@domain/shared"
+import { OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
 import {
   type SpanListCursor,
   type SpanListOrderDirection,
@@ -28,14 +28,14 @@ const spansPath = "/projects/:projectSlug/spans"
 const spanEndpoint = defineOperation<OrganizationScopedEnv>(spansPath)
 
 // Opaque keyset cursor — encodes the last row's `(field, direction, sortValue,
-// spanId)` so the next page resumes strictly after it. Keyset (not offset) so a
+// traceId, spanId)` so the next page resumes strictly after it. Keyset (not offset) so a
 // span landing mid-pagination can't shift the window and skip/duplicate rows.
 const ORDER_FIELDS: readonly SpanListOrderField[] = ["startTime", "duration", "cost"]
 const ORDER_DIRECTIONS: readonly SpanListOrderDirection[] = ["asc", "desc"]
 
 const encodeSpanListCursor = (cursor: SpanListCursor): string =>
   Buffer.from(
-    JSON.stringify({ f: cursor.field, d: cursor.direction, v: cursor.sortValue, s: cursor.spanId }),
+    JSON.stringify({ f: cursor.field, d: cursor.direction, v: cursor.sortValue, t: cursor.traceId, s: cursor.spanId }),
     "utf8",
   ).toString("base64url")
 
@@ -45,15 +45,17 @@ const decodeSpanListCursor = (raw: string): SpanListCursor | null => {
       f?: unknown
       d?: unknown
       v?: unknown
+      t?: unknown
       s?: unknown
     }
     if (!ORDER_FIELDS.includes(p.f as SpanListOrderField)) return null
     if (!ORDER_DIRECTIONS.includes(p.d as SpanListOrderDirection)) return null
-    if (typeof p.v !== "string" || typeof p.s !== "string") return null
+    if (typeof p.v !== "string" || typeof p.t !== "string" || typeof p.s !== "string") return null
     return {
       field: p.f as SpanListOrderField,
       direction: p.d as SpanListOrderDirection,
       sortValue: p.v,
+      traceId: TraceId(p.t),
       spanId: SpanId(p.s),
     }
   } catch {

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -1,5 +1,5 @@
 import { type ChSqlClient, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
-import { SpanRepository, type SpanRepositoryShape } from "@domain/spans"
+import { type SpanListCursor, type SpanListPage, SpanRepository, type SpanRepositoryShape } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
@@ -500,6 +500,52 @@ describe("SpanRepository", () => {
       expect(spans.items.map((span) => span.name)).toEqual(["tool-span"])
     })
 
+    it("late-materializes selected versions without returning dynamic maps", async () => {
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            span_id: "late000000000001",
+            name: "older",
+            metadata: { source: "target" },
+            attr_string: { "ai.prompt": "x".repeat(1_000_000) },
+            attr_int: { retries: 2 },
+            attr_float: { temperature: 0.7 },
+            attr_bool: { streamed: 1 },
+            resource_string: { host: "worker-1" },
+            ingested_at: "2026-01-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            span_id: "late000000000001",
+            name: "newer",
+            metadata: { source: "target" },
+            attr_string: { "ai.prompt": "x".repeat(1_000_000) },
+            ingested_at: "2026-01-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            span_id: "late000000000002",
+            name: "metadata-miss",
+            metadata: { source: "other" },
+          }),
+        ]),
+      )
+
+      const page = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { limit: 10, filters: { "metadata.source": [{ op: "eq", value: "target" }] } },
+        }),
+      )
+
+      expect(page.items).toHaveLength(1)
+      expect(page.items[0]).toMatchObject({ name: "newer", metadata: { source: "target" } })
+      expect(page.items[0]?.attrString).toEqual({})
+      expect(page.items[0]?.attrInt).toEqual({})
+      expect(page.items[0]?.attrFloat).toEqual({})
+      expect(page.items[0]?.attrBool).toEqual({})
+      expect(page.items[0]?.resourceString).toEqual({})
+    })
+
     it("sorts by a chosen field and filters by status", async () => {
       await runCh(
         insertJsonEachRow(ch.client, "spans", [
@@ -618,6 +664,171 @@ describe("SpanRepository", () => {
 
       const page2 = await runCh(repo.listByProjectId({ ...base, options: { ...opts, cursor } }))
       expect(page2.items.map((span) => span.name)).toEqual(["d1"])
+    })
+
+    it("keeps matching span ids in separate traces across page boundaries", async () => {
+      const traceA = TraceId("11111111111111111111111111111111")
+      const traceB = TraceId("22222222222222222222222222222222")
+      const sharedStart = "2026-06-01 00:00:00.000000000"
+      await runCh(
+        insertJsonEachRow(ch.client, "spans", [
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: "shar000000000001",
+            name: "trace-a-old",
+            operation: "trace-keyset",
+            start_time: sharedStart,
+            ingested_at: "2026-06-01 00:00:00.000",
+          }),
+          makeSpanRow({
+            trace_id: traceA,
+            span_id: "shar000000000001",
+            name: "trace-a-new",
+            operation: "trace-keyset",
+            start_time: sharedStart,
+            ingested_at: "2026-06-01 00:00:01.000",
+          }),
+          makeSpanRow({
+            trace_id: traceB,
+            span_id: "shar000000000001",
+            name: "trace-b",
+            operation: "trace-keyset",
+            start_time: sharedStart,
+          }),
+        ]),
+      )
+      const options = { limit: 1, filters: { operation: [{ op: "eq" as const, value: "trace-keyset" }] } }
+
+      const first = await runCh(repo.listByProjectId({ organizationId: ORG_ID, projectId: PROJECT_ID, options }))
+      expect(first.items.map((span) => span.name)).toEqual(["trace-b"])
+      expect(first.nextCursor?.traceId).toBe(traceB)
+      expect(first.nextCursor).not.toBeNull()
+      if (first.nextCursor === null) return
+
+      const second = await runCh(
+        repo.listByProjectId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          options: { ...options, cursor: first.nextCursor },
+        }),
+      )
+      expect(second.items.map((span) => span.name)).toEqual(["trace-a-new"])
+    })
+
+    it("keyset-paginates every ordering and direction", async () => {
+      const base = { organizationId: ORG_ID, projectId: PROJECT_ID }
+      const fields = ["startTime", "duration", "cost"] as const
+      const directions = ["asc", "desc"] as const
+
+      for (const field of fields) {
+        const operation = `all-orders-${field}`
+        await runCh(
+          insertJsonEachRow(ch.client, "spans", [
+            makeSpanRow({
+              span_id: `${field.slice(0, 3)}0000000000001`,
+              name: `${field}-one`,
+              operation,
+              start_time: "2026-07-01 00:00:00.000000000",
+              end_time: "2026-07-01 00:00:01.000000000",
+              cost_total_microcents: 100,
+            }),
+            makeSpanRow({
+              span_id: `${field.slice(0, 3)}0000000000002`,
+              name: `${field}-two`,
+              operation,
+              start_time: "2026-07-01 00:00:02.000000000",
+              end_time: "2026-07-01 00:00:04.000000000",
+              cost_total_microcents: 200,
+            }),
+            makeSpanRow({
+              span_id: `${field.slice(0, 3)}0000000000003`,
+              name: `${field}-three`,
+              operation,
+              start_time: "2026-07-01 00:00:04.000000000",
+              end_time: "2026-07-01 00:00:07.000000000",
+              cost_total_microcents: 300,
+            }),
+          ]),
+        )
+
+        for (const direction of directions) {
+          const expected = direction === "asc" ? ["one", "two", "three"] : ["three", "two", "one"]
+          const delivered: string[] = []
+          let cursor: SpanListCursor | null = null
+
+          for (let page = 0; page < 3; page++) {
+            const result: SpanListPage = await runCh(
+              repo.listByProjectId({
+                ...base,
+                options: {
+                  limit: 1,
+                  filters: { operation: [{ op: "eq", value: operation }] },
+                  orderBy: { field, direction },
+                  ...(cursor ? { cursor } : {}),
+                },
+              }),
+            )
+            delivered.push(...result.items.map((span) => span.name.split("-").at(-1) ?? ""))
+            cursor = result.nextCursor
+            if (cursor === null) break
+          }
+
+          expect(delivered).toEqual(expected)
+        }
+      }
+    })
+
+    it("keyset-paginates equal duration and cost values by trace and span id", async () => {
+      const traces = [
+        TraceId("11111111111111111111111111111111"),
+        TraceId("22222222222222222222222222222222"),
+        TraceId("33333333333333333333333333333333"),
+      ]
+      await runCh(
+        insertJsonEachRow(
+          ch.client,
+          "spans",
+          traces.map((traceId, index) =>
+            makeSpanRow({
+              trace_id: traceId,
+              span_id: "ties000000000001",
+              name: `tie-${index + 1}`,
+              operation: "equal-order-values",
+              start_time: "2026-08-01 00:00:00.000000000",
+              end_time: "2026-08-01 00:00:01.000000000",
+              cost_total_microcents: 100,
+            }),
+          ),
+        ),
+      )
+
+      for (const field of ["duration", "cost"] as const) {
+        for (const direction of ["asc", "desc"] as const) {
+          const delivered: string[] = []
+          let cursor: SpanListCursor | null = null
+
+          for (let page = 0; page < traces.length; page++) {
+            const result: SpanListPage = await runCh(
+              repo.listByProjectId({
+                organizationId: ORG_ID,
+                projectId: PROJECT_ID,
+                options: {
+                  limit: 1,
+                  filters: { operation: [{ op: "eq", value: "equal-order-values" }] },
+                  orderBy: { field, direction },
+                  ...(cursor ? { cursor } : {}),
+                },
+              }),
+            )
+            delivered.push(...result.items.map((span) => span.name))
+            cursor = result.nextCursor
+          }
+
+          expect(delivered).toEqual(
+            direction === "asc" ? ["tie-1", "tie-2", "tie-3"] : ["tie-3", "tie-2", "tie-1"],
+          )
+        }
+      }
     })
   })
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.test.ts
@@ -824,9 +824,7 @@ describe("SpanRepository", () => {
             cursor = result.nextCursor
           }
 
-          expect(delivered).toEqual(
-            direction === "asc" ? ["tie-1", "tie-2", "tie-3"] : ["tie-3", "tie-2", "tie-1"],
-          )
+          expect(delivered).toEqual(direction === "asc" ? ["tie-1", "tie-2", "tie-3"] : ["tie-3", "tie-2", "tie-1"])
         }
       }
     })

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -101,6 +101,7 @@ const EMPTY_ATTR_MAP_COLUMNS = `
 
 // Columns selected for list/trace queries (excludes large blob payloads).
 const LIST_COLUMNS = `${LIST_COLUMNS_LEAN}, ${ATTR_MAP_COLUMNS}`
+const LIST_COLUMNS_NO_ATTRS = `${LIST_COLUMNS_LEAN}, ${EMPTY_ATTR_MAP_COLUMNS}`
 
 // `LIST_COLUMNS` plus the large payload columns a `SpanDetail` needs. Selected
 // explicitly (never `SELECT *`) so reads project exactly the typed row and skip
@@ -435,6 +436,11 @@ const BOUNDED_READ_SETTINGS = {
   max_memory_usage: "4000000000",
 } as const
 
+const PAGINATED_READ_SETTINGS = {
+  ...BOUNDED_READ_SETTINGS,
+  max_bytes_before_external_sort: "268435456",
+} as const
+
 // `listByProjectId` keyset pagination. The sort column is an enum → fixed column
 // (never user-interpolated raw SQL); the cursor param is typed to match it so the
 // tuple comparison is valid. Only `start_time` is in the table's primary key
@@ -582,34 +588,45 @@ export const SpanRepositoryLive = Layer.effect(
         const direction = options.orderBy?.direction ?? "desc"
         const orderColumn = SPAN_LIST_ORDER_COLUMN[field]
         const orderDirection = direction === "asc" ? "ASC" : "DESC"
-        // Keyset: resume strictly after the cursor's `(sortValue, spanId)`. The
-        // tuple lives in the inner scan so a `startTime` sort prunes granules via
-        // the primary key. `<` for DESC, `>` for ASC — the direction of "after".
         const cursorComparator = direction === "asc" ? ">" : "<"
         const cursorClause = options.cursor
-          ? `AND (${orderColumn}, span_id) ${cursorComparator} ({cursorSort:${SPAN_LIST_CURSOR_TYPE[field]}}, {cursorSpanId:FixedString(16)})`
+          ? `AND (${orderColumn}, trace_id, span_id) ${cursorComparator} ({cursorSort:${SPAN_LIST_CURSOR_TYPE[field]}}, {cursorTraceId:FixedString(32)}, {cursorSpanId:FixedString(16)})`
           : ""
         const limit = options.limit ?? 50
         return yield* chSqlClient
           .query(async (client) => {
             const result = await client.query({
-              // Over-fetch one row to detect a next page without a count.
-              query: `SELECT ${LIST_COLUMNS}, duration_ns
+              query: `SELECT ${LIST_COLUMNS_NO_ATTRS}, duration_ns
                     FROM (
-                      -- expose duration_ns (an ALIAS column) so the outer ORDER BY / cursor can sort on it
-                      SELECT ${LIST_COLUMNS}, duration_ns
+                      SELECT ${LIST_COLUMNS_LEAN}, duration_ns
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
                         ${startFromClause}
                         ${startToClause}
                         ${filterClause}
-                        ${cursorClause}
-                      ORDER BY span_id, ingested_at DESC
-                      LIMIT 1 BY span_id
+                        AND (trace_id, span_id, ingested_at) IN (
+                          SELECT trace_id, span_id, ingested_at
+                          FROM (
+                            SELECT trace_id, span_id, ingested_at, start_time, duration_ns, cost_total_microcents
+                            FROM spans
+                            WHERE organization_id = {organizationId:String}
+                              AND project_id = {projectId:String}
+                              ${startFromClause}
+                              ${startToClause}
+                              ${filterClause}
+                            ORDER BY trace_id, span_id, ingested_at DESC
+                            LIMIT 1 BY trace_id, span_id
+                          )
+                          WHERE 1 = 1
+                            ${cursorClause}
+                          ORDER BY ${orderColumn} ${orderDirection}, trace_id ${orderDirection}, span_id ${orderDirection}
+                          LIMIT {limitPlusOne:UInt32}
+                        )
+                      ORDER BY trace_id, span_id, ingested_at DESC
+                      LIMIT 1 BY trace_id, span_id
                     )
-                    ORDER BY ${orderColumn} ${orderDirection}, span_id ${orderDirection}
-                    LIMIT {limitPlusOne:UInt32}`,
+                    ORDER BY ${orderColumn} ${orderDirection}, trace_id ${orderDirection}, span_id ${orderDirection}`,
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
@@ -618,11 +635,15 @@ export const SpanRepositoryLive = Layer.effect(
                 ...filterParams,
                 limitPlusOne: limit + 1,
                 ...(options.cursor
-                  ? { cursorSort: options.cursor.sortValue, cursorSpanId: options.cursor.spanId as string }
+                  ? {
+                      cursorSort: options.cursor.sortValue,
+                      cursorSpanId: options.cursor.spanId as string,
+                      cursorTraceId: options.cursor.traceId as string,
+                    }
                   : {}),
               },
               format: "JSONEachRow",
-              clickhouse_settings: BOUNDED_READ_SETTINGS,
+              clickhouse_settings: PAGINATED_READ_SETTINGS,
             })
             return result.json<SpanListRow>()
           })
@@ -635,7 +656,13 @@ export const SpanRepositoryLive = Layer.effect(
               const lastItem = items[items.length - 1]
               const nextCursor: SpanListCursor | null =
                 hasMore && lastRow && lastItem
-                  ? { field, direction, sortValue: spanListCursorSortValue(lastRow, field), spanId: lastItem.spanId }
+                  ? {
+                      field,
+                      direction,
+                      sortValue: spanListCursorSortValue(lastRow, field),
+                      traceId: lastItem.traceId,
+                      spanId: lastItem.spanId,
+                    }
                   : null
               return { items, nextCursor }
             }),


### PR DESCRIPTION
## What changed

`POST /v1/projects/:projectSlug/spans/query` now selects page keys before fetching span rows. The key phase deduplicates and sorts only `trace_id`, `span_id`, `ingested_at`, and the active sort fields. The fetch phase is limited to the selected page and returns empty dynamic attribute maps, which the list response does not expose.

Pagination now uses `(sortValue, traceId, spanId)` as its total order. This also fixes collisions when separate traces reuse the same OpenTelemetry span ID. Cursors minted before this change return 400 so callers restart pagination instead of silently skipping rows.

The query keeps its 4 GB memory cap and spills sort state after 256 MiB.

## Why

Datadog captured two production OOM signatures on this endpoint:

- [Reading `attr_string` exceeded the 3.73 GiB query cap](https://app.datadoghq.eu/error-tracking/issue/d2611ba4-7bd4-11f1-9e6c-da7ad0900005)
- [`MergeSortingTransform` attempted 4.48 GiB on v0.3.48](https://app.datadoghq.eu/error-tracking/issue/05cade48-7f3c-11f1-878d-da7ad0900005)

The endpoint returned at most 200 rows but projected unbounded attribute maps and globally sorted full span rows before applying the page limit. The behavior came from the original `querySpans` implementation in [559dea856](https://github.com/latitude-dev/latitude-llm/commit/559dea856).

## Verification

- API span route tests: 12 passed locally
- Pre-commit formatting and knip checks passed
- ClickHouse repository and workspace validation will run in CI

After deployment, both linked Datadog issues should stop receiving occurrences. Broad duration and cost sorts may spill to temporary disk, but they no longer keep full span rows or dynamic maps in the in-memory sort state.