### PR TITLE
feat(taxonomy): Phase 3 gardening integration — staging swap + full-window reassign (LAT-772)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -241,6 +241,16 @@ LAT_VOYAGE_API_KEY=
 # LAT_AI_RERANKING_PROVIDER=voyage
 # LAT_AI_RERANKING_MODEL=rerank-2.5
 
+# Taxonomy adaptive-clustering rollout baseline: off | shadow | enforced.
+# Environment-wide kill switch and shadow toggle for the divisive-build rollout,
+# read only in the gardening planning activity. `off` (default, and any
+# unrecognized value) keeps the byte-identical static path; `shadow`/`enforced`
+# exercise the adaptive builder, member-confidence routing thresholds,
+# shape-aware naming, and the staging + atomic-swap full-window publish path.
+# The per-organization enforcement flag (adaptiveTaxonomyClustering) ships in a
+# later phase and can only raise this baseline to `enforced`.
+# LAT_TAXONOMY_ADAPTIVE_CLUSTERING_MODE=off
+
 # Slack (optional)
 # LAT_SLACK_CLIENT_ID=
 # LAT_SLACK_CLIENT_SECRET=

--- a/apps/workflows/src/activities/index.ts
+++ b/apps/workflows/src/activities/index.ts
@@ -71,6 +71,7 @@ export {
 } from "./signal-discovery-activities.ts"
 export {
   assertGardenTaxonomyQualityActivity,
+  cleanupGardenTaxonomyStagingActivity,
   completeGardenTaxonomyRunActivity,
   deprecateGardenTaxonomyClustersActivity,
   emitGardenTaxonomyLineageActivity,

--- a/apps/workflows/src/activities/taxonomy-clustering-worker-entry.ts
+++ b/apps/workflows/src/activities/taxonomy-clustering-worker-entry.ts
@@ -1,9 +1,9 @@
 import { parentPort, workerData } from "node:worker_threads"
-import { type BuildStaticHierarchicalClustersInput, buildStaticHierarchicalClusters } from "@domain/taxonomy"
+import { runTaxonomyClusterBuild, type TaxonomyClusterBuildRequest } from "@domain/taxonomy"
 
 interface WorkerSuccessMessage {
   readonly ok: true
-  readonly tree: ReturnType<typeof buildStaticHierarchicalClusters>
+  readonly result: ReturnType<typeof runTaxonomyClusterBuild>
 }
 
 interface WorkerErrorMessage {
@@ -21,8 +21,8 @@ const errorMessage = (error: unknown): WorkerErrorMessage => {
 
 try {
   if (!parentPort) throw new Error("Taxonomy clustering worker started without a parent port")
-  const tree = buildStaticHierarchicalClusters(workerData as BuildStaticHierarchicalClustersInput)
-  parentPort.postMessage({ ok: true, tree } satisfies WorkerSuccessMessage)
+  const result = runTaxonomyClusterBuild(workerData as TaxonomyClusterBuildRequest)
+  parentPort.postMessage({ ok: true, result } satisfies WorkerSuccessMessage)
 } catch (error) {
   parentPort?.postMessage(errorMessage(error))
 }

--- a/apps/workflows/src/activities/taxonomy-clustering-worker.test.ts
+++ b/apps/workflows/src/activities/taxonomy-clustering-worker.test.ts
@@ -2,24 +2,35 @@ import { describe, expect, it } from "vitest"
 import { buildHierarchicalClustersInWorker } from "./taxonomy-clustering-worker.ts"
 
 describe("buildHierarchicalClustersInWorker", () => {
-  it("runs clustering in a worker thread", async () => {
-    const tree = await buildHierarchicalClustersInWorker({
+  it("runs the static (off) build in a worker thread and returns no diagnostics", async () => {
+    const { root, diagnostics } = await buildHierarchicalClustersInWorker({
+      mode: "off",
       embeddings: [
         [1, 0],
         [0.95, 0.05],
         [0, 1],
         [0.05, 0.95],
       ],
-      depthSchedule: [
-        { maxChildren: 2, minClusterFraction: 0.25, minClusterAbs: 1, maxSiblingCosine: 0.99, minSplitScore: 0 },
-      ],
-      restarts: 1,
-      maxIter: 5,
-      tolerance: 1e-4,
       seed: 1,
     })
 
-    expect(tree.memberIndices).toHaveLength(4)
-    expect(tree.children).toHaveLength(2)
+    expect(root.memberIndices).toHaveLength(4)
+    expect(diagnostics).toBeNull()
+  })
+
+  it("runs the adaptive (enforced) build in a worker thread and returns diagnostics", async () => {
+    // Two well-separated clusters with small within-cluster angular jitter, so
+    // the within-distance is positive (a zero-spread cluster scores CH=0 and is
+    // rejected) while the clusters stay clearly apart.
+    const unit = (angle: number): number[] => [Math.cos(angle), Math.sin(angle)]
+    const embeddings = Array.from({ length: 60 }, (_, index) =>
+      index < 30 ? unit(0.05 * (index % 4)) : unit(Math.PI / 2 + 0.05 * (index % 4)),
+    )
+    const { root, diagnostics } = await buildHierarchicalClustersInWorker({ mode: "enforced", embeddings, seed: 1 })
+
+    expect(root.memberIndices).toHaveLength(60)
+    expect(root.children).toHaveLength(2)
+    expect(diagnostics).not.toBeNull()
+    expect(diagnostics?.acceptedSplits).toBeGreaterThanOrEqual(1)
   })
 })

--- a/apps/workflows/src/activities/taxonomy-clustering-worker.ts
+++ b/apps/workflows/src/activities/taxonomy-clustering-worker.ts
@@ -3,15 +3,15 @@ import { dirname, extname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 import { Worker } from "node:worker_threads"
 import {
-  type BuildStaticHierarchicalClustersInput,
-  type ClusteringTreeNode,
   TAXONOMY_CLUSTERING_WORKER_MAX_OLD_GEN_MB,
   TAXONOMY_CLUSTERING_WORKER_TIMEOUT_MS,
+  type TaxonomyClusterBuildRequest,
+  type TaxonomyClusterBuildResult,
 } from "@domain/taxonomy"
 
 interface WorkerSuccessMessage {
   readonly ok: true
-  readonly tree: ClusteringTreeNode
+  readonly result: TaxonomyClusterBuildResult
 }
 
 interface WorkerErrorMessage {
@@ -52,8 +52,8 @@ const workerEntryUrl = () => {
  *     exits, on every terminal path (message, error, exit, timeout).
  */
 export const buildHierarchicalClustersInWorker = async (
-  input: BuildStaticHierarchicalClustersInput,
-): Promise<ClusteringTreeNode> => {
+  input: TaxonomyClusterBuildRequest,
+): Promise<TaxonomyClusterBuildResult> => {
   const entry = workerEntryUrl()
   // The deadline timer and the worker thread are torn down (LIFO) when this
   // scope exits — i.e. once the awaited promise settles, on every terminal path
@@ -67,7 +67,7 @@ export const buildHierarchicalClustersInWorker = async (
   })
   stack.defer(() => void worker.terminate())
 
-  return await new Promise<ClusteringTreeNode>((resolvePromise, rejectPromise) => {
+  return await new Promise<TaxonomyClusterBuildResult>((resolvePromise, rejectPromise) => {
     const timeout = setTimeout(() => {
       rejectPromise(new Error(`Taxonomy clustering worker timed out after ${TAXONOMY_CLUSTERING_WORKER_TIMEOUT_MS}ms`))
     }, TAXONOMY_CLUSTERING_WORKER_TIMEOUT_MS)
@@ -75,7 +75,7 @@ export const buildHierarchicalClustersInWorker = async (
 
     worker.once("message", (message: WorkerMessage) => {
       if (message.ok) {
-        resolvePromise(message.tree)
+        resolvePromise(message.result)
         return
       }
       const error = new Error(message.error)

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -13,12 +13,23 @@ import {
   CustomBehaviorRepository,
   CustomBehaviorStatus,
   emitLineageUseCase,
+  isAdaptiveModeActive,
   isDisplayableTaxonomyName,
+  parseTaxonomyAdaptiveModeBaseline,
   planHierarchicalTaxonomyUseCase,
+  type ReassignmentLeaf,
   type ReassignTaxonomyObservationByIdInput,
+  resolveTaxonomyAdaptiveMode,
+  routeObservationsToLeaves,
+  type StagingLeafCluster,
+  TAXONOMY_ADAPTIVE_CLUSTERING_MODE_ENV,
   TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
   TAXONOMY_CLUSTERING_SAMPLE_STRATEGY,
+  TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
   TAXONOMY_GARDENING_SAMPLE_LOOKBACK_DAYS,
+  TAXONOMY_OBSERVATION_RETENTION_DAYS,
+  TAXONOMY_REASSIGNMENT_BATCH_SIZE,
+  type TaxonomyAdaptiveClusteringMode,
   type TaxonomyCluster,
   type TaxonomyClusterLineage,
   TaxonomyClusterRepository,
@@ -39,10 +50,26 @@ import {
   TaxonomyRunRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
+import { parseEnv } from "@platform/env"
 import { createLogger, withTracing } from "@repo/observability"
 import { Data, Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 import { buildHierarchicalClustersInWorker } from "./taxonomy-clustering-worker.ts"
+
+/**
+ * Resolve the adaptive-clustering rollout mode. Read in the planning activity
+ * ONLY (never workflow code — Temporal determinism), from the environment
+ * baseline; the per-organization enforcement flag lands in Phase 4 (LAT-773) and
+ * is passed as `false` until then. `off` (the default and any unrecognized
+ * value) keeps the byte-identical pre-change path.
+ */
+const resolveAdaptiveMode = Effect.gen(function* () {
+  const raw = yield* parseEnv(TAXONOMY_ADAPTIVE_CLUSTERING_MODE_ENV, "string", "off")
+  return resolveTaxonomyAdaptiveMode({
+    envBaseline: parseTaxonomyAdaptiveModeBaseline(raw),
+    flagEnabledForOrg: false,
+  })
+})
 
 const logger = createLogger("taxonomy-gardening-workflow")
 
@@ -131,7 +158,30 @@ interface StoredGardenTaxonomyPlan {
   /** Non-null ⇒ the plan is scoped to this custom behavior (drives the reassign write target). */
   readonly customBehaviorId: string | null
   readonly deprecatedClusterIds: readonly string[]
+  /**
+   * Rollout mode resolved at plan time. Downstream activities branch on THIS
+   * value (never re-reading env/flag state) so the publish path is a pure
+   * function of the staged plan artifact. Absent on plans staged by pre-change
+   * code — treated as `off`.
+   */
+  readonly mode?: TaxonomyAdaptiveClusteringMode
+  /** Adaptive-only: leaf id + centroid for full-window routing. Empty/absent on off. */
+  readonly leafClusters?: readonly StagingLeafCluster[]
+  /** Adaptive-only: the full old active tree the atomic swap deprecates. Empty/absent on off. */
+  readonly supersededClusterIds?: readonly string[]
 }
+
+const planMode = (plan: StoredGardenTaxonomyPlan): TaxonomyAdaptiveClusteringMode => plan.mode ?? "off"
+
+const chunk = <A>(items: readonly A[], size: number): A[][] => {
+  const out: A[][] = []
+  for (let offset = 0; offset < items.length; offset += size) out.push(items.slice(offset, offset + size))
+  return out
+}
+
+class TaxonomyStagingInvariantError extends Data.TaggedError("TaxonomyStagingInvariantError")<{
+  readonly message: string
+}> {}
 
 export interface GardenTaxonomyNamingPlanResult {
   readonly clusterIds: readonly string[]
@@ -281,6 +331,18 @@ const withCustomBehaviorClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, o
     withClickHouse(CustomBehaviorAssignmentRepositoryLive, getClickhouseClient(), OrganizationId(organizationId)),
   )
 
+// Scoped full-window reassignment reads the global taxonomy window (filtered by
+// the behavior's sessions) and writes the scoped custom_behavior_assignments
+// slice, so it needs both ClickHouse repositories.
+const withScopedReassignClickHouse = <A, E, R>(effect: Effect.Effect<A, E, R>, organizationId: string) =>
+  effect.pipe(
+    withClickHouse(
+      Layer.mergeAll(TaxonomyObservationRepositoryLive, CustomBehaviorAssignmentRepositoryLive),
+      getClickhouseClient(),
+      OrganizationId(organizationId),
+    ),
+  )
+
 const runGardenStep = <A, E>(
   name: string,
   input: GardenTaxonomyStepInput | GardenTaxonomyActivityInput,
@@ -409,19 +471,23 @@ export const planHierarchicalGardenTaxonomyActivity = (input: GardenTaxonomyStep
   runGardenStep(
     "GardenTaxonomyWorkflow plan hierarchical tree",
     input,
-    planHierarchicalTaxonomyUseCase({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      runId: TaxonomyRunId(input.runId),
-      dimension: input.dimension,
-      now: new Date(input.now),
-      clusterBuilder: (builderInput) =>
-        Effect.tryPromise({
-          try: () => buildHierarchicalClustersInWorker(builderInput),
-          catch: (error) => (error instanceof Error ? error : new Error(String(error))),
-        }),
-      ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
-      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+    Effect.gen(function* () {
+      const mode = yield* resolveAdaptiveMode
+      return yield* planHierarchicalTaxonomyUseCase({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        runId: TaxonomyRunId(input.runId),
+        dimension: input.dimension,
+        now: new Date(input.now),
+        mode,
+        clusterBuilder: (builderInput) =>
+          Effect.tryPromise({
+            try: () => buildHierarchicalClustersInWorker(builderInput),
+            catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+          }),
+        ...(input.customBehaviorId ? { customBehaviorId: CustomBehaviorId(input.customBehaviorId) } : {}),
+        ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+      })
     }).pipe(
       Effect.flatMap((plan) =>
         Effect.gen(function* () {
@@ -431,6 +497,9 @@ export const planHierarchicalGardenTaxonomyActivity = (input: GardenTaxonomyStep
             customAssignments: plan.customAssignments,
             customBehaviorId: plan.customBehaviorId,
             deprecatedClusterIds: plan.deprecatedClusterIds.map((clusterId) => clusterId as string),
+            mode: plan.mode,
+            leafClusters: plan.leafClusters,
+            supersededClusterIds: plan.supersededClusterIds.map((clusterId) => clusterId as string),
           })
           return {
             observationsScanned: plan.observationsScanned,
@@ -466,6 +535,8 @@ export const saveGardenTaxonomyClustersActivity = (input: GardenTaxonomySaveClus
     }).pipe((effect) => withTaxonomyPostgres(effect, input.organizationId)),
   )
 
+// --- Off (sample-only) reassignment: byte-identical to the pre-change path. ---
+
 const reassignGlobalObservations = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
   Effect.gen(function* () {
     const observations = yield* TaxonomyObservationRepository
@@ -484,6 +555,107 @@ const reassignScopedAssignments = (input: GardenTaxonomyReassignObservationsInpu
     return { observationsReassigned: plan.customAssignments.length }
   }).pipe((effect) => withCustomBehaviorClickHouse(effect, input.organizationId))
 
+// --- Adaptive (full-window) reassignment into the staging leaves. ---
+
+const planLeaves = (plan: StoredGardenTaxonomyPlan): ReassignmentLeaf[] =>
+  (plan.leafClusters ?? []).map((leaf) => ({ clusterId: leaf.clusterId, centroid: leaf.centroid }))
+
+// Fraction of the window still pointing at a soon-to-deprecate cluster after the
+// bulk write that we tolerate as concurrent inserts (the catch-up pass mops
+// those up after the swap). More than this means the bulk write did not land.
+const STAGING_SNAPSHOT_STRAGGLER_FRACTION = 0.05
+
+const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const observations = yield* TaxonomyObservationRepository
+    const leaves = planLeaves(plan)
+    const window = yield* observations.listWindowForReassignment({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+    })
+    const routed = routeObservationsToLeaves(
+      window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
+      leaves,
+    )
+    const assignments: ReassignTaxonomyObservationByIdInput[] = routed.map((assignment) => ({
+      observationId: assignment.observationId,
+      assignedClusterId: assignment.assignedClusterId,
+      assignmentMethod: "gardening_reassign" as const,
+      assignmentConfidence: assignment.confidence,
+      reassignmentRunId: TaxonomyRunId(input.runId),
+      indexedAt: new Date(input.now),
+    }))
+    for (const batch of chunk(assignments, TAXONOMY_REASSIGNMENT_BATCH_SIZE)) {
+      yield* observations.reassignManyById({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        assignments: batch,
+      })
+    }
+    // Confirm the bounded snapshot no longer points at the old tree before we let
+    // the swap deprecate it.
+    const superseded = new Set(plan.supersededClusterIds ?? [])
+    const confirmation = yield* observations.listWindowForReassignment({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+    })
+    const stragglers = confirmation.filter(
+      (row) => row.assignedClusterId !== null && superseded.has(row.assignedClusterId),
+    ).length
+    if (stragglers > Math.floor(confirmation.length * STAGING_SNAPSHOT_STRAGGLER_FRACTION)) {
+      return yield* new TaxonomyStagingInvariantError({
+        message: `Full-window reassignment left ${stragglers}/${confirmation.length} observations on the old tree`,
+      })
+    }
+    return { observationsReassigned: assignments.length, windowSize: window.length }
+  }).pipe((effect) => withTaxonomyClickHouse(effect, input.organizationId))
+
+const reassignFullWindowScoped = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const observations = yield* TaxonomyObservationRepository
+    const assignmentsRepo = yield* CustomBehaviorAssignmentRepository
+    const leaves = planLeaves(plan)
+    const window = yield* observations.listWindowForReassignment({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
+    })
+    const routedById = new Map(
+      routeObservationsToLeaves(
+        window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
+        leaves,
+      ).map((assignment) => [assignment.observationId, assignment] as const),
+    )
+    const now = new Date(input.now)
+    const assignments: CustomBehaviorAssignment[] = window.flatMap((row) => {
+      const routed = routedById.get(row.observationId)
+      if (!routed) return []
+      return [
+        {
+          organizationId: OrganizationId(input.organizationId),
+          projectId: ProjectId(input.projectId),
+          customBehaviorId: CustomBehaviorId(plan.customBehaviorId as string),
+          observationId: row.observationId,
+          sessionId: row.sessionId,
+          assignedClusterId: routed.assignedClusterId,
+          assignmentConfidence: routed.confidence,
+          assignmentMethod: "gardening_reassign" as const,
+          reassignmentRunId: TaxonomyRunId(input.runId),
+          startTime: row.startTime,
+          retentionDays: TAXONOMY_OBSERVATION_RETENTION_DAYS,
+          indexedAt: now,
+        } satisfies CustomBehaviorAssignment,
+      ]
+    })
+    for (const batch of chunk(assignments, TAXONOMY_REASSIGNMENT_BATCH_SIZE)) {
+      yield* assignmentsRepo.upsertMany(batch)
+    }
+    return { observationsReassigned: assignments.length, windowSize: window.length }
+  }).pipe((effect) => withScopedReassignClickHouse(effect, input.organizationId))
+
 export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomyReassignObservationsInput) =>
   runGardenStep(
     "GardenTaxonomyWorkflow reassign observations",
@@ -491,13 +663,92 @@ export const reassignGardenTaxonomyObservationsActivity = (input: GardenTaxonomy
     // A plan staged by the pre-unification code has no `customBehaviorId` key
     // (undefined) — a truthy check keeps those, and every global run, on the
     // observation-reassign branch; only a real behavior id routes to the slice.
+    // Off does sample-only reassignment (byte-identical); adaptive routes the
+    // full bounded live window to the staging leaves.
     Effect.gen(function* () {
       const plan = yield* loadGardenTaxonomyPlan(input)
+      if (isAdaptiveModeActive(planMode(plan))) {
+        return yield* plan.customBehaviorId
+          ? reassignFullWindowScoped(input, plan)
+          : reassignFullWindowGlobal(input, plan)
+      }
       return yield* plan.customBehaviorId
         ? reassignScopedAssignments(input, plan)
         : reassignGlobalObservations(input, plan)
     }),
   )
+
+// Off: deprecate exactly the non-continued old clusters (byte-identical to the
+// pre-change path — continuations kept their ids via in-place upsert).
+const deprecateOffClusters = (input: GardenTaxonomyDeprecateClustersInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const clusters = yield* TaxonomyClusterRepository
+    for (const clusterId of plan.deprecatedClusterIds) {
+      yield* clusters.markDeprecated({ clusterId: TaxonomyClusterId(clusterId), timestamp: new Date(input.now) })
+    }
+    return { clustersDeprecated: plan.deprecatedClusterIds.length }
+  }).pipe((effect) => withTaxonomyPostgres(effect, input.organizationId))
+
+const catchUpGlobal = (input: GardenTaxonomyDeprecateClustersInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const observations = yield* TaxonomyObservationRepository
+    const leaves = planLeaves(plan)
+    const leafIds = new Set(leaves.map((leaf) => leaf.clusterId as string))
+    const window = yield* observations.listWindowForReassignment({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+    })
+    // Only observations not already pointing at a current leaf — the tail indexed
+    // between the pre-swap snapshot and now.
+    const stragglers = window.filter((row) => row.assignedClusterId === null || !leafIds.has(row.assignedClusterId))
+    const routed = routeObservationsToLeaves(
+      stragglers.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
+      leaves,
+    )
+    const assignments: ReassignTaxonomyObservationByIdInput[] = routed.map((assignment) => ({
+      observationId: assignment.observationId,
+      assignedClusterId: assignment.assignedClusterId,
+      assignmentMethod: "gardening_reassign" as const,
+      assignmentConfidence: assignment.confidence,
+      reassignmentRunId: TaxonomyRunId(input.runId),
+      indexedAt: new Date(input.now),
+    }))
+    for (const batch of chunk(assignments, TAXONOMY_REASSIGNMENT_BATCH_SIZE)) {
+      yield* observations.reassignManyById({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        assignments: batch,
+      })
+    }
+    return assignments.length
+  }).pipe((effect) => withTaxonomyClickHouse(effect, input.organizationId))
+
+// Adaptive: atomically swap the staged tree in for the old one, then run one
+// bounded catch-up pass for observations indexed during reassignment.
+const swapAndCatchUp = (input: GardenTaxonomyDeprecateClustersInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const supersededClusterIds = (plan.supersededClusterIds ?? []).map((clusterId) => TaxonomyClusterId(clusterId))
+    const stagingClusterIds = plan.clusters.map((cluster) => cluster.id)
+    yield* Effect.gen(function* () {
+      const clusters = yield* TaxonomyClusterRepository
+      yield* clusters.swapActiveTree({
+        supersededClusterIds,
+        stagingClusterIds,
+        timestamp: new Date(input.now),
+      })
+    }).pipe((effect) => withTaxonomyPostgres(effect, input.organizationId))
+
+    const caughtUp = plan.customBehaviorId
+      ? (yield* reassignFullWindowScoped(input, plan)).observationsReassigned
+      : yield* catchUpGlobal(input, plan)
+
+    return {
+      clustersDeprecated: supersededClusterIds.length,
+      clustersActivated: stagingClusterIds.length,
+      caughtUp,
+    }
+  })
 
 export const deprecateGardenTaxonomyClustersActivity = (input: GardenTaxonomyDeprecateClustersInput) =>
   runGardenStep(
@@ -505,12 +756,10 @@ export const deprecateGardenTaxonomyClustersActivity = (input: GardenTaxonomyDep
     input,
     Effect.gen(function* () {
       const plan = yield* loadGardenTaxonomyPlan(input)
-      const clusters = yield* TaxonomyClusterRepository
-      for (const clusterId of plan.deprecatedClusterIds) {
-        yield* clusters.markDeprecated({ clusterId: TaxonomyClusterId(clusterId), timestamp: new Date(input.now) })
-      }
-      return { clustersDeprecated: plan.deprecatedClusterIds.length }
-    }).pipe((effect) => withTaxonomyPostgres(effect, input.organizationId)),
+      return isAdaptiveModeActive(planMode(plan))
+        ? yield* swapAndCatchUp(input, plan)
+        : yield* deprecateOffClusters(input, plan)
+    }),
   )
 
 export const assertGardenTaxonomyQualityActivity = (input: GardenTaxonomyStepInput) =>
@@ -691,5 +940,25 @@ export const failGardenTaxonomyRunActivity = (input: GardenTaxonomyActivityInput
   const failInput: GardenTaxonomyFailInput = { ...baseStepInput(input), error: input.error }
   return failInput.customBehaviorId ? failCustomBehaviorRun(failInput) : failGlobalRun(failInput)
 }
+
+// Best-effort cleanup of abandoned staging rows when a publish fails before the
+// swap: leaves the old tree active and removes the orphaned staging tree. Safe
+// and idempotent — `deleteStaging` is guarded to `state = 'staging'`, so a swap
+// that already activated the tree makes this a no-op, and a missing plan
+// (start failed before staging) cleans nothing. Off runs are a no-op.
+export const cleanupGardenTaxonomyStagingActivity = (input: GardenTaxonomyActivityInput) =>
+  runGardenStep(
+    "GardenTaxonomyWorkflow cleanup staging",
+    input,
+    Effect.gen(function* () {
+      const step = baseStepInput(input)
+      const reference: GardenTaxonomyPlanReferenceInput = { ...step, planKey: gardenTaxonomyPlanKey(step) }
+      const plan = yield* loadGardenTaxonomyPlan(reference).pipe(Effect.orElseSucceed(() => null))
+      if (plan === null || !isAdaptiveModeActive(planMode(plan))) return { stagingDeleted: 0 }
+      const clusters = yield* TaxonomyClusterRepository
+      yield* clusters.deleteStaging({ clusterIds: plan.clusters.map((cluster) => cluster.id) })
+      return { stagingDeleted: plan.clusters.length }
+    }).pipe((effect) => withTaxonomyPostgres(effect, input.organizationId)),
+  )
 
 export { errorMessage as gardenTaxonomyErrorMessage }

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -605,20 +605,20 @@ const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput
       })
     }
     // Confirm the bounded snapshot no longer points at the old tree before we let
-    // the swap deprecate it.
-    const superseded = new Set(plan.supersededClusterIds ?? [])
-    const confirmation = yield* observations.listWindowForReassignment({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
-    })
-    const stragglers = confirmation.filter(
-      (row) => row.assignedClusterId !== null && superseded.has(row.assignedClusterId),
-    ).length
-    if (stragglers > Math.floor(confirmation.length * STAGING_SNAPSHOT_STRAGGLER_FRACTION)) {
-      return yield* new TaxonomyStagingInvariantError({
-        message: `Full-window reassignment left ${stragglers}/${confirmation.length} observations on the old tree`,
+    // the swap deprecate it. Counted server-side so no embeddings ship back.
+    const supersededClusterIds = (plan.supersededClusterIds ?? []).map((clusterId) => TaxonomyClusterId(clusterId))
+    if (supersededClusterIds.length > 0) {
+      const { total, matching } = yield* observations.countWindowAssignedToClusters({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+        clusterIds: supersededClusterIds,
       })
+      if (matching > Math.floor(total * STAGING_SNAPSHOT_STRAGGLER_FRACTION)) {
+        return yield* new TaxonomyStagingInvariantError({
+          message: `Full-window reassignment left ${matching}/${total} observations on the old tree`,
+        })
+      }
     }
     return { observationsReassigned: assignments.length, windowSize: window.length }
   }).pipe((effect) => withTaxonomyClickHouse(effect, input.organizationId))
@@ -693,15 +693,15 @@ const catchUpGlobal = (input: GardenTaxonomyDeprecateClustersInput, plan: Stored
   Effect.gen(function* () {
     const observations = yield* TaxonomyObservationRepository
     const leaves = planLeaves(plan)
-    const leafIds = new Set(leaves.map((leaf) => leaf.clusterId as string))
-    const window = yield* observations.listWindowForReassignment({
+    // Narrow the read to rows NOT already on a current leaf — the tail indexed
+    // between the pre-swap snapshot and now — so we only pull embeddings for the
+    // stragglers, not the whole 10k window.
+    const stragglers = yield* observations.listWindowForReassignment({
       organizationId: OrganizationId(input.organizationId),
       projectId: ProjectId(input.projectId),
       limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+      excludeAssignedClusterIds: leaves.map((leaf) => leaf.clusterId),
     })
-    // Only observations not already pointing at a current leaf — the tail indexed
-    // between the pre-swap snapshot and now.
-    const stragglers = window.filter((row) => row.assignedClusterId === null || !leafIds.has(row.assignedClusterId))
     const routed = routeObservationsToLeaves(
       stragglers.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
       leaves,

--- a/apps/workflows/src/activities/taxonomy-gardening-activities.ts
+++ b/apps/workflows/src/activities/taxonomy-gardening-activities.ts
@@ -565,19 +565,30 @@ const planLeaves = (plan: StoredGardenTaxonomyPlan): ReassignmentLeaf[] =>
 // those up after the swap). More than this means the bulk write did not land.
 const STAGING_SNAPSHOT_STRAGGLER_FRACTION = 0.05
 
-const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
+// Shared kernel of both full-window reassignment targets: read the bounded live
+// window (optionally scoped to the behavior's sessions) and route every row to
+// its nearest staging leaf. The caller maps the routed assignments onto its own
+// write-target shape — the two targets diverge only there.
+const routeWindowToStagingLeaves = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
   Effect.gen(function* () {
     const observations = yield* TaxonomyObservationRepository
-    const leaves = planLeaves(plan)
     const window = yield* observations.listWindowForReassignment({
       organizationId: OrganizationId(input.organizationId),
       projectId: ProjectId(input.projectId),
       limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
+      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
     })
     const routed = routeObservationsToLeaves(
       window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
-      leaves,
+      planLeaves(plan),
     )
+    return { window, routed }
+  })
+
+const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
+  Effect.gen(function* () {
+    const observations = yield* TaxonomyObservationRepository
+    const { window, routed } = yield* routeWindowToStagingLeaves(input, plan)
     const assignments: ReassignTaxonomyObservationByIdInput[] = routed.map((assignment) => ({
       observationId: assignment.observationId,
       assignedClusterId: assignment.assignedClusterId,
@@ -614,21 +625,10 @@ const reassignFullWindowGlobal = (input: GardenTaxonomyReassignObservationsInput
 
 const reassignFullWindowScoped = (input: GardenTaxonomyReassignObservationsInput, plan: StoredGardenTaxonomyPlan) =>
   Effect.gen(function* () {
-    const observations = yield* TaxonomyObservationRepository
     const assignmentsRepo = yield* CustomBehaviorAssignmentRepository
-    const leaves = planLeaves(plan)
-    const window = yield* observations.listWindowForReassignment({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      limit: TAXONOMY_GARDENING_OBSERVATION_WINDOW_MAX,
-      ...(input.filterSet ? { filterSet: input.filterSet } : {}),
-    })
-    const routedById = new Map(
-      routeObservationsToLeaves(
-        window.map((row) => ({ observationId: row.observationId, embedding: row.embedding })),
-        leaves,
-      ).map((assignment) => [assignment.observationId, assignment] as const),
-    )
+    const { window, routed } = yield* routeWindowToStagingLeaves(input, plan)
+    // Correlate routed results back to window rows for the slice's sessionId/startTime.
+    const routedById = new Map(routed.map((assignment) => [assignment.observationId, assignment] as const))
     const now = new Date(input.now)
     const assignments: CustomBehaviorAssignment[] = window.flatMap((row) => {
       const routed = routedById.get(row.observationId)

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
@@ -55,7 +55,6 @@ vi.mock("@temporalio/workflow", () => ({
   CancellationScope: {
     nonCancellable: async <T>(fn: () => Promise<T>) => fn(),
   },
-  deprecatePatch: vi.fn(),
   patched: vi.fn(() => true),
   proxyActivities: () => mockActivities,
   workflowInfo: () => ({ runId: "test-workflow-run-id" }),

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
@@ -46,6 +46,7 @@ const { mockActivities } = vi.hoisted(() => {
       status: "completed",
     })),
     failGardenTaxonomyRunActivity: vi.fn(async (input: Record<string, unknown>) => ({ ...input, status: "failed" })),
+    cleanupGardenTaxonomyStagingActivity: vi.fn(async () => ({ stagingDeleted: 0 })),
   }
   return { mockActivities }
 })
@@ -55,10 +56,12 @@ vi.mock("@temporalio/workflow", () => ({
     nonCancellable: async <T>(fn: () => Promise<T>) => fn(),
   },
   deprecatePatch: vi.fn(),
+  patched: vi.fn(() => true),
   proxyActivities: () => mockActivities,
   workflowInfo: () => ({ runId: "test-workflow-run-id" }),
 }))
 
+import { patched } from "@temporalio/workflow"
 import { gardenTaxonomyWorkflow } from "./taxonomy-gardening-workflow.ts"
 
 const globalInput = {
@@ -184,6 +187,36 @@ describe("taxonomy gardening workflow (divisive build)", () => {
       expect.objectContaining({ customBehaviorId: "b".repeat(24), error: "start exploded" }),
     )
     expect(mockActivities.planHierarchicalGardenTaxonomyActivity).not.toHaveBeenCalled()
+  })
+
+  it("carries the staging-swap patched marker and cleans up abandoned staging on a pre-swap failure", async () => {
+    mockActivities.reassignGardenTaxonomyObservationsActivity.mockRejectedValueOnce(new Error("reassign exploded"))
+
+    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("reassign exploded")
+
+    expect(patched).toHaveBeenCalledWith("taxonomy-gardening-staging-swap-v1")
+    // Save (staging) ran; reassign failed before the swap, so the orphaned
+    // staging tree is cleaned up and the run marked failed.
+    expect(mockActivities.saveGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
+    expect(mockActivities.deprecateGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
+    expect(mockActivities.cleanupGardenTaxonomyStagingActivity).toHaveBeenCalledTimes(1)
+    expect(mockActivities.failGardenTaxonomyRunActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "reassign exploded" }),
+    )
+  })
+
+  it("skips staging cleanup when replaying an in-flight pre-change history (patched marker off)", async () => {
+    vi.mocked(patched).mockReturnValueOnce(false)
+    mockActivities.reassignGardenTaxonomyObservationsActivity.mockRejectedValueOnce(new Error("reassign exploded"))
+
+    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("reassign exploded")
+
+    // A pre-change history never staged a tree, so the new cleanup activity must
+    // not run — the marker reconciles the shape without changing old behavior.
+    expect(mockActivities.cleanupGardenTaxonomyStagingActivity).not.toHaveBeenCalled()
+    expect(mockActivities.failGardenTaxonomyRunActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "reassign exploded" }),
+    )
   })
 
   it("records a failed run in a non-cancellable cleanup scope when cancellation interrupts a step", async () => {

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.test.ts
@@ -188,33 +188,46 @@ describe("taxonomy gardening workflow (divisive build)", () => {
     expect(mockActivities.planHierarchicalGardenTaxonomyActivity).not.toHaveBeenCalled()
   })
 
-  it("carries the staging-swap patched marker and cleans up abandoned staging on a pre-swap failure", async () => {
-    mockActivities.reassignGardenTaxonomyObservationsActivity.mockRejectedValueOnce(new Error("reassign exploded"))
+  it("carries the staging-swap patched marker and cleans up staging on a failure before reassignment", async () => {
+    mockActivities.saveGardenTaxonomyClustersActivity.mockRejectedValueOnce(new Error("save exploded"))
 
-    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("reassign exploded")
+    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("save exploded")
 
     expect(patched).toHaveBeenCalledWith("taxonomy-gardening-staging-swap-v1")
-    // Save (staging) ran; reassign failed before the swap, so the orphaned
-    // staging tree is cleaned up and the run marked failed.
-    expect(mockActivities.saveGardenTaxonomyClustersActivity).toHaveBeenCalledTimes(1)
-    expect(mockActivities.deprecateGardenTaxonomyClustersActivity).not.toHaveBeenCalled()
+    // Reassignment never ran, so no observation points at the staging tree — it is
+    // safe to clean up the orphaned staging rows.
+    expect(mockActivities.reassignGardenTaxonomyObservationsActivity).not.toHaveBeenCalled()
     expect(mockActivities.cleanupGardenTaxonomyStagingActivity).toHaveBeenCalledTimes(1)
     expect(mockActivities.failGardenTaxonomyRunActivity).toHaveBeenCalledWith(
-      expect.objectContaining({ error: "reassign exploded" }),
+      expect.objectContaining({ error: "save exploded" }),
+    )
+  })
+
+  it("does NOT delete staging once reassignment has run (it may already point observations there)", async () => {
+    // Reassignment repoints the live window onto the staging leaves; if the swap
+    // then fails, deleting staging would orphan those observations (#4121 review).
+    mockActivities.deprecateGardenTaxonomyClustersActivity.mockRejectedValueOnce(new Error("swap exploded"))
+
+    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("swap exploded")
+
+    expect(mockActivities.reassignGardenTaxonomyObservationsActivity).toHaveBeenCalledTimes(1)
+    expect(mockActivities.cleanupGardenTaxonomyStagingActivity).not.toHaveBeenCalled()
+    expect(mockActivities.failGardenTaxonomyRunActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "swap exploded" }),
     )
   })
 
   it("skips staging cleanup when replaying an in-flight pre-change history (patched marker off)", async () => {
     vi.mocked(patched).mockReturnValueOnce(false)
-    mockActivities.reassignGardenTaxonomyObservationsActivity.mockRejectedValueOnce(new Error("reassign exploded"))
+    mockActivities.saveGardenTaxonomyClustersActivity.mockRejectedValueOnce(new Error("save exploded"))
 
-    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("reassign exploded")
+    await expect(gardenTaxonomyWorkflow(globalInput)).rejects.toThrow("save exploded")
 
     // A pre-change history never staged a tree, so the new cleanup activity must
     // not run — the marker reconciles the shape without changing old behavior.
     expect(mockActivities.cleanupGardenTaxonomyStagingActivity).not.toHaveBeenCalled()
     expect(mockActivities.failGardenTaxonomyRunActivity).toHaveBeenCalledWith(
-      expect.objectContaining({ error: "reassign exploded" }),
+      expect.objectContaining({ error: "save exploded" }),
     )
   })
 

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -1,5 +1,5 @@
 import type { TaxonomyClusterLineage } from "@domain/taxonomy"
-import { CancellationScope, deprecatePatch, proxyActivities, workflowInfo } from "@temporalio/workflow"
+import { CancellationScope, deprecatePatch, patched, proxyActivities, workflowInfo } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
@@ -23,6 +23,7 @@ export type GardenTaxonomyWorkflowResult = activities.GardenTaxonomyActivityResu
  */
 const {
   assertGardenTaxonomyQualityActivity,
+  cleanupGardenTaxonomyStagingActivity,
   completeGardenTaxonomyRunActivity,
   deprecateGardenTaxonomyClustersActivity,
   emitGardenTaxonomyLineageActivity,
@@ -79,12 +80,20 @@ const errorMessage = (error: unknown): string => {
 export const gardenTaxonomyWorkflow = async (
   input: GardenTaxonomyWorkflowInput,
 ): Promise<GardenTaxonomyWorkflowResult> => {
+  // The staging + atomic-swap publish shape (the mode-gated reassign/deprecate
+  // activities and the failure-path staging cleanup) is a new activity shape.
+  // The command SEQUENCE stays mode-independent — activities branch on mode
+  // internally — so this single marker reconciles an in-flight pre-change
+  // history at a fixed position. Read once, before the try, so the catch path
+  // sees the same deterministic value.
+  let useStagingSwap = false
   try {
     const started = await startGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId })
     // Split-build is unconditional now; deprecatePatch sits right after start
     // (where the old `patched("…-split-build-v1")` gate did) so replay of in-flight
     // split-build histories reconciles the marker at the same position.
     deprecatePatch("taxonomy-gardening-split-build-v1")
+    useStagingSwap = patched("taxonomy-gardening-staging-swap-v1")
     const built = await planHierarchicalGardenTaxonomyActivity(started)
     // Scoped cold-start: the plan sampled below the gardening minimum and built
     // no tree, so complete the run empty and leave any prior scoped tree serving
@@ -141,9 +150,15 @@ export const gardenTaxonomyWorkflow = async (
     // behavior to `generating` up front, so a start-activity failure must still
     // mark it failed instead of leaving it stuck generating. The fail activity
     // re-derives the (deterministic) run id from the input.
-    await CancellationScope.nonCancellable(() =>
-      failGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId, error: errorMessage(error) }),
-    )
+    await CancellationScope.nonCancellable(async () => {
+      // A publish that failed before the swap leaves an orphaned staging tree;
+      // remove it so the old tree stays the only active one. No-op on off runs
+      // and when the swap already completed (guarded to state='staging').
+      if (useStagingSwap) {
+        await cleanupGardenTaxonomyStagingActivity({ ...input, workflowRunId: workflowInfo().runId })
+      }
+      await failGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId, error: errorMessage(error) })
+    })
     throw error
   }
 }

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -1,5 +1,5 @@
 import type { TaxonomyClusterLineage } from "@domain/taxonomy"
-import { CancellationScope, deprecatePatch, patched, proxyActivities, workflowInfo } from "@temporalio/workflow"
+import { CancellationScope, patched, proxyActivities, workflowInfo } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
@@ -89,10 +89,6 @@ export const gardenTaxonomyWorkflow = async (
   let useStagingSwap = false
   try {
     const started = await startGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId })
-    // Split-build is unconditional now; deprecatePatch sits right after start
-    // (where the old `patched("…-split-build-v1")` gate did) so replay of in-flight
-    // split-build histories reconciles the marker at the same position.
-    deprecatePatch("taxonomy-gardening-split-build-v1")
     useStagingSwap = patched("taxonomy-gardening-staging-swap-v1")
     const built = await planHierarchicalGardenTaxonomyActivity(started)
     // Scoped cold-start: the plan sampled below the gardening minimum and built

--- a/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
+++ b/apps/workflows/src/workflows/taxonomy-gardening-workflow.ts
@@ -87,6 +87,11 @@ export const gardenTaxonomyWorkflow = async (
   // history at a fixed position. Read once, before the try, so the catch path
   // sees the same deterministic value.
   let useStagingSwap = false
+  // Adaptive reassignment repoints the live window's observations onto the staging
+  // leaves BEFORE the swap. Once that has run, deleting staging would orphan those
+  // observations, so staging cleanup is only safe up to (and including) a failed
+  // reassignment — a later failure leaves staging for the swap retry / next pass.
+  let reassignmentStarted = false
   try {
     const started = await startGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId })
     useStagingSwap = patched("taxonomy-gardening-staging-swap-v1")
@@ -110,6 +115,9 @@ export const gardenTaxonomyWorkflow = async (
       })
     }
     await saveGardenTaxonomyClustersActivity({ ...started, planKey: built.planKey })
+    // Mark before the call: a partial/failed reassignment may already have
+    // repointed some observations onto staging, so cleanup must not delete it.
+    reassignmentStarted = true
     await reassignGardenTaxonomyObservationsActivity({ ...started, planKey: built.planKey })
     await deprecateGardenTaxonomyClustersActivity({ ...started, planKey: built.planKey })
     const lineage: TaxonomyClusterLineage[] = [...built.lineage]
@@ -147,10 +155,11 @@ export const gardenTaxonomyWorkflow = async (
     // mark it failed instead of leaving it stuck generating. The fail activity
     // re-derives the (deterministic) run id from the input.
     await CancellationScope.nonCancellable(async () => {
-      // A publish that failed before the swap leaves an orphaned staging tree;
-      // remove it so the old tree stays the only active one. No-op on off runs
-      // and when the swap already completed (guarded to state='staging').
-      if (useStagingSwap) {
+      // Clean up an orphaned staging tree ONLY when reassignment never ran, so no
+      // observation can already point at a staging leaf we would delete. Once
+      // reassignment has started, the staging tree is left for the swap retry /
+      // next pass. No-op on off runs (guarded to state='staging').
+      if (useStagingSwap && !reassignmentStarted) {
         await cleanupGardenTaxonomyStagingActivity({ ...input, workflowRunId: workflowInfo().runId })
       }
       await failGardenTaxonomyRunActivity({ ...input, workflowRunId: workflowInfo().runId, error: errorMessage(error) })

--- a/packages/domain/taxonomy/src/adaptive-mode.test.ts
+++ b/packages/domain/taxonomy/src/adaptive-mode.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import {
+  isAdaptiveModeActive,
+  parseTaxonomyAdaptiveModeBaseline,
+  resolveTaxonomyAdaptiveMode,
+} from "./adaptive-mode.ts"
+
+describe("parseTaxonomyAdaptiveModeBaseline", () => {
+  it("accepts the three known modes", () => {
+    expect(parseTaxonomyAdaptiveModeBaseline("off")).toBe("off")
+    expect(parseTaxonomyAdaptiveModeBaseline("shadow")).toBe("shadow")
+    expect(parseTaxonomyAdaptiveModeBaseline("enforced")).toBe("enforced")
+  })
+
+  it("falls back to off for anything unrecognized", () => {
+    expect(parseTaxonomyAdaptiveModeBaseline(undefined)).toBe("off")
+    expect(parseTaxonomyAdaptiveModeBaseline("")).toBe("off")
+    expect(parseTaxonomyAdaptiveModeBaseline("ENFORCED")).toBe("off")
+    expect(parseTaxonomyAdaptiveModeBaseline("on")).toBe("off")
+  })
+})
+
+describe("resolveTaxonomyAdaptiveMode", () => {
+  it("off baseline is a hard kill switch that overrides the flag", () => {
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "off", flagEnabledForOrg: true })).toBe("off")
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "off", flagEnabledForOrg: false })).toBe("off")
+  })
+
+  it("the flag can only raise the baseline to enforced", () => {
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "shadow", flagEnabledForOrg: true })).toBe("enforced")
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "enforced", flagEnabledForOrg: true })).toBe("enforced")
+  })
+
+  it("without the flag the baseline is used as-is", () => {
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "shadow", flagEnabledForOrg: false })).toBe("shadow")
+    expect(resolveTaxonomyAdaptiveMode({ envBaseline: "enforced", flagEnabledForOrg: false })).toBe("enforced")
+  })
+})
+
+describe("isAdaptiveModeActive", () => {
+  it("is false only for off", () => {
+    expect(isAdaptiveModeActive("off")).toBe(false)
+    expect(isAdaptiveModeActive("shadow")).toBe(true)
+    expect(isAdaptiveModeActive("enforced")).toBe(true)
+  })
+})

--- a/packages/domain/taxonomy/src/adaptive-mode.ts
+++ b/packages/domain/taxonomy/src/adaptive-mode.ts
@@ -1,0 +1,40 @@
+/**
+ * Rollout-mode resolution for the adaptive divisive build.
+ *
+ * The mode is resolved from two inputs so a whole environment can be shadowed
+ * while only chosen organizations are enforced:
+ *
+ *   - the environment baseline (`LAT_TAXONOMY_ADAPTIVE_CLUSTERING_MODE`), the
+ *     kill switch and shadow toggle for the whole deploy;
+ *   - the per-organization `adaptiveTaxonomyClustering` feature flag, which can
+ *     only raise the baseline to `enforced` (added in Phase 4 / LAT-773; passed
+ *     as `false` until then).
+ *
+ * `off` always wins so it stays a guaranteed global no-op, and the flag never
+ * lowers the mode. Both inputs are read in the activity layer only — this module
+ * is pure so it can be unit-tested and called from the planning activity.
+ */
+
+import { TAXONOMY_ADAPTIVE_CLUSTERING_MODES } from "./constants.ts"
+
+export type TaxonomyAdaptiveClusteringMode = (typeof TAXONOMY_ADAPTIVE_CLUSTERING_MODES)[number]
+
+export const TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT: TaxonomyAdaptiveClusteringMode = "off"
+
+/** Anything not exactly `off`/`shadow`/`enforced` falls back to the safe `off` default. */
+export const parseTaxonomyAdaptiveModeBaseline = (raw: string | undefined): TaxonomyAdaptiveClusteringMode =>
+  (TAXONOMY_ADAPTIVE_CLUSTERING_MODES as readonly string[]).includes(raw ?? "")
+    ? (raw as TaxonomyAdaptiveClusteringMode)
+    : TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT
+
+export const resolveTaxonomyAdaptiveMode = (input: {
+  readonly envBaseline: TaxonomyAdaptiveClusteringMode
+  readonly flagEnabledForOrg: boolean
+}): TaxonomyAdaptiveClusteringMode => {
+  if (input.envBaseline === "off") return "off"
+  if (input.flagEnabledForOrg) return "enforced"
+  return input.envBaseline
+}
+
+/** `off` persists the static tree unchanged; every other mode runs the new machinery. */
+export const isAdaptiveModeActive = (mode: TaxonomyAdaptiveClusteringMode): boolean => mode !== "off"

--- a/packages/domain/taxonomy/src/clustering.ts
+++ b/packages/domain/taxonomy/src/clustering.ts
@@ -95,6 +95,13 @@ export interface ClusteringTreeNode {
   /** Empty for leaves. */
   readonly children: readonly ClusteringTreeNode[]
   readonly depth: number
+  /**
+   * Member-confidence descent gate for this node's children, set only by the
+   * relative builder (undefined on static-builder nodes and on leaves). The
+   * planner persists it verbatim so the online router reads the derived
+   * threshold at descent time instead of recomputing from sibling centroids.
+   */
+  readonly splitLinkThreshold?: number
 }
 
 export interface BuildRelativeHierarchicalClustersInput {
@@ -595,7 +602,7 @@ export const buildRelativeHierarchicalClusters = (
     acceptedRelativeSeparations.push(best.relativeSeparation)
     routingThresholds.push(best.splitLinkThreshold)
     const children = best.clusterMemberIndices.map((childIndices) => recurse(childIndices, depth + 1))
-    return { memberIndices, centroid, children, depth }
+    return { memberIndices, centroid, children, depth, splitLinkThreshold: best.splitLinkThreshold }
   }
 
   const root = recurse(allIndices, 0)

--- a/packages/domain/taxonomy/src/constants.ts
+++ b/packages/domain/taxonomy/src/constants.ts
@@ -21,7 +21,33 @@ export const TAXONOMY_PENDING_DISPLAY_NAME = "Pending"
  */
 export const TAXONOMY_DIMENSIONS = ["topic"] as const
 
-export const TAXONOMY_CLUSTER_STATES = ["active", "merged", "deprecated"] as const
+/**
+ * `staging` clusters are the freshly built tree awaiting the atomic swap: they
+ * are fully written and assigned but MUST be ignored by every active read and by
+ * online routing until the publish transaction flips them to `active` (and the
+ * old tree to `deprecated`) in one step. The column is already `varchar(16)`, so
+ * widening the domain contract needs no Postgres migration.
+ */
+export const TAXONOMY_CLUSTER_STATES = ["active", "merged", "deprecated", "staging"] as const
+
+// ---------------------------------------------------------------------------
+// Adaptive-clustering rollout gate (LAT_TAXONOMY_ADAPTIVE_CLUSTERING_MODE)
+//
+// The environment baseline for the divisive-build rollout, resolved once in the
+// planning activity (never in workflow code — Temporal determinism). `off` is a
+// guaranteed byte-identical no-op: static builder, `computeSplitLinkThreshold`,
+// sample-only reassignment, centroid-similarity naming, original publish
+// sequence. `shadow`/`enforced` exercise the new machinery (adaptive builder,
+// member-confidence routing thresholds, shape-aware naming, staging + atomic
+// swap, full-window reassignment). The per-organization enforcement flag that
+// can raise the baseline to `enforced` lands in Phase 4 (LAT-773).
+// ---------------------------------------------------------------------------
+
+export const TAXONOMY_ADAPTIVE_CLUSTERING_MODES = ["off", "shadow", "enforced"] as const
+export const TAXONOMY_ADAPTIVE_CLUSTERING_MODE_ENV = "LAT_TAXONOMY_ADAPTIVE_CLUSTERING_MODE"
+
+/** Batch size for bounded ClickHouse assignment writes during full-window reassignment. */
+export const TAXONOMY_REASSIGNMENT_BATCH_SIZE = 1_000
 
 /**
  * The divisive build emits exactly these three transitions:

--- a/packages/domain/taxonomy/src/entities/cluster.ts
+++ b/packages/domain/taxonomy/src/entities/cluster.ts
@@ -18,6 +18,8 @@ export const TaxonomyClusterState = {
   Active: "active",
   Merged: "merged",
   Deprecated: "deprecated",
+  /** Built and assigned, hidden from active reads until the atomic publish swap. */
+  Staging: "staging",
 } as const satisfies Record<string, TaxonomyClusterState>
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/taxonomy/src/index.ts
+++ b/packages/domain/taxonomy/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  isAdaptiveModeActive,
+  parseTaxonomyAdaptiveModeBaseline,
+  resolveTaxonomyAdaptiveMode,
+  TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT,
+  type TaxonomyAdaptiveClusteringMode,
+} from "./adaptive-mode.ts"
+export {
   type BuildRelativeHierarchicalClustersInput,
   type BuildRelativeHierarchicalClustersResult,
   type BuildStaticHierarchicalClustersInput,
@@ -18,6 +25,8 @@ export {
   CUSTOM_BEHAVIOR_NAME_MAX_LENGTH,
   CUSTOM_BEHAVIOR_STATUSES,
   MAX_CUSTOM_BEHAVIORS_PER_PROJECT,
+  TAXONOMY_ADAPTIVE_CLUSTERING_MODE_ENV,
+  TAXONOMY_ADAPTIVE_CLUSTERING_MODES,
   TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD,
   TAXONOMY_ASSIGN_RELATIVE_MARGIN,
   TAXONOMY_ASSIGN_TEMPERATURE,
@@ -56,6 +65,7 @@ export {
   TAXONOMY_OBSERVATION_WEIGHT_SCHEME,
   TAXONOMY_PENDING_DISPLAY_NAME,
   TAXONOMY_PROJECTION_METHODS,
+  TAXONOMY_REASSIGNMENT_BATCH_SIZE,
   TAXONOMY_RUN_STATUSES,
   TAXONOMY_RUN_TRIGGERS,
   TAXONOMY_SEARCH_MIN_SCORE,
@@ -194,12 +204,19 @@ export {
   type TaxonomyObservationCounts,
   TaxonomyObservationRepository,
   type TaxonomyObservationRepositoryShape,
+  type TaxonomyReassignmentWindowObservation,
   type TaxonomyScopedClusteringObservation,
 } from "./ports/taxonomy-observation-repository.ts"
 export {
   TaxonomyRunRepository,
   type TaxonomyRunRepositoryShape,
 } from "./ports/taxonomy-run-repository.ts"
+export {
+  type ReassignmentLeaf,
+  type ReassignmentSourceObservation,
+  type RoutedLeafAssignment,
+  routeObservationsToLeaves,
+} from "./reassignment.ts"
 export {
   classifyClusterTrend,
   type GetLastRunInput,
@@ -229,10 +246,15 @@ export {
 export {
   type BuildHierarchicalTaxonomyInput,
   type BuildHierarchicalTaxonomyResult,
+  computeSplitLinkThreshold,
   type HierarchicalTaxonomyPlan,
   type PlanHierarchicalTaxonomyInput,
   planHierarchicalTaxonomyUseCase,
+  runTaxonomyClusterBuild,
+  type StagingLeafCluster,
   type TaxonomyClusterBuilder,
+  type TaxonomyClusterBuildRequest,
+  type TaxonomyClusterBuildResult,
 } from "./use-cases/build-hierarchical-taxonomy.ts"
 export { type CreateCustomBehaviorInput, createCustomBehavior } from "./use-cases/create-custom-behavior.ts"
 export {

--- a/packages/domain/taxonomy/src/lineage.test.ts
+++ b/packages/domain/taxonomy/src/lineage.test.ts
@@ -144,3 +144,74 @@ describe("matchTaxonomyLineage", () => {
     expect(result.matchedOldIds.size).toBe(1)
   })
 })
+
+describe("matchTaxonomyLineage shape-aware naming", () => {
+  // Identical centroids so the topic is unchanged (carryName eligible on cosine);
+  // only the structural shape differs between passes.
+  const carriesName = (input: {
+    readonly newShape: { readonly isLeaf: boolean; readonly childCount: number }
+    readonly oldShape: { readonly isLeaf: boolean; readonly childCount: number }
+    readonly shapeAwareNaming: boolean
+  }): boolean => {
+    const result = matchTaxonomyLineage({
+      newNodes: [{ tempId: "a", depth: 0, centroid: unit(0), ...input.newShape }],
+      oldClusters: [{ id: "X", depth: 0, centroid: unit(0), ...input.oldShape }],
+      continuationThreshold: CONTINUATION_THRESHOLD,
+      nameReuseThreshold: NAME_REUSE_THRESHOLD,
+      shapeAwareNaming: input.shapeAwareNaming,
+    })
+    const decision = result.decisions[0]
+    expect(decision?.transition).toBe("continuation")
+    return decision?.transition === "continuation" ? decision.carryName : false
+  }
+
+  it("forces a rename when a leaf becomes interior", () => {
+    expect(
+      carriesName({
+        newShape: { isLeaf: false, childCount: 3 },
+        oldShape: { isLeaf: true, childCount: 0 },
+        shapeAwareNaming: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("forces a rename when interior becomes a leaf", () => {
+    expect(
+      carriesName({
+        newShape: { isLeaf: true, childCount: 0 },
+        oldShape: { isLeaf: false, childCount: 2 },
+        shapeAwareNaming: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("forces a rename when the child count changes", () => {
+    expect(
+      carriesName({
+        newShape: { isLeaf: false, childCount: 4 },
+        oldShape: { isLeaf: false, childCount: 2 },
+        shapeAwareNaming: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("keeps the name on a same-shape high-similarity continuation", () => {
+    expect(
+      carriesName({
+        newShape: { isLeaf: false, childCount: 3 },
+        oldShape: { isLeaf: false, childCount: 3 },
+        shapeAwareNaming: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("off keeps the pre-change centroid-only rule: a shape flip still carries the name", () => {
+    expect(
+      carriesName({
+        newShape: { isLeaf: false, childCount: 3 },
+        oldShape: { isLeaf: true, childCount: 0 },
+        shapeAwareNaming: false,
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/domain/taxonomy/src/lineage.ts
+++ b/packages/domain/taxonomy/src/lineage.ts
@@ -39,6 +39,9 @@ export interface LineageNewNode {
   readonly depth: number
   /** L2-normalized centroid of the node's members. */
   readonly centroid: readonly number[]
+  /** Structural shape — used by shape-aware naming to force a rename on a flip. */
+  readonly isLeaf?: boolean
+  readonly childCount?: number
 }
 
 /** A previously-active cluster the new node may continue. */
@@ -47,6 +50,9 @@ export interface LineageOldCluster {
   readonly depth: number
   /** L2-normalized centroid. */
   readonly centroid: readonly number[]
+  /** Structural shape at the previous pass. */
+  readonly isLeaf?: boolean
+  readonly childCount?: number
 }
 
 export type LineageDecision =
@@ -75,6 +81,13 @@ export interface MatchTaxonomyLineageInput {
   readonly continuationThreshold: number
   /** Above this cosine the topic is unchanged enough to keep the old name. */
   readonly nameReuseThreshold: number
+  /**
+   * When true, a continuation additionally forfeits its old name (forcing a
+   * rename) if it flipped leaf↔interior or its child count changed — a stale
+   * name must not survive an umbrella becoming a leaf or vice versa. Off keeps
+   * the pre-change centroid-similarity-only rule (byte-identical).
+   */
+  readonly shapeAwareNaming?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -160,8 +173,13 @@ const DISALLOWED_COST = 10
  * decide, per new node, whether it continues an old cluster (reusing its id) or
  * is born fresh.
  */
+/** A continuation keeps its name only when the topic barely moved AND (when
+ * shape-aware naming is on) the node's shape is unchanged. */
+const sameShape = (newNode: LineageNewNode, old: LineageOldCluster): boolean =>
+  newNode.isLeaf === old.isLeaf && newNode.childCount === old.childCount
+
 export const matchTaxonomyLineage = (input: MatchTaxonomyLineageInput): TaxonomyLineageMatch => {
-  const { newNodes, oldClusters, continuationThreshold, nameReuseThreshold } = input
+  const { newNodes, oldClusters, continuationThreshold, nameReuseThreshold, shapeAwareNaming } = input
   const n = newNodes.length
   const m = oldClusters.length
 
@@ -205,12 +223,13 @@ export const matchTaxonomyLineage = (input: MatchTaxonomyLineageInput): Taxonomy
     const sim = similarity[i]?.[j] ?? -1
     if (old && sim >= continuationThreshold) {
       matchedOldIds.add(old.id)
+      const carryName = sim >= nameReuseThreshold && (!shapeAwareNaming || sameShape(node, old))
       decisions.push({
         tempId: node.tempId,
         transition: "continuation",
         reuseId: old.id,
         similarity: sim,
-        carryName: sim >= nameReuseThreshold,
+        carryName,
       })
     } else {
       decisions.push({ tempId: node.tempId, transition: "birth" })

--- a/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-cluster-repository.ts
@@ -103,6 +103,26 @@ export interface TaxonomyClusterRepositoryShape {
     readonly clusterId: TaxonomyClusterId
     readonly timestamp: Date
   }): Effect.Effect<void, RepositoryError, SqlClient>
+  /**
+   * Atomic tree publish. In one transaction, deprecate exactly
+   * `supersededClusterIds` (the old active tree) and activate
+   * `stagingClusterIds` (the freshly built + assigned staging tree). Active
+   * reads therefore never observe the old and new trees simultaneously.
+   * Idempotent: activating already-active staging rows and deprecating
+   * already-deprecated rows are no-ops, so an activity retry re-runs safely.
+   */
+  swapActiveTree(input: {
+    readonly supersededClusterIds: readonly TaxonomyClusterId[]
+    readonly stagingClusterIds: readonly TaxonomyClusterId[]
+    readonly timestamp: Date
+  }): Effect.Effect<void, RepositoryError, SqlClient>
+  /**
+   * Remove abandoned staging rows on a failed publish, leaving the old tree
+   * active. Guarded to `state = 'staging'` so it can never delete a live tree.
+   */
+  deleteStaging(input: {
+    readonly clusterIds: readonly TaxonomyClusterId[]
+  }): Effect.Effect<void, RepositoryError, SqlClient>
 }
 
 export class TaxonomyClusterRepository extends Context.Service<

--- a/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
@@ -53,6 +53,19 @@ export interface TaxonomyClusteringObservation {
 }
 
 /**
+ * A slim live-window row for full-window reassignment: carries the current
+ * `assignedClusterId` so the invariant-confirm and catch-up passes can tell
+ * which observations still point at a soon-to-deprecate cluster.
+ */
+export interface TaxonomyReassignmentWindowObservation {
+  readonly observationId: string
+  readonly sessionId: SessionId
+  readonly embedding: readonly number[]
+  readonly startTime: Date
+  readonly assignedClusterId: string | null
+}
+
+/**
  * A clustering-sample observation carrying its `sessionId`, so scoped custom
  * behavior assignments (which live in the `custom_behavior_assignments` slice,
  * keyed by session) can be written without a second lookup.
@@ -150,6 +163,19 @@ export interface TaxonomyObservationRepositoryShape {
     readonly limit: number
     readonly filterSet: FilterSet
   }) => Effect.Effect<readonly TaxonomyScopedClusteringObservation[], RepositoryError, ChSqlClient>
+  /**
+   * The complete bounded live window (newest ≤ `limit`, no day-stratified
+   * sampling) as slim rows carrying the current assignment — the read the
+   * adaptive full-window reassignment, invariant-confirm, and catch-up passes
+   * operate over. Optional `filterSet` scopes it to a custom behavior's sessions
+   * (the scoped write target); omit it for the global window.
+   */
+  readonly listWindowForReassignment: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly limit: number
+    readonly filterSet?: FilterSet
+  }) => Effect.Effect<readonly TaxonomyReassignmentWindowObservation[], RepositoryError, ChSqlClient>
   /**
    * True eligible totals for a custom behavior preview: the unsampled analogue
    * of `listForCustomBehaviorSample` (same `filterSet`/window scoping) counting

--- a/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/ports/taxonomy-observation-repository.ts
@@ -166,16 +166,33 @@ export interface TaxonomyObservationRepositoryShape {
   /**
    * The complete bounded live window (newest ≤ `limit`, no day-stratified
    * sampling) as slim rows carrying the current assignment — the read the
-   * adaptive full-window reassignment, invariant-confirm, and catch-up passes
-   * operate over. Optional `filterSet` scopes it to a custom behavior's sessions
-   * (the scoped write target); omit it for the global window.
+   * adaptive full-window reassignment and catch-up passes operate over. Optional
+   * `filterSet` scopes it to a custom behavior's sessions (the scoped write
+   * target); omit it for the global window. `excludeAssignedClusterIds` narrows
+   * the read to rows NOT already pointing at one of those clusters — the catch-up
+   * pass passes the current leaf ids so it only pays to pull embeddings for the
+   * stragglers indexed during reassignment, not the whole window.
    */
   readonly listWindowForReassignment: (input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly limit: number
     readonly filterSet?: FilterSet
+    readonly excludeAssignedClusterIds?: readonly TaxonomyClusterId[]
   }) => Effect.Effect<readonly TaxonomyReassignmentWindowObservation[], RepositoryError, ChSqlClient>
+  /**
+   * Server-side invariant-confirm counter: over the same bounded live window,
+   * how many rows still point at one of `clusterIds` (the soon-to-deprecate
+   * tree) and the window `total`. Aggregates in ClickHouse so the confirm never
+   * ships embeddings back to the activity.
+   */
+  readonly countWindowAssignedToClusters: (input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly limit: number
+    readonly clusterIds: readonly TaxonomyClusterId[]
+    readonly filterSet?: FilterSet
+  }) => Effect.Effect<{ readonly total: number; readonly matching: number }, RepositoryError, ChSqlClient>
   /**
    * True eligible totals for a custom behavior preview: the unsampled analogue
    * of `listForCustomBehaviorSample` (same `filterSet`/window scoping) counting

--- a/packages/domain/taxonomy/src/reassignment.test.ts
+++ b/packages/domain/taxonomy/src/reassignment.test.ts
@@ -1,0 +1,48 @@
+import type { TaxonomyClusterId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { type ReassignmentLeaf, routeObservationsToLeaves } from "./reassignment.ts"
+
+const leaf = (id: string, centroid: readonly number[]): ReassignmentLeaf => ({
+  clusterId: id as TaxonomyClusterId,
+  centroid,
+})
+
+describe("routeObservationsToLeaves", () => {
+  const leaves = [leaf("a".repeat(24), [1, 0]), leaf("b".repeat(24), [0, 1])]
+
+  it("routes each observation to its nearest leaf centroid", () => {
+    const routed = routeObservationsToLeaves(
+      [
+        { observationId: "o1", embedding: [0.9, 0.1] },
+        { observationId: "o2", embedding: [0.1, 0.9] },
+      ],
+      leaves,
+    )
+    expect(routed).toHaveLength(2)
+    expect(routed[0]).toMatchObject({ observationId: "o1", assignedClusterId: "a".repeat(24) })
+    expect(routed[1]).toMatchObject({ observationId: "o2", assignedClusterId: "b".repeat(24) })
+    // Confidence is a clamped cosine similarity in [0, 1].
+    expect(routed[0]?.confidence).toBeGreaterThan(0.9)
+    expect(routed[0]?.confidence).toBeLessThanOrEqual(1)
+  })
+
+  it("routes the FULL window, not just a sample", () => {
+    const observations = Array.from({ length: 100 }, (_, index) => ({
+      observationId: `o${index}`,
+      embedding: index % 2 === 0 ? [1, 0.02] : [0.02, 1],
+    }))
+    const routed = routeObservationsToLeaves(observations, leaves)
+    expect(routed).toHaveLength(100)
+  })
+
+  it("drops observations with empty embeddings and returns nothing when there are no leaves", () => {
+    expect(routeObservationsToLeaves([{ observationId: "o1", embedding: [] }], leaves)).toEqual([])
+    expect(routeObservationsToLeaves([{ observationId: "o1", embedding: [1, 0] }], [])).toEqual([])
+  })
+
+  it("is deterministic: an exact tie keeps the first leaf in input order", () => {
+    const tied = [leaf("a".repeat(24), [1, 0]), leaf("b".repeat(24), [1, 0])]
+    const routed = routeObservationsToLeaves([{ observationId: "o1", embedding: [1, 0] }], tied)
+    expect(routed[0]?.assignedClusterId).toBe("a".repeat(24))
+  })
+})

--- a/packages/domain/taxonomy/src/reassignment.ts
+++ b/packages/domain/taxonomy/src/reassignment.ts
@@ -1,0 +1,70 @@
+/**
+ * Full-window reassignment routing.
+ *
+ * The adaptive publish path stages the whole new tree, then routes the *complete*
+ * bounded live window (not just the ≤1,500 clustering sample) to the staging
+ * leaves before the atomic swap, so no active read is left pointing at a
+ * soon-to-deprecate cluster. Routing is a pure argmax of each observation's
+ * embedding against the leaf centroids — the leaves partition the space, so
+ * nearest-leaf matches the deepest-fit descent that built them, and it is
+ * deterministic for Temporal replay.
+ */
+
+import type { TaxonomyClusterId } from "@domain/shared"
+import { cosineSimilarityNormalized, normalizeTaxonomyEmbedding } from "./helpers.ts"
+
+export interface ReassignmentLeaf {
+  readonly clusterId: TaxonomyClusterId
+  /** Normalized leaf centroid. */
+  readonly centroid: readonly number[]
+}
+
+export interface ReassignmentSourceObservation {
+  readonly observationId: string
+  readonly embedding: readonly number[]
+}
+
+export interface RoutedLeafAssignment {
+  readonly observationId: string
+  readonly assignedClusterId: TaxonomyClusterId
+  /** Cosine similarity to the chosen leaf centroid, clamped to [0, 1]. */
+  readonly confidence: number
+}
+
+const routeOne = (embedding: readonly number[], leaves: readonly ReassignmentLeaf[]): RoutedLeafAssignment | null => {
+  if (leaves.length === 0 || embedding.length === 0) return null
+  const normalized = normalizeTaxonomyEmbedding(embedding)
+  if (normalized.length === 0) return null
+  let best: ReassignmentLeaf | null = null
+  let bestSimilarity = Number.NEGATIVE_INFINITY
+  for (const leaf of leaves) {
+    if (leaf.centroid.length === 0) continue
+    const similarity = cosineSimilarityNormalized(normalized, leaf.centroid)
+    // Deterministic tie-break: keep the first leaf (input order) on an exact tie.
+    if (similarity > bestSimilarity) {
+      bestSimilarity = similarity
+      best = leaf
+    }
+  }
+  if (best === null) return null
+  return {
+    observationId: "",
+    assignedClusterId: best.clusterId,
+    confidence: Math.max(0, Math.min(1, bestSimilarity)),
+  }
+}
+
+/** Route each observation to its nearest staging leaf. Observations with an empty
+ * embedding or no candidate leaf are dropped. */
+export const routeObservationsToLeaves = (
+  observations: readonly ReassignmentSourceObservation[],
+  leaves: readonly ReassignmentLeaf[],
+): readonly RoutedLeafAssignment[] => {
+  const out: RoutedLeafAssignment[] = []
+  for (const observation of observations) {
+    const routed = routeOne(observation.embedding, leaves)
+    if (routed === null) continue
+    out.push({ ...routed, observationId: observation.observationId })
+  }
+  return out
+}

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-cluster-repository.ts
@@ -93,7 +93,9 @@ export const createFakeTaxonomyClusterRepository = (
             (cluster) =>
               cluster.projectId === projectId &&
               (cluster.customBehaviorId ?? null) === (customBehaviorId ?? null) &&
-              (state ? cluster.state === state : true),
+              // `staging` is internal to the publish swap; never surface it unless
+              // explicitly requested (mirrors the Live repository).
+              (state ? cluster.state === state : cluster.state !== "staging"),
           )
           .sort((a, b) => {
             switch (sort ?? "observation_count_desc") {
@@ -138,6 +140,26 @@ export const createFakeTaxonomyClusterRepository = (
         const existing = clusters.get(clusterId)
         if (existing) {
           clusters.set(clusterId, { ...existing, state: "deprecated", updatedAt: timestamp })
+        }
+      }),
+
+    swapActiveTree: ({ supersededClusterIds, stagingClusterIds, timestamp }) =>
+      Effect.sync(() => {
+        for (const clusterId of supersededClusterIds) {
+          const existing = clusters.get(clusterId)
+          if (existing) clusters.set(clusterId, { ...existing, state: "deprecated", updatedAt: timestamp })
+        }
+        for (const clusterId of stagingClusterIds) {
+          const existing = clusters.get(clusterId)
+          if (existing) clusters.set(clusterId, { ...existing, state: "active", updatedAt: timestamp })
+        }
+      }),
+
+    deleteStaging: ({ clusterIds }) =>
+      Effect.sync(() => {
+        for (const clusterId of clusterIds) {
+          const existing = clusters.get(clusterId)
+          if (existing && existing.state === "staging") clusters.delete(clusterId)
         }
       }),
 

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
@@ -375,11 +375,16 @@ export const createFakeTaxonomyObservationRepository = (
 
     // The fake does not compile `filterSet` (session-filter compilation is
     // ClickHouse-specific); it returns the full newest-N live window as slim
-    // reassignment rows carrying the current assignment.
-    listWindowForReassignment: ({ organizationId, projectId, limit }) =>
-      Effect.sync(() =>
-        latestProjectWindow(organizationId, projectId)
+    // reassignment rows carrying the current assignment. `excludeAssignedClusterIds`
+    // drops rows already pointing at one of those clusters (catch-up narrowing).
+    listWindowForReassignment: ({ organizationId, projectId, limit, excludeAssignedClusterIds }) =>
+      Effect.sync(() => {
+        const excluded = new Set((excludeAssignedClusterIds ?? []).map((id) => id as string))
+        return latestProjectWindow(organizationId, projectId)
           .filter((observation) => observation.embedding.length > 0)
+          .filter(
+            (observation) => observation.assignedClusterId === null || !excluded.has(observation.assignedClusterId),
+          )
           .slice(0, limit)
           .map((observation) => ({
             observationId: observation.observationId,
@@ -387,8 +392,20 @@ export const createFakeTaxonomyObservationRepository = (
             embedding: observation.embedding,
             startTime: observation.startTime,
             assignedClusterId: observation.assignedClusterId,
-          })),
-      ),
+          }))
+      }),
+
+    countWindowAssignedToClusters: ({ organizationId, projectId, limit, clusterIds }) =>
+      Effect.sync(() => {
+        const targets = new Set(clusterIds.map((id) => id as string))
+        const window = latestProjectWindow(organizationId, projectId)
+          .filter((observation) => observation.embedding.length > 0)
+          .slice(0, limit)
+        return {
+          total: window.length,
+          matching: window.filter((o) => o.assignedClusterId !== null && targets.has(o.assignedClusterId)).length,
+        }
+      }),
 
     getClusterCountsByUser: () => Effect.succeed([]),
 

--- a/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
+++ b/packages/domain/taxonomy/src/testing/fake-taxonomy-observation-repository.ts
@@ -373,6 +373,23 @@ export const createFakeTaxonomyObservationRepository = (
         return [...counts.entries()].map(([clusterId, count]) => ({ clusterId: clusterId as never, ...count }))
       }),
 
+    // The fake does not compile `filterSet` (session-filter compilation is
+    // ClickHouse-specific); it returns the full newest-N live window as slim
+    // reassignment rows carrying the current assignment.
+    listWindowForReassignment: ({ organizationId, projectId, limit }) =>
+      Effect.sync(() =>
+        latestProjectWindow(organizationId, projectId)
+          .filter((observation) => observation.embedding.length > 0)
+          .slice(0, limit)
+          .map((observation) => ({
+            observationId: observation.observationId,
+            sessionId: observation.sessionId,
+            embedding: observation.embedding,
+            startTime: observation.startTime,
+            assignedClusterId: observation.assignedClusterId,
+          })),
+      ),
+
     getClusterCountsByUser: () => Effect.succeed([]),
 
     getClusterTrendCounts: ({ organizationId, projectId, clusterIds, currentSince, baselineSince, baselineDays }) =>

--- a/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/adaptive-gardening.test.ts
@@ -1,0 +1,343 @@
+import { EMBEDDING_DIMENSIONS } from "@domain/ai"
+import {
+  ChSqlClient,
+  CustomBehaviorId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SqlClient,
+  type TaxonomyClusterId,
+  TaxonomyRunId,
+} from "@domain/shared"
+import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD } from "../constants.ts"
+import { type TaxonomyCluster, taxonomyClusterSchema } from "../entities/cluster.ts"
+import type { TaxonomyMomentObservation } from "../entities/observation.ts"
+import { TaxonomyClusterRepository } from "../ports/taxonomy-cluster-repository.ts"
+import { TaxonomyObservationRepository } from "../ports/taxonomy-observation-repository.ts"
+import { createFakeTaxonomyClusterRepository } from "../testing/fake-taxonomy-cluster-repository.ts"
+import { createFakeTaxonomyObservationRepository } from "../testing/fake-taxonomy-observation-repository.ts"
+import { type HierarchicalTaxonomyPlan, planHierarchicalTaxonomyUseCase } from "./build-hierarchical-taxonomy.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const runId = TaxonomyRunId("r".repeat(24))
+
+// Two well-separated groups with small within-group jitter (a zero-spread
+// cluster scores CH=0 and never splits). Embeddings are normalized inside the
+// use case, so raw magnitudes are fine here.
+const groupVector = (group: 0 | 1, jitterIndex: number): number[] => {
+  const values = new Array<number>(EMBEDDING_DIMENSIONS).fill(0)
+  values[group] = 1
+  values[100 + group] = 0.03 * (jitterIndex % 5)
+  return values
+}
+
+const makeObservation = (index: number, group: 0 | 1, at: Date): TaxonomyMomentObservation => ({
+  organizationId,
+  projectId,
+  observationId: String(index).padStart(24, "o").slice(0, 24),
+  sessionId: SessionId(`session-${index}`),
+  analysisHash: String(index).repeat(64).slice(0, 64),
+  momentId: `moment-${index}`,
+  projectionMethod: "moment_text_embedding",
+  projectionHash: String(index).repeat(64).slice(0, 64),
+  projectionMetadata: { summary: `Observation ${index}` },
+  embedding: groupVector(group, index),
+  startTime: new Date(at.getTime() + index * 1000),
+  endTime: new Date(at.getTime() + index * 1000 + 500),
+  assignedClusterId: null,
+  assignmentConfidence: 0,
+  assignmentMethod: "noise",
+  reassignmentRunId: null,
+  retentionDays: 90,
+  indexedAt: new Date(at.getTime() - 60_000),
+})
+
+// 40 observations across two separable groups → root splits into two leaves.
+const twoGroupCorpus = (at: Date): TaxonomyMomentObservation[] =>
+  Array.from({ length: 40 }, (_, index) => makeObservation(index, index < 20 ? 0 : 1, at))
+
+const runPlan = (
+  observations: ReturnType<typeof createFakeTaxonomyObservationRepository>,
+  clusters: ReturnType<typeof createFakeTaxonomyClusterRepository>,
+  args: {
+    readonly now: Date
+    readonly mode?: "off" | "shadow" | "enforced"
+    readonly customBehaviorId?: CustomBehaviorId
+  },
+): Promise<HierarchicalTaxonomyPlan> =>
+  Effect.runPromise(
+    planHierarchicalTaxonomyUseCase({
+      organizationId,
+      projectId,
+      runId,
+      dimension: "topic",
+      now: args.now,
+      ...(args.mode ? { mode: args.mode } : {}),
+      ...(args.customBehaviorId
+        ? { customBehaviorId: args.customBehaviorId, filterSet: { userId: [{ op: "in", value: ["u"] }] } }
+        : {}),
+    }).pipe(
+      Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),
+      Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+      Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      Effect.provide(Layer.succeed(ChSqlClient, createFakeChSqlClient())),
+    ),
+  )
+
+const now = new Date("2026-05-24T12:00:00.000Z")
+
+describe("planHierarchicalTaxonomyUseCase adaptive (enforced) publish plan", () => {
+  it("builds a staging tree with leaf routing targets, decision metadata, and no sample assignments", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+
+    const plan = await runPlan(observations, clusters, { now, mode: "enforced" })
+
+    expect(plan.mode).toBe("enforced")
+    expect(plan.clusters.length).toBeGreaterThanOrEqual(3)
+    // Every built cluster is staging — hidden from active reads until the swap.
+    expect(plan.clusters.every((cluster) => cluster.state === "staging")).toBe(true)
+    // Full-window reassignment routes into these; sample assignments are unused.
+    expect(plan.leafClusters.length).toBeGreaterThanOrEqual(2)
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments).toEqual([])
+    expect(plan.decisionMetadata).not.toBeNull()
+    expect(plan.decisionMetadata?.acceptedSplits).toBeGreaterThanOrEqual(1)
+  })
+
+  it("stores the member-confidence splitLinkThreshold the online router reads at descent time", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+
+    const plan = await runPlan(observations, clusters, { now, mode: "enforced" })
+
+    const interior = plan.clusters.filter((cluster) => cluster.splitLinkThreshold !== null)
+    expect(interior.length).toBeGreaterThanOrEqual(1)
+    for (const cluster of interior) {
+      const threshold = cluster.splitLinkThreshold as number
+      // Floored by the global absolute threshold and a valid stored [0,1] value.
+      expect(threshold).toBeGreaterThanOrEqual(TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD)
+      expect(threshold).toBeLessThanOrEqual(1)
+      // The persisted threshold is exactly a value the builder derived.
+      expect(plan.decisionMetadata?.routingThresholds).toContain(threshold)
+    }
+  })
+
+  it("supersedes the whole old tree and gives staging fresh ids (continuity via lineage, not id reuse)", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+
+    // First adaptive pass, then simulate the swap so pass two sees them active.
+    const first = await runPlan(observations, clusters, { now, mode: "enforced" })
+    for (const cluster of first.clusters) clusters.clusters.set(cluster.id, { ...cluster, state: "active" })
+    const firstIds = new Set(first.clusters.map((cluster) => cluster.id))
+
+    const second = await runPlan(observations, clusters, {
+      now: new Date(now.getTime() + 6 * 60 * 60_000),
+      mode: "enforced",
+    })
+
+    // Fresh ids: no staging cluster reuses a prior active id.
+    expect(second.clusters.every((cluster) => !firstIds.has(cluster.id))).toBe(true)
+    // The whole old active tree is superseded for the atomic swap.
+    expect([...second.supersededClusterIds].sort()).toEqual([...firstIds].sort())
+    // Continuity is still recorded in lineage.
+    expect(second.lineage.some((row) => row.transitionType === "continuation")).toBe(true)
+  })
+})
+
+describe("planHierarchicalTaxonomyUseCase off is a byte-identical no-op", () => {
+  it("global: active clusters, sample assignments, no staging machinery", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+
+    const plan = await runPlan(observations, clusters, { now })
+
+    expect(plan.mode).toBe("off")
+    expect(plan.clusters.every((cluster) => cluster.state === "active")).toBe(true)
+    expect(plan.leafClusters).toEqual([])
+    expect(plan.supersededClusterIds).toEqual([])
+    expect(plan.decisionMetadata).toBeNull()
+    expect(plan.observationAssignments.length).toBeGreaterThan(0)
+    expect(plan.customAssignments).toEqual([])
+  })
+
+  it("scoped: active clusters, custom assignments, no staging machinery", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+    const customBehaviorId = CustomBehaviorId("b".repeat(24))
+
+    const plan = await runPlan(observations, clusters, { now, customBehaviorId })
+
+    expect(plan.mode).toBe("off")
+    expect(plan.customBehaviorId).toBe(customBehaviorId)
+    expect(plan.clusters.every((cluster) => cluster.state === "active")).toBe(true)
+    expect(plan.leafClusters).toEqual([])
+    expect(plan.supersededClusterIds).toEqual([])
+    expect(plan.decisionMetadata).toBeNull()
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments.length).toBeGreaterThan(0)
+  })
+
+  it("adaptive scoped tags staging clusters + routing leaves with the behavior", async () => {
+    const observations = createFakeTaxonomyObservationRepository(twoGroupCorpus(now))
+    const clusters = createFakeTaxonomyClusterRepository([])
+    const customBehaviorId = CustomBehaviorId("b".repeat(24))
+
+    const plan = await runPlan(observations, clusters, { now, mode: "enforced", customBehaviorId })
+
+    expect(plan.clusters.every((cluster) => cluster.state === "staging")).toBe(true)
+    expect(plan.clusters.every((cluster) => cluster.customBehaviorId === customBehaviorId)).toBe(true)
+    expect(plan.leafClusters.length).toBeGreaterThanOrEqual(2)
+    // Both write-target arrays stay empty; the scoped full-window pass writes the slice.
+    expect(plan.observationAssignments).toEqual([])
+    expect(plan.customAssignments).toEqual([])
+  })
+})
+
+describe("taxonomy cluster entity accepts the widened staging state", () => {
+  it("round-trips a staging row through the Zod schema", () => {
+    const staging: TaxonomyCluster = taxonomyClusterSchema.parse({
+      id: "c".repeat(24),
+      organizationId,
+      projectId,
+      customBehaviorId: null,
+      dimension: "topic",
+      parentClusterId: null,
+      depth: 0,
+      path: "",
+      splitLinkThreshold: 0.7,
+      name: "Pending",
+      description: "",
+      centroid: { base: [1, 0], mass: 1, model: "m", decay: 1, weights: { default: 1 } },
+      observationCount: 0,
+      state: "staging",
+      mergedIntoClusterId: null,
+      firstObservedAt: now,
+      lastObservedAt: now,
+      clusteredAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    expect(staging.state).toBe("staging")
+  })
+})
+
+describe("atomic swap + staging cleanup (both global and scoped clusters)", () => {
+  const makeStaging = (id: string, customBehaviorId: CustomBehaviorId | null): TaxonomyCluster =>
+    taxonomyClusterSchema.parse({
+      id,
+      organizationId,
+      projectId,
+      customBehaviorId,
+      dimension: "topic",
+      parentClusterId: null,
+      depth: 0,
+      path: "",
+      splitLinkThreshold: null,
+      name: "Pending",
+      description: "",
+      centroid: { base: [1, 0], mass: 1, model: "m", decay: 1, weights: { default: 1 } },
+      observationCount: 0,
+      state: "staging",
+      mergedIntoClusterId: null,
+      firstObservedAt: now,
+      lastObservedAt: now,
+      clusteredAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+  const runSwap = (
+    clusters: ReturnType<typeof createFakeTaxonomyClusterRepository>,
+    superseded: readonly string[],
+    staging: readonly string[],
+  ) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterRepository
+        yield* repo.swapActiveTree({
+          supersededClusterIds: superseded as TaxonomyClusterId[],
+          stagingClusterIds: staging as TaxonomyClusterId[],
+          timestamp: now,
+        })
+      }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+  it.each([
+    ["global", null],
+    ["scoped", CustomBehaviorId("b".repeat(24))],
+  ] as const)("leaves exactly one active tree after the swap (%s)", async (_label, scope) => {
+    const oldActive = { ...makeStaging("a".repeat(24), scope), state: "active" as const }
+    const staging = makeStaging("d".repeat(24), scope)
+    const clusters = createFakeTaxonomyClusterRepository([oldActive, staging])
+
+    await runSwap(clusters, [oldActive.id], [staging.id])
+
+    expect(clusters.clusters.get(oldActive.id)?.state).toBe("deprecated")
+    expect(clusters.clusters.get(staging.id)?.state).toBe("active")
+    const active = [...clusters.clusters.values()].filter((cluster) => cluster.state === "active")
+    expect(active).toHaveLength(1)
+    expect(active[0]?.id).toBe(staging.id)
+  })
+
+  it("is idempotent on retry (re-running the swap keeps one active tree)", async () => {
+    const oldActive = { ...makeStaging("a".repeat(24), null), state: "active" as const }
+    const staging = makeStaging("d".repeat(24), null)
+    const clusters = createFakeTaxonomyClusterRepository([oldActive, staging])
+
+    await runSwap(clusters, [oldActive.id], [staging.id])
+    await runSwap(clusters, [oldActive.id], [staging.id])
+
+    expect(clusters.clusters.get(oldActive.id)?.state).toBe("deprecated")
+    expect(clusters.clusters.get(staging.id)?.state).toBe("active")
+  })
+
+  it("cleanup deletes abandoned staging rows and never touches the active tree", async () => {
+    const oldActive = { ...makeStaging("a".repeat(24), null), state: "active" as const }
+    const staging = makeStaging("d".repeat(24), null)
+    const clusters = createFakeTaxonomyClusterRepository([oldActive, staging])
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterRepository
+        yield* repo.deleteStaging({ clusterIds: [oldActive.id, staging.id] as TaxonomyClusterId[] })
+      }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    // Guarded to state='staging': the active tree survives, the orphan is gone.
+    expect(clusters.clusters.get(oldActive.id)?.state).toBe("active")
+    expect(clusters.clusters.has(staging.id)).toBe(false)
+  })
+
+  it("invariant: active reads never return a staging row", async () => {
+    const active = { ...makeStaging("a".repeat(24), null), state: "active" as const }
+    const staging = makeStaging("d".repeat(24), null)
+    const clusters = createFakeTaxonomyClusterRepository([active, staging])
+
+    const [activeByProject, listed] = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyClusterRepository
+        const byProject = yield* repo.listActiveByProject({ projectId, dimension: "topic" })
+        const page = yield* repo.list({ projectId, dimension: "topic", limit: 50, offset: 0 })
+        return [byProject, page.items] as const
+      }).pipe(
+        Effect.provide(Layer.succeed(TaxonomyClusterRepository, clusters.repository)),
+        Effect.provide(Layer.succeed(SqlClient, createFakeSqlClient())),
+      ),
+    )
+
+    expect(activeByProject.map((cluster) => cluster.id)).toEqual([active.id])
+    expect(listed.some((cluster) => cluster.state === "staging")).toBe(false)
+  })
+})

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.test.ts
@@ -223,10 +223,13 @@ describe("planHierarchicalTaxonomyUseCase continuity matching", () => {
         now,
         clusterBuilder: (input) =>
           Effect.succeed({
-            memberIndices: input.embeddings.map((_, index) => index),
-            centroid: input.embeddings[0] ?? [],
-            children: [],
-            depth: 0,
+            root: {
+              memberIndices: input.embeddings.map((_, index) => index),
+              centroid: input.embeddings[0] ?? [],
+              children: [],
+              depth: 0,
+            },
+            diagnostics: null,
           }),
       }).pipe(
         Effect.provide(Layer.succeed(TaxonomyObservationRepository, observations.repository)),

--- a/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
+++ b/packages/domain/taxonomy/src/use-cases/build-hierarchical-taxonomy.ts
@@ -59,11 +59,18 @@ import {
 } from "@domain/shared"
 import { Effect } from "effect"
 import {
-  type BuildStaticHierarchicalClustersInput,
+  isAdaptiveModeActive,
+  TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT,
+  type TaxonomyAdaptiveClusteringMode,
+} from "../adaptive-mode.ts"
+import {
+  buildRelativeHierarchicalClusters,
   buildStaticHierarchicalClusters,
   type ClusteringTreeNode,
+  type RelativeClusteringDiagnostics,
 } from "../clustering.ts"
 import {
+  TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD,
   TAXONOMY_CLUSTERING_PROPOSAL_SAMPLE_MAX,
   TAXONOMY_CLUSTERING_SAMPLE_STRATEGY,
   TAXONOMY_CONTINUATION_THRESHOLD,
@@ -75,9 +82,10 @@ import {
   TAXONOMY_NAME_REUSE_THRESHOLD,
   TAXONOMY_OBSERVATION_RETENTION_DAYS,
   TAXONOMY_PENDING_DISPLAY_NAME,
+  TAXONOMY_TREE_RELATIVE_DEPTH_SCHEDULE,
   TAXONOMY_TREE_STATIC_DEPTH_SCHEDULE,
 } from "../constants.ts"
-import type { TaxonomyCluster } from "../entities/cluster.ts"
+import type { TaxonomyCluster, TaxonomyClusterState } from "../entities/cluster.ts"
 import type { CustomBehaviorAssignment } from "../entities/custom-behavior-assignment.ts"
 import { TaxonomyDimension, type TaxonomyDimension as TaxonomyDimensionType } from "../entities/dimension.ts"
 import type { TaxonomyClusterLineage } from "../entities/lineage.ts"
@@ -120,9 +128,52 @@ export interface BuildHierarchicalTaxonomyResult {
   readonly lineage: readonly TaxonomyClusterLineage[]
 }
 
+/**
+ * Mode-tagged build request. The builder (worker or in-process) branches on
+ * `mode` internally: `off` runs the static absolute-sibling-cosine builder,
+ * `shadow`/`enforced` run the node-relative adaptive builder. Schedules and
+ * k-means constants are resolved builder-side so the request stays slim.
+ */
+export interface TaxonomyClusterBuildRequest {
+  readonly mode: TaxonomyAdaptiveClusteringMode
+  readonly embeddings: readonly (readonly number[])[]
+  readonly seed: number
+}
+
+export interface TaxonomyClusterBuildResult {
+  readonly root: ClusteringTreeNode
+  /** Bounded, embedding-free diagnostics — null on the static (off) path. */
+  readonly diagnostics: RelativeClusteringDiagnostics | null
+}
+
 export type TaxonomyClusterBuilder = (
-  input: BuildStaticHierarchicalClustersInput,
-) => Effect.Effect<ClusteringTreeNode, Error, never>
+  input: TaxonomyClusterBuildRequest,
+) => Effect.Effect<TaxonomyClusterBuildResult, Error, never>
+
+/** In-process builder (no worker) — the default used by tests and the sync path. */
+export const runTaxonomyClusterBuild = (input: TaxonomyClusterBuildRequest): TaxonomyClusterBuildResult => {
+  if (isAdaptiveModeActive(input.mode)) {
+    const { root, diagnostics } = buildRelativeHierarchicalClusters({
+      embeddings: input.embeddings,
+      depthSchedule: TAXONOMY_TREE_RELATIVE_DEPTH_SCHEDULE,
+      restarts: TAXONOMY_KMEANS_RESTARTS,
+      maxIter: TAXONOMY_KMEANS_MAX_ITER,
+      tolerance: TAXONOMY_KMEANS_TOLERANCE,
+      seed: input.seed,
+      globalAbsoluteThreshold: TAXONOMY_ASSIGN_ABSOLUTE_THRESHOLD,
+    })
+    return { root, diagnostics }
+  }
+  const root = buildStaticHierarchicalClusters({
+    embeddings: input.embeddings,
+    depthSchedule: TAXONOMY_TREE_STATIC_DEPTH_SCHEDULE,
+    restarts: TAXONOMY_KMEANS_RESTARTS,
+    maxIter: TAXONOMY_KMEANS_MAX_ITER,
+    tolerance: TAXONOMY_KMEANS_TOLERANCE,
+    seed: input.seed,
+  })
+  return { root, diagnostics: null }
+}
 
 export interface PlanHierarchicalTaxonomyInput extends BuildHierarchicalTaxonomyInput {
   readonly clusterBuilder?: TaxonomyClusterBuilder
@@ -135,18 +186,49 @@ export interface PlanHierarchicalTaxonomyInput extends BuildHierarchicalTaxonomy
    */
   readonly customBehaviorId?: CustomBehaviorId
   readonly filterSet?: FilterSet
+  /**
+   * Rollout mode, resolved in the planning activity. `off` (default) is a
+   * byte-identical no-op: static builder, sample-only reassignment, active
+   * clusters, centroid-similarity naming. `shadow`/`enforced` build the adaptive
+   * tree as `staging` clusters for the full-window reassignment + atomic swap.
+   */
+  readonly mode?: TaxonomyAdaptiveClusteringMode
+}
+
+/** A staging leaf the full-window reassignment routes observations into. */
+export interface StagingLeafCluster {
+  readonly clusterId: TaxonomyClusterId
+  readonly centroid: readonly number[]
 }
 
 export interface HierarchicalTaxonomyPlan extends BuildHierarchicalTaxonomyResult {
+  readonly mode: TaxonomyAdaptiveClusteringMode
   /** Depth-ascending; write boundaries must preserve order so children are not saved before parents. */
   readonly clusters: readonly TaxonomyCluster[]
-  /** Global write target: reassign `assigned_cluster_id`. Empty on the scoped path. */
+  /**
+   * Global write target: reassign `assigned_cluster_id`. Empty on the scoped
+   * path AND on the adaptive path (which reassigns the full window separately).
+   */
   readonly observationAssignments: readonly ReassignTaxonomyObservationByIdInput[]
-  /** Scoped write target: the `custom_behavior_assignments` slice. Empty on the global path. */
+  /** Scoped write target: the `custom_behavior_assignments` slice. Empty on the global/adaptive path. */
   readonly customAssignments: readonly CustomBehaviorAssignment[]
+  /** Leaf id + centroid for adaptive full-window routing. Empty on the off path. */
+  readonly leafClusters: readonly StagingLeafCluster[]
   /** Non-null ⇒ the plan is scoped to this custom behavior (drives the write target). */
   readonly customBehaviorId: CustomBehaviorId | null
+  /**
+   * Death lineage targets — previously-active clusters no node continued. On the
+   * off path this is exactly what gets deprecated.
+   */
   readonly deprecatedClusterIds: readonly TaxonomyClusterId[]
+  /**
+   * The full old active tree the staging tree replaces (adaptive only; empty on
+   * off). The atomic swap deprecates exactly these ids and activates the staging
+   * clusters, so the operation is idempotent under Temporal activity retries.
+   */
+  readonly supersededClusterIds: readonly TaxonomyClusterId[]
+  /** Bounded adaptive-build diagnostics for telemetry; null on the off path. */
+  readonly decisionMetadata: RelativeClusteringDiagnostics | null
 }
 
 const lookbackStart = (now: Date): Date =>
@@ -172,6 +254,8 @@ const buildPersistedCluster = (input: {
   readonly path: string
   readonly depth: number
   readonly splitLinkThreshold: number | null
+  /** `active` on the off path; `staging` on the adaptive path until the swap. */
+  readonly state: TaxonomyClusterState
   readonly memberEmbeddings: readonly (readonly number[])[]
   readonly memberStartTimes: readonly Date[]
   readonly memberCount: number
@@ -221,7 +305,7 @@ const buildPersistedCluster = (input: {
     description: input.description,
     centroid,
     observationCount: input.memberCount,
-    state: "active",
+    state: input.state,
     mergedIntoClusterId: null,
     firstObservedAt: input.firstObservedAt ?? sortedTimes[0] ?? input.now,
     lastObservedAt: sortedTimes[sortedTimes.length - 1] ?? input.now,
@@ -277,6 +361,7 @@ interface NodeDescriptor {
   readonly splitLinkThreshold: number | null
   readonly memberIndices: readonly number[]
   readonly isLeaf: boolean
+  readonly childCount: number
 }
 
 const collectNodes = (
@@ -291,9 +376,13 @@ const collectNodes = (
     parentTempId,
     depth: node.depth,
     centroid: node.centroid,
-    splitLinkThreshold: computeSplitLinkThreshold(node.children),
+    // The relative builder attaches a member-confidence threshold per interior
+    // node; the static (off) path has none, so fall back to the sibling-cosine
+    // `computeSplitLinkThreshold` — byte-identical to pre-change.
+    splitLinkThreshold: node.splitLinkThreshold ?? computeSplitLinkThreshold(node.children),
     memberIndices: node.memberIndices,
     isLeaf: node.children.length === 0,
+    childCount: node.children.length,
   })
   for (const child of node.children) collectNodes(child, tempId, counter, out)
   return tempId
@@ -310,30 +399,59 @@ interface ResolvedTaxonomyLineage {
   readonly oldById: ReadonlyMap<string, TaxonomyCluster>
   readonly decisionByTempId: ReadonlyMap<string, LineageDecision>
   readonly finalIdByTempId: ReadonlyMap<string, string>
+  /** Old ids a new node continued — the rest are deaths, in both modes. */
+  readonly matchedOldIds: ReadonlySet<string>
 }
 
 const resolveTaxonomyLineage = (input: {
   readonly descriptors: readonly NodeDescriptor[]
   readonly previouslyActive: readonly TaxonomyCluster[]
+  readonly mode: TaxonomyAdaptiveClusteringMode
 }): ResolvedTaxonomyLineage => {
   const oldById = new Map(input.previouslyActive.map((cluster) => [cluster.id as string, cluster] as const))
+  // Old-cluster shape, derived from the flat previously-active set: a cluster is
+  // interior iff another active cluster points at it as parent.
+  const oldChildCount = new Map<string, number>()
+  for (const cluster of input.previouslyActive) {
+    if (cluster.parentClusterId === null) continue
+    const parent = cluster.parentClusterId as string
+    oldChildCount.set(parent, (oldChildCount.get(parent) ?? 0) + 1)
+  }
   const match = matchTaxonomyLineage({
-    newNodes: input.descriptors.map((node) => ({ tempId: node.tempId, depth: node.depth, centroid: node.centroid })),
-    oldClusters: input.previouslyActive.map((cluster) => ({
-      id: cluster.id,
-      depth: cluster.depth,
-      centroid: normalizeTaxonomyCentroid(cluster.centroid),
+    newNodes: input.descriptors.map((node) => ({
+      tempId: node.tempId,
+      depth: node.depth,
+      centroid: node.centroid,
+      isLeaf: node.isLeaf,
+      childCount: node.childCount,
     })),
+    oldClusters: input.previouslyActive.map((cluster) => {
+      const childCount = oldChildCount.get(cluster.id as string) ?? 0
+      return {
+        id: cluster.id,
+        depth: cluster.depth,
+        centroid: normalizeTaxonomyCentroid(cluster.centroid),
+        isLeaf: childCount === 0,
+        childCount,
+      }
+    }),
     continuationThreshold: TAXONOMY_CONTINUATION_THRESHOLD,
     nameReuseThreshold: TAXONOMY_NAME_REUSE_THRESHOLD,
+    shapeAwareNaming: isAdaptiveModeActive(input.mode),
   })
   const decisionByTempId = new Map(match.decisions.map((decision) => [decision.tempId, decision] as const))
   const finalIdByTempId = new Map<string, string>()
   for (const node of input.descriptors) {
     const decision = decisionByTempId.get(node.tempId)
-    finalIdByTempId.set(node.tempId, decision?.transition === "continuation" ? decision.reuseId : generateId())
+    // Off reuses the continued id in place (id-keyed trend continuity). Adaptive
+    // stages a fresh tree that atomically replaces the old one, so every staging
+    // node gets a fresh id and continuity is carried by the lineage rows, not the
+    // literal id — a live upsert onto a reused id would collapse the old tree
+    // before the swap.
+    const reuse = decision?.transition === "continuation" && !isAdaptiveModeActive(input.mode)
+    finalIdByTempId.set(node.tempId, reuse ? decision.reuseId : generateId())
   }
-  return { oldById, decisionByTempId, finalIdByTempId }
+  return { oldById, decisionByTempId, finalIdByTempId, matchedOldIds: match.matchedOldIds }
 }
 
 export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyInput) =>
@@ -342,6 +460,9 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
     yield* Effect.annotateCurrentSpan("taxonomy.runId", input.runId)
     const now = input.now ?? new Date()
     const dimension = input.dimension ?? TaxonomyDimension.Topic
+    const mode = input.mode ?? TAXONOMY_ADAPTIVE_CLUSTERING_MODE_DEFAULT
+    const adaptive = isAdaptiveModeActive(mode)
+    const clusterState: TaxonomyClusterState = adaptive ? "staging" : "active"
     const embeddingConfig = yield* resolveEmbeddingConfig()
     const observationsRepo = yield* TaxonomyObservationRepository
     const clustersRepo = yield* TaxonomyClusterRepository
@@ -396,24 +517,25 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         clusters: [],
         observationAssignments: [],
         customAssignments: [],
+        leafClusters: [],
         customBehaviorId: scopedBehaviorId,
         deprecatedClusterIds: [],
+        supersededClusterIds: [],
+        mode,
+        decisionMetadata: null,
       } satisfies HierarchicalTaxonomyPlan
     }
 
     const normalizedEmbeddings = observations.map((observation) => normalizeTaxonomyEmbedding(observation.embedding))
     const clusterBuilder =
       input.clusterBuilder ??
-      ((builderInput: BuildStaticHierarchicalClustersInput) =>
-        Effect.sync(() => buildStaticHierarchicalClusters(builderInput)))
-    const tree = yield* clusterBuilder({
+      ((request: TaxonomyClusterBuildRequest) => Effect.sync(() => runTaxonomyClusterBuild(request)))
+    const build = yield* clusterBuilder({
+      mode,
       embeddings: normalizedEmbeddings,
-      depthSchedule: TAXONOMY_TREE_STATIC_DEPTH_SCHEDULE,
-      restarts: TAXONOMY_KMEANS_RESTARTS,
-      maxIter: TAXONOMY_KMEANS_MAX_ITER,
-      tolerance: TAXONOMY_KMEANS_TOLERANCE,
       seed: seedFromProjectId(scopedBehaviorId ? `${input.projectId}:${scopedBehaviorId}` : input.projectId),
     })
+    const tree = build.root
 
     const descriptors: NodeDescriptor[] = []
     collectNodes(tree, null, { value: 0 }, descriptors)
@@ -423,7 +545,11 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       dimension,
       ...(input.customBehaviorId ? { customBehaviorId: input.customBehaviorId } : {}),
     })
-    const { oldById, decisionByTempId, finalIdByTempId } = resolveTaxonomyLineage({ descriptors, previouslyActive })
+    const { oldById, decisionByTempId, finalIdByTempId, matchedOldIds } = resolveTaxonomyLineage({
+      descriptors,
+      previouslyActive,
+      mode,
+    })
 
     const orderedDescriptors = [...descriptors].sort((a, b) => a.depth - b.depth)
     const pathByTempId = new Map<string, string>()
@@ -457,6 +583,7 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
         path,
         depth: node.depth,
         splitLinkThreshold: node.splitLinkThreshold,
+        state: clusterState,
         memberEmbeddings,
         memberStartTimes,
         memberCount: directCount,
@@ -515,50 +642,62 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       }),
     )
 
+    // Off writes the sample assignments here (sample-only reassignment). Adaptive
+    // reassigns the FULL bounded live window in a later activity, routing every
+    // window observation to these leaf centroids — so it publishes `leafClusters`
+    // instead and leaves both sample-assignment arrays empty.
+    const leafClusters: StagingLeafCluster[] = adaptive
+      ? bornLeaves.map((leaf) => ({ clusterId: leaf.clusterId, centroid: [...leaf.centroid] }))
+      : []
+
     // Two write targets, picked by scope: global reassigns the observation's
     // `assigned_cluster_id`; a scoped run writes the `custom_behavior_assignments`
     // slice (carrying sessionId + customBehaviorId), never the global column.
-    const observationAssignments: ReassignTaxonomyObservationByIdInput[] = scopedBehaviorId
-      ? []
-      : leafMembers.map(({ leaf, observation, confidence }) => ({
-          observationId: observation.observationId,
-          assignedClusterId: leaf.clusterId,
-          assignmentMethod: "gardening_birth" as const,
-          assignmentConfidence: confidence,
-          reassignmentRunId: input.runId,
-          indexedAt: now,
-        }))
-    const customAssignments: CustomBehaviorAssignment[] = scopedBehaviorId
-      ? leafMembers.flatMap(({ leaf, observation, confidence }) => {
-          // Scoped samples come from listForCustomBehaviorSample and carry a
-          // sessionId; guard at runtime (via a widening cast, not an unchecked
-          // one) so a non-scoped observation can never yield a `sessionId:
-          // undefined` assignment.
-          const sessionId = (observation as Partial<TaxonomyScopedClusteringObservation>).sessionId
-          if (sessionId === undefined) return []
-          return [
-            {
-              organizationId: input.organizationId,
-              projectId: input.projectId,
-              customBehaviorId: scopedBehaviorId,
-              observationId: observation.observationId,
-              sessionId,
-              assignedClusterId: leaf.clusterId,
-              assignmentConfidence: confidence,
-              assignmentMethod: "gardening_birth" as const,
-              reassignmentRunId: input.runId,
-              startTime: observation.startTime,
-              retentionDays: TAXONOMY_OBSERVATION_RETENTION_DAYS,
-              indexedAt: now,
-            } satisfies CustomBehaviorAssignment,
-          ]
-        })
-      : []
+    const observationAssignments: ReassignTaxonomyObservationByIdInput[] =
+      adaptive || scopedBehaviorId
+        ? []
+        : leafMembers.map(({ leaf, observation, confidence }) => ({
+            observationId: observation.observationId,
+            assignedClusterId: leaf.clusterId,
+            assignmentMethod: "gardening_birth" as const,
+            assignmentConfidence: confidence,
+            reassignmentRunId: input.runId,
+            indexedAt: now,
+          }))
+    const customAssignments: CustomBehaviorAssignment[] =
+      !adaptive && scopedBehaviorId
+        ? leafMembers.flatMap(({ leaf, observation, confidence }) => {
+            // Scoped samples come from listForCustomBehaviorSample and carry a
+            // sessionId; guard at runtime (via a widening cast, not an unchecked
+            // one) so a non-scoped observation can never yield a `sessionId:
+            // undefined` assignment.
+            const sessionId = (observation as Partial<TaxonomyScopedClusteringObservation>).sessionId
+            if (sessionId === undefined) return []
+            return [
+              {
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                customBehaviorId: scopedBehaviorId,
+                observationId: observation.observationId,
+                sessionId,
+                assignedClusterId: leaf.clusterId,
+                assignmentConfidence: confidence,
+                assignmentMethod: "gardening_birth" as const,
+                reassignmentRunId: input.runId,
+                startTime: observation.startTime,
+                retentionDays: TAXONOMY_OBSERVATION_RETENTION_DAYS,
+                indexedAt: now,
+              } satisfies CustomBehaviorAssignment,
+            ]
+          })
+        : []
 
-    const finalIds = new Set(finalIdByTempId.values())
+    // Deprecate every old cluster no new node continued. Keyed on the matcher's
+    // `matchedOldIds` (not on final id equality) so it is correct in adaptive
+    // mode too, where continuations get fresh ids and never appear among them.
     const deprecatedClusterIds: TaxonomyClusterId[] = []
     for (const cluster of previouslyActive) {
-      if (finalIds.has(cluster.id)) continue
+      if (matchedOldIds.has(cluster.id)) continue
       deprecatedClusterIds.push(cluster.id)
       lineage.push({
         id: TaxonomyLineageId(generateId()),
@@ -585,7 +724,11 @@ export const planHierarchicalTaxonomyUseCase = (input: PlanHierarchicalTaxonomyI
       clusters: bornClusters,
       observationAssignments,
       customAssignments,
+      leafClusters,
       customBehaviorId: scopedBehaviorId,
       deprecatedClusterIds,
+      supersededClusterIds: adaptive ? previouslyActive.map((cluster) => cluster.id) : [],
+      mode,
+      decisionMetadata: build.diagnostics,
     } satisfies HierarchicalTaxonomyPlan
   }).pipe(Effect.withSpan("taxonomy.planHierarchicalTaxonomy"))

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -377,6 +377,67 @@ describe("TaxonomyObservationRepositoryLive", () => {
     expect(byId.get("1".repeat(24))?.sessionId).toBe("window-session-a")
     expect(byId.get("1".repeat(24))?.embedding.length).toBeGreaterThan(0)
   })
+
+  it("narrows the reassignment window to stragglers via excludeAssignedClusterIds (catch-up)", async () => {
+    const projectId = ProjectId("x".repeat(24))
+    const onLeaf = makeObservation({
+      observationId: "1".repeat(24),
+      projectId,
+      assignedClusterId: TaxonomyClusterId("c".repeat(24)),
+    })
+    const straggler = makeObservation({
+      observationId: "2".repeat(24),
+      projectId,
+      assignedClusterId: TaxonomyClusterId("d".repeat(24)),
+    })
+    const unassigned = makeObservation({ observationId: "3".repeat(24), projectId, assignedClusterId: null })
+
+    const stragglers = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        yield* repo.upsertMany([onLeaf, straggler, unassigned])
+        return yield* repo.listWindowForReassignment({
+          organizationId,
+          projectId,
+          limit: 10,
+          excludeAssignedClusterIds: [TaxonomyClusterId("c".repeat(24))],
+        })
+      }),
+    )
+
+    // Rows already on the current leaf (c) are dropped; the straggler and the
+    // unassigned row remain.
+    expect(new Set(stragglers.map((row) => row.observationId))).toEqual(new Set(["2".repeat(24), "3".repeat(24)]))
+  })
+
+  it("counts window rows still pointing at the superseded tree without shipping embeddings", async () => {
+    const projectId = ProjectId("y".repeat(24))
+    const superseded = makeObservation({
+      observationId: "1".repeat(24),
+      projectId,
+      assignedClusterId: TaxonomyClusterId("a".repeat(24)),
+    })
+    const reassigned = makeObservation({
+      observationId: "2".repeat(24),
+      projectId,
+      assignedClusterId: TaxonomyClusterId("e".repeat(24)),
+    })
+
+    const counts = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        yield* repo.upsertMany([superseded, reassigned])
+        return yield* repo.countWindowAssignedToClusters({
+          organizationId,
+          projectId,
+          limit: 10,
+          clusterIds: [TaxonomyClusterId("a".repeat(24))],
+        })
+      }),
+    )
+
+    expect(counts).toEqual({ total: 2, matching: 1 })
+  })
 })
 
 const makeLlmSpanRow = (overrides: {

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.test.ts
@@ -339,6 +339,44 @@ describe("TaxonomyObservationRepositoryLive", () => {
     const days = new Set(sample.map((observation) => observation.startTime.toISOString().slice(0, 10)))
     expect(days).toEqual(new Set(["2026-05-20", "2026-05-23"]))
   })
+
+  it("reads the full live window for reassignment carrying the current assignment", async () => {
+    const windowProjectId = ProjectId("w".repeat(24))
+    const assigned = makeObservation({
+      observationId: "1".repeat(24),
+      projectId: windowProjectId,
+      sessionId: SessionId("window-session-a"),
+      assignedClusterId: TaxonomyClusterId("c".repeat(24)),
+      startTime: new Date("2026-05-24T10:00:00.000Z"),
+    })
+    const unassigned = makeObservation({
+      observationId: "2".repeat(24),
+      projectId: windowProjectId,
+      sessionId: SessionId("window-session-b"),
+      assignedClusterId: null,
+      startTime: new Date("2026-05-24T11:00:00.000Z"),
+    })
+
+    const window = await runWithRepository(
+      Effect.gen(function* () {
+        const repo = yield* TaxonomyObservationRepository
+        yield* repo.upsertMany([assigned, unassigned])
+        return yield* repo.listWindowForReassignment({
+          organizationId,
+          projectId: windowProjectId,
+          limit: 10,
+        })
+      }),
+    )
+
+    // Newest first, both rows present, assignment surfaced (empty → null).
+    expect(window.map((row) => row.observationId)).toEqual(["2".repeat(24), "1".repeat(24)])
+    const byId = new Map(window.map((row) => [row.observationId, row]))
+    expect(byId.get("1".repeat(24))?.assignedClusterId).toBe("c".repeat(24))
+    expect(byId.get("2".repeat(24))?.assignedClusterId).toBeNull()
+    expect(byId.get("1".repeat(24))?.sessionId).toBe("window-session-a")
+    expect(byId.get("1".repeat(24))?.embedding.length).toBeGreaterThan(0)
+  })
 })
 
 const makeLlmSpanRow = (overrides: {

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -547,7 +547,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             )
         }),
 
-      listWindowForReassignment: ({ organizationId, projectId, limit, filterSet }) =>
+      listWindowForReassignment: ({ organizationId, projectId, limit, filterSet, excludeAssignedClusterIds }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           // Scoped reassignment restricts the window to the behavior's sessions
@@ -578,6 +578,12 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                         )
                       )`
               }
+              // Catch-up narrows to rows NOT already on a current leaf, so only the
+              // stragglers pay to ship their embeddings back.
+              const excludeClause =
+                excludeAssignedClusterIds && excludeAssignedClusterIds.length > 0
+                  ? "AND assigned_cluster_id NOT IN {excludeAssignedClusterIds:Array(String)}"
+                  : ""
               const result = await client.query({
                 query: `SELECT
                           observation_id,
@@ -591,6 +597,7 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                           AND ${validObservationIdClause}
                           AND length(embedding) > 0
                           ${matchingSessionsClause}
+                          ${excludeClause}
                         ORDER BY start_time DESC, observation_id ASC
                         LIMIT {limit:UInt32}`,
                 query_params: {
@@ -598,6 +605,9 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
                   projectId: projectId as string,
                   limit,
                   ...filterParams,
+                  ...(excludeClause
+                    ? { excludeAssignedClusterIds: (excludeAssignedClusterIds ?? []) as readonly string[] }
+                    : {}),
                 },
                 format: "JSONEachRow",
               })
@@ -607,6 +617,70 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyObservationRepository.listWindowForReassignment"),
+              ),
+            )
+        }),
+
+      countWindowAssignedToClusters: ({ organizationId, projectId, limit, clusterIds, filterSet }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          const resolvedFilterSet = filterSet
+            ? yield* resolvePercentileFilters(organizationId, projectId, filterSet)
+            : undefined
+          return yield* chSqlClient
+            .query(async (client) => {
+              let matchingSessionsClause = ""
+              let filterParams: Record<string, unknown> = {}
+              if (resolvedFilterSet) {
+                const { havingClauses, whereClauses, params } = buildSessionFilterClauses(resolvedFilterSet)
+                filterParams = params
+                const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+                const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
+                matchingSessionsClause = `AND session_id IN (
+                        SELECT session_id
+                        FROM (
+                          SELECT ${LIST_SELECT}
+                          FROM sessions
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            ${extraWhere}
+                          GROUP BY organization_id, project_id, session_id
+                          ${havingClause}
+                        )
+                      )`
+              }
+              // Count within the same newest-N window; aggregate server-side so no
+              // rows (and no embeddings) travel back to the activity.
+              const result = await client.query({
+                query: `SELECT
+                          count() AS total,
+                          countIf(assigned_cluster_id IN {clusterIds:Array(String)}) AS matching
+                        FROM (
+                          SELECT assigned_cluster_id
+                          FROM taxonomy_observations FINAL
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            AND ${validObservationIdClause}
+                            AND length(embedding) > 0
+                            ${matchingSessionsClause}
+                          ORDER BY start_time DESC, observation_id ASC
+                          LIMIT {limit:UInt32}
+                        )`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  limit,
+                  clusterIds: clusterIds as readonly string[],
+                  ...filterParams,
+                },
+                format: "JSONEachRow",
+              })
+              const [row] = await result.json<{ total: string | number; matching: string | number }>()
+              return { total: Number(row?.total ?? 0), matching: Number(row?.matching ?? 0) }
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyObservationRepository.countWindowAssignedToClusters"),
               ),
             )
         }),

--- a/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/taxonomy-observation-repository.ts
@@ -14,6 +14,7 @@ import {
   type TaxonomyClusteringObservation,
   type TaxonomyMomentObservation,
   TaxonomyObservationRepository,
+  type TaxonomyReassignmentWindowObservation,
   type TaxonomyScopedClusteringObservation,
   taxonomyMomentObservationSchema,
 } from "@domain/taxonomy"
@@ -116,6 +117,22 @@ const toDomainClusteringObservation = (row: TaxonomyClusteringObservationRow): T
   observationId: row.observation_id,
   embedding: row.embedding,
   startTime: parseCHDate(row.start_time),
+})
+
+type TaxonomyReassignmentWindowRow = {
+  readonly observation_id: string
+  readonly session_id: string
+  readonly embedding: readonly number[]
+  readonly start_time: string
+  readonly assigned_cluster_id: string
+}
+
+const toDomainReassignmentWindow = (row: TaxonomyReassignmentWindowRow): TaxonomyReassignmentWindowObservation => ({
+  observationId: row.observation_id,
+  sessionId: SessionId(row.session_id),
+  embedding: row.embedding,
+  startTime: parseCHDate(row.start_time),
+  assignedClusterId: row.assigned_cluster_id === "" ? null : row.assigned_cluster_id,
 })
 
 type TaxonomyScopedClusteringObservationRow = TaxonomyClusteringObservationRow & { readonly session_id: string }
@@ -526,6 +543,70 @@ export const TaxonomyObservationRepositoryLive = Layer.effect(
             .pipe(
               Effect.mapError((error) =>
                 toRepositoryError(error, "TaxonomyObservationRepository.listForCustomBehaviorSample"),
+              ),
+            )
+        }),
+
+      listWindowForReassignment: ({ organizationId, projectId, limit, filterSet }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          // Scoped reassignment restricts the window to the behavior's sessions
+          // with the same compiler the sample/preview use; global reads the whole
+          // newest-N live window.
+          const resolvedFilterSet = filterSet
+            ? yield* resolvePercentileFilters(organizationId, projectId, filterSet)
+            : undefined
+          return yield* chSqlClient
+            .query(async (client) => {
+              let matchingSessionsClause = ""
+              let filterParams: Record<string, unknown> = {}
+              if (resolvedFilterSet) {
+                const { havingClauses, whereClauses, params } = buildSessionFilterClauses(resolvedFilterSet)
+                filterParams = params
+                const extraWhere = whereClauses.length > 0 ? `AND ${whereClauses.join(" AND ")}` : ""
+                const havingClause = havingClauses.length > 0 ? `HAVING ${havingClauses.join(" AND ")}` : ""
+                matchingSessionsClause = `AND session_id IN (
+                        SELECT session_id
+                        FROM (
+                          SELECT ${LIST_SELECT}
+                          FROM sessions
+                          WHERE organization_id = {organizationId:String}
+                            AND project_id = {projectId:String}
+                            ${extraWhere}
+                          GROUP BY organization_id, project_id, session_id
+                          ${havingClause}
+                        )
+                      )`
+              }
+              const result = await client.query({
+                query: `SELECT
+                          observation_id,
+                          session_id,
+                          embedding,
+                          start_time,
+                          assigned_cluster_id
+                        FROM taxonomy_observations FINAL
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND ${validObservationIdClause}
+                          AND length(embedding) > 0
+                          ${matchingSessionsClause}
+                        ORDER BY start_time DESC, observation_id ASC
+                        LIMIT {limit:UInt32}`,
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  limit,
+                  ...filterParams,
+                },
+                format: "JSONEachRow",
+              })
+              const rows = await result.json<TaxonomyReassignmentWindowRow>()
+              return rows.map(toDomainReassignmentWindow)
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                toRepositoryError(error, "TaxonomyObservationRepository.listWindowForReassignment"),
               ),
             )
         }),

--- a/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-taxonomy-repository.ts
@@ -86,7 +86,9 @@ export const AdminTaxonomyRepositoryLive = Layer.effect(
               name: row.name,
               description: row.description,
               observationCount: row.observationCount,
-              state: row.state,
+              // visibleRows is filtered to active above; the admin contract never
+              // surfaces `staging`/`merged`/`deprecated` here.
+              state: "active",
               firstObservedAt: row.firstObservedAt,
               lastObservedAt: row.lastObservedAt,
               createdAt: row.createdAt,

--- a/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-cluster-repository.ts
@@ -16,7 +16,7 @@ import {
   TaxonomyDimension,
   taxonomyClusterSchema,
 } from "@domain/taxonomy"
-import { and, asc, desc, eq, getTableColumns, gte, inArray, isNotNull, isNull, like, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, getTableColumns, gte, inArray, isNotNull, isNull, like, ne, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { taxonomyClusters } from "../schema/taxonomy-clusters.ts"
@@ -301,7 +301,9 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
             eq(taxonomyClusters.projectId, projectId),
             scopeCondition(customBehaviorId),
           ]
-          if (state) conditions.push(eq(taxonomyClusters.state, state))
+          // `staging` is an internal publish-time state; never surface it from
+          // list-clusters. An explicit `state` filter still narrows further.
+          conditions.push(state ? eq(taxonomyClusters.state, state) : ne(taxonomyClusters.state, "staging"))
 
           const orderBy = (() => {
             switch (sort ?? "observation_count_desc") {
@@ -389,6 +391,62 @@ export const TaxonomyClusterRepositoryLive = Layer.effect(
               .update(taxonomyClusters)
               .set({ state: "deprecated", updatedAt: timestamp })
               .where(and(eq(taxonomyClusters.organizationId, organizationId), eq(taxonomyClusters.id, clusterId))),
+          )
+        }),
+
+      swapActiveTree: ({ supersededClusterIds, stagingClusterIds, timestamp }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          if (supersededClusterIds.length === 0 && stagingClusterIds.length === 0) return
+          yield* sqlClient.transaction(
+            Effect.gen(function* () {
+              if (supersededClusterIds.length > 0) {
+                yield* sqlClient.query((db, organizationId) =>
+                  db
+                    .update(taxonomyClusters)
+                    .set({ state: "deprecated", updatedAt: timestamp })
+                    .where(
+                      and(
+                        eq(taxonomyClusters.organizationId, organizationId),
+                        inArray(taxonomyClusters.id, supersededClusterIds as TaxonomyClusterId[]),
+                      ),
+                    ),
+                )
+              }
+              if (stagingClusterIds.length > 0) {
+                // Guard on `state = 'staging'` so a retry (rows already active)
+                // matches nothing and never resurrects a deprecated tree.
+                yield* sqlClient.query((db, organizationId) =>
+                  db
+                    .update(taxonomyClusters)
+                    .set({ state: "active", updatedAt: timestamp })
+                    .where(
+                      and(
+                        eq(taxonomyClusters.organizationId, organizationId),
+                        eq(taxonomyClusters.state, "staging"),
+                        inArray(taxonomyClusters.id, stagingClusterIds as TaxonomyClusterId[]),
+                      ),
+                    ),
+                )
+              }
+            }),
+          )
+        }),
+
+      deleteStaging: ({ clusterIds }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          if (clusterIds.length === 0) return
+          yield* sqlClient.query((db, organizationId) =>
+            db
+              .delete(taxonomyClusters)
+              .where(
+                and(
+                  eq(taxonomyClusters.organizationId, organizationId),
+                  eq(taxonomyClusters.state, "staging"),
+                  inArray(taxonomyClusters.id, clusterIds as TaxonomyClusterId[]),
+                ),
+              ),
           )
         }),
     }

--- a/packages/platform/db-postgres/src/repositories/taxonomy-repositories.test.ts
+++ b/packages/platform/db-postgres/src/repositories/taxonomy-repositories.test.ts
@@ -1,4 +1,5 @@
 import {
+  CustomBehaviorId,
   NotFoundError,
   OrganizationId,
   ProjectId,
@@ -212,6 +213,86 @@ describe("taxonomy Postgres repositories", () => {
         expect((yield* repository.findById(first.id)).state).toBe("deprecated")
       }).pipe(provideRepos(database)),
     )
+  })
+
+  it.each([
+    ["global", null as null],
+    ["scoped", CustomBehaviorId("b".repeat(24))],
+  ])("atomically swaps the staged tree in and never surfaces staging (%s)", async (_label, customBehaviorId) => {
+    const oldActive = makeCluster({
+      id: TaxonomyClusterId("a".repeat(24)),
+      customBehaviorId,
+      centroid: centroidFrom(vector({ 0: 1 })),
+    })
+    const staging = makeCluster({
+      id: TaxonomyClusterId("e".repeat(24)),
+      customBehaviorId,
+      state: "staging",
+      centroid: centroidFrom(vector({ 1: 1 })),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* TaxonomyClusterRepository
+        yield* repository.save(oldActive)
+        yield* repository.save(staging)
+
+        // Before the swap: staging is invisible to active reads and to list.
+        const activeBefore = yield* repository.listActiveByProject({ projectId, dimension: "topic", customBehaviorId })
+        expect(activeBefore.map((cluster) => cluster.id)).toEqual([oldActive.id])
+        const listBefore = yield* repository.list({
+          projectId,
+          dimension: "topic",
+          customBehaviorId,
+          limit: 10,
+          offset: 0,
+        })
+        expect(listBefore.items.some((cluster) => cluster.state === "staging")).toBe(false)
+
+        yield* repository.swapActiveTree({
+          supersededClusterIds: [oldActive.id],
+          stagingClusterIds: [staging.id],
+          timestamp: now,
+        })
+
+        // After the swap: exactly one active tree, and it is the staged one.
+        expect((yield* repository.findById(oldActive.id)).state).toBe("deprecated")
+        expect((yield* repository.findById(staging.id)).state).toBe("active")
+        const activeAfter = yield* repository.listActiveByProject({ projectId, dimension: "topic", customBehaviorId })
+        expect(activeAfter.map((cluster) => cluster.id)).toEqual([staging.id])
+
+        // Idempotent: a retry re-runs safely and never resurrects the old tree.
+        yield* repository.swapActiveTree({
+          supersededClusterIds: [oldActive.id],
+          stagingClusterIds: [staging.id],
+          timestamp: now,
+        })
+        expect((yield* repository.findById(oldActive.id)).state).toBe("deprecated")
+        expect((yield* repository.findById(staging.id)).state).toBe("active")
+      }).pipe(provideRepos(database)),
+    )
+  })
+
+  it("cleans up abandoned staging rows without touching the active tree", async () => {
+    const active = makeCluster({ id: TaxonomyClusterId("a".repeat(24)) })
+    const staging = makeCluster({ id: TaxonomyClusterId("e".repeat(24)), state: "staging" })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* TaxonomyClusterRepository
+        yield* repository.save(active)
+        yield* repository.save(staging)
+
+        yield* repository.deleteStaging({ clusterIds: [active.id, staging.id] })
+
+        // Guarded to state='staging': the active row survives, the orphan is gone.
+        expect((yield* repository.findById(active.id)).state).toBe("active")
+        return yield* repository.findById(staging.id).pipe(
+          Effect.map(() => "found" as const),
+          Effect.orElseSucceed(() => "deleted" as const),
+        )
+      }).pipe(provideRepos(database)),
+    ).then((result) => expect(result).toBe("deleted"))
   })
 
   it("persists runs and append-only lineage rows", async () => {


### PR DESCRIPTION
## What & why

Phase 3 of the Taxonomy adaptive-clustering project (LAT-772). Wires the Phase 2 adaptive builder into the gardening plan/publish path: member-confidence routing thresholds, a `staging` state + atomic swap, and full-window reassignment — all behind a rollout gate so the mechanism changes to the **static** publish path never ship ungated.

Spec: `specs/taxonomy-adaptive-clustering.md` → "Phase 3: gardening integration" (branch `docs/taxonomy-adaptive-clustering-spec` / #4072).

## The gate

`LAT_TAXONOMY_ADAPTIVE_CLUSTERING_MODE=off|shadow|enforced` (default `off`), resolved via `parseEnv` **in the planning activity only** and carried through the staged Redis plan artifact — no workflow code reads env/flag state. The per-org `adaptiveTaxonomyClustering` flag that can raise the baseline to `enforced` is Phase 4 (LAT-773); it's wired as `false` for now.

- **`off`** — guaranteed byte-identical no-op: static builder, `computeSplitLinkThreshold`, sample-only reassignment, `active` clusters, centroid-similarity naming, original publish sequence.
- **`shadow`/`enforced`** — adaptive builder, member-confidence thresholds, shape-aware naming, staging + atomic-swap full-window publish.

The global and custom-behavior gardens share ONE builder → `planHierarchicalTaxonomyUseCase` → one `gardenTaxonomyWorkflow`. The publish path forks only at the reassignment write target: global → `taxonomy_observations.assigned_cluster_id`, scoped → `custom_behavior_assignments`. Online routing stays global-only.

## Key decisions worth review

- **Staging uses fresh cluster ids.** An atomic swap requires the old tree to stay fully live until one transaction flips it, so a continuation cannot upsert its old id in place (that would collapse the old tree pre-swap). In adaptive mode every staging node gets a fresh id and continuity is carried by lineage rows (+ preserved name/age), not the literal id. `off` keeps literal id reuse. Deprecation is keyed on the matcher's `matchedOldIds` so it's correct in both modes.
- **Atomic swap is idempotent.** `swapActiveTree` deprecates a specific superseded id list and activates staging ids guarded to `state='staging'`, in one Postgres transaction — safe under Temporal activity retries.
- **Workflow command sequence stays mode-independent**; activities branch on `plan.mode` internally. One `patched("taxonomy-gardening-staging-swap-v1")` marker covers the new activity shape (mode-gated reassign/deprecate + failure-path staging cleanup) and reconciles in-flight pre-change histories.

## Tests

- Domain: mode resolver, routing helper, shape-aware naming, adaptive staging plan (global + scoped), **`off` byte-identical no-op golden** (global + scoped), routing-threshold persistence, entity round-trip.
- Postgres integration (real PGlite): **atomic swap leaves exactly one active tree** (global + scoped), idempotent retry, staging cleanup, and the **staging invariant** (no active read returns a staging row).
- ClickHouse integration: full-window `listWindowForReassignment` reader.
- Temporal: patched-marker reconciliation (cleanup runs on pre-swap failure; skipped when the marker is off).

Full workspace typecheck (88/88) and the taxonomy + workflows + db-postgres suites pass.

## Review focus / limitations

- The staging/full-window/swap **activity orchestration** in `taxonomy-gardening-activities.ts` is validated at the unit level (repo methods + routing helper + workflow) but not end-to-end against a live Redis+CH+Temporal stack — worth a closer read.
- **ClickHouse integration tests could not run in this worktree** (the `chdb` native module wasn't built at install; all 24 chdb-backed test files fail identically at import). The new `listWindowForReassignment` test is written and typechecks, mirroring the existing working `listForClusteringSample` test, but was not executed here.
- The confirm-snapshot invariant is a straggler-fraction guard (5%); the exact threshold is a candidate for calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added taxonomy adaptive-clustering rollout modes (`off`, `shadow`, `enforced`) with environment-wide baseline and deterministic resolution.
  * Introduced a `staging` cluster state and atomic publish swaps to keep staging clusters hidden until promoted.
  * Added full-window reassignment routing for adaptive mode, plus shape-aware lineage naming.
  * Documented new configuration in `.env.example`.

* **Bug Fixes**
  * Improved failure recovery during staging swap by conditionally cleaning up abandoned adaptive staging data.

* **Tests**
  * Expanded coverage for adaptive mode parsing/resolution, staging swap/cleanup, worker clustering behavior, reassignment window routing, and shape-aware naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->