### PR TITLE
fix(hermes): stop exporting empty conversation placeholders

### DIFF
--- a/packages/telemetry/hermes/CHANGELOG.md
+++ b/packages/telemetry/hermes/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2]
+
+### Fixed
+
+- Stop exporting empty conversation placeholders. Blank or whitespace-only user/assistant turns no longer become `{ type: "text", content: "" }` parts that render as empty bubbles in Latitude. Tool-only assistant turns still export as `tool_call` parts. Content-list `tool_use` blocks now count toward keeping the interaction open so following `tool_execution` spans are not dropped. The interaction root only attaches `user_prompt` / `gen_ai.input.messages` when the current turn has real user text (blank trailing user turns are omitted, not backfilled from an earlier prompt).
+
 ## [0.1.1]
 
 ### Fixed

--- a/packages/telemetry/hermes/pyproject.toml
+++ b/packages/telemetry/hermes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry-hermes"
-version = "0.1.1"
+version = "0.1.2"
 description = "Hermes Agent plugin that streams sessions to Latitude as OTLP traces"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
@@ -223,26 +223,30 @@ class _Builder:
         task_id = kw.get("task_id") or ""
         trace_id = _trace_id()
         first_user = _last_user_text(messages) or _coerce_text(kw.get("user_message"))
+        root_attrs: Dict[str, Any] = {
+            "span.type": "interaction",
+            "interaction.kind": "user",
+            "session.id": session_id,
+            "gen_ai.session.id": session_id,
+            "hermes.task_id": task_id or None,
+            "hermes.turn_id": kw.get("turn_id") or None,
+            "latitude.tags": ["hermes"],
+            "latitude.metadata": {"hermes.session.id": session_id, "hermes.task_id": task_id}
+            if task_id
+            else {"hermes.session.id": session_id},
+        }
+        if isinstance(first_user, str) and first_user.strip():
+            root_attrs["user_prompt:gated"] = first_user
+            root_attrs["gen_ai.input.messages:gated"] = [
+                {"role": "user", "parts": [{"type": "text", "content": first_user}]}
+            ]
         root = _Span(
             trace_id=trace_id,
             span_id=_span_id(),
             parent_span_id="",
             name="interaction",
             start_ms=now,
-            attrs={
-                "span.type": "interaction",
-                "interaction.kind": "user",
-                "session.id": session_id,
-                "gen_ai.session.id": session_id,
-                "hermes.task_id": task_id or None,
-                "hermes.turn_id": kw.get("turn_id") or None,
-                "latitude.tags": ["hermes"],
-                "latitude.metadata": {"hermes.session.id": session_id, "hermes.task_id": task_id}
-                if task_id
-                else {"hermes.session.id": session_id},
-                "user_prompt:gated": first_user,
-                "gen_ai.input.messages:gated": [{"role": "user", "parts": [{"type": "text", "content": first_user}]}],
-            },
+            attrs=root_attrs,
         )
         self._evict_locked()
         return _Run(trace_key=key, trace_id=trace_id, root=root, session_id=session_id, task_id=task_id)
@@ -328,7 +332,9 @@ def _last_user_text(messages: Any) -> Optional[str]:
         return None
     for m in reversed(messages):
         if isinstance(m, dict) and m.get("role") == "user":
-            return _coerce_text(m.get("content"))
+            text = _coerce_text(m.get("content"))
+            if text.strip():
+                return text
     return None
 
 

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/builder.py
@@ -333,8 +333,7 @@ def _last_user_text(messages: Any) -> Optional[str]:
     for m in reversed(messages):
         if isinstance(m, dict) and m.get("role") == "user":
             text = _coerce_text(m.get("content"))
-            if text.strip():
-                return text
+            return text if text.strip() else None
     return None
 
 

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/config.py
@@ -52,7 +52,7 @@ _SSL_CONTEXT = _ssl_context()
 logger = logging.getLogger(__name__)
 
 SCOPE_NAME = "latitude-telemetry-hermes"
-PKG_VERSION = "0.1.1"
+PKG_VERSION = "0.1.2"
 
 # Bound on live trace state, so turns that never reach a clean finish
 # (interrupted / tool-only final step) can't leak forever.

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/messages.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/messages.py
@@ -41,10 +41,10 @@ def _normalize_message(m: Any) -> Optional[Dict[str, Any]]:
     return _content_message(role, m.get("content"), m)
 
 
-def _content_message(role: str, content: Any, envelope: Dict[str, Any]) -> Dict[str, Any]:
+def _content_message(role: str, content: Any, envelope: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     parts: List[Dict[str, Any]] = []
     if isinstance(content, str):
-        if content:
+        if content.strip():
             parts.append({"type": "text", "content": content})
     elif isinstance(content, list):
         for block in content:
@@ -55,7 +55,7 @@ def _content_message(role: str, content: Any, envelope: Dict[str, Any]) -> Dict[
         parts.append({"type": "text", "content": _safe_json(content)})
     _append_tool_calls(parts, envelope.get("tool_calls"))
     if not parts:
-        parts = [{"type": "text", "content": ""}]
+        return None
     return {"role": role, "parts": parts}
 
 
@@ -64,30 +64,45 @@ def _normalize_assistant(obj: Any) -> Optional[Dict[str, Any]]:
     if obj is None:
         return None
     if isinstance(obj, str):
+        if not obj.strip():
+            return None
         return {"role": "assistant", "parts": [{"type": "text", "content": obj}]}
     parts: List[Dict[str, Any]] = []
     reasoning = _get(obj, "reasoning")
-    if isinstance(reasoning, str) and reasoning:
+    if isinstance(reasoning, str) and reasoning.strip():
         parts.append({"type": "reasoning", "content": reasoning})
     content = _get(obj, "content")
-    if isinstance(content, str) and content:
+    if isinstance(content, str) and content.strip():
         parts.append({"type": "text", "content": content})
+    elif isinstance(content, list):
+        for block in content:
+            p = _block(block)
+            if p:
+                parts.append(p)
     _append_tool_calls(parts, _get(obj, "tool_calls"))
     if not parts:
-        parts = [{"type": "text", "content": ""}]
+        return None
     return {"role": "assistant", "parts": parts}
 
 
 def _block(block: Any) -> Optional[Dict[str, Any]]:
     if isinstance(block, str):
+        if not block.strip():
+            return None
         return {"type": "text", "content": block}
     if not isinstance(block, dict):
         return None
     btype = block.get("type") or "text"
     if btype == "text":
-        return {"type": "text", "content": block.get("content") or block.get("text") or ""}
+        text = block.get("content") or block.get("text") or ""
+        if not isinstance(text, str) or not text.strip():
+            return None
+        return {"type": "text", "content": text}
     if btype in ("thinking", "reasoning"):
-        return {"type": "reasoning", "content": block.get("thinking") or block.get("content") or ""}
+        text = block.get("thinking") or block.get("content") or ""
+        if not isinstance(text, str) or not text.strip():
+            return None
+        return {"type": "reasoning", "content": text}
     if btype == "tool_use":
         return {
             "type": "tool_call",

--- a/packages/telemetry/hermes/src/latitude_telemetry_hermes/messages.py
+++ b/packages/telemetry/hermes/src/latitude_telemetry_hermes/messages.py
@@ -170,7 +170,11 @@ def _system_prompt(messages: Any) -> Optional[str]:
 
 def _count_tool_calls(assistant: Any) -> int:
     tc = _get(assistant, "tool_calls")
-    return len(tc) if isinstance(tc, (list, tuple)) else 0
+    count = len(tc) if isinstance(tc, (list, tuple)) else 0
+    content = _get(assistant, "content")
+    if isinstance(content, list):
+        count += sum(1 for b in content if isinstance(b, dict) and b.get("type") == "tool_use")
+    return count
 
 
 def _has_content(assistant: Any, chars: int) -> bool:
@@ -180,5 +184,19 @@ def _has_content(assistant: Any, chars: int) -> bool:
     if isinstance(content, str):
         return bool(content.strip())
     if isinstance(content, list):
-        return len(content) > 0
+        for block in content:
+            if isinstance(block, str) and block.strip():
+                return True
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type") or "text"
+            if btype in ("tool_use", "tool_result"):
+                continue
+            if btype in ("thinking", "reasoning"):
+                text = block.get("thinking") or block.get("content") or ""
+            else:
+                text = block.get("content") or block.get("text") or ""
+            if isinstance(text, str) and text.strip():
+                return True
+        return False
     return (chars or 0) > 0

--- a/packages/telemetry/hermes/tests/test_messages.py
+++ b/packages/telemetry/hermes/tests/test_messages.py
@@ -1,0 +1,83 @@
+"""Message normalization: empty turns must not become empty bubbles in Latitude."""
+
+from __future__ import annotations
+
+from latitude_telemetry_hermes.messages import _normalize_assistant, _normalize_messages
+
+
+def test_normalize_messages_drops_empty_user_and_unknown_roles():
+    out = _normalize_messages(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "user", "content": ""},
+            {"role": "user", "content": "   "},
+            {"role": "user", "content": None},
+            {"role": "developer", "content": ""},
+            {"role": "assistant", "content": ""},
+        ]
+    )
+    assert out == [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
+
+
+def test_normalize_messages_keeps_tool_only_assistant_without_empty_text():
+    out = _normalize_messages(
+        [
+            {"role": "user", "content": "check weather"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "1", "function": {"name": "get_weather", "arguments": '{"city":"SF"}'}}],
+            },
+            {"role": "tool", "tool_call_id": "1", "content": "sunny"},
+            {"role": "assistant", "content": "It's sunny."},
+        ]
+    )
+    assert out == [
+        {"role": "user", "parts": [{"type": "text", "content": "check weather"}]},
+        {
+            "role": "assistant",
+            "parts": [{"type": "tool_call", "id": "1", "name": "get_weather", "arguments": {"city": "SF"}}],
+        },
+        {"role": "tool", "parts": [{"type": "tool_call_response", "id": "1", "response": "sunny"}]},
+        {"role": "assistant", "parts": [{"type": "text", "content": "It's sunny."}]},
+    ]
+
+
+def test_normalize_messages_drops_empty_text_blocks_but_keeps_siblings():
+    out = _normalize_messages(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "tool_use", "id": "t1", "name": "read", "input": {"path": "a"}},
+                ],
+            }
+        ]
+    )
+    assert out == [
+        {
+            "role": "assistant",
+            "parts": [{"type": "tool_call", "id": "t1", "name": "read", "arguments": {"path": "a"}}],
+        }
+    ]
+
+
+def test_normalize_assistant_returns_none_for_empty_output():
+    assert _normalize_assistant(None) is None
+    assert _normalize_assistant("") is None
+    assert _normalize_assistant("   ") is None
+    assert _normalize_assistant({"content": "", "tool_calls": []}) is None
+
+
+def test_normalize_assistant_keeps_tool_calls_without_empty_text():
+    out = _normalize_assistant(
+        {
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "bash", "arguments": '{"cmd":"ls"}'}}],
+        }
+    )
+    assert out == {
+        "role": "assistant",
+        "parts": [{"type": "tool_call", "id": "c1", "name": "bash", "arguments": {"cmd": "ls"}}],
+    }

