### PR TITLE
fix(monitors): allow recommended tool failure monitors to create

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
@@ -121,16 +121,20 @@ function MetricSelector({
   stream,
   onChange,
   disabled,
+  countOnly = false,
 }: {
   readonly value: MonitorMetric
   readonly stream: NonNullable<AlertDraft["target"]>["stream"]
   readonly onChange: (metric: MonitorMetric, direction?: MetricDirection) => void
   readonly disabled?: boolean
+  readonly countOnly?: boolean
 }) {
   const options = targetMetricOptions(stream)
   const selectedDimension = metricDimension(value)
   const dimensions = (["count", "errorRate", "cacheHitRate", "duration", "cost", "tokens"] as const).filter(
-    (dimension) => options.some((option) => metricDimension(option.metric) === dimension),
+    (dimension) =>
+      (!countOnly || dimension === "count") &&
+      options.some((option) => metricDimension(option.metric) === dimension),
   )
   const aggregations = options.filter((option) => metricDimension(option.metric) === selectedDimension)
 
@@ -513,6 +517,7 @@ export function AlertCardForm({
         <MetricSelector
           value={value.metric}
           stream={value.target.stream}
+          countOnly={isEscalatingKind(value.kind)}
           onChange={(metric, direction) => set(direction ? { metric, direction } : { metric })}
           {...(disabled || metricReadonly ? { disabled: true } : {})}
         />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-card-form.tsx
@@ -133,8 +133,7 @@ function MetricSelector({
   const selectedDimension = metricDimension(value)
   const dimensions = (["count", "errorRate", "cacheHitRate", "duration", "cost", "tokens"] as const).filter(
     (dimension) =>
-      (!countOnly || dimension === "count") &&
-      options.some((option) => metricDimension(option.metric) === dimension),
+      (!countOnly || dimension === "count") && options.some((option) => metricDimension(option.metric) === dimension),
   )
   const aggregations = options.filter((option) => metricDimension(option.metric) === selectedDimension)
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  draftToAlertDraft,
-  draftWithKind,
-  emptyAlertDraft,
-  targetAlertDraft,
-} from "./alert-form-helpers.ts"
+import { draftToAlertDraft, draftWithKind, emptyAlertDraft, targetAlertDraft } from "./alert-form-helpers.ts"
 
 const toolTarget = {
   type: "tool" as const,
@@ -37,10 +32,7 @@ describe("draftWithKind", () => {
       metric: { kind: "count" },
     })
 
-    const next = draftWithKind(
-      { ...draft, metric: { kind: "median", field: "duration" } },
-      "monitor.threshold",
-    )
+    const next = draftWithKind({ ...draft, metric: { kind: "median", field: "duration" } }, "monitor.threshold")
 
     expect(next.kind).toBe("monitor.threshold")
     expect(next.metric).toEqual({ kind: "median", field: "duration" })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import {
+  draftToAlertDraft,
+  draftWithKind,
+  emptyAlertDraft,
+  targetAlertDraft,
+} from "./alert-form-helpers.ts"
+
+const toolTarget = {
+  type: "tool" as const,
+  id: null,
+  kind: "tool" as const,
+  stream: "spans" as const,
+  query: null,
+  savedSearchId: null,
+  filterSet: { name: [{ op: "eq" as const, value: "searchWeb" }] },
+  metric: { kind: "count" as const },
+}
+
+describe("draftWithKind", () => {
+  it("coerces non-count metrics to count when switching to escalating", () => {
+    const draft = targetAlertDraft(toolTarget, {
+      kind: "monitor.threshold",
+      metric: { kind: "errorRate" },
+    })
+
+    const next = draftWithKind(draft, "monitor.escalating")
+
+    expect(next.kind).toBe("monitor.escalating")
+    expect(next.metric).toEqual({ kind: "count" })
+  })
+
+  it("keeps the metric when switching to threshold", () => {
+    const draft = emptyAlertDraft({
+      kind: "monitor.escalating",
+      target: toolTarget,
+      metric: { kind: "count" },
+    })
+
+    const next = draftWithKind(
+      { ...draft, metric: { kind: "median", field: "duration" } },
+      "monitor.threshold",
+    )
+
+    expect(next.kind).toBe("monitor.threshold")
+    expect(next.metric).toEqual({ kind: "median", field: "duration" })
+  })
+})
+
+describe("draftToAlertDraft", () => {
+  it("maps error-rate expected presets to threshold rules", () => {
+    const draft = targetAlertDraft(toolTarget, {
+      kind: "monitor.threshold",
+      metric: { kind: "errorRate" },
+      comparison: "timesMoreThan",
+      baselineKind: "expected",
+      amount: 3,
+      severity: "high",
+    })
+
+    expect(draftToAlertDraft(draft)).toMatchObject({
+      kind: "monitor.threshold",
+      severity: "high",
+      condition: {
+        trigger: "threshold",
+        metric: { kind: "errorRate" },
+        threshold: { mode: "expected", sensitivity: 3 },
+      },
+    })
+  })
+
+  it("maps count expected presets to escalating rules", () => {
+    const draft = targetAlertDraft(toolTarget, {
+      kind: "monitor.escalating",
+      metric: { kind: "count" },
+      comparison: "timesMoreThan",
+      baselineKind: "expected",
+      amount: 3,
+      windowAmount: 15,
+      windowUnit: "minutes",
+      severity: "medium",
+    })
+
+    expect(draftToAlertDraft(draft)).toMatchObject({
+      kind: "monitor.escalating",
+      severity: "medium",
+      condition: {
+        trigger: "escalating",
+        metric: { kind: "count" },
+        threshold: { mode: "expected", sensitivity: 3 },
+        window: { minutes: 15 },
+      },
+    })
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/alert-form-helpers.ts
@@ -108,7 +108,7 @@ export const draftWithKind = (draft: AlertDraft, kind: UserAlertKind): AlertDraf
     kind,
     sourceId: draft.sourceId,
     target: draft.target,
-    metric: draft.metric,
+    metric: kind === "monitor.escalating" || kind === "savedSearch.escalating" ? { kind: "count" } : draft.metric,
     severity: draft.severity,
     direction: draft.direction,
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
@@ -1,0 +1,186 @@
+import { createMonitorUseCase, MonitorRepository } from "@domain/monitors"
+import { createFakeMonitorRepository } from "@domain/monitors/testing"
+import { SavedSearchRepository } from "@domain/saved-searches"
+import { createFakeSavedSearchRepository } from "@domain/saved-searches/testing"
+import { OrganizationId, ProjectId, SqlClient, ValidationError } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import {
+  allToolsMonitorTarget,
+  allUsersMonitorTarget,
+  toolMonitorTarget,
+  userMonitorTarget,
+} from "../../../../../../domains/monitors/monitor-target.ts"
+import type { MonitorRuleDraft } from "../../../../../../domains/monitors/monitors.collection.ts"
+import { draftToAlertDraft, draftToTarget, targetAlertDraft } from "./alert-form-helpers.ts"
+import { toolMonitorPresets, userMonitorPresets } from "./recommended-monitor-presets.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+
+const triggerForAlertKind = (kind: MonitorRuleDraft["kind"]) =>
+  kind.includes("threshold")
+    ? ("threshold" as const)
+    : kind.includes("escalating")
+      ? ("escalating" as const)
+      : ("match" as const)
+
+/** Mirrors apps/web createMonitor server-fn mapping of UI draft → domain create input. */
+const createFromUiDraft = (input: {
+  readonly name: string
+  readonly description: string
+  readonly rule: MonitorRuleDraft
+  readonly target: NonNullable<ReturnType<typeof draftToTarget>>
+}) => {
+  const trigger = triggerForAlertKind(input.rule.kind)
+  const metric = input.target.metric ?? { kind: "count" as const }
+  return createMonitorUseCase({
+    organizationId,
+    projectId,
+    name: input.name,
+    description: input.description,
+    target: input.target,
+    rule: {
+      trigger,
+      config: {
+        ...(input.target.filterSet ? { filterSet: input.target.filterSet } : {}),
+        metric,
+        ...(input.rule.condition ? { condition: input.rule.condition } : {}),
+      },
+      severity: input.rule.severity ?? "medium",
+    },
+  })
+}
+
+const runCreate = (effect: ReturnType<typeof createFromUiDraft>) => {
+  const { repo } = createFakeMonitorRepository()
+  return Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+          Layer.succeed(SavedSearchRepository, SavedSearchRepository.of(createFakeSavedSearchRepository().repository)),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  )
+}
+
+const runCreateError = (effect: ReturnType<typeof createFromUiDraft>) => {
+  const { repo } = createFakeMonitorRepository()
+  return Effect.runPromise(
+    effect.pipe(
+      Effect.flip,
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MonitorRepository, MonitorRepository.of(repo)),
+          Layer.succeed(SavedSearchRepository, SavedSearchRepository.of(createFakeSavedSearchRepository().repository)),
+          Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+        ),
+      ),
+    ),
+  )
+}
+
+describe("recommended monitor presets", () => {
+  it.each([
+    ["specific tool", toolMonitorTarget("searchWeb")],
+    ["all tools", allToolsMonitorTarget()],
+  ] as const)("creates every tool recommended preset for %s", async (_label, target) => {
+    const presets = toolMonitorPresets(target)
+    expect(presets.length).toBeGreaterThan(0)
+
+    for (const preset of presets) {
+      const rule = draftToAlertDraft(preset.draft)
+      const presetTarget = draftToTarget(preset.draft)
+      expect(presetTarget, preset.id).toBeDefined()
+      if (!presetTarget) continue
+
+      const monitor = await runCreate(
+        createFromUiDraft({
+          name: `${preset.name} — searchWeb`,
+          description: preset.description,
+          rule,
+          target: presetTarget,
+        }),
+      )
+
+      const expectedTrigger = preset.draft.metric.kind === "count" ? "escalating" : "threshold"
+      expect(monitor.rule.trigger, preset.id).toBe(expectedTrigger)
+      expect(monitor.target.metric, preset.id).toEqual(preset.draft.metric)
+      expect(rule.kind, preset.id).toBe(`monitor.${expectedTrigger}`)
+    }
+  })
+
+  it.each([
+    ["specific user", userMonitorTarget("user-1")],
+    ["all users", allUsersMonitorTarget()],
+  ] as const)("creates every user recommended preset for %s", async (_label, target) => {
+    const presets = userMonitorPresets(target)
+    expect(presets.length).toBeGreaterThan(0)
+
+    for (const preset of presets) {
+      const rule = draftToAlertDraft(preset.draft)
+      const presetTarget = draftToTarget(preset.draft)
+      expect(presetTarget, preset.id).toBeDefined()
+      if (!presetTarget) continue
+
+      const monitor = await runCreate(
+        createFromUiDraft({
+          name: `${preset.name} — user`,
+          description: preset.description,
+          rule,
+          target: presetTarget,
+        }),
+      )
+
+      const expectedTrigger = preset.draft.metric.kind === "count" ? "escalating" : "threshold"
+      expect(monitor.rule.trigger, preset.id).toBe(expectedTrigger)
+      expect(monitor.target.metric, preset.id).toEqual(preset.draft.metric)
+    }
+  })
+
+  it("still rejects the pre-fix escalating + errorRate shape", async () => {
+    const draft = targetAlertDraft(toolMonitorTarget("searchWeb"), {
+      kind: "monitor.escalating",
+      metric: { kind: "errorRate" },
+      comparison: "timesMoreThan",
+      baselineKind: "expected",
+      amount: 3,
+      windowAmount: 15,
+      windowUnit: "minutes",
+      severity: "high",
+    })
+    const rule = draftToAlertDraft(draft)
+    const target = draftToTarget(draft)
+    expect(target).toBeDefined()
+    if (!target) return
+
+    const error = await runCreateError(
+      createFromUiDraft({
+        name: "Tool is failing — searchWeb",
+        description: "regression",
+        rule,
+        target,
+      }),
+    )
+
+    expect(error).toBeInstanceOf(ValidationError)
+    expect(error.message).toBe("Escalating monitors only support count metrics")
+  })
+
+  it("maps Tool is failing to threshold + errorRate", () => {
+    const failing = toolMonitorPresets(toolMonitorTarget("searchWeb")).find((preset) => preset.id === "failing")
+    expect(failing).toBeDefined()
+    if (!failing) return
+    expect(failing.draft.kind).toBe("monitor.threshold")
+    expect(failing.draft.metric).toEqual({ kind: "errorRate" })
+    expect(draftToAlertDraft(failing.draft).condition).toMatchObject({
+      trigger: "threshold",
+      metric: { kind: "errorRate" },
+      threshold: { mode: "expected", sensitivity: 3 },
+    })
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
@@ -2,6 +2,7 @@ import { createMonitorUseCase, MonitorRepository } from "@domain/monitors"
 import { createFakeMonitorRepository } from "@domain/monitors/testing"
 import { SavedSearchRepository } from "@domain/saved-searches"
 import { createFakeSavedSearchRepository } from "@domain/saved-searches/testing"
+import type { MonitorMetric } from "@domain/shared"
 import { OrganizationId, ProjectId, SqlClient, ValidationError } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -18,6 +19,37 @@ import { toolMonitorPresets, userMonitorPresets } from "./recommended-monitor-pr
 
 const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
+
+type MonitorTrigger = "threshold" | "escalating" | "match"
+
+interface PresetExpectation {
+  readonly trigger: MonitorTrigger
+  readonly metric: MonitorMetric
+}
+
+const SPECIFIC_TOOL_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
+  failing: { trigger: "threshold", metric: { kind: "errorRate" } },
+  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
+  "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
+  "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
+  overusing: { trigger: "escalating", metric: { kind: "count" } },
+}
+
+const ALL_TOOLS_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
+  "failures-increased": { trigger: "threshold", metric: { kind: "errorRate" } },
+  "latency-increased": { trigger: "threshold", metric: { kind: "median", field: "duration" } },
+  "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
+  "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
+  "cost-spike": { trigger: "threshold", metric: { kind: "sum", field: "cost" } },
+}
+
+const USER_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
+  errors: { trigger: "escalating", metric: { kind: "count" } },
+  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
+  "activity-spike": { trigger: "escalating", metric: { kind: "count" } },
+  "activity-drop": { trigger: "escalating", metric: { kind: "count" } },
+  "cost-spike": { trigger: "threshold", metric: { kind: "sum", field: "cost" } },
+}
 
 const triggerForAlertKind = (kind: MonitorRuleDraft["kind"]) =>
   kind.includes("threshold")
@@ -84,62 +116,56 @@ const runCreateError = (effect: ReturnType<typeof createFromUiDraft>) => {
   )
 }
 
+const assertPresetsCreate = async (
+  presets: ReturnType<typeof toolMonitorPresets>,
+  expectations: Record<string, PresetExpectation>,
+  nameSuffix: string,
+) => {
+  expect(presets.map((preset) => preset.id).sort()).toEqual(Object.keys(expectations).sort())
+
+  for (const preset of presets) {
+    const expected = expectations[preset.id]
+    expect(expected, preset.id).toBeDefined()
+    if (!expected) continue
+
+    const rule = draftToAlertDraft(preset.draft)
+    const presetTarget = draftToTarget(preset.draft)
+    expect(presetTarget, preset.id).toBeDefined()
+    if (!presetTarget) continue
+
+    const monitor = await runCreate(
+      createFromUiDraft({
+        name: `${preset.name} — ${nameSuffix}`,
+        description: preset.description,
+        rule,
+        target: presetTarget,
+      }),
+    )
+
+    expect(monitor.rule.trigger, preset.id).toBe(expected.trigger)
+    expect(monitor.target.metric, preset.id).toEqual(expected.metric)
+    expect(rule.kind, preset.id).toBe(`monitor.${expected.trigger}`)
+  }
+}
+
 describe("recommended monitor presets", () => {
-  it.each([
-    ["specific tool", toolMonitorTarget("searchWeb")],
-    ["all tools", allToolsMonitorTarget()],
-  ] as const)("creates every tool recommended preset for %s", async (_label, target) => {
-    const presets = toolMonitorPresets(target)
-    expect(presets.length).toBeGreaterThan(0)
+  it("creates every specific-tool recommended preset", async () => {
+    await assertPresetsCreate(
+      toolMonitorPresets(toolMonitorTarget("searchWeb")),
+      SPECIFIC_TOOL_PRESET_EXPECTATIONS,
+      "searchWeb",
+    )
+  })
 
-    for (const preset of presets) {
-      const rule = draftToAlertDraft(preset.draft)
-      const presetTarget = draftToTarget(preset.draft)
-      expect(presetTarget, preset.id).toBeDefined()
-      if (!presetTarget) continue
-
-      const monitor = await runCreate(
-        createFromUiDraft({
-          name: `${preset.name} — searchWeb`,
-          description: preset.description,
-          rule,
-          target: presetTarget,
-        }),
-      )
-
-      const expectedTrigger = preset.draft.metric.kind === "count" ? "escalating" : "threshold"
-      expect(monitor.rule.trigger, preset.id).toBe(expectedTrigger)
-      expect(monitor.target.metric, preset.id).toEqual(preset.draft.metric)
-      expect(rule.kind, preset.id).toBe(`monitor.${expectedTrigger}`)
-    }
+  it("creates every all-tools recommended preset", async () => {
+    await assertPresetsCreate(toolMonitorPresets(allToolsMonitorTarget()), ALL_TOOLS_PRESET_EXPECTATIONS, "all tools")
   })
 
   it.each([
     ["specific user", userMonitorTarget("user-1")],
     ["all users", allUsersMonitorTarget()],
   ] as const)("creates every user recommended preset for %s", async (_label, target) => {
-    const presets = userMonitorPresets(target)
-    expect(presets.length).toBeGreaterThan(0)
-
-    for (const preset of presets) {
-      const rule = draftToAlertDraft(preset.draft)
-      const presetTarget = draftToTarget(preset.draft)
-      expect(presetTarget, preset.id).toBeDefined()
-      if (!presetTarget) continue
-
-      const monitor = await runCreate(
-        createFromUiDraft({
-          name: `${preset.name} — user`,
-          description: preset.description,
-          rule,
-          target: presetTarget,
-        }),
-      )
-
-      const expectedTrigger = preset.draft.metric.kind === "count" ? "escalating" : "threshold"
-      expect(monitor.rule.trigger, preset.id).toBe(expectedTrigger)
-      expect(monitor.target.metric, preset.id).toEqual(preset.draft.metric)
-    }
+    await assertPresetsCreate(userMonitorPresets(target), USER_PRESET_EXPECTATIONS, "user")
   })
 
   it("still rejects the pre-fix escalating + errorRate shape", async () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
@@ -25,10 +25,11 @@ type MonitorTrigger = "threshold" | "escalating" | "match"
 interface PresetExpectation {
   readonly trigger: MonitorTrigger
   readonly metric: MonitorMetric
+  readonly hasErrorStatusFilter?: boolean
 }
 
 const SPECIFIC_TOOL_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
-  failing: { trigger: "threshold", metric: { kind: "errorRate" } },
+  failing: { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
   slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
   "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
   "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
@@ -36,15 +37,14 @@ const SPECIFIC_TOOL_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
 }
 
 const ALL_TOOLS_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
-  "failures-increased": { trigger: "threshold", metric: { kind: "errorRate" } },
+  "failures-increased": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
   "latency-increased": { trigger: "threshold", metric: { kind: "median", field: "duration" } },
   "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
   "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
-  "cost-spike": { trigger: "threshold", metric: { kind: "sum", field: "cost" } },
 }
 
 const USER_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
-  errors: { trigger: "escalating", metric: { kind: "count" } },
+  errors: { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
   slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
   "activity-spike": { trigger: "escalating", metric: { kind: "count" } },
   "activity-drop": { trigger: "escalating", metric: { kind: "count" } },
@@ -133,6 +133,10 @@ const assertPresetsCreate = async (
     expect(presetTarget, preset.id).toBeDefined()
     if (!presetTarget) continue
 
+    if (expected.hasErrorStatusFilter) {
+      expect(presetTarget.filterSet?.status, preset.id).toEqual([{ op: "eq", value: "error" }])
+    }
+
     const monitor = await runCreate(
       createFromUiDraft({
         name: `${preset.name} — ${nameSuffix}`,
@@ -168,7 +172,7 @@ describe("recommended monitor presets", () => {
     await assertPresetsCreate(userMonitorPresets(target), USER_PRESET_EXPECTATIONS, "user")
   })
 
-  it("still rejects the pre-fix escalating + errorRate shape", async () => {
+  it("still rejects escalating + errorRate", async () => {
     const draft = targetAlertDraft(toolMonitorTarget("searchWeb"), {
       kind: "monitor.escalating",
       metric: { kind: "errorRate" },
@@ -197,16 +201,28 @@ describe("recommended monitor presets", () => {
     expect(error.message).toBe("Escalating monitors only support count metrics")
   })
 
-  it("maps Tool is failing to threshold + errorRate", () => {
+  it("maps Tool is failing to escalating error-call volume", () => {
     const failing = toolMonitorPresets(toolMonitorTarget("searchWeb")).find((preset) => preset.id === "failing")
     expect(failing).toBeDefined()
     if (!failing) return
-    expect(failing.draft.kind).toBe("monitor.threshold")
-    expect(failing.draft.metric).toEqual({ kind: "errorRate" })
+    expect(failing.draft.kind).toBe("monitor.escalating")
+    expect(failing.draft.metric).toEqual({ kind: "count" })
+    expect(failing.draft.target?.filterSet?.status).toEqual([{ op: "eq", value: "error" }])
     expect(draftToAlertDraft(failing.draft).condition).toMatchObject({
-      trigger: "threshold",
-      metric: { kind: "errorRate" },
+      trigger: "escalating",
+      metric: { kind: "count" },
       threshold: { mode: "expected", sensitivity: 3 },
+    })
+  })
+
+  it("maps Tool is slow to an absolute latency threshold", () => {
+    const slow = toolMonitorPresets(toolMonitorTarget("searchWeb")).find((preset) => preset.id === "slow")
+    expect(slow).toBeDefined()
+    if (!slow) return
+    expect(draftToAlertDraft(slow.draft).condition).toMatchObject({
+      trigger: "threshold",
+      metric: { kind: "median", field: "duration" },
+      threshold: { mode: "absolute", value: 2_000_000_000 },
     })
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.test.ts
@@ -25,30 +25,34 @@ type MonitorTrigger = "threshold" | "escalating" | "match"
 interface PresetExpectation {
   readonly trigger: MonitorTrigger
   readonly metric: MonitorMetric
-  readonly hasErrorStatusFilter?: boolean
+  readonly hasErrorStatusFilter: boolean
 }
 
 const SPECIFIC_TOOL_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
   failing: { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
-  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
-  "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
-  "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
-  overusing: { trigger: "escalating", metric: { kind: "count" } },
+  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" }, hasErrorStatusFilter: false },
+  "usage-spike": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
+  "usage-drop": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
+  overusing: { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
 }
 
 const ALL_TOOLS_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
   "failures-increased": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
-  "latency-increased": { trigger: "threshold", metric: { kind: "median", field: "duration" } },
-  "usage-spike": { trigger: "escalating", metric: { kind: "count" } },
-  "usage-drop": { trigger: "escalating", metric: { kind: "count" } },
+  "latency-increased": {
+    trigger: "threshold",
+    metric: { kind: "median", field: "duration" },
+    hasErrorStatusFilter: false,
+  },
+  "usage-spike": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
+  "usage-drop": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
 }
 
 const USER_PRESET_EXPECTATIONS: Record<string, PresetExpectation> = {
   errors: { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: true },
-  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" } },
-  "activity-spike": { trigger: "escalating", metric: { kind: "count" } },
-  "activity-drop": { trigger: "escalating", metric: { kind: "count" } },
-  "cost-spike": { trigger: "threshold", metric: { kind: "sum", field: "cost" } },
+  slow: { trigger: "threshold", metric: { kind: "median", field: "duration" }, hasErrorStatusFilter: false },
+  "activity-spike": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
+  "activity-drop": { trigger: "escalating", metric: { kind: "count" }, hasErrorStatusFilter: false },
+  "cost-spike": { trigger: "threshold", metric: { kind: "sum", field: "cost" }, hasErrorStatusFilter: false },
 }
 
 const triggerForAlertKind = (kind: MonitorRuleDraft["kind"]) =>
@@ -133,9 +137,9 @@ const assertPresetsCreate = async (
     expect(presetTarget, preset.id).toBeDefined()
     if (!presetTarget) continue
 
-    if (expected.hasErrorStatusFilter) {
-      expect(presetTarget.filterSet?.status, preset.id).toEqual([{ op: "eq", value: "error" }])
-    }
+    expect(presetTarget.filterSet?.status, preset.id).toEqual(
+      expected.hasErrorStatusFilter ? [{ op: "eq", value: "error" }] : undefined,
+    )
 
     const monitor = await runCreate(
       createFromUiDraft({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.ts
@@ -1,0 +1,228 @@
+import type { MonitorTarget } from "@domain/monitors"
+import {
+  AlertTriangleIcon,
+  CoinsIcon,
+  GaugeIcon,
+  type LucideIcon,
+  TrendingDownIcon,
+  TrendingUpIcon,
+  ZapIcon,
+} from "lucide-react"
+import { describeMonitorTarget } from "../../../../../../domains/monitors/monitor-target.ts"
+import { type AlertDraft, targetAlertDraft } from "./alert-form-helpers.ts"
+
+interface RecommendedMonitorPreset {
+  readonly id: string
+  readonly name: string
+  readonly description: string
+  readonly icon: LucideIcon
+  readonly draft: AlertDraft
+}
+
+const expectedRelativeDraft = (
+  target: MonitorTarget,
+  kind: "monitor.threshold" | "monitor.escalating",
+  overrides: Partial<AlertDraft>,
+): AlertDraft =>
+  targetAlertDraft(target, {
+    kind,
+    comparison: "timesMoreThan",
+    baselineKind: "expected",
+    amount: 3,
+    windowAmount: 15,
+    windowUnit: "minutes",
+    ...overrides,
+  })
+
+const targetWithFilter = (
+  target: MonitorTarget,
+  filterSet: NonNullable<MonitorTarget["filterSet"]>,
+): MonitorTarget => ({
+  ...target,
+  filterSet: { ...(target.filterSet ?? {}), ...filterSet },
+})
+
+export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedMonitorPreset[] => {
+  const allTools = describeMonitorTarget(target)?.kind === "allTools"
+  if (allTools) {
+    return [
+      {
+        id: "failures-increased",
+        name: "Tool failures increased",
+        description: "Opens an incident when the overall tool error rate stays higher than expected.",
+        icon: AlertTriangleIcon,
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "errorRate" },
+          severity: "high",
+        }),
+      },
+      {
+        id: "latency-increased",
+        name: "Tool latency increased",
+        description: "Opens an incident when median latency across tool calls stays higher than expected.",
+        icon: GaugeIcon,
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "median", field: "duration" },
+          severity: "medium",
+        }),
+      },
+      {
+        id: "usage-spike",
+        name: "Tool usage spiked",
+        description: "Opens an incident when total tool call volume stays higher than expected.",
+        icon: TrendingUpIcon,
+        draft: expectedRelativeDraft(target, "monitor.escalating", {
+          metric: { kind: "count" },
+          severity: "medium",
+          windowAmount: 30,
+        }),
+      },
+      {
+        id: "usage-drop",
+        name: "Tool usage dropped",
+        description: "Opens an incident when total tool call volume stays lower than expected.",
+        icon: TrendingDownIcon,
+        draft: expectedRelativeDraft(target, "monitor.escalating", {
+          metric: { kind: "count" },
+          direction: "below",
+          severity: "medium",
+          windowAmount: 60,
+        }),
+      },
+      {
+        id: "cost-spike",
+        name: "Tool cost spiked",
+        description: "Opens an incident when total tool-call cost stays higher than expected.",
+        icon: ZapIcon,
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "sum", field: "cost" },
+          severity: "medium",
+          windowAmount: 30,
+        }),
+      },
+    ]
+  }
+
+  return [
+    {
+      id: "failing",
+      name: "Tool is failing",
+      description: "Opens an incident when the tool's error rate stays higher than expected.",
+      icon: AlertTriangleIcon,
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "errorRate" },
+        severity: "high",
+      }),
+    },
+    {
+      id: "slow",
+      name: "Tool is slow",
+      description: "Opens an incident when median latency stays higher than expected.",
+      icon: GaugeIcon,
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "median", field: "duration" },
+        severity: "medium",
+      }),
+    },
+    {
+      id: "usage-spike",
+      name: "Usage spiked",
+      description: "Opens an incident when call volume stays higher than expected.",
+      icon: TrendingUpIcon,
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "medium",
+      }),
+    },
+    {
+      id: "usage-drop",
+      name: "Usage dropped",
+      description: "Opens an incident when call volume stays lower than expected.",
+      icon: TrendingDownIcon,
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        direction: "below",
+        severity: "medium",
+        windowAmount: 30,
+      }),
+    },
+    {
+      id: "overusing",
+      name: "Agent is overusing it",
+      description: "Opens an incident when calls stay unusually elevated, a common sign of loops or retries.",
+      icon: ZapIcon,
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "high",
+        amount: 2,
+      }),
+    },
+  ]
+}
+
+export const userMonitorPresets = (target: MonitorTarget): readonly RecommendedMonitorPreset[] => {
+  const allUsers = describeMonitorTarget(target)?.kind === "allUsers"
+  const subject = allUsers ? "users" : "this user"
+  return [
+    {
+      id: "errors",
+      name: allUsers ? "Users are having errors" : "User is having errors",
+      description: `Opens an incident when failed traces for ${subject} stay higher than expected.`,
+      icon: AlertTriangleIcon,
+      draft: expectedRelativeDraft(
+        targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }),
+        "monitor.escalating",
+        {
+          metric: { kind: "count" },
+          severity: "high",
+          windowAmount: 30,
+        },
+      ),
+    },
+    {
+      id: "slow",
+      name: allUsers ? "Users are seeing slow responses" : "User is seeing slow responses",
+      description: `Opens an incident when median trace latency for ${subject} stays higher than expected.`,
+      icon: GaugeIcon,
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "median", field: "duration" },
+        severity: "medium",
+        windowAmount: 15,
+      }),
+    },
+    {
+      id: "activity-spike",
+      name: "Activity spiked",
+      description: `Opens an incident when session volume for ${subject} stays higher than expected.`,
+      icon: TrendingUpIcon,
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "medium",
+        windowAmount: 30,
+      }),
+    },
+    {
+      id: "activity-drop",
+      name: "Activity dropped",
+      description: `Opens an incident when session volume for ${subject} stays lower than expected.`,
+      icon: TrendingDownIcon,
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        direction: "below",
+        severity: "medium",
+        windowAmount: 60,
+      }),
+    },
+    {
+      id: "cost-spike",
+      name: "Cost spiked",
+      description: `Opens an incident when total cost for ${subject} stays higher than expected.`,
+      icon: CoinsIcon,
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "sum", field: "cost" },
+        severity: "medium",
+        windowAmount: 30,
+      }),
+    },
+  ]
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/recommended-monitor-presets.ts
@@ -19,18 +19,24 @@ interface RecommendedMonitorPreset {
   readonly draft: AlertDraft
 }
 
