### PR TITLE
fix(claude-code-telemetry): install Stop hook with @latest so it self-updates

### DIFF
--- a/dev-docs/claude-code-telemetry.md
+++ b/dev-docs/claude-code-telemetry.md
@@ -19,7 +19,7 @@ Paste into `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y @latitude-data/claude-code-telemetry"
+            "command": "npx -y @latitude-data/claude-code-telemetry@latest"
           }
         ]
       }
@@ -27,6 +27,8 @@ Paste into `~/.claude/settings.json`:
   }
 }
 ```
+
+The `@latest` tag makes the hook self-update: `npx` re-resolves the newest published version on each run (a cheap, etag-revalidated metadata check — a full download only when a new version ships), so users pick up fixes without re-installing. A bare `npx <pkg>` would reuse whatever the npx cache first fetched and never update. Keep `async: true` so this resolution runs off the turn's critical path.
 
 The hook runs on every assistant-turn completion. It reads **new** lines from the session transcript since the last run (state is tracked at `~/.claude/state/latitude/state.json`), converts them into OTLP spans, and POSTs to `${LATITUDE_BASE_URL}/v1/traces` with `Authorization: Bearer ${LATITUDE_API_KEY}` and `X-Latitude-Project: ${LATITUDE_PROJECT}`. The project must already exist under the organization that owns the API key.
 

--- a/docs/telemetry/claude-code.md
+++ b/docs/telemetry/claude-code.md
@@ -19,7 +19,7 @@ Stream Claude Code conversations into Latitude as traces. After setup, Claude Co
 3. Run the installer:
 
 ```bash
-npx -y @latitude-data/claude-code-telemetry install
+npx -y @latitude-data/claude-code-telemetry@latest install
 ```
 
 The installer prompts for your API key and project slug, then configures Claude Code to export telemetry after each turn.
@@ -27,7 +27,7 @@ The installer prompts for your API key and project slug, then configures Claude 
 You can also pass values directly:
 
 ```bash
-npx -y @latitude-data/claude-code-telemetry install \
+npx -y @latitude-data/claude-code-telemetry@latest install \
   --api-key=lat_xxx \
   --project=your-project-slug \
   --yes
@@ -50,7 +50,7 @@ Restart Claude Code for the change to take effect.
 To remove the integration:
 
 ```bash
-npx -y @latitude-data/claude-code-telemetry uninstall
+npx -y @latitude-data/claude-code-telemetry@latest uninstall
 ```
 
 ## Manual configuration
@@ -69,7 +69,7 @@ If you manage Claude Code settings yourself, add the telemetry command to `~/.cl
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "command": "npx -y @latitude-data/claude-code-telemetry@latest",
             "async": true
           }
         ]

--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11] - 2026-07-16
+
+### Changed
+
+- The installer now writes the Stop-hook command with the `@latest` tag (`npx -y @latitude-data/claude-code-telemetry@latest`) instead of a bare package name. A bare `npx <pkg>` reuses whatever version the npx cache first fetched and never updates, so users could silently stay on an old build; `@latest` re-resolves the newest published version each run (a cheap etag-revalidated check, off the critical path thanks to `async: true`), so fixes ship without a re-install. Existing installs keep working; re-running the installer or updating the command picks up the change. Docs updated to match.
+
 ## [0.0.10] - 2026-07-14
 
 ### Fixed

