### PR TITLE
feat(experiments): create from saved searches + creation presets

### DIFF
--- a/apps/web/src/domains/experiments/experiments.collection.ts
+++ b/apps/web/src/domains/experiments/experiments.collection.ts
@@ -144,15 +144,29 @@ const invalidateExperimentQueries = (queryClient: ReturnType<typeof useQueryClie
     queryClient.invalidateQueries({ queryKey: ["experiments", "comparison", projectId] }),
   ])
 
+/** A variant to seed a new experiment with (no id — the domain mints it). */
+export interface NewExperimentVariant {
+  readonly name: string
+  readonly baseline: boolean
+  readonly filterSet: FilterSet
+  readonly query: string | null
+  readonly timeRange: ExperimentVariant["timeRange"]
+}
+
 export function useCreateExperiment(projectId: string) {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (input: { readonly name: string; readonly description?: string }) =>
+    mutationFn: (input: {
+      readonly name: string
+      readonly description?: string
+      readonly variants?: readonly NewExperimentVariant[]
+    }) =>
       createExperiment({
         data: {
           projectId,
           name: input.name,
           ...(input.description !== undefined ? { description: input.description } : {}),
+          ...(input.variants !== undefined ? { variants: [...input.variants] } : {}),
         },
       }),
     onSuccess: () => invalidateExperimentQueries(queryClient, projectId),

--- a/apps/web/src/domains/experiments/experiments.collection.ts
+++ b/apps/web/src/domains/experiments/experiments.collection.ts
@@ -1,4 +1,11 @@
-import { type ExperimentVariant, ensureBaseline, newVariant, withBaseline } from "@domain/experiments"
+import {
+  EXPERIMENT_NAME_MAX_LENGTH,
+  type ExperimentVariant,
+  ensureBaseline,
+  newVariant,
+  VARIANT_NAME_MAX_LENGTH,
+  withBaseline,
+} from "@domain/experiments"
 import type { FilterSet } from "@domain/shared"
 import { type InfiniteTableInfiniteScroll, useToast } from "@repo/ui"
 import { keepPreviousData, useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
@@ -18,6 +25,7 @@ import {
   searchExperimentsOrgWide,
   updateExperiment,
 } from "./experiments.functions.ts"
+import { extractVariantTimeRange } from "./experiments.helpers.ts"
 
 export type { ExperimentComparisonRecord, ExperimentListRow, ExperimentRecord, ExperimentVariantRecord }
 
@@ -147,6 +155,38 @@ export function useCreateExperiment(projectId: string) {
           ...(input.description !== undefined ? { description: input.description } : {}),
         },
       }),
+    onSuccess: () => invalidateExperimentQueries(queryClient, projectId),
+  })
+}
+
+/**
+ * Create an experiment seeded from a search: its filters/query/time window become the baseline
+ * variant (named after the search), plus one empty comparison variant the domain auto-names. The
+ * search's time window lives inside `filterSet.startTime`, so it is lifted into the variant's
+ * `timeRange` rather than left as a hidden filter (see {@link extractVariantTimeRange}).
+ */
+export function useCreateExperimentFromSearch(projectId: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: { readonly name: string; readonly filterSet: FilterSet; readonly query: string | null }) => {
+      const { filterSet, timeRange } = extractVariantTimeRange(input.filterSet)
+      return createExperiment({
+        data: {
+          projectId,
+          name: input.name.slice(0, EXPERIMENT_NAME_MAX_LENGTH),
+          variants: [
+            {
+              name: input.name.slice(0, VARIANT_NAME_MAX_LENGTH),
+              baseline: true,
+              filterSet,
+              query: input.query,
+              timeRange,
+            },
+            { name: "", baseline: false, filterSet: {}, query: null, timeRange: null },
+          ],
+        },
+      })
+    },
     onSuccess: () => invalidateExperimentQueries(queryClient, projectId),
   })
 }

