### PR TITLE
fix(spans): reject oversized trace/span IDs before ClickHouse insert

### DIFF
--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -305,3 +305,67 @@ describe("transformOtlpToSpans trace ID normalization", () => {
     expect(spans[0]?.traceId).toBe("0af7651916cd43dd8448eb211c80319c")
   })
 })
+
+describe("transformOtlpToSpans rejects oversized trace/span IDs", () => {
+  const ctx = {
+    ...baseContext,
+    defaultProjectId: "proj-default",
+    projectIdBySlug: new Map<string, string>(),
+  }
+
+  const buildSpanWithTraceId = (
+    traceId: string,
+    spanId: string,
+  ): NonNullable<OtlpExportTraceServiceRequest["resourceSpans"]> => [
+    {
+      resource: { attributes: [str("service.name", "test")] },
+      scopeSpans: [
+        {
+          scope: { name: "scope", version: "1" },
+          spans: [
+            {
+              traceId,
+              spanId,
+              name: spanId,
+              startTimeUnixNano: "1710590400000000000",
+              endTimeUnixNano: "1710590401000000000",
+              attributes: [],
+              status: { code: 1 },
+            },
+          ],
+        },
+      ],
+    },
+  ]
+
+  it("rejects a trace ID longer than 32 chars", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpanWithTraceId(`${TRACE}extra`, "n1") },
+      ctx,
+    )
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+
+  it("rejects a span ID longer than 16 chars", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans({ resourceSpans: buildSpan("this-span-id-is-too-long") }, ctx)
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+
+  it("keeps a short, arbitrary span ID unaffected", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans({ resourceSpans: buildSpan("n1") }, ctx)
+    expect(rejectedSpans).toBe(0)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.spanId).toBe("n1")
+  })
+
+  it("rejects a 40-char hex trace ID simulating a non-conformant exporter", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpanWithTraceId("a".repeat(40), "n1") },
+      ctx,
+    )
+    expect(spans).toHaveLength(0)
+    expect(rejectedSpans).toBe(1)
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -1,4 +1,14 @@
-import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
+import {
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SPAN_ID_LENGTH,
+  SpanId,
+  TRACE_ID_LENGTH,
+  TraceId,
+} from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
 import { stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
@@ -105,8 +115,18 @@ function resolveSpanProjectId(
   return context.defaultProjectId
 }
 
+/**
+ * ClickHouse's `spans` table stores `trace_id`/`span_id` as `FixedString(32)`/`FixedString(16)` — a
+ * value longer than that fails the whole async-insert batch, not just the offending row, so an
+ * oversized ID (a non-conformant exporter, e.g. a wider `bytes` protobuf field) must be rejected here.
+ */
+function hasValidIdLengths(normalizedTraceId: string, spanId: string): boolean {
+  return normalizedTraceId.length <= TRACE_ID_LENGTH && spanId.length <= SPAN_ID_LENGTH
+}
+
 function transformSpan({
   span,
+  traceId,
   resource,
   scopeName,
   scopeVersion,
@@ -115,6 +135,7 @@ function transformSpan({
   ingestedAt,
 }: {
   span: OtlpSpan
+  traceId: string
   resource: OtlpResource | undefined
   scopeName: string
   scopeVersion: string
@@ -173,7 +194,7 @@ function transformSpan({
     sessionId: SessionId(resolved.sessionId),
     userId: ExternalUserId(resolved.userId),
     userEmail: resolved.userEmail,
-    traceId: TraceId(span.traceId.replace(/-/g, "")),
+    traceId: TraceId(traceId),
     spanId: SpanId(span.spanId),
     parentSpanId: span.parentSpanId ?? "",
     apiKeyId: context.apiKeyId,
@@ -251,7 +272,12 @@ export function transformOtlpToSpans(
           rejectedSpans++
           continue
         }
-        spans.push(transformSpan({ span, resource, scopeName, scopeVersion, context, projectId, ingestedAt }))
+        const traceId = span.traceId.replace(/-/g, "")
+        if (!hasValidIdLengths(traceId, span.spanId)) {
+          rejectedSpans++
+          continue
+        }
+        spans.push(transformSpan({ span, traceId, resource, scopeName, scopeVersion, context, projectId, ingestedAt }))
       }
     }
   }

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -97,13 +97,17 @@ function decodeAndTransform(
       return []
     }
 
-    const { spans } = transformOtlpToSpans(request, {
+    const { spans, rejectedSpans } = transformOtlpToSpans(request, {
       organizationId: input.organizationId,
       apiKeyId: input.apiKeyId,
       ingestedAt: input.ingestedAt,
       defaultProjectId: input.defaultProjectId,
       projectIdBySlug: new Map(Object.entries(input.projectIdBySlug)),
     })
+
+    if (rejectedSpans > 0) {
+      yield* Effect.annotateCurrentSpan("rejectedSpans", rejectedSpans)
+    }
 
     return spans
   })


### PR DESCRIPTION
## What does this PR do?

Fixes a recurring production error where the `workers` service fails to insert an entire batch of ingested spans into ClickHouse:

```
Repository insert failed: Repository query failed: Too large value for FixedString(32): (while reading the value of key trace_id): (at row 1)
: While executing WaitForAsyncInsert.
```
and the sibling:
```
Too large value for FixedString(16): (while reading the value of key span_id): (at row 1)
```

**Datadog issues addressed:**
- [`ff6f0454-76e7-11f1-bc51-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/ff6f0454-76e7-11f1-bc51-da7ad0900005) — `trace_id` FixedString(32) overflow (2512 occurrences/7d)
- [`ff694870-76e7-11f1-bc51-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/ff694870-76e7-11f1-bc51-da7ad0900005) — `span_id` FixedString(16) overflow (1256 occurrences/7d)

Both first seen 2026-07-03 and still recurring as of 2026-07-13 (declining volume but non-zero). A prior fix for this exact root cause (#3851) was opened and linked to these issues on 2026-07-05, but was **closed without being merged** — the vulnerable code is unchanged on `development` HEAD, so the bug is still live in production.

**Root cause:** `packages/domain/spans/src/otlp/transform.ts` builds each span's `traceId`/`spanId` straight from the untrusted OTLP wire payload (`span.traceId.replace(/-/g, "")` / `span.spanId`) via the unchecked `TraceId(...)`/`SpanId(...)` brand casts — there is no length check anywhere on the ingestion path before the value reaches ClickHouse's `spans` table, whose `trace_id`/`span_id` columns are `FixedString(32)`/`FixedString(16)`. A non-conformant exporter (or a `bytes`-typed protobuf `trace_id`/`span_id` field wider than 16/8 bytes) produces a hex string longer than those bounds. ClickHouse then fails the **whole async-insert batch**, not just the offending row — so one malformed span currently drops every other (valid) span in the same OTLP payload.

The code already had dash-stripping normalization for UUID-format trace IDs, but nothing validated the *resulting* length, and `span_id` had no normalization or validation at all.

**Fix:** `transformOtlpToSpans` already rejects a span when its `latitude.project` slug doesn't resolve to a project (incrementing a `rejectedSpans` counter and skipping just that span). This PR extends the same rejection path to spans whose normalized `traceId`/`spanId` exceed the ClickHouse column bounds, reusing the existing `TRACE_ID_LENGTH` (32) / `SPAN_ID_LENGTH` (16) constants from `@domain/shared` (already used by that package's own `traceIdSchema`/`spanIdSchema`, just never applied on this ingestion path). This is a `max`-length guard, not an exact-length one — ClickHouse silently zero-pads *shorter* `FixedString` values, and a large slice of the test suite already relies on short, arbitrary span IDs (e.g. `"n1"`), so exact-length enforcement would be a much larger, riskier behavior change than this bug needs.

## Related issue (if applicable)

N/A — found via Datadog Error Tracking, not a filed GitHub issue.

Closes #

## How was this tested?

Added 4 new unit tests in `packages/domain/spans/src/otlp/tests/project-scoping.test.ts`:
- rejects a trace ID > 32 chars (confirmed the test fails without the fix)
- rejects a span ID > 16 chars
- keeps a short, arbitrary span ID (`"n1"`) unaffected — regression guard for existing behavior/tests
- rejects a 40-char hex trace ID (simulating a non-conformant SHA-1-style exporter)

Ran:
- `pnpm --filter @domain/spans exec vitest run src/otlp/tests/project-scoping.test.ts` — all 16 tests pass; confirmed the 4 new tests fail (3 of them) against the pre-fix code by temporarily reverting `transform.ts`.
- `pnpm --filter @domain/spans exec vitest run` — 901/914 pass; the 13 failures in `ingest-spans.test.ts` are a pre-existing `Uint8Array.prototype.toBase64 is not a function` Node-version issue, confirmed present on `development` HEAD before this change too (unrelated to this fix).
- `pnpm --filter @domain/spans typecheck` (tsgo) — no errors introduced (one pre-existing, unrelated `@latitude-data/telemetry` module-resolution error from a package that needs `pnpm build`, also present on clean HEAD).
- `pnpm exec biome check` on both changed files — clean.

**Verification in production:** after deploy, occurrences of issues `ff6f0454-76e7-11f1-bc51-da7ad0900005` and `ff694870-76e7-11f1-bc51-da7ad0900005` should drop to zero (the offending span is now dropped individually instead of the whole batch failing).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_011iDv14a8MFWCdVdKYxHk7M)_