### PR TITLE
feat(spans): detect Claude Code subagents by classifying interaction as invoke_agent

### DIFF
--- a/dev-docs/claude-code-telemetry.md
+++ b/dev-docs/claude-code-telemetry.md
@@ -36,7 +36,7 @@ Each turn produces three kinds of spans, all routed through the existing `apps/i
 
 | `span.type` | Maps to `Operation` | Carries |
 | --- | --- | --- |
-| `interaction` | `prompt` | Root of the turn. `user_prompt`, `session.id`, `interaction.duration_ms`. |
+| `interaction` | `invoke_agent` | Root of the turn — the agent boundary that orchestrates the turn's generations and tool calls. `user_prompt`, `session.id`, `interaction.duration_ms`. |
 | `llm_request` | `chat` | Child of interaction. `model`, token counts (input/output/cache_read/cache_creation), `gen_ai.input.messages`, `gen_ai.output.messages` (full conversation as JSON). |
 | `tool_execution` or `tool` | `execute_tool` | Child of llm_request, one per tool call. `tool.name`, `tool.id`, `tool.input`, `tool.output`. |
 

--- a/dev-docs/pi-telemetry.md
+++ b/dev-docs/pi-telemetry.md
@@ -79,7 +79,7 @@ The extension emits one Latitude trace per pi user prompt/agent run. All spans a
 ## Trace shape
 
 ```text
-interaction                         span.type=interaction → operation prompt
+interaction                         span.type=interaction → operation invoke_agent
 ├── llm_request                     span.type=llm_request + gen_ai.operation.name=chat
 ├── tool_call:<toolName>            span.type=tool_execution + gen_ai.operation.name=execute_tool
 ├── llm_request                     next model call after tool results
@@ -94,7 +94,7 @@ The package intentionally emits the attributes Latitude's OTLP resolvers already
 
 | Attribute | Purpose |
 | --- | --- |
-| `span.type=interaction` | Resolved to operation `prompt` by `packages/domain/spans/src/otlp/resolvers/operation.ts`. |
+| `span.type=interaction` | Resolved to operation `invoke_agent` by `packages/domain/spans/src/otlp/resolvers/operation.ts`. |
 | `span.type=llm_request` | Claude-Code-compatible fallback and human-readable span typing. |
 | `gen_ai.operation.name=chat` | Resolved to operation `chat`. |
 | `gen_ai.operation.name=execute_tool` | Resolved to operation `execute_tool`. |

