### PR TITLE
docs: update README contributors list with new users and bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,6 @@ Contributions are welcome. Read the [Contributing Guide](CONTRIBUTING.md) to get
   <a href="https://github.com/eeshsaxena" title="eeshsaxena"><img src="https://avatars.githubusercontent.com/u/139802361?v=4&s=128" width="64" height="64" alt="eeshsaxena" /></a>
   <a href="https://github.com/Osamaali313" title="Osamaali313"><img src="https://avatars.githubusercontent.com/u/86572800?v=4&s=128" width="64" height="64" alt="Osamaali313" /></a>
   <a href="https://github.com/GouravSingal-code" title="GouravSingal-code"><img src="https://avatars.githubusercontent.com/u/60310438?v=4&s=128" width="64" height="64" alt="GouravSingal-code" /></a>
-  <a href="https://github.com/apps/dependabot" title="dependabot[bot]"><img src="https://avatars.githubusercontent.com/in/29110?v=4&s=128" width="64" height="64" alt="dependabot[bot]" /></a>
-  <a href="https://github.com/apps/github-actions" title="github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?v=4&s=128" width="64" height="64" alt="github-actions[bot]" /></a>
-  <a href="https://github.com/apps/cursor" title="cursor[bot]"><img src="https://avatars.githubusercontent.com/in/1210556?v=4&s=128" width="64" height="64" alt="cursor[bot]" /></a>
-  <a href="https://github.com/apps/mintlify" title="mintlify[bot]"><img src="https://avatars.githubusercontent.com/in/222410?v=4&s=128" width="64" height="64" alt="mintlify[bot]" /></a>
-  <a href="https://github.com/Copilot" title="Copilot"><img src="https://avatars.githubusercontent.com/in/1143301?v=4&s=128" width="64" height="64" alt="Copilot" /></a>
-  <a href="https://github.com/claude" title="claude"><img src="https://avatars.githubusercontent.com/u/81847?v=4&s=128" width="64" height="64" alt="claude" /></a>
-  <a href="https://github.com/apps/google-labs-jules" title="google-labs-jules[bot]"><img src="https://avatars.githubusercontent.com/in/842251?v=4&s=128" width="64" height="64" alt="google-labs-jules[bot]" /></a>
-  <a href="https://github.com/sisyphus-dev-ai" title="sisyphus-dev-ai"><img src="https://avatars.githubusercontent.com/u/238992291?v=4&s=128" width="64" height="64" alt="sisyphus-dev-ai" /></a>
 </p>
 
 ## 🔗 Links

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ Contributions are welcome. Read the [Contributing Guide](CONTRIBUTING.md) to get
   <a href="https://github.com/buweiyuqi" title="buweiyuqi"><img src="https://avatars.githubusercontent.com/u/57198914?v=4&s=128" width="64" height="64" alt="buweiyuqi" /></a>
   <a href="https://github.com/monotykamary" title="monotykamary"><img src="https://avatars.githubusercontent.com/u/1130103?v=4&s=128" width="64" height="64" alt="monotykamary" /></a>
   <a href="https://github.com/wnor543" title="wnor543"><img src="https://avatars.githubusercontent.com/u/23494178?v=4&s=128" width="64" height="64" alt="wnor543" /></a>
+  <a href="https://github.com/eeshsaxena" title="eeshsaxena"><img src="https://avatars.githubusercontent.com/u/139802361?v=4&s=128" width="64" height="64" alt="eeshsaxena" /></a>
+  <a href="https://github.com/Osamaali313" title="Osamaali313"><img src="https://avatars.githubusercontent.com/u/86572800?v=4&s=128" width="64" height="64" alt="Osamaali313" /></a>
+  <a href="https://github.com/GouravSingal-code" title="GouravSingal-code"><img src="https://avatars.githubusercontent.com/u/60310438?v=4&s=128" width="64" height="64" alt="GouravSingal-code" /></a>
+  <a href="https://github.com/apps/dependabot" title="dependabot[bot]"><img src="https://avatars.githubusercontent.com/in/29110?v=4&s=128" width="64" height="64" alt="dependabot[bot]" /></a>
+  <a href="https://github.com/apps/github-actions" title="github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?v=4&s=128" width="64" height="64" alt="github-actions[bot]" /></a>
+  <a href="https://github.com/apps/cursor" title="cursor[bot]"><img src="https://avatars.githubusercontent.com/in/1210556?v=4&s=128" width="64" height="64" alt="cursor[bot]" /></a>
+  <a href="https://github.com/apps/mintlify" title="mintlify[bot]"><img src="https://avatars.githubusercontent.com/in/222410?v=4&s=128" width="64" height="64" alt="mintlify[bot]" /></a>
+  <a href="https://github.com/Copilot" title="Copilot"><img src="https://avatars.githubusercontent.com/in/1143301?v=4&s=128" width="64" height="64" alt="Copilot" /></a>
+  <a href="https://github.com/claude" title="claude"><img src="https://avatars.githubusercontent.com/u/81847?v=4&s=128" width="64" height="64" alt="claude" /></a>
+  <a href="https://github.com/apps/google-labs-jules" title="google-labs-jules[bot]"><img src="https://avatars.githubusercontent.com/in/842251?v=4&s=128" width="64" height="64" alt="google-labs-jules[bot]" /></a>
+  <a href="https://github.com/sisyphus-dev-ai" title="sisyphus-dev-ai"><img src="https://avatars.githubusercontent.com/u/238992291?v=4&s=128" width="64" height="64" alt="sisyphus-dev-ai" /></a>
 </p>
 
 ## 🔗 Links


### PR DESCRIPTION
### Motivation

- Keep the contributors showcase current by adding recent contributors and GitHub apps/bots to the README.
- Improve visibility of automated integrations and contributors who have recently helped the project.

### Description

- Updated `README.md` contributors section to add several new GitHub users including `eeshsaxena`, `Osamaali313`, and `GouravSingal-code`.
- Added entries for GitHub apps and bots such as `dependabot[bot]`, `github-actions[bot]`, `cursor[bot]`, `mintlify[bot]`, `Copilot`, `claude`, `google-labs-jules[bot]`, and `sisyphus-dev-ai`.
- Only the contributors HTML block in `README.md` was modified and no code or config files were changed.

### Testing

- No automated tests were added because this is a documentation-only change.
- Existing CI and test suites were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e18d3be0832d9b4e93e8f9999900)