-const expectedRelativeDraft = (
-  target: MonitorTarget,
-  kind: "monitor.threshold" | "monitor.escalating",
-  overrides: Partial<AlertDraft>,
-): AlertDraft =>
+const escalatingCountDraft = (target: MonitorTarget, overrides: Partial<AlertDraft> = {}): AlertDraft =>
   targetAlertDraft(target, {
-    kind,
+    kind: "monitor.escalating",
     comparison: "timesMoreThan",
     baselineKind: "expected",
     amount: 3,
     windowAmount: 15,
     windowUnit: "minutes",
+    metric: { kind: "count" },
+    ...overrides,
+  })
+
+const absoluteThresholdDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): AlertDraft =>
+  targetAlertDraft(target, {
+    kind: "monitor.threshold",
+    comparison: "times",
+    amount: 1,
+    direction: "above",
     ...overrides,
   })
 
@@ -42,6 +48,9 @@ const targetWithFilter = (
   filterSet: { ...(target.filterSet ?? {}), ...filterSet },
 })
 
+const failingToolTarget = (target: MonitorTarget): MonitorTarget =>
+  targetWithFilter(target, { status: [{ op: "eq", value: "error" }] })
+
 export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedMonitorPreset[] => {
   const allTools = describeMonitorTarget(target)?.kind === "allTools"
   if (allTools) {
@@ -49,20 +58,18 @@ export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedM
       {
         id: "failures-increased",
         name: "Tool failures increased",
-        description: "Opens an incident when the overall tool error rate stays higher than expected.",
+        description: "Opens an incident when failed tool calls stay higher than expected.",
         icon: AlertTriangleIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
-          metric: { kind: "errorRate" },
-          severity: "high",
-        }),
+        draft: escalatingCountDraft(failingToolTarget(target), { severity: "high" }),
       },
       {
         id: "latency-increased",
         name: "Tool latency increased",
-        description: "Opens an incident when median latency across tool calls stays higher than expected.",
+        description: "Opens an incident when median latency across tool calls exceeds 2s.",
         icon: GaugeIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
+        draft: absoluteThresholdDraft(target, {
           metric: { kind: "median", field: "duration" },
+          amount: 2,
           severity: "medium",
         }),
       },
