### PR TITLE
feat(memories): memory change diffs on span detail and a session "Memory changes" section

### DIFF
--- a/apps/web/src/domains/memories/memories.collection.ts
+++ b/apps/web/src/domains/memories/memories.collection.ts
@@ -7,12 +7,14 @@ import {
   getMemoryRecordChangeDiff,
   getMemoryRecordReads,
   getMemoryStoreSnapshot,
+  getSessionMemoryDiff,
   getSessionMemorySummary,
   listMemoryRecordUsers,
   listMemoryStores,
   listMemoryStoreUsers,
   listUserMemoryStores,
   type MemoryStoreRecord,
+  type SessionMemoryDiffRecord,
   type SessionMemorySummaryRecord,
 } from "./memories.functions.ts"
 
@@ -42,6 +44,36 @@ export function useMemorySummary({
       })
       return result as SessionMemorySummaryRecord
     },
+    enabled: enabled && projectId.length > 0 && sessionId.length > 0,
+  })
+}
+
+/**
+ * A session's (or one trace's) memory writes as per-record before/after diffs
+ * for the "Memory changes" section. Heavier than the summary (fetches bodies), so
+ * it's fetched only when the section is expanded via `enabled`.
+ */
+export function useSessionMemoryDiff({
+  projectId,
+  sessionId,
+  traceId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceId?: string
+  readonly enabled?: boolean
+}) {
+  const scope = useProjectScope()
+  return useQuery({
+    queryKey: [...projectScopeKey(scope), "memory-changes-diff", projectId, sessionId, traceId ?? ""],
+    queryFn: async () => {
+      const result = await getSessionMemoryDiff({
+        data: { ...projectScopeData(scope), projectId, sessionId, ...(traceId ? { traceId } : {}) },
+      })
+      return result as SessionMemoryDiffRecord
+    },
+    staleTime: 30_000,
     enabled: enabled && projectId.length > 0 && sessionId.length > 0,
   })
 }