--- a/apps/web/src/domains/experiments/experiments.helpers.ts
+++ b/apps/web/src/domains/experiments/experiments.helpers.ts
@@ -1,0 +1,35 @@
+import type { VariantTimeRange } from "@domain/experiments"
+import type { FilterCondition, FilterSet } from "@domain/shared"
+
+/** Session-filter keys that encode a time window rather than a population attribute. */
+const TIME_FILTER_KEYS = new Set(["startTime", "endTime"])
+
+/**
+ * A saved search made with the time picker stores its window as `startTime` (`gte`/`lte`) conditions
+ * inside the filter set. Experiments instead apply `variant.timeRange` as the ClickHouse window, and
+ * the filter builder never surfaces `startTime` — so importing those keys verbatim would leave the
+ * variant silently constrained by a hidden, un-editable window on top of its own range. Lift the
+ * window out of the filter set into an absolute `timeRange`, and drop the time keys from the filters.
+ */
+export function extractVariantTimeRange(filterSet: FilterSet): { filterSet: FilterSet; timeRange: VariantTimeRange } {
+  let from: string | undefined
+  let to: string | undefined
+  let hasTimeKey = false
+  const rest: Record<string, readonly FilterCondition[]> = {}
+  for (const [key, conditions] of Object.entries(filterSet)) {
+    if (!TIME_FILTER_KEYS.has(key)) {
+      rest[key] = conditions
+      continue
+    }
+    hasTimeKey = true
+    for (const condition of conditions) {
+      if (typeof condition.value !== "string") continue
+      if (condition.op === "gte" || condition.op === "gt") from ??= condition.value
+      else if (condition.op === "lte" || condition.op === "lt") to ??= condition.value
+    }
+  }
+  if (!hasTimeKey) return { filterSet, timeRange: null }
+  const timeRange: VariantTimeRange =
+    from !== undefined ? { type: "absolute", fromIso: from, toIso: to ?? new Date().toISOString() } : null
+  return { filterSet: rest, timeRange }
+}