@@ -71,33 +78,17 @@ export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedM
         name: "Tool usage spiked",
         description: "Opens an incident when total tool call volume stays higher than expected.",
         icon: TrendingUpIcon,
-        draft: expectedRelativeDraft(target, "monitor.escalating", {
-          metric: { kind: "count" },
-          severity: "medium",
-          windowAmount: 30,
-        }),
+        draft: escalatingCountDraft(target, { severity: "medium", windowAmount: 30 }),
       },
       {
         id: "usage-drop",
         name: "Tool usage dropped",
         description: "Opens an incident when total tool call volume stays lower than expected.",
         icon: TrendingDownIcon,
-        draft: expectedRelativeDraft(target, "monitor.escalating", {
-          metric: { kind: "count" },
+        draft: escalatingCountDraft(target, {
           direction: "below",
           severity: "medium",
           windowAmount: 60,
-        }),
-      },
-      {
-        id: "cost-spike",
-        name: "Tool cost spiked",
-        description: "Opens an incident when total tool-call cost stays higher than expected.",
-        icon: ZapIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
-          metric: { kind: "sum", field: "cost" },
-          severity: "medium",
-          windowAmount: 30,
         }),
       },
     ]
@@ -107,20 +98,18 @@ export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedM
     {
       id: "failing",
       name: "Tool is failing",
-      description: "Opens an incident when the tool's error rate stays higher than expected.",
+      description: "Opens an incident when failed calls for this tool stay higher than expected.",
       icon: AlertTriangleIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
-        metric: { kind: "errorRate" },
-        severity: "high",
-      }),
+      draft: escalatingCountDraft(failingToolTarget(target), { severity: "high" }),
     },
     {
       id: "slow",
       name: "Tool is slow",
-      description: "Opens an incident when median latency stays higher than expected.",
+      description: "Opens an incident when median latency exceeds 2s.",
       icon: GaugeIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
+      draft: absoluteThresholdDraft(target, {
         metric: { kind: "median", field: "duration" },
+        amount: 2,
         severity: "medium",
       }),
     },
