### PR TITLE
fix(spans): tolerate non-array OTLP attributes during ingest

### DIFF
--- a/packages/domain/spans/src/otlp/attributes.ts
+++ b/packages/domain/spans/src/otlp/attributes.ts
@@ -1,7 +1,16 @@
 import type { OtlpKeyValue } from "./types.ts"
 
+/**
+ * OTLP/JSON bodies are cast, not validated, so a malformed payload can send `attributes`
+ * as a non-array (e.g. a key→value object). Coerce to an array so the read paths that
+ * iterate or `.find` over attributes don't crash the whole ingest batch.
+ */
+export function attrArray(attrs: readonly OtlpKeyValue[] | undefined): readonly OtlpKeyValue[] {
+  return Array.isArray(attrs) ? attrs : []
+}
+
 function findAttr(attrs: readonly OtlpKeyValue[], key: string) {
-  return attrs.find((a) => a.key === key)
+  return attrArray(attrs).find((a) => a.key === key)
 }
 
 export function stringAttr(attrs: readonly OtlpKeyValue[], key: string): string | undefined {

--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -58,7 +58,7 @@ describe("resolveSpanProjectSlug", () => {
     expect(resolveSpanProjectSlug(malformed, [])).toBeUndefined()
   })
 
-  it("falls back to the resource attribute when the span attributes is a non-array", () => {
+  it("falls back to the resource attribute when the span attributes are a non-array", () => {
     const malformed = { "latitude.project": "span-slug" } as unknown as OtlpKeyValue[]
     const resource = [str("latitude.project", "resource-slug")]
     expect(resolveSpanProjectSlug(malformed, resource)).toBe("resource-slug")
@@ -227,6 +227,43 @@ describe("transformOtlpToSpans per-span project resolution", () => {
     expect(rejectedSpans).toBe(0)
     expect(spans).toHaveLength(1)
     expect(spans[0]?.projectId).toBe("proj-default")
+  })
+
+  it("does not crash the batch when resource attributes are a non-array", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: { "service.name": "test" } as unknown as OtlpKeyValue[] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: TRACE,
+                    spanId: "res-malformed",
+                    name: "res-malformed",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...baseContext,
+        defaultProjectId: "proj-default",
+        projectIdBySlug: new Map(),
+      },
+    )
+    expect(rejectedSpans).toBe(0)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-default")
+    expect(spans[0]?.serviceName).toBe("")
   })
 
   it("handles a mixed batch: some valid spans, some rejected", () => {

--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -50,6 +50,19 @@ describe("resolveSpanProjectSlug", () => {
   it("returns undefined when neither is set", () => {
     expect(resolveSpanProjectSlug([], [])).toBeUndefined()
   })
+
+  // Malformed OTLP/JSON bodies are cast, not validated, so `attributes` can arrive as a
+  // non-array (e.g. a key→value object). It must resolve to undefined, not throw `.find`.
+  it("returns undefined when attributes is a non-array object", () => {
+    const malformed = { "latitude.project": "span-slug" } as unknown as OtlpKeyValue[]
+    expect(resolveSpanProjectSlug(malformed, [])).toBeUndefined()
+  })
+
+  it("falls back to the resource attribute when the span attributes is a non-array", () => {
+    const malformed = { "latitude.project": "span-slug" } as unknown as OtlpKeyValue[]
+    const resource = [str("latitude.project", "resource-slug")]
+    expect(resolveSpanProjectSlug(malformed, resource)).toBe("resource-slug")
+  })
 })
 
 describe("transformOtlpToSpans per-span project resolution", () => {
@@ -178,6 +191,42 @@ describe("transformOtlpToSpans per-span project resolution", () => {
     )
     expect(spans).toHaveLength(1)
     expect(spans[0]?.projectId).toBe("proj-span")
+  })
+
+  it("does not crash the batch when a span has non-array attributes", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: TRACE,
+                    spanId: "malformed",
+                    name: "malformed",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: { "latitude.project": "span-slug" } as unknown as OtlpKeyValue[],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...baseContext,
+        defaultProjectId: "proj-default",
+        projectIdBySlug: new Map([["span-slug", "proj-span"]]),
+      },
+    )
+    expect(rejectedSpans).toBe(0)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-default")
   })
 
   it("handles a mixed batch: some valid spans, some rejected", () => {

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -1,6 +1,6 @@
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
-import { stringAttr } from "./attributes.ts"
+import { attrArray, stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
 import { isDroppedSpan } from "./dropped-spans.ts"
 import { resolveAttributes } from "./resolvers/index.ts"
@@ -122,9 +122,9 @@ function transformSpan({
   projectId: string
   ingestedAt: Date
 }): SpanDetail {
-  const spanAttrs = span.attributes ?? []
+  const spanAttrs = attrArray(span.attributes)
   const spanEvents = span.events ?? []
-  const resourceAttrs = resource?.attributes ?? []
+  const resourceAttrs = attrArray(resource?.attributes)
   const otelStatusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
   const statusCode = resolveStatusCode(spanAttrs, otelStatusCode, scopeName)
 

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -42,9 +42,8 @@ function resolveAnyValue(
 }
 
 function extractResourceString(resource: OtlpResource | undefined): Record<string, string> {
-  if (!resource?.attributes) return {}
   const result: Record<string, string> = {}
-  for (const attr of resource.attributes) {
+  for (const attr of attrArray(resource?.attributes)) {
     if (attr.value?.stringValue !== undefined) {
       result[attr.key] = attr.value.stringValue
     }


### PR DESCRIPTION
## Problem

Datadog error tracking flagged `TypeError: attrs.find is not a function` in the `ingest` service (production), crashing span ingestion:

```
TypeError: attrs.find is not a function
    at findAttr        (packages/domain/spans/src/otlp/attributes.ts:4)
    at stringAttr      (packages/domain/spans/src/otlp/attributes.ts:8)
    at resolveSpanProjectSlug (packages/domain/spans/src/otlp/transform.ts:93)
    at inspectPayload  (packages/domain/spans/src/use-cases/ingest-spans.ts:76)
    at spans.ingestSpans (packages/domain/spans/src/use-cases/ingest-spans.ts:239)
```

## Root cause

`decodeOtlpRequest` decodes OTLP/JSON bodies with a bare `JSON.parse(...) as OtlpExportTraceServiceRequest` — **no runtime validation**. The `OtlpKeyValue[]` types are compile-time only. A client posting non-conforming OTLP/JSON where `attributes` is an object/map (or any non-array) instead of the spec's array of `{key, value}` sails through the cast. The first `attrs.find(...)` in `findAttr` then throws.

The per-span project-slug pre-scan added in #3111 moved this unvalidated `.find()` call to the very front of the hot path (`inspectPayload`), and the throw is uncaught inside the `Effect.gen`, so **one malformed span 500s the entire batch** before any span is processed. The protobuf path is unaffected — its decoder always yields arrays for repeated fields.

## Fix

- Add a shared `attrArray` coercion in `otlp/attributes.ts`; `findAttr` uses it, so every accessor helper (`stringAttr`/`intAttr`/`floatAttr`/`stringArrayAttr`) and the `inspectPayload` pre-scan tolerate non-array input.
- Normalize span/resource attributes at the `transformSpan` iteration site (the `for...of` over `spanAttrs`), so the fix doesn't just move the crash from the pre-scan into transform.

A malformed span now resolves to no slug (rejected or defaulted) instead of taking down the whole batch.

## Test

`otlp/tests/project-scoping.test.ts`:
- `resolveSpanProjectSlug` returns `undefined` when attributes is a non-array object, and falls back to the resource attribute.
- `transformOtlpToSpans` no longer crashes the batch when a span has non-array attributes (falls through to `defaultProjectId`).

All 15 tests in the file pass. Typecheck adds no new errors (the pre-existing `@latitude-data/telemetry` build-order error is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)