### PR TITLE
feat(web,docs): rename user-facing "Custom behaviors" to "Cohorts"

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -64,7 +64,7 @@ import { Route as AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport } fro
 import { Route as AuthenticatedProjectsProjectSlugIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/index'
 import { Route as AuthenticatedProjectsProjectSlugExperimentsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/experiments/index'
 import { Route as AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/datasets/index'
-import { Route as AuthenticatedProjectsProjectSlugCustomBehavioursIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/custom-behaviours/index'
+import { Route as AuthenticatedProjectsProjectSlugCohortsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/cohorts/index'
 import { Route as AuthenticatedProjectsProjectSlugBehavioursIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/behaviours/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsSsoRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/sso'
 import { Route as AuthenticatedProjectsProjectSlugSettingsSignalsRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/signals'
@@ -87,7 +87,7 @@ import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexR
 import { Route as AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/$issueId/index'
 import { Route as AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/experiments/$experimentSlug/index'
-import { Route as AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/index'
+import { Route as AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
 import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
@@ -398,10 +398,10 @@ const AuthenticatedProjectsProjectSlugDatasetsIndexRoute =
     path: '/datasets/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
-const AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute =
-  AuthenticatedProjectsProjectSlugCustomBehavioursIndexRouteImport.update({
-    id: '/custom-behaviours/',
-    path: '/custom-behaviours/',
+const AuthenticatedProjectsProjectSlugCohortsIndexRoute =
+  AuthenticatedProjectsProjectSlugCohortsIndexRouteImport.update({
+    id: '/cohorts/',
+    path: '/cohorts/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
 const AuthenticatedProjectsProjectSlugBehavioursIndexRoute =
@@ -540,14 +540,12 @@ const AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute =
       getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
     } as any,
   )
-const AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute =
-  AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport.update(
-    {
-      id: '/custom-behaviours/$behaviourSlug/',
-      path: '/custom-behaviours/$behaviourSlug/',
-      getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
-    } as any,
-  )
+const AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute =
+  AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRouteImport.update({
+    id: '/cohorts/$behaviourSlug/',
+    path: '/cohorts/$behaviourSlug/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute =
   AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRouteImport.update(
     {
@@ -642,7 +640,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/settings/signals': typeof AuthenticatedProjectsProjectSlugSettingsSignalsRoute
   '/projects/$projectSlug/settings/sso': typeof AuthenticatedProjectsProjectSlugSettingsSsoRoute
   '/projects/$projectSlug/behaviours/': typeof AuthenticatedProjectsProjectSlugBehavioursIndexRoute
-  '/projects/$projectSlug/custom-behaviours/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute
+  '/projects/$projectSlug/cohorts/': typeof AuthenticatedProjectsProjectSlugCohortsIndexRoute
   '/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/experiments/': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
@@ -655,7 +653,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute
-  '/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
+  '/projects/$projectSlug/cohorts/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -722,7 +720,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/settings/signals': typeof AuthenticatedProjectsProjectSlugSettingsSignalsRoute
   '/projects/$projectSlug/settings/sso': typeof AuthenticatedProjectsProjectSlugSettingsSsoRoute
   '/projects/$projectSlug/behaviours': typeof AuthenticatedProjectsProjectSlugBehavioursIndexRoute
-  '/projects/$projectSlug/custom-behaviours': typeof AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute
+  '/projects/$projectSlug/cohorts': typeof AuthenticatedProjectsProjectSlugCohortsIndexRoute
   '/projects/$projectSlug/datasets': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/experiments': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/projects/$projectSlug/issues': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
@@ -735,7 +733,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/projects/$projectSlug/behaviours/$behaviourSlug': typeof AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute
-  '/projects/$projectSlug/custom-behaviours/$behaviourSlug': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
+  '/projects/$projectSlug/cohorts/$behaviourSlug': typeof AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -808,7 +806,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/settings/signals': typeof AuthenticatedProjectsProjectSlugSettingsSignalsRoute
   '/_authenticated/projects/$projectSlug/settings/sso': typeof AuthenticatedProjectsProjectSlugSettingsSsoRoute
   '/_authenticated/projects/$projectSlug/behaviours/': typeof AuthenticatedProjectsProjectSlugBehavioursIndexRoute
-  '/_authenticated/projects/$projectSlug/custom-behaviours/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute
+  '/_authenticated/projects/$projectSlug/cohorts/': typeof AuthenticatedProjectsProjectSlugCohortsIndexRoute
   '/_authenticated/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/_authenticated/projects/$projectSlug/experiments/': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/_authenticated/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
@@ -821,7 +819,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsDestinationIdRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIntegrationKindRoute
   '/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute
-  '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
+  '/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute
   '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/_authenticated/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -894,7 +892,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/signals'
     | '/projects/$projectSlug/settings/sso'
     | '/projects/$projectSlug/behaviours/'
-    | '/projects/$projectSlug/custom-behaviours/'
+    | '/projects/$projectSlug/cohorts/'
     | '/projects/$projectSlug/datasets/'
     | '/projects/$projectSlug/experiments/'
     | '/projects/$projectSlug/issues/'
@@ -907,7 +905,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/projects/$projectSlug/behaviours/$behaviourSlug/'
-    | '/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
+    | '/projects/$projectSlug/cohorts/$behaviourSlug/'
     | '/projects/$projectSlug/experiments/$experimentSlug/'
     | '/projects/$projectSlug/issues/$issueId/'
     | '/projects/$projectSlug/monitors/$monitorSlug/'
@@ -974,7 +972,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/signals'
     | '/projects/$projectSlug/settings/sso'
     | '/projects/$projectSlug/behaviours'
-    | '/projects/$projectSlug/custom-behaviours'
+    | '/projects/$projectSlug/cohorts'
     | '/projects/$projectSlug/datasets'
     | '/projects/$projectSlug/experiments'
     | '/projects/$projectSlug/issues'
@@ -987,7 +985,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/projects/$projectSlug/behaviours/$behaviourSlug'
-    | '/projects/$projectSlug/custom-behaviours/$behaviourSlug'
+    | '/projects/$projectSlug/cohorts/$behaviourSlug'
     | '/projects/$projectSlug/experiments/$experimentSlug'
     | '/projects/$projectSlug/issues/$issueId'
     | '/projects/$projectSlug/monitors/$monitorSlug'
@@ -1059,7 +1057,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/settings/signals'
     | '/_authenticated/projects/$projectSlug/settings/sso'
     | '/_authenticated/projects/$projectSlug/behaviours/'
-    | '/_authenticated/projects/$projectSlug/custom-behaviours/'
+    | '/_authenticated/projects/$projectSlug/cohorts/'
     | '/_authenticated/projects/$projectSlug/datasets/'
     | '/_authenticated/projects/$projectSlug/experiments/'
     | '/_authenticated/projects/$projectSlug/issues/'
@@ -1072,7 +1070,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/settings/data-destinations/$destinationId'
     | '/_authenticated/projects/$projectSlug/settings/integrations/$integrationKind'
     | '/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/'
-    | '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
+    | '/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/'
     | '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/'
     | '/_authenticated/projects/$projectSlug/issues/$issueId/'
     | '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/'
@@ -1497,11 +1495,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
-    '/_authenticated/projects/$projectSlug/custom-behaviours/': {
-      id: '/_authenticated/projects/$projectSlug/custom-behaviours/'
-      path: '/custom-behaviours'
-      fullPath: '/projects/$projectSlug/custom-behaviours/'
-      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursIndexRouteImport
+    '/_authenticated/projects/$projectSlug/cohorts/': {
+      id: '/_authenticated/projects/$projectSlug/cohorts/'
+      path: '/cohorts'
+      fullPath: '/projects/$projectSlug/cohorts/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugCohortsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
     '/_authenticated/projects/$projectSlug/behaviours/': {
@@ -1658,11 +1656,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
-    '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/': {
-      id: '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
-      path: '/custom-behaviours/$behaviourSlug'
-      fullPath: '/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
-      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport
+    '/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/': {
+      id: '/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/'
+      path: '/cohorts/$behaviourSlug'
+      fullPath: '/projects/$projectSlug/cohorts/$behaviourSlug/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
     '/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/': {
@@ -1789,7 +1787,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugMonitorsSearchRoute: typeof AuthenticatedProjectsProjectSlugMonitorsSearchRoute
   AuthenticatedProjectsProjectSlugMonitorsSignalsRoute: typeof AuthenticatedProjectsProjectSlugMonitorsSignalsRoute
   AuthenticatedProjectsProjectSlugBehavioursIndexRoute: typeof AuthenticatedProjectsProjectSlugBehavioursIndexRoute
-  AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute
+  AuthenticatedProjectsProjectSlugCohortsIndexRoute: typeof AuthenticatedProjectsProjectSlugCohortsIndexRoute
   AuthenticatedProjectsProjectSlugDatasetsIndexRoute: typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   AuthenticatedProjectsProjectSlugExperimentsIndexRoute: typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
@@ -1799,7 +1797,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugUsersIndexRoute: typeof AuthenticatedProjectsProjectSlugUsersIndexRoute
   AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugEditRoute: typeof AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugEditRoute
   AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute
-  AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
+  AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute
   AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
   AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
@@ -1828,8 +1826,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugMonitorsSignalsRoute,
     AuthenticatedProjectsProjectSlugBehavioursIndexRoute:
       AuthenticatedProjectsProjectSlugBehavioursIndexRoute,
-    AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute:
-      AuthenticatedProjectsProjectSlugCustomBehavioursIndexRoute,
+    AuthenticatedProjectsProjectSlugCohortsIndexRoute:
+      AuthenticatedProjectsProjectSlugCohortsIndexRoute,
     AuthenticatedProjectsProjectSlugDatasetsIndexRoute:
       AuthenticatedProjectsProjectSlugDatasetsIndexRoute,
     AuthenticatedProjectsProjectSlugExperimentsIndexRoute:
@@ -1848,8 +1846,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugEditRoute,
     AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute:
       AuthenticatedProjectsProjectSlugBehavioursBehaviourSlugIndexRoute,
-    AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute:
-      AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute,
+    AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute:
+      AuthenticatedProjectsProjectSlugCohortsBehaviourSlugIndexRoute,
     AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute:
       AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-explorer.tsx
@@ -584,11 +584,11 @@ export function ProjectExplorer({ projectSlug }: { readonly projectSlug: string 
                     onClick={() => void createCustomBehaviorFromFilters()}
                   >
                     <Icon icon={SlidersHorizontalIcon} size="sm" />
-                    Create custom behavior
+                    Create cohort
                   </Button>
                 }
               >
-                Cluster the sessions matching these filters into their own behavior tree.
+                Group the sessions matching these filters into a cohort with its own behavior tree.
               </Tooltip>
             ) : null}
             <Tabs

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/saved-search-selector.tsx
@@ -197,14 +197,14 @@ export function SavedSearchSelector({
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                aria-label={`Create a custom behavior from saved search ${record.name}`}
+                                aria-label={`Create a cohort from saved search ${record.name}`}
                                 onClick={() => createCustomBehaviorFromSavedSearch(record)}
                               >
                                 <Icon icon={SlidersHorizontalIcon} size="sm" color="foregroundMuted" />
                               </Button>
                             }
                           >
-                            Create custom behavior
+                            Create cohort
                           </Tooltip>
                         ) : null}
                         <Tooltip

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/edit.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/edit.tsx
@@ -68,7 +68,7 @@ function EditBehaviourPage() {
           </div>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
-            <Text.H3>Custom behavior not found</Text.H3>
+            <Text.H3>Cohort not found</Text.H3>
             <Button asChild variant="outline">
               <Link to="/projects/$projectSlug/behaviours" params={{ projectSlug }}>
                 Back to behaviors

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/$behaviourSlug/index.tsx
@@ -56,7 +56,7 @@ function CustomBehaviourViewPage() {
           </div>
         ) : (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
-            <Text.H3>Custom behavior not found</Text.H3>
+            <Text.H3>Cohort not found</Text.H3>
             <Button asChild variant="outline">
               <Link to="/projects/$projectSlug/behaviours" params={{ projectSlug }}>
                 Back to behaviors

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-form-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviour-form-modal.tsx
@@ -59,7 +59,7 @@ export function BehaviourFormModal({
       },
       {
         onSuccess: (result: CustomBehaviorRecord) => {
-          toast({ description: behaviour ? "Custom behavior updated." : "Custom behavior created." })
+          toast({ description: behaviour ? "Cohort updated." : "Cohort created." })
           void navigate({
             to: "/projects/$projectSlug/behaviours/$behaviourSlug",
             params: { projectSlug, behaviourSlug: result.slug },
@@ -75,7 +75,7 @@ export function BehaviourFormModal({
     <Modal.Root open onOpenChange={(next) => (next || isSaving ? undefined : onClose())}>
       <Modal.Content size="full" height="screen" dismissible>
         <div className="flex shrink-0 flex-col gap-3 px-6 pt-6">
-          <Text.H4M>{behaviour ? "Edit behavior" : "New behavior"}</Text.H4M>
+          <Text.H4M>{behaviour ? "Edit cohort" : "New cohort"}</Text.H4M>
           <form.Field name="name">
             {(field) => (
               <Input

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-page.tsx
@@ -37,7 +37,7 @@ function ScopedTreeWaiting({ behaviour }: { readonly behaviour: CustomBehaviorRe
         <Text.H4>Waiting for matching sessions</Text.H4>
         <Text.H5 color="foregroundMuted" centered className="max-w-md">
           {`Found ${(count ?? 0).toLocaleString()} of ${threshold} matching sessions so far. `}
-          This behavior is built automatically once there are enough.
+          This cohort's behaviors are built automatically once there are enough.
         </Text.H5>
       </div>
     )
@@ -48,9 +48,9 @@ function ScopedTreeWaiting({ behaviour }: { readonly behaviour: CustomBehaviorRe
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
         <Loader2Icon className="h-6 w-6 animate-spin text-muted-foreground" />
-        <Text.H4>Building this behavior</Text.H4>
+        <Text.H4>Building this cohort</Text.H4>
         <Text.H5 color="foregroundMuted" centered className="max-w-md">
-          Analyzing the matching sessions now — it'll appear here when it's ready.
+          Analyzing the matching sessions now. Its behaviors will appear here when they're ready.
         </Text.H5>
       </div>
     )
@@ -64,8 +64,8 @@ function ScopedTreeWaiting({ behaviour }: { readonly behaviour: CustomBehaviorRe
       <Text.H4>Waiting for the next run</Text.H4>
       <Text.H5 color="foregroundMuted" centered className="max-w-md">
         {count !== undefined ? `${count.toLocaleString()} matching sessions found. ` : ""}
-        This behavior is built automatically on a schedule — it'll appear after the next run, which can take a few
-        hours.
+        This cohort's behaviors are built automatically on a schedule. They'll appear after the next run, which can take
+        a few hours.
       </Text.H5>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/-components/behaviours-scope-header.tsx
@@ -41,7 +41,7 @@ export type BehaviourFormIntent =
   | { readonly mode: "create"; readonly initialFilterSet?: FilterSet }
   | { readonly mode: "edit" }
 
-const GLOBAL_LABEL = "Global behavior"
+const GLOBAL_LABEL = "All sessions"
 
 function ScopeTitle({ current }: { readonly current: CustomBehaviorRecord | null }) {
   if (current) {
@@ -83,8 +83,8 @@ function ScopeTitle({ current }: { readonly current: CustomBehaviorRecord | null
       <div className="flex flex-row items-center gap-1.5">
         <Text.H4M>{GLOBAL_LABEL}</Text.H4M>
         <Tooltip asChild trigger={<Icon icon={InfoIcon} size="sm" color="foregroundMuted" />}>
-          Shown by default — captures every behavior in this project. You can also create your own custom behavior to
-          discover the patterns within a filtered set of sessions.
+          Shown by default. These behaviors come from every session in this project. Create a cohort to see the
+          behaviors within a filtered set of sessions instead.
         </Tooltip>
       </div>
       <Text.H6 color="foregroundMuted">No filters applied</Text.H6>
@@ -149,7 +149,7 @@ function ScopeActionsMenu({ onEdit, onDelete }: { readonly onEdit: () => void; r
   return (
     <DropdownMenuRoot modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" aria-label="Custom behavior actions">
+        <Button variant="ghost" size="icon" aria-label="Cohort actions">
           <Icon icon={MoreVerticalIcon} size="sm" />
         </Button>
       </DropdownMenuTrigger>
@@ -235,7 +235,7 @@ export function BehavioursScopeHeader({
     if (!current) return
     try {
       await del.mutateAsync(current.id)
-      toast({ description: "Custom behavior deleted." })
+      toast({ description: "Cohort deleted." })
       setDeleteOpen(false)
       await navigate({ to: "/projects/$projectSlug/behaviours", params: { projectSlug } })
     } catch (error) {
@@ -254,7 +254,7 @@ export function BehavioursScopeHeader({
             ) : null}
             <Button variant="outline" size="sm" className="h-8 w-auto" onClick={openCreate}>
               <Icon icon={PlusIcon} size="sm" />
-              New behavior
+              New cohort
             </Button>
             {current ? <ScopeActionsMenu onEdit={openEdit} onDelete={() => setDeleteOpen(true)} /> : null}
           </div>
@@ -276,8 +276,8 @@ export function BehavioursScopeHeader({
           onOpenChange={(next) => {
             if (!next && !del.isPending) setDeleteOpen(false)
           }}
-          title="Delete custom behavior"
-          description={`Delete "${current.name}"? This removes the behavior definition and its scoped taxonomy. This action cannot be undone.`}
+          title="Delete cohort"
+          description={`Delete "${current.name}"? This removes the cohort and the behaviors gardened within it. This action cannot be undone.`}
           footer={
             <div className="flex flex-row items-center gap-2">
               <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={del.isPending}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/new.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/behaviours/new.tsx
@@ -15,7 +15,7 @@ function NewBehaviourBreadcrumb() {
         Behaviors
       </BreadcrumbLink>
       <BreadcrumbSeparator />
-      <BreadcrumbText variant="current">New behavior</BreadcrumbText>
+      <BreadcrumbText variant="current">New cohort</BreadcrumbText>
     </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
-// Custom behaviors folded into the Behaviours section; keep old links working.
-export const Route = createFileRoute("/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/")({
+// Cohorts live inside the Behaviours section; this path is a friendly redirect.
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/cohorts/$behaviourSlug/")({
   beforeLoad: ({ params }) => {
     throw redirect({
       to: "/projects/$projectSlug/behaviours/$behaviourSlug",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/cohorts/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/cohorts/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
-// Custom behaviors folded into the Behaviours section; keep old links working.
-export const Route = createFileRoute("/_authenticated/projects/$projectSlug/custom-behaviours/")({
+// Cohorts live inside the Behaviours section; this path is a friendly redirect.
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/cohorts/")({
   beforeLoad: ({ params }) => {
     throw redirect({
       to: "/projects/$projectSlug/behaviours",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -213,7 +213,10 @@
           "signals/overview",
           "signals/create",
           "signals/management",
-          "search/behaviours",
+          {
+            "group": "Behaviours",
+            "pages": ["search/behaviours", "search/cohorts"]
+          },
           "experiments/overview",
           {
             "group": "Annotations",

--- a/docs/search/cohorts.mdx
+++ b/docs/search/cohorts.mdx
@@ -1,0 +1,41 @@
+---
+title: Cohorts
+description: Save a set of session filters as a cohort and get its own behaviour tree, built automatically and kept current, for just the sessions you care about.
+---
+
+<Info>
+  **Where this fits:** Cohorts are part of the **Understand** section. The [Behaviours](./behaviours)
+  page discovers topics across every session; a cohort discovers them inside a slice you define.
+</Info>
+
+A **cohort** is a saved set of session filters that gets its own behaviour tree. The [Behaviours](./behaviours) page clusters every session in your project. A cohort narrows that to the sessions that match your filters and discovers the behaviours within just that slice, so you can study one part of your traffic on its own.
+
+## Create a cohort
+
+You create a cohort by giving it a name and a set of session filters. The filters can use any session field, such as status, user, tags, or model, with one exception: you cannot filter by topic. A cohort exists to discover the topics inside it, so the topic itself is not an input.
+
+You can start a cohort from scratch on the Behaviours page, or seed one from filters you already have on the [Sessions](../observability/sessions) view or a [saved search](./saved-searches). Any topic filters are dropped when you do.
+
+## It builds itself
+
+Once you save a cohort, Latitude clusters its matching sessions into a behaviour tree on its own. You do not run anything.
+
+A new cohort needs a minimum number of matching sessions before its first tree appears. Until it reaches that point, the cohort shows how many matching sessions it has found so far. After the first build it stays living: it re-gardens on a schedule, so trends and newly emerging behaviours stay current as more sessions arrive.
+
+## Browse its behaviours
+
+A cohort's behaviours read the same way as the global [Behaviours](./behaviours) page: the same topic and subtopic hierarchy, session counts, detected moments, trends, and detail view. What changes is the scope. Every count is computed over the cohort's sessions rather than the whole project.
+
+Switch between the global view and any cohort from the scope selector at the top of the Behaviours page.
+
+<Note>
+  A cohort is different from a [percentile cohort](../observability/features/percentile-cohorts). A
+  percentile cohort groups traces by tag to compare latency and cost percentiles. A cohort here is a
+  saved session filter that produces a behaviour tree.
+</Note>
+
+## Next step
+
+- [Behaviours](./behaviours): the same view across every session in the project.
+- [Saved searches](./saved-searches): bookmark a filter and reuse it, including as the seed for a cohort.
+- [Signals](../signals/overview): turn a recurring failure in a cohort into a tracked signal.


### PR DESCRIPTION
## What

User-facing rename of the **Custom behaviors** feature to **Cohorts**, across `apps/web` and the public Mintlify docs. This is a **display-copy rename only** — no code identifiers or storage change.

Conceptual model reflected in the copy: a **cohort is the scope** (a saved session FilterSet — which sessions), and its **behaviors are the gardened output**. So the *entity* becomes "cohort", while the discovered tree stays "behaviors".

## UI changes (`apps/web`)

The custom-behavior feature lives inside the `behaviours` route (scope selector + scoped tree); these strings were renamed there and at the entry points:

- Scope header: `New behavior` → **New cohort**, `Global behavior` → **All sessions**, `Custom behavior actions` → **Cohort actions**, `Delete custom behavior` → **Delete cohort** (+ description), delete toast → "Cohort deleted."
- Create/edit modal: title `New behavior`/`Edit behavior` → **New cohort**/**Edit cohort**; toasts → "Cohort created."/"Cohort updated."
- Not-found views: `Custom behavior not found` → **Cohort not found**; `New behavior` breadcrumb → **New cohort**.
- Auto-garden waiting state: reworded to "This cohort's behaviors are built automatically…" / "Building this cohort".
- Entry points: Sessions view button and saved-search action `Create custom behavior` → **Create cohort** (+ aria-labels/tooltips).
- Global tooltip reworded to explain cohorts.

## Route

- Renamed the redirect stub `…/custom-behaviours` → `…/cohorts` (both `index` and `$behaviourSlug`), still folding into `/behaviours`; regenerated `routeTree.gen.ts` (not hand-edited).
- **No old-path redirect kept** — the feature is behind the `customBehaviors` flag and not exposed to anyone yet, so there are no existing links to preserve. (Verbal confirmation in-thread.)

## Docs

- New public page `docs/search/cohorts.mdx`, nested under **Behaviours** in the Understand nav (`docs.json`). Defines a cohort per today's implementation: create with a name + session filters (any field except topics), it gardens automatically and stays living (trends/novelty), browse its behaviors like the global Behaviours page. Disambiguated from the existing "percentile cohorts" page.

## Intentionally NOT changed (code + storage)

Per the task, all identifiers and schema stay `custom_behavior_*`: `custom_behaviors`, `custom_behavior_id`, `custom_behavior_assignments` (PG + ClickHouse); `customBehaviorId`, `customBehaviorFilterSetSchema`, `gardenCustomBehavior`, the `customBehaviors` feature flag (id **and** its backoffice/admin display name in `@domain/feature-flags`), and all ports/use-cases/workflows/queue jobs. This mirrors how the product shows the code dimension "topic" as "Behaviors" while keeping the old identifier. `dev-docs/` intentionally untouched (handled separately).

## Validation

- `pnpm --filter @app/web typecheck` ✅ and full `pnpm typecheck` ✅; Biome check ✅ (pre-commit hooks passed).
- Ran the app and verified in-browser (flag on, seeded project): scope header shows **All sessions** + **New cohort**, the create modal titled **New cohort** with a filter builder offering every session field except Topics, and `/projects/$slug/cohorts` + `/cohorts/$slug` **301-redirect to `/behaviours`**.
- `mint dev` preview: the Cohorts page renders and sits nested under Behaviours in the sidebar.

## Review focus

- Copy choices, especially `Global behavior` → **All sessions** and the reworded waiting-state / tooltip strings.
- The docs page framing of cohort vs. behavior, and the percentile-cohorts disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)