@@ -129,18 +118,14 @@ export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedM
       name: "Usage spiked",
       description: "Opens an incident when call volume stays higher than expected.",
       icon: TrendingUpIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "medium",
-      }),
+      draft: escalatingCountDraft(target, { severity: "medium" }),
     },
     {
       id: "usage-drop",
       name: "Usage dropped",
       description: "Opens an incident when call volume stays lower than expected.",
       icon: TrendingDownIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
+      draft: escalatingCountDraft(target, {
         direction: "below",
         severity: "medium",
         windowAmount: 30,
@@ -151,11 +136,7 @@ export const toolMonitorPresets = (target: MonitorTarget): readonly RecommendedM
       name: "Agent is overusing it",
       description: "Opens an incident when calls stay unusually elevated, a common sign of loops or retries.",
       icon: ZapIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "high",
-        amount: 2,
-      }),
+      draft: escalatingCountDraft(target, { severity: "high", amount: 2 }),
     },
   ]
 }
@@ -169,25 +150,20 @@ export const userMonitorPresets = (target: MonitorTarget): readonly RecommendedM
       name: allUsers ? "Users are having errors" : "User is having errors",
       description: `Opens an incident when failed traces for ${subject} stay higher than expected.`,
       icon: AlertTriangleIcon,
-      draft: expectedRelativeDraft(
-        targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }),
-        "monitor.escalating",
-        {
-          metric: { kind: "count" },
-          severity: "high",
-          windowAmount: 30,
-        },
-      ),
+      draft: escalatingCountDraft(targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }), {
+        severity: "high",
+        windowAmount: 30,
+      }),
     },
     {
       id: "slow",
       name: allUsers ? "Users are seeing slow responses" : "User is seeing slow responses",
-      description: `Opens an incident when median trace latency for ${subject} stays higher than expected.`,
+      description: `Opens an incident when median trace latency for ${subject} exceeds 2s.`,
       icon: GaugeIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
+      draft: absoluteThresholdDraft(target, {
         metric: { kind: "median", field: "duration" },
+        amount: 2,
         severity: "medium",
-        windowAmount: 15,
       }),
     },
     {
@@ -195,19 +171,14 @@ export const userMonitorPresets = (target: MonitorTarget): readonly RecommendedM
       name: "Activity spiked",
       description: `Opens an incident when session volume for ${subject} stays higher than expected.`,
       icon: TrendingUpIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "medium",
-        windowAmount: 30,
-      }),
+      draft: escalatingCountDraft(target, { severity: "medium", windowAmount: 30 }),
     },
     {
       id: "activity-drop",
       name: "Activity dropped",
       description: `Opens an incident when session volume for ${subject} stays lower than expected.`,
       icon: TrendingDownIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
+      draft: escalatingCountDraft(target, {
         direction: "below",
         severity: "medium",
         windowAmount: 60,
@@ -216,12 +187,12 @@ export const userMonitorPresets = (target: MonitorTarget): readonly RecommendedM
     {
       id: "cost-spike",
       name: "Cost spiked",
-      description: `Opens an incident when total cost for ${subject} stays higher than expected.`,
+      description: `Opens an incident when total cost for ${subject} exceeds $10 in the evaluation window.`,
       icon: CoinsIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
+      draft: absoluteThresholdDraft(target, {
         metric: { kind: "sum", field: "cost" },
+        amount: 10,
         severity: "medium",
-        windowAmount: 30,
       }),
     },
   ]

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
@@ -24,9 +24,13 @@ interface ToolMonitorPreset {
   readonly draft: AlertDraft
 }
 
-const presetDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): AlertDraft =>
+const expectedRelativeDraft = (
+  target: MonitorTarget,
+  kind: "monitor.threshold" | "monitor.escalating",
+  overrides: Partial<AlertDraft>,
+): AlertDraft =>
   targetAlertDraft(target, {
-    kind: "monitor.escalating",
+    kind,
     comparison: "timesMoreThan",
     baselineKind: "expected",
     amount: 3,
@@ -44,28 +48,38 @@ const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[]
         name: "Tool failures increased",
         description: "Opens an incident when the overall tool error rate stays higher than expected.",
         icon: AlertTriangleIcon,
-        draft: presetDraft(target, { metric: { kind: "errorRate" }, severity: "high" }),
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "errorRate" },
+          severity: "high",
+        }),
       },
       {
         id: "latency-increased",
         name: "Tool latency increased",
         description: "Opens an incident when median latency across tool calls stays higher than expected.",
         icon: GaugeIcon,
-        draft: presetDraft(target, { metric: { kind: "median", field: "duration" }, severity: "medium" }),
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "median", field: "duration" },
+          severity: "medium",
+        }),
       },
       {
         id: "usage-spike",
         name: "Tool usage spiked",
         description: "Opens an incident when total tool call volume stays higher than expected.",
         icon: TrendingUpIcon,
-        draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium", windowAmount: 30 }),
+        draft: expectedRelativeDraft(target, "monitor.escalating", {
+          metric: { kind: "count" },
+          severity: "medium",
+          windowAmount: 30,
+        }),
       },
       {
         id: "usage-drop",
         name: "Tool usage dropped",
         description: "Opens an incident when total tool call volume stays lower than expected.",
         icon: TrendingDownIcon,
-        draft: presetDraft(target, {
+        draft: expectedRelativeDraft(target, "monitor.escalating", {
           metric: { kind: "count" },
           direction: "below",
           severity: "medium",
@@ -77,7 +91,11 @@ const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[]
         name: "Tool cost spiked",
         description: "Opens an incident when total tool-call cost stays higher than expected.",
         icon: ZapIcon,
-        draft: presetDraft(target, { metric: { kind: "sum", field: "cost" }, severity: "medium", windowAmount: 30 }),
+        draft: expectedRelativeDraft(target, "monitor.threshold", {
+          metric: { kind: "sum", field: "cost" },
+          severity: "medium",
+          windowAmount: 30,
+        }),
       },
     ]
   }
@@ -88,28 +106,37 @@ const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[]
       name: "Tool is failing",
       description: "Opens an incident when the tool's error rate stays higher than expected.",
       icon: AlertTriangleIcon,
-      draft: presetDraft(target, { metric: { kind: "errorRate" }, severity: "high" }),
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "errorRate" },
+        severity: "high",
+      }),
     },
     {
       id: "slow",
       name: "Tool is slow",
       description: "Opens an incident when median latency stays higher than expected.",
       icon: GaugeIcon,
-      draft: presetDraft(target, { metric: { kind: "median", field: "duration" }, severity: "medium" }),
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "median", field: "duration" },
+        severity: "medium",
+      }),
     },
     {
       id: "usage-spike",
       name: "Usage spiked",
       description: "Opens an incident when call volume stays higher than expected.",
       icon: TrendingUpIcon,
-      draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium" }),
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "medium",
+      }),
     },
     {
       id: "usage-drop",
       name: "Usage dropped",
       description: "Opens an incident when call volume stays lower than expected.",
       icon: TrendingDownIcon,
-      draft: presetDraft(target, {
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
         metric: { kind: "count" },
         direction: "below",
         severity: "medium",
@@ -121,7 +148,11 @@ const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[]
       name: "Agent is overusing it",
       description: "Opens an incident when calls stay unusually elevated, a common sign of loops or retries.",
       icon: ZapIcon,
-      draft: presetDraft(target, { metric: { kind: "count" }, severity: "high", amount: 2 }),
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "high",
+        amount: 2,
+      }),
     },
   ]
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/tool-monitor-create-modal.tsx
@@ -1,13 +1,11 @@
 import type { MonitorTarget } from "@domain/monitors"
 import { Button, cn, Icon, Modal, Text, useToast } from "@repo/ui"
