### PR TITLE
feat(taxonomy): Custom Behaviors Phase 3b — scoped tree + Generate wiring + entry points (LAT-751)

### DIFF
--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -28,6 +28,7 @@ import {
   updateRow,
 } from "@domain/datasets"
 import {
+  CustomBehaviorId,
   DatasetId,
   DatasetRowId,
   DatasetVersionId,
@@ -788,6 +789,9 @@ const clusterSourceSchema = z.object({
     .optional(),
   timeFromIso: z.string().optional(),
   timeToIso: z.string().optional(),
+  // Present → resolve sessions from the behavior's scoped assignment slice
+  // instead of the global taxonomy subtree.
+  customBehaviorId: z.string().optional(),
 })
 
 export type ClusterSource = z.infer<typeof clusterSourceSchema>
@@ -814,6 +818,7 @@ function resolveClusterTraceIds(
       ...(cluster.momentRange ? { momentRange: cluster.momentRange } : {}),
       ...(cluster.timeFromIso ? { startTimeFrom: new Date(cluster.timeFromIso) } : {}),
       ...(cluster.timeToIso ? { startTimeTo: new Date(cluster.timeToIso) } : {}),
+      ...(cluster.customBehaviorId ? { customBehaviorId: CustomBehaviorId(cluster.customBehaviorId) } : {}),
       limit: MAX_TRACES_PER_DATASET_IMPORT + 1,
     })
     if (selection.mode === "all") return all

--- a/apps/web/src/domains/taxonomy/custom-behaviors.collection.ts
+++ b/apps/web/src/domains/taxonomy/custom-behaviors.collection.ts
@@ -4,6 +4,7 @@ import {
   type CustomBehaviorRecord,
   createCustomBehaviorFn,
   deleteCustomBehaviorFn,
+  generateCustomBehaviorFn,
   listCustomBehaviors,
   previewCustomBehaviorSample,
   updateCustomBehaviorFn,
@@ -29,6 +30,11 @@ export function useCustomBehaviorsList(projectId: string, { enabled = true } = {
     queryFn: () => listCustomBehaviors({ data: { projectId } }),
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0,
+    // Poll only while a run is actually in flight so the status badge catches
+    // the workflow's generating → ready/failed transition. `pending` is the
+    // stable never-generated state, so polling it would run forever.
+    refetchInterval: (query) =>
+      (query.state.data ?? []).some((behavior) => behavior.status === "generating") ? 5_000 : false,
   })
   return { data: data ?? [], isLoading }
 }
@@ -47,6 +53,14 @@ export function useUpdateCustomBehavior(projectId: string) {
   return useMutation({
     mutationFn: (input: { id: string; name?: string; filterSet?: FilterSet }): Promise<CustomBehaviorRecord> =>
       updateCustomBehaviorFn({ data: input }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey(projectId) }),
+  })
+}
+
+export function useGenerateCustomBehavior(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string): Promise<CustomBehaviorRecord> => generateCustomBehaviorFn({ data: { id } }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: listKey(projectId) }),
   })
 }

--- a/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
+++ b/apps/web/src/domains/taxonomy/custom-behaviors.functions.ts
@@ -1,3 +1,4 @@
+import { QueuePublisher } from "@domain/queue"
 import { CustomBehaviorId, type FilterSet, ProjectId, toSlug } from "@domain/shared"
 import {
   CUSTOM_BEHAVIOR_NAME_MAX_LENGTH,
@@ -7,6 +8,7 @@ import {
   createCustomBehavior,
   customBehaviorFilterSetSchema,
   deleteCustomBehavior,
+  generateCustomBehavior,
   previewCustomBehaviorSampleUseCase,
   updateCustomBehavior,
 } from "@domain/taxonomy"
@@ -16,7 +18,7 @@ import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
-import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+import { getClickhouseClient, getPostgresClient, getQueuePublisher } from "../../server/clients.ts"
 import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
 import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 import { withScopedPostgres } from "../../server/scoped-postgres.ts"
@@ -70,7 +72,9 @@ export const listCustomBehaviors = createServerFn({ method: "GET" })
     const behaviors = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* CustomBehaviorRepository
-        return yield* repo.listByProject({ projectId: ProjectId(data.projectId) })
+        return yield* repo.listByProject({
+          projectId: ProjectId(data.projectId),
+        })
       }).pipe(withScopedPostgres(CustomBehaviorRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
     return behaviors.map(toRecord)
@@ -131,8 +135,31 @@ export const deleteCustomBehaviorFn = createServerFn({ method: "POST" })
     )
   })
 
+export const generateCustomBehaviorFn = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ id: z.string() }))
+  .handler(async ({ data, context }): Promise<CustomBehaviorRecord> => {
+    const orgId = await resolveOrgScope(context)
+    const publisher = await getQueuePublisher()
+
+    const updated = await Effect.runPromise(
+      generateCustomBehavior({
+        customBehaviorId: CustomBehaviorId(data.id),
+      }).pipe(
+        Effect.provideService(QueuePublisher, publisher),
+        withScopedPostgres(CustomBehaviorRepositoryLive, getPostgresClient(), orgId),
+        withTracing,
+      ),
+    )
+    return toRecord(updated)
+  })
+
 export const previewCustomBehaviorSample = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), filterSet: customBehaviorFilterSetSchema }))
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      filterSet: customBehaviorFilterSetSchema,
+    }),
+  )
   .handler(async ({ data, context }): Promise<CustomBehaviorPreviewRecord> => {
     const orgId = await resolveOrgScope(context)
 

--- a/apps/web/src/domains/taxonomy/taxonomy.collection.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.collection.ts
@@ -20,35 +20,58 @@ const timeRangeKey = (timeRange: BehaviourTimeRangeRecord | undefined) =>
 const momentRangeKey = (momentRange: BehaviourMomentRangeRecord | undefined) =>
   momentRange ? `${momentRange.metric}:${momentRange.fromTurn}:${momentRange.toTurn}` : ""
 
+const scopeKey = (customBehaviorId: string | undefined) => customBehaviorId ?? "global"
+
 const clusterProfileQueryKey = (
   projectId: string,
   clusterId: string,
   timeRange: BehaviourTimeRangeRecord | undefined,
-) => ["taxonomyClusterProfile", projectId, clusterId, timeRangeKey(timeRange)] as const
+  customBehaviorId: string | undefined,
+) => ["taxonomyClusterProfile", projectId, scopeKey(customBehaviorId), clusterId, timeRangeKey(timeRange)] as const
 const behaviourSessionsQueryKey = (
   projectId: string,
   clusterId: string,
   filter: BehaviourSessionFilter,
   timeRange: BehaviourTimeRangeRecord | undefined,
   momentRange: BehaviourMomentRangeRecord | undefined,
-) => ["behaviourSessions", projectId, clusterId, filter, timeRangeKey(timeRange), momentRangeKey(momentRange)] as const
+  customBehaviorId: string | undefined,
+) =>
+  [
+    "behaviourSessions",
+    projectId,
+    scopeKey(customBehaviorId),
+    clusterId,
+    filter,
+    timeRangeKey(timeRange),
+    momentRangeKey(momentRange),
+  ] as const
 const behaviourTrajectoryQueryKey = (
   projectId: string,
   categoryClusterIds: readonly string[],
   axis: BehaviourTrajectoryAxis,
   timeRange: BehaviourTimeRangeRecord | undefined,
+  customBehaviorId: string | undefined,
 ) =>
