### PR TITLE
fix(auth): require confirmation before magic-link verification

### DIFF
--- a/apps/web/src/lib/auth/magic-link.test.ts
+++ b/apps/web/src/lib/auth/magic-link.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import {
+  createMagicLinkConfirmationUrl,
+  hasMagicLinkVerificationToken,
+  reconstructMagicLinkVerificationUrl,
+} from "./magic-link.ts"
+
+describe("magic link confirmation URLs", () => {
+  const verificationUrl =
+    "https://console.latitude.so/api/auth/magic-link/verify?token=secret&callbackURL=%2Fprojects&newUserCallbackURL=%2Fwelcome&errorCallbackURL=%2Flogin&ignored=value"
+
+  it("moves all verification parameters into a confirmation URL fragment", () => {
+    const confirmationUrl = new URL(
+      createMagicLinkConfirmationUrl({ verificationUrl, webUrl: "https://console.latitude.so" }),
+    )
+
+    expect(confirmationUrl.pathname).toBe("/auth/verify")
+    expect(confirmationUrl.search).toBe("")
+    expect(confirmationUrl.hash).toBe(
+      "#token=secret&callbackURL=%2Fprojects&newUserCallbackURL=%2Fwelcome&errorCallbackURL=%2Flogin&ignored=value",
+    )
+  })
+
+  it("reconstructs all verification parameters after confirmation", () => {
+    const reconstructedUrl = new URL(
+      reconstructMagicLinkVerificationUrl({
+        fragment:
+          "#token=secret&callbackURL=%2Fprojects&newUserCallbackURL=%2Fwelcome&errorCallbackURL=%2Flogin&ignored=value",
+        origin: "https://console.latitude.so",
+      }) ?? "",
+    )
+
+    expect(reconstructedUrl.pathname).toBe("/api/auth/magic-link/verify")
+    expect(reconstructedUrl.searchParams).toEqual(
+      new URLSearchParams({
+        token: "secret",
+        callbackURL: "/projects",
+        newUserCallbackURL: "/welcome",
+        errorCallbackURL: "/login",
+        ignored: "value",
+      }),
+    )
+  })
+
+  it("preserves search parameters nested inside every callback URL", () => {
+    const callbackURL = "/projects/project-1?tab=sessions&filter=errors"
+    const newUserCallbackURL = "/welcome?utm_source=newsletter&utm_campaign=launch&signup=email"
+    const errorCallbackURL = "/login?redirect=%2Fprojects%2Fproject-1%3Ftab%3Dsessions&reason=expired"
+    const generatedVerificationUrl = new URL("https://console.latitude.so/api/auth/magic-link/verify")
+    generatedVerificationUrl.searchParams.set("token", "secret")
+    generatedVerificationUrl.searchParams.set("callbackURL", callbackURL)
+    generatedVerificationUrl.searchParams.set("newUserCallbackURL", newUserCallbackURL)
+    generatedVerificationUrl.searchParams.set("errorCallbackURL", errorCallbackURL)
+    generatedVerificationUrl.searchParams.set("futureParameter", "future-value")
+
+    const confirmationUrl = new URL(
+      createMagicLinkConfirmationUrl({
+        verificationUrl: generatedVerificationUrl.toString(),
+        webUrl: "https://console.latitude.so",
+      }),
+    )
+    const reconstructedUrl = new URL(
+      reconstructMagicLinkVerificationUrl({
+        fragment: confirmationUrl.hash,
+        origin: confirmationUrl.origin,
+      }) ?? "",
+    )
+
+    expect(reconstructedUrl.searchParams.get("callbackURL")).toBe(callbackURL)
+    expect(reconstructedUrl.searchParams.get("newUserCallbackURL")).toBe(newUserCallbackURL)
+    expect(reconstructedUrl.searchParams.get("errorCallbackURL")).toBe(errorCallbackURL)
+    expect(reconstructedUrl.searchParams.get("futureParameter")).toBe("future-value")
+  })
+
+  it("rejects fragments without a token", () => {
+    expect(hasMagicLinkVerificationToken("#callbackURL=%2Fprojects")).toBe(false)
+    expect(
+      reconstructMagicLinkVerificationUrl({
+        fragment: "#callbackURL=%2Fprojects",
+        origin: "https://console.latitude.so",
+      }),
+    ).toBeNull()
+  })
+
+  it("rejects malformed fragments", () => {
+    expect(hasMagicLinkVerificationToken("#token=%")).toBe(false)
+  })
+})