-import { AlertTriangleIcon, GaugeIcon, TrendingDownIcon, TrendingUpIcon, ZapIcon } from "lucide-react"
 import { useState } from "react"
-import { describeMonitorTarget, monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
+import { monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
 import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
 import { AdvancedMonitorCreateFields, type AdvancedMonitorCreateValue } from "./advanced-monitor-create-fields.tsx"
 import {
-  type AlertDraft,
   alertFieldErrorsFrom,
   draftToAlertDraft,
   draftToTarget,
@@ -15,147 +13,7 @@ import {
   targetAlertDraft,
 } from "./alert-form-helpers.ts"
 import { type MonitorCreateMode, MonitorModeSwitch } from "./monitor-mode-switch.tsx"
-
-interface ToolMonitorPreset {
-  readonly id: string
-  readonly name: string
-  readonly description: string
-  readonly icon: typeof AlertTriangleIcon
-  readonly draft: AlertDraft
-}
-
-const expectedRelativeDraft = (
-  target: MonitorTarget,
-  kind: "monitor.threshold" | "monitor.escalating",
-  overrides: Partial<AlertDraft>,
-): AlertDraft =>
-  targetAlertDraft(target, {
-    kind,
-    comparison: "timesMoreThan",
-    baselineKind: "expected",
-    amount: 3,
-    windowAmount: 15,
-    windowUnit: "minutes",
-    ...overrides,
-  })
-
-const toolMonitorPresets = (target: MonitorTarget): readonly ToolMonitorPreset[] => {
-  const allTools = describeMonitorTarget(target)?.kind === "allTools"
-  if (allTools) {
-    return [
-      {
-        id: "failures-increased",
-        name: "Tool failures increased",
-        description: "Opens an incident when the overall tool error rate stays higher than expected.",
-        icon: AlertTriangleIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
-          metric: { kind: "errorRate" },
-          severity: "high",
-        }),
-      },
-      {
-        id: "latency-increased",
-        name: "Tool latency increased",
-        description: "Opens an incident when median latency across tool calls stays higher than expected.",
-        icon: GaugeIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
-          metric: { kind: "median", field: "duration" },
-          severity: "medium",
-        }),
-      },
-      {
-        id: "usage-spike",
-        name: "Tool usage spiked",
-        description: "Opens an incident when total tool call volume stays higher than expected.",
-        icon: TrendingUpIcon,
-        draft: expectedRelativeDraft(target, "monitor.escalating", {
-          metric: { kind: "count" },
-          severity: "medium",
-          windowAmount: 30,
-        }),
-      },
-      {
-        id: "usage-drop",
-        name: "Tool usage dropped",
-        description: "Opens an incident when total tool call volume stays lower than expected.",
-        icon: TrendingDownIcon,
-        draft: expectedRelativeDraft(target, "monitor.escalating", {
-          metric: { kind: "count" },
-          direction: "below",
-          severity: "medium",
-          windowAmount: 60,
-        }),
-      },
-      {
-        id: "cost-spike",
-        name: "Tool cost spiked",
-        description: "Opens an incident when total tool-call cost stays higher than expected.",
-        icon: ZapIcon,
-        draft: expectedRelativeDraft(target, "monitor.threshold", {
-          metric: { kind: "sum", field: "cost" },
-          severity: "medium",
-          windowAmount: 30,
-        }),
-      },
-    ]
-  }
-
-  return [
-    {
-      id: "failing",
-      name: "Tool is failing",
-      description: "Opens an incident when the tool's error rate stays higher than expected.",
-      icon: AlertTriangleIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
-        metric: { kind: "errorRate" },
-        severity: "high",
-      }),
-    },
-    {
-      id: "slow",
-      name: "Tool is slow",
-      description: "Opens an incident when median latency stays higher than expected.",
-      icon: GaugeIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
-        metric: { kind: "median", field: "duration" },
-        severity: "medium",
-      }),
-    },
-    {
-      id: "usage-spike",
-      name: "Usage spiked",
-      description: "Opens an incident when call volume stays higher than expected.",
-      icon: TrendingUpIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "medium",
-      }),
-    },
-    {
-      id: "usage-drop",
-      name: "Usage dropped",
-      description: "Opens an incident when call volume stays lower than expected.",
-      icon: TrendingDownIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        direction: "below",
-        severity: "medium",
-        windowAmount: 30,
-      }),
-    },
-    {
-      id: "overusing",
-      name: "Agent is overusing it",
-      description: "Opens an incident when calls stay unusually elevated, a common sign of loops or retries.",
-      icon: ZapIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "high",
-        amount: 2,
-      }),
-    },
-  ]
-}
+import { toolMonitorPresets } from "./recommended-monitor-presets.ts"
 
 export function ToolMonitorCreateModal({
   projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
@@ -1,13 +1,11 @@
 import type { MonitorTarget } from "@domain/monitors"
 import { Button, cn, Icon, Modal, Text, useToast } from "@repo/ui"
-import { AlertTriangleIcon, CoinsIcon, GaugeIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react"
 import { useState } from "react"
-import { describeMonitorTarget, monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
+import { monitorTargetName } from "../../../../../../domains/monitors/monitor-target.ts"
 import { useCreateMonitor } from "../../../../../../domains/monitors/monitors.collection.ts"
 import { extractFieldErrors, toUserMessage } from "../../../../../../lib/errors.ts"
 import { AdvancedMonitorCreateFields, type AdvancedMonitorCreateValue } from "./advanced-monitor-create-fields.tsx"
 import {
-  type AlertDraft,
   alertFieldErrorsFrom,
   draftToAlertDraft,
   draftToTarget,
@@ -15,101 +13,7 @@ import {
   targetAlertDraft,
 } from "./alert-form-helpers.ts"
 import { type MonitorCreateMode, MonitorModeSwitch } from "./monitor-mode-switch.tsx"
-
-interface UserMonitorPreset {
-  readonly id: string
-  readonly name: string
-  readonly description: string
-  readonly icon: typeof AlertTriangleIcon
-  readonly draft: AlertDraft
-}
-
-const targetWithFilter = (
-  target: MonitorTarget,
-  filterSet: NonNullable<MonitorTarget["filterSet"]>,
-): MonitorTarget => ({
-  ...target,
-  filterSet: { ...(target.filterSet ?? {}), ...filterSet },
-})
-
-const expectedRelativeDraft = (
-  target: MonitorTarget,
-  kind: "monitor.threshold" | "monitor.escalating",
-  overrides: Partial<AlertDraft>,
-): AlertDraft =>
-  targetAlertDraft(target, {
-    kind,
-    comparison: "timesMoreThan",
-    baselineKind: "expected",
-    amount: 3,
-    windowAmount: 30,
-    windowUnit: "minutes",
-    ...overrides,
-  })
-
-const userMonitorPresets = (target: MonitorTarget): readonly UserMonitorPreset[] => {
-  const allUsers = describeMonitorTarget(target)?.kind === "allUsers"
-  const subject = allUsers ? "users" : "this user"
-  return [
-    {
-      id: "errors",
-      name: allUsers ? "Users are having errors" : "User is having errors",
-      description: `Opens an incident when failed traces for ${subject} stay higher than expected.`,
-      icon: AlertTriangleIcon,
-      draft: expectedRelativeDraft(
-        targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }),
-        "monitor.escalating",
-        {
-          metric: { kind: "count" },
-          severity: "high",
-        },
-      ),
-    },
-    {
-      id: "slow",
-      name: allUsers ? "Users are seeing slow responses" : "User is seeing slow responses",
-      description: `Opens an incident when median trace latency for ${subject} stays higher than expected.`,
-      icon: GaugeIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
-        metric: { kind: "median", field: "duration" },
-        severity: "medium",
-        windowAmount: 15,
-      }),
-    },
-    {
-      id: "activity-spike",
-      name: "Activity spiked",
-      description: `Opens an incident when session volume for ${subject} stays higher than expected.`,
-      icon: TrendingUpIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        severity: "medium",
-      }),
-    },
-    {
-      id: "activity-drop",
-      name: "Activity dropped",
-      description: `Opens an incident when session volume for ${subject} stays lower than expected.`,
-      icon: TrendingDownIcon,
-      draft: expectedRelativeDraft(target, "monitor.escalating", {
-        metric: { kind: "count" },
-        direction: "below",
-        severity: "medium",
-        windowAmount: 60,
-      }),
-    },
-    {
-      id: "cost-spike",
-      name: "Cost spiked",
-      description: `Opens an incident when total cost for ${subject} stays higher than expected.`,
-      icon: CoinsIcon,
-      draft: expectedRelativeDraft(target, "monitor.threshold", {
-        metric: { kind: "sum", field: "cost" },
-        severity: "medium",
-      }),
-    },
-  ]
-}
+import { userMonitorPresets } from "./recommended-monitor-presets.ts"
 
 export function UserMonitorCreateModal({
   projectId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/monitors/-components/user-monitor-create-modal.tsx
@@ -32,9 +32,13 @@ const targetWithFilter = (
   filterSet: { ...(target.filterSet ?? {}), ...filterSet },
 })
 
-const presetDraft = (target: MonitorTarget, overrides: Partial<AlertDraft>): AlertDraft =>
+const expectedRelativeDraft = (
+  target: MonitorTarget,
+  kind: "monitor.threshold" | "monitor.escalating",
+  overrides: Partial<AlertDraft>,
+): AlertDraft =>
   targetAlertDraft(target, {
-    kind: "monitor.escalating",
+    kind,
     comparison: "timesMoreThan",
     baselineKind: "expected",
     amount: 3,
@@ -52,17 +56,21 @@ const userMonitorPresets = (target: MonitorTarget): readonly UserMonitorPreset[]
       name: allUsers ? "Users are having errors" : "User is having errors",
       description: `Opens an incident when failed traces for ${subject} stay higher than expected.`,
       icon: AlertTriangleIcon,
-      draft: presetDraft(targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }), {
-        metric: { kind: "count" },
-        severity: "high",
-      }),
+      draft: expectedRelativeDraft(
+        targetWithFilter(target, { status: [{ op: "eq", value: "error" }] }),
+        "monitor.escalating",
+        {
+          metric: { kind: "count" },
+          severity: "high",
+        },
+      ),
     },
     {
       id: "slow",
       name: allUsers ? "Users are seeing slow responses" : "User is seeing slow responses",
       description: `Opens an incident when median trace latency for ${subject} stays higher than expected.`,
       icon: GaugeIcon,
-      draft: presetDraft(target, {
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
         metric: { kind: "median", field: "duration" },
         severity: "medium",
         windowAmount: 15,
@@ -73,14 +81,17 @@ const userMonitorPresets = (target: MonitorTarget): readonly UserMonitorPreset[]
       name: "Activity spiked",
       description: `Opens an incident when session volume for ${subject} stays higher than expected.`,
       icon: TrendingUpIcon,
-      draft: presetDraft(target, { metric: { kind: "count" }, severity: "medium" }),
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
+        metric: { kind: "count" },
+        severity: "medium",
+      }),
     },
     {
       id: "activity-drop",
       name: "Activity dropped",
       description: `Opens an incident when session volume for ${subject} stays lower than expected.`,
       icon: TrendingDownIcon,
-      draft: presetDraft(target, {
+      draft: expectedRelativeDraft(target, "monitor.escalating", {
         metric: { kind: "count" },
         direction: "below",
         severity: "medium",
@@ -92,7 +103,10 @@ const userMonitorPresets = (target: MonitorTarget): readonly UserMonitorPreset[]
       name: "Cost spiked",
       description: `Opens an incident when total cost for ${subject} stays higher than expected.`,
       icon: CoinsIcon,
-      draft: presetDraft(target, { metric: { kind: "sum", field: "cost" }, severity: "medium" }),
+      draft: expectedRelativeDraft(target, "monitor.threshold", {
+        metric: { kind: "sum", field: "cost" },
+        severity: "medium",
+      }),
     },
   ]
 }

--- a/packages/domain/monitors/src/use-cases/create-monitor.test.ts
+++ b/packages/domain/monitors/src/use-cases/create-monitor.test.ts
@@ -181,6 +181,48 @@ describe("createMonitorUseCase", () => {
     expect(error.message).toBe("Condition trigger must match monitor trigger")
   })
 
+  it("creates a threshold monitor with errorRate and expected baseline", async () => {
+    const { repo } = createFakeMonitorRepository()
+
+    const result = await run(
+      createMonitorUseCase({
+        organizationId,
+        projectId,
+        name: "Tool is failing",
+        target: {
+          type: "tool",
+          id: null,
+          filterSet: {
+            operation: [{ op: "eq", value: "execute_tool" }],
+            toolName: [{ op: "eq", value: "searchWeb" }],
+          },
+        },
+        rule: {
+          trigger: "threshold",
+          severity: "high",
+          config: {
+            metric: { kind: "errorRate" },
+            condition: {
+              trigger: "threshold",
+              metric: { kind: "errorRate" },
+              threshold: { mode: "expected", sensitivity: 3 },
+              direction: "above",
+            },
+          },
+        },
+      }),
+      repo,
+    )
+
+    expect(result.rule.trigger).toBe("threshold")
+    expect(result.target.metric).toEqual({ kind: "errorRate" })
+    expect(result.rule.config.condition).toMatchObject({
+      trigger: "threshold",
+      metric: { kind: "errorRate" },
+      threshold: { mode: "expected", sensitivity: 3 },
+    })
+  })
+
   it("rejects unsupported escalating metric and threshold shapes", async () => {
     const { repo } = createFakeMonitorRepository()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recommended tool monitors like **Tool is failing** failed create with `Escalating monitors only support count metrics`, because every recommended preset submitted an escalating rule even when the metric was `errorRate`, latency, or cost.

## Fix

- **Failure presets** → escalating + count of `status=error` calls (same shape as user error presets; works with the count-oriented seasonal engine)
- **Latency presets** → absolute threshold at 2s median (expected-mode sigma floor is count-oriented and cold-starts at ~3ns)
- **User cost** → absolute $10 sum; **removed** all-tools cost preset (`execute_tool` spans are usage-gated so cost is always NULL)
- Volume presets stay escalating + count + expected
- Advanced form: Escalating coerces/restricts to count

## QA

- [x] Every recommended tool/user preset creates via the UI draft → `createMonitorUseCase` mapping
- [x] Explicit per-preset metric/trigger expectation tables
- [x] Domain create-monitor tests + `@app/web` typecheck
- Codex P1/P2 threads addressed and resolved

## Test plan

- [ ] Create **Tool is failing** for a specific tool → succeeds as escalating failed-call volume
- [ ] Create **Tool is slow** → absolute 2s median threshold
- [ ] Create **Usage spiked** → escalating + count
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b256790-4063-47cb-9410-d9c4dc10bd39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b256790-4063-47cb-9410-d9c4dc10bd39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared recommended monitoring presets for tools and users, with target-aware preset options and error-only filtering where applicable.
* **Bug Fixes**
  * Escalating alert types now enforce count-based metrics and restrict selectable metric dimensions accordingly.
  * Switching alert kinds in drafts now resets to count for escalating kinds while preserving compatible metrics for other transitions.
* **Tests**
  * Expanded coverage for preset-driven monitor creation and alert-draft conversions, including expected-condition mapping and new escalation/count validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->