### PR TITLE
fix(ingest): don't crash the whole span batch on a malformed traceId

### DIFF
--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -390,4 +390,107 @@ describe("transformOtlpToSpans trace ID normalization", () => {
     expect(spans).toHaveLength(1)
     expect(spans[0]?.traceId).toBe("0af7651916cd43dd8448eb211c80319c")
   })
+
+  it("rejects a span with a missing trace ID instead of crashing the batch", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: undefined as unknown as string,
+                    spanId: "missing-trace",
+                    name: "missing-trace",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(0)
+  })
+
+  it("rejects a span whose trace ID is a non-string value instead of crashing the batch", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: { "0": "a" } as unknown as string,
+                    spanId: "object-trace",
+                    name: "object-trace",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(0)
+  })
+
+  it("keeps processing the rest of the batch when one span has an invalid trace ID", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "ok1",
+                    name: "ok1",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                  {
+                    traceId: "" as unknown as string,
+                    spanId: "empty-trace",
+                    name: "empty-trace",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.spanId).toBe("ok1")
+  })
 })

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -250,6 +250,11 @@ export function transformOtlpToSpans(
       const scopeVersion = scopeSpans.scope?.version ?? ""
       for (const span of scopeSpans.spans ?? []) {
         if (isDroppedSpan(scopeName, span.name ?? "")) continue
+        // OTLP/JSON bodies are cast, not validated, so `traceId` can arrive missing or non-string.
+        if (typeof span.traceId !== "string" || span.traceId.length === 0) {
+          rejectedSpans++
+          continue
+        }
         const projectId = resolveSpanProjectId(span.attributes ?? [], resourceAttrs, context)
         if (!projectId) {
           rejectedSpans++

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -85,7 +85,7 @@ export interface TransformContext {
 
 interface TransformResult {
   readonly spans: readonly SpanDetail[]
-  /** Spans skipped because no `projectId` could be resolved for them. */
+  /** Spans skipped for lacking a resolvable `projectId` or a valid `traceId`. */
   readonly rejectedSpans: number
 }
 

--- a/packages/domain/spans/src/sampling/extract-sampling-key.test.ts
+++ b/packages/domain/spans/src/sampling/extract-sampling-key.test.ts
@@ -56,4 +56,14 @@ describe("extractSamplingKey", () => {
     expect(extractSamplingKey({})).toBe(null)
     expect(extractSamplingKey({ resourceSpans: [{ scopeSpans: [] }] })).toBe(null)
   })
+
+  it("returns null instead of a non-string trace ID", () => {
+    const req = request([span({ traceId: { "0": "a" } as unknown as string })])
+    expect(extractSamplingKey(req)).toBe(null)
+  })
+
+  it("returns null instead of a missing trace ID", () => {
+    const req = request([span({ traceId: undefined as unknown as string })])
+    expect(extractSamplingKey(req)).toBe(null)
+  })
 })

--- a/packages/domain/spans/src/sampling/extract-sampling-key.ts
+++ b/packages/domain/spans/src/sampling/extract-sampling-key.ts
@@ -20,7 +20,9 @@ export function extractSamplingKey(request: OtlpExportTraceServiceRequest): stri
         if (fromSpan) return fromSpan
         const fromResource = first(sessionIdCandidates, resourceAttrs)
         if (fromResource) return fromResource
-        return span.traceId || null
+        // OTLP/JSON bodies are cast, not validated, so `traceId` can arrive missing or non-string;
+        // a non-string key would crash `deterministicSample`'s hash update.
+        return typeof span.traceId === "string" && span.traceId ? span.traceId : null
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a production `TypeError: Cannot read properties of undefined (reading 'replace')` in `transformSpan` (`packages/domain/spans/src/otlp/transform.ts:180`) — [Datadog issue `28550eee-82d3-11f1-b2ea-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/28550eee-82d3-11f1-b2ea-da7ad0900005), `workers` service, 99 occurrences, first seen 2026-07-18 (new regression, first triage of this issue).

**Root cause:** `apps/ingest`/`workers` decode OTLP/JSON span-ingestion bodies with a raw `JSON.parse(...) as OtlpExportTraceServiceRequest` cast (`packages/domain/spans/src/use-cases/process-ingested-spans.ts:56`) — the payload is cast, not validated. `transform.ts` already guards against this for `attributes` (see the `attrArray` helper and its comment in `packages/domain/spans/src/otlp/attributes.ts`), but `transformSpan` still called `span.traceId.replace(/-/g, "")` unguarded. A span whose `traceId` field is missing or non-string (a malformed client payload) throws, and because `transformSpan` runs inside `transformOtlpToSpans`'s loop inside an `Effect.gen`, the exception propagates as a defect that fails the **entire ingestion batch** for that request — not just the one malformed span — causing legitimate telemetry in the same batch to be dropped/retried.

**Fix:** `transformOtlpToSpans` already has a well-established "skip and count, don't crash" mechanism for spans with an unresolvable `projectId` (`rejectedSpans`). Extended the same guard to a missing/non-string `traceId`: such spans are now rejected (counted in `rejectedSpans`) instead of throwing, and the rest of the batch is processed normally.

Note: on the ingest/worker path where this crash occurred, `transformOtlpToSpans`'s `rejectedSpans` count is not currently wired up to the OTLP `partialSuccess` response (that response is built earlier, from project-slug resolution only) — bad-`traceId` spans are silently dropped rather than reported back to the client. That's pre-existing behavior for this code path, not a regression from this change, and out of scope here; flagging in case it's worth a follow-up.

## Related issue (if applicable)

Datadog: https://app.datadoghq.eu/error-tracking/issue/28550eee-82d3-11f1-b2ea-da7ad0900005

Closes #

## How was this tested?

- Added tests in `packages/domain/spans/src/otlp/tests/project-scoping.test.ts`:
  - a span with a missing (`undefined`) `traceId` is rejected, not thrown
  - a span with a non-string `traceId` (object) is rejected, not thrown
  - a mixed batch keeps processing valid spans after skipping one with an empty `traceId`
- Verified the new tests **fail** against the pre-fix code with the exact same stack trace as the Datadog issue (`TypeError: Cannot read properties of undefined (reading 'replace')` at `transform.ts:180`), and **pass** with the fix applied.
- `pnpm --filter @domain/spans test` — all otlp/project-scoping tests pass (pre-existing unrelated failures in `ingest-spans.test.ts` are a sandbox Node-version issue — `Uint8Array.toBase64` requires Node 24+ — reproduced identically on `development` without this change).
- `pnpm exec biome check` on changed files — clean.

**Verification after deploy:** occurrences of Datadog issue `28550eee-82d3-11f1-b2ea-da7ad0900005` should drop to zero. (Malformed-`traceId` spans are dropped in the worker, not surfaced via `partialSuccess` — see note above.)

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed, missing, non-string, or empty trace IDs.
  * Invalid spans are now safely rejected without interrupting processing of other valid spans in the same batch.
  * Strengthened sampling key extraction and span transformation to avoid crashes from invalid trace ID values.
  * Added additional test coverage for robustness with malformed trace IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->