### PR TITLE
feat(spans): color waterfall bars by operation

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
@@ -10,15 +10,12 @@ export const MINIMIZED_MAX_HEIGHT = 192
 export const KEYBOARD_STEP = 8
 export const KEYBOARD_STEP_LARGE = 32
 
-export function statusBarColor(statusCode: string): string {
-  switch (statusCode) {
-    case "error":
-      return "bg-destructive"
-    case "ok":
-      return "bg-primary"
-    default:
-      return "bg-muted-foreground/40"
-  }
+export function statusBarColor(statusCode: string, operation: string): string {
+  if (statusCode === "error") return "bg-destructive"
+  if (operation === "invoke_agent") return "bg-primary"
+  if (operation === "chat") return "bg-primary/40"
+  if (operation === "execute_tool") return "bg-success/40"
+  return "bg-muted-foreground/40"
 }
 
 export function statusTextColor(statusCode: string): "foregroundMuted" | "destructive" {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
@@ -12,7 +12,7 @@ export function WaterfallBar({ span, timeRange }: { readonly span: SpanRecord; r
   if (timeRange.totalDuration === 0) {
     return (
       <div className="absolute inset-y-1 left-0 right-0">
-        <div className={cn("h-full rounded-sm", statusBarColor(span.statusCode))} />
+        <div className={cn("h-full rounded-sm", statusBarColor(span.statusCode, span.operation))} />
       </div>
     )
   }
@@ -22,7 +22,7 @@ export function WaterfallBar({ span, timeRange }: { readonly span: SpanRecord; r
 
   return (
     <div className="absolute inset-y-1.5" style={{ left: `${leftPct}%`, width: `${widthPct}%` }}>
-      <div className={cn("h-full rounded-sm min-w-[2px]", statusBarColor(span.statusCode))} />
+      <div className={cn("h-full rounded-sm min-w-[2px]", statusBarColor(span.statusCode, span.operation))} />
     </div>
   )
 }


### PR DESCRIPTION
The Spans-tab waterfall previously colored every bar by status code alone: red for `error`, accent for `ok`, gray for everything else. In practice almost nothing carries an explicit `ok`/`error` status, so the timeline read as a wall of gray and gave no sense of structure.

Bars are now colored by span operation, so the waterfall shows where each agent runs and what it did:

- **red** (`bg-destructive`) — any errored span (unchanged; still takes precedence, so failed `execute_tool` calls stay red)
- **accent** (`bg-primary`) — `invoke_agent` spans (the main agent and each subagent wrapper)
- **muted accent** (`bg-primary/40`) — `chat` spans (LLM calls)
- **green** (`bg-success/40`) — successful `execute_tool` spans
- **gray** (`bg-muted-foreground/40`) — everything else

Since agent wrappers sit at the top of each agent's subtree, the accent bars now mark where every agent begins, which is the point of the change: the timeline becomes agent-partitioned at a glance.

`statusBarColor` now takes `operation` alongside `statusCode`; both `WaterfallBar` call sites pass `span.operation`. It's the only consumer of the helper.
