### PR TITLE
fix: stop false positives on unknown tool_call id from truncated Claude Code traces

### DIFF
--- a/packages/domain/flaggers/src/helpers.test.ts
+++ b/packages/domain/flaggers/src/helpers.test.ts
@@ -166,6 +166,32 @@ describe("detectToolCallErrorsFlagger", () => {
     }
   })
 
+  it("does not flag tool responses orphaned by truncated conversation history", () => {
+    const result = detectToolCallErrorsFlagger(
+      makeTrace([
+        { role: "system", parts: [{ type: "text", content: "system prompt" }] },
+        toolResponse("toolu_01Mc2CLTvPdWYtKRaUA5VnQa", { ok: true }),
+        { role: "assistant", parts: [{ type: "text", content: "Done reviewing the images." }] },
+      ]),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("still flags tool responses with unknown ids when no assistant follows", () => {
+    const result = detectToolCallErrorsFlagger(
+      makeTrace([
+        { role: "system", parts: [{ type: "text", content: "system prompt" }] },
+        toolResponse("toolu_orphan", { ok: true }),
+      ]),
+    )
+
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("unknown tool_call id")
+    }
+  })
+
   it("does not match plain-string responses by keyword (only structured signals count)", () => {
     const result = detectToolCallErrorsFlagger(
       makeTrace([

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -67,6 +67,7 @@ export function detectToolCallErrorsFlagger(trace: TraceMessagesOnly): Determini
       const toolCallId = typeof part.id === "string" ? part.id.trim() : ""
       const call = toolCallId ? callById.get(toolCallId) : undefined
       if (!call) {
+        if (isLikelyTruncatedToolResponse(trace.allMessages, msgIdx, callById.size)) continue
         return match(`Tool response references an unknown tool_call id "${toolCallId || "<empty>"}"`, msgIdx)
       }
 
@@ -81,6 +82,18 @@ export function detectToolCallErrorsFlagger(trace: TraceMessagesOnly): Determini
   }
 
   return NO_MATCH
+}
+
+function isLikelyTruncatedToolResponse(
+  messages: TraceMessagesOnly["allMessages"],
+  messageIndex: number,
+  registeredCallCount: number,
+): boolean {
+  if (registeredCallCount > 0 || messageIndex === 0) return false
+  for (let i = messageIndex + 1; i < messages.length; i++) {
+    if (messages[i]!.role === "assistant") return true
+  }
+  return false
 }
 
 function toNonEmptyString(value: unknown): string | null {

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -759,6 +759,53 @@ describe("span size capping", () => {
     expect(JSON.stringify(llm).length).toBeLessThan(256 * 1024)
   })
 
+  it("keeps the issuing assistant message when tail truncation would orphan tool responses", () => {
+    const giant = "x".repeat(60_000)
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          userText: "analyze images",
+          calls: [
+            {
+              messageId: "msg_tools",
+              model: "claude-opus-4-8",
+              text: "",
+              startMs: 1_000,
+              endMs: 1_500,
+              tokens: { input_tokens: 100, output_tokens: 50 },
+              toolUses: [
+                { id: "toolu_01", name: "Read", input: { path: "a.jpg" }, output: giant, startMs: 1_500, endMs: 1_800 },
+                { id: "toolu_02", name: "Read", input: { path: "b.jpg" }, output: giant, startMs: 1_500, endMs: 1_800 },
+              ],
+            },
+            {
+              messageId: "msg_final",
+              model: "claude-opus-4-8",
+              text: "summary",
+              startMs: 2_000,
+              endMs: 2_500,
+              tokens: { input_tokens: 200, output_tokens: 100 },
+              toolUses: [],
+            },
+          ],
+        }),
+      ],
+    })
+    const llm = unwrap(otlpSpans(req).find((s) => getAttr(s.attributes, "llm_request.message_id") === "msg_final"))
+    const inputJson = unwrap(getAttr(llm.attributes, "gen_ai.input.messages"))
+    const messages = JSON.parse(inputJson) as Array<{ role: string; parts: Array<{ type: string; id?: string }> }>
+    const assistantWithCall = messages.find(
+      (m) => m.role === "assistant" && m.parts.some((p) => p.type === "tool_call" && p.id === "toolu_01"),
+    )
+    const toolResponses = messages.find(
+      (m) => m.role === "tool" && m.parts.some((p) => p.type === "tool_call_response" && p.id === "toolu_01"),
+    )
+    expect(assistantWithCall).toBeDefined()
+    expect(toolResponses).toBeDefined()
+  })
+
   it("clamps oversized user prompts on the interaction span", () => {
     const req = buildOtlpRequest({
       sessionId: "sess-cap",

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -602,8 +602,10 @@ function capMessagesJson(messages: Message[], maxBytes: number): CapResult {
     start--
   }
 
-  const kept = messages.slice(start)
+  const pairStart = extendStartForLeadingToolResponses(messages, start)
+  const kept = messages.slice(pairStart)
   const notes: string[] = []
+  if (pairStart < start) notes.push(`kept ${start - pairStart} message(s) for tool_call pairing`)
   if (kept.length === 0) {
     // Even the newest message alone exceeds the budget: shrink its parts instead.
     const last = messages[messages.length - 1]
@@ -614,8 +616,54 @@ function capMessagesJson(messages: Message[], maxBytes: number): CapResult {
     }
     start = messages.length - 1
   }
-  if (start > 0) notes.push(`dropped ${start} oldest of ${messages.length} messages`)
+  if (pairStart > 0) notes.push(`dropped ${pairStart} oldest of ${messages.length} messages`)
   return { json: JSON.stringify(kept), note: notes.join("; ") }
+}
+
+function toolCallIdsInMessage(message: Message): Set<string> {
+  const ids = new Set<string>()
+  for (const part of message.parts) {
+    if (part.type === "tool_call" && typeof part.id === "string" && part.id.trim() !== "") {
+      ids.add(part.id.trim())
+    }
+  }
+  return ids
+}
+
+function toolCallResponseIdsInMessage(message: Message): Set<string> {
+  const ids = new Set<string>()
+  for (const part of message.parts) {
+    if (part.type === "tool_call_response" && typeof part.id === "string" && part.id.trim() !== "") {
+      ids.add(part.id.trim())
+    }
+  }
+  return ids
+}
+
+function extendStartForLeadingToolResponses(messages: Message[], start: number): number {
+  let pairStart = start
+  while (pairStart > 0) {
+    const first = messages[pairStart]
+    if (!first || first.role !== "tool") break
+
+    const responseIds = toolCallResponseIdsInMessage(first)
+    if (responseIds.size === 0) break
+
+    const knownCallIds = new Set<string>()
+    for (const message of messages.slice(pairStart)) {
+      for (const id of toolCallIdsInMessage(message)) knownCallIds.add(id)
+    }
+    if ([...responseIds].every((id) => knownCallIds.has(id))) break
+
+    const prev = messages[pairStart - 1]
+    if (!prev || prev.role !== "assistant") break
+
+    const prevCallIds = toolCallIdsInMessage(prev)
+    if (![...responseIds].every((id) => prevCallIds.has(id))) break
+
+    pairStart--
+  }
+  return pairStart
 }
 
 function capPartsJson(parts: MessagePart[], maxBytes: number): CapResult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes false positives on the **Tool response references unknown tool_call id** signal for healthy Claude Code agentic traces (e.g. project `paula-s-claude-code`, signal `ayutdlcugpvjznou20qilfmb`).

## Root cause

Investigation on sample trace `9ad5bf1ad04fc6f2acca136bcb608bac` showed the last `llm_request` span input contained only a `tool` message with two large `tool_call_response` parts (`toolu_01Mc2CLTvPdWYtKRaUA5VnQa`, `toolu_012sh1575Na2UbS2N42evxbB`) and no preceding assistant `tool_call` messages. Trace `allMessages` is built from the last span's input plus output, so the tool-call-errors flagger saw orphan responses and fired.

Two mechanisms produce this shape:

1. **Claude Code telemetry input capping** (`capMessagesJson`) keeps the tail of the conversation under a 64KB budget. Large tool outputs can fill the budget alone, dropping the assistant message that issued the calls.
2. **Flagger strictness** — `detectToolCallErrorsFlagger` treated any unmatched `tool_call_response` id as an error, with no allowance for truncation/compaction artifacts where earlier calls are no longer present in the stored conversation window.

The underlying agent run was healthy: tool spans executed successfully and the final assistant message summarized the tool results.

## Changes

### `@domain/flaggers`

- Skip the unknown `tool_call` id check when responses appear after earlier context, no calls are registered yet in the scanned window, and a later assistant message continues the turn. This matches the compaction/truncation pattern without suppressing genuine errors (standalone orphan responses, or mismatched ids after a registered call, still flag).

### `@latitude-data/claude-code-telemetry`

- When tail-first input capping would start the kept slice on a `tool` message whose `tool_call_response` ids are unmatched, walk back to include the immediately preceding assistant message that issued those calls.

## Testing

- Added regression tests in `helpers.test.ts` mirroring the signal's conversation shape (system → orphan tool responses → assistant).
- Added regression test in `otlp.test.ts` for large paired tool outputs under the input cap.
- `pnpm --filter @domain/flaggers test`
- `pnpm --filter @latitude-data/claude-code-telemetry test`
- Typecheck on both packages

## Follow-up

Existing historical traces with already-truncated payloads will stop matching after deploy via the flagger guard. New traces also get better input pairing from the telemetry change. The signal was not muted or resolved — please verify in the console after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a814d18-b06b-52a2-966f-dd122c00fdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a814d18-b06b-52a2-966f-dd122c00fdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

