### PR TITLE
fix(flaggers): skip markdown links in output-schema validation

### DIFF
--- a/packages/domain/flaggers/src/helpers.test.ts
+++ b/packages/domain/flaggers/src/helpers.test.ts
@@ -286,6 +286,18 @@ describe("detectOutputSchemaValidationFlagger", () => {
     expect(result).toEqual({ matched: false })
   })
 
+  it("does not match markdown links that start with [", () => {
+    const result = detectOutputSchemaValidationFlagger(
+      makeAssistantTrace([
+        assistantText(
+          "[Pull request #39](https://github.com/latitude-dev/latitude-llm-public/pull/39) is open against main.",
+        ),
+      ]),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
   it("matches with the trailing-comma message when JSON is truncated after a comma", () => {
     const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText('{"a": 1,')]))
 

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -200,9 +200,7 @@ function looksLikeStructuredJsonOutput(content: string): boolean {
   const first = afterBracket[0]!
   if (first === "]" || first === "{" || first === "[" || first === '"' || first === "-") return true
   if (first >= "0" && first <= "9") return true
-  return (
-    afterBracket.startsWith("true") || afterBracket.startsWith("false") || afterBracket.startsWith("null")
-  )
+  return afterBracket.startsWith("true") || afterBracket.startsWith("false") || afterBracket.startsWith("null")
 }
 
 export function detectOutputSchemaValidationFlagger(trace: TraceDetail): DeterministicFlaggerMatch {

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -189,6 +189,22 @@ function responseIndicatesFailure(response: unknown): boolean {
   return Array.isArray(response.errors) && response.errors.length > 0
 }
 
+function looksLikeStructuredJsonOutput(content: string): boolean {
+  if (content.startsWith("{")) return true
+  if (!content.startsWith("[")) return false
+  if (/^\[[^\]]+\]\(/.test(content)) return false
+
+  const afterBracket = content.slice(1).trimStart()
+  if (afterBracket.length === 0) return true
+
+  const first = afterBracket[0]!
+  if (first === "]" || first === "{" || first === "[" || first === '"' || first === "-") return true
+  if (first >= "0" && first <= "9") return true
+  return (
+    afterBracket.startsWith("true") || afterBracket.startsWith("false") || afterBracket.startsWith("null")
+  )
+}
+
 export function detectOutputSchemaValidationFlagger(trace: TraceDetail): DeterministicFlaggerMatch {
   for (let msgIdx = 0; msgIdx < trace.allMessages.length; msgIdx++) {
     const message = trace.allMessages[msgIdx]!
@@ -196,7 +212,7 @@ export function detectOutputSchemaValidationFlagger(trace: TraceDetail): Determi
     for (const rawPart of iterMessageParts(message.parts)) {
       if (!isRecord(rawPart) || rawPart.type !== "text") continue
       const content = typeof rawPart.content === "string" ? rawPart.content.trim() : ""
-      if (!content || (!content.startsWith("{") && !content.startsWith("["))) continue
+      if (!content || !looksLikeStructuredJsonOutput(content)) continue
 
       if (content.endsWith(","))
         return match("Assistant output ended with a trailing comma, suggesting truncated JSON", msgIdx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Signal

**Structured output fails JSON parse** (`structured-output-fails-json-parse`, `pik0jpz8e326o3nvxgmzjeqh`) in project Guilhèm.

Sample trace `51e0d0e0fd2da07d49dc5b2a61389b51` (latitude-llm / Claude Code) was flagged with:

> Assistant output failed JSON parse (malformed or truncated structured output)

The scored assistant turn is normal markdown prose that starts with a link:

```
[Pull request #39](https://github.com/latitude-dev/latitude-llm-public/pull/39) is open against the blog repo's main...
```

There is no structured JSON output in that message.

## Root cause

`detectOutputSchemaValidationFlagger` treated any assistant text part starting with `[` as candidate JSON. Markdown links share that prefix, so `JSON.parse` fails and the deterministic output-schema flagger fires a false positive.

## Fix

Before parsing, skip text that matches markdown link syntax (`[label](url)`), and only treat `[`-prefixed content as JSON when the character after `[` looks like a JSON array opener (`]`, `{`, `[`, `"`, a number, `-`, or `true`/`false`/`null`).

## Testing

- Added a regression test using the trace excerpt above.
- `pnpm --filter @domain/flaggers test -- helpers.test.ts`

Signal left open for human verification after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd4da954-fbe8-5ce8-ab64-2ef98fcbca70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd4da954-fbe8-5ce8-ab64-2ef98fcbca70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

