### PR TITLE
feat(spans): support GenAI memory operation spans (Phase 0, LAT-729)

### DIFF
--- a/apps/design-system/src/routes/$component.tsx
+++ b/apps/design-system/src/routes/$component.tsx
@@ -15,6 +15,7 @@ import {
   HistogramSkeleton,
   Input,
   Label,
+  MasterDetail,
   RichTextEditor,
   Status,
   Text,
@@ -150,6 +151,24 @@ const COMPONENT_REGISTRY: Record<string, ComponentEntry> = {
       ],
     },
     Demo: FormsDemo,
+  },
+  "master-detail": {
+    title: "Master detail",
+    description: "Two-pane list and content layout with a selectable rail.",
+    usage: {
+      description:
+        "Pass items for the rail and renderDetail for the right pane. Selection is uncontrolled unless you pass selectedKey. Set a height via className so the panes scroll.",
+      lines: [
+        'import { MasterDetail } from "@repo/ui"',
+        "",
+        "<MasterDetail",
+        '  className="h-72"',
+        '  items={[{ key: "1", label: "user/preferences" }]}',
+        "  renderDetail={(key) => <Text.H5>{details[key]}</Text.H5>}",
+        "/>",
+      ],
+    },
+    Demo: MasterDetailDemo,
   },
   "rich-text-editor": {
     title: "Rich text editor",
@@ -431,6 +450,80 @@ function StatusDemo() {
         <Status label="Destructive" variant="destructive" />
       </div>
     </ComponentDemoSection>
+  )
+}
+
+function MasterDetailDemo() {
+  const details: Record<string, string> = {
+    "1": "The user prefers dark mode and concise responses.",
+    "2": "Europe/Madrid (UTC+1).",
+    "3": "Currently working on the memory-observability feature.",
+  }
+  const items = [
+    { key: "1", label: "user/preferences" },
+    { key: "2", label: "user/timezone" },
+    { key: "3", label: "user/projects" },
+  ]
+  const scored = [
+    {
+      key: "1",
+      label: "mem_9f2a",
+      trailing: (
+        <Badge variant="secondary" size="small">
+          0.95
+        </Badge>
+      ),
+    },
+    {
+      key: "2",
+      label: "mem_1c04",
+      trailing: (
+        <Badge variant="secondary" size="small">
+          0.82
+        </Badge>
+      ),
+    },
+    {
+      key: "3",
+      label: "mem_77be",
+      trailing: (
+        <Badge variant="secondary" size="small">
+          0.61
+        </Badge>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <ComponentDemoSection
+        title="List and detail"
+        description="Selectable rail on the left, the selected item's content on the right."
+        frameClassName="block"
+      >
+        <div className="mx-auto w-full max-w-2xl">
+          <MasterDetail className="h-64" items={items} renderDetail={(key) => <Text.H5>{details[key]}</Text.H5>} />
+        </div>
+      </ComponentDemoSection>
+      <ComponentDemoSection
+        title="Header and trailing"
+        description="Optional header bar and per-row trailing content, e.g. a relevance score."
+        frameClassName="block"
+      >
+        <div className="mx-auto w-full max-w-2xl">
+          <MasterDetail
+            className="h-64"
+            header={
+              <div className="bg-secondary px-3 py-2">
+                <Text.H6 color="foregroundMuted">Search results</Text.H6>
+              </div>
+            }
+            items={scored}
+            renderDetail={(key) => <Text.H5>Content for {key}</Text.H5>}
+          />
+        </div>
+      </ComponentDemoSection>
+    </>
   )
 }
 

--- a/apps/design-system/src/routes/$component.tsx
+++ b/apps/design-system/src/routes/$component.tsx
@@ -502,7 +502,15 @@ function MasterDetailDemo() {
         frameClassName="block"
       >
         <div className="mx-auto w-full max-w-2xl">
-          <MasterDetail className="h-64" items={items} renderDetail={(key) => <Text.H5>{details[key]}</Text.H5>} />
+          <MasterDetail
+            className="h-64"
+            items={items}
+            renderDetail={(key) => (
+              <div className="p-3">
+                <Text.H5>{details[key]}</Text.H5>
+              </div>
+            )}
+          />
         </div>
       </ComponentDemoSection>
       <ComponentDemoSection
@@ -519,7 +527,11 @@ function MasterDetailDemo() {
               </div>
             }
             items={scored}
-            renderDetail={(key) => <Text.H5>Content for {key}</Text.H5>}
+            renderDetail={(key) => (
+              <div className="p-3">
+                <Text.H5>Content for {key}</Text.H5>
+              </div>
+            )}
           />
         </div>
       </ComponentDemoSection>

--- a/apps/design-system/src/routes/-components/nav-config.ts
+++ b/apps/design-system/src/routes/-components/nav-config.ts
@@ -41,6 +41,7 @@ export const DESIGN_SYSTEM_NAV: DesignSystemNavSection[] = [
       { label: "Date range picker", to: "/date-range-picker" },
       { label: "Forms", to: "/forms" },
       { label: "Infinite table", to: "/infinite-table" },
+      { label: "Master detail", to: "/master-detail" },
       { label: "Rich text editor", to: "/rich-text-editor" },
       { label: "Status", to: "/status" },
       { label: "Charts", to: "/charts" },

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -41,7 +41,7 @@ export function SessionSpansTab({
   readonly onOpenTrace: (traceId: string, options?: OpenTraceOptions) => void
   readonly isActive: boolean
 }) {
-  const { filters, clearFilters, toggleErrors, toggleTools, selectModel } = useSpanFilters()
+  const { filters, clearFilters, toggleErrors, toggleTools, toggleMemory, selectModel } = useSpanFilters()
   const {
     data: spans,
     isLoading,
@@ -145,6 +145,7 @@ export function SessionSpansTab({
           filters={filters}
           onToggleErrors={toggleErrors}
           onToggleTools={toggleTools}
+          onToggleMemory={toggleMemory}
           onSelectModel={selectModel}
           onClearFilters={clearFilters}
         />
@@ -164,6 +165,7 @@ export function SessionSpansTab({
         filters={filters}
         onToggleErrors={toggleErrors}
         onToggleTools={toggleTools}
+        onToggleMemory={toggleMemory}
         onSelectModel={selectModel}
         onClearFilters={clearFilters}
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans.test.ts
@@ -137,7 +137,7 @@ describe("session span groups", () => {
       [],
     )
 
-    const filtered = filterSessionSpanGroups(groups, { errors: true, tools: false, model: "" })
+    const filtered = filterSessionSpanGroups(groups, { errors: true, tools: false, memory: false, model: "" })
 
     expect(filtered).toHaveLength(1)
     expect(filtered[0]?.traceId).toBe("trace-a")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -24,7 +24,7 @@ export function SpansTab({
   readonly onSelectSpan: (spanId: string) => void
   readonly isActive: boolean
 }) {
-  const { filters, clearFilters, toggleErrors, toggleTools, selectModel } = useSpanFilters()
+  const { filters, clearFilters, toggleErrors, toggleTools, toggleMemory, selectModel } = useSpanFilters()
   // Shares the cached spans collection with the Trace tab's fetch (same key → one fetch).
   const { data: spans, isLoading } = useSpansByTraceCollection({ projectId, traceId, startTimeFrom, startTimeTo })
   const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
@@ -94,6 +94,7 @@ export function SpansTab({
           filters={filters}
           onToggleErrors={toggleErrors}
           onToggleTools={toggleTools}
+          onToggleMemory={toggleMemory}
           onSelectModel={selectModel}
           onClearFilters={clearFilters}
         />
@@ -111,6 +112,7 @@ export function SpansTab({
         filters={filters}
         onToggleErrors={toggleErrors}
         onToggleTools={toggleTools}
+        onToggleMemory={toggleMemory}
         onSelectModel={selectModel}
         onClearFilters={clearFilters}
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/memory-operations.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/memory-operations.ts
@@ -1,0 +1,17 @@
+import type { Operation } from "@domain/spans"
+
+const MEMORY_OPERATIONS = [
+  "create_memory",
+  "update_memory",
+  "upsert_memory",
+  "delete_memory",
+  "search_memory",
+  "create_memory_store",
+  "delete_memory_store",
+] as const satisfies readonly Operation[]
+
+const MEMORY_OPERATION_SET: ReadonlySet<string> = new Set(MEMORY_OPERATIONS)
+
+export function isMemoryOperation(operation: string): boolean {
+  return MEMORY_OPERATION_SET.has(operation)
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
@@ -15,9 +15,17 @@ export function isNonEmptyJson(json: string): boolean {
   return json !== "" && json !== "[]" && json !== "{}" && json !== "null"
 }
 
-export function JsonBlock({ value }: { readonly value: unknown }) {
+export function JsonBlock({
+  value,
+  className = "bg-secondary",
+  fillHeight = false,
+}: {
+  readonly value: unknown
+  readonly className?: string
+  readonly fillHeight?: boolean
+}) {
   const formatted = useMemo(() => JSON.stringify(value, null, 2), [value])
-  return <CodeBlock value={formatted} className="bg-secondary" />
+  return <CodeBlock value={formatted} className={className} fillHeight={fillHeight} />
 }
 
 export function StatusBadge({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
@@ -1,24 +1,15 @@
 import { CodeBlock, DetailSection, DetailSummary, Text } from "@repo/ui"
 import { BracesIcon, DatabaseIcon } from "lucide-react"
-import { useMemo } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
 import { isMemoryOperation } from "../memory-operations.ts"
-import { JsonBlock } from "./helpers.tsx"
+import { MemoryRecordsView } from "./memory-records.tsx"
+import { parseMemoryRecords } from "./memory-records-parse.ts"
 
 const STORE_ID_ATTR = "gen_ai.memory.store.id"
 const RECORD_ID_ATTR = "gen_ai.memory.record.id"
 const RECORD_COUNT_ATTR = "gen_ai.memory.record.count"
 const QUERY_TEXT_ATTR = "gen_ai.memory.query.text"
 const RECORDS_ATTR = "gen_ai.memory.records"
-
-function tryParseJson(value: string): unknown | null {
-  if (!value) return null
-  try {
-    return JSON.parse(value)
-  } catch {
-    return null
-  }
-}
 
 export function isMemoryOperationSpan(span: SpanDetailRecord): boolean {
   return (
@@ -35,7 +26,8 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
   const queryText = span.attrString[QUERY_TEXT_ATTR]
   const recordCount = span.attrInt[RECORD_COUNT_ATTR] ?? span.attrString[RECORD_COUNT_ATTR]
   const recordsRaw = span.attrString[RECORDS_ATTR] ?? ""
-  const parsedRecords = useMemo(() => tryParseJson(recordsRaw), [recordsRaw])
+  const records = parseMemoryRecords(recordsRaw)
+  const isSearch = span.operation === "search_memory"
 
   const items = [
     ...(storeId ? [{ label: "Store", value: storeId, copyable: true }] : []),
@@ -43,13 +35,16 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
     ...(recordCount !== undefined ? [{ label: "Records", value: String(recordCount) }] : []),
   ]
 
+  // For a search with rendered records the query heads the records view instead, so it isn't shown twice.
+  const showQueryHere = !!queryText && !(records && isSearch)
+
   return (
     <>
-      {(items.length > 0 || queryText) && (
+      {(items.length > 0 || showQueryHere) && (
         <DetailSection icon={<DatabaseIcon className="w-4 h-4" />} label="Memory">
           <div className="flex flex-col gap-2">
             {items.length > 0 && <DetailSummary items={items} />}
-            {queryText && (
+            {showQueryHere && (
               <div className="flex flex-col gap-1">
                 <Text.H6 color="foregroundMuted">Query</Text.H6>
                 <CodeBlock value={queryText} className="bg-secondary" />
@@ -59,9 +54,13 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
         </DetailSection>
       )}
 
-      <DetailSection icon={<BracesIcon className="w-4 h-4" />} label="Records">
-        {parsedRecords !== null ? (
-          <JsonBlock value={parsedRecords} />
+      <DetailSection
+        icon={<BracesIcon className="w-4 h-4" />}
+        label="Records"
+        contentClassName="max-h-none overflow-visible pl-0"
+      >
+        {records ? (
+          <MemoryRecordsView records={records} isSearch={isSearch} {...(queryText ? { queryText } : {})} />
         ) : recordsRaw ? (
           <CodeBlock value={recordsRaw} className="bg-secondary" />
         ) : (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
@@ -1,5 +1,6 @@
 import { CodeBlock, DetailSection, DetailSummary, Text } from "@repo/ui"
-import { BracesIcon, DatabaseIcon } from "lucide-react"
+import { DatabaseIcon } from "lucide-react"
+import type { ReactNode } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
 import { isMemoryOperation } from "../memory-operations.ts"
 import { MemoryRecordsView } from "./memory-records.tsx"
@@ -20,6 +21,15 @@ export function isMemoryOperationSpan(span: SpanDetailRecord): boolean {
   )
 }
 
+function Subsection({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      {children}
+    </div>
+  )
+}
+
 export function MemoryOperationSection({ span }: { readonly span: SpanDetailRecord }) {
   const storeId = span.attrString[STORE_ID_ATTR]
   const recordId = span.attrString[RECORD_ID_ATTR]
@@ -28,45 +38,41 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
   const recordsRaw = span.attrString[RECORDS_ATTR] ?? ""
   const records = parseMemoryRecords(recordsRaw)
   const isSearch = span.operation === "search_memory"
+  const recordsLabel = isSearch ? "Results" : "Records"
 
-  const items = [
-    ...(storeId ? [{ label: "Store", value: storeId, copyable: true }] : []),
-    ...(recordId ? [{ label: "Record", value: recordId, copyable: true }] : []),
-    ...(recordCount !== undefined ? [{ label: "Records", value: String(recordCount) }] : []),
-  ]
-
-  // For a search with rendered records the query heads the records view instead, so it isn't shown twice.
-  const showQueryHere = !!queryText && !(records && isSearch)
+  // Store and count ride the records header; the identity fields only surface as
+  // summary fields when there's no records table to carry them.
+  const items = records
+    ? []
+    : [
+        ...(storeId ? [{ label: "Store", value: storeId, copyable: true }] : []),
+        ...(recordId ? [{ label: "Record", value: recordId, copyable: true }] : []),
+        ...(recordCount !== undefined ? [{ label: "Records", value: String(recordCount) }] : []),
+      ]
 
   return (
-    <>
-      {(items.length > 0 || showQueryHere) && (
-        <DetailSection icon={<DatabaseIcon className="w-4 h-4" />} label="Memory">
-          <div className="flex flex-col gap-2">
-            {items.length > 0 && <DetailSummary items={items} />}
-            {showQueryHere && (
-              <div className="flex flex-col gap-1">
-                <Text.H6 color="foregroundMuted">Query</Text.H6>
-                <CodeBlock value={queryText} className="bg-secondary" />
-              </div>
-            )}
-          </div>
-        </DetailSection>
-      )}
-
-      <DetailSection
-        icon={<BracesIcon className="w-4 h-4" />}
-        label="Records"
-        contentClassName="max-h-none overflow-visible pl-0"
-      >
-        {records ? (
-          <MemoryRecordsView records={records} isSearch={isSearch} {...(queryText ? { queryText } : {})} />
-        ) : recordsRaw ? (
-          <CodeBlock value={recordsRaw} className="bg-secondary" />
-        ) : (
-          <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
+    <DetailSection
+      icon={<DatabaseIcon className="w-4 h-4" />}
+      label="Memory"
+      contentClassName="max-h-none overflow-visible"
+    >
+      <div className="flex flex-col gap-3">
+        {items.length > 0 && <DetailSummary items={items} />}
+        {queryText && (
+          <Subsection label="Query">
+            <CodeBlock value={queryText} className="bg-secondary" />
+          </Subsection>
         )}
-      </DetailSection>
-    </>
+        <Subsection label={recordsLabel}>
+          {records ? (
+            <MemoryRecordsView records={records} isSearch={isSearch} {...(storeId ? { storeId } : {})} />
+          ) : recordsRaw ? (
+            <CodeBlock value={recordsRaw} className="bg-secondary" />
+          ) : (
+            <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
+          )}
+        </Subsection>
+      </div>
+    </DetailSection>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
@@ -1,0 +1,73 @@
+import { CodeBlock, DetailSection, DetailSummary, Text } from "@repo/ui"
+import { BracesIcon, DatabaseIcon } from "lucide-react"
+import { useMemo } from "react"
+import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
+import { isMemoryOperation } from "../memory-operations.ts"
+import { JsonBlock } from "./helpers.tsx"
+
+const STORE_ID_ATTR = "gen_ai.memory.store.id"
+const RECORD_ID_ATTR = "gen_ai.memory.record.id"
+const RECORD_COUNT_ATTR = "gen_ai.memory.record.count"
+const QUERY_TEXT_ATTR = "gen_ai.memory.query.text"
+const RECORDS_ATTR = "gen_ai.memory.records"
+
+function tryParseJson(value: string): unknown | null {
+  if (!value) return null
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+export function isMemoryOperationSpan(span: SpanDetailRecord): boolean {
+  return (
+    isMemoryOperation(span.operation) ||
+    !!span.attrString[STORE_ID_ATTR] ||
+    !!span.attrString[RECORD_ID_ATTR] ||
+    !!span.attrString[RECORDS_ATTR]
+  )
+}
+
+export function MemoryOperationSection({ span }: { readonly span: SpanDetailRecord }) {
+  const storeId = span.attrString[STORE_ID_ATTR]
+  const recordId = span.attrString[RECORD_ID_ATTR]
+  const queryText = span.attrString[QUERY_TEXT_ATTR]
+  const recordCount = span.attrInt[RECORD_COUNT_ATTR] ?? span.attrString[RECORD_COUNT_ATTR]
+  const recordsRaw = span.attrString[RECORDS_ATTR] ?? ""
+  const parsedRecords = useMemo(() => tryParseJson(recordsRaw), [recordsRaw])
+
+  const items = [
+    ...(storeId ? [{ label: "Store", value: storeId, copyable: true }] : []),
+    ...(recordId ? [{ label: "Record", value: recordId, copyable: true }] : []),
+    ...(recordCount !== undefined ? [{ label: "Records", value: String(recordCount) }] : []),
+  ]
+
+  return (
+    <>
+      {(items.length > 0 || queryText) && (
+        <DetailSection icon={<DatabaseIcon className="w-4 h-4" />} label="Memory">
+          <div className="flex flex-col gap-2">
+            {items.length > 0 && <DetailSummary items={items} />}
+            {queryText && (
+              <div className="flex flex-col gap-1">
+                <Text.H6 color="foregroundMuted">Query</Text.H6>
+                <CodeBlock value={queryText} className="bg-secondary" />
+              </div>
+            )}
+          </div>
+        </DetailSection>
+      )}
+
+      <DetailSection icon={<BracesIcon className="w-4 h-4" />} label="Records">
+        {parsedRecords !== null ? (
+          <JsonBlock value={parsedRecords} />
+        ) : recordsRaw ? (
+          <CodeBlock value={recordsRaw} className="bg-secondary" />
+        ) : (
+          <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
+        )}
+      </DetailSection>
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records-parse.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records-parse.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { parseMemoryRecords } from "./memory-records-parse.ts"
+
+describe("parseMemoryRecords", () => {
+  it("parses an array of records that carry content", () => {
+    const raw = JSON.stringify([
+      { id: "mem_1", content: "User prefers dark mode", score: 0.95 },
+      { content: { note: "no id, object content" } },
+    ])
+
+    const records = parseMemoryRecords(raw)
+
+    expect(records).toHaveLength(2)
+    expect(records?.[0]).toMatchObject({ id: "mem_1", content: "User prefers dark mode", score: 0.95 })
+    expect(records?.[1]?.content).toEqual({ note: "no id, object content" })
+  })
+
+  it("returns null for an empty payload", () => {
+    expect(parseMemoryRecords("")).toBeNull()
+  })
+
+  it("returns null for invalid JSON", () => {
+    expect(parseMemoryRecords("{not json")).toBeNull()
+  })
+
+  it("returns null for an empty array", () => {
+    expect(parseMemoryRecords("[]")).toBeNull()
+  })
+
+  it("returns null when the payload is a bare object rather than an array", () => {
+    expect(parseMemoryRecords(JSON.stringify({ content: "single, not wrapped" }))).toBeNull()
+  })
+
+  it("returns null when any element is missing content (off-schema)", () => {
+    expect(parseMemoryRecords(JSON.stringify([{ id: "mem_1" }]))).toBeNull()
+    expect(parseMemoryRecords(JSON.stringify([{ content: "ok" }, "not-an-object"]))).toBeNull()
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records-parse.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records-parse.ts
@@ -1,0 +1,28 @@
+export type MemoryRecord = {
+  readonly content: unknown
+  readonly id?: string | null
+  readonly score?: number | null
+  readonly metadata?: Record<string, unknown> | null
+}
+
+function isRecordShape(value: unknown): value is MemoryRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && "content" in value
+}
+
+/**
+ * Parse the `gen_ai.memory.records` payload against the OTEL schema (array of records, each with a
+ * required `content` field). Returns null when the payload is absent or off-schema, so the caller
+ * falls back to rendering the raw payload in a code block.
+ */
+export function parseMemoryRecords(raw: string): MemoryRecord[] | null {
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return null
+  if (!parsed.every(isRecordShape)) return null
+  return parsed as MemoryRecord[]
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
@@ -1,5 +1,5 @@
 import { Badge, CodeBlock, Icon, MasterDetail, type MasterDetailItem, Text } from "@repo/ui"
-import { SearchIcon } from "lucide-react"
+import { DatabaseIcon } from "lucide-react"
 import { JsonBlock } from "./helpers.tsx"
 import type { MemoryRecord } from "./memory-records-parse.ts"
 
@@ -11,14 +11,16 @@ function RecordDetail({ record }: { readonly record: MemoryRecord }) {
   const hasMetadata = !!record.metadata && Object.keys(record.metadata).length > 0
 
   return (
-    <div className="flex flex-col gap-3">
-      {typeof record.content === "string" ? (
-        <CodeBlock value={record.content} className="bg-secondary" />
-      ) : (
-        <JsonBlock value={record.content} />
-      )}
+    <div className="flex h-full flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
+        {typeof record.content === "string" ? (
+          <CodeBlock value={record.content} fillHeight className="h-full rounded-none bg-secondary" />
+        ) : (
+          <JsonBlock value={record.content} fillHeight className="h-full rounded-none bg-secondary" />
+        )}
+      </div>
       {(record.score != null || hasMetadata) && (
-        <div className="flex flex-col gap-2">
+        <div className="flex shrink-0 flex-col gap-2 border-t border-border p-3">
           {record.score != null && (
             <div className="flex flex-row items-center gap-2">
               <Text.H6 color="foregroundMuted">Score</Text.H6>
@@ -37,13 +39,18 @@ function RecordDetail({ record }: { readonly record: MemoryRecord }) {
   )
 }
 
-function SearchQueryHeader({ query }: { readonly query: string }) {
+function RecordsHeader({ storeId, count }: { readonly storeId?: string; readonly count: number }) {
   return (
     <div className="flex flex-row items-center gap-2 bg-secondary px-3 py-2">
-      <Icon icon={SearchIcon} size="xs" color="foregroundMuted" />
-      <Text.H6 color="foregroundMuted" ellipsis noWrap>
-        {query}
-      </Text.H6>
+      <Icon icon={DatabaseIcon} size="xs" color="foregroundMuted" />
+      {storeId ? (
+        <div className="flex min-w-0 flex-1">
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {storeId}
+          </Text.H6>
+        </div>
+      ) : null}
+      <Text.H6 color="foregroundMuted" noWrap>{`(${count})`}</Text.H6>
     </div>
   )
 }
@@ -51,11 +58,11 @@ function SearchQueryHeader({ query }: { readonly query: string }) {
 export function MemoryRecordsView({
   records,
   isSearch,
-  queryText,
+  storeId,
 }: {
   readonly records: readonly MemoryRecord[]
   readonly isSearch: boolean
-  readonly queryText?: string
+  readonly storeId?: string
 }) {
   const ordered =
     isSearch && records.some((record) => record.score != null)
@@ -84,7 +91,7 @@ export function MemoryRecordsView({
         const record = ordered[Number(key)]
         return record ? <RecordDetail record={record} /> : null
       }}
-      {...(isSearch && queryText ? { header: <SearchQueryHeader query={queryText} /> } : {})}
+      header={<RecordsHeader count={ordered.length} {...(storeId ? { storeId } : {})} />}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
@@ -1,0 +1,90 @@
+import { Badge, CodeBlock, Icon, MasterDetail, type MasterDetailItem, Text } from "@repo/ui"
+import { SearchIcon } from "lucide-react"
+import { JsonBlock } from "./helpers.tsx"
+import type { MemoryRecord } from "./memory-records-parse.ts"
+
+function formatScore(score: number): string {
+  return Number.isInteger(score) ? String(score) : score.toFixed(2)
+}
+
+function RecordDetail({ record }: { readonly record: MemoryRecord }) {
+  const hasMetadata = !!record.metadata && Object.keys(record.metadata).length > 0
+
+  return (
+    <div className="flex flex-col gap-3">
+      {typeof record.content === "string" ? (
+        <CodeBlock value={record.content} className="bg-secondary" />
+      ) : (
+        <JsonBlock value={record.content} />
+      )}
+      {(record.score != null || hasMetadata) && (
+        <div className="flex flex-col gap-2">
+          {record.score != null && (
+            <div className="flex flex-row items-center gap-2">
+              <Text.H6 color="foregroundMuted">Score</Text.H6>
+              <Text.H6 color="foreground">{formatScore(record.score)}</Text.H6>
+            </div>
+          )}
+          {hasMetadata && (
+            <div className="flex flex-col gap-1">
+              <Text.H6 color="foregroundMuted">Metadata</Text.H6>
+              <JsonBlock value={record.metadata} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SearchQueryHeader({ query }: { readonly query: string }) {
+  return (
+    <div className="flex flex-row items-center gap-2 bg-secondary px-3 py-2">
+      <Icon icon={SearchIcon} size="xs" color="foregroundMuted" />
+      <Text.H6 color="foregroundMuted" ellipsis noWrap>
+        {query}
+      </Text.H6>
+    </div>
+  )
+}
+
+export function MemoryRecordsView({
+  records,
+  isSearch,
+  queryText,
+}: {
+  readonly records: readonly MemoryRecord[]
+  readonly isSearch: boolean
+  readonly queryText?: string
+}) {
+  const ordered =
+    isSearch && records.some((record) => record.score != null)
+      ? [...records].sort((a, b) => (b.score ?? -Infinity) - (a.score ?? -Infinity))
+      : records
+
+  const items: MasterDetailItem[] = ordered.map((record, index) => ({
+    key: String(index),
+    label: record.id ?? `Record ${index + 1}`,
+    ...(isSearch && record.score != null
+      ? {
+          trailing: (
+            <Badge variant="secondary" size="small">
+              {formatScore(record.score)}
+            </Badge>
+          ),
+        }
+      : {}),
+  }))
+
+  return (
+    <MasterDetail
+      className="h-72"
+      items={items}
+      renderDetail={(key) => {
+        const record = ordered[Number(key)]
+        return record ? <RecordDetail record={record} /> : null
+      }}
+      {...(isSearch && queryText ? { header: <SearchQueryHeader query={queryText} /> } : {})}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
@@ -6,6 +6,7 @@ import { formatDuration } from "../span-tree/tree-utils.ts"
 import { mergeAttributes, StatusBadge } from "./helpers.tsx"
 import { IdentifiersSection } from "./identifiers-section.tsx"
 import { LlmSections } from "./llm-sections.tsx"
+import { isMemoryOperationSpan, MemoryOperationSection } from "./memory-operation-section.tsx"
 import { OperationalMetadataSection } from "./operational-metadata-section.tsx"
 import { RawTelemetrySections } from "./raw-telemetry-sections.tsx"
 import { isToolExecutionSpan, ToolExecutionSection } from "./tool-execution-section.tsx"
@@ -98,6 +99,7 @@ export function SpanDetailContent({ span }: { readonly span: SpanDetailRecord })
     [span],
   )
   const isToolSpan = useMemo(() => isToolExecutionSpan(span), [span])
+  const isMemorySpan = useMemo(() => isMemoryOperationSpan(span), [span])
 
   return (
     <div className="flex flex-col gap-6">
@@ -142,6 +144,9 @@ export function SpanDetailContent({ span }: { readonly span: SpanDetailRecord })
 
       {/* ── Tool execution ── */}
       {isToolSpan && <ToolExecutionSection span={span} />}
+
+      {/* ── Memory operation ── */}
+      {isMemorySpan && <MemoryOperationSection span={span} />}
 
       {/* ── Operational metadata ── */}
       <OperationalMetadataSection span={span} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters-bar.tsx
@@ -1,6 +1,6 @@
 import { cn, Icon, Select, type SelectOption, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
-import { AlertTriangleIcon, WrenchIcon, XIcon } from "lucide-react"
+import { AlertTriangleIcon, DatabaseIcon, WrenchIcon, XIcon } from "lucide-react"
 import type { ReactNode } from "react"
 import type { SpanRecord } from "../../../../../../../../domains/spans/spans.functions.ts"
 import { collectSpanModels, countMatchingSpans, hasActiveSpanFilters, type SpanFilters } from "./span-filters.ts"
@@ -10,6 +10,7 @@ type SpanFiltersBarProps = {
   readonly filters: SpanFilters
   readonly onToggleErrors: () => void
   readonly onToggleTools: () => void
+  readonly onToggleMemory: () => void
   readonly onSelectModel: (model: string) => void
   readonly onClearFilters: () => void
 }
@@ -51,6 +52,7 @@ export function SpanFiltersBar({
   filters,
   onToggleErrors,
   onToggleTools,
+  onToggleMemory,
   onSelectModel,
   onClearFilters,
 }: SpanFiltersBarProps) {
@@ -86,6 +88,17 @@ export function SpanFiltersBar({
           >
             <Icon icon={WrenchIcon} size="xs" color={filters.tools ? "accentForeground" : "foregroundMuted"} />
             <span>Tools</span>
+          </FilterToggle>
+
+          <FilterToggle
+            active={filters.memory}
+            activeClassName="border-warning-muted-foreground/30 bg-warning-muted text-warning-muted-foreground"
+            inactiveClassName="border-border bg-secondary text-muted-foreground hover:bg-muted"
+            onClick={onToggleMemory}
+            ariaLabel={filters.memory ? "Show all spans" : "Show only memory spans"}
+          >
+            <Icon icon={DatabaseIcon} size="xs" color={filters.memory ? "warningMutedForeground" : "foregroundMuted"} />
+            <span>Memory</span>
           </FilterToggle>
 
           {models.length > 0 ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.test.ts
@@ -41,8 +41,8 @@ function makeSpan(partial: Partial<SpanRecord> & Pick<SpanRecord, "spanId">): Sp
 describe("span filters", () => {
   it("returns all spans when no filters are active", () => {
     const spans = [makeSpan({ spanId: "a" }), makeSpan({ spanId: "b" })]
-    expect(hasActiveSpanFilters({ errors: false, tools: false, model: "" })).toBe(false)
-    expect(filterSpansWithAncestors(spans, { errors: false, tools: false, model: "" })).toEqual(spans)
+    expect(hasActiveSpanFilters({ errors: false, tools: false, memory: false, model: "" })).toBe(false)
+    expect(filterSpansWithAncestors(spans, { errors: false, tools: false, memory: false, model: "" })).toEqual(spans)
   })
 
   it("filters by model and keeps ancestors", () => {
@@ -52,9 +52,14 @@ describe("span filters", () => {
       makeSpan({ spanId: "other", parentSpanId: "root", model: "claude-fable-5" }),
     ]
 
-    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, model: "claude-opus-4-8" })
+    const filtered = filterSpansWithAncestors(spans, {
+      errors: false,
+      tools: false,
+      memory: false,
+      model: "claude-opus-4-8",
+    })
     expect(filtered.map((span) => span.spanId)).toEqual(["root", "child"])
-    expect(countMatchingSpans(spans, { errors: false, tools: false, model: "claude-opus-4-8" })).toBe(1)
+    expect(countMatchingSpans(spans, { errors: false, tools: false, memory: false, model: "claude-opus-4-8" })).toBe(1)
   })
 
   it("filters by errors and tools together", () => {
@@ -64,8 +69,20 @@ describe("span filters", () => {
       makeSpan({ spanId: "chat-err", operation: "chat", statusCode: "error" }),
     ]
 
-    const filtered = filterSpansWithAncestors(spans, { errors: true, tools: true, model: "" })
+    const filtered = filterSpansWithAncestors(spans, { errors: true, tools: true, memory: false, model: "" })
     expect(filtered.map((span) => span.spanId)).toEqual(["tool-err"])
+  })
+
+  it("filters by memory operation and keeps ancestors", () => {
+    const spans = [
+      makeSpan({ spanId: "root", parentSpanId: "" }),
+      makeSpan({ spanId: "mem", parentSpanId: "root", operation: "update_memory" }),
+      makeSpan({ spanId: "chat", parentSpanId: "root", operation: "chat" }),
+    ]
+
+    const filtered = filterSpansWithAncestors(spans, { errors: false, tools: false, memory: true, model: "" })
+    expect(filtered.map((span) => span.spanId)).toEqual(["root", "mem"])
+    expect(countMatchingSpans(spans, { errors: false, tools: false, memory: true, model: "" })).toBe(1)
   })
 
   it("collects unique sorted models", () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-filters.ts
@@ -1,24 +1,28 @@
 import type { SpanRecord } from "../../../../../../../../domains/spans/spans.functions.ts"
+import { isMemoryOperation } from "./memory-operations.ts"
 
 export type SpanFilters = {
   readonly errors: boolean
   readonly tools: boolean
+  readonly memory: boolean
   readonly model: string
 }
 
 export const EMPTY_SPAN_FILTERS: SpanFilters = {
   errors: false,
   tools: false,
+  memory: false,
   model: "",
 }
 
 export function hasActiveSpanFilters(filters: SpanFilters): boolean {
-  return filters.errors || filters.tools || filters.model.length > 0
+  return filters.errors || filters.tools || filters.memory || filters.model.length > 0
 }
 
 function spanMatchesFilters(span: SpanRecord, filters: SpanFilters): boolean {
   if (filters.errors && span.statusCode !== "error") return false
   if (filters.tools && span.operation !== "execute_tool") return false
+  if (filters.memory && !isMemoryOperation(span.operation)) return false
   if (filters.model.length > 0 && span.model !== filters.model) return false
   return true
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
@@ -1,3 +1,5 @@
+import { isMemoryOperation } from "../memory-operations.ts"
+
 /** Horizontal inset for waterfall bars & time labels so bars don’t touch column edges (matches `px-3`). */
 export const WATERFALL_H_INSET_PX = 12
 
@@ -15,6 +17,7 @@ export function statusBarColor(statusCode: string, operation: string): string {
   if (operation === "invoke_agent") return "bg-primary"
   if (operation === "chat") return "bg-primary/40"
   if (operation === "execute_tool") return "bg-success/40"
+  if (isMemoryOperation(operation)) return "bg-warning/60"
   return "bg-muted-foreground/40"
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/span-icon.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/span-icon.tsx
@@ -4,6 +4,8 @@ import {
   ArrowUpDownIcon,
   BotIcon,
   BoxesIcon,
+  BrainIcon,
+  DatabaseIcon,
   LinkIcon,
   ListTodoIcon,
   type LucideProps,
@@ -37,6 +39,13 @@ const OPERATION_ICON: Record<string, React.ComponentType<LucideProps>> = {
   retrieval: SearchIcon,
   guardrail: ShieldCheckIcon,
   evaluator: ScaleIcon,
+  create_memory: BrainIcon,
+  update_memory: BrainIcon,
+  upsert_memory: BrainIcon,
+  delete_memory: BrainIcon,
+  search_memory: SearchIcon,
+  create_memory_store: DatabaseIcon,
+  delete_memory_store: DatabaseIcon,
 } satisfies Record<Exclude<Operation, "unspecified" | (string & {})>, React.ComponentType<LucideProps>>
 
 export function SpanIcon({ span }: { readonly span: SpanRecord }) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/use-span-filters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/use-span-filters.ts
@@ -4,13 +4,15 @@ import { EMPTY_SPAN_FILTERS, type SpanFilters } from "./span-filters.ts"
 export function useSpanFilters() {
   const [errors, setErrors] = useParamState("spanErrors", false)
   const [tools, setTools] = useParamState("spanTools", false)
+  const [memory, setMemory] = useParamState("spanMemory", false)
   const [model, setModel] = useParamState("spanModel", "")
 
-  const filters: SpanFilters = { errors, tools, model }
+  const filters: SpanFilters = { errors, tools, memory, model }
 
   function setFilters(next: SpanFilters) {
     setErrors(next.errors)
     setTools(next.tools)
+    setMemory(next.memory)
     setModel(next.model)
   }
 
@@ -34,6 +36,7 @@ export function useSpanFilters() {
     openWithModel,
     toggleErrors: () => setErrors(!errors),
     toggleTools: () => setTools(!tools),
+    toggleMemory: () => setMemory(!memory),
     selectModel: (nextModel: string) => setModel(nextModel),
   }
 }

--- a/packages/domain/spans/src/entities/span.ts
+++ b/packages/domain/spans/src/entities/span.ts
@@ -42,11 +42,34 @@ export const operationSchema = z.union([
     "retrieval",
     "guardrail",
     "evaluator",
+    "create_memory",
+    "update_memory",
+    "upsert_memory",
+    "delete_memory",
+    "search_memory",
+    "create_memory_store",
+    "delete_memory_store",
     "unspecified",
   ]),
   z.string(),
 ])
 export type Operation = z.infer<typeof operationSchema>
+
+export const MEMORY_OPERATIONS = [
+  "create_memory",
+  "update_memory",
+  "upsert_memory",
+  "delete_memory",
+  "search_memory",
+  "create_memory_store",
+  "delete_memory_store",
+] as const satisfies readonly Operation[]
+
+const MEMORY_OPERATIONS_SET: ReadonlySet<string> = new Set(MEMORY_OPERATIONS)
+
+export function isMemoryOperation(operation: string): boolean {
+  return MEMORY_OPERATIONS_SET.has(operation)
+}
 
 /**
  * Span — the listing/query shape returned by list and trace queries.

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -44,6 +44,8 @@ export { sessionDetailSchema, sessionSchema } from "./entities/session.ts"
 export type { SessionSearchMatch } from "./entities/session-search-match.ts"
 export type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode, ToolDefinition } from "./entities/span.ts"
 export {
+  isMemoryOperation,
+  MEMORY_OPERATIONS,
   operationSchema,
   spanDetailSchema,
   spanKindSchema,

--- a/packages/domain/spans/src/otlp/any-value.ts
+++ b/packages/domain/spans/src/otlp/any-value.ts
@@ -1,0 +1,28 @@
+import type { OtlpAnyValue } from "./types.ts"
+
+/**
+ * Flatten an OTLP `AnyValue` into plain JS, recursing through `arrayValue`/`kvlistValue`.
+ * Shared by the transform (attr_string capture), the metadata enricher, and the GenAI content parser.
+ */
+export function anyValueToPlain(value: OtlpAnyValue | undefined): unknown {
+  if (!value) return undefined
+  if (value.stringValue !== undefined) return value.stringValue
+  if (value.boolValue !== undefined) return value.boolValue
+  if (value.intValue !== undefined) return Number(value.intValue)
+  if (value.doubleValue !== undefined) return value.doubleValue
+  if (value.arrayValue?.values) return value.arrayValue.values.map(anyValueToPlain)
+  if (value.kvlistValue?.values) {
+    const result: Record<string, unknown> = {}
+    for (const entry of value.kvlistValue.values) {
+      const plain = anyValueToPlain(entry.value)
+      // Plain assignment of a `__proto__` key hijacks the object's prototype and drops the value; define it as an own prop.
+      if (entry.key === "__proto__") {
+        Object.defineProperty(result, entry.key, { value: plain, enumerable: true, writable: true, configurable: true })
+      } else {
+        result[entry.key] = plain
+      }
+    }
+    return result
+  }
+  return undefined
+}

--- a/packages/domain/spans/src/otlp/content/genai.ts
+++ b/packages/domain/spans/src/otlp/content/genai.ts
@@ -5,7 +5,8 @@
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
 import { Provider, safeTranslate } from "rosetta-ai"
 import type { ToolDefinition } from "../../entities/span.ts"
-import type { OtlpAnyValue, OtlpKeyValue } from "../types.ts"
+import { anyValueToPlain } from "../any-value.ts"
+import type { OtlpKeyValue } from "../types.ts"
 import { parseGenAIDeprecated } from "./genai_deprecated.ts"
 import type { ParsedContent } from "./index.ts"
 import { toToolDefinition } from "./utils.ts"
@@ -13,23 +14,6 @@ import { parseVercelOutput } from "./vercel.ts"
 
 function messagesHaveContent(messages: readonly GenAIMessage[]): boolean {
   return messages.some((m) => Array.isArray(m.parts) && m.parts.length > 0)
-}
-
-function anyValueToJs(value: OtlpAnyValue | undefined): unknown {
-  if (!value) return undefined
-  if (value.stringValue !== undefined) return value.stringValue
-  if (value.boolValue !== undefined) return value.boolValue
-  if (value.intValue !== undefined) return Number(value.intValue)
-  if (value.doubleValue !== undefined) return value.doubleValue
-  if (value.arrayValue?.values) return value.arrayValue.values.map(anyValueToJs)
-  if (value.kvlistValue?.values) {
-    const obj: Record<string, unknown> = {}
-    for (const kv of value.kvlistValue.values) {
-      obj[kv.key] = anyValueToJs(kv.value)
-    }
-    return obj
-  }
-  return undefined
 }
 
 function extractJsonAttr(attrs: readonly OtlpKeyValue[], key: string): unknown {
@@ -43,7 +27,7 @@ function extractJsonAttr(attrs: readonly OtlpKeyValue[], key: string): unknown {
     }
   }
   if (kv.value.arrayValue || kv.value.kvlistValue) {
-    return anyValueToJs(kv.value)
+    return anyValueToPlain(kv.value)
   }
   return undefined
 }

--- a/packages/domain/spans/src/otlp/resolvers/enrichment.ts
+++ b/packages/domain/spans/src/otlp/resolvers/enrichment.ts
@@ -1,3 +1,4 @@
+import { anyValueToPlain } from "../any-value.ts"
 import type { OtlpKeyValue } from "../types.ts"
 import { type Candidate, fromString, fromStringArray } from "./utils.ts"
 
@@ -42,23 +43,6 @@ function toStringValue(val: unknown): string | undefined {
   return JSON.stringify(val)
 }
 
-function otlpValueToPlain(value: OtlpKeyValue["value"]): unknown {
-  if (!value) return undefined
-  if (value.stringValue !== undefined) return value.stringValue
-  if (value.boolValue !== undefined) return value.boolValue
-  if (value.intValue !== undefined) return Number(value.intValue)
-  if (value.doubleValue !== undefined) return value.doubleValue
-  if (value.arrayValue?.values) return value.arrayValue.values.map(otlpValueToPlain)
-  if (value.kvlistValue?.values) {
-    const result: Record<string, unknown> = {}
-    for (const entry of value.kvlistValue.values) {
-      result[entry.key] = otlpValueToPlain(entry.value)
-    }
-    return result
-  }
-  return undefined
-}
-
 function fromJsonString(key: string): Candidate<Record<string, string>> {
   return {
     resolve: (attrs) => {
@@ -91,7 +75,7 @@ function fromDotFlattened(prefix: string): Candidate<Record<string, string>> {
       for (const attr of attrs) {
         if (!attr.key.startsWith(prefixDot)) continue
         const subKey = attr.key.slice(prefixDot.length)
-        const value = toStringValue(otlpValueToPlain(attr.value))
+        const value = toStringValue(anyValueToPlain(attr.value))
         if (subKey && value !== undefined) result[subKey] = value
       }
       return Object.keys(result).length > 0 ? result : undefined

--- a/packages/domain/spans/src/otlp/transform.test.ts
+++ b/packages/domain/spans/src/otlp/transform.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import { transformOtlpToSpans } from "./transform.ts"
+import type { OtlpExportTraceServiceRequest, OtlpKeyValue } from "./types.ts"
+
+const context = {
+  organizationId: "org_test",
+  apiKeyId: "key_test",
+  ingestedAt: new Date("2026-01-01T00:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map<string, string>(),
+}
+
+function requestWithSpanAttributes(attributes: readonly OtlpKeyValue[]): OtlpExportTraceServiceRequest {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [] },
+        scopeSpans: [
+          {
+            scope: { name: "test-scope", version: "1" },
+            spans: [
+              {
+                traceId: "0".repeat(32),
+                spanId: "0".repeat(16),
+                name: "update_memory",
+                startTimeUnixNano: "1",
+                endTimeUnixNano: "2",
+                attributes,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe("transformOtlpToSpans — structured attributes", () => {
+  it("flattens array/kvlist attributes into attrString as JSON", () => {
+    const { spans } = transformOtlpToSpans(
+      requestWithSpanAttributes([
+        {
+          key: "gen_ai.memory.records",
+          value: {
+            arrayValue: {
+              values: [
+                {
+                  kvlistValue: {
+                    values: [
+                      { key: "id", value: { stringValue: "mem_1" } },
+                      { key: "content", value: { stringValue: "User prefers dark mode" } },
+                      { key: "score", value: { doubleValue: 0.95 } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ]),
+      context,
+    )
+
+    const records = spans[0]?.attrString["gen_ai.memory.records"]
+    expect(records).toBeDefined()
+    expect(JSON.parse(records as string)).toEqual([{ id: "mem_1", content: "User prefers dark mode", score: 0.95 }])
+  })
+})
+
+describe("transformOtlpToSpans — memory operations", () => {
+  it("classifies memory operations and captures scalar memory attributes", () => {
+    const { spans } = transformOtlpToSpans(
+      requestWithSpanAttributes([
+        { key: "gen_ai.operation.name", value: { stringValue: "update_memory" } },
+        { key: "gen_ai.memory.store.id", value: { stringValue: "user-prefs" } },
+        { key: "gen_ai.memory.record.id", value: { stringValue: "mem_1" } },
+        { key: "gen_ai.memory.record.count", value: { intValue: "3" } },
+      ]),
+      context,
+    )
+
+    const span = spans[0]
+    expect(span?.operation).toBe("update_memory")
+    expect(span?.attrString["gen_ai.memory.store.id"]).toBe("user-prefs")
+    expect(span?.attrString["gen_ai.memory.record.id"]).toBe("mem_1")
+    expect(span?.attrInt["gen_ai.memory.record.count"]).toBe(3)
+  })
+})

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -30,6 +30,21 @@ function nanosToDate(nanos: string | undefined): Date {
   return new Date(ms)
 }
 
+function anyValueToPlain(value: OtlpAnyValue | undefined): unknown {
+  if (!value) return undefined
+  if (value.stringValue !== undefined) return value.stringValue
+  if (value.boolValue !== undefined) return value.boolValue
+  if (value.intValue !== undefined) return Number(value.intValue)
+  if (value.doubleValue !== undefined) return value.doubleValue
+  if (value.arrayValue !== undefined) return (value.arrayValue.values ?? []).map(anyValueToPlain)
+  if (value.kvlistValue !== undefined) {
+    const result: Record<string, unknown> = {}
+    for (const entry of value.kvlistValue.values ?? []) result[entry.key] = anyValueToPlain(entry.value)
+    return result
+  }
+  return undefined
+}
+
 function resolveAnyValue(
   value: OtlpAnyValue | undefined,
 ): { type: "string" | "int" | "float" | "bool"; value: string | number | boolean } | null {
@@ -38,6 +53,10 @@ function resolveAnyValue(
   if (value.boolValue !== undefined) return { type: "bool", value: value.boolValue }
   if (value.intValue !== undefined) return { type: "int", value: Number(value.intValue) }
   if (value.doubleValue !== undefined) return { type: "float", value: value.doubleValue }
+  // Structured OTLP values (e.g. gen_ai.memory.records) are flattened to a JSON string so they survive in attr_string.
+  if (value.arrayValue !== undefined || value.kvlistValue !== undefined) {
+    return { type: "string", value: JSON.stringify(anyValueToPlain(value)) }
+  }
   return null
 }
 

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -1,5 +1,6 @@
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import type { SpanDetail, SpanKind, SpanStatusCode } from "../entities/span.ts"
+import { anyValueToPlain } from "./any-value.ts"
 import { attrArray, stringAttr } from "./attributes.ts"
 import { parseContent } from "./content/index.ts"
 import { isDroppedSpan } from "./dropped-spans.ts"
@@ -28,21 +29,6 @@ function nanosToDate(nanos: string | undefined): Date {
   if (!nanos || nanos === "0") return new Date()
   const ms = Number(BigInt(nanos) / BigInt(1_000_000))
   return new Date(ms)
-}
-
-function anyValueToPlain(value: OtlpAnyValue | undefined): unknown {
-  if (!value) return undefined
-  if (value.stringValue !== undefined) return value.stringValue
-  if (value.boolValue !== undefined) return value.boolValue
-  if (value.intValue !== undefined) return Number(value.intValue)
-  if (value.doubleValue !== undefined) return value.doubleValue
-  if (value.arrayValue !== undefined) return (value.arrayValue.values ?? []).map(anyValueToPlain)
-  if (value.kvlistValue !== undefined) {
-    const result: Record<string, unknown> = {}
-    for (const entry of value.kvlistValue.values ?? []) result[entry.key] = anyValueToPlain(entry.value)
-    return result
-  }
-  return undefined
 }
 
 function resolveAnyValue(

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -67,6 +67,13 @@ export interface SpanRepositoryShape {
   // consistent across append-only and upsert-backed stores.
   insert(spans: readonly SpanDetail[]): Effect.Effect<void, RepositoryError, ChSqlClient>
 
+  /**
+   * Every span in a trace. The dynamic attribute maps
+   * (`attrString`/`attrInt`/`attrFloat`/`attrBool`/`resourceString`) come back
+   * empty for the same reason as `listBySessionId`: a trace's spans can each
+   * carry whole conversations or memory records in their attributes, so reading
+   * them here is a memory hazard — fetch a span's attributes via `findBySpanId`.
+   */
   listByTraceId(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -491,9 +491,12 @@ export const SpanRepositoryLive = Layer.effect(
               // matching parts and is expensive for traces with many spans or
               // large payload columns. The newest ingested row wins, matching
               // the table's ReplacingMergeTree(ingested_at) semantics.
-              query: `SELECT ${LIST_COLUMNS}
+              // Drop the attr maps (same OOM hazard as listBySessionId — a trace's
+              // spans can each carry whole conversations or memory records in
+              // `attr_string`; the span detail view reads attributes via findBySpanId).
+              query: `SELECT ${LIST_COLUMNS_LEAN}, ${EMPTY_ATTR_MAP_COLUMNS}
                     FROM (
-                      SELECT ${LIST_COLUMNS}
+                      SELECT ${LIST_COLUMNS_LEAN}
                       FROM spans
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}

--- a/packages/telemetry/typescript/src/constants/attributes.ts
+++ b/packages/telemetry/typescript/src/constants/attributes.ts
@@ -6,4 +6,5 @@ export const ATTRIBUTES = {
   userId: "user.id",
   userEmail: "user.email",
   project: "latitude.project",
+  memoryScope: "latitude.memory.scope",
 } as const

--- a/packages/telemetry/typescript/src/sdk/context.ts
+++ b/packages/telemetry/typescript/src/sdk/context.ts
@@ -25,6 +25,7 @@ type LatitudeContextData = {
   sessionId: string | undefined
   userId: string | undefined
   userEmail: string | undefined
+  memoryScope: string | undefined
   project: string | undefined
 }
 
@@ -111,6 +112,7 @@ function buildCaptureContext(name: string, currentContext: Context, options: Con
     sessionId: options.sessionId ?? existingData?.sessionId,
     userId: options.userId ?? existingData?.userId,
     userEmail: options.userEmail ?? existingData?.userEmail,
+    memoryScope: options.memoryScope ?? existingData?.memoryScope,
     project: projectFromOptions ?? existingData?.project,
   }
 

--- a/packages/telemetry/typescript/src/sdk/processor.test.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.test.ts
@@ -79,9 +79,10 @@ describe("LatitudeSpanProcessor", () => {
         expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.tags, JSON.stringify(["test"]))
         expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.sessionId, "session-1")
         expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.userId, "user-1")
+        expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.memoryScope, "team-acme")
         expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.metadata, JSON.stringify({ foo: "bar" }))
       },
-      { tags: ["test"], sessionId: "session-1", userId: "user-1", metadata: { foo: "bar" } },
+      { tags: ["test"], sessionId: "session-1", userId: "user-1", memoryScope: "team-acme", metadata: { foo: "bar" } },
     )
   })
 

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -130,6 +130,9 @@ export class LatitudeSpanProcessor implements SpanProcessor {
       if (latitudeData.userEmail) {
         span.setAttribute(ATTRIBUTES.userEmail, latitudeData.userEmail)
       }
+      if (latitudeData.memoryScope) {
+        span.setAttribute(ATTRIBUTES.memoryScope, latitudeData.memoryScope)
+      }
       if (latitudeData.project) {
         span.setAttribute(ATTRIBUTES.project, latitudeData.project)
       }

--- a/packages/telemetry/typescript/src/sdk/tracer.ts
+++ b/packages/telemetry/typescript/src/sdk/tracer.ts
@@ -27,6 +27,7 @@ export function latitudeAttributesFromContext(options: ContextOptions): Attribut
   if (options.sessionId) attributes[ATTRIBUTES.sessionId] = options.sessionId
   if (options.userId) attributes[ATTRIBUTES.userId] = options.userId
   if (options.userEmail) attributes[ATTRIBUTES.userEmail] = options.userEmail
+  if (options.memoryScope) attributes[ATTRIBUTES.memoryScope] = options.memoryScope
   if (project) attributes[ATTRIBUTES.project] = project
 
   return attributes

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -12,6 +12,12 @@ export type ContextOptions = {
   userId?: string
   userEmail?: string
   /**
+   * Scope key for memory observability. Groups memory operations (`create_memory` /
+   * `update_memory` / `search_memory` spans) into one evolving memory store. On ingest the
+   * scope resolves to this value, else the span's `userId`, else an empty (unscoped) bucket.
+   */
+  memoryScope?: string
+  /**
    * Route the capture (and all child spans) to a specific Latitude project.
    *
    * Overrides the constructor `project` default for this capture only. Useful when one

--- a/packages/ui/src/components/code-block/code-block.tsx
+++ b/packages/ui/src/components/code-block/code-block.tsx
@@ -11,6 +11,8 @@ export interface CodeBlockProps {
   readonly className?: string
   readonly wrapLines?: boolean
   readonly onReady?: () => void
+  /** Fill a height-bounded parent and scroll inside the block instead of growing to fit content. */
+  readonly fillHeight?: boolean
 }
 
 const CodeMirrorReadonly = lazy(() =>
@@ -33,6 +35,7 @@ export function CodeBlock({
   className,
   wrapLines = true,
   onReady,
+  fillHeight = false,
 }: CodeBlockProps) {
   const [mounted, setMounted] = useState(false)
 
@@ -45,11 +48,12 @@ export function CodeBlock({
   }
 
   return (
-    <div className="group relative">
+    <div className={cn("group relative", { "h-full": fillHeight })}>
       <Suspense fallback={onReady ? null : <CodeBlockFallback {...(className != null && { className })} />}>
         <CodeMirrorReadonly
           value={value}
           wrapLines={wrapLines}
+          fillHeight={fillHeight}
           {...(language != null && { language })}
           {...(className != null && { className })}
           {...(onReady ? { onReady } : {})}

--- a/packages/ui/src/components/code-block/codemirror-readonly.tsx
+++ b/packages/ui/src/components/code-block/codemirror-readonly.tsx
@@ -13,6 +13,7 @@ interface CodeMirrorReadonlyProps {
   readonly wrapLines?: boolean
   readonly onReady?: () => void
   readonly language?: string | undefined
+  readonly fillHeight?: boolean
 }
 
 function isJson(value: string): boolean {
@@ -48,6 +49,11 @@ function languageSupport(language: string | undefined, isJsonContent: boolean): 
   return null
 }
 
+// Makes the editor fill a height-bounded parent so the scroller (not the page) scrolls.
+const fillHeightTheme = EditorView.theme({
+  "&": { height: "100%" },
+})
+
 const readonlyTheme = EditorView.theme({
   "&": {
     fontSize: "12px",
@@ -73,7 +79,13 @@ const readonlyTheme = EditorView.theme({
   },
 })
 
-function buildState(doc: string, isJsonContent: boolean, wrapLines: boolean, language: string | undefined) {
+function buildState(
+  doc: string,
+  isJsonContent: boolean,
+  wrapLines: boolean,
+  language: string | undefined,
+  fillHeight: boolean,
+) {
   const extensions: Extension[] = [
     readonlyTheme,
     lineNumbers(),
@@ -81,6 +93,10 @@ function buildState(doc: string, isJsonContent: boolean, wrapLines: boolean, lan
     EditorState.readOnly.of(true),
     EditorView.editable.of(false),
   ]
+
+  if (fillHeight) {
+    extensions.push(fillHeightTheme)
+  }
 
   if (wrapLines) {
     extensions.push(EditorView.lineWrapping)
@@ -94,7 +110,14 @@ function buildState(doc: string, isJsonContent: boolean, wrapLines: boolean, lan
   return EditorState.create({ doc, extensions })
 }
 
-export function CodeMirrorReadonly({ value, className, wrapLines = true, onReady, language }: CodeMirrorReadonlyProps) {
+export function CodeMirrorReadonly({
+  value,
+  className,
+  wrapLines = true,
+  onReady,
+  language,
+  fillHeight = false,
+}: CodeMirrorReadonlyProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<EditorView | null>(null)
   const initialValueRef = useRef(value)
@@ -105,7 +128,7 @@ export function CodeMirrorReadonly({ value, className, wrapLines = true, onReady
     if (!container) return
 
     const view = new EditorView({
-      state: buildState(initialValueRef.current, isJsonContent, wrapLines, language),
+      state: buildState(initialValueRef.current, isJsonContent, wrapLines, language, fillHeight),
       parent: container,
     })
     viewRef.current = view
@@ -123,9 +146,14 @@ export function CodeMirrorReadonly({ value, className, wrapLines = true, onReady
     const view = viewRef.current
     if (!view) return
     if (view.state.doc.toString() !== value) {
-      view.setState(buildState(value, isJsonContent, wrapLines, language))
+      view.setState(buildState(value, isJsonContent, wrapLines, language, fillHeight))
     }
-  }, [value, isJsonContent, wrapLines, language])
+  }, [value, isJsonContent, wrapLines, language, fillHeight])
 
-  return <div ref={containerRef} className={cn("rounded-md overflow-hidden bg-muted", className)} />
+  return (
+    <div
+      ref={containerRef}
+      className={cn("rounded-md overflow-hidden bg-muted", { "h-full": fillHeight }, className)}
+    />
+  )
 }

--- a/packages/ui/src/components/master-detail/master-detail.tsx
+++ b/packages/ui/src/components/master-detail/master-detail.tsx
@@ -90,7 +90,7 @@ export function MasterDetail({
             )
           })}
         </div>
-        <div className={cn("min-w-0 flex-1 overflow-y-auto p-3", detailClassName)}>
+        <div className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", detailClassName)}>
           {activeKey !== undefined ? renderDetail(activeKey) : null}
         </div>
       </div>

--- a/packages/ui/src/components/master-detail/master-detail.tsx
+++ b/packages/ui/src/components/master-detail/master-detail.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react"
+import { useState } from "react"
+import { cn } from "../../utils/cn.ts"
+import { Text } from "../text/text.tsx"
+
+export type MasterDetailItem = {
+  readonly key: string
+  readonly label: ReactNode
+  readonly trailing?: ReactNode
+}
+
+export type MasterDetailProps = {
+  readonly items: readonly MasterDetailItem[]
+  readonly renderDetail: (key: string) => ReactNode
+  readonly header?: ReactNode
+  readonly emptyState?: ReactNode
+  /** Controlled selection. Omit for uncontrolled (defaults to `defaultSelectedKey` or the first item). */
+  readonly selectedKey?: string
+  readonly onSelectKey?: (key: string) => void
+  readonly defaultSelectedKey?: string
+  readonly className?: string
+  readonly railClassName?: string
+  readonly detailClassName?: string
+}
+
+/**
+ * Two-pane list + content layout: a selectable rail on the left, the selected item's detail on the right.
+ * Selection is uncontrolled unless `selectedKey` is passed.
+ */
+export function MasterDetail({
+  items,
+  renderDetail,
+  header,
+  emptyState,
+  selectedKey,
+  onSelectKey,
+  defaultSelectedKey,
+  className,
+  railClassName,
+  detailClassName,
+}: MasterDetailProps) {
+  const isControlled = selectedKey !== undefined
+  const [internalKey, setInternalKey] = useState(defaultSelectedKey ?? items[0]?.key)
+
+  const desiredKey = isControlled ? selectedKey : internalKey
+  const activeKey = items.some((item) => item.key === desiredKey) ? desiredKey : items[0]?.key
+
+  function select(key: string) {
+    if (!isControlled) setInternalKey(key)
+    onSelectKey?.(key)
+  }
+
+  if (items.length === 0) {
+    return <div className={cn("rounded-md border border-border p-3", className)}>{emptyState}</div>
+  }
+
+  return (
+    <div className={cn("flex flex-col overflow-hidden rounded-md border border-border", className)}>
+      {header ? <div className="shrink-0 border-b border-border">{header}</div> : null}
+      <div className="flex min-h-0 flex-1 flex-row">
+        <div
+          className={cn(
+            "flex w-1/3 min-w-[7rem] max-w-[16rem] shrink-0 flex-col overflow-y-auto border-r border-border",
+            railClassName,
+          )}
+        >
+          {items.map((item) => {
+            const isSelected = item.key === activeKey
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => select(item.key)}
+                className={cn("flex flex-row items-center gap-2 px-3 py-2 text-left transition-colors", {
+                  "bg-accent": isSelected,
+                  "hover:bg-muted/50": !isSelected,
+                })}
+              >
+                <div className="flex min-w-0 flex-1">
+                  {typeof item.label === "string" ? (
+                    <Text.H6 ellipsis noWrap color={isSelected ? "foreground" : "foregroundMuted"}>
+                      {item.label}
+                    </Text.H6>
+                  ) : (
+                    item.label
+                  )}
+                </div>
+                {item.trailing ? <div className="shrink-0">{item.trailing}</div> : null}
+              </button>
+            )
+          })}
+        </div>
+        <div className={cn("min-w-0 flex-1 overflow-y-auto p-3", detailClassName)}>
+          {activeKey !== undefined ? renderDetail(activeKey) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -209,6 +209,11 @@ export type {
 export { Input, type InputProps } from "./components/input/input.tsx"
 export { Label } from "./components/label/label.tsx"
 export {
+  MasterDetail,
+  type MasterDetailItem,
+  type MasterDetailProps,
+} from "./components/master-detail/master-detail.tsx"
+export {
   CloseTrigger,
   Modal,
   type ModalBodyProps,

--- a/specs/memory-observability.md
+++ b/specs/memory-observability.md
@@ -134,8 +134,9 @@ Materialization runs at the **trace-end boundary** (`apps/workers/src/workers/tr
 
 New/changed code:
 
-- `packages/domain/spans/src/entities/span.ts` — extend `operationSchema` with the 7 memory ops.
-- `packages/domain/spans/src/otlp/resolvers/memory.ts` — new resolver (candidate lists for store/record/count/query/records/scope), wired into `resolvers/index.ts` and `transform.ts`.
+- `packages/domain/spans/src/entities/span.ts` — extend `operationSchema` with the 7 memory ops; export `MEMORY_OPERATIONS` / `isMemoryOperation`.
+- `packages/domain/spans/src/otlp/transform.ts` — `resolveAnyValue` flattens OTLP `arrayValue`/`kvlistValue` attributes to a JSON string so structured payloads (e.g. `gen_ai.memory.records`) survive in `attr_string`.
+- `packages/domain/spans/src/otlp/resolvers/memory.ts` — new resolver (candidate lists for store/record/count/query/records/scope), wired into `resolvers/index.ts` and `transform.ts`. *(Phase 1 — Phase 0 reads the raw attributes instead.)*
 - `packages/domain/memories/*` — new domain package (entities, ports, use-cases; see [Data model](#data-model)).
 - `packages/platform/db-clickhouse/src/repositories/memory-repository.ts` — CH adapter + migrations (`memory_events`, `memory_blobs`, `memory_current`), created via `pnpm --filter @platform/db-clickhouse ch:create`.
 - `apps/workers/src/workers/memory-projection.ts` — trace-end-triggered materializer.
@@ -350,14 +351,24 @@ Per record at T: load its mutating versions ordered by `end_time` (each carries 
 
 > **Status legend**: `[ ] pending`, `[~] in progress`, `[x] complete`
 
-### Phase 0 — Memory spans on the Spans tab (Feature 1)
+### Phase 0 — Memory spans on the Spans tab (Feature 1) — shipped
 
-- [ ] **P0-1**: Add the 7 memory operations to `operationSchema` (`packages/domain/spans/src/entities/span.ts`).
-- [ ] **P0-2**: Add `resolvers/memory.ts` (store/record/count/query/records/scope candidate lists) + wire into `resolvers/index.ts`, `ResolvedAttributes`, and `transform.ts`.
-- [ ] **P0-3**: Spans-tab rendering — `memory-operation-section.tsx` detail panel, span icon, operation color, `span-filters.ts` filter.
-- [ ] **P0-4**: Add `memoryScope` to `packages/telemetry/typescript/src/constants/attributes.ts` + SDK capture option; document the scope/user-tagging requirement.
+Phase 0 reads memory attributes straight from `attr_string`/`attr_int` + the indexed `operation` column; **no ClickHouse migration and no memory resolver** (both move to Phase 1 with the ledger).
 
-**Exit gate:** a trace containing `create_memory`/`update_memory`/`search_memory` spans classifies them, shows the detail panel, colors them in the waterfall, and filters to them — no ledger yet.
+- [x] **P0-1**: Add the 7 memory operations to `operationSchema` + export `MEMORY_OPERATIONS` / `isMemoryOperation` (`packages/domain/spans/src/entities/span.ts`).
+- [x] **P0-2**: Capture structured attributes — `resolveAnyValue` (`packages/domain/spans/src/otlp/transform.ts`) flattens `arrayValue`/`kvlistValue` to a JSON string so `gen_ai.memory.records` survives in `attr_string`. (Dedicated `resolvers/memory.ts` + resolved fields/columns deferred to Phase 1.)
+- [x] **P0-3**: Spans-tab rendering — `span-detail/memory-operation-section.tsx` detail panel (reads attr maps), memory icons (`span-icon.tsx`), waterfall color (`span-tree/helpers.ts`), and a "Memory" filter toggle (`span-filters.ts` / `use-span-filters.ts` / `span-filters-bar.tsx`). Shared `isMemoryOperation` in `spans-tab/memory-operations.ts`.
+- [x] **P0-4**: Add `memoryScope` (`latitude.memory.scope`) to the TS SDK (`constants/attributes.ts` + `ContextOptions` + both `processor.ts`/`tracer.ts` stamping paths); documented the scope/user-tagging requirement. (Ingest-side `scope` resolver deferred to Phase 1.)
+
+**Exit gate (met):** a trace containing `create_memory`/`update_memory`/`search_memory` spans classifies them, shows the detail panel, colors them in the waterfall, and filters to them — no ledger yet.
+
+**Phase 0 implementation notes (deviations from the original plan):**
+
+- **No ClickHouse migration.** Filtering rides the indexed `operation` column; scalar memory attrs and the flattened `records` JSON ride `attr_string`/`attr_int`, already returned by the span-detail read path (`findBySpanId`).
+- **The `arrayValue`/`kvlistValue` flattening is general** — every previously-dropped structured attribute now persists as a JSON string in `attr_string` (relying on `CODEC(ZSTD)`; add a length cap in `resolveAnyValue` if a pathological emitter bloats it).
+- **`OPERATION_ICON`'s `satisfies` is vacuous** (the `z.string()` catch-all collapses the `Exclude` to `never`), so memory icon entries are a manual, non-compiler-enforced addition.
+- **The web keeps its own `MEMORY_OPERATIONS`/`isMemoryOperation`** (`spans-tab/memory-operations.ts`, type-only domain import) instead of importing the domain runtime helper into the client bundle — accepted duplication of a 7-string list.
+- **Deferred to Phase 1:** `resolvers/memory.ts` + resolved fields / indexed columns, the ingest-side `scope` resolver + column, and the `"update_memory · <record.id>"` tree-row label (needs `memoryRecordId` on the list-shape `SpanRecord`).
 
 ### Phase 1 — Ledger, blobs, projection, materializer (engine)
 

--- a/specs/memory-observability.md
+++ b/specs/memory-observability.md
@@ -88,7 +88,7 @@ Span name SHOULD equal `gen_ai.operation.name`; span kind CLIENT (or INTERNAL fo
 1. **There is no `gen_ai.memory.scope` attribute** (contrary to an earlier internal report). Scope/layering must be derived — see [Scope resolution](#scope-resolution).
 2. **There is no before/after on the wire, and no token count.** `gen_ai.memory.records` is the *current* content of the records in that operation (opt-in). A diff and a token count are things **we derive**, not read. `record.count` is the only always-available quantity.
 
-`gen_ai.memory.records` content model (from the spec's example): an array of `{ id, content, score?, metadata? }` where `content` is a string or nested object. We treat, per record, the `content` field (stringified if object) as that record's new full body.
+`gen_ai.memory.records` content model (`model/gen-ai/gen-ai-memory-records.json`, verified): an array of records where **`content` (`any`) is the only required field**, plus optional `id` (string), `score` (number, populated on search results), and `metadata` (object). The attribute is declared `any` and `development`-stage, so emitters may deviate — consumers validate the shape and fall back to the raw payload. We treat, per record, the `content` field (stringified if object) as that record's new full body.
 
 ---
 

--- a/specs/memory-observability.md
+++ b/specs/memory-observability.md
@@ -53,7 +53,16 @@ The one-line model: **we treat every memory-mutating span as a commit, and deriv
 
 ## Ground truth: the OTEL memory conventions
 
-Verified against `open-telemetry/semantic-conventions-genai` (`docs/gen-ai/gen-ai-spans.md`, section "Memory"; `docs/registry/attributes/gen-ai.md`). **Everything here is at `Development` stability** — unstable, and shipping instrumentation that emits it is nascent as of mid-2026. We adopt it as the canonical wire format but must tolerate absence and change.
+### Where the conventions live (as of mid-2026)
+
+The GenAI semantic conventions were **split out of the `open-telemetry/semantic-conventions` monorepo into their own repository, [`open-telemetry/semantic-conventions-genai`](https://github.com/open-telemetry/semantic-conventions-genai)** — that repo is now the source of truth for everything `gen_ai.*`, memory included. Two consequences: the memory attributes are newer and thinner than a casual read of the old monorepo docs suggests, and the authoritative definitions are the machine-readable model files, not the rendered docs. Under **`model/gen-ai/`**:
+
+- **`registry.yaml`** — every `gen_ai.*` attribute (id, type, stability, brief). All five `gen_ai.memory.*` attributes are declared here.
+- **`spans.yaml`** — the memory operation spans and which attributes apply to each.
+- **`gen-ai-memory-records.json`** — a **JSON Schema** for the `gen_ai.memory.records` payload. The attribute's declared `type` is `any`; this companion file is what actually pins the record structure. The same "`any` attribute + companion JSON Schema" pattern is used for the other content-bearing attributes (`gen-ai-input-messages.json`, `gen-ai-output-messages.json`, `gen-ai-tool-call-*.json`, `gen-ai-tool-definitions.json`, `gen-ai-retrieval-documents.json`, `gen-ai-system-instructions.json`).
+- The rendered docs (`docs/gen-ai/gen-ai-spans.md` → "Memory"; `docs/registry/attributes/gen-ai.md`) are generated from the model — read the model files when in doubt.
+
+Everything below was verified against those model files. **Everything here is at `Development` stability** — unstable, and shipping instrumentation that emits it is nascent as of mid-2026. We adopt it as the canonical wire format but must tolerate absence and change.
 
 ### Operations (`gen_ai.operation.name` values)
 
@@ -88,7 +97,7 @@ Span name SHOULD equal `gen_ai.operation.name`; span kind CLIENT (or INTERNAL fo
 1. **There is no `gen_ai.memory.scope` attribute** (contrary to an earlier internal report). Scope/layering must be derived — see [Scope resolution](#scope-resolution).
 2. **There is no before/after on the wire, and no token count.** `gen_ai.memory.records` is the *current* content of the records in that operation (opt-in). A diff and a token count are things **we derive**, not read. `record.count` is the only always-available quantity.
 
-`gen_ai.memory.records` content model (`model/gen-ai/gen-ai-memory-records.json`, verified): an array of records where **`content` (`any`) is the only required field**, plus optional `id` (string), `score` (number, populated on search results), and `metadata` (object). The attribute is declared `any` and `development`-stage, so emitters may deviate — consumers validate the shape and fall back to the raw payload. We treat, per record, the `content` field (stringified if object) as that record's new full body.
+`gen_ai.memory.records` content model (`model/gen-ai/gen-ai-memory-records.json`, verified): an **array** of records where **`content` (`any`) is the only required field**, plus optional `id` (string), `score` (number, populated on search results), and `metadata` (object). The record object also sets **`additionalProperties: true`** — extra keys are tolerated but undefined by the standard. Notably there is **no `moved_from`/rename field and no rename operation**: a rename is not representable from a single span and is a derived (ledger/Phase 1) concern, not a wire fact. Because the attribute is declared `any` and is `development`-stage, emitters may deviate — consumers validate the shape and fall back to the raw payload. We treat, per record, the `content` field (stringified if object) as that record's new full body.
 
 ---
 
@@ -280,10 +289,10 @@ Per record at T: load its mutating versions ordered by `end_time` (each carries 
 **Goal:** the 7 memory operations are first-class spans: classified, colored, filterable, with a detail panel.
 
 - **Classification:** add the ops to `operationSchema` (`span.ts`). `resolveOperation` already reads `gen_ai.operation.name`, so they classify with no extra mapping; the enum entry unlocks first-class icon/color and filtering. `resolvers/memory.ts` extracts `store.id`, `record.id`, `record.count`, `query.text`, and `records` into resolved fields (and, passively, dot-flattened attrs already land in `attr_string`/metadata).
-- **Rendering:** a `memory-operation-section.tsx` under `span-detail/` showing operation, store, record id(s), record count, query text (reads), and the records payload — with a "View in Memory →" link to the scope page (Feature 3/4). An icon in `span-tree/span-icon.tsx` and a color in the operation color map (the operation-coloring introduced by #4023). A filter entry in `span-filters.ts` to filter a trace to its memory ops.
+- **Rendering (shipped):** `memory-operation-section.tsx` under `span-detail/` renders one **Memory** section — `query.text` for reads, then the records. When the payload matches the record schema it renders as a **master-detail** (a records rail + a content pane that fills edge-to-edge and scrolls internally; header `[db] <store id> (N)`; `search_memory` results sort by `score`); off-schema/absent payloads fall back to the raw JSON or "Content not captured". Store + count ride the records header; identity fields (`store.id`/`record.id`/`record.count`) drop to a summary row only when there's no records table. An icon in `span-tree/span-icon.tsx`, a color in the operation color map (the operation-coloring introduced by #4023), and a filter entry in `span-filters.ts`. Built on a reusable `MasterDetail` (`@repo/ui`) + a `fillHeight` mode on `CodeBlock`. The "View in Memory →" link to the scope page is deferred until Feature 3/4 exist.
 - **No storage dependency** — ships independently of the ledger.
 
-**UI copy:** `search_memory` reads render as "read"; create/update/upsert/delete render with their `change_kind` badge.
+**UI copy:** `search_memory` results render under a "Results" subsection; the other operations render their records under "Records". Per-record change badges (create/update/delete/rename icons) were explored and **dropped**: a span's `operation` is uniform across all records it carries, so a meaningful per-record change kind (and rename detection) is a Phase 1 / Memory-page concern, not something derivable in the span detail.
 
 ---
 
@@ -357,7 +366,7 @@ Phase 0 reads memory attributes straight from `attr_string`/`attr_int` + the ind
 
 - [x] **P0-1**: Add the 7 memory operations to `operationSchema` + export `MEMORY_OPERATIONS` / `isMemoryOperation` (`packages/domain/spans/src/entities/span.ts`).
 - [x] **P0-2**: Capture structured attributes — `resolveAnyValue` (`packages/domain/spans/src/otlp/transform.ts`) flattens `arrayValue`/`kvlistValue` to a JSON string so `gen_ai.memory.records` survives in `attr_string`. (Dedicated `resolvers/memory.ts` + resolved fields/columns deferred to Phase 1.)
-- [x] **P0-3**: Spans-tab rendering — `span-detail/memory-operation-section.tsx` detail panel (reads attr maps), memory icons (`span-icon.tsx`), waterfall color (`span-tree/helpers.ts`), and a "Memory" filter toggle (`span-filters.ts` / `use-span-filters.ts` / `span-filters-bar.tsx`). Shared `isMemoryOperation` in `spans-tab/memory-operations.ts`.
+- [x] **P0-3**: Spans-tab rendering — `span-detail/memory-operation-section.tsx` detail panel (reads attr maps), memory icons (`span-icon.tsx`), waterfall color (`span-tree/helpers.ts`), and a "Memory" filter toggle (`span-filters.ts` / `use-span-filters.ts` / `span-filters-bar.tsx`). Shared `isMemoryOperation` in `spans-tab/memory-operations.ts`. The records payload renders as a schema-validated master-detail (`memory-records.tsx` + `memory-records-parse.ts`) built on a new reusable `MasterDetail` (`@repo/ui`) and a `fillHeight` mode on `CodeBlock`.
 - [x] **P0-4**: Add `memoryScope` (`latitude.memory.scope`) to the TS SDK (`constants/attributes.ts` + `ContextOptions` + both `processor.ts`/`tracer.ts` stamping paths); documented the scope/user-tagging requirement. (Ingest-side `scope` resolver deferred to Phase 1.)
 
 **Exit gate (met):** a trace containing `create_memory`/`update_memory`/`search_memory` spans classifies them, shows the detail panel, colors them in the waterfall, and filters to them — no ledger yet.
@@ -368,6 +377,9 @@ Phase 0 reads memory attributes straight from `attr_string`/`attr_int` + the ind
 - **The `arrayValue`/`kvlistValue` flattening is general** — every previously-dropped structured attribute now persists as a JSON string in `attr_string` (relying on `CODEC(ZSTD)`; add a length cap in `resolveAnyValue` if a pathological emitter bloats it).
 - **`OPERATION_ICON`'s `satisfies` is vacuous** (the `z.string()` catch-all collapses the `Exclude` to `never`), so memory icon entries are a manual, non-compiler-enforced addition.
 - **The web keeps its own `MEMORY_OPERATIONS`/`isMemoryOperation`** (`spans-tab/memory-operations.ts`, type-only domain import) instead of importing the domain runtime helper into the client bundle — accepted duplication of a 7-string list.
+- **Records master-detail.** The records payload is validated against `gen-ai-memory-records.json` (`parseMemoryRecords`) and rendered as a two-pane list + content view; a new generic `MasterDetail` primitive was added to `@repo/ui` (with a design-system showcase entry) and a `fillHeight` mode to `CodeBlock`/`CodeMirrorReadonly` so content fills the pane and scrolls internally. Per-record change badges were dropped (see Feature 1 UI copy).
+- **Trace-list read path hardened.** `listByTraceId` now returns empty attr maps (mirrors `listBySessionId`/`listByTraceIds`), so the flattened `gen_ai.memory.records` payloads — which this PR is what puts into `attr_string` — don't bloat the trace-list read; the span detail still reads attributes via `findBySpanId`.
+- **Shared OTLP flattener.** The `arrayValue`/`kvlistValue`→JSON flattening lives in a single `otlp/any-value.ts` (`anyValueToPlain`), replacing three near-identical copies across `transform.ts`, the enricher, and the GenAI content parser.
 - **Deferred to Phase 1:** `resolvers/memory.ts` + resolved fields / indexed columns, the ingest-side `scope` resolver + column, and the `"update_memory · <record.id>"` tree-row label (needs `memoryRecordId` on the list-shape `SpanRecord`).
 
 ### Phase 1 — Ledger, blobs, projection, materializer (engine)

--- a/specs/memory-observability.md
+++ b/specs/memory-observability.md
@@ -1,0 +1,398 @@
+# Memory Observability
+
+> **Documentation** — durable homes after stabilization: a new `dev-docs/memory-observability.md`. Related current docs: `dev-docs/spans.md` (span ingestion/storage/query, which this extends), `dev-docs/scores.md` + `specs/signals.md` (the flagger/signal spine a future memory-pollution detector plugs into), `dev-docs/users.md` (user identity, the default scope key), `dev-docs/projects.md` (project-scoped tenancy).
+>
+> **Linear**: [LAT-729](https://linear.app/latitude/issue/LAT-729) — "Explore: Memory observability (memory diff / evolution tracking)".
+
+## Contents
+
+1. [Purpose](#purpose)
+2. [Scope and non-goals](#scope-and-non-goals)
+3. [Ground truth: the OTEL memory conventions](#ground-truth-the-otel-memory-conventions)
+4. [The git model we borrow](#the-git-model-we-borrow)
+5. [Architecture](#architecture)
+6. [Scope resolution](#scope-resolution)
+7. [Data model](#data-model)
+8. [Reconstruction, diff, and blame](#reconstruction-diff-and-blame)
+9. [Feature 1 — memory spans on the Spans tab](#feature-1--memory-spans-on-the-spans-tab)
+10. [Feature 2 — session / trace memory summary](#feature-2--session--trace-memory-summary)
+11. [Feature 3 — the Memory page](#feature-3--the-memory-page)
+12. [Feature 4 — commit-style session diff view](#feature-4--commit-style-session-diff-view)
+13. [Metering, retention, tenancy, self-hosting](#metering-retention-tenancy-self-hosting)
+14. [Decisions](#decisions)
+15. [Tasks](#tasks)
+
+---
+
+## Purpose
+
+Give teams whose agents use persistent, scoped memory a **git-like view of how that memory evolves** — what each session read, what it changed (`read 412k · write +612 −24`), the current state of any scope as a browsable filetree, and per-line provenance back to the exact span that last wrote each line. This is the observability layer nobody ships today: providers (Mem0, Supermemory, Zep) version memory inside their own store, but no observability platform ties a memory change to the **trace that caused it** and to the **evaluations that graded that trace**. That correlation is the differentiated bet.
+
+The one-line model: **we treat every memory-mutating span as a commit, and derive snapshots, diffs, and blame the way git does — by storing content-addressed states, not diffs.**
+
+---
+
+## Scope and non-goals
+
+**In scope**
+
+- Ingesting the OpenTelemetry GenAI **memory-operation** spans (`create_memory`, `update_memory`, `upsert_memory`, `delete_memory`, `search_memory`, `create_memory_store`, `delete_memory_store`) through the existing OTLP pipeline, classifying them, and rendering them on the Spans tab.
+- A content-addressed **memory ledger** (`memory_events` + `memory_blobs`) plus a hot current-state projection (`memory_current`) in ClickHouse.
+- A `@domain/memories` package that reconstructs a scope's state at any point in time, diffs two points, and computes per-line blame.
+- Four product surfaces: memory spans on the Spans tab; a per-session/trace read/write summary; a Memory page (scope list → filetree + content + blame); and a commit-style session diff view.
+
+**Non-goals (this spec)**
+
+- **No PII/consent gating.** Decision [D1](#decisions): we store memory content as sent and do not gate on opt-in in v1. This must be revisited before any GA/marketing.
+- **No provider adapters.** Mem0/Supermemory/Zep webhook or polling ingestion is out of scope; the ledger reserves a `source` column so an adapter can write the same tables later without a schema change. Decision [D10](#decisions).
+- **No rollback execution.** Latitude never mutates a customer's memory store. A "flag polluted trace → compute affected changes → present inverse operations" report is a later phase, not this spec.
+- **No automated pollution detection.** A `memory-pollution` flagger (sibling of the existing `forgetting` strategy) is future work; this spec builds the substrate it would read.
+- **No billing change.** Memory operations arrive as spans and ride existing span metering. Decision [D11](#decisions).
+
+---
+
+## Ground truth: the OTEL memory conventions
+
+Verified against `open-telemetry/semantic-conventions-genai` (`docs/gen-ai/gen-ai-spans.md`, section "Memory"; `docs/registry/attributes/gen-ai.md`). **Everything here is at `Development` stability** — unstable, and shipping instrumentation that emits it is nascent as of mid-2026. We adopt it as the canonical wire format but must tolerate absence and change.
+
+### Operations (`gen_ai.operation.name` values)
+
+Span name SHOULD equal `gen_ai.operation.name`; span kind CLIENT (or INTERNAL for in-process).
+
+| Operation | Meaning | Mutates state? |
+| --- | --- | --- |
+| `create_memory` | Create new memory records | yes (add) |
+| `update_memory` | Modify known existing records | yes (update) |
+| `upsert_memory` | Create-or-update without the caller choosing which | yes (add or update) |
+| `delete_memory` | Delete records; **absent `record.id` ⇒ delete all records in the store** | yes (remove) |
+| `search_memory` | Query/retrieve records | no (read) |
+| `create_memory_store` | Create/initialize a store | store lifecycle |
+| `delete_memory_store` | Delete/deprovision a store | store lifecycle |
+
+### Attributes (Memory span)
+
+| Attribute | Level | Type | What it gives us |
+| --- | --- | --- | --- |
+| `gen_ai.operation.name` | **Required** | string | the operation above (our discriminator) |
+| `gen_ai.memory.store.id` | Cond. Required | string | store identity, e.g. `user-preferences-store` |
+| `gen_ai.memory.record.id` | Cond. Required | string | the record touched, e.g. `mem_5j66…` |
+| `gen_ai.memory.record.count` | Recommended | int | # records affected/returned |
+| `gen_ai.memory.query.text` | **Opt-In** | string | search query text (PII warning) |
+| `gen_ai.memory.records` | **Opt-In** | any | the record **content** payload (PII warning); JSON per `model/gen-ai/gen-ai-memory-records.json` |
+| `gen_ai.provider.name` | Cond. Required | string | provider (memory system) |
+| `server.address` / `server.port` | Recommended | — | memory server endpoint |
+| `error.type` | Cond. Required | string | on error |
+
+**Two facts that shape the whole design:**
+
+1. **There is no `gen_ai.memory.scope` attribute** (contrary to an earlier internal report). Scope/layering must be derived — see [Scope resolution](#scope-resolution).
+2. **There is no before/after on the wire, and no token count.** `gen_ai.memory.records` is the *current* content of the records in that operation (opt-in). A diff and a token count are things **we derive**, not read. `record.count` is the only always-available quantity.
+
+`gen_ai.memory.records` content model (from the spec's example): an array of `{ id, content, score?, metadata? }` where `content` is a string or nested object. We treat, per record, the `content` field (stringified if object) as that record's new full body.
+
+---
+
+## The git model we borrow
+
+git is fast because it **stores snapshots, not diffs**, and makes snapshots cheap with content addressing. We steal exactly four ideas:
+
+1. **Content addressing + dedup.** Hash each record body; store each unique body once (`memory_blobs`). A record written identically twice costs one blob.
+2. **A version is a manifest of hashes.** "State of scope at time T" = the set of `(record → content_hash)` current as of T. Unchanged records share a hash, so a full snapshot is a small list, not a copy of every body.
+3. **Diffs are computed on demand and pruned by hash equality.** To diff two points, compare their manifests; where a record's hash is equal on both sides it is provably unchanged — skip it. Only line-diff the records whose hash differs. Cost ∝ what changed.
+4. **Delta/zlib packing is a storage-layer concern.** We get this from ClickHouse `CODEC(ZSTD)` on the blob column; we do not build git's packfile delta chains.
+
+Where our world is **simpler** than git: a flat namespace of records (no recursive trees — we split `record.id` on `/` only for UX), no merges/branches, small bodies.
+
+Where it is **harder**: memory is multi-tenant append-only telemetry we don't control; a shared scope is written concurrently by many sessions with no parent pointers. Decision [D2](#decisions) resolves this by the simplest rule that works: **each mutating span carries the full new body of the record it touches, i.e. each span is a full snapshot of that record; versions are ordered by span end-time; last-to-finish wins as current.** No parent-pointer isolation, no three-way merge — just "latest write per record."
+
+---
+
+## Architecture
+
+```
+OTLP POST /v1/traces  (apps/ingest/src/routes/traces.ts)
+  → ingestSpansWithBillingUseCase → ingestSpansUseCase           [unchanged]
+  → queue "span-ingestion":"ingest"
+  → processIngestedSpansUseCase (transformOtlpToSpans)           [+ memory resolver]
+      · resolveOperation now classifies the 7 memory ops
+      · resolveMemory extracts store.id/record.id/count/query/records
+  → SpanRepository.insert  → ClickHouse `spans`                  [memory spans queryable on Spans tab]
+  → TracesIngested event → debounced (90s) "trace-end":"run"
+      → NEW "memory-projection":"run"  (mirrors deterministic-flaggers)
+          · read the settled trace's memory spans
+          · per mutating record: body → content_hash, tiktoken → token_count
+          · write `memory_blobs` (dedup) + `memory_events` (ledger) + `memory_current` (projection)
+
+Read side (@domain/memories, on demand):
+  reconstructSnapshot(scope, at)   → manifest {record → blob} via argMax over ledger (or memory_current for now)
+  computeDiff(scope, from, to)     → hash-prune + jsdiff on survivors → {added/updated/removed, +/- tokens}
+  computeBlame(scope, record, at)  → walk versions newest→oldest, attribute lines → span_id/trace_id
+  sessionSummary(session)          → read tokens (search spans) + write diff (before vs after)
+```
+
+Materialization runs at the **trace-end boundary** (`apps/workers/src/workers/trace-end.ts`), not inline in ingestion, because that is the settled point where a record's final body within a trace and a stable end-time ordering are known. It is added as its own worker/queue step exactly like the deterministic-flaggers fan-out already is (isolated failure domain).
+
+New/changed code:
+
+- `packages/domain/spans/src/entities/span.ts` — extend `operationSchema` with the 7 memory ops.
+- `packages/domain/spans/src/otlp/resolvers/memory.ts` — new resolver (candidate lists for store/record/count/query/records/scope), wired into `resolvers/index.ts` and `transform.ts`.
+- `packages/domain/memories/*` — new domain package (entities, ports, use-cases; see [Data model](#data-model)).
+- `packages/platform/db-clickhouse/src/repositories/memory-repository.ts` — CH adapter + migrations (`memory_events`, `memory_blobs`, `memory_current`), created via `pnpm --filter @platform/db-clickhouse ch:create`.
+- `apps/workers/src/workers/memory-projection.ts` — trace-end-triggered materializer.
+- `apps/web/src/routes/_authenticated/projects/$projectSlug/memory/*` + a nav entry in `apps/web/src/layouts/AppSidebar/index.tsx`; memory-span detail section under `-components/trace-detail-drawer/tabs/spans-tab/span-detail/`.
+
+---
+
+## Scope resolution
+
+Scope is the unit the Memory page lists and the filetree groups under. There is no standard attribute, so we resolve a `scope` string per memory span with an ordered candidate list (same `first(candidates, attrs)` pattern as `resolvers/identity.ts`). Decision [D4](#decisions):
+
+1. `gen_ai.memory.scope` — forward-compatible with a possible future standard attribute.
+2. `latitude.memory.scope` — our own convention (added to `packages/telemetry/typescript/src/constants/attributes.ts` as `memoryScope`, and to the SDK capture options), so a customer with layered user/team/company memory can tag each write explicitly.
+3. the span's resolved **user id** (`user.id` / existing `identity.ts` userId candidates).
+4. `""` (empty string) — an explicit "unscoped" bucket that is its own scope, never dropped.
+
+Record identity within a scope is `(store_id, record_id)`. The UI filetree path is `"{store_id}/{record_id}"` split on `/`, so `store.id` becomes the top-level folder when a scope spans multiple stores, and slash-delimited record ids nest naturally. `store_id` absent ⇒ path is just `record_id`.
+
+> **Requirement to document for customers**: user-scoping only works if the memory span (or its trace) carries user identity, or the emitter sets a `*.memory.scope` attribute. Spans with neither land in the `""` scope.
+
+---
+
+## Data model
+
+Three ClickHouse tables (append-only migration rules apply; create with `ch:create`, never by hand) plus a Zod-first domain package. All tables are `organization_id`/`project_id` scoped.
+
+### `memory_events` — the ledger (source of truth)
+
+One row per memory-operation span (mutations **and** reads). `MergeTree`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `organization_id`, `project_id` | String | tenancy |
+| `scope` | String | resolved per [Scope resolution](#scope-resolution) |
+| `store_id` | String | `gen_ai.memory.store.id` (`''` if absent) |
+| `record_id` | String | `gen_ai.memory.record.id` (`''` for store-lifecycle / whole-store deletes) |
+| `operation` | LowCardinality(String) | one of the 7 ops |
+| `change_kind` | LowCardinality(String) | derived: `add` / `update` / `remove` / `read` / `store_create` / `store_delete` (see below) |
+| `content_hash` | String | sha256 hex of the record body; `''` when no content was sent |
+| `token_count` | UInt32 | tiktoken over the body (0 when no content) |
+| `record_count` | UInt32 | `gen_ai.memory.record.count` |
+| `query_text` | String CODEC(ZSTD(3)) | for `search_memory` |
+| `span_id` | FixedString(16) | authoring span (blame target) |
+| `trace_id` | FixedString(32) | |
+| `session_id` | String | `gen_ai.conversation.id` (join key for session summary) |
+| `user_id` | String | resolved user identity |
+| `start_time`, `end_time` | DateTime64(6) | **ordering is by `end_time`** ([D2](#decisions)) |
+| `source` | LowCardinality(String) | `'otlp'` today; reserved for provider adapters ([D10](#decisions)) |
+| `ingested_at` | DateTime64 | |
+
+`ORDER BY (organization_id, project_id, scope, store_id, record_id, end_time, span_id)`, `PARTITION BY toYYYYMM(end_time)`.
+
+`change_kind` derivation at materialization:
+- `search_memory` → `read` (never mutates the manifest).
+- `create_memory` → `add`; `update_memory` → `update`.
+- `upsert_memory` → `add` if the record had no prior mutating event in scope, else `update`.
+- `delete_memory` with `record.id` → `remove`; without `record.id` → a `store_delete`-flavored whole-store wipe (see reconstruction).
+- `create_memory_store` / `delete_memory_store` → `store_create` / `store_delete`.
+
+### `memory_blobs` — content-addressed bodies (git's object store)
+
+Dedup of record bodies. `ReplacingMergeTree(created_at)`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `organization_id` | String | dedup is per-org |
+| `content_hash` | String | sha256 hex (primary identity) |
+| `content` | String CODEC(ZSTD(3)) | the body, inline; mirrors `spans.input_messages` |
+| `content_file_key` | String | object-storage key (`@platform/storage-object`) when body exceeds the inline threshold; `content` empty then |
+| `byte_size` | UInt32 | |
+| `token_count` | UInt32 | tiktoken, computed once per unique body |
+| `created_at` | DateTime64 | |
+
+`ORDER BY (organization_id, content_hash)`. Inline threshold reuses the ingestion convention (`INLINE_PAYLOAD_MAX_BYTES = 50_000`, `ingest-spans.ts:22`); larger bodies go to `StorageDisk` via `putInDisk`. Records are usually small, so inline is the common path.
+
+### `memory_current` — hot current-state projection
+
+Latest mutating version per record, for fast "current snapshot" reads (T = now). `ReplacingMergeTree(end_time)` keyed `(organization_id, project_id, scope, store_id, record_id)`, one row upserted per mutating event, carrying `content_hash`, `change_kind`, `span_id`, `trace_id`, `session_id`, `token_count`, `end_time`. Reads take the latest row per key (`FINAL`/`argMax`) and drop `change_kind = 'remove'`. Point-in-time reads (T ≠ now) do **not** use this table — they aggregate the ledger.
+
+### Domain package `packages/domain/memories`
+
+Mirrors `@domain/scores` layout (`package.json` `@domain/memories`, `main`/`types` → `src/index.ts`, `./testing` export; deps `@domain/spans`, `@domain/shared`, `@domain/events`, `effect`, `zod`, plus `diff` and the tokenizer):
+
+- `src/entities/` — `memory-event.ts`, `memory-record.ts`, `memory-snapshot.ts` (`{ scope, at, records: Manifest }`), `memory-diff.ts` (`{ added, updated, removed, tokensAdded, tokensRemoved, recordsChanged }`), `memory-blame.ts` (`Array<{ line, spanId, traceId, sessionId, at }>`).
+- `src/ports/memory-repository.ts` — `insertEvents`, `upsertBlobs`, `upsertCurrent`, `readCurrentSnapshot(scope)`, `readManifestAt(scope, at)`, `readRecordVersions(scope, store, record, at?)`, `readSessionMemoryEvents(session)`, `listScopes`, `readBlobs(hashes)`.
+- `src/use-cases/` — `materialize-trace-memory.ts`, `reconstruct-snapshot.ts`, `compute-memory-diff.ts`, `compute-memory-blame.ts`, `compute-session-memory-summary.ts`, `list-memory-scopes.ts`.
+- `src/testing/` — fake repository (chdb testkit in integration tests).
+
+---
+
+## Reconstruction, diff, and blame
+
+ClickHouse cannot line-diff; it owns storage + manifest reconstruction, and `@domain/memories` owns the text algorithms (`diff` = jsdiff v8, already a workspace dependency; tokenizer = `js-tiktoken`).
+
+### Reconstruct a manifest at time T
+
+Ledger aggregation (no event replay):
+
+```sql
+SELECT store_id, record_id,
+       argMax(content_hash, end_time)  AS content_hash,
+       argMax(change_kind, end_time)   AS change_kind,
+       argMax(span_id, end_time)       AS span_id,
+       argMax(token_count, end_time)   AS token_count
+FROM memory_events
+WHERE organization_id = {org} AND project_id = {project}
+  AND scope = {scope}
+  AND change_kind IN ('add','update','remove')
+  AND end_time <= {at}
+GROUP BY store_id, record_id
+HAVING change_kind != 'remove'
+```
+
+Whole-store wipes (`delete_memory` without `record.id`) are applied as a post-filter: for each `store_id`, drop records whose latest mutation `end_time` is earlier than the store's latest wipe `end_time ≤ {at}`. `T = now` shortcuts to `memory_current`.
+
+Scaling lever (deferred, [D7](#decisions)): if a scope's event count grows large, periodic materialized snapshot checkpoints per scope turn point-in-time into "nearest checkpoint + short forward scan" — git's commit-tree tradeoff. Not built in v1.
+
+### Diff between two points
+
+Reconstruct manifest at `from` and at `to`; join on `(store_id, record_id)`:
+- present only in `to` → **added**; only in `from` → **removed**; both but `content_hash` differs → **updated**; **equal hash ⇒ skip** (the prune).
+- For added/updated/removed, fetch bodies from `memory_blobs` and run `diffLines` (jsdiff). `tokensAdded` = tiktoken over inserted segments, `tokensRemoved` = tiktoken over deleted segments (a whole added record = all its tokens added; a removed record = all removed). `recordsChanged` = counts per bucket.
+- Result renders as `+N −N tokens` and `+A ~U −R records`. Fallback to line counts when a body is absent ([D5](#decisions)).
+
+Because diff compares **endpoints only**, intra-window churn collapses for free — a record added then removed in the same window is equal-or-absent at both ends and nets out. This is the "compare initial to final, not sum of edits" requirement.
+
+### Session / trace write diff (the concurrency rule)
+
+Per [D2](#decisions), a session's write contribution is computed **per record it touched**, endpoint-to-endpoint, over that record's own version chain:
+
+For each `(store_id, record_id)` the session mutated: `before` = the body current just before the session's first mutating event on that record; `after` = the body at the session's last mutating event on that record. Diff `before → after`. Sum across records. When no other session interleaved that record, this equals the clean two-point diff; when interleaving happened, "last-to-finish wins" ([D2](#decisions)) defines `before`/`after` unambiguously by end-time, and the UI is honest that concurrent writers share a scope. Trace-level summary is the same restricted to one `trace_id`.
+
+### Blame
+
+Per record at T: load its mutating versions ordered by `end_time` (each carries full body + `span_id`/`trace_id`/`session_id`). Walk newest→oldest, diffing consecutive versions with jsdiff; a line unchanged from the older version is attributed downward, a line introduced by the newer version is attributed to it. Terminate when every current line is assigned. Output maps each current line → the last span that wrote it, linking to that trace. On demand (files are small); materialize only if a view proves hot.
+
+---
+
+## Feature 1 — memory spans on the Spans tab
+
+**Goal:** the 7 memory operations are first-class spans: classified, colored, filterable, with a detail panel.
+
+- **Classification:** add the ops to `operationSchema` (`span.ts`). `resolveOperation` already reads `gen_ai.operation.name`, so they classify with no extra mapping; the enum entry unlocks first-class icon/color and filtering. `resolvers/memory.ts` extracts `store.id`, `record.id`, `record.count`, `query.text`, and `records` into resolved fields (and, passively, dot-flattened attrs already land in `attr_string`/metadata).
+- **Rendering:** a `memory-operation-section.tsx` under `span-detail/` showing operation, store, record id(s), record count, query text (reads), and the records payload — with a "View in Memory →" link to the scope page (Feature 3/4). An icon in `span-tree/span-icon.tsx` and a color in the operation color map (the operation-coloring introduced by #4023). A filter entry in `span-filters.ts` to filter a trace to its memory ops.
+- **No storage dependency** — ships independently of the ledger.
+
+**UI copy:** `search_memory` reads render as "read"; create/update/upsert/delete render with their `change_kind` badge.
+
+---
+
+## Feature 2 — session / trace memory summary
+
+**Goal:** a compact chip on session and trace views: `read 412k · write +612 −24` (tokens), plus `+A ~U −R records` on expand.
+
+- **Read** = Σ `token_count` of the blobs returned by `search_memory` spans in the session/trace (tiktoken approx over `gen_ai.memory.records`). When content is absent, degrade to record count (`read 3 records`). ([D5](#decisions))
+- **Write** = the session/trace write diff from [Reconstruction § session write diff](#session--trace-write-diff-the-concurrency-rule): `+N −N tokens` derived from the endpoint line diff, churn collapsed. Fallback to `+/- lines` if a body is missing.
+- **Placement:** `-components/session-detail-drawer.tsx` and the trace detail header. Computed by `compute-session-memory-summary` (cached per session/trace; recomputed when the memory-projection worker writes new events for that session).
+- **Click-through:** the write chip links to Feature 4 (`/memory/{scope}?session={id}`). If the session touched multiple scopes, the chip expands to one row per scope.
+
+---
+
+## Feature 3 — the Memory page
+
+**Goal:** browse the current state of any scope like a repo.
+
+- **Nav + routes:** a "Memory" entry in `apps/web/src/layouts/AppSidebar/index.tsx`; routes:
+  - `…/projects/$projectSlug/memory/index.tsx` — **scope list**: one row per scope (userId / scope-attr / `""`), with file count, total tokens, last-updated, and # sessions that wrote it. Backed by `list-memory-scopes` over `memory_current`.
+  - `…/projects/$projectSlug/memory/$scope/index.tsx` — **scope detail**: left filetree (from `{store_id}/{record_id}` split on `/`) for the latest snapshot; right pane shows the selected record's current body; a per-line **blame gutter** where each line links to the span/trace that last wrote it (`compute-memory-blame`).
+- **Latest snapshot** uses `memory_current` (hot). Empty/`""` scope is listed explicitly.
+- Deleted records disappear from the tree; a "show deleted" toggle can surface tombstones (nice-to-have, not required for v1).
+
+---
+
+## Feature 4 — commit-style session diff view
+
+**Goal:** from a session's write chip, land on the scope at that session and read it like a GitHub commit.
+
+- **Route:** `…/memory/$scope/index.tsx?session={sessionId}` (or `…/memory/$scope/sessions/$sessionId`). Header shows the session/trace link and the `+N −N tokens · +A ~U −R records` summary.
+- **Time-travel snapshot:** reconstruct the scope's manifest **as of the session's end** (`reconstruct-snapshot(scope, at=sessionEnd)`), so the tree reflects history, not "now".
+- **Changed files marked:** files the session added/updated/removed get badges in the tree; selecting one shows a unified (default) / split diff of `before → after` for that record (the session write diff). Unchanged files are browsable but unmarked.
+- This is the surface that realizes LAT-729's "each change references the trace that caused it," at commit granularity.
+
+---
+
+## Metering, retention, tenancy, self-hosting
+
+- **Metering:** memory operations are spans; they are metered by the existing span/trace usage path. No new meter. ([D11](#decisions))
+- **Retention:** `memory_events`/`memory_current` follow project/plan retention like other CH tables. `memory_blobs` gets its own retention knob (content is the heaviest and most sensitive column); a blob is collectable once no retained event references its hash. Point-in-time reconstruction older than blob retention degrades to hashes/ids without bodies.
+- **Tenancy:** every table is `organization_id`/`project_id` scoped; `scope` strings are opaque and org-partitioned; blob dedup is per-org (never cross-tenant).
+- **Self-hosting:** no new infrastructure — blobs inline in ClickHouse (ZSTD), with the object-storage fallback using the existing `@platform/storage-object` `StorageDisk` (SeaweedFS by default). New deps `js-tiktoken` (MIT) and the already-present `diff`/jsdiff (BSD) are permissive and satisfy the OSS bundle rule; audit transitive additions when adding `js-tiktoken`.
+
+---
+
+## Decisions
+
+- **D1 — Content/PII not gated (v1).** Store `gen_ai.memory.records` content as sent; degrade gracefully when absent. Revisit consent/redaction/retention before GA. *(User call.)*
+- **D2 — Span = full record snapshot; last-to-finish wins.** Each mutating span carries the full new body of the record it touches; versions order by `end_time`; the latest is current. No parent-pointer isolation, no merge. *(User call.)*
+- **D3 — Record identity = `(store_id, record_id)`; UI path = `"{store_id}/{record_id}"` split on `/`.** Records need not be real files. *(User call.)*
+- **D4 — Scope resolution order:** `gen_ai.memory.scope` → `latitude.memory.scope` → resolved `user.id` → `""`. *(User call.)*
+- **D5 — Read metric = approx tokens (js-tiktoken), fallback record count. Write metric = `+/− tokens` from the endpoint line diff (fallback lines) + records changed.** *(User call.)*
+- **D6 — Git-style storage:** content-addressed `memory_blobs` (dedup) + `memory_events` ledger + `memory_current` projection. Store snapshots, derive diffs.
+- **D7 — Reconstruction:** current-state via `memory_current`; point-in-time / diff / blame on demand in `@domain/memories`. Per-scope snapshot checkpoints deferred until volume demands.
+- **D8 — Materialization at the trace-end boundary** via a dedicated `memory-projection` worker (isolated failure domain, mirrors deterministic-flaggers).
+- **D9 — Delete semantics:** `delete_memory` with `record.id` = record remove; without = whole-store wipe (reconstruction post-filter by store wipe time); `delete_memory_store` drops the store folder.
+- **D10 — Provider adapters out of scope**, but `memory_events.source` reserved so Mem0/Supermemory/Zep can write the same tables later.
+- **D11 — No billing change**; memory ops ride span metering.
+- **D12 — Tenancy:** all tables org+project scoped; blob dedup per-org.
+
+---
+
+## Tasks
+
+> **Status legend**: `[ ] pending`, `[~] in progress`, `[x] complete`
+
+### Phase 0 — Memory spans on the Spans tab (Feature 1)
+
+- [ ] **P0-1**: Add the 7 memory operations to `operationSchema` (`packages/domain/spans/src/entities/span.ts`).
+- [ ] **P0-2**: Add `resolvers/memory.ts` (store/record/count/query/records/scope candidate lists) + wire into `resolvers/index.ts`, `ResolvedAttributes`, and `transform.ts`.
+- [ ] **P0-3**: Spans-tab rendering — `memory-operation-section.tsx` detail panel, span icon, operation color, `span-filters.ts` filter.
+- [ ] **P0-4**: Add `memoryScope` to `packages/telemetry/typescript/src/constants/attributes.ts` + SDK capture option; document the scope/user-tagging requirement.
+
+**Exit gate:** a trace containing `create_memory`/`update_memory`/`search_memory` spans classifies them, shows the detail panel, colors them in the waterfall, and filters to them — no ledger yet.
+
+### Phase 1 — Ledger, blobs, projection, materializer (engine)
+
+- [ ] **P1-1**: `ch:create` migrations for `memory_events`, `memory_blobs`, `memory_current` (append-only rules).
+- [ ] **P1-2**: `@domain/memories` package skeleton (entities, port, index/testing exports) matching `@domain/scores`.
+- [ ] **P1-3**: `memory-repository.ts` CH adapter: insert events/blobs, upsert current, read current snapshot, read manifest-at-T, read record versions, read session events, list scopes.
+- [ ] **P1-4**: `materialize-trace-memory` use-case (body → sha256 + tiktoken `token_count`, `change_kind` derivation incl. upsert add-vs-update and whole-store wipe) + `memory-projection` worker triggered from `trace-end.ts`.
+- [ ] **P1-5**: `reconstruct-snapshot` (ledger argMax + store-wipe post-filter; `memory_current` shortcut for now).
+
+**Exit gate:** ingesting seeded memory spans populates the three tables; `reconstruct-snapshot(scope, now)` and `reconstruct-snapshot(scope, pastT)` return correct manifests in chdb integration tests; dedup verified (identical body ⇒ one blob).
+
+### Phase 2 — Diff, blame, and the session/trace summary (Feature 2)
+
+- [ ] **P2-1**: `compute-memory-diff` (hash-prune + jsdiff + token deltas + record buckets).
+- [ ] **P2-2**: `compute-session-memory-summary` (read tokens + per-record endpoint write diff, churn collapse, concurrency rule).
+- [ ] **P2-3**: `compute-memory-blame` (version-walk attribution to span/trace).
+- [ ] **P2-4**: Summary chip in `session-detail-drawer.tsx` + trace header; multi-scope expansion; click-through to Feature 4.
+
+**Exit gate:** on seeded data, `read X · write +N −N` matches hand-computed values; a record changed twice in one session counts once (net); blame attributes each line to the correct span.
+
+### Phase 3 — The Memory page (Feature 3)
+
+- [ ] **P3-1**: Nav entry + `/memory` scope-list route (`list-memory-scopes`).
+- [ ] **P3-2**: `/memory/$scope` scope-detail: filetree (path split), content pane, blame gutter linking to traces.
+
+**Exit gate:** a scope with multiple stores/records renders as a tree with correct current bodies and working per-line blame links.
+
+### Phase 4 — Commit-style session diff view (Feature 4)
+
+- [ ] **P4-1**: `/memory/$scope?session=…` route: time-travel snapshot at session end, changed-file badges, per-file unified/split diff, header summary + trace link.
+
+**Exit gate:** clicking a session's write chip lands on the scope as-of that session, marks exactly the files it changed, and shows a correct per-file diff.
+
+### Later (out of this spec)
+
+- Provider adapters (Mem0 first: webhook/history → same tables via `source`).
+- `memory-pollution` flagger → signals; rollback-report ("flag polluted trace → affected changes → inverse operations").
+- Snapshot checkpoints for high-volume scopes.


### PR DESCRIPTION
## What does this PR do?

First step of Memory Observability (LAT-729): make OTEL GenAI **memory operation** spans first-class on the Spans tab, and start capturing the attributes those spans carry. No storage engine yet — this is the self-contained on-ramp, and it doubles as a probe for whether any current traffic already emits `gen_ai.memory.*`.

The PR also lands the full design doc it implements against: `specs/memory-observability.md` (the git-like snapshot/diff/blame model, the four planned features, and the phased plan). Only Phase 0 is code here.


https://github.com/user-attachments/assets/3839edc3-003c-4c66-a661-3db6ad15156d



### Memory spans, end to end

- **Operation enum.** `operationSchema` now names the 7 memory operations — `create_memory`, `update_memory`, `upsert_memory`, `delete_memory`, `search_memory`, `create_memory_store`, `delete_memory_store` — alongside `MEMORY_OPERATIONS` / `isMemoryOperation` exports. (The enum was already a `z.union([enum, z.string()])` pass-through, so these strings flowed through un-normalized before; now they're typed and classifiable.)
- **Structured attribute capture.** `resolveAnyValue` in the OTLP transform previously dropped `arrayValue`/`kvlistValue` attributes on the floor. It now flattens them to a JSON string so structured payloads — notably `gen_ai.memory.records` (the record content array) — survive into `attr_string`. This is a general fix: any previously-dropped structured attribute now persists.
- **Spans-tab rendering.** Memory spans get a `Brain`/`Database` icon in the tree, an amber (`bg-warning/60`) waterfall bar, a **"Memory" filter toggle** (wired through both the trace and session span views), and a detail panel showing store / record / count, the search query, and the parsed records content — with a "Content not captured" fallback when the payload is absent.
- **TS SDK.** New `memoryScope` capture option → stamped as `latitude.memory.scope` on both the processor and tracer paths. This is the scope key the later phases group memory history by (falls back to the span's `user.id`, then an empty bucket).

### Decisions worth flagging (deviations from the spec's original Phase 0 plan)

- **No ClickHouse migration.** Filtering rides the indexed `operation` column; scalar memory attrs and the flattened `records` JSON ride the existing `attr_string`/`attr_int` maps already returned by the span-detail read path. The dedicated `resolvers/memory.ts`, resolved columns, and ingest-side scope resolution move to Phase 1 with the ledger.
- **The array/kvlist flattening is intentionally general** and relies on `CODEC(ZSTD)` for the extra text. If a pathological emitter bloats `attr_string`, the follow-up is a length cap in `resolveAnyValue` (noted in the spec).
- **Web keeps its own 7-string `isMemoryOperation`** (`spans-tab/memory-operations.ts`, type-only domain import) rather than pulling the domain runtime helper into the client bundle — accepted duplication.
- **`OPERATION_ICON`'s `satisfies` is vacuous** (the `z.string()` catch-all collapses the `Exclude` to `never`), so the memory icon entries are a manual, non-compiler-enforced addition.

Deferred to Phase 1 (all recorded in the spec's implementation notes): the memory ledger + content-addressed blobs + current-state projection, the `resolvers/memory.ts` resolver, and the `"update_memory · <record.id>"` tree-row label.

## Related issue (if applicable)

Refs LAT-729 (Linear). Phase 0 of a multi-phase effort — does not close the issue.

## How was this tested?

- Typecheck clean: `@domain/spans`, `@latitude-data/telemetry`, `@app/web`.
- Unit tests pass (added transform, span-filter, and processor cases): domain 916, telemetry 140, web 611.
- `knip` and Biome clean.

Manual UI check (memory span → trace on the Spans tab): confirm the memory icon + amber bar, that the "Memory" filter narrows the tree, and that the detail panel shows store/record/count + parsed records. Cleanest producer is an OTLP `POST /v1/traces` span with `gen_ai.operation.name = "update_memory"` and `gen_ai.memory.records` sent as a structured array (exercises the transform fix).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the CLA