--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The installer now writes the Stop-hook command with the `@latest` tag (`npx -y @latitude-data/claude-code-telemetry@latest`) instead of a bare package name. A bare `npx <pkg>` reuses whatever version the npx cache first fetched and never updates, so users could silently stay on an old build; `@latest` re-resolves the newest published version each run (a cheap etag-revalidated check, off the critical path thanks to `async: true`), so fixes ship without a re-install. Existing installs keep working; re-running the installer or updating the command picks up the change. Docs updated to match.
+- The installer now writes the Stop-hook command with the `@latest` tag (`npx -y @latitude-data/claude-code-telemetry@latest`) instead of a bare package name. A bare `npx <pkg>` reuses whatever version the npx cache first fetched and never updates, so users could silently stay on an old build; `@latest` re-resolves the newest published version each run (a cheap etag-revalidated check, off the critical path thanks to `async: true`), so fixes ship without a re-install. Docs updated to match.
+- Re-running `install` now **upgrades** an existing Latitude Stop hook to the current command (and forces `async: true`) instead of no-opping when any hook is already present. Previously the installer left older hooks — the exact bare-`npx` installs this release targets — untouched, so `install` prints "Stop hook updated" and rewrites them in place.
 
 ## [0.0.10] - 2026-07-14
 

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/node-version.ts
+++ b/packages/telemetry/claude-code/src/node-version.ts
@@ -8,7 +8,7 @@ export function buildVersionError(version: string): string | null {
       `The Stop hook is failing silently. To fix, ensure the "node" on your PATH is v20.12+\n` +
       `before Claude Code runs this hook.\n` +
       `With nvm, update the hook command in ~/.claude/settings.json to prefix the PATH:\n` +
-      `  "command": "PATH=\\"/home/<you>/.nvm/versions/node/v22.x.x/bin:$PATH\\" npx -y @latitude-data/claude-code-telemetry"\n`
+      `  "command": "PATH=\\"/home/<you>/.nvm/versions/node/v22.x.x/bin:$PATH\\" npx -y @latitude-data/claude-code-telemetry@latest"\n`
     )
   }
   return null

--- a/packages/telemetry/claude-code/src/settings-file.test.ts
+++ b/packages/telemetry/claude-code/src/settings-file.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import {
+  addLatitudeStopHook,
+  type ClaudeSettings,
+  hasLatitudeStopHook,
+  latitudeStopHookCommand,
+} from "./settings-file.ts"
+
+const LATEST = "npx -y @latitude-data/claude-code-telemetry@latest"
+const BARE = "npx -y @latitude-data/claude-code-telemetry"
+
+function stopCommands(settings: ClaudeSettings): string[] {
+  return (settings.hooks?.Stop ?? []).flatMap((g) => (g.hooks ?? []).map((h) => h.command ?? ""))
+}
+
+describe("addLatitudeStopHook", () => {
+  it("adds a Latitude Stop hook when none exists", () => {
+    const next = addLatitudeStopHook({}, LATEST)
+    expect(stopCommands(next)).toEqual([LATEST])
+    expect(next.hooks?.Stop?.[0]?.hooks[0]?.async).toBe(true)
+  })
+
+  it("upgrades an existing bare-npx hook to the new command", () => {
+    const before: ClaudeSettings = {
+      hooks: { Stop: [{ hooks: [{ type: "command", command: BARE, async: true }] }] },
+    }
+    const next = addLatitudeStopHook(before, LATEST)
+    // Rewritten in place — not appended as a second hook.
+    expect(stopCommands(next)).toEqual([LATEST])
+  })
+
+  it("upgrades a dev dist-path hook and forces async", () => {
+    const before: ClaudeSettings = {
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "node /repo/packages/telemetry/claude-code/dist/index.js" }] }],
+      },
+    }
+    const next = addLatitudeStopHook(before, LATEST)
+    expect(stopCommands(next)).toEqual([LATEST])
+    expect(next.hooks?.Stop?.[0]?.hooks[0]?.async).toBe(true)
+  })
+
+  it("leaves an already-current hook unchanged and does not duplicate", () => {
+    const before: ClaudeSettings = {
+      hooks: { Stop: [{ hooks: [{ type: "command", command: LATEST, async: true }] }] },
+    }
+    const next = addLatitudeStopHook(before, LATEST)
+    expect(stopCommands(next)).toEqual([LATEST])
+  })
+
+  it("preserves unrelated Stop hooks and other hook events", () => {
+    const before: ClaudeSettings = {
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "my-own-hook" }] }],
+        PreToolUse: [{ hooks: [{ type: "command", command: "guard" }] }],
+      },
+    }
+    const next = addLatitudeStopHook(before, LATEST)
+    expect(stopCommands(next)).toEqual(["my-own-hook", LATEST])
+    expect(next.hooks?.PreToolUse?.[0]?.hooks[0]?.command).toBe("guard")
+  })
+})
+
+describe("latitudeStopHookCommand / hasLatitudeStopHook", () => {
+  it("returns the existing Latitude command, or undefined when absent", () => {
+    expect(latitudeStopHookCommand({})).toBeUndefined()
+    expect(hasLatitudeStopHook({})).toBe(false)
+
+    const withBare: ClaudeSettings = {
+      hooks: { Stop: [{ hooks: [{ type: "command", command: BARE }] }] },
+    }
+    expect(latitudeStopHookCommand(withBare)).toBe(BARE)
+    expect(hasLatitudeStopHook(withBare)).toBe(true)
+  })
+})