--- a/apps/web/src/domains/experiments/experiments.presets.ts
+++ b/apps/web/src/domains/experiments/experiments.presets.ts
@@ -1,0 +1,150 @@
+import type { VariantTimeRange } from "@domain/experiments"
+import { toSlug } from "@domain/shared"
+import {
+  CalendarRangeIcon,
+  LayersIcon,
+  type LucideIcon,
+  SlidersHorizontalIcon,
+  SplitIcon,
+  TrendingUpIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import type { NewExperimentVariant } from "./experiments.collection.ts"
+
+const EXPERIMENT_PRESETS = ["custom", "abTest", "versions", "seasonal", "failures", "outliers"] as const
+export type ExperimentPreset = (typeof EXPERIMENT_PRESETS)[number]
+
+interface ExperimentPresetOption {
+  readonly value: ExperimentPreset
+  readonly label: string
+  readonly description: string
+  readonly icon: LucideIcon
+}
+
+/** Card-selector catalog for the "Preset" field, in display order. `custom` is the default. */
+export const EXPERIMENT_PRESET_OPTIONS: readonly ExperimentPresetOption[] = [
+  {
+    value: "custom",
+    label: "Custom",
+    description: "Start from scratch with two empty variants",
+    icon: SlidersHorizontalIcon,
+  },
+  {
+    value: "abTest",
+    label: "A/B Test",
+    description: "Two variants split by an A tag and a B tag",
+    icon: SplitIcon,
+  },
+  {
+    value: "versions",
+    label: "Versions",
+    description: "Current version vs the last three tagged versions",
+    icon: LayersIcon,
+  },
+  {
+    value: "seasonal",
+    label: "Seasonal",
+    description: "Four variants across Winter, Spring, Summer and Fall",
+    icon: CalendarRangeIcon,
+  },
+  {
+    value: "failures",
+    label: "Failures",
+    description: "Successful sessions vs sessions with errors",
+    icon: TriangleAlertIcon,
+  },
+  {
+    value: "outliers",
+    label: "Outliers",
+    description: "Normal sessions vs the longest, costliest and slowest to first token",
+    icon: TrendingUpIcon,
+  },
+]
+
+const emptyVariant = (name: string, baseline: boolean): NewExperimentVariant => ({
+  name,
+  baseline,
+  filterSet: {},
+  query: null,
+  timeRange: null,
+})
+
+const tagFiltered = (name: string, baseline: boolean, tag: string): NewExperimentVariant => ({
+  name,
+  baseline,
+  filterSet: { tags: [{ op: "in", value: [tag] }] },
+  query: null,
+  timeRange: null,
+})
+
+const percentileFiltered = (name: string, field: "duration" | "cost" | "ttft"): NewExperimentVariant => ({
+  name,
+  baseline: false,
+  filterSet: { [field]: [{ op: "gtePercentile", value: 99 }] },
+  query: null,
+  timeRange: null,
+})
+
+/**
+ * Absolute range of the most recently *completed* occurrence of a meteorological season, relative to
+ * `now`: the season's start month (0-indexed; `startsPreviousDecember` shifts Winter's start into the
+ * prior December) spanning `MONTHS_PER_SEASON`, stepping back a year until the season has fully ended.
+ * The upper bound is the first instant of the following month, so the whole season is covered.
+ */
+const MONTHS_PER_SEASON = 3
+const seasonRange = (now: Date, startMonth: number, startsPreviousDecember: boolean): VariantTimeRange => {
+  let year = now.getFullYear()
+  for (;;) {
+    const start = new Date(startsPreviousDecember ? year - 1 : year, startMonth, 1, 0, 0, 0, 0)
+    const end = new Date(start.getFullYear(), start.getMonth() + MONTHS_PER_SEASON, 1, 0, 0, 0, 0)
+    if (end.getTime() <= now.getTime())
+      return { type: "absolute", fromIso: start.toISOString(), toIso: end.toISOString() }
+    year -= 1
+  }
+}
+
+/**
+ * Seed variants for a creation preset, or `undefined` for `custom` (which falls back to the domain's
+ * default baseline + one empty variant). `name` is the experiment name; its slug builds the A/B tags
+ * (tags can't contain spaces).
+ */
+export const buildPresetVariants = (
+  preset: ExperimentPreset,
+  name: string,
+  now: Date,
+): readonly NewExperimentVariant[] | undefined => {
+  switch (preset) {
+    case "custom":
+      return undefined
+    case "abTest": {
+      const slug = toSlug(name)
+      return [tagFiltered("Variant A", true, `${slug}-A`), tagFiltered("Variant B", false, `${slug}-B`)]
+    }
+    case "versions":
+      return [
+        tagFiltered("Current version", true, "version-A"),
+        tagFiltered("Version B", false, "version-B"),
+        tagFiltered("Version C", false, "version-C"),
+        tagFiltered("Version D", false, "version-D"),
+      ]
+    case "seasonal":
+      return [
+        { ...emptyVariant("Winter", true), timeRange: seasonRange(now, 11, true) },
+        { ...emptyVariant("Spring", false), timeRange: seasonRange(now, 2, false) },
+        { ...emptyVariant("Summer", false), timeRange: seasonRange(now, 5, false) },
+        { ...emptyVariant("Fall", false), timeRange: seasonRange(now, 8, false) },
+      ]
+    case "failures":
+      return [
+        { ...emptyVariant("Successful sessions", true), filterSet: { errorCount: [{ op: "lte", value: 0 }] } },
+        { ...emptyVariant("Failed sessions", false), filterSet: { errorCount: [{ op: "gte", value: 1 }] } },
+      ]
+    case "outliers":
+      return [
+        emptyVariant("Normal sessions", true),
+        percentileFiltered("Longer sessions", "duration"),
+        percentileFiltered("Costlier sessions", "cost"),
+        percentileFiltered("Slower sessions", "ttft"),
+      ]
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -587,6 +587,7 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
             <div className="group/searchbar flex h-10 min-w-0 flex-1 items-center overflow-hidden rounded-lg border border-input transition-colors focus-within:ring-1 focus-within:ring-ring">
               <SavedSearchSelector
                 projectId={currentProject.id}
+                projectSlug={currentProject.slug}
                 selectedSlug={savedSearchSlug}
                 onSelect={applySavedSearch}
                 onSelectedSlugChange={setSavedSearchSlug}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/save-search-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/save-search-modal.tsx
@@ -1,8 +1,10 @@
 import type { FilterSet } from "@domain/shared"
 import { Button, CloseTrigger, FormWrapper, Icon, Input, Modal, Switch, Text, Tooltip, useToast } from "@repo/ui"
 import { useForm } from "@tanstack/react-form"
-import { BellRingIcon, ChevronRightIcon, ShieldAlertIcon } from "lucide-react"
+import { useNavigate } from "@tanstack/react-router"
+import { BellRingIcon, ChevronRightIcon, FlaskConicalIcon, ShieldAlertIcon } from "lucide-react"
 import { useState } from "react"
+import { useCreateExperimentFromSearch } from "../../../../../domains/experiments/experiments.collection.ts"
 import {
   useCreateSavedSearch,
   useUpdateSavedSearch,
@@ -75,8 +77,11 @@ function CreateModal({
   onCreateSignal,
 }: CreateProps) {
   const { toast } = useToast()
+  const navigate = useNavigate()
   const createMutation = useCreateSavedSearch(projectId)
+  const createExperimentMutation = useCreateExperimentFromSearch(projectId)
   const [withMonitor, setWithMonitor] = useState(false)
+  const [withExperiment, setWithExperiment] = useState(false)
   const [alertDraft, setAlertDraft] = useState<AlertDraft>(() => emptyAlertDraft({ sourceId: "pending" }))
   const [alertErrors, setAlertErrors] = useState<AlertFieldErrors>({})
 
@@ -115,13 +120,34 @@ function CreateModal({
         }
       },
       {
-        onSuccess: (record) => {
+        onSuccess: async (record) => {
           toast({
             title: "Search saved",
             description: createMonitor
               ? `"${record.name}" was saved and a monitor is now watching it.`
               : `"${record.name}" is now available in your saved searches.`,
           })
+          if (withExperiment) {
+            try {
+              const experiment = await createExperimentMutation.mutateAsync({
+                name: record.name,
+                filterSet,
+                query,
+              })
+              onClose()
+              void navigate({
+                to: "/projects/$projectSlug/experiments/$experimentSlug",
+                params: { projectSlug, experimentSlug: experiment.slug },
+              })
+              return
+            } catch (error) {
+              toast({
+                variant: "destructive",
+                title: "Could not create experiment",
+                description: toUserMessage(error),
+              })
+            }
+          }
           onCreated(record)
           onClose()
         },
@@ -238,6 +264,25 @@ function CreateModal({
                 ) : null}
               </div>
             )}
+            <div className="flex flex-col rounded-lg border border-border">
+              <label
+                htmlFor="save-search-experiment-toggle"
+                className="flex cursor-pointer items-center justify-between gap-3 p-3"
+              >
+                <div className="flex items-start gap-2">
+                  <Icon icon={FlaskConicalIcon} size="sm" color="foregroundMuted" className="mt-0.5 shrink-0" />
+                  <div className="flex flex-col gap-0.5">
+                    <Text.H5M>Compare this search</Text.H5M>
+                    <Text.H6 color="foregroundMuted">Create a new experiment with this search as the baseline</Text.H6>
+                  </div>
+                </div>
+                <Switch
+                  id="save-search-experiment-toggle"
+                  checked={withExperiment}
+                  onCheckedChange={setWithExperiment}
+                />
+              </label>
+            </div>
             {canCreateSignal ? (
               <button
                 type="button"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -12,22 +12,29 @@ import {
   Tooltip,
   toast,
 } from "@repo/ui"
+import { useNavigate } from "@tanstack/react-router"
 import {
+  BellPlusIcon,
   BookmarkIcon,
   BookmarkPlusIcon,
   ChevronDownIcon,
   FilterIcon,
+  FlaskConicalIcon,
   PencilIcon,
   SearchIcon,
   Trash2Icon,
 } from "lucide-react"
 import { useMemo, useState } from "react"
+import { useCreateExperimentFromSearch } from "../../../../../domains/experiments/experiments.collection.ts"
+import { savedSearchMonitorTarget } from "../../../../../domains/monitors/monitor-target.ts"
 import {
   useDeleteSavedSearch,
   useSavedSearchesList,
 } from "../../../../../domains/saved-searches/saved-searches.collection.ts"
 import type { SavedSearchRecord } from "../../../../../domains/saved-searches/saved-searches.functions.ts"
 import { toUserMessage } from "../../../../../lib/errors.ts"
+import { targetAlertDraft } from "../monitors/-components/alert-form-helpers.ts"
+import { MonitorCreateModal } from "../monitors/-components/monitor-create-modal.tsx"
 import { SaveSearchModal } from "./save-search-modal.tsx"
 
 /**
@@ -37,6 +44,7 @@ import { SaveSearchModal } from "./save-search-modal.tsx"
  */
 export function SavedSearchSelector({
   projectId,
+  projectSlug,
   selectedSlug,
   onSelect,
   onSelectedSlugChange,
@@ -44,6 +52,7 @@ export function SavedSearchSelector({
   canSaveCurrent,
 }: {
   readonly projectId: string
+  readonly projectSlug: string
   readonly selectedSlug: string
   readonly onSelect: (record: SavedSearchRecord) => void
   /** Re-point (or clear with `""`) the selected `savedSearch` slug — used when the selected search is deleted or renamed. */
@@ -55,6 +64,8 @@ export function SavedSearchSelector({
   const [filter, setFilter] = useState("")
   const [rowToDelete, setRowToDelete] = useState<SavedSearchRecord | null>(null)
   const [rowToRename, setRowToRename] = useState<SavedSearchRecord | null>(null)
+  const [rowToMonitor, setRowToMonitor] = useState<SavedSearchRecord | null>(null)
+  const [rowToCompare, setRowToCompare] = useState<SavedSearchRecord | null>(null)
 
   const { data: savedSearches } = useSavedSearchesList(projectId)
 
@@ -118,7 +129,7 @@ export function SavedSearchSelector({
                   <div
                     key={record.id}
                     className={cn(
-                      "group/row flex items-center gap-1 rounded-md pr-1",
+                      "group/row relative flex items-center rounded-md",
                       isSelected ? "bg-accent" : "hover:bg-accent/60",
                     )}
                   >
@@ -152,38 +163,75 @@ export function SavedSearchSelector({
                         ) : null}
                       </span>
                     </button>
-                    <Tooltip
-                      asChild
-                      trigger={
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100"
-                          aria-label={`Rename saved search ${record.name}`}
-                          onClick={() => setRowToRename(record)}
+                    {/* Actions sit in a panel overlaid on the row's right edge, revealed on hover/focus:
+                        a solid `bg-accent` strip holds the buttons, and a gradient to its left fades the
+                        item's name/subtitle out underneath them. `pointer-events-none` while hidden lets
+                        clicks fall through to the Select button behind it. */}
+                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center opacity-0 transition-opacity group-hover/row:pointer-events-auto group-hover/row:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+                      <div aria-hidden className="h-full w-10 bg-gradient-to-l from-accent to-transparent" />
+                      <div className="flex h-full items-center gap-0.5 rounded-r-md bg-accent pr-1">
+                        <Tooltip
+                          asChild
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Create a monitor from ${record.name}`}
+                              onClick={() => setRowToMonitor(record)}
+                            >
+                              <Icon icon={BellPlusIcon} size="sm" color="foregroundMuted" />
+                            </Button>
+                          }
                         >
-                          <Icon icon={PencilIcon} size="sm" color="foregroundMuted" />
-                        </Button>
-                      }
-                    >
-                      Rename
-                    </Tooltip>
-                    <Tooltip
-                      asChild
-                      trigger={
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100"
-                          aria-label={`Delete saved search ${record.name}`}
-                          onClick={() => setRowToDelete(record)}
+                          Monitor
+                        </Tooltip>
+                        <Tooltip
+                          asChild
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Create an experiment from ${record.name}`}
+                              onClick={() => setRowToCompare(record)}
+                            >
+                              <Icon icon={FlaskConicalIcon} size="sm" color="foregroundMuted" />
+                            </Button>
+                          }
                         >
-                          <Icon icon={Trash2Icon} size="sm" color="destructive" />
-                        </Button>
-                      }
-                    >
-                      Remove
-                    </Tooltip>
+                          Compare
+                        </Tooltip>
+                        <Tooltip
+                          asChild
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Rename saved search ${record.name}`}
+                              onClick={() => setRowToRename(record)}
+                            >
+                              <Icon icon={PencilIcon} size="sm" color="foregroundMuted" />
+                            </Button>
+                          }
+                        >
+                          Rename
+                        </Tooltip>
+                        <Tooltip
+                          asChild
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Delete saved search ${record.name}`}
+                              onClick={() => setRowToDelete(record)}
+                            >
+                              <Icon icon={Trash2Icon} size="sm" color="destructive" />
+                            </Button>
+                          }
+                        >
+                          Remove
+                        </Tooltip>
+                      </div>
+                    </div>
                   </div>
                 )
               })
@@ -229,7 +277,81 @@ export function SavedSearchSelector({
           }}
         />
       ) : null}
+      {rowToMonitor ? (
+        <MonitorCreateModal
+          projectId={projectId}
+          projectSlug={projectSlug}
+          initialAlert={targetAlertDraft(savedSearchMonitorTarget(rowToMonitor.id))}
+          onClose={() => setRowToMonitor(null)}
+        />
+      ) : null}
+      {rowToCompare ? (
+        <CompareSavedSearchModal
+          row={rowToCompare}
+          projectId={projectId}
+          projectSlug={projectSlug}
+          onClose={() => setRowToCompare(null)}
+          onCreated={() => setOpen(false)}
+        />
+      ) : null}
     </>
+  )
+}
+
+function CompareSavedSearchModal({
+  row,
+  projectId,
+  projectSlug,
+  onClose,
+  onCreated,
+}: {
+  readonly row: SavedSearchRecord
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly onClose: () => void
+  readonly onCreated: () => void
+}) {
+  const navigate = useNavigate()
+  const createExperiment = useCreateExperimentFromSearch(projectId)
+
+  const handleCreate = async () => {
+    try {
+      const experiment = await createExperiment.mutateAsync({
+        name: row.name,
+        filterSet: row.filterSet,
+        query: row.query,
+      })
+      onCreated()
+      onClose()
+      void navigate({
+        to: "/projects/$projectSlug/experiments/$experimentSlug",
+        params: { projectSlug, experimentSlug: experiment.slug },
+      })
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not create experiment", description: toUserMessage(error) })
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      onOpenChange={onClose}
+      title="Create experiment from search"
+      description="The search's filters and query will be imported into a new experiment variant as the baseline."
+      footer={
+        <>
+          <CloseTrigger />
+          <Button
+            onClick={() => void handleCreate()}
+            disabled={createExperiment.isPending}
+            isLoading={createExperiment.isPending}
+          >
+            Create experiment
+          </Button>
+        </>
+      }
+    />
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-modals.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/experiment-modals.tsx
@@ -1,4 +1,4 @@
-import { Button, CloseTrigger, Input, Modal, Textarea, useToast } from "@repo/ui"
+import { Button, CloseTrigger, cn, Icon, Input, Modal, Text, Textarea, useToast } from "@repo/ui"
 import { useForm } from "@tanstack/react-form"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
@@ -8,6 +8,11 @@ import {
   useDeleteExperiment,
   useUpdateExperiment,
 } from "../../../../../../domains/experiments/experiments.collection.ts"
+import {
+  buildPresetVariants,
+  EXPERIMENT_PRESET_OPTIONS,
+  type ExperimentPreset,
+} from "../../../../../../domains/experiments/experiments.presets.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../../../lib/form-server-action.ts"
 
@@ -24,11 +29,20 @@ export function ExperimentCreateModal({
   const { toast } = useToast()
   const navigate = useNavigate()
   const create = useCreateExperiment(projectId)
+  const [preset, setPreset] = useState<ExperimentPreset>("custom")
 
   const form = useForm({
     defaultValues: { name: "", description: "" },
     onSubmit: createFormSubmitHandler(
-      async (value) => create.mutateAsync({ name: value.name.trim(), description: value.description.trim() }),
+      async (value) => {
+        const name = value.name.trim()
+        const variants = buildPresetVariants(preset, name, new Date())
+        return create.mutateAsync({
+          name,
+          description: value.description.trim(),
+          ...(variants ? { variants } : {}),
+        })
+      },
       {
         onSuccess: (experiment: ExperimentRecord) => {
           onClose()
@@ -90,6 +104,37 @@ export function ExperimentCreateModal({
             />
           )}
         </form.Field>
+        <div className="flex flex-col gap-2">
+          <Text.H5M>Preset</Text.H5M>
+          <div className="grid grid-cols-2 gap-2">
+            {EXPERIMENT_PRESET_OPTIONS.map((option) => {
+              const active = option.value === preset
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={active}
+                  className={cn(
+                    "flex min-w-0 cursor-pointer items-start gap-2 rounded-lg border border-border p-3 text-left transition-colors",
+                    active ? "border-primary bg-primary/5" : "hover:bg-muted",
+                  )}
+                  onClick={() => setPreset(option.value)}
+                >
+                  <Icon
+                    icon={option.icon}
+                    size="sm"
+                    color={active ? "primary" : "foregroundMuted"}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <span className="flex min-w-0 flex-col gap-0.5">
+                    <Text.H5M>{option.label}</Text.H5M>
+                    <Text.H6 color="foregroundMuted">{option.description}</Text.H6>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
       </form>
     </Modal>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/variant-modals.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/experiments/-components/variant-modals.tsx
@@ -1,41 +1,9 @@
 import type { VariantTimeRange } from "@domain/experiments"
-import type { FilterCondition, FilterSet } from "@domain/shared"
+import type { FilterSet } from "@domain/shared"
 import { Button, CloseTrigger, Input, Modal, Select, Text } from "@repo/ui"
 import { useMemo, useState } from "react"
+import { extractVariantTimeRange } from "../../../../../../domains/experiments/experiments.helpers.ts"
 import { useSavedSearchesList } from "../../../../../../domains/saved-searches/saved-searches.collection.ts"
-
-/** Session-filter keys that encode a time window rather than a population attribute. */
-const TIME_FILTER_KEYS = new Set(["startTime", "endTime"])
-
-/**
- * A saved search made with the time picker stores its window as `startTime` (`gte`/`lte`) conditions
- * inside the filter set. Experiments instead apply `variant.timeRange` as the ClickHouse window, and
- * the filter builder never surfaces `startTime` — so importing those keys verbatim would leave the
- * variant silently constrained by a hidden, un-editable window on top of its own range. Lift the
- * window out of the filter set into an absolute `timeRange`, and drop the time keys from the filters.
- */
-function extractVariantTimeRange(filterSet: FilterSet): { filterSet: FilterSet; timeRange: VariantTimeRange } {
-  let from: string | undefined
-  let to: string | undefined
-  let hasTimeKey = false
-  const rest: Record<string, readonly FilterCondition[]> = {}
-  for (const [key, conditions] of Object.entries(filterSet)) {
-    if (!TIME_FILTER_KEYS.has(key)) {
-      rest[key] = conditions
-      continue
-    }
-    hasTimeKey = true
-    for (const condition of conditions) {
-      if (typeof condition.value !== "string") continue
-      if (condition.op === "gte" || condition.op === "gt") from ??= condition.value
-      else if (condition.op === "lte" || condition.op === "lt") to ??= condition.value
-    }
-  }
-  if (!hasTimeKey) return { filterSet, timeRange: null }
-  const timeRange: VariantTimeRange =
-    from !== undefined ? { type: "absolute", fromIso: from, toIso: to ?? new Date().toISOString() } : null
-  return { filterSet: rest, timeRange }
-}
 
 /** Rename a single variant. */
 export function VariantRenameModal({

--- a/packages/sdk/python/CHANGELOG.md
+++ b/packages/sdk/python/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] - 2026-07-14
+
+### Added
+
+- `client.experiments` — manage project experiments that compare two or more variants against a baseline: `list`, `create`, `get`, `update`, `delete`. Each variant is a population defined by a `filter_set`, an optional search `query`, and a `time_range`; exactly one variant carries the `baseline` flag. `client.experiments.get` returns the full comparison — per-variant metrics grouped by entity (`sessions`, `users`, `tools`, `signals`, `behaviours`), where every metric is a `{ "value": ..., "delta": ... }` pair whose `delta` is the signed change versus the baseline (`None` on the baseline variant itself). `tools`, `signals`, and `behaviours` also carry a `top` ranked list.
+
 ## [9.0.0] - 2026-07-10
 
 ### Changed (breaking)

--- a/packages/sdk/typescript/CHANGELOG.md
+++ b/packages/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] - 2026-07-14
+
+### Added
+
+- `client.experiments` — manage project experiments that compare two or more variants against a baseline: `list`, `create`, `get`, `update`, `delete`. Each variant is a population defined by a `filterSet`, an optional search `query`, and a `timeRange`; exactly one variant carries the `baseline` flag. `client.experiments.get` returns the full comparison — per-variant metrics grouped by entity (`sessions`, `users`, `tools`, `signals`, `behaviours`), where every metric is a `{ value, delta }` pair whose `delta` is the signed change versus the baseline (`null` on the baseline variant itself). `tools`, `signals`, and `behaviours` also carry a `top` ranked list.
+
 ## [9.0.0] - 2026-07-10
 
 ### Changed (breaking)


### PR DESCRIPTION
Follow-up UX work on the experiments feature (builds on #4017). Three ways to spin up an experiment faster, plus the missing SDK changelog entries.

## Create an experiment from a search

- **"Compare this search" toggle** in the save-search modal: on save (alongside the optional monitor), creates an experiment with the search as the baseline variant + one default variant, then redirects to it.
- **Saved-search selector rows** gain **Monitor** and **Compare** actions next to Rename/Remove (order: Monitor, Compare, Rename, Remove), shown in a hover overlay panel with a solid background that fades the row's name underneath. Monitor opens the pre-scoped monitor modal; Compare opens a confirmation modal before creating.
- Lifted `extractVariantTimeRange` into a shared web helper so the search's `startTime` window becomes the variant's `timeRange` (not a hidden filter), reused by the variant-import modal and both create-from-search paths.

## Creation presets

New **Preset** card-selector in the experiment create modal (below Description), matching the monitor modal's metric-card style. Always one selected; default **Custom**. Each preset seeds a variant set:

| Preset | Variants |
| --- | --- |
| **Custom** | Domain default (baseline + one empty variant). |
| **A/B Test** | `Variant A` (baseline, tag `<slug>-A`) / `Variant B` (tag `<slug>-B`) — slug of the experiment name, since tags can't contain spaces. |
| **Versions** | `Current version` (baseline, `version-A`) + `Version B/C/D` (`version-B..D`). |
| **Seasonal** | `Winter` (baseline) / `Spring` / `Summer` / `Fall`, each with the most recently completed meteorological season as an absolute time range. |
| **Failures** | `Successful sessions` (baseline, errorCount ≤ 0) vs `Failed sessions` (errorCount ≥ 1). |
| **Outliers** | `Normal sessions` (baseline) vs `Longer` (duration p99), `Costlier` (cost p99), `Slower` (ttft p99) via `gtePercentile`. |

`useCreateExperiment` now forwards an optional `variants` array. Every preset's filters (tags, errorCount, `gtePercentile`) are resolved by the same `sessions` stream the metrics reader uses, so presets produce working comparisons, not just schema-valid records.

## SDK changelogs

Added the `9.1.0` entries (TypeScript + Python) documenting the experiments API surface — the versions were already bumped in #4017 but the changelog entries were missing.

## Verification

- `pnpm --filter @app/web typecheck` clean; Biome clean; pre-commit knip passed.
- Confirmed the variant-metrics reader resolves the preset filters end-to-end (`sessions` stream `buildInner` runs `resolvePercentileFilters`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)