### PR TITLE
fix(agent-dispatch): skip gracefully when organization or incident is already deleted

### DIFF
--- a/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.test.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.test.ts
@@ -7,7 +7,7 @@ import { createProject, ProjectRepository } from "@domain/projects"
 import { createFakeProjectRepository } from "@domain/projects/testing"
 import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
 import { createFakeScoreAnalyticsRepository, createFakeScoreRepository } from "@domain/scores/testing"
-import { AlertIncidentId, OrganizationId, ProjectId, SignalId, SqlClient } from "@domain/shared"
+import { AlertIncidentId, NotFoundError, OrganizationId, ProjectId, SignalId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { type Signal, SignalRepository } from "@domain/signals"
 import { createFakeSignalRepository } from "@domain/signals/testing"
@@ -101,11 +101,12 @@ const makeLayer = (opts: {
   configs?: readonly AgentDispatchConfigRow[]
   incident?: Incident | null
   guardrailCalls?: Array<{ configId: string; projectId: string }>
+  seedOrganization?: boolean
 }) => {
   const organization = createOrganization({ id: orgId, name: "Acme", slug: "acme" })
   const project = createProject({ id: projectId, organizationId: orgId, name: "Demo", slug: "demo" })
   const { repository: organizationRepository, organizations } = createFakeOrganizationRepository()
-  organizations.set(orgId, organization)
+  if (opts.seedOrganization ?? true) organizations.set(orgId, organization)
   const { repository: projectRepository } = createFakeProjectRepository([project])
   const { repository: signalRepository } = createFakeSignalRepository([opts.signal])
   const { repository: scoreRepository } = createFakeScoreRepository()
@@ -145,7 +146,7 @@ const makeLayer = (opts: {
     findById: (id) => {
       const incident = opts.incident
       if (incident === null || incident === undefined || incident.id !== id) {
-        return Effect.die(new Error("incident not found"))
+        return Effect.fail(new NotFoundError({ entity: "Incident", id }))
       }
       return Effect.succeed(incident)
     },
@@ -344,5 +345,37 @@ describe("requestAgentDispatchUseCase", () => {
     expect(result.requests).toHaveLength(1)
     expect(result.requests[0]?.trigger).toBe("incident.opened")
     expect(result.requests[0]?.sourceId).toBe(signalId)
+  })
+
+  it("skips when the organization has already been deleted", async () => {
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase(input).pipe(
+        Effect.provide(makeLayer({ signal: makeSignal({ origin: "system" }), seedOrganization: false })),
+      ),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "organization-not-found" })
+  })
+
+  it("skips incident-sourced dispatches when the incident has already been deleted", async () => {
+    const result = await Effect.runPromise(
+      requestAgentDispatchUseCase({
+        source: {
+          type: "incident",
+          organizationId: orgId,
+          alertIncidentId: incidentId,
+        },
+        webAppUrl: "https://console.latitude.so",
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            signal: makeSignal({ origin: "system" }),
+            incident: null,
+          }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ status: "skipped", reason: "incident-not-found" })
   })
 })

--- a/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts
+++ b/packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts
@@ -102,15 +102,24 @@ export const requestAgentDispatchUseCase = (input: {
 }) =>
   Effect.gen(function* () {
     const organizations = yield* OrganizationRepository
-    const organization = yield* organizations.findById(input.source.organizationId)
+    const organization = yield* organizations
+      .findById(input.source.organizationId)
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    if (organization === null) return { status: "skipped", reason: "organization-not-found" } as const
     if (isSandbox(organization)) return { status: "skipped", reason: "sandbox" } as const
 
     const configRepo = yield* AgentDispatchConfigRepository
     const incidents = yield* IncidentRepository
-    const projectId =
-      input.source.type === "signal"
-        ? input.source.projectId
-        : (yield* incidents.findById(AlertIncidentId(input.source.alertIncidentId))).projectId
+    let projectId: ProjectId
+    if (input.source.type === "signal") {
+      projectId = input.source.projectId
+    } else {
+      const incidentForProject = yield* incidents
+        .findById(AlertIncidentId(input.source.alertIncidentId))
+        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+      if (incidentForProject === null) return { status: "skipped", reason: "incident-not-found" } as const
+      projectId = incidentForProject.projectId
+    }
     const rows = yield* configRepo.listByProjectIncludingDefaults(projectId)
     const configs = resolveEffectiveConfigsForProject(projectId, rows).filter((config) => config.enabled)
     if (configs.length === 0) return { status: "skipped", reason: "no-config" } as const
@@ -157,7 +166,10 @@ export const requestAgentDispatchUseCase = (input: {
       return { status: "ok", requests } as const
     }
 
-    const incident = yield* incidents.findById(AlertIncidentId(input.source.alertIncidentId))
+    const incident = yield* incidents
+      .findById(AlertIncidentId(input.source.alertIncidentId))
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    if (incident === null) return { status: "skipped", reason: "incident-not-found" } as const
     const trigger = resolveIncidentTrigger(incident)
     if (trigger === null) return { status: "skipped", reason: "unsupported-source" } as const
 


### PR DESCRIPTION
## What does this PR do?

Fixes a small, previously-flagged bug in `requestAgentDispatchUseCase` (`packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts`): the organization and incident lookups (`organizations.findById`, `incidents.findById` — used at two call sites) did not catch `NotFoundError`, unlike the sibling signal lookups in the same function, which already treat a missing record as a graceful skip (`Effect.catchTag("NotFoundError", () => Effect.succeed(null))`).

When a signal/incident domain event raced a since-deleted organization or incident (queue processing lag between the event firing and the `agent-dispatch.request` BullMQ job running), the job threw instead of returning `{status: "skipped", ...}`, producing noisy retries and Datadog Error Tracking issues instead of a silent, expected skip.

The fix mirrors the existing pattern already used for `SignalRepository.findById` in the same file: both lookups now catch `NotFoundError` and return `{status: "skipped", reason: "organization-not-found"}` / `{status: "skipped", reason: "incident-not-found"}` instead of propagating the failure.

### Datadog issues addressed

- [`ET-375` / `4dea99da-6bbd-11f1-9869-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/4dea99da-6bbd-11f1-9869-da7ad0900005) — `NotFoundError` in `organization-repository.ts` during `agent-dispatch.request` (workers), ~5 occurrences over 4 weeks.
- [`ET-374` / `4deecbfe-6bbd-11f1-bca4-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/4deecbfe-6bbd-11f1-bca4-da7ad0900005) — duplicate fingerprint of the same underlying event (`NotFoundError$1` vs `NotFoundError`, a minifier class-name variance; same `trace_id`/`span_id`/`timestamp`).

Both issues had already been triaged in a prior weekly Datadog review, which identified this exact root cause and proposed this exact fix as a low-risk follow-up, but didn't open a PR at the time since the volume alone didn't clear the bar for an automated single-issue fix. This PR implements that follow-up.

### Root cause

`requestAgentDispatchUseCase` (`packages/domain/agent-dispatch/src/use-cases/request-agent-dispatch.ts`) calls `organizations.findById(...)` and `incidents.findById(...)` without catching `NotFoundError`. When a signal/incident references an organization or incident that has since been deleted, the lookup fails with a typed `NotFoundError` that propagates uncaught out of the use case, surfacing as a worker-level exception in `apps/workers/src/workers/agent-dispatch.ts` instead of a clean, logged skip — the same graceful-skip treatment the function already gives to a missing signal.

### Fix

Wrapped both `findById` calls with `Effect.catchTag("NotFoundError", () => Effect.succeed(null))`, mirroring the existing `SignalRepository.findById` handling in the same file, and added an early `{status: "skipped", reason: "..."}` return for each.

## Related issue (if applicable)

N/A — found and root-caused via Datadog Error Tracking, no linked GitHub issue.

## How was this tested?

- Added two new test cases to `request-agent-dispatch.test.ts`:
  - `skips when the organization has already been deleted`
  - `skips incident-sourced dispatches when the incident has already been deleted`
- Confirmed both new tests **fail** without the fix (unhandled `NotFoundError` propagates as an unhandled defect) and **pass** with it.
- `pnpm --filter @domain/agent-dispatch test` — all 30 tests pass (up from 28 pre-existing + 2 new).
- `pnpm --filter @domain/agent-dispatch typecheck` (tsgo) — clean.
- `pnpm exec biome check` on changed files — clean.

### Verification in production

After deploy, occurrences of Error Tracking issues `4dea99da-6bbd-11f1-9869-da7ad0900005` / `4deecbfe-6bbd-11f1-bca4-da7ad0900005` should drop to zero (recurrence would now surface as a `status: "skipped"` info log in the `agent-dispatch.request` worker instead of an error).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_016ZZbuKF488S81we3KqsS7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent dispatch requests now skip gracefully when the associated organization cannot be found.
  * Incident-based dispatches now skip gracefully when the referenced incident is unavailable.
  * Existing sandbox handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->