-  ["behaviourTrajectory", projectId, [...categoryClusterIds].sort().join(","), axis, timeRangeKey(timeRange)] as const
+  [
+    "behaviourTrajectory",
+    projectId,
+    scopeKey(customBehaviorId),
+    [...categoryClusterIds].sort().join(","),
+    axis,
+    timeRangeKey(timeRange),
+  ] as const
 const projectBehavioursQueryKey = (input: {
   readonly projectId: string
   readonly dimension: BehaviourDimension
   readonly segment: BehaviourSegment
   readonly sortBy: BehaviourSortBy
   readonly timeRange: BehaviourTimeRangeRecord | undefined
+  readonly customBehaviorId: string | undefined
 }) =>
   [
     "projectBehaviours",
     input.projectId,
+    scopeKey(input.customBehaviorId),
     input.dimension,
     input.segment,
     input.sortBy,
@@ -59,11 +82,19 @@ export function useClusterProfile(
   projectId: string,
   clusterId: string | undefined,
   timeRange: BehaviourTimeRangeRecord | undefined,
+  customBehaviorId?: string,
 ) {
   return useQuery({
-    queryKey: clusterProfileQueryKey(projectId, clusterId ?? "", timeRange),
+    queryKey: clusterProfileQueryKey(projectId, clusterId ?? "", timeRange, customBehaviorId),
     queryFn: () =>
-      getClusterProfile({ data: { projectId, clusterId: clusterId ?? "", ...(timeRange ? { timeRange } : {}) } }),
+      getClusterProfile({
+        data: {
+          projectId,
+          clusterId: clusterId ?? "",
+          ...(timeRange ? { timeRange } : {}),
+          ...(customBehaviorId ? { customBehaviorId } : {}),
+        },
+      }),
     staleTime: 30_000,
     enabled: projectId.length > 0 && Boolean(clusterId),
   })
@@ -75,9 +106,10 @@ export function useBehaviourSessions(
   filter: BehaviourSessionFilter,
   timeRange: BehaviourTimeRangeRecord | undefined,
   momentRange: BehaviourMomentRangeRecord | undefined,
+  customBehaviorId?: string,
 ) {
   return useInfiniteQuery({
-    queryKey: behaviourSessionsQueryKey(projectId, clusterId ?? "", filter, timeRange, momentRange),
+    queryKey: behaviourSessionsQueryKey(projectId, clusterId ?? "", filter, timeRange, momentRange, customBehaviorId),
     queryFn: ({ pageParam }) =>
       getBehaviourSessions({
         data: {
@@ -88,6 +120,7 @@ export function useBehaviourSessions(
           limit: 50,
           ...(timeRange ? { timeRange } : {}),
           ...(momentRange ? { momentRange } : {}),
+          ...(customBehaviorId ? { customBehaviorId } : {}),
         },
       }),
     initialPageParam: 0,
@@ -102,12 +135,19 @@ export function useBehaviourTrajectory(
   categoryClusterIds: readonly string[],
   axis: BehaviourTrajectoryAxis,
   timeRange: BehaviourTimeRangeRecord | undefined,
+  customBehaviorId?: string,
 ) {
   return useQuery({
-    queryKey: behaviourTrajectoryQueryKey(projectId, categoryClusterIds, axis, timeRange),
+    queryKey: behaviourTrajectoryQueryKey(projectId, categoryClusterIds, axis, timeRange, customBehaviorId),
     queryFn: () =>
       getBehaviourTrajectory({
-        data: { projectId, categoryClusterIds: [...categoryClusterIds], axis, ...(timeRange ? { timeRange } : {}) },
+        data: {
+          projectId,
+          categoryClusterIds: [...categoryClusterIds],
+          axis,
+          ...(timeRange ? { timeRange } : {}),
+          ...(customBehaviorId ? { customBehaviorId } : {}),
+        },
       }),
     staleTime: 30_000,
     enabled: projectId.length > 0 && categoryClusterIds.length > 0,
@@ -121,6 +161,8 @@ export function useProjectBehaviours({
   sortBy,
   timeRange,
   pollUntilTopics,
+  poll,
+  customBehaviorId,
 }: {
   readonly projectId: string
   readonly dimension: BehaviourDimension
@@ -128,14 +170,30 @@ export function useProjectBehaviours({
   readonly sortBy: BehaviourSortBy
   readonly timeRange?: BehaviourTimeRangeRecord
   readonly pollUntilTopics?: boolean
+  /** Force a refetch loop regardless of current topics — used while a scoped
+   * behavior is generating so the tree appears as soon as the run writes it. */
+  readonly poll?: boolean
+  readonly customBehaviorId?: string
 }) {
   return useQuery({
-    queryKey: projectBehavioursQueryKey({ projectId, dimension, segment, sortBy, timeRange }),
+    queryKey: projectBehavioursQueryKey({ projectId, dimension, segment, sortBy, timeRange, customBehaviorId }),
     queryFn: () =>
-      getProjectBehaviours({ data: { projectId, dimension, segment, sortBy, ...(timeRange ? { timeRange } : {}) } }),
+      getProjectBehaviours({
+        data: {
+          projectId,
+          dimension,
+          segment,
+          sortBy,
+          ...(timeRange ? { timeRange } : {}),
+          ...(customBehaviorId ? { customBehaviorId } : {}),
+        },
+      }),
     staleTime: 30_000,
     enabled: projectId.length > 0,
-    refetchInterval: (query) => (pollUntilTopics && (query.state.data?.topics.length ?? 0) === 0 ? 5_000 : false),
+    refetchInterval: (query) => {
+      if (poll) return 4_000
+      return pollUntilTopics && (query.state.data?.topics.length ?? 0) === 0 ? 5_000 : false
+    },
   })
 }
 

--- a/apps/web/src/domains/taxonomy/taxonomy.functions.ts
+++ b/apps/web/src/domains/taxonomy/taxonomy.functions.ts
@@ -1,9 +1,11 @@
 import { MOMENT_KINDS, type MomentKind } from "@domain/conversation-intelligence"
-import { normalizeCentroid, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { CustomBehaviorId, normalizeCentroid, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import {
   type ClusterAnalysisAggregate,
+  getBehaviourTrajectoryUseCase,
   getClusterSessionIntelligenceUseCase,
   isDisplayableTaxonomyName,
+  listBehaviourSessionsUseCase,
   listProjectBehavioursUseCase,
   type ProjectBehaviourNode,
   type TaxonomyCluster,
@@ -11,7 +13,11 @@ import {
   TaxonomyClusterRepository,
   type TaxonomyClusterTrendSummary,
 } from "@domain/taxonomy"
-import { TaxonomyClusterIntelligenceRepositoryLive, TaxonomyObservationRepositoryLive } from "@platform/db-clickhouse"
+import {
+  CustomBehaviorAssignmentRepositoryLive,
+  TaxonomyClusterIntelligenceRepositoryLive,
+  TaxonomyObservationRepositoryLive,
+} from "@platform/db-clickhouse"
 import { TaxonomyClusterRepositoryLive } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -172,6 +178,9 @@ const parseBehaviourTimeRange = (timeRange: BehaviourTimeRangeRecord | undefined
 const clickHouseTaxonomyIntelligenceLayer = Layer.mergeAll(
   TaxonomyObservationRepositoryLive,
   TaxonomyClusterIntelligenceRepositoryLive,
+  // Provides scoped per-cluster counts to listProjectBehavioursUseCase when a
+  // customBehaviorId is passed; unused (never resolved) on the global path.
+  CustomBehaviorAssignmentRepositoryLive,
 )
 
 const postgresTaxonomyReadLayer = Layer.mergeAll(TaxonomyClusterRepositoryLive)
@@ -383,6 +392,7 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
       minObservations: z.number().int().positive().optional(),
       limit: z.number().int().positive().max(500).optional(),
       timeRange: behaviourTimeRangeSchema,
+      customBehaviorId: z.string().optional(),
     }),
   )
   .handler(async ({ data, context }): Promise<ProjectBehavioursRecord> => {
@@ -395,6 +405,7 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
         const result = yield* listProjectBehavioursUseCase({
           organizationId: orgId,
           projectId,
+          ...(data.customBehaviorId ? { customBehaviorId: CustomBehaviorId(data.customBehaviorId) } : {}),
           ...(data.dimension ? { dimension: data.dimension } : {}),
           // high_escalation filters on intelligence rollups below, after the
           // tree and aggregates are loaded; the domain use-case has no
@@ -424,6 +435,7 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
                 clusterIds: [TaxonomyClusterId(node.cluster.id)],
                 sourceWindowStart,
                 sourceWindowEnd,
+                ...(data.customBehaviorId ? { customBehaviorId: CustomBehaviorId(data.customBehaviorId) } : {}),
               })
               .pipe(Effect.map((aggregate) => [node.cluster.id, aggregate] as const)),
           { concurrency: 6 },
@@ -447,15 +459,6 @@ export const getProjectBehaviours = createServerFn({ method: "GET" })
     )
   })
 
-const trajectoryBucketExpression = (axis: BehaviourTrajectoryAxis) =>
-  axis === "day" ? "toString(toDate(cs.startTime))" : "toString(m.first_message_index)"
-
-const parseTrajectoryNumber = (value: unknown): number => {
-  if (typeof value === "number") return value
-  if (typeof value === "string") return Number(value)
-  return 0
-}
-
 export const getBehaviourTrajectory = createServerFn({ method: "GET" })
   .inputValidator(
     z.object({
@@ -463,6 +466,7 @@ export const getBehaviourTrajectory = createServerFn({ method: "GET" })
       categoryClusterIds: z.array(z.string()).max(100),
       axis: z.enum(["day", "turn"]),
       timeRange: behaviourTimeRangeSchema,
+      customBehaviorId: z.string().optional(),
     }),
   )
   .handler(async ({ data, context }): Promise<BehaviourTrajectoryRecord> => {
@@ -472,209 +476,22 @@ export const getBehaviourTrajectory = createServerFn({ method: "GET" })
     const categoryClusterIds = [...new Set(data.categoryClusterIds)].filter((id) => id.length > 0)
     if (categoryClusterIds.length === 0) return { buckets: [], rows: [] }
 
-    const subtreeEntries = await Effect.runPromise(
-      Effect.gen(function* () {
-        const clusters = yield* TaxonomyClusterRepository
-        return yield* Effect.forEach(
-          categoryClusterIds,
-          (clusterId) =>
-            clusters
-              .listSubtreeIds({ projectId, clusterId: TaxonomyClusterId(clusterId) })
-              .pipe(Effect.map((clusterIds) => [clusterId, clusterIds] as const)),
-          { concurrency: 6 },
-        )
-      }).pipe(withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
+    return Effect.runPromise(
+      getBehaviourTrajectoryUseCase({
+        organizationId: orgId,
+        projectId,
+        categoryClusterIds: categoryClusterIds.map((id) => TaxonomyClusterId(id)),
+        axis: data.axis,
+        ...(timeRange.from ? { startTimeFrom: timeRange.from } : {}),
+        ...(timeRange.to ? { startTimeTo: timeRange.to } : {}),
+        ...(data.customBehaviorId ? { customBehaviorId: CustomBehaviorId(data.customBehaviorId) } : {}),
+      }).pipe(
+        withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
+        withTracing,
+      ),
     )
-
-    const bucketExpression = trajectoryBucketExpression(data.axis)
-    const timeFromClause = timeRange.from ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
-    const timeToClause = timeRange.to ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
-    const clickhouse = getClickhouseClient()
-    const rowsByCategory = await Promise.all(
-      subtreeEntries.map(async ([categoryClusterId, clusterIds]) => {
-        const result = await clickhouse.query({
-          query: `
-            WITH latest_analyses AS (
-              SELECT organization_id, project_id, session_id, analysis_hash
-              FROM session_analyses FINAL
-              WHERE organization_id = {organizationId:String}
-                AND project_id = {projectId:String}
-            ),
-            cluster_sessions AS (
-              SELECT
-                o.organization_id AS organization_id,
-                o.project_id AS project_id,
-                o.session_id AS session_id,
-                any(a.analysis_hash) AS analysisHash,
-                min(o.start_time) AS startTime
-              FROM taxonomy_observations AS o FINAL
-              INNER JOIN latest_analyses AS a
-                ON o.organization_id = a.organization_id
-               AND o.project_id = a.project_id
-               AND o.session_id = a.session_id
-               AND o.analysis_hash = a.analysis_hash
-              WHERE o.organization_id = {organizationId:String}
-                AND o.project_id = {projectId:String}
-                AND o.assigned_cluster_id IN {clusterIds:Array(String)}
-                ${timeFromClause}
-                ${timeToClause}
-              GROUP BY o.organization_id, o.project_id, o.session_id
-            )
-            SELECT
-              ${bucketExpression} AS bucket,
-              count() AS frequency,
-              countIf(m.kind = 'escalation') AS escalation,
-              countIf(m.kind = 'resolution') AS resolution,
-              countIf(m.kind IN ('abandonment', 'user_frustration')) AS churnRisk,
-              countIf(m.kind IN ('resolution', 'user_satisfaction')) AS wins,
-              max(m.last_message_index) AS maxLastMessageIndex,
-              maxIf(m.last_message_index, m.kind = 'escalation') AS maxEscalationLastMessageIndex,
-              maxIf(m.last_message_index, m.kind = 'resolution') AS maxResolutionLastMessageIndex,
-              maxIf(m.last_message_index, m.kind IN ('abandonment', 'user_frustration')) AS maxChurnRiskLastMessageIndex,
-              maxIf(m.last_message_index, m.kind IN ('resolution', 'user_satisfaction')) AS maxWinsLastMessageIndex
-            FROM cluster_sessions AS cs
-            INNER JOIN session_moment_labels AS m FINAL
-              ON cs.organization_id = m.organization_id
-             AND cs.project_id = m.project_id
-             AND cs.session_id = m.session_id
-             AND cs.analysisHash = m.analysis_hash
-            GROUP BY bucket
-            ORDER BY ${data.axis === "day" ? "bucket ASC" : "toUInt16(bucket) ASC"}
-          `,
-          query_params: {
-            organizationId: orgId,
-            projectId: data.projectId,
-            clusterIds,
-            axis: data.axis,
-            ...(timeRange.from ? { startTimeFrom: timeRange.from.toISOString().replace("Z", "") } : {}),
-            ...(timeRange.to ? { startTimeTo: timeRange.to.toISOString().replace("Z", "") } : {}),
-          },
-          format: "JSONEachRow",
-        })
-        const rows = (await result.json()) as Array<{
-          readonly bucket: string
-          readonly frequency: number | string
-          readonly escalation: number | string
-          readonly resolution: number | string
-          readonly churnRisk: number | string
-          readonly wins: number | string
-          readonly maxLastMessageIndex: number | string
-          readonly maxEscalationLastMessageIndex: number | string
-          readonly maxResolutionLastMessageIndex: number | string
-          readonly maxChurnRiskLastMessageIndex: number | string
-          readonly maxWinsLastMessageIndex: number | string
-        }>
-        return rows.map((row) => ({
-          categoryClusterId,
-          bucket: row.bucket,
-          frequency: parseTrajectoryNumber(row.frequency),
-          escalation: parseTrajectoryNumber(row.escalation),
-          resolution: parseTrajectoryNumber(row.resolution),
-          churnRisk: parseTrajectoryNumber(row.churnRisk),
-          wins: parseTrajectoryNumber(row.wins),
-          maxLastMessageIndex: parseTrajectoryNumber(row.maxLastMessageIndex),
-          maxEscalationLastMessageIndex: parseTrajectoryNumber(row.maxEscalationLastMessageIndex),
-          maxResolutionLastMessageIndex: parseTrajectoryNumber(row.maxResolutionLastMessageIndex),
-          maxChurnRiskLastMessageIndex: parseTrajectoryNumber(row.maxChurnRiskLastMessageIndex),
-          maxWinsLastMessageIndex: parseTrajectoryNumber(row.maxWinsLastMessageIndex),
-        }))
-      }),
-    )
-
-    const rows = rowsByCategory.flat()
-    const buckets = [...new Set(rows.map((row) => row.bucket))].sort((left, right) =>
-      data.axis === "day" ? left.localeCompare(right) : Number(left) - Number(right),
-    )
-    return { buckets, rows }
   })
-
-const behaviourSessionFilterMatches = (session: BehaviourSessionRecord, filter: BehaviourSessionFilter) => {
-  if (filter === "all") return true
-  if (filter === "resolution") return session.momentKinds.includes("resolution")
-  if (filter === "abandonment") return session.momentKinds.includes("abandonment")
-  return session.momentKinds.includes(filter)
-}
-
-const behaviourSessionFilterSql = `
-  ({filter:String} = 'all'
-    OR ({filter:String} = 'resolution' AND has(momentKinds, 'resolution'))
-    OR ({filter:String} = 'abandonment' AND has(momentKinds, 'abandonment'))
-    OR ({filter:String} NOT IN ('all', 'resolution', 'abandonment') AND has(momentKinds, {filter:String})))
-`
-
-const behaviourMetricMomentSql = `
-  (({momentMetric:String} = 'frequency' AND m.kind != '')
-    OR ({momentMetric:String} = 'escalation' AND m.kind = 'escalation')
-    OR ({momentMetric:String} = 'resolution' AND m.kind = 'resolution')
-    OR ({momentMetric:String} = 'churnRisk' AND m.kind IN ('abandonment', 'user_frustration'))
-    OR ({momentMetric:String} = 'wins' AND m.kind IN ('resolution', 'user_satisfaction')))
-`
-
-const behaviourMomentRangeSql = `
-  ${behaviourMetricMomentSql}
-  AND m.first_message_index >= {turnFrom:UInt16}
-  AND m.first_message_index <= {turnTo:UInt16}
-`
-
-// Observations are pinned to each session's CURRENT analysis: superseded
-// analysis generations are never deleted, so an unscoped read unions every
-// re-analysis and \`any(analysis_hash)\` could pick a stale hash, breaking the
-// trace link and silently dropping every moment label.
-const behaviourClusterSessionsCte = (
-  timeFromClause = "",
-  timeToClause = "",
-  momentRange: BehaviourMomentRangeRecord | undefined = undefined,
-) => `
-  WITH latest_analyses AS (
-    SELECT organization_id, project_id, session_id, analysis_hash, trace_ids
-    FROM session_analyses FINAL
-    WHERE organization_id = {organizationId:String}
-      AND project_id = {projectId:String}
-  ),
-  cluster_sessions AS (
-    SELECT
-      o.organization_id AS organization_id,
-      o.project_id AS project_id,
-      o.session_id AS session_id,
-      any(a.analysis_hash) AS analysisHash,
-      arrayElement(any(a.trace_ids), 1) AS traceId,
-      argMin(o.moment_id, o.start_time) AS momentId,
-      any(JSONExtractString(o.projection_metadata, 'summary')) AS summary,
-      min(o.start_time) AS startTime,
-      max(o.end_time) AS endTime
-    FROM taxonomy_observations AS o FINAL
-    INNER JOIN latest_analyses AS a
-      ON o.organization_id = a.organization_id
-     AND o.project_id = a.project_id
-     AND o.session_id = a.session_id
-     AND o.analysis_hash = a.analysis_hash
-    WHERE o.organization_id = {organizationId:String}
-      AND o.project_id = {projectId:String}
-      AND o.assigned_cluster_id IN {clusterIds:Array(String)}
-      ${timeFromClause}
-      ${timeToClause}
-    GROUP BY o.organization_id, o.project_id, o.session_id
-  ),
-  enriched_sessions AS (
-    SELECT
-      cs.session_id AS sessionId,
-      any(cs.traceId) AS traceId,
-      ${momentRange ? `argMinIf(m.moment_id, m.first_message_index, ${behaviourMomentRangeSql})` : "any(cs.momentId)"}
-        AS momentId,
-      any(cs.summary) AS summary,
-      any(cs.startTime) AS startTime,
-      any(cs.endTime) AS endTime,
-      ${momentRange ? `countIf(${behaviourMomentRangeSql})` : "toUInt64(0)"} AS selectedMomentCount,
-      groupUniqArrayIf(m.kind, m.kind != '') AS momentKinds
-    FROM cluster_sessions AS cs
-    LEFT JOIN session_moment_labels AS m FINAL
-      ON cs.organization_id = m.organization_id
-     AND cs.project_id = m.project_id
-     AND cs.session_id = m.session_id
-     AND cs.analysisHash = m.analysis_hash
-    GROUP BY cs.session_id
-  )
-`
 
 export const getBehaviourSessions = createServerFn({ method: "GET" })
   .inputValidator(
@@ -686,120 +503,60 @@ export const getBehaviourSessions = createServerFn({ method: "GET" })
       filter: z.enum(["all", ...MOMENT_KINDS]).optional(),
       timeRange: behaviourTimeRangeSchema,
       momentRange: behaviourMomentRangeSchema,
+      customBehaviorId: z.string().optional(),
     }),
   )
   .handler(async ({ data, context }): Promise<BehaviourSessionsRecord> => {
     const orgId = await resolveOrgScope(context)
-    const offset = data.offset ?? 0
-    const limit = data.limit ?? 50
-    const filter = data.filter ?? "all"
     const timeRange = parseBehaviourTimeRange(data.timeRange)
-    const momentRange = data.momentRange
-    // Tree node: sessions assigned anywhere in its subtree belong to it.
-    const clusterIds = await Effect.runPromise(
-      Effect.gen(function* () {
-        const clusters = yield* TaxonomyClusterRepository
-        return yield* clusters.listSubtreeIds({
-          projectId: ProjectId(data.projectId),
-          clusterId: TaxonomyClusterId(data.clusterId),
-        })
-      }).pipe(withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId), withTracing),
+
+    const page = await Effect.runPromise(
+      listBehaviourSessionsUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        clusterId: TaxonomyClusterId(data.clusterId),
+        filter: data.filter ?? "all",
+        ...(data.momentRange ? { momentRange: data.momentRange } : {}),
+        ...(timeRange.from ? { startTimeFrom: timeRange.from } : {}),
+        ...(timeRange.to ? { startTimeTo: timeRange.to } : {}),
+        offset: data.offset ?? 0,
+        limit: data.limit ?? 50,
+        ...(data.customBehaviorId ? { customBehaviorId: CustomBehaviorId(data.customBehaviorId) } : {}),
+      }).pipe(
+        withScopedPostgres(postgresTaxonomyReadLayer, getPostgresClient(), orgId),
+        withScopedClickHouse(clickHouseTaxonomyIntelligenceLayer, getClickhouseClient(), orgId),
+        withTracing,
+      ),
     )
-    const timeFromClause = timeRange.from ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
-    const timeToClause = timeRange.to ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
-    const timeQueryParams = {
-      ...(timeRange.from ? { startTimeFrom: timeRange.from.toISOString().replace("Z", "") } : {}),
-      ...(timeRange.to ? { startTimeTo: timeRange.to.toISOString().replace("Z", "") } : {}),
-    }
-    const momentRangeClause = momentRange ? "AND selectedMomentCount > 0" : ""
-    const momentRangeQueryParams = momentRange
-      ? { momentMetric: momentRange.metric, turnFrom: momentRange.fromTurn, turnTo: momentRange.toTurn }
-      : {}
-    const result = await getClickhouseClient().query({
-      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, momentRange)}
-              SELECT sessionId, traceId, momentId, summary, startTime, endTime, momentKinds
-              FROM enriched_sessions
-              WHERE ${behaviourSessionFilterSql}
-              ${momentRangeClause}
-              ORDER BY endTime DESC
-              LIMIT {pageSize:UInt32}
-              OFFSET {offset:UInt32}`,
-      query_params: {
-        organizationId: orgId,
-        projectId: data.projectId,
-        clusterIds,
-        filter,
-        pageSize: limit + 1,
-        offset,
-        ...timeQueryParams,
-        ...momentRangeQueryParams,
-      },
-      format: "JSONEachRow",
-    })
-    const rows = (await result.json()) as Array<{
-      readonly sessionId: string
-      readonly traceId: string
-      readonly momentId: string
-      readonly summary: string
-      readonly startTime: string
-      readonly endTime: string
-      readonly momentKinds: readonly string[]
-    }>
-    const histogramInterval =
-      timeRange.from && (!timeRange.to || timeRange.to.getTime() - timeRange.from.getTime() <= 2 * 24 * 60 * 60_000)
-        ? "1 HOUR"
-        : "1 DAY"
-    const histogramResult = await getClickhouseClient().query({
-      query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, momentRange)}
-              SELECT
-                toStartOfInterval(endTime, INTERVAL ${histogramInterval}) AS startTime,
-                count() AS count
-              FROM enriched_sessions
-              WHERE ${behaviourSessionFilterSql}
-              ${momentRangeClause}
-              GROUP BY startTime
-              ORDER BY startTime ASC`,
-      query_params: {
-        organizationId: orgId,
-        projectId: data.projectId,
-        clusterIds,
-        filter,
-        ...timeQueryParams,
-        ...momentRangeQueryParams,
-      },
-      format: "JSONEachRow",
-    })
-    const histogram = (await histogramResult.json()) as Array<{
-      readonly startTime: string
-      readonly count: number
-    }>
-    const sessions = rows
-      .map(
-        (row): BehaviourSessionRecord => ({
-          sessionId: row.sessionId,
-          traceId: row.traceId,
-          momentId: row.momentId,
-          summary: row.summary,
-          startTime: new Date(row.startTime).toISOString(),
-          endTime: new Date(row.endTime).toISOString(),
-          momentKinds: row.momentKinds,
-        }),
-      )
-      .filter((session) => behaviourSessionFilterMatches(session, filter))
-    const pagedSessions = sessions.slice(0, limit)
+
     return {
-      sessions: pagedSessions,
-      hasMore: sessions.length > limit,
-      nextOffset: sessions.length > limit ? offset + limit : null,
-      histogram: histogram.map((bucket) => ({
-        startTime: new Date(bucket.startTime).toISOString(),
-        count: Number(bucket.count),
+      sessions: page.sessions.map((session) => ({
+        sessionId: session.sessionId,
+        traceId: session.traceId,
+        momentId: session.momentId,
+        summary: session.summary,
+        startTime: session.startTime.toISOString(),
+        endTime: session.endTime.toISOString(),
+        momentKinds: session.momentKinds,
+      })),
+      hasMore: page.hasMore,
+      nextOffset: page.nextOffset,
+      histogram: page.histogram.map((bucket) => ({
+        startTime: bucket.startTime.toISOString(),
+        count: bucket.count,
       })),
     }
   })
 
 export const getClusterProfile = createServerFn({ method: "GET" })
-  .inputValidator(z.object({ projectId: z.string(), clusterId: z.string(), timeRange: behaviourTimeRangeSchema }))
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      clusterId: z.string(),
+      timeRange: behaviourTimeRangeSchema,
+      customBehaviorId: z.string().optional(),
+    }),
+  )
   .handler(async ({ data, context }): Promise<ClusterSessionIntelligenceRecord> => {
     const orgId = await resolveOrgScope(context)
     const projectId = ProjectId(data.projectId)
@@ -812,6 +569,7 @@ export const getClusterProfile = createServerFn({ method: "GET" })
         clusterId: TaxonomyClusterId(data.clusterId),
         sourceWindowStart: timeRange.from ?? new Date(0),
         sourceWindowEnd: timeRange.to ?? new Date(),
+        ...(data.customBehaviorId ? { customBehaviorId: CustomBehaviorId(data.customBehaviorId) } : {}),
       }).pipe(
         Effect.map((result) => ({
           rates: result.rates,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -86,6 +86,7 @@ import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexR
 import { Route as AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/$issueId/index'
 import { Route as AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/experiments/$experimentSlug/index'
+import { Route as AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
 import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
 
@@ -530,6 +531,14 @@ const AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute =
       getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
     } as any,
   )
+const AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute =
+  AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport.update(
+    {
+      id: '/custom-behaviours/$behaviourSlug/',
+      path: '/custom-behaviours/$behaviourSlug/',
+      getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+    } as any,
+  )
 const AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute =
   AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRouteImport.update(
     {
@@ -618,6 +627,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/users/': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
+  '/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -694,6 +704,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/users': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
+  '/projects/$projectSlug/custom-behaviours/$behaviourSlug': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -776,6 +787,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/users/': typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
+  '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/_authenticated/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -858,6 +870,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/users/'
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
+    | '/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
     | '/projects/$projectSlug/experiments/$experimentSlug/'
     | '/projects/$projectSlug/issues/$issueId/'
     | '/projects/$projectSlug/monitors/$monitorSlug/'
@@ -934,6 +947,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/users'
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
+    | '/projects/$projectSlug/custom-behaviours/$behaviourSlug'
     | '/projects/$projectSlug/experiments/$experimentSlug'
     | '/projects/$projectSlug/issues/$issueId'
     | '/projects/$projectSlug/monitors/$monitorSlug'
@@ -1015,6 +1029,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/users/'
     | '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
+    | '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
     | '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/'
     | '/_authenticated/projects/$projectSlug/issues/$issueId/'
     | '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/'
@@ -1593,6 +1608,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/': {
+      id: '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
+      path: '/custom-behaviours/$behaviourSlug'
+      fullPath: '/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind': {
       id: '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
       path: '/integrations/$integrationKind'
@@ -1710,6 +1732,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugSignalsIndexRoute: typeof AuthenticatedProjectsProjectSlugSignalsIndexRoute
   AuthenticatedProjectsProjectSlugToolsIndexRoute: typeof AuthenticatedProjectsProjectSlugToolsIndexRoute
   AuthenticatedProjectsProjectSlugUsersIndexRoute: typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
+  AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -1752,6 +1775,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugToolsIndexRoute,
     AuthenticatedProjectsProjectSlugUsersIndexRoute:
       AuthenticatedProjectsProjectSlugUsersIndexRoute,
+    AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute:
+      AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute,
     AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute:
       AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -1,5 +1,6 @@
 import type { MonitorTarget } from "@domain/monitors"
 import type { FilterSet } from "@domain/shared"
+import { stripCustomBehaviorExcludedFields } from "@domain/taxonomy"
 import { Button, Icon, type InfiniteTableSorting, type SortDirection, Tabs, Tooltip, toast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { useHotkeys } from "@tanstack/react-hotkeys"
@@ -12,6 +13,7 @@ import {
   FilterXIcon,
   MessagesSquareIcon,
   ShieldAlertIcon,
+  SlidersHorizontalIcon,
   TextIcon,
   XIcon,
 } from "lucide-react"
@@ -23,6 +25,7 @@ import {
   addTracesToDatasetFunction,
   createDatasetFromTracesFunction,
 } from "../../../../../domains/datasets/datasets.functions.ts"
+import { useFeatureFlags } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useMonitors } from "../../../../../domains/monitors/monitors.collection.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { useSavedSearchBySlug } from "../../../../../domains/saved-searches/saved-searches.collection.ts"
@@ -247,6 +250,18 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
   // condition array is not a user-applied filter, so ignore empties here.
   const hasActiveFilters = Object.values(filters).some((conds) => conds.length > 0)
   const hasSelectedSavedSearch = savedSearchSlug.length > 0
+  const featureFlags = useFeatureFlags()
+  // A custom behavior copies the current filter minus topics (a behavior scoped
+  // on behaviors is circular). Only offer it when a non-topics filter exists.
+  const customBehaviorSeedFilters = useMemo(() => stripCustomBehaviorExcludedFields(filters), [filters])
+  const canCreateCustomBehavior =
+    featureFlags.has("customBehaviors") && Object.keys(customBehaviorSeedFilters).length > 0
+  const createCustomBehaviorFromFilters = () =>
+    navigate({
+      to: "/projects/$projectSlug/custom-behaviours",
+      params: { projectSlug },
+      search: { create: serializeFilters(customBehaviorSeedFilters) },
+    })
   const sessionsMonitorTarget = useMemo<MonitorTarget>(
     () => ({
       type: "session",
@@ -557,6 +572,24 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
                   additionalMonitors={savedSearchMonitors}
                 />
               )
+            ) : null}
+            {isSessions && canCreateCustomBehavior ? (
+              <Tooltip
+                asChild
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 w-auto"
+                    onClick={() => void createCustomBehaviorFromFilters()}
+                  >
+                    <Icon icon={SlidersHorizontalIcon} size="sm" />
+                    Create custom behavior
+                  </Button>
+                }
+              >
+                Cluster the sessions matching these filters into their own behavior tree.
+              </Tooltip>
             ) : null}
             <Tabs
               variant="bordered"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -1,3 +1,4 @@
+import { stripCustomBehaviorExcludedFields } from "@domain/taxonomy"
 import {
   Button,
   CloseTrigger,
@@ -22,10 +23,12 @@ import {
   FlaskConicalIcon,
   PencilIcon,
   SearchIcon,
+  SlidersHorizontalIcon,
   Trash2Icon,
 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useCreateExperimentFromSearch } from "../../../../../domains/experiments/experiments.collection.ts"
+import { useFeatureFlags } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { savedSearchMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
 import {
   useDeleteSavedSearch,
@@ -36,6 +39,7 @@ import { toUserMessage } from "../../../../../lib/errors.ts"
 import { targetAlertDraft } from "../monitors/-components/alert-form-helpers.ts"
 import { MonitorCreateModal } from "../monitors/-components/monitor-create-modal.tsx"
 import { SaveSearchModal } from "./save-search-modal.tsx"
+import { serializeFilters } from "./trace-page-state.ts"
 
 /**
  * Dropdown listing the project's saved searches with a filter, per-row actions,
@@ -60,6 +64,9 @@ export function SavedSearchSelector({
   readonly onSaveCurrent: () => void
   readonly canSaveCurrent: boolean
 }) {
+  const navigate = useNavigate()
+  const featureFlags = useFeatureFlags()
+  const customBehaviorsEnabled = featureFlags.has("customBehaviors")
   const [open, setOpen] = useState(false)
   const [filter, setFilter] = useState("")
   const [rowToDelete, setRowToDelete] = useState<SavedSearchRecord | null>(null)
@@ -68,6 +75,18 @@ export function SavedSearchSelector({
   const [rowToCompare, setRowToCompare] = useState<SavedSearchRecord | null>(null)
 
   const { data: savedSearches } = useSavedSearchesList(projectId)
+
+  // Per spec, a custom behavior seeded from a saved search copies its filterSet
+  // only (never the semantic query), with the excluded `topics` field stripped.
+  const createCustomBehaviorFromSavedSearch = (record: SavedSearchRecord) => {
+    const seed = stripCustomBehaviorExcludedFields(record.filterSet)
+    setOpen(false)
+    navigate({
+      to: "/projects/$projectSlug/custom-behaviours",
+      params: { projectSlug },
+      search: { create: serializeFilters(seed) },
+    })
+  }
 
   const selected = useMemo(
     () => savedSearches.find((search) => search.slug === selectedSlug) ?? null,
@@ -170,6 +189,24 @@ export function SavedSearchSelector({
                     <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center opacity-0 transition-opacity group-hover/row:pointer-events-auto group-hover/row:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
                       <div aria-hidden className="h-full w-10 bg-gradient-to-l from-accent to-transparent" />
                       <div className="flex h-full items-center gap-0.5 rounded-r-md bg-accent pr-1">
+                        {customBehaviorsEnabled &&
+                        Object.keys(stripCustomBehaviorExcludedFields(record.filterSet)).length > 0 ? (
+                          <Tooltip
+                            asChild
+                            trigger={
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                aria-label={`Create a custom behavior from saved search ${record.name}`}
+                                onClick={() => createCustomBehaviorFromSavedSearch(record)}
+                              >
+                                <Icon icon={SlidersHorizontalIcon} size="sm" color="foregroundMuted" />
+                              </Button>
+                            }
+                          >
+                            Create custom behavior
+                          </Tooltip>
+                        ) : null}
                         <Tooltip
                           asChild
                           trigger={

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-tree-nav.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-tree-nav.ts
@@ -1,0 +1,37 @@
+import type {
+  BehaviourNodeRecord,
+  BehaviourTrajectoryMetric,
+} from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
+
+export const isBehaviourTrajectoryMetric = (value: string): value is BehaviourTrajectoryMetric =>
+  value === "frequency" || value === "escalation" || value === "resolution" || value === "churnRisk" || value === "wins"
+
+export const findNodeByPath = (
+  topics: readonly BehaviourNodeRecord[],
+  path: readonly string[],
+): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
+  let nodes = topics
+  let parent: BehaviourNodeRecord | null = null
+  let selected: { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null = null
+  for (const id of path) {
+    const node = nodes.find((candidate) => candidate.cluster.id === id)
+    if (!node) return null
+    selected = { node, parent }
+    nodes = node.children
+    parent = node
+  }
+  return selected
+}
+
+export const findNodeById = (
+  nodes: readonly BehaviourNodeRecord[],
+  clusterId: string,
+  parent: BehaviourNodeRecord | null = null,
+): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
+  for (const node of nodes) {
+    if (node.cluster.id === clusterId) return { node, parent }
+    const found = findNodeById(node.children, clusterId, node)
+    if (found) return found
+  }
+  return null
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-trajectory-chart.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-trajectory-chart.tsx
@@ -207,6 +207,7 @@ export function BehavioursTrajectoryChart({
   topics,
   selectedPath,
   timeRange,
+  customBehaviorId,
   onSelectPath,
   onSelectPoint,
 }: {
@@ -214,6 +215,7 @@ export function BehavioursTrajectoryChart({
   readonly topics: readonly BehaviourNodeRecord[]
   readonly selectedPath: readonly string[]
   readonly timeRange: BehaviourTimeRangeRecord | undefined
+  readonly customBehaviorId?: string
   readonly onSelectPath: (path: readonly string[]) => void
   readonly onSelectPoint: (selection: {
     readonly path: readonly string[]
@@ -229,7 +231,7 @@ export function BehavioursTrajectoryChart({
   const visibleLevel = useMemo(() => resolveVisibleLevel(topics, selectedPath), [topics, selectedPath])
   const visibleNodes = showAll ? visibleLevel.nodes : visibleLevel.nodes.slice(0, MAX_COLLAPSED_ROWS)
   const visibleIds = visibleNodes.map((node) => node.cluster.id)
-  const { data, isLoading } = useBehaviourTrajectory(projectId, visibleIds, axis, timeRange)
+  const { data, isLoading } = useBehaviourTrajectory(projectId, visibleIds, axis, timeRange, customBehaviorId)
   const rawRows = data?.rows ?? []
   const trajectory = useMemo(() => coarsenTrajectoryRows(rawRows, axis, metric), [rawRows, axis, metric])
   const rows = trajectory.rows

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-view.tsx
@@ -259,6 +259,7 @@ export function BehaviourDetailDrawer({
   timeRange,
   momentRange,
   momentRangeMaxTurn,
+  customBehaviorId,
   onMomentRangeChange,
   onClose,
 }: {
@@ -268,6 +269,7 @@ export function BehaviourDetailDrawer({
   readonly timeRange: BehaviourTimeRangeRecord | undefined
   readonly momentRange: BehaviourMomentRangeRecord | undefined
   readonly momentRangeMaxTurn: number
+  readonly customBehaviorId?: string
   readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
   readonly onClose: () => void
 }) {
@@ -278,14 +280,14 @@ export function BehaviourDetailDrawer({
   const [sessionPanelEntered, setSessionPanelEntered] = useState(false)
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
-  const { data: intelligence } = useClusterProfile(projectId, cluster.id, timeRange)
+  const { data: intelligence } = useClusterProfile(projectId, cluster.id, timeRange, customBehaviorId)
   const {
     data: behaviourSessionsData,
     isLoading: behaviourSessionsLoading,
     fetchNextPage: fetchNextBehaviourSessionsPage,
     hasNextPage: hasNextBehaviourSessionsPage,
     isFetchingNextPage: isFetchingNextBehaviourSessionsPage,
-  } = useBehaviourSessions(projectId, cluster.id, sessionFilter, timeRange, momentRange)
+  } = useBehaviourSessions(projectId, cluster.id, sessionFilter, timeRange, momentRange, customBehaviorId)
   const behaviourSessions = behaviourSessionsData?.pages.flatMap((page) => page.sessions) ?? []
   const behaviourSessionHistogram = behaviourSessionsData?.pages[0]?.histogram ?? []
   // A session row's identity is its (first) trace id — the unit a dataset row is
@@ -313,8 +315,9 @@ export function BehaviourDetailDrawer({
         : {}),
       ...(timeRange?.fromIso ? { timeFromIso: timeRange.fromIso } : {}),
       ...(timeRange?.toIso ? { timeToIso: timeRange.toIso } : {}),
+      ...(customBehaviorId ? { customBehaviorId } : {}),
     }),
-    [cluster.id, sessionFilter, momentRange, timeRange],
+    [cluster.id, sessionFilter, momentRange, timeRange, customBehaviorId],
   )
   const datasetSelection = sessionSelection.bulkSelection
   const detectedSignals = intelligence?.topMoments ?? []
@@ -855,6 +858,7 @@ export function BehavioursView({
   timeFilter,
   timeRange,
   momentRange,
+  customBehaviorId,
   onSegmentChange,
   onBehaviourPathChange,
   onMomentRangeChange,
@@ -862,12 +866,19 @@ export function BehavioursView({
   readonly topics: readonly BehaviourNodeRecord[]
   readonly projectId: string
   readonly isLoading: boolean
-  readonly segment: BehaviourSegment
+  /** Global-only chrome, like `timeFilter`: pass `segment` + `onSegmentChange`
+   * to show the segment tabs; omit them (e.g. a scoped tree, whose trends are
+   * neutral) to hide them. */
+  readonly segment?: BehaviourSegment
   readonly behaviourPath: readonly string[]
+  /** Slot for the global time-window picker; scoped trees pass `null` (fixed 7d). */
   readonly timeFilter: ReactNode
   readonly timeRange: BehaviourTimeRangeRecord | undefined
   readonly momentRange: BehaviourMomentRangeRecord | undefined
-  readonly onSegmentChange: (segment: BehaviourSegment) => void
+  /** Data scope only: reads the behavior's scoped clusters/sessions/trajectory.
+   * It does not drive chrome — visible controls are chosen by the caller. */
+  readonly customBehaviorId?: string
+  readonly onSegmentChange?: (segment: BehaviourSegment) => void
   readonly onBehaviourPathChange: (path: readonly string[]) => void
   readonly onMomentRangeChange: (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => void
 }) {
@@ -1079,15 +1090,17 @@ export function BehavioursView({
             {timeFilter}
             {momentRange ? <BehaviourBadge label={selectedMomentRangeLabel(momentRange)} icon={TagIcon} /> : null}
           </Layout.ActionRowItem>
-          <Layout.ActionRowItem>
-            <Tabs
-              variant="bordered"
-              size="sm"
-              options={segmentOptions.map((option) => ({ id: option.id, label: option.label }))}
-              active={segment}
-              onSelect={(value) => onSegmentChange(value)}
-            />
-          </Layout.ActionRowItem>
+          {onSegmentChange ? (
+            <Layout.ActionRowItem>
+              <Tabs
+                variant="bordered"
+                size="sm"
+                options={segmentOptions.map((option) => ({ id: option.id, label: option.label }))}
+                active={segment ?? "all"}
+                onSelect={(value) => onSegmentChange(value)}
+              />
+            </Layout.ActionRowItem>
+          ) : null}
         </Layout.ActionsRow>
       </Layout.Actions>
       <Layout.Body>
@@ -1105,6 +1118,7 @@ export function BehavioursView({
                 topics={topics}
                 selectedPath={behaviourPath}
                 timeRange={timeRange}
+                {...(customBehaviorId ? { customBehaviorId } : {})}
                 onSelectPath={handleDotChartPathChange}
                 onSelectPoint={handleDotChartPointSelect}
               />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/index.tsx
@@ -4,52 +4,16 @@ import { ExternalLinkIcon, Loader2Icon, TagsIcon } from "lucide-react"
 import { useMemo } from "react"
 import { useAnalyticsTimeWindow } from "../../../../../domains/projects/use-analytics-time-window.ts"
 import { type BehaviourSegment, useProjectBehaviours } from "../../../../../domains/taxonomy/taxonomy.collection.ts"
-import type {
-  BehaviourMomentRangeRecord,
-  BehaviourNodeRecord,
-  BehaviourTrajectoryMetric,
-} from "../../../../../domains/taxonomy/taxonomy.functions.ts"
+import type { BehaviourMomentRangeRecord } from "../../../../../domains/taxonomy/taxonomy.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
+import { findNodeById, findNodeByPath, isBehaviourTrajectoryMetric } from "./-components/behaviour-tree-nav.ts"
 import { BehaviourDetailDrawer, BehavioursView } from "./-components/behaviours-view.tsx"
 
-const isBehaviourTrajectoryMetric = (value: string): value is BehaviourTrajectoryMetric =>
-  value === "frequency" || value === "escalation" || value === "resolution" || value === "churnRisk" || value === "wins"
-
 const isDemoProjectName = (name: string) => /(^|\b)demo project(\b|$)/i.test(name)
-
-const findNodeByPath = (
-  topics: readonly BehaviourNodeRecord[],
-  path: readonly string[],
-): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
-  let nodes = topics
-  let parent: BehaviourNodeRecord | null = null
-  let selected: { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null = null
-  for (const id of path) {
-    const node = nodes.find((candidate) => candidate.cluster.id === id)
-    if (!node) return null
-    selected = { node, parent }
-    nodes = node.children
-    parent = node
-  }
-  return selected
-}
-
-const findNodeById = (
-  nodes: readonly BehaviourNodeRecord[],
-  clusterId: string,
-  parent: BehaviourNodeRecord | null = null,
-): { readonly node: BehaviourNodeRecord; readonly parent: BehaviourNodeRecord | null } | null => {
-  for (const node of nodes) {
-    if (node.cluster.id === clusterId) return { node, parent }
-    const found = findNodeById(node.children, clusterId, node)
-    if (found) return found
-  }
-  return null
-}
 
 function BehavioursBreadcrumb() {
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/index.tsx
@@ -1,0 +1,39 @@
+import { createFileRoute, getRouteApi, redirect } from "@tanstack/react-router"
+import { listEnabledFeatureFlagIdentifiers } from "../../../../../../domains/feature-flags/feature-flags.functions.ts"
+import { BreadcrumbLink, BreadcrumbSeparator, BreadcrumbText } from "../../../../-components/breadcrumb-ui.tsx"
+import { useRouteProject } from "../../-route-data.ts"
+import { CustomBehaviourDetail } from "../-components/custom-behaviour-detail.tsx"
+
+const behaviourRoute = getRouteApi("/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/")
+
+function CustomBehaviourBreadcrumb() {
+  const { projectSlug, behaviourSlug } = behaviourRoute.useParams()
+  return (
+    <>
+      <BreadcrumbLink to="/projects/$projectSlug/custom-behaviours" params={{ projectSlug }}>
+        Custom behaviors
+      </BreadcrumbLink>
+      <BreadcrumbSeparator />
+      <BreadcrumbText variant="current">{behaviourSlug}</BreadcrumbText>
+    </>
+  )
+}
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/")({
+  beforeLoad: async ({ params }) => {
+    const enabled = await listEnabledFeatureFlagIdentifiers()
+    if (!enabled.includes("customBehaviors")) {
+      throw redirect({ to: "/projects/$projectSlug", params: { projectSlug: params.projectSlug } })
+    }
+  },
+  staticData: {
+    breadcrumb: CustomBehaviourBreadcrumb,
+  },
+  component: CustomBehaviourDetailPage,
+})
+
+function CustomBehaviourDetailPage() {
+  const project = useRouteProject()
+  const { projectSlug, behaviourSlug } = Route.useParams()
+  return <CustomBehaviourDetail projectId={project.id} projectSlug={projectSlug} behaviourSlug={behaviourSlug} />
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviour-detail.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviour-detail.tsx
@@ -1,0 +1,221 @@
+import type { CustomBehaviorStatus } from "@domain/taxonomy"
+import { Badge, type BadgeProps, Button, Icon, Text, useToast } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import { AlertTriangleIcon, Loader2Icon, RefreshCwIcon, SparklesIcon } from "lucide-react"
+import { useMemo } from "react"
+import { summarizeFilterSet } from "../../../../../../components/filters-builder/filter-summary.ts"
+import {
+  useCustomBehaviorsList,
+  useGenerateCustomBehavior,
+} from "../../../../../../domains/taxonomy/custom-behaviors.collection.ts"
+import type { CustomBehaviorRecord } from "../../../../../../domains/taxonomy/custom-behaviors.functions.ts"
+import { useProjectBehaviours } from "../../../../../../domains/taxonomy/taxonomy.collection.ts"
+import type { BehaviourMomentRangeRecord } from "../../../../../../domains/taxonomy/taxonomy.functions.ts"
+import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
+import {
+  findNodeById,
+  findNodeByPath,
+  isBehaviourTrajectoryMetric,
+} from "../../behaviours/-components/behaviour-tree-nav.ts"
+import { BehaviourDetailDrawer, BehavioursView } from "../../behaviours/-components/behaviours-view.tsx"
+
+const STATUS_META: Record<CustomBehaviorStatus, { readonly label: string; readonly variant: BadgeProps["variant"] }> = {
+  pending: { label: "Pending", variant: "muted" },
+  generating: { label: "Generating", variant: "warningMuted" },
+  ready: { label: "Ready", variant: "successMuted" },
+  failed: { label: "Failed", variant: "destructiveMuted" },
+}
+
+function FilterSummary({ behaviour }: { readonly behaviour: CustomBehaviorRecord }) {
+  const labels = summarizeFilterSet(behaviour.filterSet)
+  if (labels.length === 0) return <Text.H6 color="foregroundMuted">All sessions</Text.H6>
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-1">
+      {labels.map((label) => (
+        <Badge key={label} variant="muted" size="small">
+          {label}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function CustomBehaviourTreePage({ behaviour }: { readonly behaviour: CustomBehaviorRecord }) {
+  const { toast } = useToast()
+  const generate = useGenerateCustomBehavior(behaviour.projectId)
+  const [behaviourPathParam, setBehaviourPathParam] = useParamState("behaviourPath", "", { history: "push" })
+  const [momentMetric, setMomentMetric] = useParamState("behaviourMomentMetric", "")
+  const [momentTurnFrom, setMomentTurnFrom] = useParamState("behaviourMomentTurnFrom", "")
+  const [momentTurnTo, setMomentTurnTo] = useParamState("behaviourMomentTurnTo", "")
+  const [momentTurnMax, setMomentTurnMax] = useParamState("behaviourMomentTurnMax", "")
+
+  const { data, isLoading } = useProjectBehaviours({
+    projectId: behaviour.projectId,
+    dimension: "topic",
+    segment: "all",
+    sortBy: "category",
+    customBehaviorId: behaviour.id,
+    poll: behaviour.status === "generating",
+  })
+  const topics = data?.topics ?? []
+
+  const momentRange = useMemo((): BehaviourMomentRangeRecord | undefined => {
+    if (!isBehaviourTrajectoryMetric(momentMetric)) return undefined
+    const fromTurn = Number(momentTurnFrom)
+    const toTurn = Number(momentTurnTo)
+    if (!Number.isInteger(fromTurn) || !Number.isInteger(toTurn) || fromTurn < 0 || toTurn < fromTurn) return undefined
+    return { metric: momentMetric, fromTurn, toTurn }
+  }, [momentMetric, momentTurnFrom, momentTurnTo])
+  const setMomentRangeWithMax = (range: BehaviourMomentRangeRecord | undefined, maxTurn?: number) => {
+    setMomentMetric(range?.metric ?? "")
+    setMomentTurnFrom(range ? String(range.fromTurn) : "")
+    setMomentTurnTo(range ? String(range.toTurn) : "")
+    setMomentTurnMax(range && maxTurn !== undefined ? String(Math.max(maxTurn, range.toTurn)) : "")
+  }
+  const parsedMomentTurnMax = Number(momentTurnMax)
+  const momentRangeMaxTurn =
+    momentRange && Number.isInteger(parsedMomentTurnMax) && parsedMomentTurnMax >= momentRange.toTurn
+      ? parsedMomentTurnMax
+      : (momentRange?.toTurn ?? 0)
+
+  const behaviourPath = useMemo(
+    () => (behaviourPathParam ? behaviourPathParam.split(".").filter(Boolean) : []),
+    [behaviourPathParam],
+  )
+  const setBehaviourPath = (path: readonly string[]) => setBehaviourPathParam(path.join("."))
+  const activeBehaviourId = behaviourPath.at(-1)
+  const activeNode = useMemo(() => {
+    if (!activeBehaviourId) return null
+    return findNodeByPath(topics, behaviourPath) ?? findNodeById(topics, activeBehaviourId)
+  }, [activeBehaviourId, behaviourPath, topics])
+
+  const status = STATUS_META[behaviour.status]
+  const isGenerating = behaviour.status === "generating"
+  const neverGenerated = behaviour.status === "pending"
+  const hasTree = topics.length > 0
+
+  const runGenerate = async () => {
+    try {
+      await generate.mutateAsync(behaviour.id)
+      toast({ description: "Generation started. The tree updates when it completes." })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
+  return (
+    <Layout>
+      <Layout.Content>
+        <Layout.Header
+          title={
+            <div className="flex flex-row items-center gap-3">
+              <Text.H4M>{behaviour.name}</Text.H4M>
+              <Badge variant={status.variant}>{status.label}</Badge>
+            </div>
+          }
+          description={<FilterSummary behaviour={behaviour} />}
+          actions={
+            <Button variant="default" onClick={() => void runGenerate()} disabled={isGenerating || generate.isPending}>
+              <Icon size="sm" icon={neverGenerated ? SparklesIcon : RefreshCwIcon} />
+              {isGenerating ? "Generating…" : neverGenerated ? "Generate" : "Regenerate"}
+            </Button>
+          }
+        />
+        {behaviour.status === "failed" ? (
+          <div className="flex flex-row items-center gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2">
+            <Icon icon={AlertTriangleIcon} size="sm" color="destructive" />
+            <Text.H6 color="destructive">
+              The last generation failed. Showing the previous tree — regenerate to try again.
+            </Text.H6>
+          </div>
+        ) : null}
+        {isGenerating ? (
+          <div className="flex flex-row items-center gap-2 rounded-md border border-border bg-secondary px-3 py-2">
+            <Loader2Icon className="h-4 w-4 animate-spin text-muted-foreground" />
+            <Text.H6 color="warningMutedForeground">
+              Generating the scoped tree. Any existing tree stays visible until the new pass completes.
+            </Text.H6>
+          </div>
+        ) : null}
+        {isLoading || hasTree ? (
+          <BehavioursView
+            topics={topics}
+            projectId={behaviour.projectId}
+            isLoading={isLoading}
+            behaviourPath={behaviourPath}
+            timeFilter={null}
+            timeRange={undefined}
+            momentRange={momentRange}
+            customBehaviorId={behaviour.id}
+            onBehaviourPathChange={setBehaviourPath}
+            onMomentRangeChange={setMomentRangeWithMax}
+          />
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <Text.H4>No scoped tree yet</Text.H4>
+            <Text.H5 color="foregroundMuted" centered>
+              Generate to cluster this behavior's sessions into their own tree. Clustering runs over the last 7 days and
+              needs enough matching observations.
+            </Text.H5>
+          </div>
+        )}
+      </Layout.Content>
+      {activeNode ? (
+        <Layout.Aside>
+          <BehaviourDetailDrawer
+            node={activeNode.node}
+            parentName={activeNode.parent?.cluster.name ?? null}
+            projectId={behaviour.projectId}
+            timeRange={undefined}
+            momentRange={momentRange}
+            momentRangeMaxTurn={momentRangeMaxTurn}
+            customBehaviorId={behaviour.id}
+            onMomentRangeChange={setMomentRangeWithMax}
+            onClose={() => {
+              setBehaviourPath([])
+              setMomentRangeWithMax(undefined)
+            }}
+          />
+        </Layout.Aside>
+      ) : null}
+    </Layout>
+  )
+}
+
+export function CustomBehaviourDetail({
+  projectId,
+  projectSlug,
+  behaviourSlug,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly behaviourSlug: string
+}) {
+  const { data: behaviours, isLoading } = useCustomBehaviorsList(projectId)
+  const behaviour = behaviours.find((candidate) => candidate.slug === behaviourSlug)
+
+  if (behaviour) return <CustomBehaviourTreePage key={behaviour.id} behaviour={behaviour} />
+
+  return (
+    <Layout>
+      <Layout.Content>
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center p-8">
+            <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+            <Text.H3>Custom behavior not found</Text.H3>
+            <Button asChild variant="outline">
+              <Link to="/projects/$projectSlug/custom-behaviours" params={{ projectSlug }}>
+                Back to custom behaviors
+              </Link>
+            </Button>
+          </div>
+        )}
+      </Layout.Content>
+    </Layout>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviour-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviour-modal.tsx
@@ -65,17 +65,20 @@ function PreviewStrip({ projectId, filterSet }: { readonly projectId: string; re
 export function CustomBehaviourModal({
   projectId,
   behaviour,
+  initialFilterSet,
   onClose,
 }: {
   readonly projectId: string
   /** Present → edit; null → create. */
   readonly behaviour: CustomBehaviorRecord | null
+  /** Seeds the create form's filters (e.g. copied from a Sessions view or saved search). */
+  readonly initialFilterSet?: FilterSet
   readonly onClose: () => void
 }) {
   const { toast } = useToast()
   const create = useCreateCustomBehavior(projectId)
   const update = useUpdateCustomBehavior(projectId)
-  const [filterSet, setFilterSet] = useState<FilterSet>(behaviour?.filterSet ?? {})
+  const [filterSet, setFilterSet] = useState<FilterSet>(behaviour?.filterSet ?? initialFilterSet ?? {})
   const hasFilters = customBehaviorFilterSetHasConditions(filterSet)
 
   const form = useForm({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviours-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/-components/custom-behaviours-list.tsx
@@ -19,13 +19,15 @@ import {
   useToast,
 } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
-import { Loader2, PencilIcon, PlusIcon, SlidersHorizontalIcon, Trash2 } from "lucide-react"
+import { Link } from "@tanstack/react-router"
+import { Loader2, PencilIcon, PlusIcon, RefreshCwIcon, SlidersHorizontalIcon, SparklesIcon, Trash2 } from "lucide-react"
 import { useState } from "react"
 import { summarizeFilterSet } from "../../../../../../components/filters-builder/filter-summary.ts"
 import {
   useCustomBehaviorPreview,
   useCustomBehaviorsList,
   useDeleteCustomBehavior,
+  useGenerateCustomBehavior,
 } from "../../../../../../domains/taxonomy/custom-behaviors.collection.ts"
 import type { CustomBehaviorRecord } from "../../../../../../domains/taxonomy/custom-behaviors.functions.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
@@ -73,20 +75,43 @@ function FilterSummaryCell({ filterSet }: { readonly filterSet: FilterSet }) {
 
 function CustomBehaviourRow({
   projectId,
+  projectSlug,
   behaviour,
   onEdit,
   onDelete,
 }: {
   readonly projectId: string
+  readonly projectSlug: string
   readonly behaviour: CustomBehaviorRecord
   readonly onEdit: (behaviour: CustomBehaviorRecord) => void
   readonly onDelete: (behaviour: CustomBehaviorRecord) => void
 }) {
   const status = STATUS_META[behaviour.status]
+  const generate = useGenerateCustomBehavior(projectId)
+  const { toast } = useToast()
+  const isGenerating = behaviour.status === "generating"
+  const neverGenerated = behaviour.status === "pending"
+
+  const runGenerate = async () => {
+    try {
+      await generate.mutateAsync(behaviour.id)
+      toast({ description: "Generation started. The tree updates when it completes." })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    }
+  }
+
   return (
     <TableRow verticalPadding hoverable={false}>
       <TableCell>
-        <Text.H5>{behaviour.name}</Text.H5>
+        <Link
+          to="/projects/$projectSlug/custom-behaviours/$behaviourSlug"
+          params={{ projectSlug, behaviourSlug: behaviour.slug }}
+          aria-label={`Open the ${behaviour.name} behavior tree`}
+          className="hover:underline"
+        >
+          <Text.H5>{behaviour.name}</Text.H5>
+        </Link>
       </TableCell>
       <TableCell>
         <Badge variant={status.variant}>{status.label}</Badge>
@@ -104,6 +129,26 @@ function CustomBehaviourRow({
       </TableCell>
       <TableCell align="right">
         <div className="inline-flex flex-row items-center gap-1">
+          <Tooltip
+            asChild
+            trigger={
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => void runGenerate()}
+                disabled={isGenerating || generate.isPending}
+                aria-label={neverGenerated ? "Generate custom behavior" : "Regenerate custom behavior"}
+              >
+                <Icon
+                  icon={isGenerating || generate.isPending ? Loader2 : neverGenerated ? SparklesIcon : RefreshCwIcon}
+                  size="sm"
+                  className={isGenerating || generate.isPending ? "animate-spin" : ""}
+                />
+              </Button>
+            }
+          >
+            {isGenerating ? "Generating…" : neverGenerated ? "Generate" : "Regenerate"}
+          </Tooltip>
           <Tooltip
             asChild
             trigger={
@@ -135,23 +180,36 @@ function CustomBehaviourRow({
   )
 }
 
-export function CustomBehavioursList({ projectId }: { readonly projectId: string }) {
+export function CustomBehavioursList({
+  projectId,
+  projectSlug,
+  initialCreateFilterSet,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  /** When present, the create modal opens on mount with these filters prefilled
+   * (topics already stripped) — set by the "Create custom behavior" entry points. */
+  readonly initialCreateFilterSet?: FilterSet
+}) {
   const { toast } = useToast()
   const { data: behaviours, isLoading } = useCustomBehaviorsList(projectId)
   const del = useDeleteCustomBehavior(projectId)
-  const [modalOpen, setModalOpen] = useState(false)
+  const [modalOpen, setModalOpen] = useState(Boolean(initialCreateFilterSet))
   const [editTarget, setEditTarget] = useState<CustomBehaviorRecord | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<CustomBehaviorRecord | null>(null)
+  const [prefillFilterSet, setPrefillFilterSet] = useState<FilterSet | undefined>(initialCreateFilterSet)
 
   const sorted = [...behaviours].sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0))
   const atCap = behaviours.length >= MAX_CUSTOM_BEHAVIORS_PER_PROJECT
 
   const openCreate = () => {
     setEditTarget(null)
+    setPrefillFilterSet(undefined)
     setModalOpen(true)
   }
   const openEdit = (behaviour: CustomBehaviorRecord) => {
     setEditTarget(behaviour)
+    setPrefillFilterSet(undefined)
     setModalOpen(true)
   }
 
@@ -228,6 +286,7 @@ export function CustomBehavioursList({ projectId }: { readonly projectId: string
                   <CustomBehaviourRow
                     key={behaviour.id}
                     projectId={projectId}
+                    projectSlug={projectSlug}
                     behaviour={behaviour}
                     onEdit={openEdit}
                     onDelete={setDeleteTarget}
@@ -243,7 +302,11 @@ export function CustomBehavioursList({ projectId }: { readonly projectId: string
             key={editTarget?.id ?? "new"}
             projectId={projectId}
             behaviour={editTarget}
-            onClose={() => setModalOpen(false)}
+            {...(prefillFilterSet ? { initialFilterSet: prefillFilterSet } : {})}
+            onClose={() => {
+              setModalOpen(false)
+              setPrefillFilterSet(undefined)
+            }}
           />
         ) : null}
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/custom-behaviours/index.tsx
@@ -1,10 +1,15 @@
+import { stripCustomBehaviorExcludedFields } from "@domain/taxonomy"
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { useMemo } from "react"
 import { listEnabledFeatureFlagIdentifiers } from "../../../../../domains/feature-flags/feature-flags.functions.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
+import { parseFilters } from "../-components/trace-page-state.ts"
 import { useRouteProject } from "../-route-data.ts"
 import { CustomBehavioursList } from "./-components/custom-behaviours-list.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/custom-behaviours/")({
+  validateSearch: (search: Record<string, unknown>): { readonly create?: string } =>
+    typeof search.create === "string" ? { create: search.create } : {},
   beforeLoad: async ({ params }) => {
     const enabled = await listEnabledFeatureFlagIdentifiers()
     if (!enabled.includes("customBehaviors")) {
@@ -19,5 +24,18 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/cust
 
 function CustomBehavioursPage() {
   const project = useRouteProject()
-  return <CustomBehavioursList projectId={project.id} />
+  const { projectSlug } = Route.useParams()
+  const { create } = Route.useSearch()
+  const initialCreateFilterSet = useMemo(() => {
+    if (!create) return undefined
+    const parsed = stripCustomBehaviorExcludedFields(parseFilters(create))
+    return Object.keys(parsed).length > 0 ? parsed : undefined
+  }, [create])
+  return (
+    <CustomBehavioursList
+      projectId={project.id}
+      projectSlug={projectSlug}
+      {...(initialCreateFilterSet ? { initialCreateFilterSet } : {})}
+    />
+  )
 }

--- a/packages/domain/taxonomy/src/entities/custom-behavior.test.ts
+++ b/packages/domain/taxonomy/src/entities/custom-behavior.test.ts
@@ -1,5 +1,6 @@
+import type { FilterSet } from "@domain/shared"
 import { describe, expect, it } from "vitest"
-import { customBehaviorFilterSetSchema } from "./custom-behavior.ts"
+import { customBehaviorFilterSetSchema, stripCustomBehaviorExcludedFields } from "./custom-behavior.ts"
 
 describe("customBehaviorFilterSetSchema", () => {
   it("rejects a filter set containing topics", () => {
@@ -27,5 +28,28 @@ describe("customBehaviorFilterSetSchema", () => {
   it("accepts an empty filter set", () => {
     const result = customBehaviorFilterSetSchema.safeParse({})
     expect(result.success).toBe(true)
+  })
+})
+
+describe("stripCustomBehaviorExcludedFields", () => {
+  it("drops topics while keeping every other field (including moments)", () => {
+    const filterSet = {
+      topics: [{ op: "in", value: ["support"] }],
+      moments: [{ op: "in", value: ["escalation"] }],
+      models: [{ op: "in", value: ["gpt-4o"] }],
+    } as unknown as FilterSet
+    const stripped = stripCustomBehaviorExcludedFields(filterSet)
+    expect(Object.hasOwn(stripped, "topics")).toBe(false)
+    expect(stripped).toEqual({
+      moments: [{ op: "in", value: ["escalation"] }],
+      models: [{ op: "in", value: ["gpt-4o"] }],
+    })
+    // The stripped result must satisfy the custom-behavior contract.
+    expect(customBehaviorFilterSetSchema.safeParse(stripped).success).toBe(true)
+  })
+
+  it("returns the same set unchanged when topics is absent", () => {
+    const filterSet = { moments: [{ op: "in", value: ["escalation"] }] } as unknown as FilterSet
+    expect(stripCustomBehaviorExcludedFields(filterSet)).toBe(filterSet)
   })
 })

--- a/packages/domain/taxonomy/src/entities/custom-behavior.ts
+++ b/packages/domain/taxonomy/src/entities/custom-behavior.ts
@@ -53,6 +53,17 @@ export const customBehaviorFilterSetSchema: z.ZodType<FilterSet> = filterSetSche
   }
 })
 
+/**
+ * Drop the excluded (`topics`) field from a FilterSet so a Sessions or saved-
+ * search filter can seed a custom behavior. Entry points copy a filter and
+ * strip topics here rather than re-deriving the exclusion at each call site.
+ */
+export const stripCustomBehaviorExcludedFields = (filterSet: FilterSet): FilterSet => {
+  if (!Object.hasOwn(filterSet, CUSTOM_BEHAVIOR_EXCLUDED_FILTER_FIELD)) return filterSet
+  const { [CUSTOM_BEHAVIOR_EXCLUDED_FILTER_FIELD]: _excluded, ...rest } = filterSet
+  return rest
+}
+
 export const CUSTOM_BEHAVIOR_EMPTY_FILTER_MESSAGE =
   "A custom behavior needs at least one filter — an unfiltered scope is the project-wide Behaviors taxonomy"
 

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -71,6 +71,7 @@ export {
   customBehaviorFilterSetSchema,
   customBehaviorSchema,
   customBehaviorStatusSchema,
+  stripCustomBehaviorExcludedFields,
 } from "./entities/custom-behavior.ts"
 export {
   type CustomBehaviorAssignment,
@@ -141,8 +142,15 @@ export {
 export {
   type ClusterAnalysisAggregate,
   type ClusterRepresentativeExample,
+  type ClusterSessionHistogramBucket,
   type ClusterSessionMomentRange,
+  type ClusterSessionRow,
+  type ClusterSessionsPage,
   type ClusterSessionTraceIdsInput,
+  type ClusterTrajectoryAxis,
+  type ClusterTrajectoryRow,
+  type GetClusterTrajectoryInput,
+  type ListClusterSessionsInput,
   TaxonomyClusterIntelligenceRepository,
   type TaxonomyClusterIntelligenceRepositoryShape,
 } from "./ports/taxonomy-cluster-intelligence-repository.ts"
@@ -232,6 +240,13 @@ export {
   deprecateCustomBehaviorTreeUseCase,
 } from "./use-cases/deprecate-custom-behavior-tree.ts"
 export { type EmitLineageInput, emitLineageUseCase } from "./use-cases/emit-lineage.ts"
+export { type GenerateCustomBehaviorInput, generateCustomBehavior } from "./use-cases/generate-custom-behavior.ts"
+export {
+  type BehaviourTrajectoryCategoryRow,
+  type BehaviourTrajectoryResult,
+  type GetBehaviourTrajectoryInput,
+  getBehaviourTrajectoryUseCase,
+} from "./use-cases/get-behaviour-trajectory.ts"
 export {
   type GetClusterSessionIntelligenceInput,
   type GetClusterSessionIntelligenceResult,
@@ -242,6 +257,10 @@ export {
   type GetClusterDetailsResult,
   getClusterDetailsUseCase,
 } from "./use-cases/get-details.ts"
+export {
+  type ListBehaviourSessionsInput,
+  listBehaviourSessionsUseCase,
+} from "./use-cases/list-behaviour-sessions.ts"
 export {
   type ListClusterSessionTraceIdsInput,
   listClusterSessionTraceIdsUseCase,

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-intelligence-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-intelligence-repository.ts
@@ -1,5 +1,6 @@
 import type {
   ChSqlClient,
+  CustomBehaviorId,
   OrganizationId,
   ProjectId,
   RepositoryError,
@@ -30,6 +31,8 @@ export interface ClusterSessionTraceIdsInput {
   readonly startTimeFrom?: Date
   readonly startTimeTo?: Date
   readonly limit: number
+  /** Omit/null = global taxonomy; an id resolves membership from that behavior's scoped assignment slice. */
+  readonly customBehaviorId?: CustomBehaviorId | null
 }
 
 export interface ClusterAnalysisAggregate {
@@ -48,6 +51,72 @@ export interface ClusterRepresentativeExample {
   readonly summary: string
 }
 
+export interface ClusterSessionRow {
+  readonly sessionId: string
+  readonly traceId: string
+  /** First semantic moment linking the session to the cluster (or, with a
+   * momentRange, the earliest moment matching that metric/turn window). */
+  readonly momentId: string
+  readonly summary: string
+  readonly startTime: Date
+  readonly endTime: Date
+  readonly momentKinds: readonly string[]
+}
+
+export interface ClusterSessionHistogramBucket {
+  readonly startTime: Date
+  readonly count: number
+}
+
+export interface ClusterSessionsPage {
+  readonly sessions: readonly ClusterSessionRow[]
+  /** Session counts bucketed over the whole filtered set (not just this page). */
+  readonly histogram: readonly ClusterSessionHistogramBucket[]
+  readonly hasMore: boolean
+  readonly nextOffset: number | null
+}
+
+export interface ListClusterSessionsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly clusterIds: readonly TaxonomyClusterId[]
+  /** "all" or a single moment kind the session must contain. */
+  readonly filter: string
+  readonly momentRange?: ClusterSessionMomentRange
+  readonly startTimeFrom?: Date
+  readonly startTimeTo?: Date
+  readonly offset: number
+  readonly limit: number
+  /** Omit/null = global taxonomy; an id reads the scoped assignment slice. */
+  readonly customBehaviorId?: CustomBehaviorId | null
+}
+
+export type ClusterTrajectoryAxis = "day" | "turn"
+
+export interface ClusterTrajectoryRow {
+  readonly bucket: string
+  readonly frequency: number
+  readonly escalation: number
+  readonly resolution: number
+  readonly churnRisk: number
+  readonly wins: number
+  readonly maxLastMessageIndex: number
+  readonly maxEscalationLastMessageIndex: number
+  readonly maxResolutionLastMessageIndex: number
+  readonly maxChurnRiskLastMessageIndex: number
+  readonly maxWinsLastMessageIndex: number
+}
+
+export interface GetClusterTrajectoryInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly clusterIds: readonly TaxonomyClusterId[]
+  readonly axis: ClusterTrajectoryAxis
+  readonly startTimeFrom?: Date
+  readonly startTimeTo?: Date
+  readonly customBehaviorId?: CustomBehaviorId | null
+}
+
 export interface TaxonomyClusterIntelligenceRepositoryShape {
   getClusterAggregate(input: {
     readonly organizationId: OrganizationId
@@ -55,6 +124,8 @@ export interface TaxonomyClusterIntelligenceRepositoryShape {
     readonly clusterIds: readonly TaxonomyClusterId[]
     readonly sourceWindowStart: Date
     readonly sourceWindowEnd: Date
+    /** Omit/null = global taxonomy; an id reads the scoped assignment slice. */
+    readonly customBehaviorId?: CustomBehaviorId | null
   }): Effect.Effect<ClusterAnalysisAggregate, RepositoryError, ChSqlClient>
   listRepresentativeExamples(input: {
     readonly organizationId: OrganizationId
@@ -63,6 +134,8 @@ export interface TaxonomyClusterIntelligenceRepositoryShape {
     readonly sourceWindowStart: Date
     readonly sourceWindowEnd: Date
     readonly limit: number
+    /** Omit/null = global taxonomy; an id reads the scoped assignment slice. */
+    readonly customBehaviorId?: CustomBehaviorId | null
   }): Effect.Effect<readonly ClusterRepresentativeExample[], RepositoryError, ChSqlClient>
   /**
    * One trace id per session assigned to the cluster subtree, scoped by the
@@ -73,6 +146,19 @@ export interface TaxonomyClusterIntelligenceRepositoryShape {
   listSessionTraceIds(
     input: ClusterSessionTraceIdsInput,
   ): Effect.Effect<readonly TraceId[], RepositoryError, ChSqlClient>
+  /**
+   * One page of sessions assigned to the cluster subtree (plus a histogram over
+   * the whole filtered set), honouring the Behaviours drawer's moment-kind /
+   * turn-range / time filters. Backs the drawer's session list.
+   */
+  listClusterSessions(input: ListClusterSessionsInput): Effect.Effect<ClusterSessionsPage, RepositoryError, ChSqlClient>
+  /**
+   * Per-bucket moment-metric counts for a cluster subtree over the day or turn
+   * axis. Backs the Behaviours trajectory chart (one call per category subtree).
+   */
+  getClusterTrajectory(
+    input: GetClusterTrajectoryInput,
+  ): Effect.Effect<readonly ClusterTrajectoryRow[], RepositoryError, ChSqlClient>
 }
 
 export class TaxonomyClusterIntelligenceRepository extends Context.Service<

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
@@ -64,6 +64,8 @@ export interface TaxonomyClusterRepositoryShape {
   listSubtreeIds(input: {
     readonly projectId: ProjectId
     readonly clusterId: TaxonomyClusterId
+    /** Omit/null = global taxonomy (custom_behavior_id IS NULL); an id scopes to that behavior's sub-tree. */
+    readonly customBehaviorId?: CustomBehaviorId | null
   }): Effect.Effect<readonly TaxonomyClusterId[], RepositoryError, SqlClient>
   /**
    * Exact pgvector cosine over `(organization_id, project_id)` for state =

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-intelligence-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-intelligence-repository.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect"
+import type {
+  ClusterAnalysisAggregate,
+  TaxonomyClusterIntelligenceRepositoryShape,
+} from "../ports/taxonomy-cluster-intelligence-repository.ts"
+
+const EMPTY_AGGREGATE: ClusterAnalysisAggregate = {
+  sourceObservationCount: 0,
+  sourceSessionCount: 0,
+  sourceAnalysisCount: 0,
+  sourceAnalysisCoverage: 0,
+  momentKindDistribution: {},
+  eligibleSessionCount: 0,
+  skippedCount: 0,
+  failedCount: 0,
+}
+
+/**
+ * In-memory intelligence repo for use-case tests. Every method returns an empty
+ * result by default; pass `overrides` to return fixtures or capture the inputs a
+ * use-case forwards (e.g. the resolved subtree ids or the custom-behavior scope).
+ */
+export const createFakeTaxonomyClusterIntelligenceRepository = (
+  overrides?: Partial<TaxonomyClusterIntelligenceRepositoryShape>,
+) => {
+  const repository: TaxonomyClusterIntelligenceRepositoryShape = {
+    getClusterAggregate: () => Effect.succeed(EMPTY_AGGREGATE),
+    listRepresentativeExamples: () => Effect.succeed([]),
+    listSessionTraceIds: () => Effect.succeed([]),
+    listClusterSessions: () => Effect.succeed({ sessions: [], histogram: [], hasMore: false, nextOffset: null }),
+    getClusterTrajectory: () => Effect.succeed([]),
+    ...overrides,
+  }
+  return { repository }
+}

--- a/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/behaviour-reads.test.ts
@@ -1,0 +1,223 @@
+import { ChSqlClient, CustomBehaviorId, OrganizationId, ProjectId, SqlClient, TaxonomyClusterId } from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { TaxonomyCluster } from "../entities/cluster.ts"
+import type {
+  ClusterSessionsPage,
+  ClusterTrajectoryRow,
+  GetClusterTrajectoryInput,
+  ListClusterSessionsInput,
+  TaxonomyClusterIntelligenceRepositoryShape,
+} from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import { TaxonomyClusterIntelligenceRepository } from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import { TaxonomyClusterRepository, type TaxonomyClusterRepositoryShape } from "../ports/taxonomy-cluster-repository.ts"
+import { createFakeTaxonomyClusterIntelligenceRepository } from "../testing/fake-taxonomy-cluster-intelligence-repository.ts"
+import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
+import { getBehaviourTrajectoryUseCase } from "./get-behaviour-trajectory.ts"
+import { listBehaviourSessionsUseCase } from "./list-behaviour-sessions.ts"
+
+const ORG_ID = OrganizationId("o".repeat(24))
+const PROJECT_ID = ProjectId("p".repeat(24))
+const CUSTOM_BEHAVIOR_ID = CustomBehaviorId("b".repeat(24))
+
+// The fake cluster repo's listSubtreeIds keys off id / project / state / path
+// only, so a minimal cast is enough — these use-cases never touch the rest.
+const cluster = (id: string, path: string): TaxonomyCluster =>
+  ({ id: TaxonomyClusterId(id), projectId: PROJECT_ID, state: "active", path }) as unknown as TaxonomyCluster
+
+const trajectoryRow = (bucket: string, frequency: number): ClusterTrajectoryRow => ({
+  bucket,
+  frequency,
+  escalation: 0,
+  resolution: 0,
+  churnRisk: 0,
+  wins: 0,
+  maxLastMessageIndex: 0,
+  maxEscalationLastMessageIndex: 0,
+  maxResolutionLastMessageIndex: 0,
+  maxChurnRiskLastMessageIndex: 0,
+  maxWinsLastMessageIndex: 0,
+})
+
+const run = <A, E>(
+  clusters: TaxonomyClusterRepositoryShape,
+  intelligence: TaxonomyClusterIntelligenceRepositoryShape,
+  effect: Effect.Effect<
+    A,
+    E,
+    TaxonomyClusterRepository | TaxonomyClusterIntelligenceRepository | SqlClient | ChSqlClient
+  >,
+) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters)),
+      Effect.provide(Layer.succeed(TaxonomyClusterIntelligenceRepository, intelligence)),
+      Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+    ),
+  )
+
+describe("listBehaviourSessionsUseCase", () => {
+  const ROOT = "r".repeat(24)
+  const CHILD = "c".repeat(24)
+
+  it("resolves the whole subtree and forwards it (plus filters + scope) to the intelligence repo", async () => {
+    const clusters = createFakeTaxonomyClusterRepository([cluster(ROOT, ""), cluster(CHILD, `${ROOT}/`)])
+    const page: ClusterSessionsPage = {
+      sessions: [
+        {
+          sessionId: "s1",
+          traceId: "t1",
+          momentId: "m1",
+          summary: "hi",
+          startTime: new Date("2026-05-24T00:00:00.000Z"),
+          endTime: new Date("2026-05-24T01:00:00.000Z"),
+          momentKinds: ["escalation"],
+        },
+      ],
+      histogram: [{ startTime: new Date("2026-05-24T00:00:00.000Z"), count: 1 }],
+      hasMore: false,
+      nextOffset: null,
+    }
+    let captured: ListClusterSessionsInput | undefined
+    const intelligence = createFakeTaxonomyClusterIntelligenceRepository({
+      listClusterSessions: (input) => {
+        captured = input
+        return Effect.succeed(page)
+      },
+    })
+
+    const result = await run(
+      clusters.repository,
+      intelligence.repository,
+      listBehaviourSessionsUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        clusterId: TaxonomyClusterId(ROOT),
+        filter: "escalation",
+        offset: 10,
+        limit: 20,
+        customBehaviorId: CUSTOM_BEHAVIOR_ID,
+      }),
+    )
+
+    expect([...(captured?.clusterIds ?? [])].map(String).sort()).toEqual([ROOT, CHILD].sort())
+    expect(captured?.customBehaviorId).toBe(CUSTOM_BEHAVIOR_ID)
+    expect(captured?.filter).toBe("escalation")
+    expect(captured?.offset).toBe(10)
+    expect(captured?.limit).toBe(20)
+    expect(result).toBe(page)
+  })
+
+  it("returns an empty page without querying sessions when the subtree is empty", async () => {
+    const clusters = createFakeTaxonomyClusterRepository([])
+    let called = false
+    const intelligence = createFakeTaxonomyClusterIntelligenceRepository({
+      listClusterSessions: () => {
+        called = true
+        return Effect.succeed({ sessions: [], histogram: [], hasMore: false, nextOffset: null })
+      },
+    })
+
+    const result = await run(
+      clusters.repository,
+      intelligence.repository,
+      listBehaviourSessionsUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        clusterId: TaxonomyClusterId(ROOT),
+      }),
+    )
+
+    expect(called).toBe(false)
+    expect(result).toEqual({ sessions: [], histogram: [], hasMore: false, nextOffset: null })
+  })
+})
+
+describe("getBehaviourTrajectoryUseCase", () => {
+  const A = "a".repeat(24)
+  const B = "b".repeat(24)
+
+  const intelligenceFor = () =>
+    createFakeTaxonomyClusterIntelligenceRepository({
+      getClusterTrajectory: (input: GetClusterTrajectoryInput) =>
+        Effect.succeed(
+          input.clusterIds.includes(TaxonomyClusterId(A)) ? [trajectoryRow("10", 1)] : [trajectoryRow("2", 3)],
+        ),
+    })
+
+  it("tags each category's rows and unions buckets numerically for the turn axis", async () => {
+    const clusters = createFakeTaxonomyClusterRepository([cluster(A, ""), cluster(B, "")])
+
+    const result = await run(
+      clusters.repository,
+      intelligenceFor().repository,
+      getBehaviourTrajectoryUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        categoryClusterIds: [TaxonomyClusterId(A), TaxonomyClusterId(B)],
+        axis: "turn",
+      }),
+    )
+
+    expect(result.buckets).toEqual(["2", "10"])
+    expect(Object.fromEntries(result.rows.map((row) => [row.categoryClusterId, row.bucket]))).toEqual({
+      [A]: "10",
+      [B]: "2",
+    })
+  })
+
+  it("dedupes repeated categories and returns empty for no categories", async () => {
+    const clusters = createFakeTaxonomyClusterRepository([cluster(A, "")])
+
+    const deduped = await run(
+      clusters.repository,
+      intelligenceFor().repository,
+      getBehaviourTrajectoryUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        categoryClusterIds: [TaxonomyClusterId(A), TaxonomyClusterId(A)],
+        axis: "turn",
+      }),
+    )
+    expect(deduped.rows.filter((row) => row.categoryClusterId === A)).toHaveLength(1)
+
+    const empty = await run(
+      clusters.repository,
+      intelligenceFor().repository,
+      getBehaviourTrajectoryUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        categoryClusterIds: [],
+        axis: "turn",
+      }),
+    )
+    expect(empty).toEqual({ buckets: [], rows: [] })
+  })
+
+  it("sorts day-axis buckets lexically", async () => {
+    const clusters = createFakeTaxonomyClusterRepository([cluster(A, ""), cluster(B, "")])
+    const intelligence = createFakeTaxonomyClusterIntelligenceRepository({
+      getClusterTrajectory: (input: GetClusterTrajectoryInput) =>
+        Effect.succeed(
+          input.clusterIds.includes(TaxonomyClusterId(A))
+            ? [trajectoryRow("2026-05-10", 1)]
+            : [trajectoryRow("2026-05-02", 1)],
+        ),
+    })
+
+    const result = await run(
+      clusters.repository,
+      intelligence.repository,
+      getBehaviourTrajectoryUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        categoryClusterIds: [TaxonomyClusterId(A), TaxonomyClusterId(B)],
+        axis: "day",
+      }),
+    )
+
+    expect(result.buckets).toEqual(["2026-05-02", "2026-05-10"])
+  })
+})

--- a/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/custom-behavior-crud.test.ts
@@ -1,9 +1,11 @@
-import { CustomBehaviorId, type FilterSet, ProjectId, SqlClient } from "@domain/shared"
+import { QueuePublisher } from "@domain/queue"
+import { createFakeQueuePublisher } from "@domain/queue/testing"
+import { CustomBehaviorId, type FilterSet, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { MAX_CUSTOM_BEHAVIORS_PER_PROJECT } from "../constants.ts"
-import { CustomBehaviorStatus } from "../entities/custom-behavior.ts"
+import { type CustomBehavior, CustomBehaviorStatus } from "../entities/custom-behavior.ts"
 import {
   CustomBehaviorFilterInvalidError,
   CustomBehaviorLimitReachedError,
@@ -13,11 +15,27 @@ import { CustomBehaviorRepository } from "../ports/custom-behavior-repository.ts
 import { createFakeCustomBehaviorRepository } from "../testing/fake-custom-behavior-repository.ts"
 import { createCustomBehavior } from "./create-custom-behavior.ts"
 import { deleteCustomBehavior } from "./delete-custom-behavior.ts"
+import { generateCustomBehavior } from "./generate-custom-behavior.ts"
+import { taxonomyGardenCustomBehaviorDedupeKey } from "./trigger-project-gardening.ts"
 import { updateCustomBehavior } from "./update-custom-behavior.ts"
 
+const ORG_ID = OrganizationId("o".repeat(24))
 const PROJECT_ID = ProjectId("p".repeat(24))
 const OTHER_PROJECT_ID = ProjectId("q".repeat(24))
 const FILTER: FilterSet = { moments: [{ op: "in", value: ["escalation"] }] }
+
+const makeBehavior = (overrides: Partial<CustomBehavior> = {}): CustomBehavior => ({
+  id: CustomBehaviorId("b".repeat(24)),
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  slug: "refunds",
+  name: "Refunds",
+  filterSet: FILTER,
+  status: CustomBehaviorStatus.Pending,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  ...overrides,
+})
 
 function makeLayer() {
   const { repository, rows } = createFakeCustomBehaviorRepository()
@@ -182,5 +200,71 @@ describe("deleteCustomBehavior", () => {
     await expect(
       Effect.runPromise(deleteCustomBehavior({ id: CustomBehaviorId("z".repeat(24)) }).pipe(Effect.provide(layer))),
     ).rejects.toThrow()
+  })
+})
+
+describe("generateCustomBehavior", () => {
+  it("flips the row to generating and enqueues gardenCustomBehavior with the record's org + project", async () => {
+    const behavior = makeBehavior()
+    const { repository, rows } = createFakeCustomBehaviorRepository([behavior])
+    const queue = createFakeQueuePublisher()
+
+    const result = await Effect.runPromise(
+      generateCustomBehavior({ customBehaviorId: behavior.id }).pipe(
+        Effect.provide(Layer.succeed(CustomBehaviorRepository, repository)),
+        Effect.provide(Layer.succeed(QueuePublisher, queue.publisher)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    expect(result.status).toBe(CustomBehaviorStatus.Generating)
+    expect(rows.get(behavior.id)?.status).toBe(CustomBehaviorStatus.Generating)
+    expect(queue.published).toHaveLength(1)
+    expect(queue.published[0]).toMatchObject({
+      queue: "taxonomy",
+      task: "gardenCustomBehavior",
+      payload: {
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        customBehaviorId: behavior.id,
+        reason: "manual",
+      },
+      options: {
+        dedupeKey: taxonomyGardenCustomBehaviorDedupeKey({ organizationId: ORG_ID, customBehaviorId: behavior.id }),
+      },
+    })
+  })
+
+  it("rolls the status back to its prior value when the enqueue fails", async () => {
+    const behavior = makeBehavior({ status: CustomBehaviorStatus.Failed })
+    const { repository, rows } = createFakeCustomBehaviorRepository([behavior])
+    const queue = createFakeQueuePublisher({ publish: () => Effect.die(new Error("queue down")) })
+
+    const exit = await Effect.runPromiseExit(
+      generateCustomBehavior({ customBehaviorId: behavior.id }).pipe(
+        Effect.provide(Layer.succeed(CustomBehaviorRepository, repository)),
+        Effect.provide(Layer.succeed(QueuePublisher, queue.publisher)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(rows.get(behavior.id)?.status).toBe(CustomBehaviorStatus.Failed)
+  })
+
+  it("fails with NotFoundError and enqueues nothing for a missing behavior", async () => {
+    const { repository } = createFakeCustomBehaviorRepository([])
+    const queue = createFakeQueuePublisher()
+
+    const exit = await Effect.runPromiseExit(
+      generateCustomBehavior({ customBehaviorId: CustomBehaviorId("z".repeat(24)) }).pipe(
+        Effect.provide(Layer.succeed(CustomBehaviorRepository, repository)),
+        Effect.provide(Layer.succeed(QueuePublisher, queue.publisher)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(queue.published).toHaveLength(0)
   })
 })

--- a/packages/domain/taxonomy/src/use-cases/generate-custom-behavior.ts
+++ b/packages/domain/taxonomy/src/use-cases/generate-custom-behavior.ts
@@ -1,0 +1,56 @@
+import { QueuePublisher } from "@domain/queue"
+import type { CustomBehaviorId } from "@domain/shared"
+import { Effect } from "effect"
+import { type CustomBehavior, CustomBehaviorStatus } from "../entities/custom-behavior.ts"
+import { CustomBehaviorRepository } from "../ports/custom-behavior-repository.ts"
+import { taxonomyGardenCustomBehaviorDedupeKey } from "./trigger-project-gardening.ts"
+
+export interface GenerateCustomBehaviorInput {
+  readonly customBehaviorId: CustomBehaviorId
+  readonly reason?: "manual" | "cron"
+}
+
+/**
+ * Trigger a scoped generation run for one custom behavior: flip the row to
+ * `generating`, then enqueue the `gardenCustomBehavior` job (deduped on its
+ * workflow id). The flip happens BEFORE the enqueue so the workflow — which owns
+ * every later transition (`generating` → `ready`/`failed`) — always writes the
+ * terminal status last; writing `generating` after enqueue races a fast failure
+ * (e.g. the ≥15-observation gate) and would strand the row at `generating`. If
+ * the enqueue itself fails the row is rolled back to its prior status.
+ *
+ * Organization and project come from the persisted record, never caller input,
+ * so a run can only ever be scoped to the behavior's own project.
+ */
+export const generateCustomBehavior = Effect.fn("taxonomy.generateCustomBehavior")(function* (
+  input: GenerateCustomBehaviorInput,
+) {
+  yield* Effect.annotateCurrentSpan("customBehaviorId", input.customBehaviorId)
+  const repo = yield* CustomBehaviorRepository
+  const publisher = yield* QueuePublisher
+
+  const behavior = yield* repo.findById(input.customBehaviorId)
+  const generating: CustomBehavior = { ...behavior, status: CustomBehaviorStatus.Generating, updatedAt: new Date() }
+  yield* repo.save(generating)
+
+  yield* publisher
+    .publish(
+      "taxonomy",
+      "gardenCustomBehavior",
+      {
+        organizationId: behavior.organizationId,
+        projectId: behavior.projectId,
+        customBehaviorId: behavior.id,
+        reason: input.reason ?? "manual",
+      },
+      {
+        dedupeKey: taxonomyGardenCustomBehaviorDedupeKey({
+          organizationId: behavior.organizationId,
+          customBehaviorId: behavior.id,
+        }),
+      },
+    )
+    .pipe(Effect.onError(() => repo.save(behavior).pipe(Effect.ignore)))
+
+  return generating
+})

--- a/packages/domain/taxonomy/src/use-cases/get-behaviour-trajectory.ts
+++ b/packages/domain/taxonomy/src/use-cases/get-behaviour-trajectory.ts
@@ -1,0 +1,76 @@
+import type { CustomBehaviorId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { Effect } from "effect"
+import {
+  type ClusterTrajectoryAxis,
+  type ClusterTrajectoryRow,
+  TaxonomyClusterIntelligenceRepository,
+} from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
+
+export interface GetBehaviourTrajectoryInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly categoryClusterIds: readonly TaxonomyClusterId[]
+  readonly axis: ClusterTrajectoryAxis
+  readonly startTimeFrom?: Date
+  readonly startTimeTo?: Date
+  /** Omit/null = global taxonomy; an id reads that behavior's scoped slice. */
+  readonly customBehaviorId?: CustomBehaviorId | null
+}
+
+export interface BehaviourTrajectoryCategoryRow extends ClusterTrajectoryRow {
+  readonly categoryClusterId: string
+}
+
+export interface BehaviourTrajectoryResult {
+  readonly buckets: readonly string[]
+  readonly rows: readonly BehaviourTrajectoryCategoryRow[]
+}
+
+/**
+ * Moment-metric trajectory for one or more category subtrees. Resolves each
+ * category's subtree in Postgres and reads its per-bucket counts from ClickHouse
+ * (global or the scoped slice), tagging rows by category and unioning the bucket
+ * axis (lexical for days, numeric for turns).
+ */
+export const getBehaviourTrajectoryUseCase = (input: GetBehaviourTrajectoryInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("taxonomy.projectId", input.projectId)
+    const categoryClusterIds = [...new Set(input.categoryClusterIds)]
+    if (categoryClusterIds.length === 0) return { buckets: [], rows: [] } satisfies BehaviourTrajectoryResult
+
+    const clusters = yield* TaxonomyClusterRepository
+    const intelligence = yield* TaxonomyClusterIntelligenceRepository
+    const scope = input.customBehaviorId != null ? { customBehaviorId: input.customBehaviorId } : {}
+
+    const perCategory = yield* Effect.forEach(
+      categoryClusterIds,
+      (categoryClusterId) =>
+        Effect.gen(function* () {
+          const clusterIds = yield* clusters.listSubtreeIds({
+            projectId: input.projectId,
+            clusterId: categoryClusterId,
+            ...scope,
+          })
+          const rows = yield* intelligence.getClusterTrajectory({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            clusterIds,
+            axis: input.axis,
+            ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
+            ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
+            ...scope,
+          })
+          return rows.map(
+            (row): BehaviourTrajectoryCategoryRow => ({ ...row, categoryClusterId: categoryClusterId as string }),
+          )
+        }),
+      { concurrency: 6 },
+    )
+
+    const rows = perCategory.flat()
+    const buckets = [...new Set(rows.map((row) => row.bucket))].sort((left, right) =>
+      input.axis === "day" ? left.localeCompare(right) : Number(left) - Number(right),
+    )
+    return { buckets, rows } satisfies BehaviourTrajectoryResult
+  }).pipe(Effect.withSpan("taxonomy.getBehaviourTrajectory"))

--- a/packages/domain/taxonomy/src/use-cases/get-cluster-session-intelligence.ts
+++ b/packages/domain/taxonomy/src/use-cases/get-cluster-session-intelligence.ts
@@ -1,4 +1,4 @@
-import type { OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import type { CustomBehaviorId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import { Effect } from "effect"
 import type {
   ClusterAnalysisAggregate,
@@ -15,6 +15,8 @@ export interface GetClusterSessionIntelligenceInput {
   readonly sourceWindowDays?: number
   readonly sourceWindowStart?: Date
   readonly sourceWindowEnd?: Date
+  /** Omit/null = global taxonomy; an id scopes the subtree to that behavior's sub-tree. */
+  readonly customBehaviorId?: CustomBehaviorId | null
 }
 
 export interface GetClusterSessionIntelligenceResult {
@@ -48,13 +50,19 @@ export const getClusterSessionIntelligenceUseCase = (input: GetClusterSessionInt
     // A tree node's profile covers its whole subtree: interior nodes hold
     // only residue directly, but represent every session routed below them —
     // matching the subtree-scoped session list shown next to this profile.
-    const clusterIds = yield* clusters.listSubtreeIds({ projectId: input.projectId, clusterId: input.clusterId })
+    const clusterIds = yield* clusters.listSubtreeIds({
+      projectId: input.projectId,
+      clusterId: input.clusterId,
+      ...(input.customBehaviorId != null ? { customBehaviorId: input.customBehaviorId } : {}),
+    })
+    const scope = input.customBehaviorId != null ? { customBehaviorId: input.customBehaviorId } : {}
     const aggregate = yield* intelligence.getClusterAggregate({
       organizationId: input.organizationId,
       projectId: input.projectId,
       clusterIds,
       sourceWindowStart,
       sourceWindowEnd,
+      ...scope,
     })
     const representativeExamples = yield* intelligence.listRepresentativeExamples({
       organizationId: input.organizationId,
@@ -63,6 +71,7 @@ export const getClusterSessionIntelligenceUseCase = (input: GetClusterSessionInt
       sourceWindowStart,
       sourceWindowEnd,
       limit: 10,
+      ...scope,
     })
     const eligibleSessionDenominator = aggregate.eligibleSessionCount
     const queryLatencyMs = Date.now() - queryStartedAt

--- a/packages/domain/taxonomy/src/use-cases/list-behaviour-sessions.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-behaviour-sessions.ts
@@ -1,10 +1,13 @@
 import type { CustomBehaviorId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import { Effect } from "effect"
-import type { ClusterSessionMomentRange } from "../ports/taxonomy-cluster-intelligence-repository.ts"
-import { TaxonomyClusterIntelligenceRepository } from "../ports/taxonomy-cluster-intelligence-repository.ts"
+import {
+  type ClusterSessionMomentRange,
+  type ClusterSessionsPage,
+  TaxonomyClusterIntelligenceRepository,
+} from "../ports/taxonomy-cluster-intelligence-repository.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 
-export interface ListClusterSessionTraceIdsInput {
+export interface ListBehaviourSessionsInput {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
   readonly clusterId: TaxonomyClusterId
@@ -13,30 +16,34 @@ export interface ListClusterSessionTraceIdsInput {
   readonly momentRange?: ClusterSessionMomentRange
   readonly startTimeFrom?: Date
   readonly startTimeTo?: Date
-  readonly limit: number
-  /** Omit/null = global taxonomy; an id resolves the subtree + sessions from that behavior's scoped slice. */
+  readonly offset?: number
+  readonly limit?: number
+  /** Omit/null = global taxonomy; an id reads that behavior's scoped slice. */
   readonly customBehaviorId?: CustomBehaviorId | null
 }
 
+const EMPTY_PAGE: ClusterSessionsPage = { sessions: [], histogram: [], hasMore: false, nextOffset: null }
+
 /**
- * Resolves a cluster (its whole subtree) to one trace id per assigned session,
- * honouring the Behaviours drawer's moment-kind / turn-range / time filters.
- * Shared by the manual "Add to dataset" export and the auto-feed pipeline.
+ * One page of a behaviour node's sessions (its whole subtree), honouring the
+ * drawer's moment-kind / turn-range / time filters. Resolves the subtree in
+ * Postgres, then reads sessions from ClickHouse — the global taxonomy or, when
+ * `customBehaviorId` is set, the behavior's scoped assignment slice.
  */
-export const listClusterSessionTraceIdsUseCase = (input: ListClusterSessionTraceIdsInput) =>
+export const listBehaviourSessionsUseCase = (input: ListBehaviourSessionsInput) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("taxonomy.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("taxonomy.clusterId", input.clusterId)
     const clusters = yield* TaxonomyClusterRepository
     const intelligence = yield* TaxonomyClusterIntelligenceRepository
     const scope = input.customBehaviorId != null ? { customBehaviorId: input.customBehaviorId } : {}
-    // A tree node represents its whole subtree: sessions are assigned to leaves.
     const clusterIds = yield* clusters.listSubtreeIds({
       projectId: input.projectId,
       clusterId: input.clusterId,
       ...scope,
     })
-    return yield* intelligence.listSessionTraceIds({
+    if (clusterIds.length === 0) return EMPTY_PAGE
+    return yield* intelligence.listClusterSessions({
       organizationId: input.organizationId,
       projectId: input.projectId,
       clusterIds,
@@ -44,7 +51,8 @@ export const listClusterSessionTraceIdsUseCase = (input: ListClusterSessionTrace
       ...(input.momentRange ? { momentRange: input.momentRange } : {}),
       ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
       ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
-      limit: input.limit,
+      offset: input.offset ?? 0,
+      limit: input.limit ?? 50,
       ...scope,
     })
-  }).pipe(Effect.withSpan("taxonomy.listClusterSessionTraceIds"))
+  }).pipe(Effect.withSpan("taxonomy.listBehaviourSessions"))

--- a/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
+++ b/packages/domain/taxonomy/src/use-cases/list-project-behaviours.ts
@@ -1,8 +1,9 @@
-import type { OrganizationId, ProjectId } from "@domain/shared"
-import { Effect } from "effect"
+import { type CustomBehaviorId, type OrganizationId, type ProjectId, RepositoryError } from "@domain/shared"
+import { Effect, Option } from "effect"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
 import { isDisplayableTaxonomyName } from "../helpers.ts"
+import { CustomBehaviorAssignmentRepository } from "../ports/custom-behavior-assignment-repository.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
 import { classifyClusterTrend, type TaxonomyClusterTrendSummary } from "./analytics.ts"
@@ -25,6 +26,14 @@ export interface ListProjectBehavioursInput {
   readonly segment?: BehaviourSegment
   readonly sortBy?: BehaviourSortBy
   readonly limit?: number
+  /**
+   * Omit/null = global taxonomy tree. An id scopes the whole read to that
+   * behavior's sub-tree: scoped clusters from Postgres and per-cluster counts
+   * from the ClickHouse `custom_behavior_assignments` slice (never the global
+   * `taxonomy_observations.assigned_cluster_id`). Scoped trees are regenerated
+   * wholesale, so cross-run trend has no meaning — nodes read as steady.
+   */
+  readonly customBehaviorId?: CustomBehaviorId | null
 }
 
 /**
@@ -148,8 +157,17 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
 
     const clusterRepository = yield* TaxonomyClusterRepository
     const observationRepository = yield* TaxonomyObservationRepository
+    const customBehaviorId = input.customBehaviorId ?? null
+    // Scoped counts live in the ClickHouse custom_behavior_assignments slice.
+    // Kept out of this use-case's required services (via serviceOption) so the
+    // global Behaviours read contract is unchanged; scoped callers provide it.
+    const assignmentRepositoryOption = yield* Effect.serviceOption(CustomBehaviorAssignmentRepository)
 
-    const allActiveClusters = yield* clusterRepository.listActiveByProject({ projectId: input.projectId, dimension })
+    const allActiveClusters = yield* clusterRepository.listActiveByProject({
+      projectId: input.projectId,
+      dimension,
+      customBehaviorId,
+    })
     const displayable = allActiveClusters.filter((cluster) => isDisplayableTaxonomyName(cluster.name))
     const childrenByParentId = new Map<string, TaxonomyCluster[]>()
     for (const cluster of displayable) {
@@ -159,23 +177,48 @@ export const listProjectBehavioursUseCase = (input: ListProjectBehavioursInput) 
       childrenByParentId.set(cluster.parentClusterId, siblings)
     }
 
-    const assignmentCounts = yield* observationRepository.getClusterAssignmentCounts({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      clusterIds: displayable.map((cluster) => cluster.id),
-      ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
-      ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
-    })
+    // Scoped trees read their per-cluster counts from the custom-behavior
+    // assignment slice (never global observations); a global tree reads the
+    // time-windowed global assignment counts.
+    const assignmentCounts =
+      customBehaviorId != null
+        ? yield* Option.match(assignmentRepositoryOption, {
+            onNone: () =>
+              Effect.fail(
+                new RepositoryError({
+                  cause: new Error("CustomBehaviorAssignmentRepository is required to read a scoped behavior tree"),
+                  operation: "listProjectBehaviours.scopedAssignmentCounts",
+                }),
+              ),
+            onSome: (repository) =>
+              repository.getClusterAssignmentCounts({
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                customBehaviorId,
+              }),
+          })
+        : yield* observationRepository.getClusterAssignmentCounts({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            clusterIds: displayable.map((cluster) => cluster.id),
+            ...(input.startTimeFrom ? { startTimeFrom: input.startTimeFrom } : {}),
+            ...(input.startTimeTo ? { startTimeTo: input.startTimeTo } : {}),
+          })
     const directCountByClusterId = new Map(assignmentCounts.map((count) => [count.clusterId, count.count] as const))
 
-    const trendCounts = yield* observationRepository.getClusterTrendCounts({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      clusterIds: displayable.map((cluster) => cluster.id),
-      currentSince: new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY),
-      baselineSince: new Date(now.getTime() - trendWindowDays * MS_PER_DAY),
-      baselineDays: Math.max(trendWindowDays - TREND_CURRENT_DAYS, 1),
-    })
+    // A scoped tree is rebuilt wholesale each generation, so cross-run trend is
+    // undefined — every scoped node reads as steady (the buildNode fallback).
+    const trendCounts =
+      customBehaviorId != null
+        ? []
+        : yield* observationRepository.getClusterTrendCounts({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            clusterIds: displayable.map((cluster) => cluster.id),
+            currentSince: new Date(now.getTime() - TREND_CURRENT_DAYS * MS_PER_DAY),
+            baselineSince: new Date(now.getTime() - trendWindowDays * MS_PER_DAY),
+            baselineDays: Math.max(trendWindowDays - TREND_CURRENT_DAYS, 1),
+          })
     const trendByClusterId = new Map(
       trendCounts.map((trend) => [trend.clusterId, classifyClusterTrend(trend)] as const),
     )

--- a/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/read-use-cases.test.ts
@@ -1,6 +1,7 @@
 import { AI, type AIShape, type GenerateResult } from "@domain/ai"
 import {
   ChSqlClient,
+  CustomBehaviorId,
   OrganizationId,
   ProjectId,
   SessionId,
@@ -15,10 +16,12 @@ import { describe, expect, it } from "vitest"
 import type { TaxonomyCluster } from "../entities/cluster.ts"
 import type { TaxonomyMomentObservation } from "../entities/observation.ts"
 import { createTaxonomyCentroid, updateTaxonomyCentroid } from "../helpers.ts"
+import { CustomBehaviorAssignmentRepository } from "../ports/custom-behavior-assignment-repository.ts"
 import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
 import { TaxonomyLineageRepository } from "../ports/taxonomy-lineage-repository.ts"
 import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
 import { TaxonomyRunRepository } from "../ports/taxonomy-run-repository.ts"
+import { createFakeCustomBehaviorAssignmentRepository } from "../testing/fake-custom-behavior-assignment-repository.ts"
 import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
 import { createFakeTaxonomyLineageRepository } from "../testing/fake-taxonomy-lineage-repository.ts"
 import { createFakeTaxonomyObservationRepository } from "../testing/fake-taxonomy-observation-repository.ts"
@@ -587,5 +590,68 @@ describe("analytics read use-cases", () => {
 
     expect(result.run?.id).toBe(runId)
     expect(result.lineage.map((row) => row.transitionType)).toEqual(["birth"])
+  })
+})
+
+describe("listProjectBehavioursUseCase (custom behavior scope)", () => {
+  const behaviorId = CustomBehaviorId("c".repeat(24))
+  const globalId = TaxonomyClusterId("g".repeat(24))
+  const scopedA = TaxonomyClusterId("1".repeat(24))
+  const scopedB = TaxonomyClusterId("2".repeat(24))
+
+  // One repo holding both a global cluster and a behavior's scoped clusters, so
+  // each read must isolate its own slice.
+  const seededClusters = () =>
+    createFakeTaxonomyClusterRepository([
+      makeCluster({ id: globalId, name: "Global topic", observationCount: 4 }),
+      makeCluster({ id: scopedA, name: "Scoped A", customBehaviorId: behaviorId, observationCount: 0 }),
+      makeCluster({ id: scopedB, name: "Scoped B", customBehaviorId: behaviorId, observationCount: 0 }),
+    ])
+
+  it("reads counts from the assignment slice, marks trend steady, and excludes global clusters", async () => {
+    const clusters = seededClusters()
+    // Global observation counts must NOT be the source for a scoped read; seed
+    // the global cluster with observations to prove they are ignored here.
+    const observations = createFakeTaxonomyObservationRepository([makeObservation(1, globalId)])
+    const assignments = createFakeCustomBehaviorAssignmentRepository(
+      {},
+      {
+        getClusterAssignmentCounts: () =>
+          Effect.succeed([
+            { clusterId: scopedA, count: 5 },
+            { clusterId: scopedB, count: 3 },
+          ]),
+      },
+    )
+
+    const result = await Effect.runPromise(
+      listProjectBehavioursUseCase({ organizationId, projectId, now, customBehaviorId: behaviorId }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(CustomBehaviorAssignmentRepository, assignments.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    expect(result.topics.map((topic) => topic.cluster.id)).toEqual([scopedA, scopedB])
+    expect(result.topics.map((topic) => topic.subtreeObservationCount)).toEqual([5, 3])
+    expect(result.topics.every((topic) => topic.trend.status === "steady")).toBe(true)
+  })
+
+  it("the global read ignores custom-behavior clusters entirely", async () => {
+    const clusters = seededClusters()
+    const observations = createFakeTaxonomyObservationRepository([makeObservation(1, globalId)])
+
+    const result = await Effect.runPromise(
+      listProjectBehavioursUseCase({ organizationId, projectId, now }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+        Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+      ),
+    )
+
+    expect(result.topics.map((topic) => topic.cluster.id)).toEqual([globalId])
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.test.ts
@@ -1,4 +1,4 @@
-import { type ChSqlClient, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
+import { type ChSqlClient, CustomBehaviorId, OrganizationId, ProjectId, TaxonomyClusterId } from "@domain/shared"
 import { TaxonomyClusterIntelligenceRepository } from "@domain/taxonomy"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
@@ -9,6 +9,9 @@ import { TaxonomyClusterIntelligenceRepositoryLive } from "./taxonomy-cluster-in
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
 const clusterId = TaxonomyClusterId("c".repeat(24))
+const customBehaviorId = CustomBehaviorId("b".repeat(24))
+const scopedClusterId = TaxonomyClusterId("s".repeat(24))
+const otherClusterId = TaxonomyClusterId("x".repeat(24))
 const analysisHash = "a".repeat(64)
 const ts = "2026-05-24 12:00:00.000000000"
 
@@ -73,6 +76,51 @@ const insertMomentLabel = (sessionId: string, kind: string, firstMessageIndex: n
         first_message_index: firstMessageIndex,
         last_message_index: firstMessageIndex,
         evidence: "",
+      },
+    ],
+    format: "JSONEachRow",
+  })
+
+// An observation whose GLOBAL assigned_cluster_id is deliberately NOT the
+// scoped cluster, so a scoped read that still finds it proves it resolved
+// membership from custom_behavior_assignments rather than assigned_cluster_id.
+const insertObservationAssignedElsewhere = (sessionId: string) =>
+  ch.client.insert({
+    table: "taxonomy_observations",
+    values: [
+      {
+        organization_id: organizationId as string,
+        project_id: projectId as string,
+        observation_id: `obs-${sessionId}`,
+        session_id: sessionId,
+        analysis_hash: analysisHash,
+        moment_id: `moment-${sessionId}`,
+        projection_method: "session_user_intent_embedding",
+        projection_hash: "d".repeat(64),
+        projection_metadata: JSON.stringify({ summary: `summary ${sessionId}` }),
+        embedding: [1, 0, 0],
+        assigned_cluster_id: otherClusterId as string,
+        assignment_confidence: 1,
+        assignment_method: "gardening_reassign",
+        start_time: ts,
+        end_time: ts,
+      },
+    ],
+    format: "JSONEachRow",
+  })
+
+const insertCustomBehaviorAssignment = (sessionId: string) =>
+  ch.client.insert({
+    table: "custom_behavior_assignments",
+    values: [
+      {
+        organization_id: organizationId as string,
+        project_id: projectId as string,
+        custom_behavior_id: customBehaviorId as string,
+        observation_id: `obs-${sessionId}`,
+        session_id: sessionId,
+        assigned_cluster_id: scopedClusterId as string,
+        start_time: ts,
       },
     ],
     format: "JSONEachRow",
@@ -177,5 +225,131 @@ describe("TaxonomyClusterIntelligenceRepository.listSessionTraceIds", () => {
     await insertAnalysis("any", [traceIdFor(1)])
 
     expect(await runList({ clusterIds: [] })).toEqual([])
+  })
+})
+
+describe("TaxonomyClusterIntelligenceRepository scoped custom-behavior reads", () => {
+  it("resolves membership from the assignment slice, not the global assigned_cluster_id", async () => {
+    await insertObservationAssignedElsewhere("scoped")
+    await insertAnalysis("scoped", [traceIdFor(7)])
+    await insertCustomBehaviorAssignment("scoped")
+
+    const scoped = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterIntelligenceRepository
+        return yield* repo.listSessionTraceIds({
+          organizationId,
+          projectId,
+          clusterIds: [scopedClusterId],
+          filter: "all",
+          limit: 100,
+          customBehaviorId,
+        })
+      }),
+    )
+    expect(scoped).toEqual([traceIdFor(7)])
+
+    // The same scoped cluster id resolves to nothing on the global path, because
+    // no observation carries it in assigned_cluster_id.
+    const global = await runList({ clusterIds: [scopedClusterId] })
+    expect(global).toEqual([])
+
+    // And the scoped aggregate reads the slice's sessions too (global would be 0).
+    const aggregate = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterIntelligenceRepository
+        return yield* repo.getClusterAggregate({
+          organizationId,
+          projectId,
+          clusterIds: [scopedClusterId],
+          sourceWindowStart: new Date("2026-05-01T00:00:00.000Z"),
+          sourceWindowEnd: new Date("2026-06-01T00:00:00.000Z"),
+          customBehaviorId,
+        })
+      }),
+    )
+    expect(aggregate.sourceSessionCount).toBe(1)
+  })
+})
+
+describe("TaxonomyClusterIntelligenceRepository.listClusterSessions", () => {
+  const listSessions = (overrides: {
+    clusterIds?: readonly TaxonomyClusterId[]
+    filter?: string
+    offset?: number
+    limit?: number
+    customBehaviorId?: CustomBehaviorId
+  }) =>
+    run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterIntelligenceRepository
+        return yield* repo.listClusterSessions({
+          organizationId,
+          projectId,
+          clusterIds: overrides.clusterIds ?? [clusterId],
+          filter: overrides.filter ?? "all",
+          offset: overrides.offset ?? 0,
+          limit: overrides.limit ?? 50,
+          ...(overrides.customBehaviorId ? { customBehaviorId: overrides.customBehaviorId } : {}),
+        })
+      }),
+    )
+
+  it("returns filtered sessions with a histogram and paginates", async () => {
+    await insertObservation("escalated")
+    await insertAnalysis("escalated", [traceIdFor(1)])
+    await insertMomentLabel("escalated", "escalation", 3)
+    await insertObservation("resolved")
+    await insertAnalysis("resolved", [traceIdFor(2)])
+    await insertMomentLabel("resolved", "resolution", 1)
+
+    const all = await listSessions({})
+    expect([...all.sessions.map((session) => session.sessionId)].sort()).toEqual(["escalated", "resolved"])
+    expect(all.sessions.every((session) => session.startTime instanceof Date)).toBe(true)
+    expect(all.histogram.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(2)
+    expect(all.hasMore).toBe(false)
+
+    expect((await listSessions({ filter: "escalation" })).sessions.map((session) => session.sessionId)).toEqual([
+      "escalated",
+    ])
+
+    const page = await listSessions({ limit: 1 })
+    expect(page.sessions).toHaveLength(1)
+    expect(page.hasMore).toBe(true)
+    expect(page.nextOffset).toBe(1)
+  })
+
+  it("reads the scoped slice when customBehaviorId is set", async () => {
+    await insertObservationAssignedElsewhere("scoped")
+    await insertAnalysis("scoped", [traceIdFor(9)])
+    await insertCustomBehaviorAssignment("scoped")
+
+    const scoped = await listSessions({ clusterIds: [scopedClusterId], customBehaviorId })
+    expect(scoped.sessions.map((session) => session.sessionId)).toEqual(["scoped"])
+
+    // The same scoped cluster id resolves to nothing on the global path.
+    expect((await listSessions({ clusterIds: [scopedClusterId] })).sessions).toEqual([])
+  })
+})
+
+describe("TaxonomyClusterIntelligenceRepository.getClusterTrajectory", () => {
+  it("buckets moment-metric counts by turn", async () => {
+    await insertObservation("s1")
+    await insertAnalysis("s1", [traceIdFor(1)])
+    await insertMomentLabel("s1", "escalation", 3)
+    await insertObservation("s2")
+    await insertAnalysis("s2", [traceIdFor(2)])
+    await insertMomentLabel("s2", "resolution", 5)
+
+    const rows = await run(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterIntelligenceRepository
+        return yield* repo.getClusterTrajectory({ organizationId, projectId, clusterIds: [clusterId], axis: "turn" })
+      }),
+    )
+    const byBucket = Object.fromEntries(rows.map((row) => [row.bucket, row]))
+    expect(byBucket["3"]?.escalation).toBe(1)
+    expect(byBucket["5"]?.resolution).toBe(1)
+    expect(rows.reduce((sum, row) => sum + row.frequency, 0)).toBe(2)
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-cluster-intelligence-repository.ts
@@ -1,5 +1,5 @@
 import type { ClickHouseClient } from "@clickhouse/client"
-import { ChSqlClient, type ChSqlClientShape, TraceId, toRepositoryError } from "@domain/shared"
+import { ChSqlClient, type ChSqlClientShape, type CustomBehaviorId, TraceId, toRepositoryError } from "@domain/shared"
 import {
   type ClusterAnalysisAggregate,
   type ClusterRepresentativeExample,
@@ -7,6 +7,24 @@ import {
 } from "@domain/taxonomy"
 import { formatCHDate } from "@repo/utils"
 import { Effect, Layer } from "effect"
+
+// Which observations belong to the requested clusters. Global reads match the
+// observation's own `assigned_cluster_id`; a scoped custom-behavior read never
+// touches that column and instead intersects with the behavior's
+// `custom_behavior_assignments` slice (keyed by custom_behavior_id).
+const GLOBAL_CLUSTER_MEMBERSHIP = "o.assigned_cluster_id IN {clusterIds:Array(String)}"
+const SCOPED_CLUSTER_MEMBERSHIP = `o.observation_id IN (
+    SELECT observation_id
+    FROM custom_behavior_assignments FINAL
+    WHERE organization_id = {organizationId:String}
+      AND project_id = {projectId:String}
+      AND custom_behavior_id = {customBehaviorId:String}
+      AND assigned_cluster_id IN {clusterIds:Array(String)}
+  )`
+const clusterMembership = (customBehaviorId: CustomBehaviorId | null | undefined) =>
+  customBehaviorId == null ? GLOBAL_CLUSTER_MEMBERSHIP : SCOPED_CLUSTER_MEMBERSHIP
+const scopeParams = (customBehaviorId: CustomBehaviorId | null | undefined) =>
+  customBehaviorId == null ? {} : { customBehaviorId: customBehaviorId as string }
 
 const behaviourSessionFilterSql = `
   ({filter:String} = 'all'
@@ -33,7 +51,12 @@ const behaviourMomentRangeSql = `
 // analysis generations are never deleted, so an unscoped read unions every
 // re-analysis and `any(analysis_hash)` could pick a stale hash, breaking the
 // trace link and silently dropping every moment label.
-const behaviourClusterSessionsCte = (timeFromClause: string, timeToClause: string, hasMomentRange: boolean) => `
+const behaviourClusterSessionsCte = (
+  timeFromClause: string,
+  timeToClause: string,
+  hasMomentRange: boolean,
+  membershipClause: string,
+) => `
   WITH latest_analyses AS (
     SELECT organization_id, project_id, session_id, analysis_hash, trace_ids
     FROM session_analyses FINAL
@@ -47,6 +70,8 @@ const behaviourClusterSessionsCte = (timeFromClause: string, timeToClause: strin
       o.session_id AS session_id,
       any(a.analysis_hash) AS analysisHash,
       arrayElement(any(a.trace_ids), 1) AS traceId,
+      argMin(o.moment_id, o.start_time) AS momentId,
+      any(JSONExtractString(o.projection_metadata, 'summary')) AS summary,
       min(o.start_time) AS startTime,
       max(o.end_time) AS endTime
     FROM taxonomy_observations AS o FINAL
@@ -57,7 +82,7 @@ const behaviourClusterSessionsCte = (timeFromClause: string, timeToClause: strin
      AND o.analysis_hash = a.analysis_hash
     WHERE o.organization_id = {organizationId:String}
       AND o.project_id = {projectId:String}
-      AND o.assigned_cluster_id IN {clusterIds:Array(String)}
+      AND ${membershipClause}
       ${timeFromClause}
       ${timeToClause}
     GROUP BY o.organization_id, o.project_id, o.session_id
@@ -66,6 +91,10 @@ const behaviourClusterSessionsCte = (timeFromClause: string, timeToClause: strin
     SELECT
       cs.session_id AS sessionId,
       any(cs.traceId) AS traceId,
+      ${hasMomentRange ? `argMinIf(m.moment_id, m.first_message_index, ${behaviourMomentRangeSql})` : "any(cs.momentId)"}
+        AS momentId,
+      any(cs.summary) AS summary,
+      any(cs.startTime) AS startTime,
       any(cs.endTime) AS endTime,
       ${hasMomentRange ? `countIf(${behaviourMomentRangeSql})` : "toUInt64(0)"} AS selectedMomentCount,
       groupUniqArrayIf(m.kind, m.kind != '') AS momentKinds
@@ -101,13 +130,59 @@ type ExampleRow = {
 const distributionFromRows = (rows: readonly DistributionRow[]) =>
   Object.fromEntries(rows.filter((row) => row.key.length > 0).map((row) => [row.key, row.count]))
 
+const trajectoryBucketExpression = (axis: "day" | "turn") =>
+  axis === "day" ? "toString(toDate(cs.startTime))" : "toString(m.first_message_index)"
+
+const parseNumber = (value: unknown): number => {
+  if (typeof value === "number") return value
+  if (typeof value === "string") return Number(value)
+  return 0
+}
+
+type SessionRow = {
+  readonly sessionId: string
+  readonly traceId: string
+  readonly momentId: string
+  readonly summary: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly momentKinds: readonly string[]
+}
+
+type SessionHistogramRow = {
+  readonly startTime: string
+  readonly count: number | string
+}
+
+type TrajectoryRow = {
+  readonly bucket: string
+  readonly frequency: number | string
+  readonly escalation: number | string
+  readonly resolution: number | string
+  readonly churnRisk: number | string
+  readonly wins: number | string
+  readonly maxLastMessageIndex: number | string
+  readonly maxEscalationLastMessageIndex: number | string
+  readonly maxResolutionLastMessageIndex: number | string
+  readonly maxChurnRiskLastMessageIndex: number | string
+  readonly maxWinsLastMessageIndex: number | string
+}
+
 export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
   TaxonomyClusterIntelligenceRepository,
   Effect.gen(function* () {
     return {
-      getClusterAggregate: ({ organizationId, projectId, clusterIds, sourceWindowStart, sourceWindowEnd }) =>
+      getClusterAggregate: ({
+        organizationId,
+        projectId,
+        clusterIds,
+        sourceWindowStart,
+        sourceWindowEnd,
+        customBehaviorId,
+      }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const membership = clusterMembership(customBehaviorId)
           return yield* chSqlClient
             .query(async (client) => {
               const params = {
@@ -116,6 +191,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                 clusterIds: clusterIds as readonly string[],
                 sourceWindowStart: formatCHDate(sourceWindowStart),
                 sourceWindowEnd: formatCHDate(sourceWindowEnd),
+                ...scopeParams(customBehaviorId),
               }
               const aggregateResult = await client.query({
                 // Superseded analysis generations are never deleted; pinning
@@ -135,7 +211,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                          AND o.session_id = a.session_id
                         WHERE o.organization_id = {organizationId:String}
                           AND o.project_id = {projectId:String}
-                          AND o.assigned_cluster_id IN {clusterIds:Array(String)}
+                          AND ${membership}
                           AND (a.analysis_hash = '' OR o.analysis_hash = a.analysis_hash)
                           AND o.start_time >= {sourceWindowStart:DateTime64(9, 'UTC')}
                           AND o.start_time < {sourceWindowEnd:DateTime64(9, 'UTC')}`,
@@ -164,7 +240,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                          AND a.analysis_hash = m.analysis_hash
                         WHERE o.organization_id = {organizationId:String}
                           AND o.project_id = {projectId:String}
-                          AND o.assigned_cluster_id IN {clusterIds:Array(String)}
+                          AND ${membership}
                           AND o.analysis_hash = a.analysis_hash
                           AND a.analysis_status = 'analyzed'
                           AND o.start_time >= {sourceWindowStart:DateTime64(9, 'UTC')}
@@ -200,6 +276,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
         sourceWindowStart,
         sourceWindowEnd,
         limit,
+        customBehaviorId,
       }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
@@ -212,7 +289,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                         FROM taxonomy_observations AS o FINAL
                         WHERE o.organization_id = {organizationId:String}
                           AND o.project_id = {projectId:String}
-                          AND o.assigned_cluster_id IN {clusterIds:Array(String)}
+                          AND ${clusterMembership(customBehaviorId)}
                           AND o.start_time >= {sourceWindowStart:DateTime64(9, 'UTC')}
                           AND o.start_time < {sourceWindowEnd:DateTime64(9, 'UTC')}
                         ORDER BY o.start_time DESC
@@ -224,6 +301,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                   sourceWindowStart: formatCHDate(sourceWindowStart),
                   sourceWindowEnd: formatCHDate(sourceWindowEnd),
                   limit,
+                  ...scopeParams(customBehaviorId),
                 },
                 format: "JSONEachRow",
               })
@@ -249,6 +327,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
         startTimeFrom,
         startTimeTo,
         limit,
+        customBehaviorId,
       }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
@@ -259,7 +338,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, Boolean(momentRange))}
+                query: `${behaviourClusterSessionsCte(timeFromClause, timeToClause, Boolean(momentRange), clusterMembership(customBehaviorId))}
                         SELECT traceId
                         FROM enriched_sessions
                         WHERE traceId != ''
@@ -278,6 +357,7 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
                   ...(momentRange
                     ? { momentMetric: momentRange.metric, turnFrom: momentRange.fromTurn, turnTo: momentRange.toTurn }
                     : {}),
+                  ...scopeParams(customBehaviorId),
                 },
                 format: "JSONEachRow",
               })
@@ -286,6 +366,196 @@ export const TaxonomyClusterIntelligenceRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyClusterIntelligenceRepository.listSessionTraceIds"),
+              ),
+            )
+        }),
+      listClusterSessions: ({
+        organizationId,
+        projectId,
+        clusterIds,
+        filter,
+        momentRange,
+        startTimeFrom,
+        startTimeTo,
+        offset,
+        limit,
+        customBehaviorId,
+      }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          if (clusterIds.length === 0) return { sessions: [], histogram: [], hasMore: false, nextOffset: null }
+          const timeFromClause = startTimeFrom ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
+          const timeToClause = startTimeTo ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
+          const momentRangeClause = momentRange ? "AND selectedMomentCount > 0" : ""
+          const cte = behaviourClusterSessionsCte(
+            timeFromClause,
+            timeToClause,
+            Boolean(momentRange),
+            clusterMembership(customBehaviorId),
+          )
+          const queryParams = {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            clusterIds: clusterIds as readonly string[],
+            filter,
+            ...(startTimeFrom ? { startTimeFrom: formatCHDate(startTimeFrom) } : {}),
+            ...(startTimeTo ? { startTimeTo: formatCHDate(startTimeTo) } : {}),
+            ...(momentRange
+              ? { momentMetric: momentRange.metric, turnFrom: momentRange.fromTurn, turnTo: momentRange.toTurn }
+              : {}),
+            ...scopeParams(customBehaviorId),
+          }
+          // Short windows (≤2 days) bucket hourly; longer windows daily.
+          const histogramInterval =
+            startTimeFrom && (!startTimeTo || startTimeTo.getTime() - startTimeFrom.getTime() <= 2 * 24 * 60 * 60_000)
+              ? "1 HOUR"
+              : "1 DAY"
+          return yield* chSqlClient
+            .query(async (client) => {
+              const sessionsResult = await client.query({
+                query: `${cte}
+                        SELECT sessionId, traceId, momentId, summary, startTime, endTime, momentKinds
+                        FROM enriched_sessions
+                        WHERE ${behaviourSessionFilterSql}
+                        ${momentRangeClause}
+                        ORDER BY endTime DESC
+                        LIMIT {pageSize:UInt32}
+                        OFFSET {offset:UInt32}`,
+                query_params: { ...queryParams, pageSize: limit + 1, offset },
+                format: "JSONEachRow",
+              })
+              const rows = (await sessionsResult.json()) as SessionRow[]
+              const histogramResult = await client.query({
+                query: `${cte}
+                        SELECT
+                          toStartOfInterval(endTime, INTERVAL ${histogramInterval}) AS startTime,
+                          count() AS count
+                        FROM enriched_sessions
+                        WHERE ${behaviourSessionFilterSql}
+                        ${momentRangeClause}
+                        GROUP BY startTime
+                        ORDER BY startTime ASC`,
+                query_params: queryParams,
+                format: "JSONEachRow",
+              })
+              const histogramRows = (await histogramResult.json()) as SessionHistogramRow[]
+              const hasMore = rows.length > limit
+              return {
+                sessions: rows.slice(0, limit).map((row) => ({
+                  sessionId: row.sessionId,
+                  traceId: row.traceId,
+                  momentId: row.momentId,
+                  summary: row.summary,
+                  startTime: new Date(row.startTime),
+                  endTime: new Date(row.endTime),
+                  momentKinds: row.momentKinds,
+                })),
+                histogram: histogramRows.map((bucket) => ({
+                  startTime: new Date(bucket.startTime),
+                  count: Number(bucket.count),
+                })),
+                hasMore,
+                nextOffset: hasMore ? offset + limit : null,
+              }
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyClusterIntelligenceRepository.listClusterSessions"),
+              ),
+            )
+        }),
+      getClusterTrajectory: ({
+        organizationId,
+        projectId,
+        clusterIds,
+        axis,
+        startTimeFrom,
+        startTimeTo,
+        customBehaviorId,
+      }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          if (clusterIds.length === 0) return []
+          const timeFromClause = startTimeFrom ? "AND o.start_time >= {startTimeFrom:DateTime64(9, 'UTC')}" : ""
+          const timeToClause = startTimeTo ? "AND o.start_time < {startTimeTo:DateTime64(9, 'UTC')}" : ""
+          const bucketExpression = trajectoryBucketExpression(axis)
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `
+                  WITH latest_analyses AS (
+                    SELECT organization_id, project_id, session_id, analysis_hash
+                    FROM session_analyses FINAL
+                    WHERE organization_id = {organizationId:String}
+                      AND project_id = {projectId:String}
+                  ),
+                  cluster_sessions AS (
+                    SELECT
+                      o.organization_id AS organization_id,
+                      o.project_id AS project_id,
+                      o.session_id AS session_id,
+                      any(a.analysis_hash) AS analysisHash,
+                      min(o.start_time) AS startTime
+                    FROM taxonomy_observations AS o FINAL
+                    INNER JOIN latest_analyses AS a
+                      ON o.organization_id = a.organization_id
+                     AND o.project_id = a.project_id
+                     AND o.session_id = a.session_id
+                     AND o.analysis_hash = a.analysis_hash
+                    WHERE o.organization_id = {organizationId:String}
+                      AND o.project_id = {projectId:String}
+                      AND ${clusterMembership(customBehaviorId)}
+                      ${timeFromClause}
+                      ${timeToClause}
+                    GROUP BY o.organization_id, o.project_id, o.session_id
+                  )
+                  SELECT
+                    ${bucketExpression} AS bucket,
+                    count() AS frequency,
+                    countIf(m.kind = 'escalation') AS escalation,
+                    countIf(m.kind = 'resolution') AS resolution,
+                    countIf(m.kind IN ('abandonment', 'user_frustration')) AS churnRisk,
+                    countIf(m.kind IN ('resolution', 'user_satisfaction')) AS wins,
+                    max(m.last_message_index) AS maxLastMessageIndex,
+                    maxIf(m.last_message_index, m.kind = 'escalation') AS maxEscalationLastMessageIndex,
+                    maxIf(m.last_message_index, m.kind = 'resolution') AS maxResolutionLastMessageIndex,
+                    maxIf(m.last_message_index, m.kind IN ('abandonment', 'user_frustration')) AS maxChurnRiskLastMessageIndex,
+                    maxIf(m.last_message_index, m.kind IN ('resolution', 'user_satisfaction')) AS maxWinsLastMessageIndex
+                  FROM cluster_sessions AS cs
+                  INNER JOIN session_moment_labels AS m FINAL
+                    ON cs.organization_id = m.organization_id
+                   AND cs.project_id = m.project_id
+                   AND cs.session_id = m.session_id
+                   AND cs.analysisHash = m.analysis_hash
+                  GROUP BY bucket
+                  ORDER BY ${axis === "day" ? "bucket ASC" : "toUInt16(bucket) ASC"}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  clusterIds: clusterIds as readonly string[],
+                  ...(startTimeFrom ? { startTimeFrom: formatCHDate(startTimeFrom) } : {}),
+                  ...(startTimeTo ? { startTimeTo: formatCHDate(startTimeTo) } : {}),
+                  ...scopeParams(customBehaviorId),
+                },
+                format: "JSONEachRow",
+              })
+              return ((await result.json()) as TrajectoryRow[]).map((row) => ({
+                bucket: row.bucket,
+                frequency: parseNumber(row.frequency),
+                escalation: parseNumber(row.escalation),
+                resolution: parseNumber(row.resolution),
+                churnRisk: parseNumber(row.churnRisk),
+                wins: parseNumber(row.wins),
+                maxLastMessageIndex: parseNumber(row.maxLastMessageIndex),
+                maxEscalationLastMessageIndex: parseNumber(row.maxEscalationLastMessageIndex),
+                maxResolutionLastMessageIndex: parseNumber(row.maxResolutionLastMessageIndex),
+                maxChurnRiskLastMessageIndex: parseNumber(row.maxChurnRiskLastMessageIndex),
+                maxWinsLastMessageIndex: parseNumber(row.maxWinsLastMessageIndex),
+              }))
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyClusterIntelligenceRepository.getClusterTrajectory"),
               ),
             )
         }),

--- a/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
@@ -203,7 +203,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
           return rows.map(toDomainCluster)
         }),
 
-      listSubtreeIds: ({ projectId, clusterId }) =>
+      listSubtreeIds: ({ projectId, clusterId, customBehaviorId }) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const rows = yield* sqlClient.query((db, organizationId) =>
@@ -215,7 +215,7 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
                   eq(taxonomyClusters.organizationId, organizationId),
                   eq(taxonomyClusters.projectId, projectId),
                   eq(taxonomyClusters.state, "active"),
-                  isNull(taxonomyClusters.customBehaviorId),
+                  scopeCondition(customBehaviorId),
                   or(eq(taxonomyClusters.id, clusterId), like(taxonomyClusters.path, `%${clusterId}/%`)),
                 ),
               ),


### PR DESCRIPTION
## What

Phase 3b of Custom Behaviors (LAT-751) — where the two parallel tracks rejoin: the **Generate** button (→ the Phase 2 `gardenCustomBehavior` workflow) and the **scoped tree view** (← what Phase 2 wrote). Builds on the Phase 3a CRUD/preview UI; does not reimplement it.

## Changes

**Generate / regenerate**
- `generateCustomBehaviorFn` (web server fn) enqueues the `taxonomy` / `gardenCustomBehavior` job with payload `{organizationId, projectId, customBehaviorId, reason:"manual"}` and `dedupeKey: taxonomyGardenCustomBehaviorDedupeKey(...)`, then optimistically flips the row to `generating`. The Phase 2 workflow stays authoritative (re-sets `generating` → `ready`/`failed`).
- Status surfaced in the list (which polls while any row is `pending`/`generating`) via a per-row Generate/Regenerate button, and on the detail page with a banner.

**Scoped behavior tree (reuses the Behaviours UI, parameterized by `customBehaviorId`)**
- New route `/custom-behaviours/$behaviourSlug` renders `BehavioursView` + drawer + trajectory chart scoped to the behavior.
- Read path threads `customBehaviorId` through `listProjectBehavioursUseCase` (scoped per-cluster counts from the ClickHouse `custom_behavior_assignments` slice; neutral trend since scoped trees are rebuilt wholesale), `listSubtreeIds` (PG), `getClusterSessionIntelligenceUseCase`, and the web `getProjectBehaviours` / `getBehaviourSessions` / `getBehaviourTrajectory` / `getClusterProfile` functions (CH cluster-membership predicate swapped from `taxonomy_observations.assigned_cluster_id` to the scoped assignment slice).
- The scoped assignment repo is a **runtime-optional** service (`Effect.serviceOption`) so the global Behaviours read contract is unchanged.
- A failed/failing run keeps the prior tree visible (deprecate-last is Phase 2; the read is status-independent) with a failure banner.

**Entry points** (both prefill the create modal via a `?create=` param, `topics` stripped)
- Sessions view: "Create custom behavior" copies the current `FilterSet` minus `topics`.
- Saved search: per-row action copies the saved search's `filterSet` only (no semantic query, per spec).

Decisions honored: topics excluded everywhere (`stripCustomBehaviorExcludedFields`), moments kept; fixed 7d (no lookback control); cap 10; saved-searches authz. Out of scope: online assignment, public API.

## Verification

Typecheck (full workspace) + `@domain/taxonomy` tests green. Driven end-to-end in the running app (branch on :3001 against the shared dev stack, with the main-worktree worker/workflows consuming the queue):
- **Generate enqueues → worker consumes → Temporal workflow starts** with the exact dedupe key `org:…:taxonomy:gardenCustomBehavior:cbdemo…1` (confirmed in worker + workflow logs); status transitioned `pending → failed` and the UI reflected it (badge + Regenerate + banner).
- List, detail, failed-state + empty-tree render; **Sessions** and **saved-search** entry points both prefill the create modal (topics excluded, only `moments` present).
- Global **Behaviours** page renders unchanged (real tree + segment tabs) — regression check passed.

⚠️ A *successful* scoped tree render could not be observed live: the seeded cohorts in the local dev DB have only ~2 matching `taxonomy_observations`, so the workflow correctly fails the ≥15-observation gate (`insufficient_observations`). This is an environment/data limitation (the QA seed's live generation was deferred, per LAT-752), not a code issue — the shared render pipeline is proven by the global page, and the scoped read returns empty cleanly. A reviewer with a generatable cohort should confirm the completed-tree + drawer-sessions render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)