### PR TITLE
fix(billing): charge deterministic evaluation scans one credit

### DIFF
--- a/apps/workers/src/workers/billing.ts
+++ b/apps/workers/src/workers/billing.ts
@@ -44,7 +44,7 @@ interface RecordTraceUsageBatchPayload {
 interface RecordBillableActionPayload {
   readonly organizationId: string
   readonly projectId: string
-  readonly action: "trace" | "flagger-scan" | "live-eval-scan" | "eval-generation"
+  readonly action: "trace" | "flagger-scan" | "deterministic-eval-scan" | "live-eval-scan" | "eval-generation"
   readonly idempotencyKey: string
   readonly context: {
     readonly planSlug: "free" | "pro" | "enterprise"

--- a/dev-docs/billing.md
+++ b/dev-docs/billing.md
@@ -24,7 +24,8 @@ Chargeable actions:
 
 - `trace = 1 credit`
 - `flagger-scan = 30 credits`
-- `live-eval-scan = 30 credits`
+- `deterministic-eval-scan = 1 credit`
+- `live-eval-scan = 30 credits` for scripts that call `llm()`
 - `eval-generation = 1,000 credits`
 
 ## Effective Plan Resolution
@@ -93,7 +94,7 @@ Canonical charge points:
 
 - trace ingest metering: `apps/workers/src/workers/span-ingestion.ts` emits `TracesIngested`, `apps/workers/src/workers/domain-events.ts` routes billing work, and `apps/workers/src/workers/billing.ts` records once per distinct trace id using `trace:{organizationId}:{projectId}:{traceId}`
 - LLM flagger scans: `apps/workflows/src/activities/flagger-activities.ts` before `draftAnnotate`
-- live evaluations: `apps/workers/src/workers/live-evaluations.ts` immediately before hosted AI execution
+- live evaluations: `apps/workers/src/workers/live-evaluations.ts` immediately before execution; script capabilities select `deterministic-eval-scan` or `live-eval-scan`
 - eval generation: `apps/workflows/src/activities/evaluation-alignment-activities.ts` before expensive alignment generation/optimization work, keyed by `billingOperationId`
 
 Retries must not double-charge. Idempotency is enforced by `billing_usage_events` on `(billing_period_start, idempotency_key)` and use-case fallback behavior that re-reads the same period snapshot when an event already exists.
@@ -104,7 +105,7 @@ Free organizations are hard capped.
 
 Enforcement rules:
 
-- chargeable AI work (`flagger-scan`, `live-eval-scan`, `eval-generation`) is skipped before execution once no credits remain
+- chargeable scan and AI work (`flagger-scan`, `deterministic-eval-scan`, `live-eval-scan`, `eval-generation`) is skipped before execution once no credits remain
 - ingest: the **ingest HTTP route** rejects over-limit payloads with **`402`**. Accepted payloads persist first; metering runs afterward inside the ingest worker (`402` semantics use `NoCreditsRemainingError` aligned with metering domain errors).
 
 The system never partially accepts only part of one ingest payload. Do **not** bypass the ingest billing gate—other producers must enqueue `span-ingestion` only after applying the **same credit checks**.
@@ -133,7 +134,7 @@ This applies to the same charge points as normal billing metering:
 Two layers of enforcement run in `authorizeBillableAction`:
 
 1. **Snapshot projection (Postgres)**: reads the current period's `consumedCredits`, computes the projected spend with this action included, and refuses immediately if the projection already exceeds the cap. This catches the simple sequential case.
-2. **Atomic spend reservation (Redis)**: when the caller supplies an `idempotencyKey`, the use-case asks the `BillingSpendReservation` port to reserve `creditsRequested` against an in-memory counter for the period, refusing if the resulting reservation total would exceed the cap. The Redis adapter runs this as a single Lua script so concurrent `live-eval-scan` and `flagger-scan` callers cannot all race past the snapshot check at the cap boundary. The same `idempotencyKey` reused on retry is a no-op success — matching the period-scoped Postgres usage-event idempotency semantics so worker retries don't double-reserve.
+2. **Atomic spend reservation (Redis)**: when the caller supplies an `idempotencyKey`, the use-case asks the `BillingSpendReservation` port to reserve `creditsRequested` against an in-memory counter for the period, refusing if the resulting reservation total would exceed the cap. The Redis adapter runs this as a single Lua script so concurrent scan callers cannot all race past the snapshot check at the cap boundary. The same `idempotencyKey` reused on retry is a no-op success — matching the period-scoped Postgres usage-event idempotency semantics so worker retries don't double-reserve.
 
 The reservation counter is initialized lazily from the Postgres `consumedCredits` snapshot when the key is missing, so a fresh period or a Redis cold start re-syncs to the authoritative value. The counter is not decremented when the worker writes to Postgres — the reservation already counts that consumption — and the period TTL evicts the key after rollover.
 

--- a/packages/domain/billing/src/constants.ts
+++ b/packages/domain/billing/src/constants.ts
@@ -10,13 +10,20 @@ export const BILLING_OVERAGE_SYNC_THROTTLE_MS = 5 * 60_000 // 5 minutes
 
 export const SELF_SERVE_PLAN_SLUGS: readonly PlanSlug[] = ["pro"] as const
 
-export const CHARGEABLE_ACTIONS = ["trace", "flagger-scan", "live-eval-scan", "eval-generation"] as const
+export const CHARGEABLE_ACTIONS = [
+  "trace",
+  "flagger-scan",
+  "deterministic-eval-scan",
+  "live-eval-scan",
+  "eval-generation",
+] as const
 
 export type ChargeableAction = (typeof CHARGEABLE_ACTIONS)[number]
 
 export const ACTION_CREDITS: Record<ChargeableAction, number> = {
   trace: 1,
   "flagger-scan": 30,
+  "deterministic-eval-scan": 1,
   "live-eval-scan": 30,
   "eval-generation": 1000,
 } as const

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -891,6 +891,8 @@ describe("runLiveEvaluationUseCase", () => {
     })
     const evaluationRepository = createEvaluationRepository(() => Effect.succeed(evaluation))
     const signalRepository = createSignalRepository(() => Effect.succeed(issue))
+    const { repository: billingUsageEventRepository, eventsByPeriodAndIdempotencyKey } =
+      createFakeBillingUsageEventRepository()
     const operations: string[] = []
     const { layer: aiLayer } = createFakeAI()
     const scriptRuntime = createFakeScriptRuntime({
@@ -923,7 +925,7 @@ describe("runLiveEvaluationUseCase", () => {
             evaluationRepository,
             signalRepository,
             aiLayer,
-            billingLayer: createBillingLayer(),
+            billingLayer: createBillingLayer({ billingUsageEventRepository }),
             scoreWriteLayer,
             scriptRuntimeLayer: scriptRuntime.layer,
           }),
@@ -933,6 +935,9 @@ describe("runLiveEvaluationUseCase", () => {
 
     expect(result.action).toBe("persisted")
     expect(operations).toEqual(["script-run", "billing-outbox-write", "score-outbox-write"])
+    expect([...eventsByPeriodAndIdempotencyKey.values()]).toEqual([
+      expect.objectContaining({ action: "live-eval-scan", credits: 30 }),
+    ])
     expect(scriptRuntime.calls.run).toHaveLength(1)
   })
 
@@ -1427,6 +1432,8 @@ describe("runLiveEvaluationUseCase", () => {
     })
     const evaluationRepository = createEvaluationRepository(() => Effect.succeed(evaluation))
     const signalRepository = createSignalRepository(() => Effect.succeed(issue))
+    const { repository: billingUsageEventRepository, eventsByPeriodAndIdempotencyKey } =
+      createFakeBillingUsageEventRepository()
     const scriptRuntime = createFakeScriptRuntime({
       run: () => Effect.succeed({ value: 1, feedback: "no exhibition", duration: 9_000, tokens: 0, cost: 0 }),
     })
@@ -1440,6 +1447,7 @@ describe("runLiveEvaluationUseCase", () => {
             evaluationRepository,
             signalRepository,
             aiLayer,
+            billingLayer: createBillingLayer({ billingUsageEventRepository }),
             scriptRuntimeLayer: scriptRuntime.layer,
           }),
         ),
@@ -1458,6 +1466,9 @@ describe("runLiveEvaluationUseCase", () => {
     expect(scriptRuntime.calls.run).toHaveLength(1)
     expect(scriptRuntime.calls.run[0]?.script.source).toBe(evaluation.script)
     expect(calls.generate).toHaveLength(0)
+    expect([...eventsByPeriodAndIdempotencyKey.values()]).toEqual([
+      expect.objectContaining({ action: "deterministic-eval-scan", credits: 1 }),
+    ])
   })
 
   it("records detector health per run and surfaces the degraded transition through the outbox once", async () => {

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -15,7 +15,9 @@ import { type QueuePublishError, QueuePublisher } from "@domain/queue"
 import {
   DETECTOR_HEALTH_WINDOW_SECONDS,
   DetectorHealthTracker,
-  requiresEmbedding,
+  detectScriptCapabilities,
+  hasEmbeddingCapability,
+  hasLlmCapability,
   type ScriptRuntime,
 } from "@domain/sandbox"
 import {
@@ -185,6 +187,7 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
     }
 
     const liveEvaluationEligibility = getLiveEvaluationEligibility(evaluation)
+    const scriptCapabilities = detectScriptCapabilities(evaluation.script)
 
     if (!liveEvaluationEligibility.eligible) {
       return {
@@ -231,7 +234,7 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
     // Readiness gate — only for scripts that call semanticSimilarity(), before any billing or execution
     // work. We check the triggering trace: it's the one whose embeddings race this run, and older traces
     // in the session were embedded on their own ingest cycles.
-    if (requiresEmbedding(evaluation.script)) {
+    if (hasEmbeddingCapability(scriptCapabilities)) {
       const embeddingsReady = yield* hasSessionEmbeddings({
         organizationId: OrganizationId(input.organizationId),
         projectId,
@@ -297,14 +300,15 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
     } satisfies LiveEvaluationSignalContext
 
     const billingOrganizationId = OrganizationId(input.organizationId)
-    const idempotencyKey = buildBillingIdempotencyKey("live-eval-scan", [
+    const billingAction = hasLlmCapability(scriptCapabilities) ? "live-eval-scan" : "deterministic-eval-scan"
+    const idempotencyKey = buildBillingIdempotencyKey(billingAction, [
       input.organizationId,
       evaluation.id,
       input.traceId,
     ])
     const authorization = yield* authorizeBillableAction({
       organizationId: billingOrganizationId,
-      action: "live-eval-scan",
+      action: billingAction,
       skipIfBlocked: true,
       idempotencyKey,
     })
@@ -363,7 +367,7 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
     yield* recordBillableActionUseCase({
       organizationId: billingOrganizationId,
       projectId: ProjectId(input.projectId),
-      action: "live-eval-scan",
+      action: billingAction,
       idempotencyKey,
       context: authorization.context,
       traceId: TraceId(input.traceId),

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -610,7 +610,7 @@ const _registry = {
     recordBillableAction: {
       readonly organizationId: string
       readonly projectId: string
-      readonly action: "trace" | "flagger-scan" | "live-eval-scan" | "eval-generation"
+      readonly action: "trace" | "flagger-scan" | "deterministic-eval-scan" | "live-eval-scan" | "eval-generation"
       readonly idempotencyKey: string
       readonly context: {
         readonly planSlug: "free" | "pro" | "enterprise"


### PR DESCRIPTION
## What does this PR do?

Deterministic live-evaluation scripts now use a one-credit billing action selected from script capabilities, while scripts that call `llm()` keep the existing 30-credit action.

## Related issue (if applicable)

N/A

## How was this tested?

- `pnpm --filter @domain/evaluations test -- src/use-cases/live/run-live-evaluation.test.ts`
- `pnpm --filter @domain/billing test`
- Package typechecks for billing, evaluations, queue, and workers
- Package Biome checks for billing, evaluations, queue, and workers

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA