### PR TITLE
fix(deps): patch Undici security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
       "tslib": "2.8.1",
       "protobufjs": "8.0.2",
       "srvx": "0.11.21",
+      "undici@<7.0.0": "6.27.0",
+      "undici@>=7.0.0 <7.28.0": "7.28.0",
       "better-auth>zod": "4.3.6",
       "@better-auth/core>zod": "4.3.6",
       "@better-auth/sso>zod": "4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,8 @@ overrides:
   tslib: 2.8.1
   protobufjs: 8.0.2
   srvx: 0.11.21
+  undici@<7.0.0: 6.27.0
+  undici@>=7.0.0 <7.28.0: 7.28.0
   better-auth>zod: 4.3.6
   '@better-auth/core>zod': 4.3.6
   '@better-auth/sso>zod': 4.3.6
@@ -13376,12 +13378,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -21782,7 +21784,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.25.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -23253,7 +23255,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -24205,7 +24207,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.15
       tinyglobby: 0.2.17
-      undici: 6.26.0
+      undici: 6.27.0
       which: 6.0.1
 
   node-releases@2.0.38: {}
@@ -26052,9 +26054,9 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
Overrides vulnerable Undici 6.x resolutions to 6.27.0 and vulnerable 7.x resolutions to 7.28.0. This patches the high-severity WebSocket denial-of-service, SOCKS5 TLS validation bypass, and cross-origin proxy-pool reuse advisories while preserving each consumer’s major version.

Validation:
- `pnpm audit --audit-level high`: no remaining Undici high/critical advisory
- `pnpm --filter latitude-infra typecheck`: passed
- `pnpm --filter @app/web check`: passed with seven existing non-null-assertion warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency version overrides to explicitly pin `undici` for specific semver ranges, improving compatibility across supported runtime versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->