--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -105,6 +105,7 @@ export const agentNameCandidates: Candidate<string>[] = [
   fromString("gen_ai.agent.name"), // OTEL GenAI semconv (Vercel AI SDK v7, generic OTEL)
   fromString("openai.agents.name"), // OpenAI Agents SDK bridge
   fromString("subagent.type"), // Claude Code
+  fromString("subagent.id", (v) => v.split(":")[0]?.trim() || undefined), // Claude Code
   fromString("openclaw.subagent.label"), // OpenClaw wrapper span
   fromString("openclaw.agent.name"), // OpenClaw agent span + children
   fromString("latitude.capture.name"), // Latitude capture wrapper

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -60,9 +60,12 @@ const OPENAI_AGENTS_OPERATION: Record<string, Operation> = {
   "agents.guardrail": "guardrail",
 }
 
+// `interaction` orchestrates a turn's generations + tool calls (and nests via
+// tool:Agent) exactly like an agent invocation, so it maps to invoke_agent — the
+// lossy-wrapper contract holds (no own usage; truth lives on the chat leaves).
 const CLAUDE_CODE_OPERATION: Record<string, string> = {
   llm_request: "chat",
-  interaction: "prompt",
+  interaction: "invoke_agent",
   tool_execution: "execute_tool",
   /** Native Claude Code / Agent SDK OTEL (`claude_code.tool` spans) */
   tool: "execute_tool",
@@ -83,7 +86,7 @@ const CLAUDE_CODE_NATIVE_SPAN_PREFIX = "claude_code."
 function operationFromClaudeCodeNativeSpanName(spanName: string): string | undefined {
   if (!spanName.startsWith(CLAUDE_CODE_NATIVE_SPAN_PREFIX)) return undefined
   const rest = spanName.slice(CLAUDE_CODE_NATIVE_SPAN_PREFIX.length)
-  if (rest === "interaction") return "prompt"
+  if (rest === "interaction") return "invoke_agent"
   if (rest === "llm_request") return "chat"
   if (rest === "tool" || rest.startsWith("tool.")) return "execute_tool"
   return undefined

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -282,6 +282,21 @@ describe("resolveAttributes", () => {
       expect(result.agentName).toBe("capture-agent")
     })
 
+    it("resolves the name half of Claude Code subagent.id as a last resort", () => {
+      const attrs: OtlpKeyValue[] = [strAttr("subagent.id", "Explore:ab6332237989040a9")]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.agentName).toBe("Explore")
+    })
+
+    it("prefers subagent.type over the id-embedded subagent.id name", () => {
+      const attrs: OtlpKeyValue[] = [
+        strAttr("subagent.id", "Explore:ab6332237989040a9"),
+        strAttr("subagent.type", "general-purpose"),
+      ]
+      const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
+      expect(result.agentName).toBe("general-purpose")
+    })
+
     it("prefers gen_ai.agent.name over lower-ranked candidates", () => {
       const attrs: OtlpKeyValue[] = [
         strAttr("subagent.type", "general-purpose"),

--- a/packages/domain/spans/src/otlp/tests/claude-code.test.ts
+++ b/packages/domain/spans/src/otlp/tests/claude-code.test.ts
@@ -38,7 +38,7 @@ function runTransform(span: OtlpSpan): SpanDetail {
 }
 
 describe("Claude Code OTLP span expansion", () => {
-  it("maps interaction spans: user_prompt → gen_ai.input.messages and operation", () => {
+  it("maps interaction spans: user_prompt → gen_ai.input.messages and invoke_agent operation", () => {
     const span: OtlpSpan = {
       traceId: TRACE_ID,
       spanId: "aaaaaaaaaaaaaaaa",
@@ -62,7 +62,7 @@ describe("Claude Code OTLP span expansion", () => {
 
     expect(d.sessionId).toBe(SESSION)
     expect(d.userId).toBe(USER_ID)
-    expect(d.operation).toBe("prompt")
+    expect(d.operation).toBe("invoke_agent")
     expect(d.inputMessages).toHaveLength(1)
     expect(d.inputMessages[0]?.role).toBe("user")
     const parts = d.inputMessages[0]?.parts
@@ -150,7 +150,7 @@ describe("Claude Code OTLP span expansion", () => {
       attributes: [str("session.id", SESSION), str("user.id", USER_ID), str("user_prompt", "hello from agent sdk")],
       status: { code: 1 },
     }
-    expect(runTransform(interaction).operation).toBe("prompt")
+    expect(runTransform(interaction).operation).toBe("invoke_agent")
 
     const llm: OtlpSpan = {
       traceId: TRACE_ID,

--- a/packages/domain/spans/src/use-cases/build-agent-graph.test.ts
+++ b/packages/domain/spans/src/use-cases/build-agent-graph.test.ts
@@ -121,6 +121,47 @@ describe("buildAgentGraph", () => {
     expect((subs[0] as AgentNode).trigger.type).toBe("invoke_agent")
   })
 
+  it("treats a Claude Code interaction as the backed main and tool:Agent → nested interaction as a subagent", () => {
+    clock = 0
+    const spans = [
+      // Root turn: interaction (invoke_agent) with a chat leaf and two tool calls.
+      span({ spanId: "root", operation: "invoke_agent", name: "interaction" }),
+      gen({ spanId: "g1", parentSpanId: "root" }),
+      span({
+        spanId: "read",
+        operation: "execute_tool",
+        toolName: "Read",
+        toolCallId: "tc-read",
+        parentSpanId: "root",
+      }),
+      span({
+        spanId: "agent",
+        operation: "execute_tool",
+        toolName: "Agent",
+        toolCallId: "tc-agent",
+        parentSpanId: "root",
+      }),
+      // The Agent tool nests its own interaction with its own generation.
+      span({ spanId: "sub-int", operation: "invoke_agent", name: "interaction", parentSpanId: "agent" }),
+      gen({ spanId: "g2", parentSpanId: "sub-int" }),
+    ]
+    const graph = buildAgentGraph({ spans })
+    expect(graph.roots).toHaveLength(1)
+    const main = graph.roots[0] as AgentNode
+    expect(main.kind).toBe("main")
+    expect(main.isVirtual).toBe(false)
+    expect(main.ref.spanId).toBe("root")
+    expect(main.label).toBe("Main agent")
+    const subs = findSubagents(graph)
+    expect(subs).toHaveLength(1)
+    const sub = subs[0] as AgentNode
+    expect(sub.ref.spanId).toBe("agent")
+    expect(sub.trigger).toEqual({ type: "tool", toolName: "Agent", toolCallId: "tc-agent" })
+    expect(sub.label).toBe("Agent")
+    expect(sub.ownGenerationCount).toBe(1)
+    expect(main.ownGenerationCount).toBe(1)
+  })
+
   it("detects parallel subagents under the main", () => {
     clock = 0
     const spans = [
@@ -379,6 +420,18 @@ describe("buildAgentGraph", () => {
       ]
       const graph = buildAgentGraph({ spans })
       expect((graph.roots[0] as AgentNode).label).toBe("orchestrator")
+    })
+
+    it("keeps the main labeled 'Main agent' rather than the backing span's framework name", () => {
+      clock = 0
+      const spans = [
+        span({ spanId: "root", operation: "invoke_agent", name: "interaction" }),
+        gen({ spanId: "g1", parentSpanId: "root" }),
+      ]
+      const graph = buildAgentGraph({ spans })
+      const main = graph.roots[0] as AgentNode
+      expect(main.isVirtual).toBe(false)
+      expect(main.label).toBe("Main agent")
     })
 
     it("names an invoke_agent subagent from its own agentName", () => {

--- a/packages/domain/spans/src/use-cases/build-agent-graph.ts
+++ b/packages/domain/spans/src/use-cases/build-agent-graph.ts
@@ -344,7 +344,7 @@ function buildTraceGraph(traceId: string, traceSpans: readonly AgentGraphSpanInp
     isVirtual: !backedMain,
     parentId: null,
     depth: 0,
-    label: backedMain ? labelFor(backedMain, "main") : "Main agent",
+    label: "Main agent",
     trigger: { type: "root" },
     representativeGenerationSpanId: undefined,
     models: [],
@@ -375,7 +375,7 @@ function buildTraceGraph(traceId: string, traceSpans: readonly AgentGraphSpanInp
       isVirtual: false,
       parentId: null, // filled after all nodes exist
       depth: 0,
-      label: labelFor(c, "subagent"),
+      label: subagentLabelFor(c),
       trigger,
       representativeGenerationSpanId: undefined,
       models: [],
@@ -489,8 +489,10 @@ function registerNode(node: AgentNode, nodesById: Map<string, AgentNode>): void 
   for (const child of node.children) registerNode(child, nodesById)
 }
 
-function labelFor(span: AgentGraphSpanInput, kind: AgentNodeKind): string {
-  if (kind === "main") return span.name || "Main agent"
+// Structural fallback only; the resolved agentName (finalize step) overrides it
+// when present. The boundary span's own `name` is a framework token (e.g.
+// "interaction"), so a tool-triggered subagent prefers its tool name.
+function subagentLabelFor(span: AgentGraphSpanInput): string {
   if (span.operation === "execute_tool") return span.toolName || span.name || "Subagent"
   return span.name || "Subagent"
 }


### PR DESCRIPTION
Part of the subagent-visualization effort. Extends automatic subagent detection to Claude Code, which previously showed up as a single flat "Main agent" with no subagents identified.

## What changes

Claude Code's `interaction` span (`span.type: interaction`, and the native `claude_code.interaction` name) now resolves to the `invoke_agent` operation instead of `prompt`. An `interaction` orchestrates one turn's generations and tool calls — and nests via `tool:Agent` into a child `interaction` — which is structurally the same thing every other framework's `invoke_agent` span represents. It also fits the operation's lossy-wrapper contract: no own tokens/cost, with the real usage on the `chat` leaves underneath.

With that one reclassification, `buildAgentGraph` handles Claude Code with no graph-logic change:

- the root `interaction` becomes the backed (non-virtual) main agent,
- plain tool calls with no generations stay plain tools,
- a `tool:Agent` that wraps a nested `interaction` is detected as a subagent, with the nested interaction collapsing in as its identity span.

## Agent naming

Claude Code Task subagents emit only `subagent.id` (`"<name>:<id>"`, e.g. `"Explore:ab63322…"`) — no `subagent.type` or agent-name attribute. Added a lowest-priority `agentName` candidate that takes the name half (split on `:`), so a subagent labels as "Explore" rather than falling back to the "Agent" tool name. Real name attributes still win when present.

## Label fix

Because the main now has a real backing span, its name is a framework token (`"interaction"`). The agent-graph label helper used that span name for the main node, which would surface "interaction" instead of "Main agent". The main now defaults to "Main agent" and is overridden by the resolved `agentName` when one exists — the same two-phase resolution already used for subagents. This also fixes the pre-existing Vercel case, where the main showed "ai.generateText".

## Notes

- Forward-only. `operation` is computed at ingest, so existing Claude Code spans keep `prompt` until reprocessed; no migration.
- No change to the usage/cost or conversation rollups — those already gate on the `chat` leaves and exclude `invoke_agent`.

## Testing

`@domain/spans` unit tests + typecheck + biome pass. Added coverage for the Claude Code trace shape, the generic main-label fallback, and `subagent.id` name extraction (plus its precedence under `subagent.type`). Affected web suites (agents breakdown, conversation timeline, duration composition) pass.
