### PR TITLE
Raise production web minimum capacity

### DIFF
--- a/infra/config.ts
+++ b/infra/config.ts
@@ -218,8 +218,8 @@ export const productionConfig: EnvironmentConfig = {
         memory: 3072,
         port: 8080,
         healthCheckPath: "/api/health",
-        desiredCount: 1,
-        minCount: 1,
+        desiredCount: 2,
+        minCount: 2,
         maxCount: 4,
       },
       {


### PR DESCRIPTION
Production web containers have been crashing with OOMs. This raises the ECS desired count and autoscaling minimum from one task to two, while keeping the maximum at four.

The production Pulumi stack has already been applied and verified with two running web tasks and no pending tasks.

Validation:
- `mise exec -- pnpm --filter latitude-infra typecheck`
- Pulumi production preview and apply: 2 resources updated, 216 unchanged
- ECS service stability and `https://console.latitude.so/api/health`