--- a/packages/telemetry/hermes/tests/test_messages.py
+++ b/packages/telemetry/hermes/tests/test_messages.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from latitude_telemetry_hermes.messages import _normalize_assistant, _normalize_messages
+from latitude_telemetry_hermes.builder import _last_user_text
+from latitude_telemetry_hermes.messages import (
+    _count_tool_calls,
+    _has_content,
+    _normalize_assistant,
+    _normalize_messages,
+)
 
 
 def test_normalize_messages_drops_empty_user_and_unknown_roles():
@@ -81,3 +87,21 @@ def test_normalize_assistant_keeps_tool_calls_without_empty_text():
         "role": "assistant",
         "parts": [{"type": "tool_call", "id": "c1", "name": "bash", "arguments": {"cmd": "ls"}}],
     }
+
+
+def test_count_tool_calls_includes_content_list_tool_use():
+    assistant = {
+        "content": [{"type": "tool_use", "id": "t1", "name": "read", "input": {"path": "a"}}],
+    }
+    assert _count_tool_calls(assistant) == 1
+    assert _has_content(assistant, 0) is False
+
+
+def test_last_user_text_does_not_backfill_from_older_prompt():
+    messages = [
+        {"role": "user", "content": "old prompt"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "   "},
+    ]
+    assert _last_user_text(messages) is None
+    assert _last_user_text([{"role": "user", "content": "hello"}]) == "hello"

--- a/packages/telemetry/hermes/uv.lock
+++ b/packages/telemetry/hermes/uv.lock
@@ -35,7 +35,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry-hermes"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary

Hermes sessions were filling the Conversation tab with empty blue bubbles. The plugin normalized blank/whitespace-only turns into `{ type: "text", content: "" }` placeholders, and Latitude rendered every message as a bubble shell.

This stops exporting those empty messages:

- Drop user/assistant turns with no renderable parts (keep tool-only assistant turns as `tool_call` parts)
- Ignore whitespace-only text/reasoning blocks
- Only attach `user_prompt` / root `gen_ai.input.messages` when there is real user text

Already-ingested traces keep their stored empty messages; new exports with this package version will not add more.

## Test plan

- [x] `uv run pytest tests/test_messages.py tests/test_plugin.py` in `packages/telemetry/hermes` (16 passed)
- [ ] Reinstall/update the plugin in a Hermes env and run a multi-tool agent turn
- [ ] Confirm Conversation shows real user text + tool-call blocks, without empty right-side bubbles
- [ ] Confirm Spans still capture `llm_request` / `tool_execution` structure


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Whitespace-only user messages and blocks are now omitted from telemetry.
  * Interaction root now attaches `user_prompt` / `gen_ai.input.messages` only when the current turn has real user text.
  * Assistant turns with only tool calls still export correctly, without empty text/reasoning parts.
  * Tool-use blocks are counted for capability detection, preserving subsequent tool-execution spans.

* **Tests**
  * Added/expanded coverage for normalization of empty/whitespace content, tool-call-only assistants, tool-call counting, and “no backfill” last-user-text behavior.

* **Chores**
  * Updated Hermes package version and changelog for 0.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->