### PR TITLE
fix(spans): coerce non-array OTLP attributes before lookup

### DIFF
--- a/packages/domain/spans/src/otlp/attributes.test.ts
+++ b/packages/domain/spans/src/otlp/attributes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { coerceOtlpKeyValues, stringAttr } from "./attributes.ts"
+import type { OtlpKeyValue } from "./types.ts"
+
+const kv = (key: string, value: string): OtlpKeyValue => ({ key, value: { stringValue: value } })
+
+describe("coerceOtlpKeyValues", () => {
+  it("returns an empty array for nullish input", () => {
+    expect(coerceOtlpKeyValues(undefined)).toEqual([])
+    expect(coerceOtlpKeyValues(null)).toEqual([])
+  })
+
+  it("passes through a valid KeyValue array", () => {
+    const attrs = [kv("latitude.project", "primary"), kv("session.id", "sess-1")]
+    expect(coerceOtlpKeyValues(attrs)).toEqual(attrs)
+  })
+
+  it("wraps a single KeyValue object", () => {
+    const single = kv("latitude.project", "primary")
+    expect(coerceOtlpKeyValues(single)).toEqual([single])
+  })
+
+  it("reads a plain map of AnyValue entries", () => {
+    const attrs = {
+      "latitude.project": { stringValue: "primary" },
+      "session.id": { stringValue: "sess-1" },
+    }
+    expect(coerceOtlpKeyValues(attrs)).toEqual([kv("latitude.project", "primary"), kv("session.id", "sess-1")])
+  })
+
+  it("reads a plain map of primitive values", () => {
+    const attrs = {
+      "latitude.project": "primary",
+      enabled: true,
+      retries: 3,
+    }
+    expect(coerceOtlpKeyValues(attrs)).toEqual([
+      kv("latitude.project", "primary"),
+      { key: "enabled", value: { boolValue: true } },
+      { key: "retries", value: { intValue: "3" } },
+    ])
+  })
+
+  it("reads a KeyValueList wrapper", () => {
+    const attrs = { values: [kv("latitude.project", "primary")] }
+    expect(coerceOtlpKeyValues(attrs)).toEqual([kv("latitude.project", "primary")])
+  })
+})
+
+describe("stringAttr", () => {
+  it("does not throw when attributes are a single KeyValue object", () => {
+    expect(stringAttr(kv("latitude.project", "primary"), "latitude.project")).toBe("primary")
+  })
+})

--- a/packages/domain/spans/src/otlp/attributes.ts
+++ b/packages/domain/spans/src/otlp/attributes.ts
@@ -1,15 +1,67 @@
-import type { OtlpKeyValue } from "./types.ts"
+import type { OtlpAnyValue, OtlpKeyValue } from "./types.ts"
 
-function findAttr(attrs: readonly OtlpKeyValue[], key: string) {
-  return attrs.find((a) => a.key === key)
+function isOtlpKeyValue(value: unknown): value is OtlpKeyValue {
+  return typeof value === "object" && value !== null && typeof (value as OtlpKeyValue).key === "string"
 }
 
-export function stringAttr(attrs: readonly OtlpKeyValue[], key: string): string | undefined {
+function isAnyValue(value: unknown): value is OtlpAnyValue {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    "stringValue" in v ||
+    "boolValue" in v ||
+    "intValue" in v ||
+    "doubleValue" in v ||
+    "arrayValue" in v ||
+    "kvlistValue" in v ||
+    "bytesValue" in v
+  )
+}
+
+/** OTLP exporters sometimes send a single KeyValue or a plain map instead of a KeyValue[]. */
+export function coerceOtlpKeyValues(attrs: unknown): readonly OtlpKeyValue[] {
+  if (attrs == null) return []
+  if (Array.isArray(attrs)) return attrs.filter(isOtlpKeyValue)
+  if (isOtlpKeyValue(attrs)) return [attrs]
+
+  if (typeof attrs === "object") {
+    const obj = attrs as Record<string, unknown>
+    if (Array.isArray(obj.values)) return obj.values.filter(isOtlpKeyValue)
+
+    const entries = Object.entries(obj)
+    if (entries.length === 0) return []
+
+    const fromMap: OtlpKeyValue[] = []
+    for (const [key, value] of entries) {
+      if (typeof value === "string") {
+        fromMap.push({ key, value: { stringValue: value } })
+      } else if (typeof value === "boolean") {
+        fromMap.push({ key, value: { boolValue: value } })
+      } else if (typeof value === "number") {
+        fromMap.push({
+          key,
+          value: Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value },
+        })
+      } else if (isAnyValue(value)) {
+        fromMap.push({ key, value })
+      }
+    }
+    if (fromMap.length > 0) return fromMap
+  }
+
+  return []
+}
+
+function findAttr(attrs: unknown, key: string) {
+  return coerceOtlpKeyValues(attrs).find((a) => a.key === key)
+}
+
+export function stringAttr(attrs: unknown, key: string): string | undefined {
   const v = findAttr(attrs, key)?.value?.stringValue
   return v || undefined
 }
 
