### PR TITLE
fix(clickhouse): batch findMessagesForSession by trace to avoid OOM

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -326,6 +326,11 @@ type SpanMessagesRow = {
   output_messages: string
 }
 
+type SpanMessagesRowWithTime = SpanMessagesRow & { start_time: string }
+
+const sortSpanMessageRowsByStartTime = (rows: readonly SpanMessagesRowWithTime[]): SpanMessagesRowWithTime[] =>
+  [...rows].sort((a, b) => parseCHDate(a.start_time).getTime() - parseCHDate(b.start_time).getTime())
+
 const toDomainSpanMessages = (row: SpanMessagesRow): SpanMessagesData => ({
   traceId: toTraceId(normalizeCHString(row.trace_id)),
   spanId: SpanId(row.span_id),
@@ -446,6 +451,23 @@ const PAGINATED_READ_SETTINGS = {
   ...BOUNDED_READ_SETTINGS,
   max_bytes_before_external_sort: "268435456",
 } as const
+
+const CONVERSATION_MESSAGE_OPERATIONS_SQL = "('chat', 'text_completion', 'generate_content', 'execute_tool')"
+
+const MESSAGES_FOR_TRACE_SQL = `SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
+                      FROM (
+                        SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
+                        FROM spans
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
+                          AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
+                          AND trace_id = {traceId:FixedString(32)}
+                          AND operation IN ${CONVERSATION_MESSAGE_OPERATIONS_SQL}
+                        ORDER BY span_id, ingested_at DESC
+                        LIMIT 1 BY span_id
+                      )
+                      ORDER BY start_time ASC`
 
 // `listByProjectId` keyset pagination. The sort column is an enum → fixed column
 // (never user-interpolated raw SQL); the cursor param is typed to match it so the
@@ -1100,25 +1122,7 @@ export const SpanRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                // Dedupe ReplacingMergeTree rows with `LIMIT 1 BY span_id`
-                // (newest `ingested_at` wins) instead of `FINAL`, which
-                // merges all matching parts at query time and is the
-                // dominant memory cost for traces with heavy
-                // input/output_messages payloads.
-                query: `SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
-                      FROM (
-                        SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
-                        FROM spans
-                        WHERE organization_id = {organizationId:String}
-                          AND project_id = {projectId:String}
-                          AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
-                          AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
-                          AND trace_id = {traceId:FixedString(32)}
-                          AND operation IN ('chat', 'text_completion', 'generate_content', 'execute_tool')
-                        ORDER BY span_id, ingested_at DESC
-                        LIMIT 1 BY span_id
-                      )
-                      ORDER BY start_time ASC`,
+                query: MESSAGES_FOR_TRACE_SQL,
                 query_params: {
                   organizationId: organizationId as string,
                   projectId: projectId as string,
@@ -1129,7 +1133,7 @@ export const SpanRepositoryLive = Layer.effect(
                 format: "JSONEachRow",
                 clickhouse_settings: BOUNDED_READ_SETTINGS,
               })
-              return result.json<SpanMessagesRow>()
+              return result.json<SpanMessagesRowWithTime>()
             })
             .pipe(
               Effect.map((rows) => rows.map(toDomainSpanMessages)),
@@ -1211,39 +1215,49 @@ export const SpanRepositoryLive = Layer.effect(
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           const membership = sessionMembership(sessionId as string)
-          return yield* chSqlClient
+          const queryParams = {
+            organizationId: organizationId as string,
+            projectId: projectId as string,
+            startTimeFrom: formatCHDate(startTimeFrom),
+            startTimeTo: formatCHDate(startTimeTo),
+            ...membership.params,
+          }
+          const traceIdRows = yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages
-                      FROM (
-                        SELECT trace_id, span_id, operation, tool_call_id, tool_name, tool_input, input_messages, output_messages, start_time
-                        FROM spans
-                        WHERE organization_id = {organizationId:String}
-                          AND project_id = {projectId:String}
-                          AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
-                          AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
-                          AND ${membership.clause}
-                          AND operation IN ('chat', 'text_completion', 'generate_content', 'execute_tool')
-                        ORDER BY trace_id, span_id, ingested_at DESC
-                        LIMIT 1 BY trace_id, span_id
-                      )
-                      ORDER BY start_time ASC`,
-                query_params: {
-                  organizationId: organizationId as string,
-                  projectId: projectId as string,
-                  startTimeFrom: formatCHDate(startTimeFrom),
-                  startTimeTo: formatCHDate(startTimeTo),
-                  ...membership.params,
-                },
+                query: `SELECT DISTINCT trace_id
+                      FROM spans
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
+                        AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
+                        AND ${membership.clause}
+                        AND operation IN ${CONVERSATION_MESSAGE_OPERATIONS_SQL}`,
+                query_params: queryParams,
                 format: "JSONEachRow",
                 clickhouse_settings: BOUNDED_READ_SETTINGS,
               })
-              return result.json<SpanMessagesRow>()
+              return result.json<{ trace_id: string }>()
             })
-            .pipe(
-              Effect.map((rows) => rows.map(toDomainSpanMessages)),
-              Effect.mapError((error) => toRepositoryError(error, "findMessagesForSession")),
-            )
+            .pipe(Effect.mapError((error) => toRepositoryError(error, "findMessagesForSession")))
+
+          const allRows: SpanMessagesRowWithTime[] = []
+          for (const { trace_id: traceId } of traceIdRows) {
+            const rows = yield* chSqlClient
+              .query(async (client) => {
+                const result = await client.query({
+                  query: MESSAGES_FOR_TRACE_SQL,
+                  query_params: { ...queryParams, traceId },
+                  format: "JSONEachRow",
+                  clickhouse_settings: BOUNDED_READ_SETTINGS,
+                })
+                return result.json<SpanMessagesRowWithTime>()
+              })
+              .pipe(Effect.mapError((error) => toRepositoryError(error, "findMessagesForSession")))
+            allRows.push(...rows)
+          }
+
+          return sortSpanMessageRowsByStartTime(allRows).map(toDomainSpanMessages)
         }),
 
       findLatestOutputTraceId: ({ organizationId, projectId, traceIds }) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a production `RepositoryError` on `findMessagesForSession` where ClickHouse exceeded its per-query memory cap (`MergingSortedTransform` at ~1.06 GiB vs 953 MiB limit) when loading the conversation timeline for a long multi-trace session.

## Root cause

`findMessagesForSession` (added in #3546 for the session conversation timeline) ran one query across every trace in a session, pulling `input_messages` / `output_messages` for all LLM/tool spans and sorting the combined result in ClickHouse. On agent sessions with many traces and heavy message payloads, that single sort-merge blew past `BOUNDED_READ_SETTINGS.max_memory_usage`.

## Fix

1. Lean `SELECT DISTINCT trace_id` over the session membership predicate (no message columns).
2. Reuse the existing per-trace message projection (`MESSAGES_FOR_TRACE_SQL`, same as `findMessagesForTrace`) for each trace.
3. Merge and sort by `start_time` in application code.

Memory per query stays bounded to one trace's spans instead of the whole session.

## Datadog

- Issue: https://app.datadoghq.eu/error-tracking/issue/94d691fc-812d-11f1-a5f3-da7ad0900005
- Service: `web`, 4 occurrences, first seen 2026-07-16 on commit `bd9d571`
- Introduced by: https://github.com/latitude-dev/latitude-llm/commit/d11aa542cedfec851503adfe3d58c9655e716896 (#3546)

## Testing

- Existing `findMessagesForSession` chdb integration tests unchanged (orphan session + multi-trace dedupe/order).
- `pnpm --filter @platform/db-clickhouse typecheck` passes.
- chdb native module unavailable in this cloud VM, so integration tests were not executed here.

## Verification after deploy

Occurrences of issue `94d691fc-812d-11f1-a5f3-da7ad0900005` should drop to zero when opening the Conversation tab on long multi-trace sessions.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C03BZFX9KCK/p1784217491966249?thread_ts=1784217491.966249&cid=C03BZFX9KCK)

<div><a href="https://cursor.com/agents/bc-ea9827d5-dd26-5db4-857b-b77ea8b65f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea9827d5-dd26-5db4-857b-b77ea8b65f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