--- a/packages/telemetry/claude-code/src/settings-file.ts
+++ b/packages/telemetry/claude-code/src/settings-file.ts
@@ -78,27 +78,39 @@ function isLatitudeHookCommand(command: string | undefined): boolean {
 }
 
 export function hasLatitudeStopHook(settings: ClaudeSettings): boolean {
-  const groups = settings.hooks?.Stop ?? []
-  for (const group of groups) {
-    for (const hook of group.hooks ?? []) {
-      if (isLatitudeHookCommand(hook.command)) return true
-    }
-  }
-  return false
+  return latitudeStopHookCommand(settings) !== undefined
 }
 
+// The command of the first existing Latitude Stop hook, if any — lets the installer
+// tell "fresh install" from "upgrade an older command" (e.g. a bare `npx` hook).
+export function latitudeStopHookCommand(settings: ClaudeSettings): string | undefined {
+  for (const group of settings.hooks?.Stop ?? []) {
+    for (const hook of group.hooks ?? []) {
+      if (isLatitudeHookCommand(hook.command)) return hook.command
+    }
+  }
+  return undefined
+}
+
+// Ensure a Latitude Stop hook runs `command`. An existing Latitude hook (including
+// an older bare-`npx` command or a dev dist path) is rewritten to `command` and
+// forced async, so re-running install upgrades stale hooks instead of leaving them
+// as-is. Only adds a new entry when none is present.
 export function addLatitudeStopHook(
   settings: ClaudeSettings,
   command = "npx -y @latitude-data/claude-code-telemetry@latest",
 ): ClaudeSettings {
-  if (hasLatitudeStopHook(settings)) return settings
-  const hooks = { ...(settings.hooks ?? {}) }
-  const stop = [...(hooks.Stop ?? [])]
-  stop.push({
-    hooks: [{ type: "command", command, async: true }],
-  })
-  hooks.Stop = stop
-  return { ...settings, hooks }
+  let found = false
+  const stop: HookGroup[] = (settings.hooks?.Stop ?? []).map((group) => ({
+    ...group,
+    hooks: (group.hooks ?? []).map((hook) => {
+      if (!isLatitudeHookCommand(hook.command)) return hook
+      found = true
+      return { ...hook, type: "command", command, async: true }
+    }),
+  }))
+  if (!found) stop.push({ hooks: [{ type: "command", command, async: true }] })
+  return { ...settings, hooks: { ...(settings.hooks ?? {}), Stop: stop } }
 }
 
 export function removeLatitudeStopHook(settings: ClaudeSettings): ClaudeSettings {

--- a/packages/telemetry/claude-code/src/settings-file.ts
+++ b/packages/telemetry/claude-code/src/settings-file.ts
@@ -89,7 +89,7 @@ export function hasLatitudeStopHook(settings: ClaudeSettings): boolean {
 
 export function addLatitudeStopHook(
   settings: ClaudeSettings,
-  command = "npx -y @latitude-data/claude-code-telemetry",
+  command = "npx -y @latitude-data/claude-code-telemetry@latest",
 ): ClaudeSettings {
   if (hasLatitudeStopHook(settings)) return settings
   const hooks = { ...(settings.hooks ?? {}) }

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -10,6 +10,7 @@ import {
   backupSettings,
   type ClaudeSettings,
   hasLatitudeStopHook,
+  latitudeStopHookCommand,
   readSettings,
   removeEnv,
   removeLatitudeStopHook,
@@ -259,8 +260,15 @@ async function applyChanges(args: ApplyArgs): Promise<void> {
   if (useLaunchctl || useSystemd) next = removeEnv(next, "BUN_OPTIONS")
   else next = setEnv(next, "BUN_OPTIONS", `--preload=${INTERCEPT_INSTALL_PATH}`)
 
-  const hookAlreadyThere = hasLatitudeStopHook(next)
+  const priorHookCommand = latitudeStopHookCommand(next)
   next = addLatitudeStopHook(next, DEFAULT_HOOK_COMMAND)
+
+  const hookNote =
+    priorHookCommand === undefined
+      ? "  + Stop hook installed"
+      : priorHookCommand === DEFAULT_HOOK_COMMAND
+        ? ""
+        : "  + Stop hook updated"
 
   const step = stepLogger(interactive)
 
@@ -270,7 +278,7 @@ async function applyChanges(args: ApplyArgs): Promise<void> {
   step.stop(
     [
       `~/.claude/settings.json updated`,
-      hookAlreadyThere ? "" : "  + Stop hook installed",
+      hookNote,
       backedUp ? pc.dim(`  (backup at ${SETTINGS_BACKUP_PATH})`) : pc.dim("  (new file)"),
     ]
       .filter(Boolean)

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -27,7 +27,10 @@ const PLIST_PATH = join(homedir(), "Library", "LaunchAgents", "so.latitude.claud
 const PLIST_LABEL = "so.latitude.claude-code-telemetry"
 // Linux: systemd user environment drop-in; mirrors the macOS plist for persistence.
 const ENVIRONMENT_D_CONF_PATH = join(homedir(), ".config", "environment.d", "latitude-telemetry.conf")
-const DEFAULT_HOOK_COMMAND = "npx -y @latitude-data/claude-code-telemetry"
+// Pin the `@latest` tag so the hook re-resolves the newest published version on
+// each run (a cheap, etag-revalidated metadata check) and self-updates. A bare
+// `npx <pkg>` reuses whatever the npx cache first fetched and never updates.
+const DEFAULT_HOOK_COMMAND = "npx -y @latitude-data/claude-code-telemetry@latest"
 const DOCS_URL = "https://docs.latitude.so/telemetry/claude-code"
 
 // Environments pick the app + ingest domain pair. Every URL shown or written


### PR DESCRIPTION
## What

The installer now writes the Claude Code Stop-hook command with the `@latest` tag:

```
npx -y @latitude-data/claude-code-telemetry@latest
```

instead of the bare `npx -y @latitude-data/claude-code-telemetry`.

## Why

A bare `npx <pkg>` reuses whatever version the npx cache first fetched and does not re-resolve, so a user who installed the hook once can silently stay on an old build forever and never receive fixes. We just hit exactly this: a local install kept running a months-old build after new versions shipped.

`@latest` makes `npx` re-resolve the newest published version on each run. That is a conditional metadata request (etag → usually `304`), with a tarball download only when a genuinely new version exists — and the hook already runs with `async: true`, so the resolution happens off the turn's critical path and does not block the client.

## Changes

- `DEFAULT_HOOK_COMMAND` (what the installer writes) and the `addLatitudeStopHook` fallback default now use `@latest`.
- `node-version.ts` PATH-fix help text and the public (`docs/telemetry/claude-code.md`) + internal (`dev-docs/claude-code-telemetry.md`) docs updated to the `@latest` command, including the `install` / `uninstall` invocations so users run the current installer.
- Bumped to `0.0.11`.

Existing installs keep working; re-running the installer (or editing the command) picks up the self-updating form. `isLatitudeHookCommand` already matches on the package-name substring, so hook detection, dedupe, and uninstall are unaffected by the tag.
