### PR TITLE
fix(utils): don't treat a leading digit as an emoji

### DIFF
--- a/packages/utils/src/extractLeadingEmoji.test.ts
+++ b/packages/utils/src/extractLeadingEmoji.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
+
+describe("extractLeadingEmoji", () => {
+  it("extracts a leading emoji and trims the separating space", () => {
+    expect(extractLeadingEmoji("🚀 Launch")).toEqual(["🚀", "Launch"])
+  })
+
+  it("extracts an emoji written with a variation selector", () => {
+    expect(extractLeadingEmoji("❤️ Loved")).toEqual(["❤️", "Loved"])
+  })
+
+  it("returns the text untouched when there is no leading emoji", () => {
+    expect(extractLeadingEmoji("Hello world")).toEqual([null, "Hello world"])
+  })
+
+  it("ignores an emoji that is not at the start", () => {
+    expect(extractLeadingEmoji("Launch 🚀")).toEqual([null, "Launch 🚀"])
+  })
+
+  it("handles an empty string", () => {
+    expect(extractLeadingEmoji("")).toEqual([null, ""])
+  })
+
+  // Keycap bases (0-9, #, *) are `Emoji_Component`s but only render as emoji
+  // when combined with U+20E3. Treating a bare one as an emoji mangled titles
+  // that simply start with a number.
+  describe("titles starting with a keycap base", () => {
+    it.each([
+      "2024 roadmap",
+      "3 apples",
+      "1. First step",
+      "0 to 60",
+      "5xx errors",
+      "#hashtag title",
+      "*starred",
+    ])("leaves %j untouched", (title) => {
+      expect(extractLeadingEmoji(title)).toEqual([null, title])
+    })
+  })
+})

--- a/packages/utils/src/extractLeadingEmoji.ts
+++ b/packages/utils/src/extractLeadingEmoji.ts
@@ -1,5 +1,9 @@
+// `\p{Emoji_Component}` also covers the keycap bases (`0`-`9`, `#`, `*`), which
+// only render as emoji when followed by U+20E3 (e.g. `1\uFE0F\u20E3`). Without the
+// lookahead a title such as "2024 roadmap" has its leading digit peeled off as
+// an emoji, leaving "024 roadmap" as the name.
 const EMOJI_REGEX =
-  /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Emoji_Component}(?:\u200D\p{Emoji_Presentation})*)\s*/u
+  /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|(?![0-9#*])\p{Emoji_Component}(?:\u200D\p{Emoji_Presentation})*)\s*/u
 
 export function extractLeadingEmoji(text: string): [string | null, string] {
   const match = text.match(EMOJI_REGEX)


### PR DESCRIPTION
## What does this PR do?

Fixes project/org titles that start with a number being mangled in the sidebar and command palettes.

`extractLeadingEmoji` matched a leading emoji with, among others, this branch:

```
\p{Emoji_Component}(?:‍\p{Emoji_Presentation})*
```

`\p{Emoji_Component}` covers more than the pieces that only occur inside emoji sequences - it also includes the **keycap bases** `0`-`9`, `#` and `*`. Those only render as emoji when combined with U+20E3 (`1` + U+FE0F + U+20E3 = the keycap emoji), so a bare leading digit was being pulled out as though it were an emoji:

```js
extractLeadingEmoji("2024 roadmap")  // -> ["2", "024 roadmap"]
extractLeadingEmoji("1. First step") // -> ["1", ". First step"]
extractLeadingEmoji("#hashtag")      // -> ["#", "hashtag"]
```

Callers render the first element as a badge and the second as the name (`layouts/AppSidebar/index.tsx`, `components/command-palette/commands/use-project-commands.tsx` and `use-global-commands.tsx`, `routes/backoffice/-components/recent-chips.tsx`), so a project called "2024 roadmap" showed a "2" badge next to the name "024 roadmap" - which matches the screenshot in #3894 ("the name of the project in the list, and the name of the left hand bar also looks funny").

The fix adds a negative lookahead so that branch no longer matches a bare keycap base. Real emoji are unaffected, since they match the earlier `\p{Emoji_Presentation}` / `\p{Emoji}️` branches.

The module had no test file, so this adds one.

### One thing worth flagging separately

While writing the tests I noticed the regex also splits multi-codepoint emoji, because `\p{Emoji_Presentation}` is first in the alternation and matches just the first codepoint:

| input | current result |
| --- | --- |
| thumbs-up + skin tone | modifier is left behind in the name |
| a flag (2 regional indicators) | only half the flag is extracted |
| a keycap | U+20E3 is left behind in the name |
| a ZWJ family sequence | only the first person is extracted |

That is pre-existing and separate from #3894, so I've deliberately left it out of this PR. The clean fix for all of it is `/^\p{RGI_Emoji}/v`, which handles flags, keycaps, skin tones and ZWJ sequences in one property escape - I verified it gives the right answer for every case above. It needs the `v` flag though, and `tsconfig.base.json` targets ES2022, so TS rejects it (`TS1501: This regular expression flag is only available when targeting 'es2024' or later`). Happy to follow up with that if you'd like to bump the target, or to open an issue for it - your call.

## Related issue (if applicable)

Closes #3894

## How was this tested?

Added `packages/utils/src/extractLeadingEmoji.test.ts` (12 cases): the #3894 regressions (`2024 roadmap`, `3 apples`, `1. First step`, `0 to 60`, `5xx errors`, `#hashtag title`, `*starred`), plus the existing behaviour that must not regress (plain emoji, variation-selector emoji, no-emoji text, emoji not at the start, empty string).

- `pnpm --filter @repo/utils test` - 12/12 in the new file pass; the rest of the package is green apart from `format.test.ts > formatChartWindowCaption`, which fails the same way on an unmodified checkout here (looks locale/timezone dependent, unrelated to this change).
- `pnpm --filter @repo/utils typecheck` - clean.
- `biome check` on both changed files - clean.

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
