### PR TITLE
feat(memories): add the Memory page with store list, record detail, and access views

### DIFF
--- a/apps/web/src/domains/memories/memories.collection.ts
+++ b/apps/web/src/domains/memories/memories.collection.ts
@@ -8,6 +8,7 @@ import {
   getSessionMemorySummary,
   listMemoryStores,
   listMemoryStoreUsers,
+  listUserMemoryStores,
   type MemoryStoreRecord,
   type SessionMemorySummaryRecord,
 } from "./memories.functions.ts"
@@ -138,5 +139,24 @@ export function useMemoryStoreUsers({
     queryFn: () => listMemoryStoreUsers({ data: { ...projectScopeData(scope), projectId, storeId } }),
     staleTime: 30_000,
     enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The memory stores one end-user accessed, for the user detail page. */
+export function useUserMemoryStores({
+  projectId,
+  userId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly userId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "user-memory-stores", projectId, userId],
+    queryFn: () => listUserMemoryStores({ data: { ...projectScopeData(scope), projectId, userId } }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0 && userId.length > 0,
   })
 }

--- a/apps/web/src/domains/memories/memories.collection.ts
+++ b/apps/web/src/domains/memories/memories.collection.ts
@@ -4,8 +4,10 @@ import { useMemo } from "react"
 import { projectScopeData, projectScopeKey, useProjectScope } from "../projects/project-scope.tsx"
 import {
   getMemoryRecord,
+  getMemoryRecordReads,
   getMemoryStoreSnapshot,
   getSessionMemorySummary,
+  listMemoryRecordUsers,
   listMemoryStores,
   listMemoryStoreUsers,
   listUserMemoryStores,
@@ -119,6 +121,48 @@ export function useMemoryRecord({
     queryFn: () => getMemoryRecord({ data: { ...projectScopeData(scope), projectId, storeId, recordId } }),
     staleTime: 30_000,
     // No `recordId.length` guard: the unnamed record (id `''`) is a valid selection.
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** One record's retrieval (read) events for the Reads tab; gate with `enabled` so it loads on demand. */
+export function useMemoryRecordReads({
+  projectId,
+  storeId,
+  recordId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly recordId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-record-reads", projectId, storeId, recordId],
+    queryFn: () => getMemoryRecordReads({ data: { ...projectScopeData(scope), projectId, storeId, recordId } }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The end-users who accessed one record; gate with `enabled` so it loads on demand. */
+export function useMemoryRecordUsers({
+  projectId,
+  storeId,
+  recordId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly recordId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-record-users", projectId, storeId, recordId],
+    queryFn: () => listMemoryRecordUsers({ data: { ...projectScopeData(scope), projectId, storeId, recordId } }),
+    staleTime: 30_000,
     enabled: enabled && projectId.length > 0,
   })
 }

--- a/apps/web/src/domains/memories/memories.collection.ts
+++ b/apps/web/src/domains/memories/memories.collection.ts
@@ -1,6 +1,18 @@
-import { useQuery } from "@tanstack/react-query"
+import type { InfiniteTableInfiniteScroll } from "@repo/ui"
+import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
 import { projectScopeData, projectScopeKey, useProjectScope } from "../projects/project-scope.tsx"
-import { getSessionMemorySummary, type SessionMemorySummaryRecord } from "./memories.functions.ts"
+import {
+  getMemoryRecord,
+  getMemoryStoreSnapshot,
+  getSessionMemorySummary,
+  listMemoryStores,
+  listMemoryStoreUsers,
+  type MemoryStoreRecord,
+  type SessionMemorySummaryRecord,
+} from "./memories.functions.ts"
+
+type MemoryStoreSortField = "lastUpdated" | "lastRead" | "records" | "tokens" | "sessions" | "users"
 
 /**
  * Memory footprint for a session's summary chip; pass `traceId` to restrict it
@@ -27,5 +39,104 @@ export function useMemorySummary({
       return result as SessionMemorySummaryRecord
     },
     enabled: enabled && projectId.length > 0 && sessionId.length > 0,
+  })
+}
+
+/** The project's memory stores, server-sorted and paginated for the store-list table. */
+export function useMemoryStores({
+  projectId,
+  sort,
+  direction,
+  limit = 50,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly sort: MemoryStoreSortField
+  readonly direction: "asc" | "desc"
+  readonly limit?: number
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: [...projectScopeKey(scope), "memory-stores", projectId, sort, direction, limit],
+    queryFn: ({ pageParam }) =>
+      listMemoryStores({ data: { ...projectScopeData(scope), projectId, sort, direction, limit, offset: pageParam } }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
+    placeholderData: keepPreviousData,
+    enabled: enabled && projectId.length > 0,
+  })
+
+  const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
+    () => ({ hasMore: hasNextPage ?? false, isLoadingMore: isFetchingNextPage, onLoadMore: fetchNextPage }),
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  )
+  const stores = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data])
+
+  return {
+    stores: stores as readonly MemoryStoreRecord[],
+    totalCount: data?.pages[0]?.totalCount ?? 0,
+    isLoading,
+    infiniteScroll,
+  }
+}
+
+/** One store's current record ids for the detail filetree. */
+export function useMemoryStoreSnapshot({
+  projectId,
+  storeId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-store-snapshot", projectId, storeId],
+    queryFn: () => getMemoryStoreSnapshot({ data: { ...projectScopeData(scope), projectId, storeId } }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The selected record's current body plus its update history. */
+export function useMemoryRecord({
+  projectId,
+  storeId,
+  recordId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly recordId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-record", projectId, storeId, recordId],
+    queryFn: () => getMemoryRecord({ data: { ...projectScopeData(scope), projectId, storeId, recordId } }),
+    staleTime: 30_000,
+    // No `recordId.length` guard: the unnamed record (id `''`) is a valid selection.
+    enabled: enabled && projectId.length > 0,
+  })
+}
+
+/** The end-users who accessed one store. */
+export function useMemoryStoreUsers({
+  projectId,
+  storeId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-store-users", projectId, storeId],
+    queryFn: () => listMemoryStoreUsers({ data: { ...projectScopeData(scope), projectId, storeId } }),
+    staleTime: 30_000,
+    enabled: enabled && projectId.length > 0,
   })
 }

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -1,10 +1,12 @@
 import {
   computeSessionMemorySummaryUseCase,
   listMemoryStoresUseCase,
+  listRecordUsersUseCase,
   listStoreUsersUseCase,
   listUserStoresUseCase,
   type MemoryChangeKind,
   MemoryRepository,
+  readRecordReadsUseCase,
   reconstructSnapshotUseCase,
   type SessionMemorySummary,
 } from "@domain/memories"
@@ -52,6 +54,7 @@ export interface MemoryRecordVersionRecord {
   readonly spanId: string
   readonly traceId: string
   readonly sessionId: string
+  readonly userId: string
   readonly endTime: string
 }
 
@@ -59,6 +62,23 @@ interface MemoryRecordDetailRecord {
   readonly body: string | null
   readonly tokenCount: number
   readonly versions: readonly MemoryRecordVersionRecord[]
+}
+
+export interface MemoryRecordReadRecord {
+  readonly spanId: string
+  readonly traceId: string
+  readonly sessionId: string
+  readonly userId: string
+  readonly queryText: string
+  readonly tokenCount: number
+  readonly endTime: string
+}
+
+export interface MemoryRecordUserRecord {
+  readonly userId: string
+  readonly readCount: number
+  readonly writeCount: number
+  readonly lastAccessedAt: string
 }
 
 interface MemoryStoreUserRecord {
@@ -191,10 +211,72 @@ export const getMemoryRecord = createServerFn({ method: "GET" })
             spanId: version.spanId as string,
             traceId: version.traceId as string,
             sessionId: version.sessionId as string,
+            userId: version.userId as string,
             endTime: version.endTime.toISOString(),
           })),
         } satisfies MemoryRecordDetailRecord
       }).pipe(withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/** One record's retrieval (read) events — newest first, capped — for the Reads tab. */
+export const getMemoryRecordReads = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), storeId: z.string(), recordId: z.string() }))
+  .handler(async ({ data, context }): Promise<readonly MemoryRecordReadRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      readRecordReadsUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        storeId: data.storeId,
+        recordId: data.recordId,
+      }).pipe(
+        Effect.map((events) =>
+          events.map(
+            (event): MemoryRecordReadRecord => ({
+              spanId: event.spanId as string,
+              traceId: event.traceId as string,
+              sessionId: event.sessionId as string,
+              userId: event.userId as string,
+              queryText: event.queryText,
+              tokenCount: event.tokenCount,
+              endTime: event.endTime.toISOString(),
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** The end-users who accessed one record (reads + writes counted), newest access first. */
+export const listMemoryRecordUsers = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), storeId: z.string(), recordId: z.string() }))
+  .handler(async ({ data, context }): Promise<readonly MemoryRecordUserRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      listRecordUsersUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        storeId: data.storeId,
+        recordId: data.recordId,
+      }).pipe(
+        Effect.map((users) =>
+          users.map(
+            (user): MemoryRecordUserRecord => ({
+              userId: user.userId as string,
+              readCount: user.readCount,
+              writeCount: user.writeCount,
+              lastAccessedAt: user.lastAccessedAt.toISOString(),
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
     )
   })
 

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -2,12 +2,13 @@ import {
   computeSessionMemorySummaryUseCase,
   listMemoryStoresUseCase,
   listStoreUsersUseCase,
+  listUserStoresUseCase,
   type MemoryChangeKind,
   MemoryRepository,
   reconstructSnapshotUseCase,
   type SessionMemorySummary,
 } from "@domain/memories"
-import { ProjectId, SessionId, TraceId } from "@domain/shared"
+import { ExternalUserId, ProjectId, SessionId, TraceId } from "@domain/shared"
 import { MemoryRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -62,6 +63,11 @@ interface MemoryRecordDetailRecord {
 
 interface MemoryStoreUserRecord {
   readonly userId: string
+  readonly lastAccessedAt: string
+}
+
+interface MemoryUserStoreRecord {
+  readonly storeId: string
   readonly lastAccessedAt: string
 }
 
@@ -209,6 +215,32 @@ export const listMemoryStoreUsers = createServerFn({ method: "GET" })
             (user): MemoryStoreUserRecord => ({
               userId: user.userId as string,
               lastAccessedAt: user.lastAccessedAt.toISOString(),
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** The memory stores one end-user accessed (reads count), newest access first. */
+export const listUserMemoryStores = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), userId: z.string() }))
+  .handler(async ({ data, context }): Promise<readonly MemoryUserStoreRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      listUserStoresUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        userId: ExternalUserId(data.userId),
+      }).pipe(
+        Effect.map((stores) =>
+          stores.map(
+            (store): MemoryUserStoreRecord => ({
+              storeId: store.storeId,
+              lastAccessedAt: store.lastAccessedAt.toISOString(),
             }),
           ),
         ),

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -195,9 +195,10 @@ export const getMemoryRecord = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           records: [{ storeId: data.storeId, recordId: data.recordId }],
         })
-        // Version chain is end_time ASC; the current body is the newest non-remove version.
+        // Version chain is end_time ASC; the current body is the latest version, unless it removed the record.
         const newestFirst = [...versions].reverse()
-        const current = newestFirst.find((version) => version.changeKind !== "remove")
+        const latest = newestFirst[0]
+        const current = latest && latest.changeKind !== "remove" ? latest : undefined
         const blobs = current
           ? yield* memoryRepository.readBlobs({ organizationId: orgId, hashes: [current.contentHash] })
           : []

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -1,4 +1,12 @@
-import { computeSessionMemorySummaryUseCase, type SessionMemorySummary } from "@domain/memories"
+import {
+  computeSessionMemorySummaryUseCase,
+  listMemoryStoresUseCase,
+  listStoreUsersUseCase,
+  type MemoryChangeKind,
+  MemoryRepository,
+  reconstructSnapshotUseCase,
+  type SessionMemorySummary,
+} from "@domain/memories"
 import { ProjectId, SessionId, TraceId } from "@domain/shared"
 import { MemoryRepositoryLive } from "@platform/db-clickhouse"
 import { withTracing } from "@repo/observability"
@@ -10,6 +18,52 @@ import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
 import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 
 export type SessionMemorySummaryRecord = SessionMemorySummary
+
+export interface MemoryStoreRecord {
+  readonly storeId: string
+  readonly recordCount: number
+  readonly tokenCount: number
+  readonly lastUpdatedAt: string
+  readonly lastReadAt: string | null
+  readonly sessionCount: number
+  readonly userCount: number
+}
+
+interface MemoryStoresPageRecord {
+  readonly items: readonly MemoryStoreRecord[]
+  readonly totalCount: number
+  readonly hasMore: boolean
+  readonly limit: number
+  readonly offset: number
+}
+
+export interface MemoryStoreSnapshotRecord {
+  readonly records: readonly {
+    readonly recordId: string
+    readonly tokenCount: number
+    readonly lastUpdatedAt: string
+  }[]
+}
+
+export interface MemoryRecordVersionRecord {
+  readonly changeKind: MemoryChangeKind
+  readonly tokenCount: number
+  readonly spanId: string
+  readonly traceId: string
+  readonly sessionId: string
+  readonly endTime: string
+}
+
+interface MemoryRecordDetailRecord {
+  readonly body: string | null
+  readonly tokenCount: number
+  readonly versions: readonly MemoryRecordVersionRecord[]
+}
+
+interface MemoryStoreUserRecord {
+  readonly userId: string
+  readonly lastAccessedAt: string
+}
 
 /**
  * A session's (or one trace's) memory footprint for the summary chip. No cache
@@ -28,5 +82,138 @@ export const getSessionMemorySummary = createServerFn({ method: "GET" })
         sessionId: SessionId(data.sessionId),
         ...(data.traceId ? { traceId: TraceId(data.traceId) } : {}),
       }).pipe(withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/** The project's memory stores, one roll-up row each, server-sorted and paginated. */
+export const listMemoryStores = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      sort: z.enum(["lastUpdated", "lastRead", "records", "tokens", "sessions", "users"]).default("lastUpdated"),
+      direction: z.enum(["asc", "desc"]).default("desc"),
+      limit: z.number().int().min(1).max(200).default(50),
+      offset: z.number().int().min(0).default(0),
+    }),
+  )
+  .handler(async ({ data, context }): Promise<MemoryStoresPageRecord> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      listMemoryStoresUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        options: { sortBy: data.sort, sortDirection: data.direction, limit: data.limit, offset: data.offset },
+      }).pipe(
+        Effect.map(
+          (page): MemoryStoresPageRecord => ({
+            items: page.items.map((store) => ({
+              storeId: store.storeId,
+              recordCount: store.recordCount,
+              tokenCount: store.tokenCount,
+              lastUpdatedAt: store.lastUpdatedAt.toISOString(),
+              lastReadAt: store.lastReadAt ? store.lastReadAt.toISOString() : null,
+              sessionCount: store.sessionCount,
+              userCount: store.userCount,
+            })),
+            totalCount: page.totalCount,
+            hasMore: page.hasMore,
+            limit: page.limit,
+            offset: page.offset,
+          }),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** One store's current record ids (with light metadata) for the detail filetree. */
+export const getMemoryStoreSnapshot = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), storeId: z.string() }))
+  .handler(async ({ data, context }): Promise<MemoryStoreSnapshotRecord> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      reconstructSnapshotUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        storeId: data.storeId,
+      }).pipe(
+        Effect.map(
+          (snapshot): MemoryStoreSnapshotRecord => ({
+            records: snapshot.records.map((record) => ({
+              recordId: record.recordId,
+              tokenCount: record.tokenCount,
+              lastUpdatedAt: record.endTime.toISOString(),
+            })),
+          }),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
+    )
+  })
+
+/** One record's current body plus the ordered chain of sessions/traces that mutated it. */
+export const getMemoryRecord = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), storeId: z.string(), recordId: z.string() }))
+  .handler(async ({ data, context }): Promise<MemoryRecordDetailRecord> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const memoryRepository = yield* MemoryRepository
+        const versions = yield* memoryRepository.readRecordVersions({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          records: [{ storeId: data.storeId, recordId: data.recordId }],
+        })
+        // Version chain is end_time ASC; the current body is the newest non-remove version.
+        const newestFirst = [...versions].reverse()
+        const current = newestFirst.find((version) => version.changeKind !== "remove")
+        const blobs = current
+          ? yield* memoryRepository.readBlobs({ organizationId: orgId, hashes: [current.contentHash] })
+          : []
+        const body = current ? (blobs.find((blob) => blob.contentHash === current.contentHash)?.content ?? null) : null
+        return {
+          body,
+          tokenCount: current?.tokenCount ?? 0,
+          versions: newestFirst.map((version) => ({
+            changeKind: version.changeKind,
+            tokenCount: version.tokenCount,
+            spanId: version.spanId as string,
+            traceId: version.traceId as string,
+            sessionId: version.sessionId as string,
+            endTime: version.endTime.toISOString(),
+          })),
+        } satisfies MemoryRecordDetailRecord
+      }).pipe(withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/** The end-users who accessed one store (reads count), newest access first. */
+export const listMemoryStoreUsers = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), storeId: z.string() }))
+  .handler(async ({ data, context }): Promise<readonly MemoryStoreUserRecord[]> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      listStoreUsersUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        storeId: data.storeId,
+      }).pipe(
+        Effect.map((users) =>
+          users.map(
+            (user): MemoryStoreUserRecord => ({
+              userId: user.userId as string,
+              lastAccessedAt: user.lastAccessedAt.toISOString(),
+            }),
+          ),
+        ),
+        withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
+      ),
     )
   })

