### PR TITLE
fix(telemetry-hermes): flush on session end + split api_request/llm_call hooks

### DIFF
--- a/packages/telemetry/hermes/CHANGELOG.md
+++ b/packages/telemetry/hermes/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Fixed
+
+- Flush telemetry on session end so short/one-shot runs (`hermes -z "…"`) no longer drop their trace. The plugin now registers `on_session_end` and `on_session_finalize`, ships the ending session's still-open run, and joins the export threads so the HTTP delivery completes before the process exits. Finalization is scoped to the ending session, so a gateway teardown of one session never disturbs runs still live in a concurrent session. Previously the background export thread was killed at interpreter exit before the request finished; only long-lived interactive sessions emitted.
+
+### Changed
+
+- Split the `pre_api_request`/`post_api_request` callbacks from `pre_llm_call`/`post_llm_call`. They fire at different times with different payloads, so binding one callback to both created duplicate/mislabeled spans. The `*_api_request` pair is now the LLM-call span boundary (request/response/usage/provider/model/api_request_id); the `*_llm_call` pair frames the turn. The exported OTLP span shape is unchanged.
+
 ## [0.1.0]
 
 ### Added

--- a/packages/telemetry/hermes/README.md
+++ b/packages/telemetry/hermes/README.md
@@ -66,7 +66,10 @@ structure and timing without prompt/response/tool content, set `LATITUDE_NO_CONT
 Hermes loads pip-installed plugins via the `hermes_agent.plugins` entry point and calls
 the module's `register(ctx)` function, which subscribes to the lifecycle hooks
 (`pre_api_request` / `post_api_request`, `pre_llm_call` / `post_llm_call`,
-`pre_tool_call` / `post_tool_call`) — the same hooks the bundled `langfuse` plugin uses.
+`pre_tool_call` / `post_tool_call`, and `on_session_end` / `on_session_finalize`) — the
+same hooks the bundled `langfuse` and `nemo_relay` plugins use. The `*_api_request` pair is
+the LLM-call span boundary; the `*_llm_call` pair frames the turn; the session hooks flush
+the exporter so short / one-shot runs (`hermes -z "…"`) ship before the process exits.
 
 The plugin owns the **OTLP mapping** for that hook stream. It assembles one trace per
 turn:

--- a/packages/telemetry/hermes/pyproject.toml
+++ b/packages/telemetry/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry-hermes"
-version = "0.1.0"
+version = "0.1.1"
 description = "Hermes Agent plugin that streams sessions to Latitude as OTLP traces"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
@@ -25,7 +25,43 @@ class _Builder:
         self._runs: Dict[str, _Run] = {}
         self._lock = threading.Lock()
 
-    def on_pre_llm_request(self, **kw: Any) -> None:
+    def on_pre_llm_call(self, **kw: Any) -> None:
+        """Turn-level framing: open the interaction run at the start of a turn.
+
+        Fires once per turn, before any API call. Carries the conversation but
+        no per-call request payload, so it only seeds the interaction root; the
+        llm_request child spans are created by on_pre_api_request.
+        """
+        messages = _pick_messages(kw)
+        if not messages:
+            return
+        key = _trace_key(
+            kw.get("task_id", ""), kw.get("session_id", ""), kw.get("turn_id", ""), kw.get("api_request_id", "")
+        )
+        now = _now_ms()
+        with self._lock:
+            run = self._runs.get(key)
+            if run is None:
+                run = self._start_run(key, kw, messages, now)
+                self._runs[key] = run
+            run.updated_at = time.time()
+
+    def on_post_llm_call(self, **kw: Any) -> Optional[Dict[str, Any]]:
+        """Turn-level framing: finalize and ship the run when the turn ends.
+
+        No-op when on_post_api_request already finished the run on a final
+        content answer (the run is gone); otherwise (turn ended on a tool call
+        or was cut short) this ships the trace so nothing leaks past turn end.
+        """
+        key = _trace_key(
+            kw.get("task_id", ""), kw.get("session_id", ""), kw.get("turn_id", ""), kw.get("api_request_id", "")
+        )
+        with self._lock:
+            if key not in self._runs:
+                return None
+            return self._finish_locked(key)
+
+    def on_pre_api_request(self, **kw: Any) -> None:
         messages = _pick_messages(kw)
         if not messages:  # not a request-shaped call (e.g. context injection)
             return
@@ -75,7 +111,7 @@ class _Builder:
             run.generations[req_key] = span
             run.llm_calls += 1
 
-    def on_post_llm_call(self, **kw: Any) -> Optional[Dict[str, Any]]:
+    def on_post_api_request(self, **kw: Any) -> Optional[Dict[str, Any]]:
         key = _trace_key(
             kw.get("task_id", ""), kw.get("session_id", ""), kw.get("turn_id", ""), kw.get("api_request_id", "")
         )
@@ -95,6 +131,7 @@ class _Builder:
             output = _normalize_assistant(assistant)
             if output:
                 span.attrs["gen_ai.output.messages:gated"] = [output]
+                run.last_output = output
             model = kw.get("model")
             provider = kw.get("provider")
             if model:
@@ -221,13 +258,33 @@ class _Builder:
             "service.instance.id": run.session_id,
         }
 
+    def finish_scoped(self, session_id: str, task_id: str) -> List[Dict[str, Any]]:
+        """Finalize the still-open runs of one ending session and return their payloads.
+
+        Called on session end so short/one-shot runs that never hit a clean
+        finish still ship before the process exits. Scoped to the ending
+        session so a gateway teardown of one session never pops or abandons
+        runs still live in a concurrent session. With no session identifier
+        (single CLI session) it finalizes every open run.
+        """
+        with self._lock:
+            keys = [key for key, run in self._runs.items() if _run_in_scope(run, session_id, task_id)]
+            payloads: List[Dict[str, Any]] = []
+            for key in keys:
+                payload = self._finish_locked(key)
+                if payload is not None:
+                    payloads.append(payload)
+            return payloads
+
     def _finish_locked(self, key: str) -> Optional[Dict[str, Any]]:
         run = self._runs.pop(key, None)
         if run is None:
             return None
         now = _now_ms()
+        if "gen_ai.output.messages:gated" not in run.root.attrs and run.last_output:
+            run.root.attrs["gen_ai.output.messages:gated"] = [run.last_output]
         for span in run.generations.values():
-            _abandon(span, "llm_request abandoned before post_llm_call", now)
+            _abandon(span, "llm_request abandoned before post_api_request", now)
             run.closed.append(span)
         for span in run.open_tools.values():
             _abandon(span, "tool_execution abandoned before post_tool_call", now)
@@ -243,6 +300,16 @@ class _Builder:
             return
         oldest = min(self._runs, key=lambda k: self._runs[k].updated_at)
         self._runs.pop(oldest, None)
+
+
+def _run_in_scope(run: _Run, session_id: str, task_id: str) -> bool:
+    if not session_id and not task_id:  # single CLI session: no id to scope by
+        return True
+    if session_id and run.session_id == session_id:
+        return True
+    if task_id and run.task_id == task_id:
+        return True
+    return False
 
 
 def _pick_messages(kw: Dict[str, Any]) -> List[Any]:

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
@@ -52,7 +52,7 @@ _SSL_CONTEXT = _ssl_context()
 logger = logging.getLogger(__name__)
 
 SCOPE_NAME = "latitude-telemetry-hermes"
-PKG_VERSION = "0.1.0"
+PKG_VERSION = "0.1.1"
 
 # Bound on live trace state, so turns that never reach a clean finish
 # (interrupted / tool-only final step) can't leak forever.

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/hooks.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/hooks.py
@@ -8,18 +8,36 @@ from typing import Any
 
 from .builder import _Builder
 from .config import _config, _debug
-from .transport import _ship
+from .transport import _flush, _ship
 
 _BUILDER = _Builder()
 
 
-def on_pre_llm_request(**kwargs: Any) -> None:
+def on_pre_api_request(**kwargs: Any) -> None:
     if not _config()["enabled"]:
         return
     try:
-        _BUILDER.on_pre_llm_request(**kwargs)
+        _BUILDER.on_pre_api_request(**kwargs)
     except Exception as exc:  # fail-open
-        _debug(f"pre_llm_request handler failed: {exc}")
+        _debug(f"pre_api_request handler failed: {exc}")
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    if not _config()["enabled"]:
+        return
+    try:
+        _ship(_BUILDER.on_post_api_request(**kwargs))
+    except Exception as exc:  # fail-open
+        _debug(f"post_api_request handler failed: {exc}")
+
+
+def on_pre_llm_call(**kwargs: Any) -> None:
+    if not _config()["enabled"]:
+        return
+    try:
+        _BUILDER.on_pre_llm_call(**kwargs)
+    except Exception as exc:  # fail-open
+        _debug(f"pre_llm_call handler failed: {exc}")
 
 
 def on_post_llm_call(**kwargs: Any) -> None:
@@ -49,16 +67,43 @@ def on_post_tool_call(**kwargs: Any) -> None:
         _debug(f"post_tool_call handler failed: {exc}")
 
 
+def on_session_end(**kwargs: Any) -> None:
+    """Ship any still-open run and block until the HTTP export finishes.
+
+    Fires at the end of every run_conversation (including one-shot `-z` runs)
+    and on session teardown. Without the flush the daemon export threads are
+    killed when a short run exits and the trace is lost.
+    """
+    if not _config()["enabled"]:
+        return
+    try:
+        session_id = kwargs.get("session_id") or ""
+        task_id = kwargs.get("task_id") or ""
+        for payload in _BUILDER.finish_scoped(session_id, task_id):
+            _ship(payload)
+    except Exception as exc:  # fail-open
+        _debug(f"session_end handler failed: {exc}")
+    finally:
+        try:
+            _flush()
+        except Exception as exc:  # fail-open
+            _debug(f"flush failed: {exc}")
+
+
 def register(ctx: Any) -> None:
     """Entry point called by the Hermes plugin system.
 
-    Registers for both hook-name variants so the plugin works across Hermes
-    versions: pre/post_api_request fire per API call (preferred);
-    pre/post_llm_call fire once per turn.
+    The two callback families fire at different times with different kwargs, so
+    they bind to different builder methods: pre/post_api_request are the
+    LLM-call span boundary (they carry request/response/usage/provider/model/
+    api_request_id), while pre/post_llm_call frame the turn. on_session_end and
+    on_session_finalize flush the exporter so short/one-shot runs still ship.
     """
-    ctx.register_hook("pre_api_request", on_pre_llm_request)
-    ctx.register_hook("post_api_request", on_post_llm_call)
-    ctx.register_hook("pre_llm_call", on_pre_llm_request)
+    ctx.register_hook("pre_api_request", on_pre_api_request)
+    ctx.register_hook("post_api_request", on_post_api_request)
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("on_session_end", on_session_end)
+    ctx.register_hook("on_session_finalize", on_session_end)

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/model.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/model.py
@@ -29,5 +29,6 @@ class _Run:
     open_tools: Dict[str, _Span] = field(default_factory=dict)
     closed: List[_Span] = field(default_factory=list)
     system_prompt: Optional[str] = None
+    last_output: Optional[Dict[str, Any]] = None
     llm_calls: int = 0
     updated_at: float = field(default_factory=time.time)

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/transport.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/transport.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from typing import Any, Dict, Optional
 from urllib import request as _urlreq
 
 from .config import _SSL_CONTEXT, _config, _debug
+
+# Outstanding export threads, so session-end can join them and guarantee the
+# HTTP delivery finishes before a short/one-shot run exits (daemon threads are
+# killed on interpreter exit otherwise, dropping the trace).
+_INFLIGHT: set[threading.Thread] = set()
+_INFLIGHT_LOCK = threading.Lock()
 
 
 def _post_traces(payload: Dict[str, Any]) -> None:
@@ -29,7 +36,39 @@ def _post_traces(payload: Dict[str, Any]) -> None:
         _debug(f"ingest failed: {exc}")
 
 
+def _deliver(result: Dict[str, Any]) -> None:
+    try:
+        _post_traces(result)
+    finally:
+        with _INFLIGHT_LOCK:
+            _INFLIGHT.discard(threading.current_thread())
+
+
 def _ship(result: Optional[Dict[str, Any]]) -> None:
     if not result:
         return
-    threading.Thread(target=_post_traces, args=(result,), daemon=True).start()
+    thread = threading.Thread(target=lambda: _deliver(result), daemon=True)
+    with _INFLIGHT_LOCK:
+        _INFLIGHT.add(thread)
+    thread.start()
+
+
+def _flush(timeout: float = 10.0) -> None:
+    """Join outstanding export threads so HTTP delivery completes before exit.
+
+    Re-snapshots after each drain so a thread shipped while we were joining
+    (e.g. another session finishing concurrently) is still awaited, until the
+    set is empty or the deadline passes.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        with _INFLIGHT_LOCK:
+            threads = list(_INFLIGHT)
+        if not threads:
+            return
+        for thread in threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _debug(f"flush timed out with {len(threads)} export thread(s) still in-flight")
+                return
+            thread.join(timeout=remaining)

--- a/packages/telemetry/hermes/tests/test_plugin.py
+++ b/packages/telemetry/hermes/tests/test_plugin.py
@@ -6,9 +6,14 @@ pip entry-point contract: register() must wire every hook Hermes invokes.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Any, Dict, List
 
+import latitude_telemetry_hermes.hooks as hooks
+import latitude_telemetry_hermes.transport as transport
 from latitude_telemetry_hermes import register
+from latitude_telemetry_hermes.builder import _Builder
 from latitude_telemetry_hermes.config import PKG_VERSION, SCOPE_NAME
 from latitude_telemetry_hermes.model import _Run, _Span
 from latitude_telemetry_hermes.otlp import _build_otlp, _encode_attrs, _otlp_value
@@ -35,25 +40,131 @@ def _attr_map(attrs: List[Dict[str, Any]]) -> Dict[str, Any]:
 # --- entry-point contract --------------------------------------------------
 
 
-def test_register_wires_all_hermes_hooks():
-    """Hermes loads the module and calls register(ctx); it must register every
-    hook variant so it works across Hermes versions."""
-    registered: List[str] = []
+def _wire() -> Dict[str, Any]:
+    """Run register(ctx) and return the {hook_name: callback} it wired."""
+    registered: Dict[str, Any] = {}
 
     class FakeCtx:
         def register_hook(self, name: str, fn: Any) -> None:
-            registered.append(name)
+            registered[name] = fn
 
     register(FakeCtx())
+    return registered
 
-    assert set(registered) == {
+
+def test_register_wires_all_hermes_hooks():
+    """Hermes loads the module and calls register(ctx); it must register every
+    hook it consumes, including the session-end flush hooks."""
+    assert set(_wire()) == {
         "pre_api_request",
         "post_api_request",
         "pre_llm_call",
         "post_llm_call",
         "pre_tool_call",
         "post_tool_call",
+        "on_session_end",
+        "on_session_finalize",
     }
+
+
+def test_api_request_and_llm_call_hooks_bind_to_distinct_builder_methods(monkeypatch):
+    """The two callback families fire at different times with different kwargs,
+    so each must route to its own builder method — not a shared one."""
+    registered = _wire()
+    monkeypatch.setattr(hooks, "_config", lambda: {"enabled": True})
+    monkeypatch.setattr(hooks, "_ship", lambda payload: None)
+
+    calls: List[str] = []
+    monkeypatch.setattr(hooks._BUILDER, "on_pre_api_request", lambda **kw: calls.append("pre_api_request"))
+    monkeypatch.setattr(hooks._BUILDER, "on_post_api_request", lambda **kw: calls.append("post_api_request"))
+    monkeypatch.setattr(hooks._BUILDER, "on_pre_llm_call", lambda **kw: calls.append("pre_llm_call"))
+    monkeypatch.setattr(hooks._BUILDER, "on_post_llm_call", lambda **kw: calls.append("post_llm_call"))
+
+    for name in ("pre_api_request", "post_api_request", "pre_llm_call", "post_llm_call"):
+        registered[name]()
+
+    assert calls == ["pre_api_request", "post_api_request", "pre_llm_call", "post_llm_call"]
+
+
+def test_on_session_end_finalizes_open_run_and_ships(monkeypatch):
+    """A run left open when a one-shot run ends must be finalized and shipped,
+    then the exporter flushed, before the process exits."""
+    registered = _wire()
+    monkeypatch.setattr(hooks, "_config", lambda: {"enabled": True})
+
+    fresh = _Builder()
+    monkeypatch.setattr(hooks, "_BUILDER", fresh)
+    shipped: List[Dict[str, Any]] = []
+    monkeypatch.setattr(hooks, "_ship", lambda payload: shipped.append(payload) if payload else None)
+    flushed: List[bool] = []
+    monkeypatch.setattr(hooks, "_flush", lambda *a, **k: flushed.append(True))
+
+    # An API request opens a run; with no matching post_api_request it stays open.
+    registered["pre_api_request"](
+        session_id="s",
+        turn_id="turn-1",
+        messages=[{"role": "user", "content": "hi"}],
+        provider="openai",
+        model="gpt-4",
+        api_call_count=1,
+    )
+    assert fresh._runs, "expected an open run before session end"
+
+    registered["on_session_end"]()
+
+    assert flushed == [True], "session end must flush the exporter"
+    assert len(shipped) == 1, "the open run must be shipped exactly once"
+    assert not fresh._runs, "the run must be finalized and removed"
+    spans = shipped[0]["resourceSpans"][0]["scopeSpans"][0]["spans"]
+    assert "interaction" in {s["name"] for s in spans}
+
+
+def test_on_session_end_only_finalizes_its_own_session(monkeypatch):
+    """In a gateway with concurrent sessions, ending one session must not pop
+    or abandon runs still live in another session."""
+    registered = _wire()
+    monkeypatch.setattr(hooks, "_config", lambda: {"enabled": True})
+
+    fresh = _Builder()
+    monkeypatch.setattr(hooks, "_BUILDER", fresh)
+    shipped: List[Dict[str, Any]] = []
+    monkeypatch.setattr(hooks, "_ship", lambda payload: shipped.append(payload) if payload else None)
+    monkeypatch.setattr(hooks, "_flush", lambda *a, **k: None)
+
+    for sid in ("s1", "s2"):
+        registered["pre_api_request"](
+            session_id=sid,
+            turn_id=f"turn-{sid}",
+            messages=[{"role": "user", "content": "hi"}],
+            api_call_count=1,
+        )
+    assert len(fresh._runs) == 2
+
+    registered["on_session_end"](session_id="s1")
+
+    assert len(shipped) == 1, "only the ending session's run ships"
+    remaining = list(fresh._runs.values())
+    assert len(remaining) == 1 and remaining[0].session_id == "s2", "the other session stays live"
+
+
+def test_ship_flush_joins_export_thread(monkeypatch):
+    """_flush must block until in-flight export threads finish delivering."""
+    posted: List[Dict[str, Any]] = []
+    started = threading.Event()
+
+    def fake_post(payload: Dict[str, Any]) -> None:
+        started.set()
+        time.sleep(0.05)
+        posted.append(payload)
+
+    monkeypatch.setattr(transport, "_post_traces", fake_post)
+
+    transport._ship({"resourceSpans": []})
+    assert started.wait(1.0)
+    transport._flush(timeout=2.0)
+
+    assert posted == [{"resourceSpans": []}], "delivery must complete before flush returns"
+    assert not transport._INFLIGHT, "flushed threads must be drained"
 
 
 # --- OTLP value encoding ---------------------------------------------------

--- a/packages/telemetry/hermes/uv.lock
+++ b/packages/telemetry/hermes/uv.lock
@@ -35,7 +35,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry-hermes"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Closes #4029

## Root cause

`latitude-telemetry-hermes` dropped telemetry for **short / one-shot Hermes runs** (`hermes -z "…"`). Interactive sessions emitted fine.

This is **not** a Hermes 0.18.x hook-API break — a full source diff of v2026.6.19 (0.17.0) vs v2026.7.7.2 (0.18.2) shows the plugin hook system (`register_hook`, the `hermes_agent.plugins` entry point, all hook names + emit sites) is byte-identical, and Nous's bundled `langfuse`/`nemo_relay` plugins use the same API and still fire. The plugin's hooks *do* fire on 0.18.x.

Two real defects:

1. **No flush on exit.** The plugin ships each trace on a `daemon` thread and never joins it. A one-shot run's `run_conversation` returns and the process exits before that background HTTP POST completes, so the daemon thread is killed mid-request and the trace is lost. Interactive sessions stay alive long enough for the POST to land, which is why they worked.
2. **Conflated callbacks.** `register()` bound the *same* callback to both `pre_api_request` and `pre_llm_call` (and the `post_` pair). They fire at different times with different kwargs — `pre_llm_call` once per turn (no `provider`/`request`/`api_request_id`), `pre_api_request` per API call with the full payload — so one callback for both created duplicate / mislabeled `llm_request` spans.

## Changes

- **Flush on session end** (`hooks.py`): register `on_session_end` + `on_session_finalize`, both wired to a handler that finalizes any still-open run via a new `_Builder.finish_all()`, ships it, and then flushes.
- **Deterministic send path** (`transport.py`): track outstanding export threads in `_INFLIGHT` and add `_flush(timeout)` that joins them, so HTTP delivery is guaranteed to complete before the process exits. Each thread self-removes on completion.
- **Split the callback pairs** (`hooks.py`, `builder.py`): `pre/post_api_request` are the LLM-call span boundary (they carry request/response/usage/provider/model/api_request_id → `on_pre_api_request` / `on_post_api_request`); `pre/post_llm_call` frame the turn (`on_pre_llm_call` opens the interaction run, `on_post_llm_call` finalizes+ships it if not already shipped). Only `pre_api_request` creates `llm_request` spans now, so the duplicate/phantom span is gone. The final assistant output is tracked on the run (`_Run.last_output`) so a turn that ends on a tool call still gets its root output. **Exported OTLP span shape is unchanged.**
- Version bump `0.1.0 → 0.1.1`, CHANGELOG entry, README hook list updated.

## Testing

`cd packages/telemetry/hermes && uv run pytest` → **10 passed**; `uv run ruff check .` clean. New tests:
- `test_register_wires_all_hermes_hooks` — now asserts the two session hooks are wired too.
- `test_api_request_and_llm_call_hooks_bind_to_distinct_builder_methods` — each hook routes to its own builder method (no shared callback).
- `test_on_session_end_finalizes_open_run_and_ships` — an open run is finalized, shipped once, removed, and the exporter is flushed.
- `test_ship_flush_joins_export_thread` — `_flush` blocks until the in-flight export thread finishes delivering, and drains `_INFLIGHT`.

Existing OTLP-shape/content-gating tests remain green (shape unchanged). Not exercised against a live Hermes install; the split callback behavior is covered by unit tests around the builder methods and hook wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