--- a/apps/web/src/domains/memories/memories.functions.ts
+++ b/apps/web/src/domains/memories/memories.functions.ts
@@ -1,6 +1,7 @@
 import {
   computeRecordChangeDiffUseCase,
   computeRecordHistoryUseCase,
+  computeSessionMemoryDiffUseCase,
   computeSessionMemorySummaryUseCase,
   listMemoryStoresUseCase,
   listRecordUsersUseCase,
@@ -10,6 +11,7 @@ import {
   type RecordChangeDiff,
   readRecordReadsUseCase,
   reconstructSnapshotUseCase,
+  type SessionMemoryDiff,
   type SessionMemorySummary,
 } from "@domain/memories"
 import { ExternalUserId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
@@ -23,6 +25,7 @@ import { resolveOrgScope } from "../../server/resolve-org-scope.ts"
 import { withScopedClickHouse } from "../../server/scoped-clickhouse.ts"
 
 export type SessionMemorySummaryRecord = SessionMemorySummary
+export type SessionMemoryDiffRecord = SessionMemoryDiff
 
 export interface MemoryStoreRecord {
   readonly storeId: string
@@ -109,6 +112,25 @@ export const getSessionMemorySummary = createServerFn({ method: "GET" })
 
     return Effect.runPromise(
       computeSessionMemorySummaryUseCase({
+        organizationId: orgId,
+        projectId: ProjectId(data.projectId),
+        sessionId: SessionId(data.sessionId),
+        ...(data.traceId ? { traceId: TraceId(data.traceId) } : {}),
+      }).pipe(withScopedClickHouse(MemoryRepositoryLive, getClickhouseClient(), orgId), withTracing),
+    )
+  })
+
+/**
+ * A session's (or one trace's) memory writes as per-record before/after diffs,
+ * for the "Memory changes" section. Fetched only when the section is expanded.
+ */
+export const getSessionMemoryDiff = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), sessionId: z.string(), traceId: z.string().optional() }))
+  .handler(async ({ data, context }): Promise<SessionMemoryDiffRecord> => {
+    const orgId = await resolveOrgScope(context)
+
+    return Effect.runPromise(
+      computeSessionMemoryDiffUseCase({
         organizationId: orgId,
         projectId: ProjectId(data.projectId),
         sessionId: SessionId(data.sessionId),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/looks-like-json.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/looks-like-json.ts
@@ -1,0 +1,11 @@
+/** Cheap JSON detection to pick a syntax-highlight language for record bodies. */
+export function looksLikeJson(body: string): boolean {
+  const trimmed = body.trim()
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return false
+  try {
+    JSON.parse(trimmed)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
@@ -1,0 +1,117 @@
+import { cn, DetailSection, MasterDetail, type MasterDetailItem, Skeleton, Text } from "@repo/ui"
+import { DatabaseIcon, type LucideIcon, MinusIcon, PencilIcon, PlusIcon } from "lucide-react"
+import { useMemorySummary, useSessionMemoryDiff } from "../../../../../../domains/memories/memories.collection.ts"
+import type { SessionMemoryDiffRecord } from "../../../../../../domains/memories/memories.functions.ts"
+import { MemoryRecordDiff } from "./memory-record-diff.tsx"
+import { RecordsHeader } from "./records-header.tsx"
+
+type RecordDiff = SessionMemoryDiffRecord["records"][number]
+
+const KIND_META: Record<RecordDiff["kind"], { readonly icon: LucideIcon; readonly className: string }> = {
+  added: { icon: PlusIcon, className: "text-success" },
+  updated: { icon: PencilIcon, className: "text-muted-foreground" },
+  removed: { icon: MinusIcon, className: "text-destructive" },
+}
+
+function StoreChangesBlock({
+  storeId,
+  records,
+}: {
+  readonly storeId: string
+  readonly records: readonly RecordDiff[]
+}) {
+  const items: MasterDetailItem[] = records.map((record, index) => {
+    const meta = KIND_META[record.kind]
+    return {
+      key: String(index),
+      label: record.recordId || `Record ${index + 1}`,
+      trailing: <meta.icon className={cn("h-3.5 w-3.5", meta.className)} />,
+    }
+  })
+
+  return (
+    <MasterDetail
+      className="h-72"
+      items={items}
+      header={<RecordsHeader count={records.length} {...(storeId ? { storeId } : {})} />}
+      renderDetail={(key) => {
+        const record = records[Number(key)]
+        if (!record) return null
+        return (
+          <div className="flex h-full flex-col">
+            <div className="min-h-0 flex-1">
+              <MemoryRecordDiff before={record.beforeBody} after={record.afterBody} degraded={record.degraded} />
+            </div>
+          </div>
+        )
+      }}
+    />
+  )
+}
+
+function MemoryChangesBody({
+  projectId,
+  sessionId,
+  traceId,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceId?: string
+}) {
+  const { data, isLoading } = useSessionMemoryDiff({ projectId, sessionId, ...(traceId ? { traceId } : {}) })
+
+  if (isLoading) return <Skeleton className="h-7 w-48" />
+  if (!data || data.records.length === 0)
+    return (
+      <Text.H6 color="foregroundMuted" italic>
+        No memory changes
+      </Text.H6>
+    )
+
+  const groups: { storeId: string; records: RecordDiff[] }[] = []
+  for (const record of data.records) {
+    const group = groups.find((candidate) => candidate.storeId === record.storeId)
+    if (group) group.records.push(record)
+    else groups.push({ storeId: record.storeId, records: [record] })
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {groups.map((group) => (
+        <StoreChangesBlock key={group.storeId} storeId={group.storeId} records={group.records} />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * A collapsible "Memory changes" section for the session/trace detail body,
+ * sitting under Tools: the aggregated per-record before/after diffs a session (or
+ * one trace) made to memory, grouped by store. Visibility rides the already-cached
+ * `useMemorySummary` (renders only when there were writes); the heavier body-diff
+ * read fires only when the section is expanded. Pass `traceId` for the trace view.
+ */
+export function MemoryChangesSection({
+  projectId,
+  sessionId,
+  traceId,
+}: {
+  readonly projectId: string
+  readonly sessionId: string
+  readonly traceId?: string
+}) {
+  const { data: summary } = useMemorySummary({ projectId, sessionId, ...(traceId ? { traceId } : {}) })
+  const hasChanges = !!summary && (summary.total.tokensAdded > 0 || summary.total.tokensRemoved > 0)
+  if (!hasChanges) return null
+
+  return (
+    <DetailSection
+      icon={<DatabaseIcon className="h-4 w-4" />}
+      label="Memory changes"
+      defaultOpen={false}
+      contentClassName="max-h-none overflow-visible"
+    >
+      {() => <MemoryChangesBody projectId={projectId} sessionId={sessionId} {...(traceId ? { traceId } : {})} />}
+    </DetailSection>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
@@ -3,6 +3,7 @@ import { DatabaseIcon, type LucideIcon, MinusIcon, PencilIcon, PlusIcon } from "
 import { useMemorySummary, useSessionMemoryDiff } from "../../../../../../domains/memories/memories.collection.ts"
 import type { SessionMemoryDiffRecord } from "../../../../../../domains/memories/memories.functions.ts"
 import { MemoryRecordDiff } from "./memory-record-diff.tsx"
+import { RecordPaneHeader } from "./record-pane-header.tsx"
 import { RecordsHeader } from "./records-header.tsx"
 
 type RecordDiff = SessionMemoryDiffRecord["records"][number]
@@ -39,6 +40,11 @@ function StoreChangesBlock({
         if (!record) return null
         return (
           <div className="flex h-full flex-col">
+            <RecordPaneHeader
+              storeId={storeId}
+              recordId={record.recordId}
+              {...(record.lastChangeSpanId ? { changeSpanId: record.lastChangeSpanId } : {})}
+            />
             <div className="min-h-0 flex-1">
               <MemoryRecordDiff before={record.beforeBody} after={record.afterBody} degraded={record.degraded} />
             </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-changes-section.tsx
@@ -64,9 +64,15 @@ function MemoryChangesBody({
   readonly sessionId: string
   readonly traceId?: string
 }) {
-  const { data, isLoading } = useSessionMemoryDiff({ projectId, sessionId, ...(traceId ? { traceId } : {}) })
+  const { data, isLoading, isError } = useSessionMemoryDiff({ projectId, sessionId, ...(traceId ? { traceId } : {}) })
 
   if (isLoading) return <Skeleton className="h-7 w-48" />
+  if (isError)
+    return (
+      <Text.H6 color="foregroundMuted" italic>
+        Couldn't load memory changes
+      </Text.H6>
+    )
   if (!data || data.records.length === 0)
     return (
       <Text.H6 color="foregroundMuted" italic>
@@ -107,7 +113,7 @@ export function MemoryChangesSection({
   readonly traceId?: string
 }) {
   const { data: summary } = useMemorySummary({ projectId, sessionId, ...(traceId ? { traceId } : {}) })
-  const hasChanges = !!summary && (summary.total.tokensAdded > 0 || summary.total.tokensRemoved > 0)
+  const hasChanges = !!summary && summary.total.writeRecords > 0
   if (!hasChanges) return null
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
@@ -1,0 +1,49 @@
+import { CodeDiff, Text } from "@repo/ui"
+import type { ReactNode } from "react"
+import { looksLikeJson } from "./looks-like-json.ts"
+
+function Centered({ children }: { readonly children: ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <Text.H6 color="foregroundMuted">{children}</Text.H6>
+    </div>
+  )
+}
+
+/**
+ * A read-only unified diff of one memory record change. `before`/`after` are the
+ * bodies (`null` = an add's missing before or a remove's missing after). When the
+ * change is `degraded` (a body was never captured or has been pruned) it renders
+ * `fallback` if given, else an "unavailable" note — never a misleading whole-body
+ * diff. Shared by the span detail and the session/trace "Memory changes" section.
+ */
+export function MemoryRecordDiff({
+  before,
+  after,
+  degraded,
+  unavailableLabel = "Content not captured for this change",
+  fallback,
+}: {
+  readonly before: string | null
+  readonly after: string | null
+  readonly degraded: boolean
+  readonly unavailableLabel?: string
+  readonly fallback?: ReactNode
+}) {
+  if (degraded) return fallback != null ? fallback : <Centered>{unavailableLabel}</Centered>
+
+  const beforeBody = before ?? ""
+  const afterBody = after ?? ""
+  if (beforeBody === afterBody) return <Centered>No content changes</Centered>
+
+  const language = looksLikeJson(afterBody) || looksLikeJson(beforeBody) ? "json" : undefined
+  return (
+    <CodeDiff
+      before={beforeBody}
+      after={afterBody}
+      fillHeight
+      className="h-full rounded-none"
+      {...(language ? { language } : {})}
+    />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
@@ -2,6 +2,9 @@ import { CodeDiff, Text } from "@repo/ui"
 import type { ReactNode } from "react"
 import { looksLikeJson } from "./looks-like-json.ts"
 
+/** Unchanged lines kept around each change; the rest fold behind an expander. */
+const DIFF_CONTEXT_LINES = 3
+
 function Centered({ children }: { readonly children: ReactNode }) {
   return (
     <div className="flex h-full items-center justify-center">
@@ -42,6 +45,7 @@ export function MemoryRecordDiff({
       before={beforeBody}
       after={afterBody}
       fillHeight
+      contextLines={DIFF_CONTEXT_LINES}
       className="h-full rounded-none"
       {...(language ? { language } : {})}
     />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/memory-record-diff.tsx
@@ -13,13 +13,7 @@ function Centered({ children }: { readonly children: ReactNode }) {
   )
 }
 
-/**
- * A read-only unified diff of one memory record change. `before`/`after` are the
- * bodies (`null` = an add's missing before or a remove's missing after). When the
- * change is `degraded` (a body was never captured or has been pruned) it renders
- * `fallback` if given, else an "unavailable" note — never a misleading whole-body
- * diff. Shared by the span detail and the session/trace "Memory changes" section.
- */
+/** Read-only unified diff of one record change; renders `fallback` (or an unavailable note) when `degraded`. */
 export function MemoryRecordDiff({
   before,
   after,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/record-pane-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/record-pane-header.tsx
@@ -1,0 +1,42 @@
+import { Text } from "@repo/ui"
+import { Link, useParams } from "@tanstack/react-router"
+import { ArrowUpRightIcon } from "lucide-react"
+import { useHasFeatureFlag } from "../../../../../../domains/feature-flags/feature-flags.collection.ts"
+import { encodeRecordParam, encodeStoreSegment, recordDisplayLabel } from "../../memory/-components/store-encoding.ts"
+
+/**
+ * A slim header above a record preview (span detail / session "Memory changes")
+ * with an "Open in Memory" link to the full record page — deep-linking the record
+ * and, when given, a specific change. Renders nothing when the Memory page is
+ * gated off, since the destination would be unavailable.
+ */
+export function RecordPaneHeader({
+  storeId,
+  recordId,
+  changeSpanId,
+}: {
+  readonly storeId: string
+  readonly recordId: string
+  readonly changeSpanId?: string
+}) {
+  const enabled = useHasFeatureFlag("memoryObservability")
+  const { projectSlug } = useParams({ strict: false })
+  if (!enabled || projectSlug == null) return null
+
+  return (
+    <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-secondary/50 px-3 py-1">
+      <Text.H6 color="foregroundMuted" ellipsis noWrap className="font-mono">
+        {recordDisplayLabel(recordId)}
+      </Text.H6>
+      <Link
+        to="/projects/$projectSlug/memory/$store"
+        params={{ projectSlug, store: encodeStoreSegment(storeId) }}
+        search={{ record: encodeRecordParam(recordId), ...(changeSpanId ? { change: changeSpanId } : {}) }}
+        className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+      >
+        Open in Memory
+        <ArrowUpRightIcon className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/records-header.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/records-header.tsx
@@ -1,0 +1,19 @@
+import { Icon, Text } from "@repo/ui"
+import { DatabaseIcon } from "lucide-react"
+
+/** Store header for a memory records master-detail: `[db] <store id> (N)`. */
+export function RecordsHeader({ storeId, count }: { readonly storeId?: string; readonly count: number }) {
+  return (
+    <div className="flex flex-row items-center gap-2 bg-secondary px-3 py-2">
+      <Icon icon={DatabaseIcon} size="xs" color="foregroundMuted" />
+      {storeId ? (
+        <div className="flex min-w-0 flex-1">
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            {storeId}
+          </Text.H6>
+        </div>
+      ) : null}
+      <Text.H6 color="foregroundMuted" noWrap>{`(${count})`}</Text.H6>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/span-record-change-diff.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/span-record-change-diff.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@repo/ui"
+import type { ReactNode } from "react"
+import { useMemoryRecordChangeDiff } from "../../../../../../domains/memories/memories.collection.ts"
+import { MemoryRecordDiff } from "./memory-record-diff.tsx"
+
+/**
+ * One span's change to a record, diffed against its prior recorded snapshot (from
+ * the ledger). Renders `fallback` while the change is not yet materialized,
+ * unresolved, or degraded — the "after" body already lives on the span, so the
+ * caller passes the full-content view as the fallback and the pane is never empty.
+ */
+export function SpanRecordChangeDiff({
+  projectId,
+  spanId,
+  storeId,
+  recordId,
+  fallback,
+}: {
+  readonly projectId: string
+  readonly spanId: string
+  readonly storeId: string
+  readonly recordId: string
+  readonly fallback: ReactNode
+}) {
+  const { data, isLoading, isError } = useMemoryRecordChangeDiff({ projectId, storeId, recordId, spanId })
+
+  if (isLoading) {
+    return (
+      <div className="h-full p-3">
+        <Skeleton className="h-full w-full" />
+      </div>
+    )
+  }
+  if (isError || data == null) return fallback
+
+  return (
+    <MemoryRecordDiff before={data.beforeBody} after={data.afterBody} degraded={data.degraded} fallback={fallback} />
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/span-record-change-diff.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/memory-changes/span-record-change-diff.tsx
@@ -3,12 +3,7 @@ import type { ReactNode } from "react"
 import { useMemoryRecordChangeDiff } from "../../../../../../domains/memories/memories.collection.ts"
 import { MemoryRecordDiff } from "./memory-record-diff.tsx"
 
-/**
- * One span's change to a record, diffed against its prior recorded snapshot (from
- * the ledger). Renders `fallback` while the change is not yet materialized,
- * unresolved, or degraded — the "after" body already lives on the span, so the
- * caller passes the full-content view as the fallback and the pane is never empty.
- */
+/** One span's change to a record vs its prior recorded snapshot; renders `fallback` until it resolves. */
 export function SpanRecordChangeDiff({
   projectId,
   spanId,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/metadata-tab.tsx
@@ -15,6 +15,7 @@ import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextI
 import { useMemo } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
+import { MemoryChangesSection } from "../memory-changes/memory-changes-section.tsx"
 import { MemorySummary } from "../memory-summary.tsx"
 import { SessionOutlierBadge, type SessionOutlierMetric } from "../session-outlier-badge.tsx"
 import { aggregateToolPills, ToolPillList } from "../tool-pills.tsx"
@@ -195,6 +196,8 @@ export function MetadataTab({
           )
         }
       </DetailSection>
+
+      <MemoryChangesSection projectId={session.projectId} sessionId={session.sessionId} />
 
       <DetailSection icon={<TextIcon className="h-4 w-4" />} label="Metadata" defaultOpen={false}>
         {() =>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/memory-operations.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/memory-operations.ts
@@ -12,6 +12,20 @@ const MEMORY_OPERATIONS = [
 
 const MEMORY_OPERATION_SET: ReadonlySet<string> = new Set(MEMORY_OPERATIONS)
 
+const MEMORY_MUTATING_OPERATIONS = [
+  "create_memory",
+  "update_memory",
+  "upsert_memory",
+  "delete_memory",
+] as const satisfies readonly Operation[]
+
+const MEMORY_MUTATING_OPERATION_SET: ReadonlySet<string> = new Set(MEMORY_MUTATING_OPERATIONS)
+
 export function isMemoryOperation(operation: string): boolean {
   return MEMORY_OPERATION_SET.has(operation)
+}
+
+/** Memory ops that change a record's body — the ones whose span detail shows a diff. */
+export function isMutatingMemoryOperation(operation: string): boolean {
+  return MEMORY_MUTATING_OPERATION_SET.has(operation)
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-operation-section.tsx
@@ -2,7 +2,8 @@ import { CodeBlock, DetailSection, DetailSummary, Text } from "@repo/ui"
 import { DatabaseIcon } from "lucide-react"
 import type { ReactNode } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { isMemoryOperation } from "../memory-operations.ts"
+import { SpanRecordChangeDiff } from "../../../../memory-changes/span-record-change-diff.tsx"
+import { isMemoryOperation, isMutatingMemoryOperation } from "../memory-operations.ts"
 import { MemoryRecordsView } from "./memory-records.tsx"
 import { parseMemoryRecords } from "./memory-records-parse.ts"
 
@@ -38,6 +39,7 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
   const recordsRaw = span.attrString[RECORDS_ATTR] ?? ""
   const records = parseMemoryRecords(recordsRaw)
   const isSearch = span.operation === "search_memory"
+  const isMutating = isMutatingMemoryOperation(span.operation)
   const recordsLabel = isSearch ? "Results" : "Records"
 
   // Store and count ride the records header; the identity fields only surface as
@@ -65,7 +67,31 @@ export function MemoryOperationSection({ span }: { readonly span: SpanDetailReco
         )}
         <Subsection label={recordsLabel}>
           {records ? (
-            <MemoryRecordsView records={records} isSearch={isSearch} {...(storeId ? { storeId } : {})} />
+            <MemoryRecordsView
+              records={records}
+              isSearch={isSearch}
+              projectId={span.projectId}
+              spanId={span.spanId}
+              diffable={isMutating}
+              {...(storeId ? { storeId } : {})}
+              {...(recordId ? { fallbackRecordId: recordId } : {})}
+            />
+          ) : isMutating && recordId ? (
+            <div className="h-72 overflow-hidden rounded-md border border-border">
+              <SpanRecordChangeDiff
+                projectId={span.projectId}
+                spanId={span.spanId}
+                storeId={storeId ?? ""}
+                recordId={recordId}
+                fallback={
+                  recordsRaw ? (
+                    <CodeBlock value={recordsRaw} className="bg-secondary" />
+                  ) : (
+                    <Text.H6 color="foregroundMuted">Content not captured</Text.H6>
+                  )
+                }
+              />
+            </div>
           ) : recordsRaw ? (
             <CodeBlock value={recordsRaw} className="bg-secondary" />
           ) : (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
@@ -1,5 +1,6 @@
-import { Badge, CodeBlock, Icon, MasterDetail, type MasterDetailItem, Text } from "@repo/ui"
-import { DatabaseIcon } from "lucide-react"
+import { Badge, CodeBlock, MasterDetail, type MasterDetailItem, Text } from "@repo/ui"
+import { RecordsHeader } from "../../../../memory-changes/records-header.tsx"
+import { SpanRecordChangeDiff } from "../../../../memory-changes/span-record-change-diff.tsx"
 import { JsonBlock } from "./helpers.tsx"
 import type { MemoryRecord } from "./memory-records-parse.ts"
 
@@ -39,30 +40,22 @@ function RecordDetail({ record }: { readonly record: MemoryRecord }) {
   )
 }
 
-function RecordsHeader({ storeId, count }: { readonly storeId?: string; readonly count: number }) {
-  return (
-    <div className="flex flex-row items-center gap-2 bg-secondary px-3 py-2">
-      <Icon icon={DatabaseIcon} size="xs" color="foregroundMuted" />
-      {storeId ? (
-        <div className="flex min-w-0 flex-1">
-          <Text.H6 color="foregroundMuted" ellipsis noWrap>
-            {storeId}
-          </Text.H6>
-        </div>
-      ) : null}
-      <Text.H6 color="foregroundMuted" noWrap>{`(${count})`}</Text.H6>
-    </div>
-  )
-}
-
 export function MemoryRecordsView({
   records,
   isSearch,
   storeId,
+  projectId,
+  spanId,
+  diffable,
+  fallbackRecordId,
 }: {
   readonly records: readonly MemoryRecord[]
   readonly isSearch: boolean
   readonly storeId?: string
+  readonly projectId: string
+  readonly spanId: string
+  readonly diffable: boolean
+  readonly fallbackRecordId?: string
 }) {
   const ordered =
     isSearch && records.some((record) => record.score != null)
@@ -89,7 +82,21 @@ export function MemoryRecordsView({
       items={items}
       renderDetail={(key) => {
         const record = ordered[Number(key)]
-        return record ? <RecordDetail record={record} /> : null
+        if (!record) return null
+        if (!diffable) return <RecordDetail record={record} />
+        return (
+          <div className="flex h-full flex-col">
+            <div className="min-h-0 flex-1">
+              <SpanRecordChangeDiff
+                projectId={projectId}
+                spanId={spanId}
+                storeId={storeId ?? ""}
+                recordId={record.id ?? fallbackRecordId ?? ""}
+                fallback={<RecordDetail record={record} />}
+              />
+            </div>
+          </div>
+        )
       }}
       header={<RecordsHeader count={ordered.length} {...(storeId ? { storeId } : {})} />}
     />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/memory-records.tsx
@@ -1,4 +1,5 @@
 import { Badge, CodeBlock, MasterDetail, type MasterDetailItem, Text } from "@repo/ui"
+import { RecordPaneHeader } from "../../../../memory-changes/record-pane-header.tsx"
 import { RecordsHeader } from "../../../../memory-changes/records-header.tsx"
 import { SpanRecordChangeDiff } from "../../../../memory-changes/span-record-change-diff.tsx"
 import { JsonBlock } from "./helpers.tsx"
@@ -83,17 +84,26 @@ export function MemoryRecordsView({
       renderDetail={(key) => {
         const record = ordered[Number(key)]
         if (!record) return null
-        if (!diffable) return <RecordDetail record={record} />
+        const recordId = record.id ?? fallbackRecordId ?? ""
         return (
           <div className="flex h-full flex-col">
+            <RecordPaneHeader
+              storeId={storeId ?? ""}
+              recordId={recordId}
+              {...(diffable ? { changeSpanId: spanId } : {})}
+            />
             <div className="min-h-0 flex-1">
-              <SpanRecordChangeDiff
-                projectId={projectId}
-                spanId={spanId}
-                storeId={storeId ?? ""}
-                recordId={record.id ?? fallbackRecordId ?? ""}
-                fallback={<RecordDetail record={record} />}
-              />
+              {diffable ? (
+                <SpanRecordChangeDiff
+                  projectId={projectId}
+                  spanId={spanId}
+                  storeId={storeId ?? ""}
+                  recordId={recordId}
+                  fallback={<RecordDetail record={record} />}
+                />
+              ) : (
+                <RecordDetail record={record} />
+              )}
             </div>
           </div>
         )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -15,6 +15,7 @@ import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, FingerprintIcon, TextI
 import { useMemo } from "react"
 import type { SpanRecord } from "../../../../../../../domains/spans/spans.functions.ts"
 import type { TraceDetailRecord, TraceRecord } from "../../../../../../../domains/traces/traces.functions.ts"
+import { MemoryChangesSection } from "../../memory-changes/memory-changes-section.tsx"
 import { MemorySummary } from "../../memory-summary.tsx"
 import { AgentsBreakdown } from "../../session-detail-drawer/agents-breakdown/agents-breakdown.tsx"
 import { useAgentGraph } from "../../session-detail-drawer/agents-breakdown/use-agent-graph.ts"
@@ -213,6 +214,11 @@ export function TraceTab({
           )
         }
       </DetailSection>
+
+      {/* ── Memory changes ── */}
+      {traceRecord && (
+        <MemoryChangesSection projectId={projectId} sessionId={traceRecord.sessionId || traceId} traceId={traceId} />
+      )}
 
       {/* ── Metadata ── */}
       <DetailSection icon={<TextIcon className="w-4 h-4" />} label="Metadata" defaultOpen={false}>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -260,7 +260,11 @@ function RecordChangeDiffBody({
         <div className="p-3">
           <Skeleton className="h-full w-full" />
         </div>
-      ) : data == null ? null : (
+      ) : data == null ? (
+        <div className="flex h-full items-center justify-center">
+          <Text.H6 color="foregroundMuted">Diff unavailable</Text.H6>
+        </div>
+      ) : (
         <MemoryRecordDiff before={data.beforeBody} after={data.afterBody} degraded={data.degraded} />
       )}
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, CodeDiff, cn, Icon, Sheet, Skeleton, Text, useMountEffect } from "@repo/ui"
+import { CodeBlock, cn, Icon, Sheet, Skeleton, Text, useMountEffect } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import {
@@ -28,19 +28,10 @@ import type {
   MemoryRecordUserRecord,
   MemoryRecordVersionRecord,
 } from "../../../../../../../domains/memories/memories.functions.ts"
+import { looksLikeJson } from "../../../-components/memory-changes/looks-like-json.ts"
+import { MemoryRecordDiff } from "../../../-components/memory-changes/memory-record-diff.tsx"
 import { SessionDetailDrawer } from "../../../-components/session-detail-drawer.tsx"
 import { recordDisplayLabel } from "../../-components/store-encoding.ts"
-
-function looksLikeJson(body: string): boolean {
-  const trimmed = body.trim()
-  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return false
-  try {
-    JSON.parse(trimmed)
-    return true
-  } catch {
-    return false
-  }
-}
 
 const CHANGE_META = {
   add: { icon: PlusIcon, className: "text-success", label: "Created" },
@@ -262,10 +253,6 @@ function RecordChangeDiffBody({
   readonly version: MemoryRecordVersionRecord
 }) {
   const { data, isLoading } = useMemoryRecordChangeDiff({ projectId, storeId, recordId, spanId: version.spanId })
-  const before = data?.beforeBody ?? ""
-  const after = data?.afterBody ?? ""
-  const language = looksLikeJson(after) || looksLikeJson(before) ? "json" : undefined
-  const unchanged = data != null && !data.degraded && before === after
 
   return (
     <div className="min-h-0 flex-1">
@@ -273,22 +260,8 @@ function RecordChangeDiffBody({
         <div className="p-3">
           <Skeleton className="h-full w-full" />
         </div>
-      ) : data == null ? null : data.degraded ? (
-        <div className="flex h-full items-center justify-center">
-          <Text.H6 color="foregroundMuted">Content not captured for this change</Text.H6>
-        </div>
-      ) : unchanged ? (
-        <div className="flex h-full items-center justify-center">
-          <Text.H6 color="foregroundMuted">No content changes</Text.H6>
-        </div>
-      ) : (
-        <CodeDiff
-          before={before}
-          after={after}
-          fillHeight
-          className="h-full rounded-none"
-          {...(language ? { language } : {})}
-        />
+      ) : data == null ? null : (
+        <MemoryRecordDiff before={data.beforeBody} after={data.afterBody} degraded={data.degraded} />
       )}
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/index.tsx
@@ -29,6 +29,12 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/memo
   staticData: {
     breadcrumb: StoreBreadcrumb,
   },
+  // `record` / `change` are read synchronously via useParamState; declaring them
+  // here lets cross-page links deep-link a record (and a specific change).
+  validateSearch: (search: Record<string, unknown>): { record?: string; change?: string } => ({
+    ...(typeof search.record === "string" ? { record: search.record } : {}),
+    ...(typeof search.change === "string" ? { change: search.change } : {}),
+  }),
   component: StoreDetailPage,
 })
 

--- a/packages/domain/memories/src/index.ts
+++ b/packages/domain/memories/src/index.ts
@@ -63,6 +63,12 @@ export {
   type RecordHistoryVersion,
 } from "./use-cases/compute-record-history.ts"
 export {
+  type ComputeSessionMemoryDiffInput,
+  computeSessionMemoryDiffUseCase,
+  type SessionMemoryDiff,
+  type SessionMemoryRecordDiff,
+} from "./use-cases/compute-session-memory-diff.ts"
+export {
   type ComputeSessionMemorySummaryInput,
   computeSessionMemorySummaryUseCase,
   type MemoryRecordSummary,

--- a/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
@@ -1,0 +1,251 @@
+import { ChSqlClient, ExternalUserId, OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { type MemoryOperationSpan, SpanRepository } from "@domain/spans"
+import { createFakeSpanRepository } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+import { createFakeMemoryRepository } from "../testing/index.ts"
+import { computeSessionMemoryDiffUseCase } from "./compute-session-memory-diff.ts"
+import { materializeTraceMemoryUseCase } from "./materialize-trace-memory.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const traceId = TraceId("t".repeat(32))
+const base = new Date("2026-06-01T12:00:00.000Z").getTime()
+const at = (seconds: number) => new Date(base + seconds * 1000)
+const spanId = (char: string) => SpanId(char.repeat(16))
+const records = (...items: { id: string; content: string }[]) => JSON.stringify(items)
+
+type Fake = ReturnType<typeof createFakeMemoryRepository>
+
+const makeSpan = (o: Partial<MemoryOperationSpan> = {}): MemoryOperationSpan => ({
+  spanId: spanId("s"),
+  traceId,
+  sessionId: SessionId("sess1"),
+  userId: ExternalUserId("user1"),
+  operation: "create_memory",
+  startTime: at(0),
+  endTime: at(0),
+  storeId: "store1",
+  recordId: "",
+  recordCount: 1,
+  queryText: "",
+  recordsRaw: "",
+  ...o,
+})
+
+const layerFor = (memory: Fake) =>
+  Layer.mergeAll(
+    Layer.succeed(MemoryRepository, memory.repository),
+    Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+  )
+
+const materialize = (
+  spans: readonly MemoryOperationSpan[],
+  memory: Fake,
+  sessionId: SessionId = SessionId("sess1"),
+) => {
+  const spanRepo = createFakeSpanRepository({
+    listMemoryOperationSpansByTraceId: () => Effect.succeed(spans),
+  }).repository
+  const layer = Layer.merge(layerFor(memory), Layer.succeed(SpanRepository, spanRepo))
+  return Effect.runPromise(
+    materializeTraceMemoryUseCase({ organizationId, projectId, traceId, sessionId }).pipe(Effect.provide(layer)),
+  )
+}
+
+const diff = (memory: Fake, input: { sessionId: SessionId; traceId?: TraceId }) =>
+  Effect.runPromise(
+    computeSessionMemoryDiffUseCase({ organizationId, projectId, ...input }).pipe(Effect.provide(layerFor(memory))),
+  )
+
+describe("computeSessionMemoryDiff", () => {
+  it("collapses a same-session create→update into one added change (no pre-session before)", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          operation: "create_memory",
+          recordsRaw: records({ id: "rec1", content: "v1" }),
+          endTime: at(1),
+        }),
+        makeSpan({
+          spanId: spanId("2"),
+          operation: "update_memory",
+          recordsRaw: records({ id: "rec1", content: "v1 v2" }),
+          endTime: at(2),
+        }),
+      ],
+      memory,
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sess1") })
+    expect(result.records).toHaveLength(1)
+    const rec1 = result.records[0]
+    expect(rec1?.recordId).toBe("rec1")
+    expect(rec1?.kind).toBe("added")
+    expect(rec1?.beforeBody).toBeNull()
+    expect(rec1?.afterBody).toBe("v1 v2")
+    expect(rec1?.degraded).toBe(false)
+    expect(rec1?.tokensAdded).toBeGreaterThan(0)
+    expect(rec1?.tokensRemoved).toBe(0)
+  })
+
+  it("diffs against the pre-session version when another session wrote the record earlier", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          operation: "create_memory",
+          recordsRaw: records({ id: "rec1", content: "hello" }),
+          endTime: at(0),
+        }),
+      ],
+      memory,
+      SessionId("sessOld"),
+    )
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("2"),
+          operation: "update_memory",
+          recordsRaw: records({ id: "rec1", content: "hello world" }),
+          endTime: at(5),
+        }),
+      ],
+      memory,
+      SessionId("sessNew"),
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sessNew") })
+    expect(result.records).toHaveLength(1)
+    const rec1 = result.records[0]
+    expect(rec1?.kind).toBe("updated")
+    expect(rec1?.beforeBody).toBe("hello")
+    expect(rec1?.afterBody).toBe("hello world")
+    expect(rec1?.degraded).toBe(false)
+    expect(rec1?.tokensAdded).toBeGreaterThan(0)
+  })
+
+  it("omits a record added and removed within the same session", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          operation: "create_memory",
+          recordsRaw: records({ id: "rec2", content: "temp" }),
+          endTime: at(0),
+        }),
+        makeSpan({ spanId: spanId("2"), operation: "delete_memory", recordId: "rec2", endTime: at(1) }),
+      ],
+      memory,
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sess1") })
+    expect(result.records).toHaveLength(0)
+  })
+
+  it("diffs each touched record across stores", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({ spanId: spanId("1"), recordsRaw: records({ id: "rec1", content: "a" }) }),
+        makeSpan({ spanId: spanId("2"), storeId: "store2", recordsRaw: records({ id: "rec2", content: "b" }) }),
+      ],
+      memory,
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sess1") })
+    expect(result.records.map((r) => r.storeId).sort()).toEqual(["store1", "store2"])
+    expect(result.records.every((r) => r.kind === "added" && r.afterBody != null && r.beforeBody === null)).toBe(true)
+  })
+
+  it("marks records a later whole-store wipe removed", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({ spanId: spanId("1"), recordsRaw: records({ id: "rec1", content: "a" }), endTime: at(0) }),
+        makeSpan({ spanId: spanId("2"), recordsRaw: records({ id: "rec2", content: "b" }), endTime: at(0) }),
+      ],
+      memory,
+      SessionId("sessOld"),
+    )
+    await materialize(
+      [makeSpan({ spanId: spanId("9"), operation: "delete_memory", recordId: "", endTime: at(5) })],
+      memory,
+      SessionId("sessNew"),
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sessNew") })
+    expect(result.records).toHaveLength(2)
+    expect(result.records.every((r) => r.kind === "removed" && r.afterBody === null && r.beforeBody != null)).toBe(true)
+    expect(result.records.every((r) => r.tokensRemoved > 0 && r.tokensAdded === 0)).toBe(true)
+  })
+
+  it("flags a change as degraded when the body is unavailable", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          operation: "create_memory",
+          recordsRaw: records({ id: "rec1", content: "hello" }),
+          endTime: at(0),
+        }),
+      ],
+      memory,
+      SessionId("sessOld"),
+    )
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("2"),
+          operation: "update_memory",
+          recordsRaw: records({ id: "rec1", content: "hello world" }),
+          endTime: at(5),
+        }),
+      ],
+      memory,
+      SessionId("sessNew"),
+    )
+    memory.blobs.clear() // simulate opted-out / pruned bodies
+
+    const result = await diff(memory, { sessionId: SessionId("sessNew") })
+    expect(result.records).toHaveLength(1)
+    const rec1 = result.records[0]
+    expect(rec1?.kind).toBe("updated")
+    expect(rec1?.degraded).toBe(true)
+    expect(rec1?.beforeBody).toBeNull()
+    expect(rec1?.afterBody).toBeNull()
+  })
+
+  it("restricts the diff to one trace when a trace id is given", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          traceId: TraceId("1".repeat(32)),
+          recordsRaw: records({ id: "rec1", content: "a" }),
+        }),
+        makeSpan({
+          spanId: spanId("2"),
+          traceId: TraceId("2".repeat(32)),
+          recordsRaw: records({ id: "rec2", content: "b" }),
+        }),
+      ],
+      memory,
+    )
+
+    const oneTrace = await diff(memory, { sessionId: SessionId("sess1"), traceId: TraceId("1".repeat(32)) })
+    expect(oneTrace.records).toHaveLength(1)
+    expect(oneTrace.records[0]?.recordId).toBe("rec1")
+
+    const whole = await diff(memory, { sessionId: SessionId("sess1") })
+    expect(whole.records).toHaveLength(2)
+  })
+})

--- a/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
@@ -91,6 +91,7 @@ describe("computeSessionMemoryDiff", () => {
     expect(rec1?.degraded).toBe(false)
     expect(rec1?.tokensAdded).toBeGreaterThan(0)
     expect(rec1?.tokensRemoved).toBe(0)
+    expect(rec1?.lastChangeSpanId).toBe(spanId("2")) // the session's last touch (the update)
   })
 
   it("diffs against the pre-session version when another session wrote the record earlier", async () => {
@@ -128,6 +129,7 @@ describe("computeSessionMemoryDiff", () => {
     expect(rec1?.afterBody).toBe("hello world")
     expect(rec1?.degraded).toBe(false)
     expect(rec1?.tokensAdded).toBeGreaterThan(0)
+    expect(rec1?.lastChangeSpanId).toBe(spanId("2"))
   })
 
   it("omits a record added and removed within the same session", async () => {
@@ -184,6 +186,7 @@ describe("computeSessionMemoryDiff", () => {
     expect(result.records).toHaveLength(2)
     expect(result.records.every((r) => r.kind === "removed" && r.afterBody === null && r.beforeBody != null)).toBe(true)
     expect(result.records.every((r) => r.tokensRemoved > 0 && r.tokensAdded === 0)).toBe(true)
+    expect(result.records.every((r) => r.lastChangeSpanId === null)).toBe(true) // wipe the session didn't otherwise touch
   })
 
   it("flags a change as degraded when the body is unavailable", async () => {

--- a/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-diff.test.ts
@@ -226,6 +226,40 @@ describe("computeSessionMemoryDiff", () => {
     expect(rec1?.afterBody).toBeNull()
   })
 
+  it("does not deep-link a record wiped after it was changed in the same session", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("1"),
+          operation: "create_memory",
+          recordsRaw: records({ id: "rec1", content: "hi" }),
+          endTime: at(0),
+        }),
+      ],
+      memory,
+      SessionId("sessOld"),
+    )
+    await materialize(
+      [
+        makeSpan({
+          spanId: spanId("2"),
+          operation: "update_memory",
+          recordsRaw: records({ id: "rec1", content: "hi there" }),
+          endTime: at(5),
+        }),
+        makeSpan({ spanId: spanId("3"), operation: "delete_memory", recordId: "", endTime: at(6) }),
+      ],
+      memory,
+      SessionId("sessNew"),
+    )
+
+    const result = await diff(memory, { sessionId: SessionId("sessNew") })
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0]?.kind).toBe("removed")
+    expect(result.records[0]?.lastChangeSpanId).toBeNull() // not the pre-wipe update span
+  })
+
   it("restricts the diff to one trace when a trace id is given", async () => {
     const memory = createFakeMemoryRepository()
     await materialize(

--- a/packages/domain/memories/src/use-cases/compute-session-memory-diff.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-diff.ts
@@ -26,6 +26,8 @@ export interface SessionMemoryRecordDiff {
   readonly tokensAdded: number
   readonly tokensRemoved: number
   readonly degraded: boolean
+  /** Span of the session's last change to this record, for deep-linking to that change; `null` if none. */
+  readonly lastChangeSpanId: string | null
 }
 
 /** A session's (or trace's) memory writes as per-record before/after diffs. */
@@ -65,6 +67,7 @@ export const computeSessionMemoryDiffUseCase = Effect.fn("memories.computeSessio
       tokensAdded: delta.tokensAdded,
       tokensRemoved: delta.tokensRemoved,
       degraded: delta.degraded,
+      lastChangeSpanId: endpoint.afterSpanId,
     }
   })
 

--- a/packages/domain/memories/src/use-cases/compute-session-memory-diff.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-diff.ts
@@ -1,0 +1,72 @@
+import type { OrganizationId, ProjectId, SessionId, TraceId } from "@domain/shared"
+import { Effect } from "effect"
+import { recordTokenDelta } from "./diff-record-bodies.ts"
+import { computeSessionWriteEndpoints } from "./session-write-endpoints.ts"
+
+export interface ComputeSessionMemoryDiffInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly sessionId: SessionId
+  /** Restrict to one trace's contribution; omit for the whole session. */
+  readonly traceId?: TraceId
+}
+
+/**
+ * One record's net change within a session/trace, with the before/after bodies
+ * for a unified diff. `beforeBody` is `null` for an add; `afterBody` is `null`
+ * for a remove. `degraded` marks a change whose relevant body was never captured
+ * or has been pruned ([D5]) — the caller shows a fallback, not a misleading diff.
+ */
+export interface SessionMemoryRecordDiff {
+  readonly storeId: string
+  readonly recordId: string
+  readonly kind: "added" | "updated" | "removed"
+  readonly beforeBody: string | null
+  readonly afterBody: string | null
+  readonly tokensAdded: number
+  readonly tokensRemoved: number
+  readonly degraded: boolean
+}
+
+/** A session's (or trace's) memory writes as per-record before/after diffs. */
+export interface SessionMemoryDiff {
+  readonly records: readonly SessionMemoryRecordDiff[]
+}
+
+/**
+ * The per-record diff for a session/trace: each record it mutated, resolved
+ * endpoint-to-endpoint ([D2], churn collapsed), with the before/after bodies for
+ * a unified diff. Read-only records are excluded — this is the write view.
+ */
+export const computeSessionMemoryDiffUseCase = Effect.fn("memories.computeSessionMemoryDiff")(function* (
+  input: ComputeSessionMemoryDiffInput,
+) {
+  const { endpoints, bodyByHash } = yield* computeSessionWriteEndpoints(input)
+  const body = (hash: string): string | null => (hash === "" ? null : (bodyByHash.get(hash) ?? null))
+
+  const records: SessionMemoryRecordDiff[] = endpoints.map((endpoint) => {
+    const beforeBody = body(endpoint.beforeHash)
+    const afterBody = endpoint.afterPresent ? body(endpoint.afterHash) : null
+    const delta = recordTokenDelta({
+      kind: endpoint.kind,
+      beforeHash: endpoint.beforeHash,
+      afterHash: endpoint.afterHash,
+      beforeBody,
+      afterBody,
+      beforeTokens: endpoint.beforeTokens,
+      afterTokens: endpoint.afterTokens,
+    })
+    return {
+      storeId: endpoint.storeId,
+      recordId: endpoint.recordId,
+      kind: endpoint.kind,
+      beforeBody,
+      afterBody,
+      tokensAdded: delta.tokensAdded,
+      tokensRemoved: delta.tokensRemoved,
+      degraded: delta.degraded,
+    }
+  })
+
+  return { records } satisfies SessionMemoryDiff
+})

--- a/packages/domain/memories/src/use-cases/compute-session-memory-summary.test.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-summary.test.ts
@@ -154,7 +154,20 @@ describe("computeSessionMemorySummary", () => {
 
     const summary = await summarize(memory, { sessionId: SessionId("sess1") })
     expect(summary.records).toHaveLength(0)
-    expect(summary.total).toEqual({ readTokens: 0, tokensAdded: 0, tokensRemoved: 0 })
+    expect(summary.total).toEqual({ readTokens: 0, tokensAdded: 0, tokensRemoved: 0, writeRecords: 0 })
+  })
+
+  it("counts a zero-token write in writeRecords even when it drops from the records list", async () => {
+    const memory = createFakeMemoryRepository()
+    await materialize(
+      [makeSpan({ spanId: spanId("1"), operation: "create_memory", recordsRaw: records({ id: "rec1", content: "" }) })],
+      memory,
+    )
+
+    const summary = await summarize(memory, { sessionId: SessionId("sess1") })
+    expect(summary.records).toHaveLength(0) // no read/added/removed tokens, so filtered from the breakdown
+    expect(summary.total.tokensAdded).toBe(0)
+    expect(summary.total.writeRecords).toBe(1) // but the write still counts, so the section stays visible
   })
 
   it("lists each touched record across multiple stores in the session", async () => {

--- a/packages/domain/memories/src/use-cases/compute-session-memory-summary.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-summary.ts
@@ -24,6 +24,8 @@ export interface MemorySummaryTotals {
   readonly readTokens: number
   readonly tokensAdded: number
   readonly tokensRemoved: number
+  /** Records the session wrote (added/updated/removed), including zero-token-delta writes. */
+  readonly writeRecords: number
 }
 
 /** A session's (or trace's) memory footprint: per-record read/write tokens plus the total. */
@@ -75,8 +77,9 @@ export const computeSessionMemorySummaryUseCase = Effect.fn("memories.computeSes
       readTokens: acc.readTokens + record.readTokens,
       tokensAdded: acc.tokensAdded + record.tokensAdded,
       tokensRemoved: acc.tokensRemoved + record.tokensRemoved,
+      writeRecords: acc.writeRecords,
     }),
-    { readTokens: 0, tokensAdded: 0, tokensRemoved: 0 },
+    { readTokens: 0, tokensAdded: 0, tokensRemoved: 0, writeRecords: endpoints.length },
   )
 
   return { records, total } satisfies SessionMemorySummary

--- a/packages/domain/memories/src/use-cases/compute-session-memory-summary.ts
+++ b/packages/domain/memories/src/use-cases/compute-session-memory-summary.ts
@@ -1,10 +1,7 @@
 import type { OrganizationId, ProjectId, SessionId, TraceId } from "@domain/shared"
 import { Effect } from "effect"
-import type { MemoryEvent } from "../entities/memory-event.ts"
-import type { MemoryRecordVersion } from "../entities/memory-snapshot.ts"
-import { MemoryRepository } from "../ports/memory-repository.ts"
 import { recordTokenDelta } from "./diff-record-bodies.ts"
-import { reconstructSnapshotUseCase } from "./reconstruct-snapshot.ts"
+import { computeSessionWriteEndpoints, recordKey } from "./session-write-endpoints.ts"
 
 export interface ComputeSessionMemorySummaryInput {
   readonly organizationId: OrganizationId
@@ -35,152 +32,17 @@ export interface SessionMemorySummary {
   readonly total: MemorySummaryTotals
 }
 
-const recordKey = (storeId: string, recordId: string) => `${storeId}\u0000${recordId}`
-
-type WriteEndpoint = {
-  readonly storeId: string
-  readonly recordId: string
-  readonly kind: "added" | "updated" | "removed"
-  readonly beforeHash: string
-  readonly afterHash: string
-  readonly beforeTokens: number
-  readonly afterTokens: number
-  readonly afterPresent: boolean
-}
-
 /**
  * A session's memory footprint, broken down per record: read tokens (Σ over the
  * record's `search_memory` events) and the write diff under the strict per-record
  * rule ([D2]) — `before` is the version current just before the session's first
  * touch, `after` its last touch, so intra-session churn collapses to the net
- * change. A whole-store wipe within the session removes the store's records live
- * at the wipe.
+ * change. A record read *and* written merges into one entry.
  */
 export const computeSessionMemorySummaryUseCase = Effect.fn("memories.computeSessionMemorySummary")(function* (
   input: ComputeSessionMemorySummaryInput,
 ) {
-  const { organizationId, projectId, sessionId, traceId } = input
-  const memoryRepository = yield* MemoryRepository
-
-  const events = yield* memoryRepository.readSessionMemoryEvents({
-    organizationId,
-    projectId,
-    sessionId,
-    ...(traceId !== undefined ? { traceId } : {}),
-  })
-
-  const meta = new Map<string, { storeId: string; recordId: string }>()
-  const seen = (storeId: string, recordId: string) => {
-    const key = recordKey(storeId, recordId)
-    if (!meta.has(key)) meta.set(key, { storeId, recordId })
-    return key
-  }
-
-  const readByRecord = new Map<string, number>()
-  const endpoints: WriteEndpoint[] = []
-  const hashes = new Set<string>()
-
-  const mutatingByRecord = new Map<string, MemoryEvent[]>()
-  const wipeAtByStore = new Map<string, Date>()
-
-  for (const event of events) {
-    if (event.changeKind === "read") {
-      const key = seen(event.storeId, event.recordId)
-      readByRecord.set(key, (readByRecord.get(key) ?? 0) + event.tokenCount)
-    } else if (event.changeKind === "store_delete") {
-      const prev = wipeAtByStore.get(event.storeId)
-      if (prev === undefined || event.endTime.getTime() > prev.getTime())
-        wipeAtByStore.set(event.storeId, event.endTime)
-    } else if (event.changeKind === "add" || event.changeKind === "update" || event.changeKind === "remove") {
-      const key = recordKey(event.storeId, event.recordId)
-      const list = mutatingByRecord.get(key)
-      if (list) list.push(event)
-      else mutatingByRecord.set(key, [event])
-    }
-  }
-
-  const addEndpoint = (endpoint: Omit<WriteEndpoint, "kind">) => {
-    const { beforeHash, afterHash, afterPresent } = endpoint
-    const kind = !afterPresent
-      ? beforeHash === ""
-        ? null
-        : "removed"
-      : beforeHash === ""
-        ? "added"
-        : afterHash === beforeHash
-          ? null
-          : "updated"
-    if (kind === null) return
-    endpoints.push({ kind, ...endpoint })
-    if (beforeHash !== "") hashes.add(beforeHash)
-    if (afterPresent && afterHash !== "") hashes.add(afterHash)
-  }
-
-  const touchedRecords = [...mutatingByRecord.values()].map((list) => ({
-    storeId: list[0]!.storeId,
-    recordId: list[0]!.recordId,
-  }))
-  const versions =
-    touchedRecords.length > 0
-      ? yield* memoryRepository.readRecordVersions({ organizationId, projectId, records: touchedRecords })
-      : []
-  const chainByRecord = new Map<string, MemoryRecordVersion[]>()
-  for (const version of versions) {
-    const key = recordKey(version.storeId, version.recordId)
-    const list = chainByRecord.get(key)
-    if (list) list.push(version)
-    else chainByRecord.set(key, [version])
-  }
-
-  for (const [key, list] of mutatingByRecord) {
-    const first = list[0]!
-    const last = list[list.length - 1]!
-    // chain is end_time ASC; the last version before the session's first touch is the "before".
-    let before: MemoryRecordVersion | undefined
-    for (const version of chainByRecord.get(key) ?? []) {
-      if (version.endTime.getTime() < first.endTime.getTime()) before = version
-    }
-    const beforePresent = before !== undefined && before.changeKind !== "remove"
-    const wipeAt = wipeAtByStore.get(first.storeId)
-    const wipedAfter = wipeAt !== undefined && wipeAt.getTime() > last.endTime.getTime()
-    const afterPresent = wipedAfter ? false : last.changeKind !== "remove"
-    addEndpoint({
-      storeId: first.storeId,
-      recordId: first.recordId,
-      beforeHash: beforePresent ? before!.contentHash : "",
-      beforeTokens: beforePresent ? before!.tokenCount : 0,
-      afterHash: afterPresent ? last.contentHash : "",
-      afterTokens: afterPresent ? last.tokenCount : 0,
-      afterPresent,
-    })
-  }
-
-  // Records the wipe removed that the session did not otherwise touch. Read the
-  // store's live records as of just before the wipe via reconstruction (not raw
-  // readManifestAt at the wipe): reconstruction applies the store-wipe
-  // post-filter, so records already dropped by an earlier wipe aren't counted
-  // as removed again. The 1ms-before instant keeps the current wipe out of that
-  // filter while including everything live up to it.
-  const touchedKeys = new Set(mutatingByRecord.keys())
-  for (const [storeId, wipeAt] of wipeAtByStore) {
-    const beforeWipe = new Date(wipeAt.getTime() - 1)
-    const snapshot = yield* reconstructSnapshotUseCase({ organizationId, projectId, storeId, at: beforeWipe })
-    for (const record of snapshot.records) {
-      if (touchedKeys.has(recordKey(record.storeId, record.recordId))) continue
-      addEndpoint({
-        storeId: record.storeId,
-        recordId: record.recordId,
-        beforeHash: record.contentHash,
-        beforeTokens: record.tokenCount,
-        afterHash: "",
-        afterTokens: 0,
-        afterPresent: false,
-      })
-    }
-  }
-
-  const blobs = yield* memoryRepository.readBlobs({ organizationId, hashes: [...hashes] })
-  const bodyByHash = new Map(blobs.map((blob) => [blob.contentHash, blob.content]))
+  const { endpoints, bodyByHash, readByRecord, meta } = yield* computeSessionWriteEndpoints(input)
   const body = (hash: string): string | null => (hash === "" ? null : (bodyByHash.get(hash) ?? null))
 
   const writeByRecord = new Map<string, { added: number; removed: number }>()
@@ -194,8 +56,10 @@ export const computeSessionMemorySummaryUseCase = Effect.fn("memories.computeSes
       beforeTokens: endpoint.beforeTokens,
       afterTokens: endpoint.afterTokens,
     })
-    const key = seen(endpoint.storeId, endpoint.recordId)
-    writeByRecord.set(key, { added: delta.tokensAdded, removed: delta.tokensRemoved })
+    writeByRecord.set(recordKey(endpoint.storeId, endpoint.recordId), {
+      added: delta.tokensAdded,
+      removed: delta.tokensRemoved,
+    })
   }
 
   const records: MemoryRecordSummary[] = []

--- a/packages/domain/memories/src/use-cases/session-write-endpoints.ts
+++ b/packages/domain/memories/src/use-cases/session-write-endpoints.ts
@@ -147,7 +147,8 @@ export const computeSessionWriteEndpoints = Effect.fn("memories.computeSessionWr
       afterHash: afterPresent ? last.contentHash : "",
       afterTokens: afterPresent ? last.tokenCount : 0,
       afterPresent,
-      afterSpanId: last.spanId,
+      // A wipe removal has no per-record version to deep-link; linking the pre-wipe change would mislead.
+      afterSpanId: wipedAfter ? null : last.spanId,
     })
   }
 

--- a/packages/domain/memories/src/use-cases/session-write-endpoints.ts
+++ b/packages/domain/memories/src/use-cases/session-write-endpoints.ts
@@ -1,0 +1,179 @@
+import type { OrganizationId, ProjectId, SessionId, TraceId } from "@domain/shared"
+import { Effect } from "effect"
+import type { MemoryEvent } from "../entities/memory-event.ts"
+import type { MemoryRecordVersion } from "../entities/memory-snapshot.ts"
+import { MemoryRepository } from "../ports/memory-repository.ts"
+import { reconstructSnapshotUseCase } from "./reconstruct-snapshot.ts"
+
+interface SessionWriteEndpointsInput {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly sessionId: SessionId
+  /** Restrict to one trace's contribution; omit for the whole session. */
+  readonly traceId?: TraceId
+}
+
+/** One record's net write within a session/trace, resolved endpoint-to-endpoint ([D2]). */
+interface SessionWriteEndpoint {
+  readonly storeId: string
+  readonly recordId: string
+  readonly kind: "added" | "updated" | "removed"
+  readonly beforeHash: string
+  readonly afterHash: string
+  readonly beforeTokens: number
+  readonly afterTokens: number
+  readonly afterPresent: boolean
+}
+
+/**
+ * The raw material both the session memory summary and diff are built from: the
+ * per-record write endpoints (net change under the strict per-record rule),
+ * their bodies, and the per-record read tokens. `meta` carries every record the
+ * session read or wrote, in first-seen order.
+ */
+interface SessionWriteEndpoints {
+  readonly endpoints: readonly SessionWriteEndpoint[]
+  readonly bodyByHash: ReadonlyMap<string, string>
+  readonly readByRecord: ReadonlyMap<string, number>
+  readonly meta: ReadonlyMap<string, { readonly storeId: string; readonly recordId: string }>
+}
+
+export const recordKey = (storeId: string, recordId: string) => `${storeId}\u0000${recordId}`
+
+/**
+ * Resolve a session's (or trace's) memory writes per record under the strict
+ * per-record rule ([D2]): `before` is the version current just before the
+ * session's first touch, `after` its last touch, so intra-session churn
+ * collapses to the net change. A whole-store wipe within the session removes the
+ * store's records live at the wipe. Shared by `compute-session-memory-summary`
+ * (token deltas) and `compute-session-memory-diff` (before/after bodies).
+ */
+export const computeSessionWriteEndpoints = Effect.fn("memories.computeSessionWriteEndpoints")(function* (
+  input: SessionWriteEndpointsInput,
+) {
+  const { organizationId, projectId, sessionId, traceId } = input
+  const memoryRepository = yield* MemoryRepository
+
+  const events = yield* memoryRepository.readSessionMemoryEvents({
+    organizationId,
+    projectId,
+    sessionId,
+    ...(traceId !== undefined ? { traceId } : {}),
+  })
+
+  const meta = new Map<string, { storeId: string; recordId: string }>()
+  const seen = (storeId: string, recordId: string) => {
+    const key = recordKey(storeId, recordId)
+    if (!meta.has(key)) meta.set(key, { storeId, recordId })
+    return key
+  }
+
+  const readByRecord = new Map<string, number>()
+  const endpoints: SessionWriteEndpoint[] = []
+  const hashes = new Set<string>()
+
+  const mutatingByRecord = new Map<string, MemoryEvent[]>()
+  const wipeAtByStore = new Map<string, Date>()
+
+  for (const event of events) {
+    if (event.changeKind === "read") {
+      const key = seen(event.storeId, event.recordId)
+      readByRecord.set(key, (readByRecord.get(key) ?? 0) + event.tokenCount)
+    } else if (event.changeKind === "store_delete") {
+      const prev = wipeAtByStore.get(event.storeId)
+      if (prev === undefined || event.endTime.getTime() > prev.getTime())
+        wipeAtByStore.set(event.storeId, event.endTime)
+    } else if (event.changeKind === "add" || event.changeKind === "update" || event.changeKind === "remove") {
+      const key = recordKey(event.storeId, event.recordId)
+      const list = mutatingByRecord.get(key)
+      if (list) list.push(event)
+      else mutatingByRecord.set(key, [event])
+    }
+  }
+
+  const addEndpoint = (endpoint: Omit<SessionWriteEndpoint, "kind">) => {
+    const { beforeHash, afterHash, afterPresent } = endpoint
+    const kind = !afterPresent
+      ? beforeHash === ""
+        ? null
+        : "removed"
+      : beforeHash === ""
+        ? "added"
+        : afterHash === beforeHash
+          ? null
+          : "updated"
+    if (kind === null) return
+    endpoints.push({ kind, ...endpoint })
+    seen(endpoint.storeId, endpoint.recordId)
+    if (beforeHash !== "") hashes.add(beforeHash)
+    if (afterPresent && afterHash !== "") hashes.add(afterHash)
+  }
+
+  const touchedRecords = [...mutatingByRecord.values()].map((list) => ({
+    storeId: list[0]!.storeId,
+    recordId: list[0]!.recordId,
+  }))
+  const versions =
+    touchedRecords.length > 0
+      ? yield* memoryRepository.readRecordVersions({ organizationId, projectId, records: touchedRecords })
+      : []
+  const chainByRecord = new Map<string, MemoryRecordVersion[]>()
+  for (const version of versions) {
+    const key = recordKey(version.storeId, version.recordId)
+    const list = chainByRecord.get(key)
+    if (list) list.push(version)
+    else chainByRecord.set(key, [version])
+  }
+
+  for (const [key, list] of mutatingByRecord) {
+    const first = list[0]!
+    const last = list[list.length - 1]!
+    // chain is end_time ASC; the last version before the session's first touch is the "before".
+    let before: MemoryRecordVersion | undefined
+    for (const version of chainByRecord.get(key) ?? []) {
+      if (version.endTime.getTime() < first.endTime.getTime()) before = version
+    }
+    const beforePresent = before !== undefined && before.changeKind !== "remove"
+    const wipeAt = wipeAtByStore.get(first.storeId)
+    const wipedAfter = wipeAt !== undefined && wipeAt.getTime() > last.endTime.getTime()
+    const afterPresent = wipedAfter ? false : last.changeKind !== "remove"
+    addEndpoint({
+      storeId: first.storeId,
+      recordId: first.recordId,
+      beforeHash: beforePresent ? before!.contentHash : "",
+      beforeTokens: beforePresent ? before!.tokenCount : 0,
+      afterHash: afterPresent ? last.contentHash : "",
+      afterTokens: afterPresent ? last.tokenCount : 0,
+      afterPresent,
+    })
+  }
+
+  // Records the wipe removed that the session did not otherwise touch. Read the
+  // store's live records as of just before the wipe via reconstruction (not raw
+  // readManifestAt at the wipe): reconstruction applies the store-wipe
+  // post-filter, so records already dropped by an earlier wipe aren't counted
+  // as removed again. The 1ms-before instant keeps the current wipe out of that
+  // filter while including everything live up to it.
+  const touchedKeys = new Set(mutatingByRecord.keys())
+  for (const [storeId, wipeAt] of wipeAtByStore) {
+    const beforeWipe = new Date(wipeAt.getTime() - 1)
+    const snapshot = yield* reconstructSnapshotUseCase({ organizationId, projectId, storeId, at: beforeWipe })
+    for (const record of snapshot.records) {
+      if (touchedKeys.has(recordKey(record.storeId, record.recordId))) continue
+      addEndpoint({
+        storeId: record.storeId,
+        recordId: record.recordId,
+        beforeHash: record.contentHash,
+        beforeTokens: record.tokenCount,
+        afterHash: "",
+        afterTokens: 0,
+        afterPresent: false,
+      })
+    }
+  }
+
+  const blobs = yield* memoryRepository.readBlobs({ organizationId, hashes: [...hashes] })
+  const bodyByHash = new Map(blobs.map((blob) => [blob.contentHash, blob.content]))
+
+  return { endpoints, bodyByHash, readByRecord, meta } satisfies SessionWriteEndpoints
+})

--- a/packages/domain/memories/src/use-cases/session-write-endpoints.ts
+++ b/packages/domain/memories/src/use-cases/session-write-endpoints.ts
@@ -23,6 +23,8 @@ interface SessionWriteEndpoint {
   readonly beforeTokens: number
   readonly afterTokens: number
   readonly afterPresent: boolean
+  /** Span of the session's last mutating touch on this record; `null` for a wipe the session didn't otherwise touch. */
+  readonly afterSpanId: string | null
 }
 
 /**
@@ -145,6 +147,7 @@ export const computeSessionWriteEndpoints = Effect.fn("memories.computeSessionWr
       afterHash: afterPresent ? last.contentHash : "",
       afterTokens: afterPresent ? last.tokenCount : 0,
       afterPresent,
+      afterSpanId: last.spanId,
     })
   }
 
@@ -168,6 +171,7 @@ export const computeSessionWriteEndpoints = Effect.fn("memories.computeSessionWr
         afterHash: "",
         afterTokens: 0,
         afterPresent: false,
+        afterSpanId: null,
       })
     }
   }

--- a/packages/ui/src/components/code-block/code-diff-view.tsx
+++ b/packages/ui/src/components/code-block/code-diff-view.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react"
+import { ChevronDown, ChevronUp, UnfoldVertical } from "lucide-react"
+import { Fragment, useMemo, useState } from "react"
 import { cn } from "../../utils/cn.ts"
-import { computeDiffRows, type DiffRow, type DiffRowKind } from "./diff-model.ts"
+import { computeDiffRows, type DiffFoldItem, type DiffRow, type DiffRowKind, foldDiffRows } from "./diff-model.ts"
 import { highlightToLines, type LineToken } from "./highlight-lines.ts"
 
 interface CodeDiffViewProps {
@@ -9,7 +10,14 @@ interface CodeDiffViewProps {
   readonly className?: string
   readonly language?: string | undefined
   readonly fillHeight?: boolean
+  /** Collapse unchanged runs, keeping this many context lines around each change. Omit to show every line. */
+  readonly contextLines?: number | undefined
 }
+
+/** Rows revealed per click when expanding a fold from either end (GitHub's step). */
+const EXPAND_STEP = 20
+
+type FoldState = { readonly top: number; readonly bottom: number }
 
 interface RenderSegment {
   readonly text: string
@@ -94,8 +102,62 @@ function DiffLine({ row, segments }: { row: DiffRow; segments: RenderSegment[] }
   )
 }
 
+const FOLD_BUTTON = "rounded p-0.5 hover:bg-muted hover:text-foreground"
+
+function FoldBar({
+  count,
+  onExpandDown,
+  onExpandUp,
+  onExpandAll,
+}: {
+  readonly count: number
+  readonly onExpandDown: () => void
+  readonly onExpandUp: () => void
+  readonly onExpandAll: () => void
+}) {
+  const label = `${count} unchanged ${count === 1 ? "line" : "lines"}`
+  return (
+    <div className="flex select-none items-stretch bg-muted/40 text-muted-foreground/80">
+      <div className="flex min-w-[5rem] shrink-0 items-center justify-center gap-1 border-r border-border/60 py-0.5">
+        {count > EXPAND_STEP ? (
+          <>
+            <button type="button" title="Expand down" onClick={onExpandDown} className={FOLD_BUTTON}>
+              <ChevronDown className="h-3.5 w-3.5" />
+            </button>
+            <button type="button" title="Expand up" onClick={onExpandUp} className={FOLD_BUTTON}>
+              <ChevronUp className="h-3.5 w-3.5" />
+            </button>
+          </>
+        ) : (
+          <button type="button" title="Expand all" onClick={onExpandAll} className={FOLD_BUTTON}>
+            <UnfoldVertical className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        title="Expand all"
+        onClick={onExpandAll}
+        className="flex min-w-0 flex-1 items-center gap-2 py-0.5 pl-2 pr-3 text-left hover:text-foreground"
+      >
+        <span aria-hidden className="text-muted-foreground/50">
+          ⋯
+        </span>
+        <span className="truncate">{label}</span>
+      </button>
+    </div>
+  )
+}
+
 /** Read-only, GitHub-style unified diff of two text bodies, syntax-highlighted per line. */
-export function CodeDiffView({ before, after, className, language, fillHeight = false }: CodeDiffViewProps) {
+export function CodeDiffView({
+  before,
+  after,
+  className,
+  language,
+  fillHeight = false,
+  contextLines,
+}: CodeDiffViewProps) {
   const { rows, beforeLines, afterLines } = useMemo(
     () => ({
       rows: computeDiffRows(before, after),
@@ -104,6 +166,50 @@ export function CodeDiffView({ before, after, className, language, fillHeight = 
     }),
     [before, after, language],
   )
+  const items = useMemo(() => (contextLines == null ? null : foldDiffRows(rows, contextLines)), [rows, contextLines])
+  // Fold expansion resets when the diff content changes — this instance is reused
+  // across records in a master-detail — derived from props without a mount effect.
+  const [store, setStore] = useState<{ before: string; after: string; folds: Record<string, FoldState> }>({
+    before,
+    after,
+    folds: {},
+  })
+  const folds = store.before === before && store.after === after ? store.folds : {}
+  const setFold = (id: string, next: FoldState) =>
+    setStore((prev) => {
+      const base = prev.before === before && prev.after === after ? prev.folds : {}
+      return { before, after, folds: { ...base, [id]: next } }
+    })
+
+  const renderLine = (row: DiffRow, key: string) => {
+    const lineTokens =
+      row.kind === "remove"
+        ? (beforeLines[(row.oldLineNumber ?? 1) - 1] ?? [])
+        : (afterLines[(row.newLineNumber ?? 1) - 1] ?? [])
+    return <DiffLine key={key} row={row} segments={buildRenderSegments(lineTokens, row.emphases)} />
+  }
+
+  const renderFold = (fold: DiffFoldItem) => {
+    const total = fold.rows.length
+    const state = folds[fold.id] ?? { top: 0, bottom: 0 }
+    const top = Math.min(state.top, total)
+    const bottom = Math.min(state.bottom, total - top)
+    const remaining = total - top - bottom
+    return (
+      <Fragment key={fold.id}>
+        {fold.rows.slice(0, top).map((row, k) => renderLine(row, `${fold.id}-t-${k}`))}
+        {remaining > 0 && (
+          <FoldBar
+            count={remaining}
+            onExpandDown={() => setFold(fold.id, { top: Math.min(top + EXPAND_STEP, total - bottom), bottom })}
+            onExpandUp={() => setFold(fold.id, { top, bottom: Math.min(bottom + EXPAND_STEP, total - top) })}
+            onExpandAll={() => setFold(fold.id, { top: total, bottom: 0 })}
+          />
+        )}
+        {bottom > 0 && fold.rows.slice(total - bottom).map((row, k) => renderLine(row, `${fold.id}-b-${k}`))}
+      </Fragment>
+    )
+  }
 
   return (
     <div
@@ -113,13 +219,9 @@ export function CodeDiffView({ before, after, className, language, fillHeight = 
         className,
       )}
     >
-      {rows.map((row, index) => {
-        const lineTokens =
-          row.kind === "remove"
-            ? (beforeLines[(row.oldLineNumber ?? 1) - 1] ?? [])
-            : (afterLines[(row.newLineNumber ?? 1) - 1] ?? [])
-        return <DiffLine key={index} row={row} segments={buildRenderSegments(lineTokens, row.emphases)} />
-      })}
+      {items == null
+        ? rows.map((row, index) => renderLine(row, String(index)))
+        : items.map((item, index) => (item.type === "line" ? renderLine(item.row, String(index)) : renderFold(item)))}
     </div>
   )
 }

--- a/packages/ui/src/components/code-block/code-diff-view.tsx
+++ b/packages/ui/src/components/code-block/code-diff-view.tsx
@@ -121,15 +121,27 @@ function FoldBar({
       <div className="flex min-w-[5rem] shrink-0 items-center justify-center gap-1 border-r border-border/60 py-0.5">
         {count > EXPAND_STEP ? (
           <>
-            <button type="button" title="Expand down" onClick={onExpandDown} className={FOLD_BUTTON}>
+            <button
+              type="button"
+              title="Expand down"
+              aria-label="Expand down"
+              onClick={onExpandDown}
+              className={FOLD_BUTTON}
+            >
               <ChevronDown className="h-3.5 w-3.5" />
             </button>
-            <button type="button" title="Expand up" onClick={onExpandUp} className={FOLD_BUTTON}>
+            <button type="button" title="Expand up" aria-label="Expand up" onClick={onExpandUp} className={FOLD_BUTTON}>
               <ChevronUp className="h-3.5 w-3.5" />
             </button>
           </>
         ) : (
-          <button type="button" title="Expand all" onClick={onExpandAll} className={FOLD_BUTTON}>
+          <button
+            type="button"
+            title="Expand all"
+            aria-label="Expand all"
+            onClick={onExpandAll}
+            className={FOLD_BUTTON}
+          >
             <UnfoldVertical className="h-3.5 w-3.5" />
           </button>
         )}
@@ -167,8 +179,7 @@ export function CodeDiffView({
     [before, after, language],
   )
   const items = useMemo(() => (contextLines == null ? null : foldDiffRows(rows, contextLines)), [rows, contextLines])
-  // Fold expansion resets when the diff content changes — this instance is reused
-  // across records in a master-detail — derived from props without a mount effect.
+  // Reset fold expansion when the diff content changes (this viewer is reused across records).
   const [store, setStore] = useState<{ before: string; after: string; folds: Record<string, FoldState> }>({
     before,
     after,

--- a/packages/ui/src/components/code-block/code-diff.tsx
+++ b/packages/ui/src/components/code-block/code-diff.tsx
@@ -9,6 +9,8 @@ export interface CodeDiffProps {
   readonly className?: string
   /** Fill a height-bounded parent and scroll inside the block instead of growing to fit content. */
   readonly fillHeight?: boolean
+  /** Collapse unchanged runs, keeping this many context lines around each change. Omit to show every line. */
+  readonly contextLines?: number
 }
 
 const CodeDiffView = lazy(() => import("./code-diff-view.tsx").then((m) => ({ default: m.CodeDiffView })))
@@ -22,7 +24,7 @@ function CodeDiffFallback({ className }: { readonly className?: string }) {
 }
 
 /** Read-only, GitHub-style unified diff of two text bodies, syntax-highlighted per line. */
-export function CodeDiff({ before, after, language, className, fillHeight = false }: CodeDiffProps) {
+export function CodeDiff({ before, after, language, className, fillHeight = false, contextLines }: CodeDiffProps) {
   const [mounted, setMounted] = useState(false)
 
   useMountEffect(() => {
@@ -41,6 +43,7 @@ export function CodeDiff({ before, after, language, className, fillHeight = fals
         fillHeight={fillHeight}
         {...(language != null && { language })}
         {...(className != null && { className })}
+        {...(contextLines != null && { contextLines })}
       />
     </Suspense>
   )

--- a/packages/ui/src/components/code-block/diff-model.test.ts
+++ b/packages/ui/src/components/code-block/diff-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { computeDiffRows, type DiffRow } from "./diff-model.ts"
+import { computeDiffRows, type DiffFoldItem, type DiffItem, type DiffRow, foldDiffRows } from "./diff-model.ts"
 
 describe("computeDiffRows", () => {
   it("numbers context lines by their real position on each side across a hunk", () => {
@@ -60,5 +60,61 @@ describe("computeDiffRows", () => {
     expect(rows.every((r) => r.emphases.length === 0)).toBe(true)
     expect([rows[0]?.oldLineNumber, rows[0]?.newLineNumber]).toEqual([1, null])
     expect([rows[1]?.oldLineNumber, rows[1]?.newLineNumber]).toEqual([null, 1])
+  })
+})
+
+const joined = (lines: string[]) => `${lines.join("\n")}\n`
+const range = (prefix: string, n: number) => Array.from({ length: n }, (_, i) => `${prefix}${i + 1}`)
+const folds = (items: DiffItem[]) => items.filter((item): item is DiffFoldItem => item.type === "fold")
+const contextTexts = (items: DiffItem[]) =>
+  items.flatMap((item) => (item.type === "line" && item.row.kind === "context" ? [item.row.text] : []))
+
+describe("foldDiffRows", () => {
+  it("folds a large interior gap, keeping context lines on both sides", () => {
+    const mid = range("m", 20)
+    const rows = computeDiffRows(joined(["A", ...mid, "B"]), joined(["A2", ...mid, "B2"]))
+    const items = foldDiffRows(rows, 3)
+
+    expect(folds(items)).toHaveLength(1)
+    expect(folds(items)[0]?.rows).toHaveLength(14) // 20 - 3 head - 3 tail
+    expect(contextTexts(items)).toEqual(["m1", "m2", "m3", "m18", "m19", "m20"])
+  })
+
+  it("does not fold a gap no larger than the context it would keep", () => {
+    const rows = computeDiffRows(joined(["A", ...range("m", 4), "B"]), joined(["A2", ...range("m", 4), "B2"]))
+    const items = foldDiffRows(rows, 3)
+
+    expect(folds(items)).toHaveLength(0)
+    expect(contextTexts(items)).toEqual(["m1", "m2", "m3", "m4"])
+  })
+
+  it("folds a leading gap, keeping only the context before the first change", () => {
+    const rows = computeDiffRows(joined([...range("h", 20), "X"]), joined([...range("h", 20), "Y"]))
+    const items = foldDiffRows(rows, 3)
+
+    expect(folds(items)).toHaveLength(1)
+    expect(folds(items)[0]?.rows).toHaveLength(17)
+    expect(contextTexts(items)).toEqual(["h18", "h19", "h20"])
+  })
+
+  it("folds a trailing gap, keeping only the context after the last change", () => {
+    const rows = computeDiffRows(joined(["X", ...range("t", 20)]), joined(["Y", ...range("t", 20)]))
+    const items = foldDiffRows(rows, 3)
+
+    expect(folds(items)).toHaveLength(1)
+    expect(folds(items)[0]?.rows).toHaveLength(17)
+    expect(contextTexts(items)).toEqual(["t1", "t2", "t3"])
+  })
+
+  it("never folds when there are no changes", () => {
+    const items = foldDiffRows(computeDiffRows(joined(range("x", 30)), joined(range("x", 30))), 3)
+    expect(folds(items)).toHaveLength(0)
+    expect(items).toHaveLength(30)
+  })
+
+  it("never folds a pure addition (no context rows)", () => {
+    const items = foldDiffRows(computeDiffRows("", joined(range("n", 10))), 3)
+    expect(folds(items)).toHaveLength(0)
+    expect(items).toHaveLength(10)
   })
 })

--- a/packages/ui/src/components/code-block/diff-model.ts
+++ b/packages/ui/src/components/code-block/diff-model.ts
@@ -141,3 +141,48 @@ export function computeDiffRows(before: string, after: string): DiffRow[] {
 
   return rows
 }
+
+/** A run of unchanged rows collapsed by default; `rows` are hidden until expanded. */
+export interface DiffFoldItem {
+  readonly type: "fold"
+  readonly id: string
+  readonly rows: readonly DiffRow[]
+}
+
+/** A row-model item: either a rendered line or a collapsed fold of unchanged lines. */
+export type DiffItem = { readonly type: "line"; readonly row: DiffRow } | DiffFoldItem
+
+/**
+ * Collapse runs of unchanged context into folds, keeping `contextLines` next to
+ * every change (GitHub-style). A fold is emitted only when a run is longer than
+ * the context it would keep, so nothing is hidden that wasn't worth hiding. With
+ * no changes — or a pure add/remove, which has no context — every line is kept.
+ */
+export function foldDiffRows(rows: readonly DiffRow[], contextLines: number): DiffItem[] {
+  if (!rows.some((row) => row.kind !== "context")) return rows.map((row) => ({ type: "line", row }))
+
+  const items: DiffItem[] = []
+  let i = 0
+  while (i < rows.length) {
+    if (rows[i]!.kind !== "context") {
+      items.push({ type: "line", row: rows[i]! })
+      i++
+      continue
+    }
+
+    let end = i
+    while (end < rows.length && rows[end]!.kind === "context") end++
+    const head = i === 0 ? 0 : contextLines
+    const tail = end === rows.length ? 0 : contextLines
+
+    if (end - i > head + tail) {
+      for (let k = i; k < i + head; k++) items.push({ type: "line", row: rows[k]! })
+      items.push({ type: "fold", id: `fold-${i + head}`, rows: rows.slice(i + head, end - tail) })
+      for (let k = end - tail; k < end; k++) items.push({ type: "line", row: rows[k]! })
+    } else {
+      for (let k = i; k < end; k++) items.push({ type: "line", row: rows[k]! })
+    }
+    i = end
+  }
+  return items
+}

--- a/packages/ui/src/components/code-block/diff-model.ts
+++ b/packages/ui/src/components/code-block/diff-model.ts
@@ -152,12 +152,7 @@ export interface DiffFoldItem {
 /** A row-model item: either a rendered line or a collapsed fold of unchanged lines. */
 export type DiffItem = { readonly type: "line"; readonly row: DiffRow } | DiffFoldItem
 
-/**
- * Collapse runs of unchanged context into folds, keeping `contextLines` next to
- * every change (GitHub-style). A fold is emitted only when a run is longer than
- * the context it would keep, so nothing is hidden that wasn't worth hiding. With
- * no changes — or a pure add/remove, which has no context — every line is kept.
- */
+/** Collapse unchanged context into folds, keeping `contextLines` around each change (only when longer). */
 export function foldDiffRows(rows: readonly DiffRow[], contextLines: number): DiffItem[] {
   if (!rows.some((row) => row.kind !== "context")) return rows.map((row) => ({ type: "line", row }))
 


### PR DESCRIPTION
Part of Memory Observability (LAT-729). Makes memory *changes* readable as diffs where people already look — the span detail and the session/trace drawers — instead of only as full record bodies, and adds a bridge into the full Memory record page.

This is an inline take on the spec's session commit view (P4-1/P4-2): rather than a separate `/memory/$store?session=` route, the diffs live in the existing previews. The standalone store-as-of-session route stays deferred.

## span detail: change diffs

For mutating memory ops (`create_memory` / `update_memory` / `upsert_memory` / `delete_memory`), the "Memory" section now renders each record's before→after diff against its prior recorded snapshot, instead of the full new body. It reuses the existing per-change diff stack (`useMemoryRecordChangeDiff` → `computeRecordChangeDiffUseCase`), so no new domain code. When the change isn't in the ledger yet (span opened before the trace-end projection runs) or a body is unavailable, it falls back to the full content the span already carries — the pane is never empty. `search_memory` and store-lifecycle spans are unchanged.

## "memory changes" section (session + trace)

A new collapsible **Memory changes** section under Tools in the session (`metadata-tab`) and trace (`trace-tab`) detail bodies. It shows the aggregated per-record diffs a session (or one trace) made to memory, grouped by store. A record changed several times in the session collapses to one net diff — state before the session's first touch → state after its last — following the per-record last-writer-wins rule, so a store written by several sessions still produces a correct per-record diff. Visibility rides the already-cached memory summary (renders only when there were writes); the heavier body-diff read fires only when the section is expanded. The token-pill summary under Cost is unchanged.

## collapsed context (folding)

`CodeDiff` (`@repo/ui`) gains an opt-in `contextLines` prop: unchanged runs collapse to a few lines of context around each change, with GitHub-style incremental expanders (reveal N from either end, or expand all). The memory diffs turn it on. Fold-only over raw text — no JSON normalization — so single-line/minified JSON has nothing to fold; create/delete and small records show fully. Fold state is derived from the diff content, so it resets when the viewer is reused across records in a master-detail.

## open in memory (deep-link)

Each record preview pane gets a slim header with an **Open in Memory ↗** link to the full record page. A span change deep-links that exact change (`?change=spanId`); a read links the record's current content; the session view links the session's *last* change to that record (a new `lastChangeSpanId` carried on the session diff). It's a distinct control, separate from row selection, and renders only when `memoryObservability` is on — the previews are visible to everyone, but the Memory page is flag-gated. The store route gains `validateSearch` for `record`/`change` so the typed link can set them (they were already read via `useParamState`).

## engine

New `compute-session-memory-diff` use-case returns per-record before/after bodies for a session/trace. The session write-endpoint logic (endpoint resolution, churn collapse, whole-store-wipe handling) was extracted from `compute-session-memory-summary` into a shared core, so the token summary and the diff stay in lockstep. No schema change, no migration.

## testing

Fake-repo tests for `compute-session-memory-diff` (added/updated/removed, same-session churn collapse, multi-store, degraded body, whole-store wipe, `lastChangeSpanId`) and pure-function tests for `foldDiffRows`; the existing `compute-session-memory-summary` tests are the regression guard for the endpoint extraction. `@domain/memories` + `@app/web` typecheck, Biome, and knip all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible **“Memory changes”** section to session and trace details, showing **added/updated/removed** records.
  * Added read-only **before/after** diff previews for each record (with optional trace filtering) and an **“Open in Memory”** link.
  * Enhanced code diffs with **expand/collapse for unchanged context** and improved handling for JSON-like content.

* **Bug Fixes**
  * Improved degraded/unavailable messaging with clearer fallbacks (including a “Diff unavailable” state) and better deep-link support for opening specific records/changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->