--- a/apps/web/src/domains/projects/project-sections.ts
+++ b/apps/web/src/domains/projects/project-sections.ts
@@ -1,6 +1,7 @@
 import type { FeatureFlagId } from "@domain/feature-flags"
 import {
   BellRingIcon,
+  BrainIcon,
   Building2,
   CreditCard,
   DatabaseIcon,
@@ -61,6 +62,15 @@ const PROJECT_SECTIONS: readonly ProjectSection[] = [
     group: "observe",
     path: (slug) => `/projects/${slug}/tools`,
     isActive: (pathname, slug) => pathname.startsWith(`/projects/${slug}/tools`),
+  },
+  {
+    key: "memory",
+    label: "Memory",
+    icon: BrainIcon,
+    group: "observe",
+    path: (slug) => `/projects/${slug}/memory`,
+    isActive: (pathname, slug) => pathname.startsWith(`/projects/${slug}/memory`),
+    featureFlag: "memoryObservability",
   },
   {
     key: "signals",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -61,6 +61,7 @@ import { Route as AuthenticatedProjectsProjectSlugToolsIndexRouteImport } from '
 import { Route as AuthenticatedProjectsProjectSlugSignalsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/signals/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/index'
 import { Route as AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/index'
+import { Route as AuthenticatedProjectsProjectSlugMemoryIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/memory/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/index'
 import { Route as AuthenticatedProjectsProjectSlugExperimentsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/experiments/index'
 import { Route as AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/datasets/index'
@@ -85,6 +86,7 @@ import { Route as AuthenticatedProjectsProjectSlugSignalsSignalIdIndexRouteImpor
 import { Route as AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/integrations/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/settings/data-destinations/index'
 import { Route as AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/monitors/$monitorSlug/index'
+import { Route as AuthenticatedProjectsProjectSlugMemoryStoreIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/memory/$store/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/$issueId/index'
 import { Route as AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/experiments/$experimentSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/index'
@@ -380,6 +382,12 @@ const AuthenticatedProjectsProjectSlugMonitorsIndexRoute =
     path: '/monitors/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugMemoryIndexRoute =
+  AuthenticatedProjectsProjectSlugMemoryIndexRouteImport.update({
+    id: '/memory/',
+    path: '/memory/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugIssuesIndexRoute =
   AuthenticatedProjectsProjectSlugIssuesIndexRouteImport.update({
     id: '/issues/',
@@ -526,6 +534,12 @@ const AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute =
     path: '/monitors/$monitorSlug/',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute =
+  AuthenticatedProjectsProjectSlugMemoryStoreIndexRouteImport.update({
+    id: '/memory/$store/',
+    path: '/memory/$store/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute =
   AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRouteImport.update({
     id: '/issues/$issueId/',
@@ -646,6 +660,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/experiments/': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/memory/': typeof AuthenticatedProjectsProjectSlugMemoryIndexRoute
   '/projects/$projectSlug/monitors/': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/projects/$projectSlug/settings/': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
   '/projects/$projectSlug/signals/': typeof AuthenticatedProjectsProjectSlugSignalsIndexRoute
@@ -658,6 +673,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
+  '/projects/$projectSlug/memory/$store/': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/projects/$projectSlug/settings/data-destinations/': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
   '/projects/$projectSlug/settings/integrations/': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
@@ -726,6 +742,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/datasets': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/experiments': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/projects/$projectSlug/issues': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/memory': typeof AuthenticatedProjectsProjectSlugMemoryIndexRoute
   '/projects/$projectSlug/monitors': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
   '/projects/$projectSlug/signals': typeof AuthenticatedProjectsProjectSlugSignalsIndexRoute
@@ -738,6 +755,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/custom-behaviours/$behaviourSlug': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/projects/$projectSlug/experiments/$experimentSlug': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/projects/$projectSlug/issues/$issueId': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
+  '/projects/$projectSlug/memory/$store': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/projects/$projectSlug/monitors/$monitorSlug': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/projects/$projectSlug/settings/data-destinations': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
   '/projects/$projectSlug/settings/integrations': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
@@ -812,6 +830,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/_authenticated/projects/$projectSlug/experiments/': typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   '/_authenticated/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/_authenticated/projects/$projectSlug/memory/': typeof AuthenticatedProjectsProjectSlugMemoryIndexRoute
   '/_authenticated/projects/$projectSlug/monitors/': typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   '/_authenticated/projects/$projectSlug/settings/': typeof AuthenticatedProjectsProjectSlugSettingsIndexRoute
   '/_authenticated/projects/$projectSlug/signals/': typeof AuthenticatedProjectsProjectSlugSignalsIndexRoute
@@ -824,6 +843,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/': typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/': typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   '/_authenticated/projects/$projectSlug/issues/$issueId/': typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
+  '/_authenticated/projects/$projectSlug/memory/$store/': typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/': typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   '/_authenticated/projects/$projectSlug/settings/data-destinations/': typeof AuthenticatedProjectsProjectSlugSettingsDataDestinationsIndexRoute
   '/_authenticated/projects/$projectSlug/settings/integrations/': typeof AuthenticatedProjectsProjectSlugSettingsIntegrationsIndexRoute
@@ -898,6 +918,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/datasets/'
     | '/projects/$projectSlug/experiments/'
     | '/projects/$projectSlug/issues/'
+    | '/projects/$projectSlug/memory/'
     | '/projects/$projectSlug/monitors/'
     | '/projects/$projectSlug/settings/'
     | '/projects/$projectSlug/signals/'
@@ -910,6 +931,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
     | '/projects/$projectSlug/experiments/$experimentSlug/'
     | '/projects/$projectSlug/issues/$issueId/'
+    | '/projects/$projectSlug/memory/$store/'
     | '/projects/$projectSlug/monitors/$monitorSlug/'
     | '/projects/$projectSlug/settings/data-destinations/'
     | '/projects/$projectSlug/settings/integrations/'
@@ -978,6 +1000,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/datasets'
     | '/projects/$projectSlug/experiments'
     | '/projects/$projectSlug/issues'
+    | '/projects/$projectSlug/memory'
     | '/projects/$projectSlug/monitors'
     | '/projects/$projectSlug/settings'
     | '/projects/$projectSlug/signals'
@@ -990,6 +1013,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/custom-behaviours/$behaviourSlug'
     | '/projects/$projectSlug/experiments/$experimentSlug'
     | '/projects/$projectSlug/issues/$issueId'
+    | '/projects/$projectSlug/memory/$store'
     | '/projects/$projectSlug/monitors/$monitorSlug'
     | '/projects/$projectSlug/settings/data-destinations'
     | '/projects/$projectSlug/settings/integrations'
@@ -1063,6 +1087,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/datasets/'
     | '/_authenticated/projects/$projectSlug/experiments/'
     | '/_authenticated/projects/$projectSlug/issues/'
+    | '/_authenticated/projects/$projectSlug/memory/'
     | '/_authenticated/projects/$projectSlug/monitors/'
     | '/_authenticated/projects/$projectSlug/settings/'
     | '/_authenticated/projects/$projectSlug/signals/'
@@ -1075,6 +1100,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/custom-behaviours/$behaviourSlug/'
     | '/_authenticated/projects/$projectSlug/experiments/$experimentSlug/'
     | '/_authenticated/projects/$projectSlug/issues/$issueId/'
+    | '/_authenticated/projects/$projectSlug/memory/$store/'
     | '/_authenticated/projects/$projectSlug/monitors/$monitorSlug/'
     | '/_authenticated/projects/$projectSlug/settings/data-destinations/'
     | '/_authenticated/projects/$projectSlug/settings/integrations/'
@@ -1476,6 +1502,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugMonitorsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/memory/': {
+      id: '/_authenticated/projects/$projectSlug/memory/'
+      path: '/memory'
+      fullPath: '/projects/$projectSlug/memory/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugMemoryIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/issues/': {
       id: '/_authenticated/projects/$projectSlug/issues/'
       path: '/issues'
@@ -1644,6 +1677,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/memory/$store/': {
+      id: '/_authenticated/projects/$projectSlug/memory/$store/'
+      path: '/memory/$store'
+      fullPath: '/projects/$projectSlug/memory/$store/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/issues/$issueId/': {
       id: '/_authenticated/projects/$projectSlug/issues/$issueId/'
       path: '/issues/$issueId'
@@ -1793,6 +1833,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugDatasetsIndexRoute: typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   AuthenticatedProjectsProjectSlugExperimentsIndexRoute: typeof AuthenticatedProjectsProjectSlugExperimentsIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  AuthenticatedProjectsProjectSlugMemoryIndexRoute: typeof AuthenticatedProjectsProjectSlugMemoryIndexRoute
   AuthenticatedProjectsProjectSlugMonitorsIndexRoute: typeof AuthenticatedProjectsProjectSlugMonitorsIndexRoute
   AuthenticatedProjectsProjectSlugSignalsIndexRoute: typeof AuthenticatedProjectsProjectSlugSignalsIndexRoute
   AuthenticatedProjectsProjectSlugToolsIndexRoute: typeof AuthenticatedProjectsProjectSlugToolsIndexRoute
@@ -1802,6 +1843,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugCustomBehavioursBehaviourSlugIndexRoute
   AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute
+  AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute: typeof AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute
   AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute
   AuthenticatedProjectsProjectSlugSignalsSignalIdIndexRoute: typeof AuthenticatedProjectsProjectSlugSignalsSignalIdIndexRoute
   AuthenticatedProjectsProjectSlugToolsToolNameIndexRoute: typeof AuthenticatedProjectsProjectSlugToolsToolNameIndexRoute
@@ -1836,6 +1878,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugExperimentsIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIndexRoute:
       AuthenticatedProjectsProjectSlugIssuesIndexRoute,
+    AuthenticatedProjectsProjectSlugMemoryIndexRoute:
+      AuthenticatedProjectsProjectSlugMemoryIndexRoute,
     AuthenticatedProjectsProjectSlugMonitorsIndexRoute:
       AuthenticatedProjectsProjectSlugMonitorsIndexRoute,
     AuthenticatedProjectsProjectSlugSignalsIndexRoute:
@@ -1854,6 +1898,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugExperimentsExperimentSlugIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute:
       AuthenticatedProjectsProjectSlugIssuesIssueIdIndexRoute,
+    AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute:
+      AuthenticatedProjectsProjectSlugMemoryStoreIndexRoute,
     AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute:
       AuthenticatedProjectsProjectSlugMonitorsMonitorSlugIndexRoute,
     AuthenticatedProjectsProjectSlugSignalsSignalIdIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.test.ts
@@ -31,4 +31,16 @@ describe("buildRecordTree", () => {
     expect(tree[0]!.segment).toBe("")
     expect(tree[0]!.recordId).toBe("")
   })
+
+  it("preserves leading separators so a leading-slash id does not collide with a root id", () => {
+    const tree = buildRecordTree([{ recordId: "a" }, { recordId: "/a/c" }])
+    // "/a/c" splits to ["", "a", "c"]: an empty-segment root distinct from "a".
+    expect(tree.map((node) => node.segment)).toEqual(["", "a"])
+    const empty = tree.find((node) => node.segment === "")!
+    expect(empty.children.map((child) => child.path)).toEqual(["/a"])
+    expect(empty.children[0]!.children.map((child) => child.path)).toEqual(["/a/c"])
+    const rootA = tree.find((node) => node.segment === "a")!
+    expect(rootA.path).toBe("a")
+    expect(rootA.recordId).toBe("a")
+  })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { buildRecordTree } from "./build-record-tree.ts"
+
+describe("buildRecordTree", () => {
+  it("keeps records without '/' as flat, alphabetically sorted siblings", () => {
+    const tree = buildRecordTree([{ recordId: "b" }, { recordId: "a" }])
+    expect(tree.map((node) => node.segment)).toEqual(["a", "b"])
+    expect(tree.every((node) => node.recordId !== undefined && node.children.length === 0)).toBe(true)
+  })
+
+  it("nests ids split on '/', folders before files", () => {
+    const tree = buildRecordTree([{ recordId: "prefs/theme" }, { recordId: "prefs/lang" }, { recordId: "top" }])
+    expect(tree.map((node) => node.segment)).toEqual(["prefs", "top"])
+    const prefs = tree[0]!
+    expect(prefs.recordId).toBeUndefined()
+    expect(prefs.children.map((child) => child.segment)).toEqual(["lang", "theme"])
+    expect(prefs.children.map((child) => child.recordId)).toEqual(["prefs/lang", "prefs/theme"])
+  })
+
+  it("supports a node that is both a record and a parent", () => {
+    const tree = buildRecordTree([{ recordId: "a" }, { recordId: "a/b" }])
+    expect(tree).toHaveLength(1)
+    const a = tree[0]!
+    expect(a.recordId).toBe("a")
+    expect(a.children.map((child) => child.recordId)).toEqual(["a/b"])
+  })
+
+  it("keeps the unnamed record (id '') as a single leaf", () => {
+    const tree = buildRecordTree([{ recordId: "" }])
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.segment).toBe("")
+    expect(tree[0]!.recordId).toBe("")
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.ts
@@ -1,0 +1,55 @@
+export interface RecordTreeNode {
+  readonly segment: string
+  readonly path: string
+  /** Set when this node is itself a record (a leaf, or a folder that is also a record). */
+  readonly recordId?: string
+  readonly children: readonly RecordTreeNode[]
+}
+
+interface MutableNode {
+  readonly segment: string
+  readonly path: string
+  recordId?: string
+  readonly children: Map<string, MutableNode>
+}
+
+/** Build a nested tree from record ids split on `/`; ids without `/` become flat siblings. */
+export function buildRecordTree(records: readonly { readonly recordId: string }[]): readonly RecordTreeNode[] {
+  const roots = new Map<string, MutableNode>()
+  for (const { recordId } of records) {
+    const segments = recordId.split("/")
+    let level = roots
+    let prefix = ""
+    let node: MutableNode | undefined
+    for (const segment of segments) {
+      prefix = prefix === "" ? segment : `${prefix}/${segment}`
+      const existing = level.get(segment)
+      node = existing ?? { segment, path: prefix, children: new Map() }
+      if (!existing) level.set(segment, node)
+      level = node.children
+    }
+    if (node) node.recordId = recordId
+  }
+  return freezeLevel(roots)
+}
+
+function freezeLevel(level: Map<string, MutableNode>): readonly RecordTreeNode[] {
+  return [...level.values()]
+    .map(
+      (node): RecordTreeNode => ({
+        segment: node.segment,
+        path: node.path,
+        ...(node.recordId !== undefined ? { recordId: node.recordId } : {}),
+        children: freezeLevel(node.children),
+      }),
+    )
+    .sort(compareNodes)
+}
+
+// Folders before files, then alphabetical within each group.
+function compareNodes(a: RecordTreeNode, b: RecordTreeNode): number {
+  const aFolder = a.children.length > 0
+  const bFolder = b.children.length > 0
+  if (aFolder !== bFolder) return aFolder ? -1 : 1
+  return a.segment < b.segment ? -1 : a.segment > b.segment ? 1 : 0
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/build-record-tree.ts
@@ -21,8 +21,8 @@ export function buildRecordTree(records: readonly { readonly recordId: string }[
     let level = roots
     let prefix = ""
     let node: MutableNode | undefined
-    for (const segment of segments) {
-      prefix = prefix === "" ? segment : `${prefix}/${segment}`
+    for (const [index, segment] of segments.entries()) {
+      prefix = index === 0 ? segment : `${prefix}/${segment}`
       const existing = level.get(segment)
       node = existing ?? { segment, path: prefix, children: new Map() }
       if (!existing) level.set(segment, node)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -176,6 +176,7 @@ function usePanelResize(setOpen: (open: boolean) => void) {
     }
     if (upRef.current) {
       document.removeEventListener("pointerup", upRef.current)
+      document.removeEventListener("pointercancel", upRef.current)
       upRef.current = null
     }
     document.body.style.removeProperty("user-select")
@@ -230,6 +231,7 @@ function usePanelResize(setOpen: (open: boolean) => void) {
       upRef.current = onUp
       document.addEventListener("pointermove", onMove)
       document.addEventListener("pointerup", onUp)
+      document.addEventListener("pointercancel", onUp)
     },
     [height, maxHeight, cleanup, setOpen],
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, cn, Icon, Skeleton, Text } from "@repo/ui"
+import { CodeBlock, cn, Icon, Skeleton, Text, useMountEffect } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
 import {
   ChevronDownIcon,
@@ -9,7 +9,7 @@ import {
   PencilIcon,
   PlusIcon,
 } from "lucide-react"
-import { useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { useMemoryRecord } from "../../../../../../../domains/memories/memories.collection.ts"
 import type { MemoryRecordVersionRecord } from "../../../../../../../domains/memories/memories.functions.ts"
 import { recordDisplayLabel } from "../../-components/store-encoding.ts"
@@ -105,13 +105,137 @@ export function RecordContentView({
   )
 }
 
+const MIN_HISTORY_HEIGHT = 96
+const DEFAULT_HISTORY_HEIGHT = 160
+// Reserve this much for the editor header + code area + history header so the code never vanishes.
+const MIN_CONTENT_ABOVE = 200
+// Drag the list shorter than this and it closes instead of clamping to the minimum.
+const CLOSE_DRAG_THRESHOLD = 64
+const KEYBOARD_STEP = 24
+
+// Vertical sibling of the span-tree `useResizablePanel`: drags the history list taller/shorter.
+function useHistoryResize(setOpen: (open: boolean) => void) {
+  const footerRef = useRef<HTMLDivElement>(null)
+  const [height, setHeight] = useState(DEFAULT_HISTORY_HEIGHT)
+  const [isDragging, setIsDragging] = useState(false)
+  const drag = useRef<{ startY: number; startHeight: number; max: number } | null>(null)
+  const moveRef = useRef<((event: PointerEvent) => void) | null>(null)
+  const upRef = useRef<(() => void) | null>(null)
+
+  const cleanup = useCallback(() => {
+    if (moveRef.current) {
+      document.removeEventListener("pointermove", moveRef.current)
+      moveRef.current = null
+    }
+    if (upRef.current) {
+      document.removeEventListener("pointerup", upRef.current)
+      upRef.current = null
+    }
+    document.body.style.removeProperty("user-select")
+    document.body.style.removeProperty("cursor")
+  }, [])
+
+  const maxHeight = useCallback(() => {
+    const panel = footerRef.current?.parentElement
+    if (!panel) return DEFAULT_HISTORY_HEIGHT
+    return Math.max(MIN_HISTORY_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
+  }, [])
+
+  useMountEffect(() => {
+    const panel = footerRef.current?.parentElement
+    if (!panel) return
+    const observer = new ResizeObserver(() => setHeight((prev) => Math.min(prev, maxHeight())))
+    observer.observe(panel)
+    return () => {
+      observer.disconnect()
+      cleanup()
+    }
+  })
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      event.preventDefault()
+      if (!footerRef.current?.parentElement) return
+      drag.current = { startY: event.clientY, startHeight: height, max: maxHeight() }
+      setIsDragging(true)
+      document.body.style.userSelect = "none"
+      document.body.style.cursor = "ns-resize"
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const current = drag.current
+        if (!current) return
+        const raw = current.startHeight + (current.startY - moveEvent.clientY)
+        if (raw < CLOSE_DRAG_THRESHOLD) {
+          drag.current = null
+          setIsDragging(false)
+          cleanup()
+          setOpen(false)
+          return
+        }
+        setHeight(Math.max(MIN_HISTORY_HEIGHT, Math.min(current.max, raw)))
+      }
+      const onUp = () => {
+        drag.current = null
+        setIsDragging(false)
+        cleanup()
+      }
+      moveRef.current = onMove
+      upRef.current = onUp
+      document.addEventListener("pointermove", onMove)
+      document.addEventListener("pointerup", onUp)
+    },
+    [height, maxHeight, cleanup, setOpen],
+  )
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+      event.preventDefault()
+      const delta = event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP
+      setHeight((prev) => Math.max(MIN_HISTORY_HEIGHT, Math.min(maxHeight(), prev + delta)))
+    },
+    [maxHeight],
+  )
+
+  return { footerRef, height, isDragging, onPointerDown, onKeyDown }
+}
+
 function RecordHistoryPanel({ versions }: { readonly versions: readonly MemoryRecordVersionRecord[] }) {
   const [open, setOpen] = useState(true)
+  const { footerRef, height, isDragging, onPointerDown, onKeyDown } = useHistoryResize(setOpen)
   const mutating = versions.filter((version) => isMutating(version.changeKind))
   if (mutating.length === 0) return null
 
   return (
-    <div className="shrink-0 border-t">
+    <div ref={footerRef} className="relative shrink-0 border-t">
+      {open ? (
+        // biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize record history"
+          aria-valuenow={height}
+          aria-valuemin={MIN_HISTORY_HEIGHT}
+          aria-valuemax={
+            footerRef.current?.parentElement
+              ? Math.max(MIN_HISTORY_HEIGHT, footerRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
+              : DEFAULT_HISTORY_HEIGHT
+          }
+          tabIndex={0}
+          onPointerDown={onPointerDown}
+          onKeyDown={onKeyDown}
+          className="group absolute inset-x-0 -top-1 z-10 flex h-2 cursor-ns-resize touch-none items-center justify-center focus-visible:outline-none"
+        >
+          <div
+            className={cn(
+              "h-1 w-10 rounded-full transition-opacity",
+              isDragging
+                ? "bg-muted-foreground/60 opacity-100"
+                : "bg-border opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
+            )}
+          />
+        </div>
+      ) : null}
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
@@ -128,7 +252,7 @@ function RecordHistoryPanel({ versions }: { readonly versions: readonly MemoryRe
         <Icon icon={open ? ChevronDownIcon : ChevronUpIcon} size="sm" color="foregroundMuted" className="shrink-0" />
       </button>
       {open ? (
-        <div className="h-40 overflow-y-auto border-t px-1 py-1">
+        <div className="overflow-y-auto border-t px-1 py-1" style={{ height }}>
           {mutating.map((version) => {
             const meta = CHANGE_META[version.changeKind as MutatingKind]
             const ChangeIcon = meta.icon

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,6 +1,15 @@
-import { CodeBlock, cn, Skeleton, Text } from "@repo/ui"
+import { CodeBlock, cn, Icon, Skeleton, Text } from "@repo/ui"
 import { formatCount, relativeTime } from "@repo/utils"
-import { MinusIcon, PencilIcon, PlusIcon } from "lucide-react"
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  FileTextIcon,
+  HistoryIcon,
+  MinusIcon,
+  PencilIcon,
+  PlusIcon,
+} from "lucide-react"
+import { useState } from "react"
 import { useMemoryRecord } from "../../../../../../../domains/memories/memories.collection.ts"
 import type { MemoryRecordVersionRecord } from "../../../../../../../domains/memories/memories.functions.ts"
 import { recordDisplayLabel } from "../../-components/store-encoding.ts"
@@ -38,9 +47,13 @@ export function RecordContentView({
 
   if (isLoading) {
     return (
-      <div className="flex min-h-0 flex-1 flex-col gap-3">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-64 w-full" />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex h-11 shrink-0 items-center border-b px-3">
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <div className="flex-1 p-3">
+          <Skeleton className="h-full w-full" />
+        </div>
       </div>
     )
   }
@@ -48,56 +61,92 @@ export function RecordContentView({
 
   const body = data.body ?? ""
   const language = body !== "" && looksLikeJson(body) ? "json" : undefined
+  const lineCount = body === "" ? 0 : body.split("\n").length
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
-      <div className="flex items-center justify-between gap-2">
-        <Text.H5M className="min-w-0 font-mono" noWrap ellipsis>
-          {recordDisplayLabel(recordId)}
-        </Text.H5M>
-        <Text.H6 color="foregroundMuted" className="shrink-0">
-          {formatCount(data.tokenCount)} tok
-        </Text.H6>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+      <div className="flex h-11 shrink-0 items-center justify-between gap-3 border-b px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <FileTextIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Text.H5M className="min-w-0 font-mono" noWrap ellipsis>
+            {recordDisplayLabel(recordId)}
+          </Text.H5M>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {language === "json" ? (
+            <span className="rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase leading-none tracking-wide text-muted-foreground">
+              JSON
+            </span>
+          ) : null}
+          {data.body !== null ? (
+            <Text.H6 color="foregroundMuted" noWrap>
+              {formatCount(lineCount)} {lineCount === 1 ? "line" : "lines"} · {formatCount(data.tokenCount)} tok
+            </Text.H6>
+          ) : (
+            <Text.H6 color="foregroundMuted" noWrap>
+              {formatCount(data.tokenCount)} tok
+            </Text.H6>
+          )}
+        </div>
       </div>
+
       <div className="min-h-0 flex-1">
         {data.body !== null ? (
-          <CodeBlock value={body} fillHeight {...(language ? { language } : {})} />
+          <CodeBlock value={body} fillHeight className="h-full rounded-none" {...(language ? { language } : {})} />
         ) : (
-          <div className="flex h-full items-center justify-center rounded-lg border border-dashed">
+          <div className="flex h-full items-center justify-center">
             <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
           </div>
         )}
       </div>
-      <UpdatedByHistory versions={data.versions} />
+
+      <RecordHistoryPanel versions={data.versions} />
     </div>
   )
 }
 
-function UpdatedByHistory({ versions }: { readonly versions: readonly MemoryRecordVersionRecord[] }) {
+function RecordHistoryPanel({ versions }: { readonly versions: readonly MemoryRecordVersionRecord[] }) {
+  const [open, setOpen] = useState(true)
   const mutating = versions.filter((version) => isMutating(version.changeKind))
   if (mutating.length === 0) return null
 
   return (
-    <div className="flex flex-col gap-1.5">
-      <Text.H6 color="foregroundMuted">Updated by</Text.H6>
-      <div className="flex max-h-56 flex-col overflow-y-auto">
-        {mutating.map((version) => {
-          const meta = CHANGE_META[version.changeKind as MutatingKind]
-          const ChangeIcon = meta.icon
-          return (
-            <div key={`${version.spanId}-${version.endTime}`} className="flex items-center gap-2 px-1 py-1.5">
-              <ChangeIcon className={cn("h-3.5 w-3.5 shrink-0", meta.className)} />
-              <Text.H6 className="w-16 shrink-0">{meta.label}</Text.H6>
-              <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate font-mono">
-                {version.sessionId || "—"}
-              </Text.H6>
-              <Text.H6 color="foregroundMuted" className="shrink-0">
-                {relativeTime(new Date(version.endTime))}
-              </Text.H6>
-            </div>
-          )
-        })}
-      </div>
+    <div className="shrink-0 border-t">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex h-10 w-full cursor-pointer items-center justify-between gap-2 px-3 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+      >
+        <div className="flex items-center gap-2">
+          <HistoryIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Text.H6M>Record History</Text.H6M>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
+            {mutating.length}
+          </span>
+        </div>
+        <Icon icon={open ? ChevronDownIcon : ChevronUpIcon} size="sm" color="foregroundMuted" className="shrink-0" />
+      </button>
+      {open ? (
+        <div className="h-40 overflow-y-auto border-t px-1 py-1">
+          {mutating.map((version) => {
+            const meta = CHANGE_META[version.changeKind as MutatingKind]
+            const ChangeIcon = meta.icon
+            return (
+              <div key={`${version.spanId}-${version.endTime}`} className="flex items-center gap-2 px-2 py-1.5">
+                <ChangeIcon className={cn("h-3.5 w-3.5 shrink-0", meta.className)} />
+                <Text.H6 className="w-14 shrink-0">{meta.label}</Text.H6>
+                <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate font-mono">
+                  {version.sessionId || "—"}
+                </Text.H6>
+                <Text.H6 color="foregroundMuted" className="shrink-0">
+                  {relativeTime(new Date(version.endTime))}
+                </Text.H6>
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,0 +1,103 @@
+import { CodeBlock, cn, Skeleton, Text } from "@repo/ui"
+import { formatCount, relativeTime } from "@repo/utils"
+import { MinusIcon, PencilIcon, PlusIcon } from "lucide-react"
+import { useMemoryRecord } from "../../../../../../../domains/memories/memories.collection.ts"
+import type { MemoryRecordVersionRecord } from "../../../../../../../domains/memories/memories.functions.ts"
+import { recordDisplayLabel } from "../../-components/store-encoding.ts"
+
+function looksLikeJson(body: string): boolean {
+  const trimmed = body.trim()
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return false
+  try {
+    JSON.parse(trimmed)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const CHANGE_META = {
+  add: { icon: PlusIcon, className: "text-success", label: "Created" },
+  update: { icon: PencilIcon, className: "text-muted-foreground", label: "Updated" },
+  remove: { icon: MinusIcon, className: "text-destructive", label: "Removed" },
+} as const
+
+type MutatingKind = keyof typeof CHANGE_META
+const isMutating = (kind: string): kind is MutatingKind => kind === "add" || kind === "update" || kind === "remove"
+
+export function RecordContentView({
+  projectId,
+  storeId,
+  recordId,
+}: {
+  readonly projectId: string
+  readonly storeId: string
+  readonly recordId: string
+}) {
+  const { data, isLoading } = useMemoryRecord({ projectId, storeId, recordId })
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+  if (!data) return null
+
+  const body = data.body ?? ""
+  const language = body !== "" && looksLikeJson(body) ? "json" : undefined
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <Text.H5M className="min-w-0 font-mono" noWrap ellipsis>
+          {recordDisplayLabel(recordId)}
+        </Text.H5M>
+        <Text.H6 color="foregroundMuted" className="shrink-0">
+          {formatCount(data.tokenCount)} tok
+        </Text.H6>
+      </div>
+      <div className="min-h-0 flex-1">
+        {data.body !== null ? (
+          <CodeBlock value={body} fillHeight {...(language ? { language } : {})} />
+        ) : (
+          <div className="flex h-full items-center justify-center rounded-lg border border-dashed">
+            <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
+          </div>
+        )}
+      </div>
+      <UpdatedByHistory versions={data.versions} />
+    </div>
+  )
+}
+
+function UpdatedByHistory({ versions }: { readonly versions: readonly MemoryRecordVersionRecord[] }) {
+  const mutating = versions.filter((version) => isMutating(version.changeKind))
+  if (mutating.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Text.H6 color="foregroundMuted">Updated by</Text.H6>
+      <div className="flex max-h-56 flex-col overflow-y-auto">
+        {mutating.map((version) => {
+          const meta = CHANGE_META[version.changeKind as MutatingKind]
+          const ChangeIcon = meta.icon
+          return (
+            <div key={`${version.spanId}-${version.endTime}`} className="flex items-center gap-2 px-1 py-1.5">
+              <ChangeIcon className={cn("h-3.5 w-3.5 shrink-0", meta.className)} />
+              <Text.H6 className="w-16 shrink-0">{meta.label}</Text.H6>
+              <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate font-mono">
+                {version.sessionId || "—"}
+              </Text.H6>
+              <Text.H6 color="foregroundMuted" className="shrink-0">
+                {relativeTime(new Date(version.endTime))}
+              </Text.H6>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,17 +1,32 @@
-import { CodeBlock, cn, Icon, Skeleton, Text, useMountEffect } from "@repo/ui"
-import { formatCount, relativeTime } from "@repo/utils"
+import { CodeBlock, cn, Icon, Sheet, Skeleton, Text, useMountEffect } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import {
   ChevronDownIcon,
+  ChevronRightIcon,
   ChevronUpIcon,
   FileTextIcon,
   HistoryIcon,
+  type LucideIcon,
   MinusIcon,
   PencilIcon,
   PlusIcon,
+  SearchIcon,
+  UserRoundIcon,
+  UsersRoundIcon,
 } from "lucide-react"
-import { useCallback, useRef, useState } from "react"
-import { useMemoryRecord } from "../../../../../../../domains/memories/memories.collection.ts"
-import type { MemoryRecordVersionRecord } from "../../../../../../../domains/memories/memories.functions.ts"
+import { type ReactNode, useCallback, useMemo, useRef, useState } from "react"
+import {
+  useMemoryRecord,
+  useMemoryRecordReads,
+  useMemoryRecordUsers,
+} from "../../../../../../../domains/memories/memories.collection.ts"
+import type {
+  MemoryRecordReadRecord,
+  MemoryRecordUserRecord,
+  MemoryRecordVersionRecord,
+} from "../../../../../../../domains/memories/memories.functions.ts"
+import { SessionDetailDrawer } from "../../../-components/session-detail-drawer.tsx"
 import { recordDisplayLabel } from "../../-components/store-encoding.ts"
 
 function looksLikeJson(body: string): boolean {
@@ -34,16 +49,29 @@ const CHANGE_META = {
 type MutatingKind = keyof typeof CHANGE_META
 const isMutating = (kind: string): kind is MutatingKind => kind === "add" || kind === "update" || kind === "remove"
 
+const DATETIME_FMT = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+})
+
+const plural = (count: number, noun: string) => `${formatCount(count)} ${count === 1 ? noun : `${noun}s`}`
+
 export function RecordContentView({
   projectId,
+  projectSlug,
   storeId,
   recordId,
 }: {
   readonly projectId: string
+  readonly projectSlug: string
   readonly storeId: string
   readonly recordId: string
 }) {
   const { data, isLoading } = useMemoryRecord({ projectId, storeId, recordId })
+  const [openSessionId, setOpenSessionId] = useState<string | null>(null)
 
   if (isLoading) {
     return (
@@ -100,23 +128,42 @@ export function RecordContentView({
         )}
       </div>
 
-      <RecordHistoryPanel versions={data.versions} />
+      <RecordActivityPanel
+        projectId={projectId}
+        projectSlug={projectSlug}
+        storeId={storeId}
+        recordId={recordId}
+        versions={data.versions}
+        onOpenSession={setOpenSessionId}
+      />
+
+      <Sheet open={openSessionId !== null} onClose={() => setOpenSessionId(null)} closeAriaLabel="Close session panel">
+        {openSessionId ? (
+          <SessionDetailDrawer
+            key={openSessionId}
+            projectId={projectId}
+            sessionId={openSessionId}
+            onClose={() => setOpenSessionId(null)}
+            defaultTab="session"
+          />
+        ) : null}
+      </Sheet>
     </div>
   )
 }
 
-const MIN_HISTORY_HEIGHT = 96
-const DEFAULT_HISTORY_HEIGHT = 160
-// Reserve this much for the editor header + code area + history header so the code never vanishes.
+const MIN_PANEL_HEIGHT = 96
+const DEFAULT_PANEL_HEIGHT = 160
+// Reserve this much for the editor header + code area + panel header so the code never vanishes.
 const MIN_CONTENT_ABOVE = 200
 // Drag the list shorter than this and it closes instead of clamping to the minimum.
 const CLOSE_DRAG_THRESHOLD = 64
 const KEYBOARD_STEP = 24
 
-// Vertical sibling of the span-tree `useResizablePanel`: drags the history list taller/shorter.
-function useHistoryResize(setOpen: (open: boolean) => void) {
+// Vertical sibling of the span-tree `useResizablePanel`: drags the activity list taller/shorter.
+function usePanelResize(setOpen: (open: boolean) => void) {
   const footerRef = useRef<HTMLDivElement>(null)
-  const [height, setHeight] = useState(DEFAULT_HISTORY_HEIGHT)
+  const [height, setHeight] = useState(DEFAULT_PANEL_HEIGHT)
   const [isDragging, setIsDragging] = useState(false)
   const drag = useRef<{ startY: number; startHeight: number; max: number } | null>(null)
   const moveRef = useRef<((event: PointerEvent) => void) | null>(null)
@@ -137,8 +184,8 @@ function useHistoryResize(setOpen: (open: boolean) => void) {
 
   const maxHeight = useCallback(() => {
     const panel = footerRef.current?.parentElement
-    if (!panel) return DEFAULT_HISTORY_HEIGHT
-    return Math.max(MIN_HISTORY_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
+    if (!panel) return DEFAULT_PANEL_HEIGHT
+    return Math.max(MIN_PANEL_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
   }, [])
 
   useMountEffect(() => {
@@ -172,7 +219,7 @@ function useHistoryResize(setOpen: (open: boolean) => void) {
           setOpen(false)
           return
         }
-        setHeight(Math.max(MIN_HISTORY_HEIGHT, Math.min(current.max, raw)))
+        setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(current.max, raw)))
       }
       const onUp = () => {
         drag.current = null
@@ -192,7 +239,7 @@ function useHistoryResize(setOpen: (open: boolean) => void) {
       if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
       event.preventDefault()
       const delta = event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP
-      setHeight((prev) => Math.max(MIN_HISTORY_HEIGHT, Math.min(maxHeight(), prev + delta)))
+      setHeight((prev) => Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), prev + delta)))
     },
     [maxHeight],
   )
@@ -200,27 +247,62 @@ function useHistoryResize(setOpen: (open: boolean) => void) {
   return { footerRef, height, isDragging, onPointerDown, onKeyDown }
 }
 
-function RecordHistoryPanel({ versions }: { readonly versions: readonly MemoryRecordVersionRecord[] }) {
+type TabId = "changes" | "reads" | "users"
+const TABS: readonly { readonly id: TabId; readonly label: string; readonly icon: LucideIcon }[] = [
+  { id: "changes", label: "Changes", icon: HistoryIcon },
+  { id: "reads", label: "Reads", icon: SearchIcon },
+  { id: "users", label: "Users", icon: UsersRoundIcon },
+]
+
+function RecordActivityPanel({
+  projectId,
+  projectSlug,
+  storeId,
+  recordId,
+  versions,
+  onOpenSession,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly storeId: string
+  readonly recordId: string
+  readonly versions: readonly MemoryRecordVersionRecord[]
+  readonly onOpenSession: (sessionId: string) => void
+}) {
   const [open, setOpen] = useState(true)
-  const { footerRef, height, isDragging, onPointerDown, onKeyDown } = useHistoryResize(setOpen)
-  const mutating = versions.filter((version) => isMutating(version.changeKind))
-  if (mutating.length === 0) return null
+  const [activeTab, setActiveTab] = useState<TabId>("changes")
+  const { footerRef, height, isDragging, onPointerDown, onKeyDown } = usePanelResize(setOpen)
+
+  const changes = useMemo(() => versions.filter((version) => isMutating(version.changeKind)), [versions])
+  const reads = useMemoryRecordReads({ projectId, storeId, recordId, enabled: open })
+  const users = useMemoryRecordUsers({ projectId, storeId, recordId, enabled: open })
+
+  const counts: Record<TabId, number | undefined> = {
+    changes: changes.length,
+    reads: reads.data?.length,
+    users: users.data?.length,
+  }
+
+  const selectTab = (tab: TabId) => {
+    setActiveTab(tab)
+    if (!open) setOpen(true)
+  }
+
+  const maxHeight = footerRef.current?.parentElement
+    ? Math.max(MIN_PANEL_HEIGHT, footerRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
+    : DEFAULT_PANEL_HEIGHT
 
   return (
-    <div ref={footerRef} className="relative shrink-0 border-t">
+    <div ref={footerRef} className="relative shrink-0 border-t bg-background">
       {open ? (
         // biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events
         <div
           role="separator"
           aria-orientation="horizontal"
-          aria-label="Resize record history"
+          aria-label="Resize record activity"
           aria-valuenow={height}
-          aria-valuemin={MIN_HISTORY_HEIGHT}
-          aria-valuemax={
-            footerRef.current?.parentElement
-              ? Math.max(MIN_HISTORY_HEIGHT, footerRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
-              : DEFAULT_HISTORY_HEIGHT
-          }
+          aria-valuemin={MIN_PANEL_HEIGHT}
+          aria-valuemax={maxHeight}
           tabIndex={0}
           onPointerDown={onPointerDown}
           onKeyDown={onKeyDown}
@@ -236,41 +318,275 @@ function RecordHistoryPanel({ versions }: { readonly versions: readonly MemoryRe
           />
         </div>
       ) : null}
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        className="flex h-10 w-full cursor-pointer items-center justify-between gap-2 px-3 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
-      >
-        <div className="flex items-center gap-2">
-          <HistoryIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <Text.H6M>Record History</Text.H6M>
-          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
-            {mutating.length}
-          </span>
-        </div>
-        <Icon icon={open ? ChevronDownIcon : ChevronUpIcon} size="sm" color="foregroundMuted" className="shrink-0" />
-      </button>
-      {open ? (
-        <div className="overflow-y-auto border-t px-1 py-1" style={{ height }}>
-          {mutating.map((version) => {
-            const meta = CHANGE_META[version.changeKind as MutatingKind]
-            const ChangeIcon = meta.icon
+
+      <div className="flex h-10 items-center justify-between gap-2 pr-1">
+        <div className="flex h-full items-stretch" role="tablist" aria-label="Record activity">
+          {TABS.map((tab) => {
+            const isActive = activeTab === tab.id
+            const count = counts[tab.id]
+            const TabIcon = tab.icon
             return (
-              <div key={`${version.spanId}-${version.endTime}`} className="flex items-center gap-2 px-2 py-1.5">
-                <ChangeIcon className={cn("h-3.5 w-3.5 shrink-0", meta.className)} />
-                <Text.H6 className="w-14 shrink-0">{meta.label}</Text.H6>
-                <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate font-mono">
-                  {version.sessionId || "—"}
-                </Text.H6>
-                <Text.H6 color="foregroundMuted" className="shrink-0">
-                  {relativeTime(new Date(version.endTime))}
-                </Text.H6>
-              </div>
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                onClick={() => selectTab(tab.id)}
+                aria-selected={isActive}
+                className={cn(
+                  "relative flex cursor-pointer items-center gap-1.5 px-3 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+                  isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <TabIcon className="h-3.5 w-3.5 shrink-0" />
+                <Text.H6M color={isActive ? "foreground" : "foregroundMuted"}>{tab.label}</Text.H6M>
+                {count !== undefined ? (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
+                    {count}
+                  </span>
+                ) : null}
+                {isActive && open ? (
+                  <span className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-primary" />
+                ) : null}
+              </button>
             )
           })}
         </div>
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          aria-label={open ? "Collapse panel" : "Expand panel"}
+          className="flex h-7 w-7 items-center justify-center rounded transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+        >
+          <Icon icon={open ? ChevronDownIcon : ChevronUpIcon} size="sm" color="foregroundMuted" />
+        </button>
+      </div>
+
+      {open ? (
+        <div className="overflow-y-auto border-t px-1 py-1" style={{ height }}>
+          {activeTab === "changes" ? (
+            <ChangesBody changes={changes} onOpenSession={onOpenSession} />
+          ) : activeTab === "reads" ? (
+            <ReadsBody isLoading={reads.isLoading} reads={reads.data ?? []} onOpenSession={onOpenSession} />
+          ) : (
+            <UsersBody isLoading={users.isLoading} users={users.data ?? []} projectSlug={projectSlug} />
+          )}
+        </div>
       ) : null}
     </div>
+  )
+}
+
+// Row rhythm shared across the three lists: uniform height, leading anchor,
+// middot-separated self-labeling facts, hover-revealed open affordance.
+const ROW_CLASS = "group flex h-7 w-full items-center gap-1.5 rounded px-2 text-left"
+const ROW_INTERACTIVE =
+  "cursor-pointer transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+
+function ActivityTime({ iso, className }: { readonly iso: string; readonly className?: string }) {
+  const date = new Date(iso)
+  return (
+    <Text.H6 color="foregroundMuted" className={cn("shrink-0 whitespace-nowrap tabular-nums", className)}>
+      <span title={date.toLocaleString()}>{DATETIME_FMT.format(date)}</span>
+    </Text.H6>
+  )
+}
+
+function Sep() {
+  return (
+    <span aria-hidden className="shrink-0 text-muted-foreground/40">
+      ·
+    </span>
+  )
+}
+
+function UserMeta({ userId, className }: { readonly userId: string; readonly className?: string }) {
+  if (!userId) {
+    return (
+      <Text.H6 color="foregroundMuted" className={cn("shrink-0 whitespace-nowrap italic", className)}>
+        no user
+      </Text.H6>
+    )
+  }
+  return (
+    <span className={cn("flex min-w-0 items-center gap-1", className)}>
+      <UserRoundIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
+      <Text.H6 color="foregroundMuted" className="truncate font-mono">
+        {userId}
+      </Text.H6>
+    </span>
+  )
+}
+
+function TokenDelta({ delta }: { readonly delta: number }) {
+  if (delta === 0) {
+    return (
+      <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap tabular-nums">
+        ±0 tok
+      </Text.H6>
+    )
+  }
+  const positive = delta > 0
+  return (
+    <Text.H6 className={cn("shrink-0 whitespace-nowrap tabular-nums", positive ? "text-success" : "text-destructive")}>
+      {positive ? "+" : "−"}
+      {formatCount(Math.abs(delta))} tok
+    </Text.H6>
+  )
+}
+
+// Right-aligned, hover-revealed — signals the row opens a session in the drawer.
+function OpenHint() {
+  return (
+    <ChevronRightIcon className="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+  )
+}
+
+function ActivityRow({
+  sessionId,
+  onOpenSession,
+  children,
+}: {
+  readonly sessionId: string
+  readonly onOpenSession: (sessionId: string) => void
+  readonly children: ReactNode
+}) {
+  if (!sessionId) {
+    return <div className={ROW_CLASS}>{children}</div>
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenSession(sessionId)}
+      aria-label={`Open session ${sessionId}`}
+      className={cn(ROW_CLASS, ROW_INTERACTIVE)}
+    >
+      {children}
+      <OpenHint />
+    </button>
+  )
+}
+
+function EmptyRow({ children }: { readonly children: ReactNode }) {
+  return (
+    <div className="px-3 py-4">
+      <Text.H6 color="foregroundMuted">{children}</Text.H6>
+    </div>
+  )
+}
+
+function LoadingRows() {
+  return (
+    <div className="flex flex-col gap-1.5 p-2">
+      {[0, 1, 2].map((index) => (
+        <Skeleton key={index} className="h-6 w-full" />
+      ))}
+    </div>
+  )
+}
+
+function ChangesBody({
+  changes,
+  onOpenSession,
+}: {
+  readonly changes: readonly MemoryRecordVersionRecord[]
+  readonly onOpenSession: (sessionId: string) => void
+}) {
+  if (changes.length === 0) return <EmptyRow>No changes recorded for this record.</EmptyRow>
+  return (
+    <>
+      {changes.map((version, index) => {
+        const meta = CHANGE_META[version.changeKind as MutatingKind]
+        const ChangeIcon = meta.icon
+        const delta = version.tokenCount - (changes[index + 1]?.tokenCount ?? 0)
+        return (
+          <ActivityRow
+            key={`${version.spanId}-${version.endTime}`}
+            sessionId={version.sessionId}
+            onOpenSession={onOpenSession}
+          >
+            <ActivityTime iso={version.endTime} />
+            <span className="flex shrink-0 items-center gap-1.5">
+              <ChangeIcon className={cn("h-3.5 w-3.5 shrink-0", meta.className)} />
+              <Text.H6 className="whitespace-nowrap">{meta.label}</Text.H6>
+            </span>
+            <Sep />
+            <TokenDelta delta={delta} />
+            <Sep />
+            <UserMeta userId={version.userId} className="max-w-[14rem]" />
+          </ActivityRow>
+        )
+      })}
+    </>
+  )
+}
+
+function ReadsBody({
+  isLoading,
+  reads,
+  onOpenSession,
+}: {
+  readonly isLoading: boolean
+  readonly reads: readonly MemoryRecordReadRecord[]
+  readonly onOpenSession: (sessionId: string) => void
+}) {
+  if (isLoading) return <LoadingRows />
+  if (reads.length === 0) return <EmptyRow>This record hasn't been retrieved yet.</EmptyRow>
+  return (
+    <>
+      {reads.map((read) => (
+        <ActivityRow key={`${read.spanId}-${read.endTime}`} sessionId={read.sessionId} onOpenSession={onOpenSession}>
+          <ActivityTime iso={read.endTime} />
+          {read.queryText ? (
+            <Text.H6 className="min-w-0 flex-1 truncate">
+              <span title={read.queryText}>{read.queryText}</span>
+            </Text.H6>
+          ) : (
+            <Text.H6 color="foregroundMuted" className="min-w-0 flex-1 truncate italic">
+              no query
+            </Text.H6>
+          )}
+          <Sep />
+          <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap tabular-nums">
+            {formatCount(read.tokenCount)} tok
+          </Text.H6>
+          <Sep />
+          <UserMeta userId={read.userId} className="max-w-[10rem]" />
+        </ActivityRow>
+      ))}
+    </>
+  )
+}
+
+function UsersBody({
+  isLoading,
+  users,
+  projectSlug,
+}: {
+  readonly isLoading: boolean
+  readonly users: readonly MemoryRecordUserRecord[]
+  readonly projectSlug: string
+}) {
+  if (isLoading) return <LoadingRows />
+  if (users.length === 0) return <EmptyRow>No user has accessed this record.</EmptyRow>
+  return (
+    <>
+      {users.map((user) => (
+        <Link
+          key={user.userId}
+          to="/projects/$projectSlug/users/$userId"
+          params={{ projectSlug, userId: user.userId }}
+          className={cn(ROW_CLASS, ROW_INTERACTIVE)}
+        >
+          <UserRoundIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Text.H6 className="min-w-0 flex-1 truncate font-mono">{user.userId}</Text.H6>
+          <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap">
+            {plural(user.readCount, "read")} · {plural(user.writeCount, "write")}
+          </Text.H6>
+          <ActivityTime iso={user.lastAccessedAt} className="ml-3" />
+          <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+        </Link>
+      ))}
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-tree-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-tree-sidebar.tsx
@@ -1,0 +1,107 @@
+import { cn, Skeleton, Text } from "@repo/ui"
+import { ChevronDownIcon, ChevronRightIcon, FileTextIcon, FolderIcon } from "lucide-react"
+import { useState } from "react"
+import type { MemoryStoreSnapshotRecord } from "../../../../../../../domains/memories/memories.functions.ts"
+import { recordDisplayLabel } from "../../-components/store-encoding.ts"
+import { buildRecordTree, type RecordTreeNode } from "./build-record-tree.ts"
+
+export function RecordTreeSidebar({
+  records,
+  isLoading,
+  selectedRecordId,
+  onSelect,
+}: {
+  readonly records: MemoryStoreSnapshotRecord["records"]
+  readonly isLoading: boolean
+  readonly selectedRecordId?: string | undefined
+  readonly onSelect: (recordId: string) => void
+}) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-1 p-3">
+        {[0, 1, 2, 3].map((row) => (
+          <Skeleton key={row} className="h-7 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="flex min-h-16 items-center justify-center p-3">
+        <Text.H6 color="foregroundMuted">No records</Text.H6>
+      </div>
+    )
+  }
+
+  const tree = buildRecordTree(records)
+  return (
+    <div className="flex flex-col gap-0.5 overflow-y-auto p-2">
+      {tree.map((node) => (
+        <NodeRow key={node.path} node={node} depth={0} selectedRecordId={selectedRecordId} onSelect={onSelect} />
+      ))}
+    </div>
+  )
+}
+
+function NodeRow({
+  node,
+  depth,
+  selectedRecordId,
+  onSelect,
+}: {
+  readonly node: RecordTreeNode
+  readonly depth: number
+  readonly selectedRecordId?: string | undefined
+  readonly onSelect: (recordId: string) => void
+}) {
+  const isFolder = node.children.length > 0
+  const [open, setOpen] = useState(true)
+  const isSelected = node.recordId !== undefined && node.recordId === selectedRecordId
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (node.recordId !== undefined) onSelect(node.recordId)
+          if (isFolder) setOpen((value) => !value)
+        }}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left transition-colors hover:bg-background",
+          isSelected && "bg-accent",
+        )}
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+      >
+        {isFolder ? (
+          open ? (
+            <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )
+        ) : (
+          <span className="w-3.5 shrink-0" />
+        )}
+        {isFolder ? (
+          <FolderIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <FileTextIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <Text.H6 className="min-w-0 flex-1" noWrap ellipsis>
+          {recordDisplayLabel(node.segment)}
+        </Text.H6>
+      </button>
+      {isFolder && open
+        ? node.children.map((child) => (
+            <NodeRow
+              key={child.path}
+              node={child}
+              depth={depth + 1}
+              selectedRecordId={selectedRecordId}
+              onSelect={onSelect}
+            />
+          ))
+        : null}
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-tree-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-tree-sidebar.tsx
@@ -1,9 +1,18 @@
-import { cn, Skeleton, Text } from "@repo/ui"
-import { ChevronDownIcon, ChevronRightIcon, FileTextIcon, FolderIcon } from "lucide-react"
-import { useState } from "react"
+import { cn, Icon, Skeleton, Text } from "@repo/ui"
+import {
+  ChevronRightIcon,
+  ChevronsDownUpIcon,
+  ChevronsUpDownIcon,
+  FileTextIcon,
+  FolderIcon,
+  FolderOpenIcon,
+} from "lucide-react"
+import { useMemo, useState } from "react"
 import type { MemoryStoreSnapshotRecord } from "../../../../../../../domains/memories/memories.functions.ts"
 import { recordDisplayLabel } from "../../-components/store-encoding.ts"
 import { buildRecordTree, type RecordTreeNode } from "./build-record-tree.ts"
+
+const INDENT_STEP = "w-4"
 
 export function RecordTreeSidebar({
   records,
@@ -16,92 +25,161 @@ export function RecordTreeSidebar({
   readonly selectedRecordId?: string | undefined
   readonly onSelect: (recordId: string) => void
 }) {
-  if (isLoading) {
-    return (
-      <div className="flex flex-col gap-1 p-3">
-        {[0, 1, 2, 3].map((row) => (
-          <Skeleton key={row} className="h-7 w-full" />
-        ))}
-      </div>
-    )
-  }
+  const tree = useMemo(() => buildRecordTree(records), [records])
+  const folderPaths = useMemo(() => collectFolderPaths(tree), [tree])
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(() => new Set())
 
-  if (records.length === 0) {
-    return (
-      <div className="flex min-h-16 items-center justify-center p-3">
-        <Text.H6 color="foregroundMuted">No records</Text.H6>
-      </div>
-    )
-  }
+  const allCollapsed = folderPaths.length > 0 && folderPaths.every((path) => collapsed.has(path))
+  const toggle = (path: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  const toggleAll = () => setCollapsed(allCollapsed ? new Set() : new Set(folderPaths))
 
-  const tree = buildRecordTree(records)
   return (
-    <div className="flex flex-col gap-0.5 overflow-y-auto p-2">
-      {tree.map((node) => (
-        <NodeRow key={node.path} node={node} depth={0} selectedRecordId={selectedRecordId} onSelect={onSelect} />
-      ))}
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex h-9 shrink-0 items-center justify-between gap-2 border-b px-3">
+        <Text.H6M color="foregroundMuted" noWrap ellipsis>
+          Records{records.length > 0 ? ` · ${records.length}` : ""}
+        </Text.H6M>
+        {folderPaths.length > 0 ? (
+          <button
+            type="button"
+            onClick={toggleAll}
+            title={allCollapsed ? "Expand all" : "Collapse all"}
+            className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Icon icon={allCollapsed ? ChevronsUpDownIcon : ChevronsDownUpIcon} size="sm" />
+          </button>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-1 p-3">
+          {[0, 1, 2, 3, 4].map((row) => (
+            <Skeleton key={row} className="h-7 w-full" />
+          ))}
+        </div>
+      ) : records.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-3">
+          <Text.H6 color="foregroundMuted">No records</Text.H6>
+        </div>
+      ) : (
+        <div role="tree" className="flex min-h-0 flex-1 flex-col overflow-y-auto py-2">
+          {tree.map((node) => (
+            <NodeRow
+              key={node.path}
+              node={node}
+              rails={[]}
+              collapsed={collapsed}
+              onToggle={toggle}
+              selectedRecordId={selectedRecordId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
     </div>
   )
 }
 
 function NodeRow({
   node,
-  depth,
+  rails,
+  collapsed,
+  onToggle,
   selectedRecordId,
   onSelect,
 }: {
   readonly node: RecordTreeNode
-  readonly depth: number
+  /** One entry per ancestor level: whether that level's guide line sits on the active (selected) path. */
+  readonly rails: readonly boolean[]
+  readonly collapsed: ReadonlySet<string>
+  readonly onToggle: (path: string) => void
   readonly selectedRecordId?: string | undefined
   readonly onSelect: (recordId: string) => void
 }) {
   const isFolder = node.children.length > 0
-  const [open, setOpen] = useState(true)
+  const open = isFolder && !collapsed.has(node.path)
   const isSelected = node.recordId !== undefined && node.recordId === selectedRecordId
+  const childRailActive = selectedRecordId?.startsWith(`${node.path}/`) ?? false
 
   return (
     <>
       <button
         type="button"
+        role="treeitem"
+        {...(isFolder ? { "aria-expanded": open } : {})}
+        aria-selected={isSelected}
         onClick={() => {
+          if (isFolder) onToggle(node.path)
           if (node.recordId !== undefined) onSelect(node.recordId)
-          if (isFolder) setOpen((value) => !value)
         }}
         className={cn(
-          "flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left transition-colors hover:bg-background",
-          isSelected && "bg-accent",
+          "group flex h-7 w-full shrink-0 cursor-pointer items-center px-2 text-left transition-colors",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+          isSelected ? "bg-accent" : "hover:bg-muted",
         )}
-        style={{ paddingLeft: `${depth * 12 + 8}px` }}
       >
-        {isFolder ? (
-          open ? (
-            <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          )
-        ) : (
-          <span className="w-3.5 shrink-0" />
-        )}
-        {isFolder ? (
-          <FolderIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <FileTextIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <Text.H6 className="min-w-0 flex-1" noWrap ellipsis>
+        {rails.map((active, level) => (
+          <span key={`${node.path}:${level}`} className={cn("flex h-full shrink-0 justify-center", INDENT_STEP)}>
+            <span className={cn("h-full w-px", active ? "bg-accent-foreground/50" : "bg-border")} />
+          </span>
+        ))}
+        <span className={cn("flex h-full shrink-0 items-center justify-center", INDENT_STEP)}>
+          {isFolder ? (
+            <ChevronRightIcon
+              className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", open && "rotate-90")}
+            />
+          ) : null}
+        </span>
+        <Icon
+          icon={isFolder ? (open ? FolderOpenIcon : FolderIcon) : FileTextIcon}
+          size="sm"
+          color={isSelected ? "accentForeground" : "foregroundMuted"}
+          className="mr-1.5 shrink-0"
+        />
+        <Text.H6
+          color={isSelected ? "accentForeground" : "foreground"}
+          className={cn("min-w-0 flex-1", isSelected && "font-medium")}
+          noWrap
+          ellipsis
+        >
           {recordDisplayLabel(node.segment)}
         </Text.H6>
       </button>
-      {isFolder && open
-        ? node.children.map((child) => (
+      {isFolder && open ? (
+        <div className="flex flex-col">
+          {node.children.map((child) => (
             <NodeRow
               key={child.path}
               node={child}
-              depth={depth + 1}
+              rails={[...rails, childRailActive]}
+              collapsed={collapsed}
+              onToggle={onToggle}
               selectedRecordId={selectedRecordId}
               onSelect={onSelect}
             />
-          ))
-        : null}
+          ))}
+        </div>
+      ) : null}
     </>
   )
+}
+
+function collectFolderPaths(nodes: readonly RecordTreeNode[]): readonly string[] {
+  const paths: string[] = []
+  const walk = (list: readonly RecordTreeNode[]) => {
+    for (const node of list) {
+      if (node.children.length > 0) {
+        paths.push(node.path)
+        walk(node.children)
+      }
+    }
+  }
+  walk(nodes)
+  return paths
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/store-users-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/store-users-list.tsx
@@ -1,0 +1,40 @@
+import { Skeleton, Text } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import { UserRoundIcon } from "lucide-react"
+import { useMemoryStoreUsers } from "../../../../../../../domains/memories/memories.collection.ts"
+
+export function StoreUsersList({
+  projectId,
+  projectSlug,
+  storeId,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly storeId: string
+}) {
+  const { data: users, isLoading } = useMemoryStoreUsers({ projectId, storeId })
+
+  if (isLoading) return <Skeleton className="h-9 w-full shrink-0" />
+  if (!users || users.length === 0) return null
+
+  return (
+    <div className="flex shrink-0 flex-col gap-2 rounded-lg bg-secondary p-3">
+      <Text.H6 color="foregroundMuted">Accessed by {users.length === 1 ? "1 user" : `${users.length} users`}</Text.H6>
+      <div className="flex flex-wrap gap-1.5">
+        {users.map((user) => (
+          <Link
+            key={user.userId}
+            to="/projects/$projectSlug/users/$userId"
+            params={{ projectSlug, userId: user.userId }}
+            className="flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 transition-colors hover:bg-accent"
+          >
+            <UserRoundIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Text.H6 noWrap ellipsis className="max-w-[16rem] font-mono">
+              {user.userId}
+            </Text.H6>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/store-users-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/store-users-list.tsx
@@ -14,27 +14,27 @@ export function StoreUsersList({
 }) {
   const { data: users, isLoading } = useMemoryStoreUsers({ projectId, storeId })
 
-  if (isLoading) return <Skeleton className="h-9 w-full shrink-0" />
+  if (isLoading) return <Skeleton className="h-6 w-48" />
   if (!users || users.length === 0) return null
 
   return (
-    <div className="flex shrink-0 flex-col gap-2 rounded-lg bg-secondary p-3">
-      <Text.H6 color="foregroundMuted">Accessed by {users.length === 1 ? "1 user" : `${users.length} users`}</Text.H6>
-      <div className="flex flex-wrap gap-1.5">
-        {users.map((user) => (
-          <Link
-            key={user.userId}
-            to="/projects/$projectSlug/users/$userId"
-            params={{ projectSlug, userId: user.userId }}
-            className="flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 transition-colors hover:bg-accent"
-          >
-            <UserRoundIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            <Text.H6 noWrap ellipsis className="max-w-[16rem] font-mono">
-              {user.userId}
-            </Text.H6>
-          </Link>
-        ))}
-      </div>
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Text.H6 color="foregroundMuted" className="mr-0.5">
+        Accessed by {users.length === 1 ? "1 user" : `${users.length} users`}
+      </Text.H6>
+      {users.map((user) => (
+        <Link
+          key={user.userId}
+          to="/projects/$projectSlug/users/$userId"
+          params={{ projectSlug, userId: user.userId }}
+          className="flex items-center gap-1.5 rounded-md border bg-background px-2 py-0.5 transition-colors hover:bg-accent"
+        >
+          <UserRoundIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Text.H6 noWrap ellipsis className="max-w-[16rem] font-mono">
+            {user.userId}
+          </Text.H6>
+        </Link>
+      ))}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -77,7 +77,12 @@ function StoreDetailPage() {
         </Layout.Sidebar>
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {selectedRecordId !== undefined ? (
-            <RecordContentView projectId={project.id} storeId={storeId} recordId={selectedRecordId} />
+            <RecordContentView
+              projectId={project.id}
+              projectSlug={projectSlug}
+              storeId={storeId}
+              recordId={selectedRecordId}
+            />
           ) : (
             <div className="flex flex-1 items-center justify-center p-6">
               <Text.H5 color="foregroundMuted">Select a record to view its contents.</Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -1,11 +1,13 @@
 import { Button, Text, Tooltip } from "@repo/ui"
 import { createFileRoute, Link, useParams } from "@tanstack/react-router"
 import { ArrowLeftIcon, DatabaseIcon } from "lucide-react"
+import { useHasFeatureFlag } from "../../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useMemoryStoreSnapshot } from "../../../../../../domains/memories/memories.collection.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../../-components/breadcrumb-ui.tsx"
 import { useRouteProject } from "../../-route-data.ts"
+import { MemoryUnavailableState } from "../-components/memory-empty-state.tsx"
 import {
   decodeRecordParam,
   decodeStoreSegment,
@@ -31,13 +33,22 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memo
 })
 
 function StoreDetailPage() {
+  const enabled = useHasFeatureFlag("memoryObservability")
   const project = useRouteProject()
   const { projectSlug, store } = Route.useParams()
   const storeId = decodeStoreSegment(store)
   const [recordParam, setRecordParam] = useParamState("record", "")
   const selectedRecordId = recordParam === "" ? undefined : decodeRecordParam(recordParam)
 
-  const { data: snapshot, isLoading } = useMemoryStoreSnapshot({ projectId: project.id, storeId })
+  const { data: snapshot, isLoading } = useMemoryStoreSnapshot({ projectId: project.id, storeId, enabled })
+
+  if (!enabled) {
+    return (
+      <Layout>
+        <MemoryUnavailableState />
+      </Layout>
+    )
+  }
 
   return (
     <Layout className="gap-0">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -1,0 +1,76 @@
+import { Text } from "@repo/ui"
+import { createFileRoute, useParams } from "@tanstack/react-router"
+import { DatabaseIcon } from "lucide-react"
+import { useMemoryStoreSnapshot } from "../../../../../../domains/memories/memories.collection.ts"
+import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
+import { BreadcrumbText } from "../../../../-components/breadcrumb-ui.tsx"
+import { useRouteProject } from "../../-route-data.ts"
+import {
+  decodeRecordParam,
+  decodeStoreSegment,
+  encodeRecordParam,
+  storeDisplayLabel,
+} from "../-components/store-encoding.ts"
+import { RecordContentView } from "./-components/record-content-view.tsx"
+import { RecordTreeSidebar } from "./-components/record-tree-sidebar.tsx"
+import { StoreUsersList } from "./-components/store-users-list.tsx"
+
+function StoreBreadcrumb() {
+  const { store } = useParams({ strict: false })
+  return (
+    <BreadcrumbText variant="current">{store ? storeDisplayLabel(decodeStoreSegment(store)) : "Store"}</BreadcrumbText>
+  )
+}
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memory/$store/")({
+  staticData: {
+    breadcrumb: StoreBreadcrumb,
+  },
+  component: StoreDetailPage,
+})
+
+function StoreDetailPage() {
+  const project = useRouteProject()
+  const { projectSlug, store } = Route.useParams()
+  const storeId = decodeStoreSegment(store)
+  const [recordParam, setRecordParam] = useParamState("record", "")
+  const selectedRecordId = recordParam === "" ? undefined : decodeRecordParam(recordParam)
+
+  const { data: snapshot, isLoading } = useMemoryStoreSnapshot({ projectId: project.id, storeId })
+
+  return (
+    <Layout>
+      <Layout.Header
+        title={
+          <div className="flex min-w-0 items-center gap-2">
+            <DatabaseIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <Text.H4 className={storeId === "" ? "italic text-muted-foreground" : "font-mono"} noWrap ellipsis>
+              {storeDisplayLabel(storeId)}
+            </Text.H4>
+          </div>
+        }
+      />
+      <Layout.Body>
+        <Layout.Sidebar>
+          <RecordTreeSidebar
+            records={snapshot?.records ?? []}
+            isLoading={isLoading}
+            selectedRecordId={selectedRecordId}
+            onSelect={(recordId) => setRecordParam(encodeRecordParam(recordId))}
+          />
+        </Layout.Sidebar>
+        <Layout.List>
+          <StoreUsersList projectId={project.id} projectSlug={projectSlug} storeId={storeId} />
+          {selectedRecordId !== undefined ? (
+            <RecordContentView projectId={project.id} storeId={storeId} recordId={selectedRecordId} />
+          ) : (
+            <div className="flex flex-1 items-center justify-center">
+              <Text.H5 color="foregroundMuted">Select a record to view its contents.</Text.H5>
+            </div>
+          )}
+        </Layout.List>
+      </Layout.Body>
+    </Layout>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -1,6 +1,6 @@
-import { Text } from "@repo/ui"
-import { createFileRoute, useParams } from "@tanstack/react-router"
-import { DatabaseIcon } from "lucide-react"
+import { Button, Text, Tooltip } from "@repo/ui"
+import { createFileRoute, Link, useParams } from "@tanstack/react-router"
+import { ArrowLeftIcon, DatabaseIcon } from "lucide-react"
 import { useMemoryStoreSnapshot } from "../../../../../../domains/memories/memories.collection.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
@@ -40,16 +40,31 @@ function StoreDetailPage() {
   const { data: snapshot, isLoading } = useMemoryStoreSnapshot({ projectId: project.id, storeId })
 
   return (
-    <Layout>
+    <Layout className="gap-0">
       <Layout.Header
+        className="border-b px-6 py-4"
         title={
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-3">
+            <Tooltip
+              asChild
+              side="bottom"
+              trigger={
+                <Button asChild variant="ghost" className="h-8 w-8 shrink-0 p-0" aria-label="Back to memory stores">
+                  <Link to="/projects/$projectSlug/memory" params={{ projectSlug }}>
+                    <ArrowLeftIcon className="h-4 w-4 text-muted-foreground" />
+                  </Link>
+                </Button>
+              }
+            >
+              Back to stores
+            </Tooltip>
             <DatabaseIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
             <Text.H4 className={storeId === "" ? "italic text-muted-foreground" : "font-mono"} noWrap ellipsis>
               {storeDisplayLabel(storeId)}
             </Text.H4>
           </div>
         }
+        description={<StoreUsersList projectId={project.id} projectSlug={projectSlug} storeId={storeId} />}
       />
       <Layout.Body>
         <Layout.Sidebar>
@@ -60,16 +75,15 @@ function StoreDetailPage() {
             onSelect={(recordId) => setRecordParam(encodeRecordParam(recordId))}
           />
         </Layout.Sidebar>
-        <Layout.List>
-          <StoreUsersList projectId={project.id} projectSlug={projectSlug} storeId={storeId} />
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {selectedRecordId !== undefined ? (
             <RecordContentView projectId={project.id} storeId={storeId} recordId={selectedRecordId} />
           ) : (
-            <div className="flex flex-1 items-center justify-center">
+            <div className="flex flex-1 items-center justify-center p-6">
               <Text.H5 color="foregroundMuted">Select a record to view its contents.</Text.H5>
             </div>
           )}
-        </Layout.List>
+        </div>
       </Layout.Body>
     </Layout>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
@@ -1,6 +1,24 @@
 import { Icon, Text } from "@repo/ui"
 import { BrainIcon } from "lucide-react"
 
+export function MemoryUnavailableState() {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={BrainIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>Memory isn't available</Text.H3>
+          <Text.H5 color="foregroundMuted" centered>
+            Memory observability isn't enabled for this project.
+          </Text.H5>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function MemoryEmptyState({ isLoading = false }: { readonly isLoading?: boolean }) {
   return (
     <div className="h-full w-full flex items-center justify-center p-8">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
@@ -1,0 +1,22 @@
+import { Icon, Text } from "@repo/ui"
+import { BrainIcon } from "lucide-react"
+
+export function MemoryEmptyState({ isLoading = false }: { readonly isLoading?: boolean }) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={BrainIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>{isLoading ? "Loading memory" : "No memory stores yet"}</Text.H3>
+          <Text.H5 color="foregroundMuted" centered>
+            {isLoading
+              ? "Preparing your memory view."
+              : "Memory stores appear when your traces emit memory operations (create, update, search) carrying a store id."}
+          </Text.H5>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-stores-view.tsx
@@ -1,0 +1,134 @@
+import { cn, InfiniteTable, type InfiniteTableColumn, type InfiniteTableInfiniteScroll } from "@repo/ui"
+import { formatCount, relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { DatabaseIcon } from "lucide-react"
+import type { MemoryStoreRecord } from "../../../../../../domains/memories/memories.functions.ts"
+import {
+  ListingLayout as Layout,
+  listingLayoutIntrinsicScroll,
+} from "../../../../../../layouts/ListingLayout/index.tsx"
+import { encodeStoreSegment, storeDisplayLabel } from "./store-encoding.ts"
+
+export interface MemoryStoresSorting {
+  readonly column: "lastUpdated" | "lastRead" | "records" | "tokens" | "sessions" | "users"
+  readonly direction: "asc" | "desc"
+}
+
+export const DEFAULT_MEMORY_SORTING: MemoryStoresSorting = { column: "lastUpdated", direction: "desc" }
+
+export function MemoryStoresView({
+  stores,
+  isLoading,
+  sorting,
+  onSortChange,
+  infiniteScroll,
+  projectSlug,
+}: {
+  readonly stores: readonly MemoryStoreRecord[]
+  readonly isLoading: boolean
+  readonly sorting: MemoryStoresSorting
+  readonly onSortChange: (sorting: MemoryStoresSorting) => void
+  readonly infiniteScroll: InfiniteTableInfiniteScroll
+  readonly projectSlug: string
+}) {
+  const columns: InfiniteTableColumn<MemoryStoreRecord>[] = [
+    {
+      key: "store",
+      header: "Store",
+      width: 320,
+      minWidth: 220,
+      render: (store) => (
+        <div className="flex min-w-0 items-center gap-2">
+          <DatabaseIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate font-mono text-[13px]",
+              store.storeId === "" && "italic text-muted-foreground",
+            )}
+            title={storeDisplayLabel(store.storeId)}
+          >
+            {storeDisplayLabel(store.storeId)}
+          </span>
+        </div>
+      ),
+    },
+    {
+      key: "records",
+      header: "Records",
+      width: 96,
+      align: "end",
+      sortKey: "records",
+      render: (store) => formatCount(store.recordCount),
+    },
+    {
+      key: "tokens",
+      header: "Tokens",
+      width: 110,
+      align: "end",
+      sortKey: "tokens",
+      render: (store) => formatCount(store.tokenCount),
+    },
+    {
+      key: "lastUpdated",
+      header: "Last updated",
+      width: 130,
+      sortKey: "lastUpdated",
+      render: (store) => relativeTime(new Date(store.lastUpdatedAt)),
+    },
+    {
+      key: "lastRead",
+      header: "Last read",
+      width: 130,
+      sortKey: "lastRead",
+      render: (store) => (store.lastReadAt ? relativeTime(new Date(store.lastReadAt)) : "-"),
+    },
+    {
+      key: "sessions",
+      header: "Sessions",
+      width: 96,
+      align: "end",
+      sortKey: "sessions",
+      render: (store) => formatCount(store.sessionCount),
+    },
+    {
+      key: "users",
+      header: "Users",
+      width: 90,
+      align: "end",
+      sortKey: "users",
+      render: (store) => formatCount(store.userCount),
+    },
+  ]
+
+  return (
+    <Layout.Body>
+      <Layout.List>
+        <InfiniteTable
+          {...listingLayoutIntrinsicScroll.infiniteTable}
+          data={stores}
+          isLoading={isLoading}
+          columns={columns}
+          getRowKey={(store) => store.storeId}
+          sorting={sorting}
+          defaultSorting={DEFAULT_MEMORY_SORTING}
+          onSortChange={(next) =>
+            onSortChange({
+              column: next.column as MemoryStoresSorting["column"],
+              direction: next.direction as MemoryStoresSorting["direction"],
+            })
+          }
+          infiniteScroll={infiniteScroll}
+          renderRowLink={(store, props) => (
+            <Link
+              to="/projects/$projectSlug/memory/$store"
+              params={{ projectSlug, store: encodeStoreSegment(store.storeId) }}
+              aria-label={`Open store ${storeDisplayLabel(store.storeId)}`}
+              {...props}
+            />
+          )}
+          blankSlate="No memory stores match."
+        />
+      </Layout.List>
+    </Layout.Body>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { decodeRecordParam, decodeStoreSegment, encodeRecordParam, encodeStoreSegment } from "./store-encoding.ts"
+
+describe("store segment encoding", () => {
+  it("round-trips ordinary and empty store ids", () => {
+    for (const storeId of ["", "user-42", "team/shared", "a b", "%7E"]) {
+      expect(decodeStoreSegment(encodeStoreSegment(storeId))).toBe(storeId)
+    }
+  })
+
+  it("keeps a real store id that matches the unattributed sentinel distinct from empty", () => {
+    for (const storeId of ["~unattributed", "~foo", "~"]) {
+      expect(encodeStoreSegment(storeId)).not.toBe(encodeStoreSegment(""))
+      expect(decodeStoreSegment(encodeStoreSegment(storeId))).toBe(storeId)
+    }
+    expect(decodeStoreSegment(encodeStoreSegment(""))).toBe("")
+  })
+})
+
+describe("record param encoding", () => {
+  it("round-trips ordinary and empty record ids", () => {
+    for (const recordId of ["", "prefs/theme", "note-1", "~unnamed", "~", "~foo"]) {
+      expect(decodeRecordParam(encodeRecordParam(recordId))).toBe(recordId)
+    }
+  })
+
+  it("keeps a real record id that matches the unnamed sentinel distinct from empty", () => {
+    expect(encodeRecordParam("~unnamed")).not.toBe(encodeRecordParam(""))
+    expect(decodeRecordParam(encodeRecordParam("~unnamed"))).toBe("~unnamed")
+    expect(decodeRecordParam(encodeRecordParam(""))).toBe("")
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.ts
@@ -1,11 +1,17 @@
+// Sentinels start with `~`; escaping any real id that already starts with `~`
+// keeps a real `~unattributed` / `~unnamed` id from colliding with a sentinel
+// across a round-trip.
+const escapeSentinel = (value: string): string => (value.startsWith("~") ? `~${value}` : value)
+const unescapeSentinel = (value: string): string => (value.startsWith("~") ? value.slice(1) : value)
+
 const UNATTRIBUTED_STORE_SEGMENT = "~unattributed"
 
 /** Store ids are opaque (may contain `/`), so keep them in one encoded path segment. */
 export const encodeStoreSegment = (storeId: string): string =>
-  storeId === "" ? UNATTRIBUTED_STORE_SEGMENT : encodeURIComponent(storeId)
+  storeId === "" ? UNATTRIBUTED_STORE_SEGMENT : encodeURIComponent(escapeSentinel(storeId))
 
 export const decodeStoreSegment = (segment: string): string =>
-  segment === UNATTRIBUTED_STORE_SEGMENT ? "" : decodeURIComponent(segment)
+  segment === UNATTRIBUTED_STORE_SEGMENT ? "" : unescapeSentinel(decodeURIComponent(segment))
 
 export const storeDisplayLabel = (storeId: string): string => (storeId === "" ? "(unattributed)" : storeId)
 
@@ -13,8 +19,10 @@ export const storeDisplayLabel = (storeId: string): string => (storeId === "" ? 
 // (id `''`) needs a sentinel to be distinguishable from "no selection".
 const UNNAMED_RECORD_PARAM = "~unnamed"
 
-export const encodeRecordParam = (recordId: string): string => (recordId === "" ? UNNAMED_RECORD_PARAM : recordId)
+export const encodeRecordParam = (recordId: string): string =>
+  recordId === "" ? UNNAMED_RECORD_PARAM : escapeSentinel(recordId)
 
-export const decodeRecordParam = (param: string): string => (param === UNNAMED_RECORD_PARAM ? "" : param)
+export const decodeRecordParam = (param: string): string =>
+  param === UNNAMED_RECORD_PARAM ? "" : unescapeSentinel(param)
 
 export const recordDisplayLabel = (recordId: string): string => (recordId === "" ? "(unnamed)" : recordId)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/store-encoding.ts
@@ -1,0 +1,20 @@
+const UNATTRIBUTED_STORE_SEGMENT = "~unattributed"
+
+/** Store ids are opaque (may contain `/`), so keep them in one encoded path segment. */
+export const encodeStoreSegment = (storeId: string): string =>
+  storeId === "" ? UNATTRIBUTED_STORE_SEGMENT : encodeURIComponent(storeId)
+
+export const decodeStoreSegment = (segment: string): string =>
+  segment === UNATTRIBUTED_STORE_SEGMENT ? "" : decodeURIComponent(segment)
+
+export const storeDisplayLabel = (storeId: string): string => (storeId === "" ? "(unattributed)" : storeId)
+
+// The `?record=` param is empty when nothing is selected, so the unnamed record
+// (id `''`) needs a sentinel to be distinguishable from "no selection".
+const UNNAMED_RECORD_PARAM = "~unnamed"
+
+export const encodeRecordParam = (recordId: string): string => (recordId === "" ? UNNAMED_RECORD_PARAM : recordId)
+
+export const decodeRecordParam = (param: string): string => (param === UNNAMED_RECORD_PARAM ? "" : param)
+
+export const recordDisplayLabel = (recordId: string): string => (recordId === "" ? "(unnamed)" : recordId)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { useCallback, useMemo } from "react"
+import { useHasFeatureFlag } from "../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { useMemoryStores } from "../../../../../domains/memories/memories.collection.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
 import { useRouteProject } from "../-route-data.ts"
-import { MemoryEmptyState } from "./-components/memory-empty-state.tsx"
+import { MemoryEmptyState, MemoryUnavailableState } from "./-components/memory-empty-state.tsx"
 import {
   DEFAULT_MEMORY_SORTING,
   type MemoryStoresSorting,
@@ -48,6 +49,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memo
 })
 
 function MemoryPage() {
+  const enabled = useHasFeatureFlag("memoryObservability")
   const project = useRouteProject()
   const { projectSlug } = Route.useParams()
   const [rawSorting, setRawSorting] = useParamState("memorySort", serializeSorting(DEFAULT_MEMORY_SORTING), {
@@ -60,7 +62,16 @@ function MemoryPage() {
     projectId: project.id,
     sort: sorting.column,
     direction: sorting.direction,
+    enabled,
   })
+
+  if (!enabled) {
+    return (
+      <Layout>
+        <MemoryUnavailableState />
+      </Layout>
+    )
+  }
 
   const showEmptyState = !isLoading && stores.length === 0
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
@@ -1,0 +1,83 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { useCallback, useMemo } from "react"
+import { useMemoryStores } from "../../../../../domains/memories/memories.collection.ts"
+import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { BreadcrumbText } from "../../../-components/breadcrumb-ui.tsx"
+import { useRouteProject } from "../-route-data.ts"
+import { MemoryEmptyState } from "./-components/memory-empty-state.tsx"
+import {
+  DEFAULT_MEMORY_SORTING,
+  type MemoryStoresSorting,
+  MemoryStoresView,
+} from "./-components/memory-stores-view.tsx"
+
+const SORT_COLUMNS = [
+  "lastUpdated",
+  "lastRead",
+  "records",
+  "tokens",
+  "sessions",
+  "users",
+] as const satisfies readonly MemoryStoresSorting["column"][]
+const SORT_DIRECTIONS = ["asc", "desc"] as const satisfies readonly MemoryStoresSorting["direction"][]
+const SORT_PARAM_PATTERN = /^(lastUpdated|lastRead|records|tokens|sessions|users):(asc|desc)$/
+
+function serializeSorting(sorting: MemoryStoresSorting): string {
+  return `${sorting.column}:${sorting.direction}`
+}
+
+function parseSorting(raw: string): MemoryStoresSorting {
+  const [rawColumn, rawDirection] = raw.split(":")
+  // Return allowlist constants, not the raw URL values, so the param's taint ends here.
+  const column = SORT_COLUMNS.find((candidate) => candidate === rawColumn)
+  const direction = SORT_DIRECTIONS.find((candidate) => candidate === rawDirection)
+  if (column && direction) return { column, direction }
+  return DEFAULT_MEMORY_SORTING
+}
+
+function MemoryBreadcrumb() {
+  return <BreadcrumbText variant="current">Memory</BreadcrumbText>
+}
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memory/")({
+  staticData: {
+    breadcrumb: MemoryBreadcrumb,
+  },
+  component: MemoryPage,
+})
+
+function MemoryPage() {
+  const project = useRouteProject()
+  const { projectSlug } = Route.useParams()
+  const [rawSorting, setRawSorting] = useParamState("memorySort", serializeSorting(DEFAULT_MEMORY_SORTING), {
+    validate: (value): value is string => SORT_PARAM_PATTERN.test(value),
+  })
+  const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
+  const setSorting = useCallback((next: MemoryStoresSorting) => setRawSorting(serializeSorting(next)), [setRawSorting])
+
+  const { stores, isLoading, infiniteScroll } = useMemoryStores({
+    projectId: project.id,
+    sort: sorting.column,
+    direction: sorting.direction,
+  })
+
+  const showEmptyState = !isLoading && stores.length === 0
+
+  return (
+    <Layout>
+      {showEmptyState ? (
+        <MemoryEmptyState isLoading={isLoading} />
+      ) : (
+        <MemoryStoresView
+          stores={stores}
+          isLoading={isLoading}
+          sorting={sorting}
+          onSortChange={setSorting}
+          infiniteScroll={infiniteScroll}
+          projectSlug={projectSlug}
+        />
+      )}
+    </Layout>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/-components/user-memory-stores-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/-components/user-memory-stores-section.tsx
@@ -1,0 +1,63 @@
+import { cn, Skeleton, Text } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import { DatabaseIcon } from "lucide-react"
+import { useUserMemoryStores } from "../../../../../../../domains/memories/memories.collection.ts"
+import { encodeStoreSegment, storeDisplayLabel } from "../../../memory/-components/store-encoding.ts"
+import { formatAgoLabel } from "../../-components/user-formatters.ts"
+
+export function UserMemoryStoresSection({
+  projectId,
+  projectSlug,
+  userId,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly userId: string
+}) {
+  const { data: stores, isLoading } = useUserMemoryStores({ projectId, userId })
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    )
+  }
+
+  if (!stores || stores.length === 0) {
+    return (
+      <div className="flex min-h-16 items-center">
+        <Text.H6 color="foregroundMuted">No memory stores accessed by this user yet.</Text.H6>
+      </div>
+    )
+  }
+
+  return (
+    <div className="-mx-2 flex max-h-[min(24rem,45vh)] flex-col overflow-y-auto px-2">
+      {stores.map((store) => (
+        <Link
+          key={store.storeId}
+          to="/projects/$projectSlug/memory/$store"
+          params={{ projectSlug, store: encodeStoreSegment(store.storeId) }}
+          aria-label={`Open store ${storeDisplayLabel(store.storeId)}`}
+          className="-mx-2 flex items-center gap-3 rounded-md px-2 py-2.5 transition-colors hover:bg-background"
+        >
+          <DatabaseIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Text.H5
+            className={cn("min-w-0 flex-1 font-mono", store.storeId === "" && "font-sans italic text-muted-foreground")}
+            noWrap
+            ellipsis
+          >
+            {storeDisplayLabel(store.storeId)}
+          </Text.H5>
+          <div className="flex w-16 shrink-0 justify-end">
+            <Text.H6 color="foregroundMuted" noWrap>
+              {formatAgoLabel(store.lastAccessedAt)}
+            </Text.H6>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/users/$userId/index.tsx
@@ -18,6 +18,7 @@ import { createFileRoute, Link, useParams } from "@tanstack/react-router"
 import { ArrowLeftIcon, TextAlignStartIcon } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useUserActivity, useUserProfile } from "../../../../../../domains/end-users/end-users.collection.ts"
+import { useHasFeatureFlag } from "../../../../../../domains/feature-flags/feature-flags.collection.ts"
 import { userMonitorTarget } from "../../../../../../domains/monitors/monitor-target.ts"
 import { defaultProjectTimeWindowDays } from "../../../../../../domains/projects/default-time-window.ts"
 import { useSessionsCount, useSessionsInfiniteScroll } from "../../../../../../domains/sessions/sessions.collection.ts"
@@ -35,6 +36,7 @@ import {
 } from "../-components/user-formatters.ts"
 import { UserBehavioursSection } from "./-components/user-behaviours-section.tsx"
 import { UserSignalsSection } from "./-components/user-issues-section.tsx"
+import { UserMemoryStoresSection } from "./-components/user-memory-stores-section.tsx"
 import { UserNeighborNav } from "./-components/user-neighbor-nav.tsx"
 import { UserSessionsTable } from "./-components/user-sessions-table.tsx"
 import { UserStatStrip } from "./-components/user-stat-strip.tsx"
@@ -170,6 +172,7 @@ function UserDetailPage() {
   const [errorsParam, setErrorsParam] = useParamState("errors", "")
   const errorsOnly = errorsParam === "1"
   const { data: profile, isLoading: profileLoading } = useUserProfile({ projectId: project.id, userId, errorsOnly })
+  const showMemoryStores = useHasFeatureFlag("memoryObservability")
   const [sessionsSorting, setSessionsSorting] = useState(DEFAULT_SESSIONS_SORTING)
 
   const sessionFilters: FilterSet = useMemo(
@@ -305,6 +308,13 @@ function UserDetailPage() {
               </div>
 
               <UserUsageSection projectId={project.id} userId={userId} errorsOnly={errorsOnly} />
+
+              {showMemoryStores ? (
+                <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-4">
+                  <Text.H6 color="foregroundMuted">Memory stores</Text.H6>
+                  <UserMemoryStoresSection projectId={project.id} projectSlug={projectSlug} userId={userId} />
+                </div>
+              ) : null}
 
               <div className="flex min-w-0 flex-col gap-3">
                 <div className="flex items-center justify-between gap-2">

--- a/packages/domain/feature-flags/src/registry.ts
+++ b/packages/domain/feature-flags/src/registry.ts
@@ -23,6 +23,12 @@ export const FEATURE_FLAGS = {
     description:
       "Project-scoped, filter-defined behavior taxonomies with their own authoring UI. Hidden until the Generate flow ships.",
   },
+  memoryObservability: {
+    emoji: "🧠",
+    name: "Memory observability",
+    description:
+      "Adds the Memory page (stores browsed as records with update history) and the user-page memory-stores section.",
+  },
 } as const satisfies Record<
   string,
   {

--- a/packages/domain/memories/src/entities/memory-snapshot.ts
+++ b/packages/domain/memories/src/entities/memory-snapshot.ts
@@ -1,10 +1,12 @@
-import type { SessionId, SpanId, TraceId } from "@domain/shared"
+import type { ExternalUserId, SessionId, SpanId, TraceId } from "@domain/shared"
 import type { MemoryChangeKind } from "./memory-event.ts"
 
 /**
  * The current version of one record within a store's manifest. `(storeId,
  * recordId)` is the record identity (D3); the remaining fields point back at the
  * span that authored this version (blame target) and carry its token count.
+ * `userId` is the end-user the authoring span was attributed to (empty for
+ * manifest-reconstruction reads, which don't carry it).
  */
 export interface MemoryRecordVersion {
   readonly storeId: string
@@ -15,6 +17,7 @@ export interface MemoryRecordVersion {
   readonly spanId: SpanId
   readonly traceId: TraceId
   readonly sessionId: SessionId
+  readonly userId: ExternalUserId
   readonly endTime: Date
 }
 

--- a/packages/domain/memories/src/entities/memory-store.ts
+++ b/packages/domain/memories/src/entities/memory-store.ts
@@ -1,0 +1,48 @@
+import type { ExternalUserId } from "@domain/shared"
+
+/**
+ * One row of the store roll-up. Current-derived metrics (record/token/updated)
+ * come from `memory_current`; event-derived metrics (sessions/users/read) come
+ * from `memory_events` and are `0` / `null` when the store has no ledger events.
+ */
+export interface MemoryStoreListItem {
+  readonly storeId: string
+  readonly recordCount: number
+  readonly tokenCount: number
+  readonly lastUpdatedAt: Date
+  readonly sessionCount: number
+  readonly userCount: number
+  readonly lastReadAt: Date | null
+}
+
+export const MEMORY_STORE_SORT_FIELDS = ["lastUpdated", "lastRead", "records", "tokens", "sessions", "users"] as const
+export type MemoryStoreSortField = (typeof MEMORY_STORE_SORT_FIELDS)[number]
+export const isMemoryStoreSortField = (value: string): value is MemoryStoreSortField =>
+  (MEMORY_STORE_SORT_FIELDS as readonly string[]).includes(value)
+
+export interface MemoryStoreListOptions {
+  readonly limit?: number
+  readonly offset?: number
+  readonly sortBy?: MemoryStoreSortField
+  readonly sortDirection?: "asc" | "desc"
+}
+
+export interface MemoryStoreListPage {
+  readonly items: readonly MemoryStoreListItem[]
+  readonly totalCount: number
+  readonly hasMore: boolean
+  readonly limit: number
+  readonly offset: number
+}
+
+/** A user who touched one store (reads count as access). */
+export interface MemoryStoreUser {
+  readonly userId: ExternalUserId
+  readonly lastAccessedAt: Date
+}
+
+/** A store one user touched (reads count as access). */
+export interface MemoryUserStore {
+  readonly storeId: string
+  readonly lastAccessedAt: Date
+}

--- a/packages/domain/memories/src/entities/memory-store.ts
+++ b/packages/domain/memories/src/entities/memory-store.ts
@@ -46,3 +46,11 @@ export interface MemoryUserStore {
   readonly storeId: string
   readonly lastAccessedAt: Date
 }
+
+/** A user who touched one record, with reads and writes counted separately. */
+export interface MemoryRecordUser {
+  readonly userId: ExternalUserId
+  readonly readCount: number
+  readonly writeCount: number
+  readonly lastAccessedAt: Date
+}

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -33,6 +33,16 @@ export type {
   MemoryStoreWipe,
 } from "./entities/memory-snapshot.ts"
 export {
+  isMemoryStoreSortField,
+  MEMORY_STORE_SORT_FIELDS,
+  type MemoryStoreListItem,
+  type MemoryStoreListOptions,
+  type MemoryStoreListPage,
+  type MemoryStoreSortField,
+  type MemoryStoreUser,
+  type MemoryUserStore,
+} from "./entities/memory-store.ts"
+export {
   MemoryRepository,
   type MemoryRepositoryShape,
 } from "./ports/memory-repository.ts"

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -35,6 +35,7 @@ export type {
 export {
   isMemoryStoreSortField,
   MEMORY_STORE_SORT_FIELDS,
+  type MemoryRecordUser,
   type MemoryStoreListItem,
   type MemoryStoreListOptions,
   type MemoryStoreListPage,
@@ -62,6 +63,10 @@ export {
   listMemoryStoresUseCase,
 } from "./use-cases/list-memory-stores.ts"
 export {
+  type ListRecordUsersInput,
+  listRecordUsersUseCase,
+} from "./use-cases/list-record-users.ts"
+export {
   type ListStoreUsersInput,
   listStoreUsersUseCase,
 } from "./use-cases/list-store-users.ts"
@@ -74,6 +79,10 @@ export {
   type MaterializeTraceMemoryResult,
   materializeTraceMemoryUseCase,
 } from "./use-cases/materialize-trace-memory.ts"
+export {
+  type ReadRecordReadsInput,
+  readRecordReadsUseCase,
+} from "./use-cases/read-record-reads.ts"
 export {
   type ReconstructSnapshotInput,
   reconstructSnapshotUseCase,

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -58,6 +58,18 @@ export {
   type SessionMemorySummary,
 } from "./use-cases/compute-session-memory-summary.ts"
 export {
+  type ListMemoryStoresInput,
+  listMemoryStoresUseCase,
+} from "./use-cases/list-memory-stores.ts"
+export {
+  type ListStoreUsersInput,
+  listStoreUsersUseCase,
+} from "./use-cases/list-store-users.ts"
+export {
+  type ListUserStoresInput,
+  listUserStoresUseCase,
+} from "./use-cases/list-user-stores.ts"
+export {
   type MaterializeTraceMemoryInput,
   type MaterializeTraceMemoryResult,
   materializeTraceMemoryUseCase,

--- a/packages/domain/memories/src/ports/memory-repository.ts
+++ b/packages/domain/memories/src/ports/memory-repository.ts
@@ -1,16 +1,31 @@
-import type { ChSqlClient, OrganizationId, ProjectId, RepositoryError, SessionId, TraceId } from "@domain/shared"
+import type {
+  ChSqlClient,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  RepositoryError,
+  SessionId,
+  TraceId,
+} from "@domain/shared"
 import { Context, type Effect } from "effect"
 import type { MemoryBlob } from "../entities/memory-blob.ts"
 import type { MemoryCurrentEntry } from "../entities/memory-current.ts"
 import type { MemoryEvent } from "../entities/memory-event.ts"
 import type { MemoryRecordVersion, MemoryStoreWipe } from "../entities/memory-snapshot.ts"
+import type {
+  MemoryStoreListOptions,
+  MemoryStoreListPage,
+  MemoryStoreUser,
+  MemoryUserStore,
+} from "../entities/memory-store.ts"
 
 /**
  * Repository port for the memory ledger (ClickHouse). The `ChSqlClient`
  * requirement is intentionally leaked (per-request org scope). Covers writes,
- * current + point-in-time reconstruction, content-blob fetches, and the
- * session / record-version reads the diff and summary computations consume.
- * Blame and store-listing reads grow the port when those surfaces land.
+ * current + point-in-time reconstruction, content-blob fetches, the session /
+ * record-version reads the diff and summary computations consume, and the
+ * store-listing / store-access reads the Memory page consumes. Blame reads grow
+ * the port when that surface lands.
  */
 export interface MemoryRepositoryShape {
   insertEvents(events: readonly MemoryEvent[]): Effect.Effect<void, RepositoryError, ChSqlClient>
@@ -61,6 +76,31 @@ export interface MemoryRepositoryShape {
     readonly records: readonly { readonly storeId: string; readonly recordId: string }[]
     readonly at?: Date
   }): Effect.Effect<readonly MemoryRecordVersion[], RepositoryError, ChSqlClient>
+
+  /**
+   * One roll-up row per store (stores with ≥1 live record in `memory_current`),
+   * with `memory_events` session/user/last-read stats left-joined. Server-side
+   * sort + limit/offset pagination.
+   */
+  listStores(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly options?: MemoryStoreListOptions
+  }): Effect.Effect<MemoryStoreListPage, RepositoryError, ChSqlClient>
+
+  /** Distinct users who touched one store (reads count as access), newest-first. */
+  listStoreUsers(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId: string
+  }): Effect.Effect<readonly MemoryStoreUser[], RepositoryError, ChSqlClient>
+
+  /** Distinct stores one user touched (reads count as access), newest-first. */
+  listUserStores(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly userId: ExternalUserId
+  }): Effect.Effect<readonly MemoryUserStore[], RepositoryError, ChSqlClient>
 }
 
 export class MemoryRepository extends Context.Service<MemoryRepository, MemoryRepositoryShape>()(

--- a/packages/domain/memories/src/ports/memory-repository.ts
+++ b/packages/domain/memories/src/ports/memory-repository.ts
@@ -13,6 +13,7 @@ import type { MemoryCurrentEntry } from "../entities/memory-current.ts"
 import type { MemoryEvent } from "../entities/memory-event.ts"
 import type { MemoryRecordVersion, MemoryStoreWipe } from "../entities/memory-snapshot.ts"
 import type {
+  MemoryRecordUser,
   MemoryStoreListOptions,
   MemoryStoreListPage,
   MemoryStoreUser,
@@ -87,6 +88,23 @@ export interface MemoryRepositoryShape {
     readonly projectId: ProjectId
     readonly options?: MemoryStoreListOptions
   }): Effect.Effect<MemoryStoreListPage, RepositoryError, ChSqlClient>
+
+  /** Read (retrieval) events for one record, deduped, newest-first, capped by `limit`. */
+  readRecordReadEvents(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId: string
+    readonly recordId: string
+    readonly limit?: number
+  }): Effect.Effect<readonly MemoryEvent[], RepositoryError, ChSqlClient>
+
+  /** Per-user read/write roll-up for one record, newest access first. */
+  listRecordUsers(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly storeId: string
+    readonly recordId: string
+  }): Effect.Effect<readonly MemoryRecordUser[], RepositoryError, ChSqlClient>
 
   /** Distinct users who touched one store (reads count as access), newest-first. */
   listStoreUsers(input: {

--- a/packages/domain/memories/src/testing/fake-memory-repository.ts
+++ b/packages/domain/memories/src/testing/fake-memory-repository.ts
@@ -8,6 +8,7 @@ import type { MemoryStoreListItem } from "../entities/memory-store.ts"
 import type { MemoryRepositoryShape } from "../ports/memory-repository.ts"
 
 const STORE_ACCESS_LIST_CAP = 1000
+const RECORD_READ_EVENTS_CAP = 200
 
 const recordKey = (storeId: string, recordId: string) => `${storeId}\u0000${recordId}`
 const blobKey = (organizationId: string, contentHash: string) => `${organizationId}\u0000${contentHash}`
@@ -216,7 +217,7 @@ export const createFakeMemoryRepository = (overrides?: Partial<MemoryRepositoryS
           deduped.set(`${event.spanId} ${event.storeId} ${event.recordId}`, event)
         }
         const sorted = [...deduped.values()].sort((a, b) => b.endTime.getTime() - a.endTime.getTime())
-        return limit !== undefined ? sorted.slice(0, limit) : sorted
+        return sorted.slice(0, limit ?? RECORD_READ_EVENTS_CAP)
       }),
     listRecordUsers: ({ organizationId, projectId, storeId, recordId }) =>
       Effect.sync(() => {

--- a/packages/domain/memories/src/testing/fake-memory-repository.ts
+++ b/packages/domain/memories/src/testing/fake-memory-repository.ts
@@ -1,9 +1,13 @@
+import type { ExternalUserId } from "@domain/shared"
 import { Effect } from "effect"
 import type { MemoryBlob } from "../entities/memory-blob.ts"
 import type { MemoryCurrentEntry } from "../entities/memory-current.ts"
 import { MEMORY_MUTATING_CHANGE_KINDS, type MemoryEvent } from "../entities/memory-event.ts"
 import type { MemoryRecordVersion, MemoryStoreWipe } from "../entities/memory-snapshot.ts"
+import type { MemoryStoreListItem } from "../entities/memory-store.ts"
 import type { MemoryRepositoryShape } from "../ports/memory-repository.ts"
+
+const STORE_ACCESS_LIST_CAP = 1000
 
 const recordKey = (storeId: string, recordId: string) => `${storeId}\u0000${recordId}`
 const blobKey = (organizationId: string, contentHash: string) => `${organizationId}\u0000${contentHash}`
@@ -123,6 +127,120 @@ export const createFakeMemoryRepository = (overrides?: Partial<MemoryRepositoryS
               a.endTime.getTime() - b.endTime.getTime(),
           )
           .map(toVersion)
+      }),
+    listStores: ({ organizationId, projectId, options }) =>
+      Effect.sync(() => {
+        const liveByStore = new Map<string, { recordCount: number; tokenCount: number; lastUpdatedAt: Date }>()
+        for (const entry of current.values()) {
+          if (entry.organizationId !== organizationId || entry.projectId !== projectId) continue
+          if (entry.changeKind === "remove") continue
+          const agg = liveByStore.get(entry.storeId)
+          if (!agg)
+            liveByStore.set(entry.storeId, {
+              recordCount: 1,
+              tokenCount: entry.tokenCount,
+              lastUpdatedAt: entry.endTime,
+            })
+          else {
+            agg.recordCount += 1
+            agg.tokenCount += entry.tokenCount
+            if (entry.endTime > agg.lastUpdatedAt) agg.lastUpdatedAt = entry.endTime
+          }
+        }
+
+        const eventByStore = new Map<string, { sessions: Set<string>; users: Set<string>; lastReadAt: Date | null }>()
+        for (const event of events) {
+          if (event.organizationId !== organizationId || event.projectId !== projectId) continue
+          let agg = eventByStore.get(event.storeId)
+          if (!agg) {
+            agg = { sessions: new Set(), users: new Set(), lastReadAt: null }
+            eventByStore.set(event.storeId, agg)
+          }
+          if (event.sessionId !== "") agg.sessions.add(event.sessionId)
+          if (event.userId !== "") agg.users.add(event.userId)
+          if (event.changeKind === "read" && (agg.lastReadAt === null || event.endTime > agg.lastReadAt))
+            agg.lastReadAt = event.endTime
+        }
+
+        const items: MemoryStoreListItem[] = [...liveByStore.entries()].map(([storeId, agg]) => {
+          const ev = eventByStore.get(storeId)
+          return {
+            storeId,
+            recordCount: agg.recordCount,
+            tokenCount: agg.tokenCount,
+            lastUpdatedAt: agg.lastUpdatedAt,
+            sessionCount: ev ? ev.sessions.size : 0,
+            userCount: ev ? ev.users.size : 0,
+            lastReadAt: ev ? ev.lastReadAt : null,
+          }
+        })
+
+        const sortBy = options?.sortBy ?? "lastUpdated"
+        const dir = options?.sortDirection === "asc" ? 1 : -1
+        const sortValue = (item: MemoryStoreListItem): number => {
+          switch (sortBy) {
+            case "lastUpdated":
+              return item.lastUpdatedAt.getTime()
+            case "lastRead":
+              return item.lastReadAt ? item.lastReadAt.getTime() : 0
+            case "records":
+              return item.recordCount
+            case "tokens":
+              return item.tokenCount
+            case "sessions":
+              return item.sessionCount
+            case "users":
+              return item.userCount
+          }
+        }
+        items.sort((a, b) => {
+          const cmp = (sortValue(a) - sortValue(b)) * dir
+          if (cmp !== 0) return cmp
+          return a.storeId < b.storeId ? -1 : a.storeId > b.storeId ? 1 : 0
+        })
+
+        const totalCount = items.length
+        const limit = options?.limit ?? 50
+        const offset = options?.offset ?? 0
+        const rest = items.slice(offset)
+        const hasMore = rest.length > limit
+        return { items: hasMore ? rest.slice(0, limit) : rest, totalCount, hasMore, limit, offset }
+      }),
+    listStoreUsers: ({ organizationId, projectId, storeId }) =>
+      Effect.sync(() => {
+        const latest = new Map<ExternalUserId, Date>()
+        for (const event of events) {
+          if (event.organizationId !== organizationId || event.projectId !== projectId) continue
+          if (event.storeId !== storeId || event.userId === "") continue
+          const existing = latest.get(event.userId)
+          if (!existing || event.endTime > existing) latest.set(event.userId, event.endTime)
+        }
+        return [...latest.entries()]
+          .map(([userId, lastAccessedAt]) => ({ userId, lastAccessedAt }))
+          .sort(
+            (a, b) =>
+              b.lastAccessedAt.getTime() - a.lastAccessedAt.getTime() ||
+              (a.userId < b.userId ? -1 : a.userId > b.userId ? 1 : 0),
+          )
+          .slice(0, STORE_ACCESS_LIST_CAP)
+      }),
+    listUserStores: ({ organizationId, projectId, userId }) =>
+      Effect.sync(() => {
+        const latest = new Map<string, Date>()
+        for (const event of events) {
+          if (event.organizationId !== organizationId || event.projectId !== projectId) continue
+          if (event.userId !== userId) continue
+          const existing = latest.get(event.storeId)
+          if (!existing || event.endTime > existing) latest.set(event.storeId, event.endTime)
+        }
+        return [...latest.entries()]
+          .map(([storeId, lastAccessedAt]) => ({ storeId, lastAccessedAt }))
+          .sort(
+            (a, b) =>
+              b.lastAccessedAt.getTime() - a.lastAccessedAt.getTime() ||
+              (a.storeId < b.storeId ? -1 : a.storeId > b.storeId ? 1 : 0),
+          )
+          .slice(0, STORE_ACCESS_LIST_CAP)
       }),
     ...overrides,
   }

--- a/packages/domain/memories/src/testing/fake-memory-repository.ts
+++ b/packages/domain/memories/src/testing/fake-memory-repository.ts
@@ -23,6 +23,7 @@ const toVersion = (entry: MemoryCurrentEntry | MemoryEvent): MemoryRecordVersion
   spanId: entry.spanId,
   traceId: entry.traceId,
   sessionId: entry.sessionId,
+  userId: "userId" in entry ? entry.userId : ("" as ExternalUserId),
   endTime: entry.endTime,
 })
 
@@ -205,6 +206,44 @@ export const createFakeMemoryRepository = (overrides?: Partial<MemoryRepositoryS
         const rest = items.slice(offset)
         const hasMore = rest.length > limit
         return { items: hasMore ? rest.slice(0, limit) : rest, totalCount, hasMore, limit, offset }
+      }),
+    readRecordReadEvents: ({ organizationId, projectId, storeId, recordId, limit }) =>
+      Effect.sync(() => {
+        const deduped = new Map<string, MemoryEvent>()
+        for (const event of events) {
+          if (event.organizationId !== organizationId || event.projectId !== projectId) continue
+          if (event.storeId !== storeId || event.recordId !== recordId || event.changeKind !== "read") continue
+          deduped.set(`${event.spanId} ${event.storeId} ${event.recordId}`, event)
+        }
+        const sorted = [...deduped.values()].sort((a, b) => b.endTime.getTime() - a.endTime.getTime())
+        return limit !== undefined ? sorted.slice(0, limit) : sorted
+      }),
+    listRecordUsers: ({ organizationId, projectId, storeId, recordId }) =>
+      Effect.sync(() => {
+        const byUser = new Map<ExternalUserId, { readCount: number; writeCount: number; lastAccessedAt: Date }>()
+        const seenSpans = new Set<string>()
+        for (const event of events) {
+          if (event.organizationId !== organizationId || event.projectId !== projectId) continue
+          if (event.storeId !== storeId || event.recordId !== recordId || event.userId === "") continue
+          if (seenSpans.has(event.spanId)) continue
+          seenSpans.add(event.spanId)
+          let agg = byUser.get(event.userId)
+          if (!agg) {
+            agg = { readCount: 0, writeCount: 0, lastAccessedAt: event.endTime }
+            byUser.set(event.userId, agg)
+          }
+          if (event.changeKind === "read") agg.readCount += 1
+          else if (isMutating(event.changeKind)) agg.writeCount += 1
+          if (event.endTime > agg.lastAccessedAt) agg.lastAccessedAt = event.endTime
+        }
+        return [...byUser.entries()]
+          .map(([userId, agg]) => ({ userId, ...agg }))
+          .sort(
+            (a, b) =>
+              b.lastAccessedAt.getTime() - a.lastAccessedAt.getTime() ||
+              (a.userId < b.userId ? -1 : a.userId > b.userId ? 1 : 0),
+          )
+          .slice(0, STORE_ACCESS_LIST_CAP)
       }),
     listStoreUsers: ({ organizationId, projectId, storeId }) =>
       Effect.sync(() => {

--- a/packages/domain/memories/src/use-cases/list-memory-stores.test.ts
+++ b/packages/domain/memories/src/use-cases/list-memory-stores.test.ts
@@ -1,0 +1,348 @@
+import { ChSqlClient, ExternalUserId, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { MemoryCurrentEntry } from "../entities/memory-current.ts"
+import type { MemoryEvent } from "../entities/memory-event.ts"
+import type { MemoryStoreListOptions } from "../entities/memory-store.ts"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+import { createFakeMemoryRepository } from "../testing/index.ts"
+import { listMemoryStoresUseCase } from "./list-memory-stores.ts"
+import { listStoreUsersUseCase } from "./list-store-users.ts"
+import { listUserStoresUseCase } from "./list-user-stores.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const spanId = SpanId("s".repeat(16))
+const traceId = TraceId("t".repeat(32))
+const base = new Date("2026-06-01T12:00:00.000Z").getTime()
+const at = (seconds: number) => new Date(base + seconds * 1000)
+
+type Fake = ReturnType<typeof createFakeMemoryRepository>
+
+const makeEvent = (o: Partial<MemoryEvent> = {}): MemoryEvent => ({
+  organizationId,
+  projectId,
+  storeId: "store1",
+  recordId: "rec1",
+  operation: "create_memory",
+  changeKind: "add",
+  contentHash: "hash-a",
+  tokenCount: 10,
+  recordCount: 1,
+  queryText: "",
+  spanId,
+  traceId,
+  sessionId: SessionId("sess1"),
+  userId: ExternalUserId("user1"),
+  startTime: at(0),
+  endTime: at(0),
+  source: "otlp",
+  ...o,
+})
+
+const makeCurrent = (o: Partial<MemoryCurrentEntry> = {}): MemoryCurrentEntry => ({
+  organizationId,
+  projectId,
+  storeId: "store1",
+  recordId: "rec1",
+  contentHash: "hash-a",
+  changeKind: "add",
+  tokenCount: 10,
+  spanId,
+  traceId,
+  sessionId: SessionId("sess1"),
+  endTime: at(0),
+  ...o,
+})
+
+const layerFor = (memory: Fake) =>
+  Layer.mergeAll(
+    Layer.succeed(MemoryRepository, memory.repository),
+    Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+  )
+
+const seed = (memory: Fake, events: readonly MemoryEvent[], current: readonly MemoryCurrentEntry[]) => {
+  for (const event of events) memory.events.push(event)
+  return Effect.runPromise(memory.repository.upsertCurrent(current).pipe(Effect.provide(layerFor(memory))))
+}
+
+const listStores = (memory: Fake, options?: MemoryStoreListOptions) =>
+  Effect.runPromise(
+    listMemoryStoresUseCase({ organizationId, projectId, options }).pipe(Effect.provide(layerFor(memory))),
+  )
+
+const listStoreUsers = (memory: Fake, storeId: string) =>
+  Effect.runPromise(
+    listStoreUsersUseCase({ organizationId, projectId, storeId }).pipe(Effect.provide(layerFor(memory))),
+  )
+
+const listUserStores = (memory: Fake, userId: string) =>
+  Effect.runPromise(
+    listUserStoresUseCase({ organizationId, projectId, userId: ExternalUserId(userId) }).pipe(
+      Effect.provide(layerFor(memory)),
+    ),
+  )
+
+describe("listMemoryStores", () => {
+  it("rolls up records/tokens/lastUpdated from live rows and sessions/users/lastRead from events", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [
+        // reads count toward session/user; empty ids are excluded
+        makeEvent({
+          recordId: "rec1",
+          changeKind: "add",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(1),
+        }),
+        makeEvent({
+          recordId: "rec2",
+          changeKind: "add",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(3),
+        }),
+        makeEvent({
+          recordId: "rec1",
+          changeKind: "read",
+          sessionId: SessionId("s3"),
+          userId: ExternalUserId("u3"),
+          endTime: at(9),
+        }),
+        // an anonymous read still advances lastReadAt but is excluded from the distinct counts
+        makeEvent({
+          recordId: "rec1",
+          changeKind: "read",
+          sessionId: SessionId(""),
+          userId: ExternalUserId(""),
+          endTime: at(20),
+        }),
+      ],
+      [
+        makeCurrent({ recordId: "rec1", tokenCount: 10, endTime: at(1) }),
+        makeCurrent({ recordId: "rec2", tokenCount: 15, endTime: at(3) }),
+        // a removed record is not live: excluded from record/token counts
+        makeCurrent({ recordId: "rec3", changeKind: "remove", tokenCount: 0, endTime: at(4) }),
+      ],
+    )
+
+    const page = await listStores(memory)
+    expect(page.items).toHaveLength(1)
+    const store = page.items[0]!
+    expect(store.storeId).toBe("store1")
+    expect(store.recordCount).toBe(2)
+    expect(store.tokenCount).toBe(25)
+    expect(store.lastUpdatedAt.getTime()).toBe(at(3).getTime())
+    expect(store.sessionCount).toBe(3)
+    expect(store.userCount).toBe(3)
+    expect(store.lastReadAt?.getTime()).toBe(at(20).getTime())
+    expect(page.totalCount).toBe(1)
+  })
+
+  it("returns null lastReadAt for a store that was never read", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(memory, [makeEvent({ changeKind: "add", endTime: at(1) })], [makeCurrent({ endTime: at(1) })])
+    const page = await listStores(memory)
+    expect(page.items[0]!.lastReadAt).toBeNull()
+  })
+
+  it("lists the unattributed '' store and a live-but-eventless store; hides a store with no live records", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [
+        // events for a store whose records are all removed → not listed
+        makeEvent({ storeId: "gone", recordId: "g1", changeKind: "add", endTime: at(1) }),
+      ],
+      [
+        makeCurrent({ storeId: "", recordId: "r1", endTime: at(1) }),
+        makeCurrent({ storeId: "eventless", recordId: "r1", endTime: at(2) }),
+        makeCurrent({ storeId: "gone", recordId: "g1", changeKind: "remove", endTime: at(2) }),
+      ],
+    )
+    const page = await listStores(memory)
+    const byId = new Map(page.items.map((s) => [s.storeId, s]))
+    expect([...byId.keys()].sort()).toEqual(["", "eventless"])
+    expect(byId.get("eventless")!.sessionCount).toBe(0)
+    expect(byId.get("eventless")!.userCount).toBe(0)
+    expect(byId.get("eventless")!.lastReadAt).toBeNull()
+  })
+
+  const seedStores = (memory: Fake) =>
+    seed(
+      memory,
+      [
+        makeEvent({
+          storeId: "A",
+          recordId: "r1",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(10),
+        }),
+        makeEvent({
+          storeId: "A",
+          recordId: "r1",
+          changeKind: "read",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(50),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r1",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(15),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r2",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(20),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r3",
+          sessionId: SessionId("s3"),
+          userId: ExternalUserId("u1"),
+          endTime: at(18),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r1",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(3),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r2",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(5),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r2",
+          changeKind: "read",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u3"),
+          endTime: at(30),
+        }),
+      ],
+      [
+        makeCurrent({ storeId: "A", recordId: "r1", tokenCount: 100, endTime: at(10) }),
+        makeCurrent({ storeId: "B", recordId: "r1", tokenCount: 20, endTime: at(15) }),
+        makeCurrent({ storeId: "B", recordId: "r2", tokenCount: 20, endTime: at(20) }),
+        makeCurrent({ storeId: "B", recordId: "r3", tokenCount: 10, endTime: at(18) }),
+        makeCurrent({ storeId: "C", recordId: "r1", tokenCount: 150, endTime: at(3) }),
+        makeCurrent({ storeId: "C", recordId: "r2", tokenCount: 50, endTime: at(5) }),
+      ],
+    )
+
+  const order = (memory: Fake, options: MemoryStoreListOptions) =>
+    listStores(memory, options).then((page) => page.items.map((s) => s.storeId))
+
+  it("sorts server-side on each column, both directions", async () => {
+    const memory = createFakeMemoryRepository()
+    await seedStores(memory)
+    // A: 1 rec/100 tok/updated@10/1 sess/1 user/read@50
+    // B: 3 rec/50 tok/updated@20/3 sess/2 user/never read
+    // C: 2 rec/200 tok/updated@5/2 sess/3 user/read@30
+    expect(await order(memory, {})).toEqual(["B", "A", "C"]) // default lastUpdated desc
+    expect(await order(memory, { sortBy: "records", sortDirection: "desc" })).toEqual(["B", "C", "A"])
+    expect(await order(memory, { sortBy: "tokens", sortDirection: "asc" })).toEqual(["B", "A", "C"])
+    expect(await order(memory, { sortBy: "users", sortDirection: "desc" })).toEqual(["C", "B", "A"])
+    expect(await order(memory, { sortBy: "sessions", sortDirection: "asc" })).toEqual(["A", "C", "B"])
+    expect(await order(memory, { sortBy: "lastRead", sortDirection: "desc" })).toEqual(["A", "C", "B"]) // never-read last
+  })
+
+  it("breaks ties on store_id ascending regardless of sort direction", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [],
+      [
+        makeCurrent({ storeId: "zzz", recordId: "r1", tokenCount: 5, endTime: at(1) }),
+        makeCurrent({ storeId: "aaa", recordId: "r1", tokenCount: 5, endTime: at(1) }),
+      ],
+    )
+    expect(await order(memory, { sortBy: "tokens", sortDirection: "desc" })).toEqual(["aaa", "zzz"])
+    expect(await order(memory, { sortBy: "tokens", sortDirection: "asc" })).toEqual(["aaa", "zzz"])
+  })
+
+  it("paginates with a stable total count", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [],
+      Array.from({ length: 5 }, (_, i) => makeCurrent({ storeId: `store${i}`, recordId: "r1", endTime: at(i) })),
+    )
+    const p0 = await listStores(memory, { limit: 2, offset: 0, sortBy: "lastUpdated", sortDirection: "asc" })
+    expect(p0.items.map((s) => s.storeId)).toEqual(["store0", "store1"])
+    expect(p0.hasMore).toBe(true)
+    expect(p0.totalCount).toBe(5)
+    const p2 = await listStores(memory, { limit: 2, offset: 4, sortBy: "lastUpdated", sortDirection: "asc" })
+    expect(p2.items.map((s) => s.storeId)).toEqual(["store4"])
+    expect(p2.hasMore).toBe(false)
+    expect(p2.totalCount).toBe(5)
+  })
+
+  it("does not double-count a duplicated (retried) event", async () => {
+    const memory = createFakeMemoryRepository()
+    const dup = makeEvent({
+      changeKind: "read",
+      sessionId: SessionId("s1"),
+      userId: ExternalUserId("u1"),
+      endTime: at(9),
+    })
+    await seed(memory, [dup, dup], [makeCurrent({ endTime: at(1) })])
+    const store = (await listStores(memory)).items[0]!
+    expect(store.sessionCount).toBe(1)
+    expect(store.userCount).toBe(1)
+    expect(store.lastReadAt?.getTime()).toBe(at(9).getTime())
+  })
+})
+
+describe("listStoreUsers", () => {
+  it("lists distinct users of one store (reads count, '' excluded), newest-first", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [
+        makeEvent({ storeId: "s", userId: ExternalUserId("u1"), changeKind: "add", endTime: at(1) }),
+        makeEvent({ storeId: "s", userId: ExternalUserId("u1"), changeKind: "read", endTime: at(5) }),
+        makeEvent({ storeId: "s", userId: ExternalUserId("u2"), changeKind: "read", endTime: at(9) }),
+        makeEvent({ storeId: "s", userId: ExternalUserId(""), changeKind: "add", endTime: at(3) }),
+        makeEvent({ storeId: "other", userId: ExternalUserId("u3"), changeKind: "add", endTime: at(2) }),
+      ],
+      [],
+    )
+    const users = await listStoreUsers(memory, "s")
+    expect(users.map((u) => u.userId as string)).toEqual(["u2", "u1"])
+    expect(users[0]!.lastAccessedAt.getTime()).toBe(at(9).getTime())
+    expect(users[1]!.lastAccessedAt.getTime()).toBe(at(5).getTime())
+  })
+})
+
+describe("listUserStores", () => {
+  it("lists distinct stores one user touched (reads count, '' store kept), newest-first", async () => {
+    const memory = createFakeMemoryRepository()
+    await seed(
+      memory,
+      [
+        makeEvent({ storeId: "store1", userId: ExternalUserId("u1"), changeKind: "add", endTime: at(1) }),
+        makeEvent({ storeId: "store2", userId: ExternalUserId("u1"), changeKind: "read", endTime: at(9) }),
+        makeEvent({ storeId: "", userId: ExternalUserId("u1"), changeKind: "add", endTime: at(4) }),
+        makeEvent({ storeId: "store3", userId: ExternalUserId("u2"), changeKind: "add", endTime: at(2) }),
+      ],
+      [],
+    )
+    const stores = await listUserStores(memory, "u1")
+    expect(stores.map((s) => s.storeId)).toEqual(["store2", "", "store1"])
+  })
+})

--- a/packages/domain/memories/src/use-cases/list-memory-stores.test.ts
+++ b/packages/domain/memories/src/use-cases/list-memory-stores.test.ts
@@ -69,7 +69,9 @@ const seed = (memory: Fake, events: readonly MemoryEvent[], current: readonly Me
 
 const listStores = (memory: Fake, options?: MemoryStoreListOptions) =>
   Effect.runPromise(
-    listMemoryStoresUseCase({ organizationId, projectId, options }).pipe(Effect.provide(layerFor(memory))),
+    listMemoryStoresUseCase({ organizationId, projectId, ...(options ? { options } : {}) }).pipe(
+      Effect.provide(layerFor(memory)),
+    ),
   )
 
 const listStoreUsers = (memory: Fake, storeId: string) =>

--- a/packages/domain/memories/src/use-cases/list-memory-stores.ts
+++ b/packages/domain/memories/src/use-cases/list-memory-stores.ts
@@ -1,0 +1,16 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryStoreListOptions } from "../entities/memory-store.ts"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+
+export interface ListMemoryStoresInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly options?: MemoryStoreListOptions
+}
+
+/** A project's memory stores, one roll-up row each, server-sorted and paginated. */
+export const listMemoryStoresUseCase = Effect.fn("memories.listMemoryStores")(function* (input: ListMemoryStoresInput) {
+  const memoryRepository = yield* MemoryRepository
+  return yield* memoryRepository.listStores(input)
+})

--- a/packages/domain/memories/src/use-cases/list-record-users.ts
+++ b/packages/domain/memories/src/use-cases/list-record-users.ts
@@ -1,0 +1,16 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+
+export interface ListRecordUsersInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId: string
+  readonly recordId: string
+}
+
+/** The end-users who accessed one record (reads and writes), newest access first. */
+export const listRecordUsersUseCase = Effect.fn("memories.listRecordUsers")(function* (input: ListRecordUsersInput) {
+  const memoryRepository = yield* MemoryRepository
+  return yield* memoryRepository.listRecordUsers(input)
+})

--- a/packages/domain/memories/src/use-cases/list-store-users.ts
+++ b/packages/domain/memories/src/use-cases/list-store-users.ts
@@ -1,0 +1,15 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+
+export interface ListStoreUsersInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId: string
+}
+
+/** The end-users who accessed one store (reads count), newest access first. */
+export const listStoreUsersUseCase = Effect.fn("memories.listStoreUsers")(function* (input: ListStoreUsersInput) {
+  const memoryRepository = yield* MemoryRepository
+  return yield* memoryRepository.listStoreUsers(input)
+})

--- a/packages/domain/memories/src/use-cases/list-user-stores.ts
+++ b/packages/domain/memories/src/use-cases/list-user-stores.ts
@@ -1,0 +1,15 @@
+import type { ExternalUserId, OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+
+export interface ListUserStoresInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly userId: ExternalUserId
+}
+
+/** The memory stores one end-user accessed (reads count), newest access first. */
+export const listUserStoresUseCase = Effect.fn("memories.listUserStores")(function* (input: ListUserStoresInput) {
+  const memoryRepository = yield* MemoryRepository
+  return yield* memoryRepository.listUserStores(input)
+})

--- a/packages/domain/memories/src/use-cases/read-record-reads.ts
+++ b/packages/domain/memories/src/use-cases/read-record-reads.ts
@@ -1,0 +1,17 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+
+export interface ReadRecordReadsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly storeId: string
+  readonly recordId: string
+  readonly limit?: number
+}
+
+/** The retrieval (read) events for one record, newest first. */
+export const readRecordReadsUseCase = Effect.fn("memories.readRecordReads")(function* (input: ReadRecordReadsInput) {
+  const memoryRepository = yield* MemoryRepository
+  return yield* memoryRepository.readRecordReadEvents(input)
+})

--- a/packages/platform/db-clickhouse/src/repositories/memory-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-repository.test.ts
@@ -546,3 +546,110 @@ describe("MemoryRepository store listing", () => {
     expect(stores[0]!.lastAccessedAt.getTime()).toBe(at(5).getTime())
   })
 })
+
+describe("MemoryRepository record activity", () => {
+  it("reads one record's retrieval events, newest first, deduped, capped by limit", async () => {
+    const dupRead = makeEvent({
+      recordId: "recA",
+      spanId: spanN(1),
+      changeKind: "read",
+      queryText: "q1",
+      userId: ExternalUserId("u1"),
+      tokenCount: 5,
+      endTime: at(2),
+    })
+    await withRepo((repo) =>
+      repo.insertEvents([
+        dupRead,
+        dupRead,
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(2),
+          changeKind: "read",
+          queryText: "q2",
+          userId: ExternalUserId("u2"),
+          endTime: at(5),
+        }),
+        makeEvent({ recordId: "recA", spanId: spanN(3), changeKind: "add", endTime: at(1) }),
+        makeEvent({ recordId: "recB", spanId: spanN(4), changeKind: "read", queryText: "other", endTime: at(9) }),
+      ]),
+    )
+    const reads = await withRepo((repo) =>
+      repo.readRecordReadEvents({ organizationId, projectId, storeId: "store1", recordId: "recA" }),
+    )
+    expect(reads.map((r) => [r.queryText, r.userId as string])).toEqual([
+      ["q2", "u2"],
+      ["q1", "u1"],
+    ])
+
+    const limited = await withRepo((repo) =>
+      repo.readRecordReadEvents({ organizationId, projectId, storeId: "store1", recordId: "recA", limit: 1 }),
+    )
+    expect(limited.map((r) => r.queryText)).toEqual(["q2"])
+  })
+
+  it("rolls up a record's users with read/write counts (deduped, '' excluded), newest access first", async () => {
+    await withRepo((repo) =>
+      repo.insertEvents([
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(1),
+          changeKind: "add",
+          userId: ExternalUserId("u1"),
+          endTime: at(1),
+        }),
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(2),
+          changeKind: "read",
+          userId: ExternalUserId("u1"),
+          endTime: at(4),
+        }),
+        // retried duplicate of spanN(2) → counted once
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(2),
+          changeKind: "read",
+          userId: ExternalUserId("u1"),
+          endTime: at(4),
+        }),
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(3),
+          changeKind: "read",
+          userId: ExternalUserId("u1"),
+          endTime: at(6),
+        }),
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(4),
+          changeKind: "read",
+          userId: ExternalUserId("u2"),
+          endTime: at(9),
+        }),
+        makeEvent({
+          recordId: "recA",
+          spanId: spanN(5),
+          changeKind: "update",
+          userId: ExternalUserId(""),
+          endTime: at(3),
+        }),
+        makeEvent({
+          recordId: "recB",
+          spanId: spanN(6),
+          changeKind: "read",
+          userId: ExternalUserId("u3"),
+          endTime: at(20),
+        }),
+      ]),
+    )
+    const users = await withRepo((repo) =>
+      repo.listRecordUsers({ organizationId, projectId, storeId: "store1", recordId: "recA" }),
+    )
+    expect(users.map((u) => [u.userId as string, u.readCount, u.writeCount])).toEqual([
+      ["u2", 1, 0],
+      ["u1", 2, 1],
+    ])
+    expect(users[0]!.lastAccessedAt.getTime()).toBe(at(9).getTime())
+  })
+})

--- a/packages/platform/db-clickhouse/src/repositories/memory-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-repository.test.ts
@@ -1,4 +1,10 @@
-import type { MemoryBlob, MemoryCurrentEntry, MemoryEvent, MemoryRepositoryShape } from "@domain/memories"
+import type {
+  MemoryBlob,
+  MemoryCurrentEntry,
+  MemoryEvent,
+  MemoryRepositoryShape,
+  MemoryStoreListOptions,
+} from "@domain/memories"
 import { MemoryRepository } from "@domain/memories"
 import {
   type ChSqlClient,
@@ -284,5 +290,259 @@ describe("MemoryRepository", () => {
 
     const bounded = await withRepo((repo) => repo.readRecordVersions({ organizationId, projectId, records, at: at(1) }))
     expect(bounded.map((v) => v.contentHash)).toEqual(["a0"])
+  })
+})
+
+describe("MemoryRepository store listing", () => {
+  const storesById = async () => {
+    const page = await withRepo((repo) => repo.listStores({ organizationId, projectId }))
+    return new Map(page.items.map((s) => [s.storeId, s]))
+  }
+
+  it("rolls up per-store metrics: live records/tokens/lastUpdated + event sessions/users/lastRead", async () => {
+    await withRepo((repo) =>
+      repo.upsertCurrent([
+        makeCurrent({ recordId: "rec1", tokenCount: 10, endTime: at(1) }),
+        makeCurrent({ recordId: "rec2", tokenCount: 15, endTime: at(3) }),
+        makeCurrent({ recordId: "rec3", changeKind: "remove", tokenCount: 0, endTime: at(4) }),
+      ]),
+    )
+    await withRepo((repo) =>
+      repo.insertEvents([
+        makeEvent({
+          spanId: spanN(1),
+          recordId: "rec1",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(1),
+        }),
+        makeEvent({
+          spanId: spanN(2),
+          recordId: "rec2",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(3),
+        }),
+        makeEvent({
+          spanId: spanN(3),
+          recordId: "rec1",
+          changeKind: "read",
+          sessionId: SessionId("s3"),
+          userId: ExternalUserId("u3"),
+          endTime: at(9),
+        }),
+        // anonymous read: advances lastRead, excluded from distinct counts
+        makeEvent({
+          spanId: spanN(4),
+          recordId: "rec1",
+          changeKind: "read",
+          sessionId: SessionId(""),
+          userId: ExternalUserId(""),
+          endTime: at(20),
+        }),
+      ]),
+    )
+    const store = (await storesById()).get("store1")!
+    expect(store.recordCount).toBe(2)
+    expect(store.tokenCount).toBe(25)
+    expect(store.lastUpdatedAt.getTime()).toBe(at(3).getTime())
+    expect(store.sessionCount).toBe(3)
+    expect(store.userCount).toBe(3)
+    expect(store.lastReadAt?.getTime()).toBe(at(20).getTime())
+  })
+
+  it("lists the '' store and a live-but-eventless store; omits a store with no live records", async () => {
+    await withRepo((repo) =>
+      repo.upsertCurrent([
+        makeCurrent({ storeId: "", recordId: "r1", endTime: at(1) }),
+        makeCurrent({ storeId: "eventless", recordId: "r1", endTime: at(2) }),
+        makeCurrent({ storeId: "gone", recordId: "g1", changeKind: "remove", endTime: at(2) }),
+      ]),
+    )
+    await withRepo((repo) =>
+      repo.insertEvents([makeEvent({ storeId: "gone", recordId: "g1", spanId: spanN(1), endTime: at(1) })]),
+    )
+    const byId = await storesById()
+    expect([...byId.keys()].sort()).toEqual(["", "eventless"])
+    const eventless = byId.get("eventless")!
+    expect(eventless.sessionCount).toBe(0)
+    expect(eventless.userCount).toBe(0)
+    expect(eventless.lastReadAt).toBeNull()
+  })
+
+  const seedThreeStores = async () => {
+    await withRepo((repo) =>
+      repo.upsertCurrent([
+        makeCurrent({ storeId: "A", recordId: "r1", tokenCount: 100, endTime: at(10) }),
+        makeCurrent({ storeId: "B", recordId: "r1", tokenCount: 20, endTime: at(15) }),
+        makeCurrent({ storeId: "B", recordId: "r2", tokenCount: 20, endTime: at(20) }),
+        makeCurrent({ storeId: "B", recordId: "r3", tokenCount: 10, endTime: at(18) }),
+        makeCurrent({ storeId: "C", recordId: "r1", tokenCount: 150, endTime: at(3) }),
+        makeCurrent({ storeId: "C", recordId: "r2", tokenCount: 50, endTime: at(5) }),
+      ]),
+    )
+    await withRepo((repo) =>
+      repo.insertEvents([
+        makeEvent({
+          storeId: "A",
+          recordId: "r1",
+          spanId: spanN(1),
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(10),
+        }),
+        makeEvent({
+          storeId: "A",
+          recordId: "r1",
+          spanId: spanN(2),
+          changeKind: "read",
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(50),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r1",
+          spanId: spanN(3),
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(15),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r2",
+          spanId: spanN(4),
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(20),
+        }),
+        makeEvent({
+          storeId: "B",
+          recordId: "r3",
+          spanId: spanN(5),
+          sessionId: SessionId("s3"),
+          userId: ExternalUserId("u1"),
+          endTime: at(18),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r1",
+          spanId: spanN(6),
+          sessionId: SessionId("s1"),
+          userId: ExternalUserId("u1"),
+          endTime: at(3),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r2",
+          spanId: spanN(7),
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u2"),
+          endTime: at(5),
+        }),
+        makeEvent({
+          storeId: "C",
+          recordId: "r2",
+          spanId: spanN(8),
+          changeKind: "read",
+          sessionId: SessionId("s2"),
+          userId: ExternalUserId("u3"),
+          endTime: at(30),
+        }),
+      ]),
+    )
+  }
+
+  const order = (options?: MemoryStoreListOptions) =>
+    withRepo((repo) => repo.listStores({ organizationId, projectId, ...(options ? { options } : {}) })).then((page) =>
+      page.items.map((s) => s.storeId),
+    )
+
+  it("sorts server-side by the requested column and direction, tie-broken on store_id", async () => {
+    await seedThreeStores()
+    // A: 1 rec/updated@10/1 user/read@50 · B: 3 rec/updated@20/2 user/never read · C: 2 rec/updated@5/3 user/read@30
+    expect(await order()).toEqual(["B", "A", "C"]) // default lastUpdated desc
+    expect(await order({ sortBy: "records", sortDirection: "desc" })).toEqual(["B", "C", "A"])
+    expect(await order({ sortBy: "users", sortDirection: "desc" })).toEqual(["C", "B", "A"])
+    expect(await order({ sortBy: "lastRead", sortDirection: "desc" })).toEqual(["A", "C", "B"]) // never-read last
+  })
+
+  it("paginates with limit/offset and a stable total count", async () => {
+    await withRepo((repo) =>
+      repo.upsertCurrent(
+        Array.from({ length: 5 }, (_, i) => makeCurrent({ storeId: `store${i}`, recordId: "r1", endTime: at(i) })),
+      ),
+    )
+    const p0 = await withRepo((repo) =>
+      repo.listStores({
+        organizationId,
+        projectId,
+        options: { limit: 2, offset: 0, sortBy: "lastUpdated", sortDirection: "asc" },
+      }),
+    )
+    expect(p0.items.map((s) => s.storeId)).toEqual(["store0", "store1"])
+    expect(p0.hasMore).toBe(true)
+    expect(p0.totalCount).toBe(5)
+    const p2 = await withRepo((repo) =>
+      repo.listStores({
+        organizationId,
+        projectId,
+        options: { limit: 2, offset: 4, sortBy: "lastUpdated", sortDirection: "asc" },
+      }),
+    )
+    expect(p2.items.map((s) => s.storeId)).toEqual(["store4"])
+    expect(p2.hasMore).toBe(false)
+    expect(p2.totalCount).toBe(5)
+  })
+
+  it("does not double-count a retried duplicate event", async () => {
+    const dup = makeEvent({
+      changeKind: "read",
+      sessionId: SessionId("s1"),
+      userId: ExternalUserId("u1"),
+      endTime: at(9),
+    })
+    await withRepo((repo) => repo.upsertCurrent([makeCurrent({ endTime: at(1) })]))
+    await withRepo((repo) => repo.insertEvents([dup, dup]))
+    const store = (await storesById()).get("store1")!
+    expect(store.sessionCount).toBe(1)
+    expect(store.userCount).toBe(1)
+    expect(store.lastReadAt?.getTime()).toBe(at(9).getTime())
+  })
+
+  it("lists distinct users of a store (reads count, '' excluded) and distinct stores of a user ('' kept)", async () => {
+    await withRepo((repo) =>
+      repo.insertEvents([
+        makeEvent({ storeId: "s", recordId: "r1", spanId: spanN(1), userId: ExternalUserId("u1"), endTime: at(1) }),
+        makeEvent({
+          storeId: "s",
+          recordId: "r1",
+          spanId: spanN(2),
+          changeKind: "read",
+          userId: ExternalUserId("u1"),
+          endTime: at(5),
+        }),
+        makeEvent({
+          storeId: "s",
+          recordId: "r2",
+          spanId: spanN(3),
+          changeKind: "read",
+          userId: ExternalUserId("u2"),
+          endTime: at(9),
+        }),
+        makeEvent({ storeId: "s", recordId: "r3", spanId: spanN(4), userId: ExternalUserId(""), endTime: at(3) }),
+        makeEvent({ storeId: "", recordId: "r1", spanId: spanN(5), userId: ExternalUserId("u1"), endTime: at(4) }),
+        makeEvent({ storeId: "other", recordId: "r1", spanId: spanN(6), userId: ExternalUserId("u3"), endTime: at(2) }),
+      ]),
+    )
+    const users = await withRepo((repo) => repo.listStoreUsers({ organizationId, projectId, storeId: "s" }))
+    expect(users.map((u) => u.userId as string)).toEqual(["u2", "u1"])
+    expect(users[0]!.lastAccessedAt.getTime()).toBe(at(9).getTime())
+
+    const stores = await withRepo((repo) =>
+      repo.listUserStores({ organizationId, projectId, userId: ExternalUserId("u1") }),
+    )
+    expect(stores.map((s) => s.storeId)).toEqual(["s", ""])
+    expect(stores[0]!.lastAccessedAt.getTime()).toBe(at(5).getTime())
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/memory-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-repository.ts
@@ -5,6 +5,7 @@ import type {
   MemoryCurrentEntry,
   MemoryEvent,
   MemoryEventSource,
+  MemoryRecordUser,
   MemoryRecordVersion,
   MemoryRepositoryShape,
   MemoryStoreListItem,
@@ -49,6 +50,9 @@ type MemoryRecordVersionRow = {
   readonly span_id: string
   readonly trace_id: string
   readonly session_id: string
+  // Only selected by the record-version read (from `memory_events`); the
+  // manifest/current reads project it as absent, hence optional.
+  readonly user_id?: string
   readonly record_end_time: string
 }
 
@@ -113,6 +117,7 @@ const STORE_SORT_EXPRS: Record<MemoryStoreSortField, string> = {
 }
 
 const STORE_ACCESS_LIST_CAP = 1000
+const RECORD_READ_EVENTS_CAP = 200
 
 // The store set + current-derived metrics: latest version per record (removes
 // dropped), grouped by store. `store_id = ''` is kept (the unattributed bucket).
@@ -166,6 +171,13 @@ type StoreUserRow = {
 
 type UserStoreRow = {
   readonly store_id: string
+  readonly last_accessed_at: string
+}
+
+type RecordUserRow = {
+  readonly user_id: string
+  readonly read_count: string | number
+  readonly write_count: string | number
   readonly last_accessed_at: string
 }
 
@@ -269,6 +281,7 @@ const toVersion = (row: MemoryRecordVersionRow): MemoryRecordVersion => ({
   spanId: SpanId(normalizeCHString(row.span_id)),
   traceId: TraceId(normalizeCHString(row.trace_id)),
   sessionId: SessionId(row.session_id),
+  userId: ExternalUserId(normalizeCHString(row.user_id ?? "")),
   endTime: parseCHDate(row.record_end_time),
 })
 
@@ -513,9 +526,9 @@ export const MemoryRepositoryLive = Layer.effect(
           .query(async (client) => {
             const result = await client.query({
               query: `SELECT store_id, record_id, content_hash, change_kind, token_count,
-                             span_id, trace_id, session_id, end_time AS record_end_time
+                             span_id, trace_id, session_id, user_id, end_time AS record_end_time
                       FROM (
-                        SELECT ${VERSION_COLUMNS}, ingested_at
+                        SELECT ${VERSION_COLUMNS}, user_id, ingested_at
                         FROM memory_events
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
@@ -595,6 +608,102 @@ export const MemoryRepositoryLive = Layer.effect(
         }
       })
 
+    const readRecordReadEvents: MemoryRepositoryShape["readRecordReadEvents"] = ({
+      organizationId,
+      projectId,
+      storeId,
+      recordId,
+      limit,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              // Dedup retried projection rows to one per span (store/record are
+              // pinned by the WHERE), then newest read first.
+              query: `SELECT ${EVENT_COLUMNS}
+                      FROM (
+                        SELECT ${EVENT_COLUMNS}, ingested_at
+                        FROM memory_events
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND store_id = {storeId:String}
+                          AND record_id = {recordId:String}
+                          AND change_kind = 'read'
+                        ORDER BY span_id, store_id, record_id, ingested_at DESC
+                        LIMIT 1 BY span_id, store_id, record_id
+                      )
+                      ORDER BY end_time DESC
+                      LIMIT {limit:UInt32}`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                storeId,
+                recordId,
+                limit: limit ?? RECORD_READ_EVENTS_CAP,
+              },
+              format: "JSONEachRow",
+            })
+            const rows = await result.json<MemoryEventRow>()
+            return rows.map(toEvent(organizationId, projectId))
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.readRecordReadEvents")))
+      })
+
+    const listRecordUsers: MemoryRepositoryShape["listRecordUsers"] = ({
+      organizationId,
+      projectId,
+      storeId,
+      recordId,
+    }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              // Dedup retried projection rows to one per span before counting —
+              // `countIf` (unlike `maxIf`) is not idempotent to duplicates.
+              query: `SELECT user_id,
+                             countIf(change_kind = 'read')                       AS read_count,
+                             countIf(change_kind IN ('add', 'update', 'remove')) AS write_count,
+                             max(end_time)                                       AS last_accessed_at
+                      FROM (
+                        SELECT span_id, user_id, change_kind, end_time
+                        FROM memory_events
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND store_id = {storeId:String}
+                          AND record_id = {recordId:String}
+                          AND user_id != ''
+                        ORDER BY span_id, ingested_at DESC
+                        LIMIT 1 BY span_id
+                      )
+                      GROUP BY user_id
+                      ORDER BY last_accessed_at DESC, user_id ASC
+                      LIMIT {cap:UInt16}`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                storeId,
+                recordId,
+                cap: STORE_ACCESS_LIST_CAP,
+              },
+              format: "JSONEachRow",
+            })
+            const rows = await result.json<RecordUserRow>()
+            return rows.map(
+              (row): MemoryRecordUser => ({
+                userId: ExternalUserId(normalizeCHString(row.user_id)),
+                readCount: Number(row.read_count),
+                writeCount: Number(row.write_count),
+                lastAccessedAt: parseCHDate(row.last_accessed_at),
+              }),
+            )
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.listRecordUsers")))
+      })
+
     const listStoreUsers: MemoryRepositoryShape["listStoreUsers"] = ({ organizationId, projectId, storeId }) =>
       Effect.gen(function* () {
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
@@ -672,6 +781,8 @@ export const MemoryRepositoryLive = Layer.effect(
       readBlobs,
       readSessionMemoryEvents,
       readRecordVersions,
+      readRecordReadEvents,
+      listRecordUsers,
       listStores,
       listStoreUsers,
       listUserStores,

--- a/packages/platform/db-clickhouse/src/repositories/memory-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/memory-repository.ts
@@ -7,7 +7,11 @@ import type {
   MemoryEventSource,
   MemoryRecordVersion,
   MemoryRepositoryShape,
+  MemoryStoreListItem,
+  MemoryStoreSortField,
+  MemoryStoreUser,
   MemoryStoreWipe,
+  MemoryUserStore,
 } from "@domain/memories"
 import { MemoryRepository } from "@domain/memories"
 import {
@@ -95,6 +99,89 @@ type MemoryBlobRow = {
   readonly content_file_key: string
   readonly byte_size: string | number
   readonly token_count: string | number
+}
+
+// Fixed map — never interpolate user input into ORDER BY. Values are the output
+// aliases of the store-list query below.
+const STORE_SORT_EXPRS: Record<MemoryStoreSortField, string> = {
+  lastUpdated: "last_updated_at",
+  lastRead: "last_read_at",
+  records: "record_count",
+  tokens: "token_count",
+  sessions: "session_count",
+  users: "user_count",
+}
+
+const STORE_ACCESS_LIST_CAP = 1000
+
+// The store set + current-derived metrics: latest version per record (removes
+// dropped), grouped by store. `store_id = ''` is kept (the unattributed bucket).
+const CURRENT_STORE_AGG = `
+  SELECT
+    store_id,
+    count()          AS record_count,
+    sum(token_count) AS token_count,
+    max(end_time)    AS last_updated_at
+  FROM (
+    SELECT store_id, record_id, token_count, change_kind, end_time
+    FROM memory_current
+    WHERE organization_id = {organizationId:String}
+      AND project_id = {projectId:String}
+    ORDER BY store_id, record_id, end_time DESC
+    LIMIT 1 BY store_id, record_id
+  )
+  WHERE change_kind != 'remove'
+  GROUP BY store_id
+`
+
+// Event-derived metrics across ALL change_kinds (reads count). No dedup subquery:
+// uniqExactIf / maxIf are idempotent to retried-projection duplicates, whose
+// (span_id, store_id, record_id) rows carry identical session/user/end_time.
+const EVENT_STORE_AGG = `
+  SELECT
+    store_id,
+    uniqExactIf(session_id, session_id != '') AS session_count,
+    uniqExactIf(user_id, user_id != '')       AS user_count,
+    maxIf(end_time, change_kind = 'read')      AS last_read_at
+  FROM memory_events
+  WHERE organization_id = {organizationId:String}
+    AND project_id = {projectId:String}
+  GROUP BY store_id
+`
+
+type MemoryStoreRow = {
+  readonly store_id: string
+  readonly record_count: string | number
+  readonly token_count: string | number
+  readonly last_updated_at: string
+  readonly session_count: string | number
+  readonly user_count: string | number
+  readonly last_read_at: string
+}
+
+type StoreUserRow = {
+  readonly user_id: string
+  readonly last_accessed_at: string
+}
+
+type UserStoreRow = {
+  readonly store_id: string
+  readonly last_accessed_at: string
+}
+
+const toStoreListItem = (row: MemoryStoreRow): MemoryStoreListItem => {
+  // The LEFT JOIN default (or `maxIf` with no matching read) yields the
+  // DateTime64 epoch, which we surface as "never read".
+  const lastRead = parseCHDate(row.last_read_at)
+  return {
+    storeId: row.store_id,
+    recordCount: Number(row.record_count),
+    tokenCount: Number(row.token_count),
+    lastUpdatedAt: parseCHDate(row.last_updated_at),
+    sessionCount: Number(row.session_count),
+    userCount: Number(row.user_count),
+    lastReadAt: lastRead.getTime() > 0 ? lastRead : null,
+  }
 }
 
 const toEvent =
@@ -455,6 +542,126 @@ export const MemoryRepositoryLive = Layer.effect(
           .pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.readRecordVersions")))
       })
 
+    const listStores: MemoryRepositoryShape["listStores"] = ({ organizationId, projectId, options }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        const limit = options?.limit ?? 50
+        const offset = options?.offset ?? 0
+        const sortExpr = STORE_SORT_EXPRS[options?.sortBy ?? "lastUpdated"]
+        const orderDir = options?.sortDirection === "asc" ? "ASC" : "DESC"
+        const params = { organizationId: organizationId as string, projectId: projectId as string }
+
+        const [rows, countRows] = yield* Effect.all(
+          [
+            chSqlClient.query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                          c.store_id        AS store_id,
+                          c.record_count    AS record_count,
+                          c.token_count     AS token_count,
+                          c.last_updated_at AS last_updated_at,
+                          e.session_count   AS session_count,
+                          e.user_count      AS user_count,
+                          e.last_read_at    AS last_read_at
+                        FROM (${CURRENT_STORE_AGG}) AS c
+                        LEFT JOIN (${EVENT_STORE_AGG}) AS e ON c.store_id = e.store_id
+                        ORDER BY ${sortExpr} ${orderDir}, store_id ASC
+                        LIMIT {limit:UInt32} OFFSET {offset:UInt32}`,
+                query_params: { ...params, limit: limit + 1, offset },
+                format: "JSONEachRow",
+              })
+              return result.json<MemoryStoreRow>()
+            }),
+            chSqlClient.query(async (client) => {
+              const result = await client.query({
+                query: `SELECT count() AS total FROM (${CURRENT_STORE_AGG})`,
+                query_params: params,
+                format: "JSONEachRow",
+              })
+              return result.json<{ total: string | number }>()
+            }),
+          ],
+          { concurrency: 2 },
+        ).pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.listStores")))
+
+        const hasMore = rows.length > limit
+        const pageRows = hasMore ? rows.slice(0, limit) : rows
+        return {
+          items: pageRows.map(toStoreListItem),
+          totalCount: Number(countRows[0]?.total ?? 0),
+          hasMore,
+          limit,
+          offset,
+        }
+      })
+
+    const listStoreUsers: MemoryRepositoryShape["listStoreUsers"] = ({ organizationId, projectId, storeId }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT user_id, max(end_time) AS last_accessed_at
+                      FROM memory_events
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND store_id = {storeId:String}
+                        AND user_id != ''
+                      GROUP BY user_id
+                      ORDER BY last_accessed_at DESC, user_id ASC
+                      LIMIT {cap:UInt16}`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                storeId,
+                cap: STORE_ACCESS_LIST_CAP,
+              },
+              format: "JSONEachRow",
+            })
+            const rows = await result.json<StoreUserRow>()
+            return rows.map(
+              (row): MemoryStoreUser => ({
+                userId: ExternalUserId(normalizeCHString(row.user_id)),
+                lastAccessedAt: parseCHDate(row.last_accessed_at),
+              }),
+            )
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.listStoreUsers")))
+      })
+
+    const listUserStores: MemoryRepositoryShape["listUserStores"] = ({ organizationId, projectId, userId }) =>
+      Effect.gen(function* () {
+        const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+        return yield* chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT store_id, max(end_time) AS last_accessed_at
+                      FROM memory_events
+                      WHERE organization_id = {organizationId:String}
+                        AND project_id = {projectId:String}
+                        AND user_id = {userId:String}
+                      GROUP BY store_id
+                      ORDER BY last_accessed_at DESC, store_id ASC
+                      LIMIT {cap:UInt16}`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                userId: userId as string,
+                cap: STORE_ACCESS_LIST_CAP,
+              },
+              format: "JSONEachRow",
+            })
+            const rows = await result.json<UserStoreRow>()
+            return rows.map(
+              (row): MemoryUserStore => ({
+                storeId: row.store_id,
+                lastAccessedAt: parseCHDate(row.last_accessed_at),
+              }),
+            )
+          })
+          .pipe(Effect.mapError((error) => toRepositoryError(error, "MemoryRepository.listUserStores")))
+      })
+
     return {
       insertEvents,
       upsertBlobs,
@@ -465,6 +672,9 @@ export const MemoryRepositoryLive = Layer.effect(
       readBlobs,
       readSessionMemoryEvents,
       readRecordVersions,
+      listStores,
+      listStoreUsers,
+      listUserStores,
     }
   }),
 )


### PR DESCRIPTION
Adds the **Memory** page — a product surface for inspecting what an agent has stored, changed, and retrieved. This is Phase 3 of Memory Observability (LAT-729) and builds on the store-centric model from #4074. The whole page sits behind the `memoryObservability` feature flag (enabled per org from the backoffice); the underlying tables carry no production data yet.

Three views ship here.

## store list (`/memory`)

One row per memory store, rolled up from the ledger: record count, token total, distinct sessions and users, last updated, and last read. Sortable on any column server-side, paginated with offset infinite-scroll. The unattributed store (empty `store_id`) is kept and shown.

## store detail (`/memory/$store`)

An IDE-style layout:

- **Record tree** (left): record ids split on `/` into a collapsible folder tree, folders first.
- **Record body** (center): the current content in a read-only code block with JSON detection.
- **Activity panel** (bottom): a resizable, collapsible panel with three tabs.
  - **Changes** — write history (create/update/remove) with per-version token deltas and the authoring user.
  - **Reads** — retrieval events, each showing the search query that surfaced the record, tokens returned, and the user.
  - **Users** — a per-record read/write roll-up, each linking to the user's page.

  Rows on Changes and Reads open the originating session in the session drawer.

## end-user page

A section listing the memory stores an end-user has accessed, linking into store detail.

## data

Everything reads from `memory_current` (the current-state projection) and the append-only `memory_events` ledger:

- The store roll-up is a single query — a per-store aggregate over `memory_current` left-joined to a per-store aggregate over `memory_events` (distinct sessions/users, last-read time) — with server-side sort, limit/offset, and a parallel total count.
- Per-record reads and the per-user roll-up dedup retried projection rows before counting; reads are capped at 200, access lists at 1000.
- The sessions count includes reads as well as writes; anonymous reads advance `last read` but are excluded from the distinct counts, and empty user ids are excluded from the user lists.

New `@domain/memories` entities, port methods, and use-cases back these, and the in-memory fake repository mirrors the ClickHouse semantics for the use-case tests.

## scope and follow-ups

- Per-line blame on a record is deferred to a later phase to keep this shippable.
- The commit-style session diff view is Phase 4.

## testing

29 domain use-case tests (fake repo) + 15 ClickHouse adapter tests (roll-up, sorting, pagination, dedup, per-record reads/users) + `@app/web` typecheck and the web suite; knip and biome clean.

Refs LAT-729.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a project Memory section for browsing memory stores, including sortable/infinite scrolling lists.
  * Introduced memory store pages with a hierarchical record tree, record content display, and URL-safe handling of special/empty identifiers.
  * Added record activity tabs (changes, reads, users), plus store- and user-level “accessed by” views.
  * Enabled Memory UI via the new `memoryObservability` feature flag.
* **Tests**
  * Expanded coverage for record-tree navigation, identifier encoding/decoding, sorting/pagination, activity/read aggregation, and access metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->