--- a/apps/web/src/lib/auth/magic-link.ts
+++ b/apps/web/src/lib/auth/magic-link.ts
@@ -1,0 +1,51 @@
+const magicLinkVerificationPath = "/api/auth/magic-link/verify"
+const magicLinkConfirmationPath = "/auth/verify"
+
+export function createMagicLinkConfirmationUrl({
+  verificationUrl,
+  webUrl,
+}: {
+  readonly verificationUrl: string
+  readonly webUrl: string
+}): string {
+  const verificationSearchParams = new URL(verificationUrl).searchParams
+  const confirmationUrl = new URL(magicLinkConfirmationPath, webUrl)
+  confirmationUrl.hash = verificationSearchParams.toString()
+
+  return confirmationUrl.toString()
+}
+
+export function reconstructMagicLinkVerificationUrl({
+  fragment,
+  origin,
+}: {
+  readonly fragment: string
+  readonly origin: string
+}): string | null {
+  const verificationSearchParams = getMagicLinkVerificationSearchParams(fragment)
+
+  if (!verificationSearchParams) {
+    return null
+  }
+
+  const verificationUrl = new URL(magicLinkVerificationPath, origin)
+  verificationUrl.search = verificationSearchParams.toString()
+
+  return verificationUrl.toString()
+}
+
+export function hasMagicLinkVerificationToken(fragment: string): boolean {
+  return getMagicLinkVerificationSearchParams(fragment) !== null
+}
+
+function getMagicLinkVerificationSearchParams(fragment: string): URLSearchParams | null {
+  try {
+    decodeURIComponent(fragment.replace(/^#/, "").replace(/\+/g, " "))
+  } catch {
+    return null
+  }
+
+  const verificationSearchParams = new URLSearchParams(fragment.replace(/^#/, ""))
+
+  return verificationSearchParams.get("token") ? verificationSearchParams : null
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as ClaimTokenRouteImport } from './routes/claim.$token'
 import { Route as CcWrappedIdRouteImport } from './routes/cc-wrapped/$id'
 import { Route as BackofficeWrappedRouteImport } from './routes/backoffice/wrapped'
 import { Route as BackofficeSearchRouteImport } from './routes/backoffice/search'
+import { Route as AuthVerifyRouteImport } from './routes/auth/verify'
 import { Route as AuthInviteRouteImport } from './routes/auth/invite'
 import { Route as AuthConsentRouteImport } from './routes/auth/consent'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
@@ -148,6 +149,11 @@ const BackofficeSearchRoute = BackofficeSearchRouteImport.update({
   id: '/search',
   path: '/search',
   getParentRoute: () => BackofficeRouteRoute,
+} as any)
+const AuthVerifyRoute = AuthVerifyRouteImport.update({
+  id: '/auth/verify',
+  path: '/auth/verify',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuthInviteRoute = AuthInviteRouteImport.update({
   id: '/auth/invite',
@@ -528,6 +534,7 @@ export interface FileRoutesByFullPath {
   '/api/health': typeof ApiHealthRoute
   '/auth/consent': typeof AuthConsentRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/backoffice/search': typeof BackofficeSearchRoute
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
@@ -601,6 +608,7 @@ export interface FileRoutesByTo {
   '/api/health': typeof ApiHealthRoute
   '/auth/consent': typeof AuthConsentRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/backoffice/search': typeof BackofficeSearchRoute
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
@@ -677,6 +685,7 @@ export interface FileRoutesById {
   '/api/health': typeof ApiHealthRoute
   '/auth/consent': typeof AuthConsentRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/auth/verify': typeof AuthVerifyRoute
   '/backoffice/search': typeof BackofficeSearchRoute
   '/backoffice/wrapped': typeof BackofficeWrappedRoute
   '/cc-wrapped/$id': typeof CcWrappedIdRouteWithChildren
@@ -756,6 +765,7 @@ export interface FileRouteTypes {
     | '/api/health'
     | '/auth/consent'
     | '/auth/invite'
+    | '/auth/verify'
     | '/backoffice/search'
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
@@ -829,6 +839,7 @@ export interface FileRouteTypes {
     | '/api/health'
     | '/auth/consent'
     | '/auth/invite'
+    | '/auth/verify'
     | '/backoffice/search'
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
@@ -904,6 +915,7 @@ export interface FileRouteTypes {
     | '/api/health'
     | '/auth/consent'
     | '/auth/invite'
+    | '/auth/verify'
     | '/backoffice/search'
     | '/backoffice/wrapped'
     | '/cc-wrapped/$id'
@@ -982,6 +994,7 @@ export interface RootRouteChildren {
   ApiHealthRoute: typeof ApiHealthRoute
   AuthConsentRoute: typeof AuthConsentRoute
   AuthInviteRoute: typeof AuthInviteRoute
+  AuthVerifyRoute: typeof AuthVerifyRoute
   CcWrappedIdRoute: typeof CcWrappedIdRouteWithChildren
   ClaimTokenRoute: typeof ClaimTokenRoute
   DownloadsExportRoute: typeof DownloadsExportRoute
@@ -1090,6 +1103,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/backoffice/search'
       preLoaderRoute: typeof BackofficeSearchRouteImport
       parentRoute: typeof BackofficeRouteRoute
+    }
+    '/auth/verify': {
+      id: '/auth/verify'
+      path: '/auth/verify'
+      fullPath: '/auth/verify'
+      preLoaderRoute: typeof AuthVerifyRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/auth/invite': {
       id: '/auth/invite'
@@ -1782,6 +1802,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiHealthRoute: ApiHealthRoute,
   AuthConsentRoute: AuthConsentRoute,
   AuthInviteRoute: AuthInviteRoute,
+  AuthVerifyRoute: AuthVerifyRoute,
   CcWrappedIdRoute: CcWrappedIdRouteWithChildren,
   ClaimTokenRoute: ClaimTokenRoute,
   DownloadsExportRoute: DownloadsExportRoute,

--- a/apps/web/src/routes/auth/verify.tsx
+++ b/apps/web/src/routes/auth/verify.tsx
@@ -1,0 +1,63 @@
+import { Button, Icon, Text, useMountEffect } from "@repo/ui"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { AlertCircle, ShieldCheck } from "lucide-react"
+import { useState } from "react"
+import { AuthScreen } from "../../components/auth-screen.tsx"
+import { hasMagicLinkVerificationToken, reconstructMagicLinkVerificationUrl } from "../../lib/auth/magic-link.ts"
+
+export const Route = createFileRoute("/auth/verify")({
+  component: VerifyMagicLinkPage,
+})
+
+function VerifyMagicLinkPage() {
+  const [hasVerificationToken, setHasVerificationToken] = useState<boolean | undefined>(undefined)
+
+  useMountEffect(() => {
+    setHasVerificationToken(hasMagicLinkVerificationToken(window.location.hash))
+  })
+
+  const confirm = () => {
+    const verificationUrl = reconstructMagicLinkVerificationUrl({
+      fragment: window.location.hash,
+      origin: window.location.origin,
+    })
+
+    if (verificationUrl) {
+      window.location.assign(verificationUrl)
+    } else {
+      setHasVerificationToken(false)
+    }
+  }
+
+  return (
+    <AuthScreen title="Confirm your sign in" description="Review your request before continuing to Latitude.">
+      <div className="flex flex-col gap-4 rounded-xl border border-border bg-muted/50 p-6">
+        {hasVerificationToken === false ? (
+          <>
+            <div role="alert" className="flex flex-col items-center gap-3 text-center">
+              <Icon icon={AlertCircle} size="lg" className="text-destructive" />
+              <Text.H5 color="foregroundMuted">
+                This confirmation link is missing or invalid. Request a new link and try again.
+              </Text.H5>
+            </div>
+            <Button asChild size="full">
+              <Link to="/login">Back to sign in</Link>
+            </Button>
+          </>
+        ) : (
+          <>
+            <div className="flex flex-col items-center gap-3 text-center">
+              <Icon icon={ShieldCheck} size="lg" className="text-primary" />
+              <Text.H5 color="foregroundMuted">
+                Select continue to verify this sign-in link and securely finish signing in.
+              </Text.H5>
+            </div>
+            <Button size="full" disabled={hasVerificationToken === undefined} onClick={confirm}>
+              Continue to Latitude
+            </Button>
+          </>
+        )}
+      </div>
+    </AuthScreen>
+  )
+}

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -30,6 +30,7 @@ import { mcp } from "better-auth/plugins"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
 import { Effect } from "effect"
 import { parseSignupAttributionCookie } from "../lib/analytics/signup-attribution-cookie.ts"
+import { createMagicLinkConfirmationUrl } from "../lib/auth/magic-link.ts"
 
 let postgresClientInstance: PostgresClient | undefined
 let adminPostgresClientInstance: PostgresClient | undefined
@@ -307,7 +308,7 @@ export const getBetterAuth = () => {
               organizationId: "system",
               payload: {
                 email,
-                magicLinkUrl: url,
+                magicLinkUrl: createMagicLinkConfirmationUrl({ verificationUrl: url, webUrl }),
                 organizationId: "system",
               },
             })

--- a/packages/domain/email/src/templates/magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/magic-link/EmailTemplate.tsx
@@ -34,5 +34,5 @@ export function MagicLinkEmail({ userName, magicLinkUrl }: MagicLinkEmailProps) 
 
 MagicLinkEmail.PreviewProps = {
   userName: "Alex",
-  magicLinkUrl: "https://console.latitude.so/auth/verify?token=magic-link-preview",
+  magicLinkUrl: "https://console.latitude.so/auth/verify#token=magic-link-preview",
 } satisfies MagicLinkEmailProps

--- a/packages/domain/email/src/templates/signup-existing-account-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/signup-existing-account-magic-link/EmailTemplate.tsx
@@ -44,5 +44,5 @@ export function SignupExistingAccountMagicLinkEmail({
 
 SignupExistingAccountMagicLinkEmail.PreviewProps = {
   userName: "Alex",
-  magicLinkUrl: "https://console.latitude.so/auth/verify?token=signup-existing-preview",
+  magicLinkUrl: "https://console.latitude.so/auth/verify#token=signup-existing-preview",
 } satisfies SignupExistingAccountMagicLinkEmailProps

--- a/packages/domain/email/src/templates/signup-magic-link/EmailTemplate.tsx
+++ b/packages/domain/email/src/templates/signup-magic-link/EmailTemplate.tsx
@@ -37,5 +37,5 @@ export function SignupMagicLinkEmail({ userName, magicLinkUrl }: SignupMagicLink
 
 SignupMagicLinkEmail.PreviewProps = {
   userName: "Alex",
-  magicLinkUrl: "https://console.latitude.so/api/auth/magic-link/verify?token=signup-preview",
+  magicLinkUrl: "https://console.latitude.so/auth/verify#token=signup-preview",
 } satisfies SignupMagicLinkEmailProps


### PR DESCRIPTION
## What changed

- Rewrite outgoing Better Auth magic links to a scanner-safe `/auth/verify` URL.
- Keep the one-time token and every generated verification parameter in the URL fragment, including nested callback search parameters.
- Add an explicit confirmation screen that reconstructs the Better Auth verification URL only after the user clicks Continue.
- Show a recovery state for missing or malformed links and update email template previews.

## Why

Email security scanners can preload links before the recipient opens the message. A direct GET to Better Auth consumes the one-time token and can create a session for the scanner. URL fragments are not sent with the initial HTTP request, so the confirmation page can render without consuming the link.

## Validation

- `pnpm --filter @app/web exec vitest run src/lib/auth/magic-link.test.ts`
- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @domain/email check`
- `pnpm --filter @domain/email typecheck`
- `pnpm --filter @app/web build`
- Manual Mailpit QA for existing-user sign-in, new-user signup and onboarding, invalid links, and scanner-style GETs without confirmation

## Screenshot

![Magic-link confirmation page](https://github.com/latitude-dev/latitude-llm/raw/refs/heads/gh-attach-assets/0ad58cfd-8619-4fa8-9a36-2e033a1f0ad6/05-sign-in-confirmation.png)