-export function intAttr(attrs: readonly OtlpKeyValue[], key: string): number | undefined {
+export function intAttr(attrs: unknown, key: string): number | undefined {
   const kv = findAttr(attrs, key)
   if (!kv?.value) return undefined
   if (kv.value.intValue !== undefined) return Number(kv.value.intValue)
@@ -17,7 +69,7 @@ export function intAttr(attrs: readonly OtlpKeyValue[], key: string): number | u
   return undefined
 }
 
-export function floatAttr(attrs: readonly OtlpKeyValue[], key: string): number | undefined {
+export function floatAttr(attrs: unknown, key: string): number | undefined {
   const kv = findAttr(attrs, key)
   if (!kv?.value) return undefined
   if (kv.value.doubleValue !== undefined) return kv.value.doubleValue
@@ -25,7 +77,7 @@ export function floatAttr(attrs: readonly OtlpKeyValue[], key: string): number |
   return undefined
 }
 
-export function stringArrayAttr(attrs: readonly OtlpKeyValue[], key: string): string[] | undefined {
+export function stringArrayAttr(attrs: unknown, key: string): string[] | undefined {
   const kv = findAttr(attrs, key)
   if (!kv?.value?.arrayValue?.values) return undefined
   const values = kv.value.arrayValue.values

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -1,13 +1,13 @@
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
-import { stringAttr } from "./attributes.ts"
+import { coerceOtlpKeyValues, stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
 import { isDroppedSpan } from "./dropped-spans.ts"
 import { resolveAttributes } from "./resolvers/index.ts"
 import { resolvePerformance } from "./resolvers/performance.ts"
 import { resolveStatusCode } from "./resolvers/status.ts"
 import { resolveToolExecution } from "./resolvers/tool-execution.ts"
-import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpResource, OtlpSpan } from "./types.ts"
+import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpResource, OtlpSpan } from "./types.ts"
 
 const INT_TO_SPAN_KIND: Record<number, SpanKind> = {
   0: "unspecified",
@@ -42,9 +42,10 @@ function resolveAnyValue(
 }
 
 function extractResourceString(resource: OtlpResource | undefined): Record<string, string> {
-  if (!resource?.attributes) return {}
+  const attributes = coerceOtlpKeyValues(resource?.attributes)
+  if (attributes.length === 0) return {}
   const result: Record<string, string> = {}
-  for (const attr of resource.attributes) {
+  for (const attr of attributes) {
     if (attr.value?.stringValue !== undefined) {
       result[attr.key] = attr.value.stringValue
     }
@@ -86,18 +87,11 @@ interface TransformResult {
 }
 
 /** Reads `latitude.project` from span attrs first, falling back to resource attrs. */
-export function resolveSpanProjectSlug(
-  spanAttrs: readonly OtlpKeyValue[],
-  resourceAttrs: readonly OtlpKeyValue[],
-): string | undefined {
+export function resolveSpanProjectSlug(spanAttrs: unknown, resourceAttrs: unknown): string | undefined {
   return stringAttr(spanAttrs, "latitude.project") ?? stringAttr(resourceAttrs, "latitude.project")
 }
 
-function resolveSpanProjectId(
-  spanAttrs: readonly OtlpKeyValue[],
-  resourceAttrs: readonly OtlpKeyValue[],
-  context: TransformContext,
-): string | null {
+function resolveSpanProjectId(spanAttrs: unknown, resourceAttrs: unknown, context: TransformContext): string | null {
   const slug = resolveSpanProjectSlug(spanAttrs, resourceAttrs)
   if (slug) {
     return context.projectIdBySlug.get(slug) ?? null
@@ -122,9 +116,9 @@ function transformSpan({
   projectId: string
   ingestedAt: Date
 }): SpanDetail {
-  const spanAttrs = span.attributes ?? []
+  const spanAttrs = coerceOtlpKeyValues(span.attributes)
   const spanEvents = span.events ?? []
-  const resourceAttrs = resource?.attributes ?? []
+  const resourceAttrs = coerceOtlpKeyValues(resource?.attributes)
   const otelStatusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
   const statusCode = resolveStatusCode(spanAttrs, otelStatusCode, scopeName)
 
@@ -240,13 +234,13 @@ export function transformOtlpToSpans(
 
   for (const resourceSpans of request.resourceSpans ?? []) {
     const resource = resourceSpans.resource
-    const resourceAttrs = resource?.attributes ?? []
+    const resourceAttrs = coerceOtlpKeyValues(resource?.attributes)
     for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
       const scopeName = scopeSpans.scope?.name ?? ""
       const scopeVersion = scopeSpans.scope?.version ?? ""
       for (const span of scopeSpans.spans ?? []) {
         if (isDroppedSpan(scopeName, span.name ?? "")) continue
-        const projectId = resolveSpanProjectId(span.attributes ?? [], resourceAttrs, context)
+        const projectId = resolveSpanProjectId(span.attributes, resourceAttrs, context)
         if (!projectId) {
           rejectedSpans++
           continue

--- a/packages/domain/spans/src/sampling/extract-sampling-key.ts
+++ b/packages/domain/spans/src/sampling/extract-sampling-key.ts
@@ -1,3 +1,4 @@
+import { coerceOtlpKeyValues } from "../otlp/attributes.ts"
 import { sessionIdCandidates } from "../otlp/resolvers/identity.ts"
 import { first } from "../otlp/resolvers/utils.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
@@ -13,10 +14,10 @@ import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
  */
 export function extractSamplingKey(request: OtlpExportTraceServiceRequest): string | null {
   for (const resourceSpans of request.resourceSpans ?? []) {
-    const resourceAttrs = resourceSpans.resource?.attributes ?? []
+    const resourceAttrs = coerceOtlpKeyValues(resourceSpans.resource?.attributes)
     for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
       for (const span of scopeSpans.spans ?? []) {
-        const fromSpan = first(sessionIdCandidates, span.attributes ?? [])
+        const fromSpan = first(sessionIdCandidates, coerceOtlpKeyValues(span.attributes))
         if (fromSpan) return fromSpan
         const fromResource = first(sessionIdCandidates, resourceAttrs)
         if (fromResource) return fromResource

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -315,6 +315,41 @@ describe("ingestSpansUseCase project scoping", () => {
     expect(published).toHaveLength(0)
   })
 
+  it("accepts spans whose latitude.project attribute is a single KeyValue object", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    const payload = new TextEncoder().encode(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                scope: { name: "test", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "b7ad6b7169203331",
+                    name: "test-span",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: { key: "latitude.project", value: { stringValue: "primary" } },
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const result = await Effect.runPromise(runUseCase(makeInput(payload), disk, publisher))
+
+    expect(result).toEqual({ totalSpans: 1, acceptedSpans: 1, rejectedSpans: 0 })
+    expect(published).toHaveLength(1)
+  })
+
   it("rejects spans whose latitude.project slug isn't in the org and keeps the rest", async () => {
     const { disk } = createFakeStorageDisk()
     const { publisher, published } = createFakeQueuePublisher()

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -13,6 +13,7 @@ import {
 import { base64Encode } from "@repo/utils"
 import { Effect } from "effect"
 import { SpanDecodingError } from "../errors.ts"
+import { coerceOtlpKeyValues } from "../otlp/attributes.ts"
 import { decodeOtlpProtobuf } from "../otlp/proto.ts"
 import { resolveSpanProjectSlug } from "../otlp/transform.ts"
 import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
@@ -69,11 +70,11 @@ function inspectPayload(request: OtlpExportTraceServiceRequest): PayloadInspecti
   let totalSpans = 0
 
   for (const resourceSpans of request.resourceSpans ?? []) {
-    const resourceAttrs = resourceSpans.resource?.attributes ?? []
+    const resourceAttrs = coerceOtlpKeyValues(resourceSpans.resource?.attributes)
     for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
       for (const span of scopeSpans.spans ?? []) {
         totalSpans++
-        const slug = resolveSpanProjectSlug(span.attributes ?? [], resourceAttrs)
+        const slug = resolveSpanProjectSlug(span.attributes, resourceAttrs)
         spanSlugs.push(slug)
         if (slug) uniqueSlugs.add(slug)
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production ingest started throwing `TypeError: attrs.find is not a function` while resolving `latitude.project` during OTLP batch inspection ([Datadog issue 438a17b0-7f8e-11f1-9a41-da7ad0900005](https://app.datadoghq.eu/error-tracking/issue/438a17b0-7f8e-11f1-9a41-da7ad0900005)).

The stack trace points at `findAttr` in `attributes.ts`, called from `resolveSpanProjectSlug` → `inspectPayload` on `POST /v1/traces`. Our code assumed `span.attributes` and `resource.attributes` are always `KeyValue[]`, but some OTLP JSON exporters send a single `KeyValue` object or a plain map instead. The `?? []` fallback only handles `null`/`undefined`, so a truthy non-array value crashes ingest.

## Fix

Add `coerceOtlpKeyValues` to normalize attribute shapes before lookup or iteration:

- `KeyValue[]` — pass through
- single `KeyValue` object — wrap in an array
- plain map (`{ "latitude.project": { stringValue: "..." } }` or primitive values) — convert to `KeyValue[]`
- `KeyValueList` wrapper (`{ values: [...] }`) — unwrap

Use it in `attributes.ts` (all attr helpers), `transform.ts`, `ingest-spans.ts` (`inspectPayload`), and `extract-sampling-key.ts`.

## Tests

- Unit tests for `coerceOtlpKeyValues` and `stringAttr` with malformed shapes
- Ingest test asserting a span with a single-object `attributes` field is accepted and routed

## Verification

After deploy, occurrences of issue `438a17b0-7f8e-11f1-9a41-da7ad0900005` should stop. Locally:

```bash
pnpm --filter @domain/spans exec vitest run src/otlp/attributes.test.ts src/otlp/tests/project-scoping.test.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1784038693750869?thread_ts=1784038693.750869&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-687f2be7-47eb-5cc9-9c54-76addaec8d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-687f2be7-47eb-5cc9-9c54-76addaec8d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

