### PR TITLE
fix(flaggers): skip forward-incompatible flagger rows instead of failing the whole read

### DIFF
--- a/packages/platform/db-postgres/src/repositories/flagger-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/flagger-repository.test.ts
@@ -15,16 +15,14 @@ const pg = setupTestPostgres()
 const runWithLive = <A, E>(effect: Effect.Effect<A, E, FlaggerRepository | SqlClient>) =>
   Effect.runPromise(effect.pipe(withPostgres(FlaggerRepositoryLive, pg.adminPostgresClient, ORG_ID)))
 
-// Simulates a row written by a backfill migration for a strategy slug this build's
-// FLAGGER_STRATEGY_SLUGS doesn't recognize yet (see 20260716185032_backfill-new-flagger-slugs).
-const insertRawRow = (slug: string, idSuffix: string) =>
+const insertRawRow = (slug: string, idSuffix: string, sampling = 10) =>
   pg.db.insert(flaggers).values({
     id: `flagger-${idSuffix}`.padEnd(24, "0").slice(0, 24),
     organizationId: ORG_ID,
     projectId: PROJECT_ID,
     slug: slug as FlaggerSlug,
     enabled: true,
-    sampling: 10,
+    sampling,
   })
 
 describe("FlaggerRepositoryLive", () => {
@@ -57,5 +55,18 @@ describe("FlaggerRepositoryLive", () => {
     )
 
     expect(row).toBeNull()
+  })
+
+  it("listByProject still fails when a recognized slug has an invalid sampling value", async () => {
+    await insertRawRow("frustration", "bad-sampling", 101)
+
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* FlaggerRepository
+          return yield* repo.listByProject({ projectId: PROJECT_ID })
+        }),
+      ),
+    ).rejects.toThrow()
   })
 })

--- a/packages/platform/db-postgres/src/repositories/flagger-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/flagger-repository.test.ts
@@ -1,0 +1,61 @@
+import { FlaggerRepository, type FlaggerSlug } from "@domain/flaggers"
+import { OrganizationId, ProjectId, type SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { beforeEach, describe, expect, it } from "vitest"
+import { flaggers } from "../schema/flaggers.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { FlaggerRepositoryLive } from "./flagger-repository.ts"
+
+const ORG_ID = OrganizationId("org-flagger-repo-test".padEnd(24, "x").slice(0, 24))
+const PROJECT_ID = ProjectId("project-flagger-repo".padEnd(24, "x").slice(0, 24))
+
+const pg = setupTestPostgres()
+
+const runWithLive = <A, E>(effect: Effect.Effect<A, E, FlaggerRepository | SqlClient>) =>
+  Effect.runPromise(effect.pipe(withPostgres(FlaggerRepositoryLive, pg.adminPostgresClient, ORG_ID)))
+
+// Simulates a row written by a backfill migration for a strategy slug this build's
+// FLAGGER_STRATEGY_SLUGS doesn't recognize yet (see 20260716185032_backfill-new-flagger-slugs).
+const insertRawRow = (slug: string, idSuffix: string) =>
+  pg.db.insert(flaggers).values({
+    id: `flagger-${idSuffix}`.padEnd(24, "0").slice(0, 24),
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    slug: slug as FlaggerSlug,
+    enabled: true,
+    sampling: 10,
+  })
+
+describe("FlaggerRepositoryLive", () => {
+  beforeEach(async () => {
+    await pg.db.delete(flaggers)
+  })
+
+  it("listByProject skips rows with a slug unrecognized by this build instead of failing the whole list", async () => {
+    await insertRawRow("frustration", "known")
+    await insertRawRow("some-future-strategy", "unknown")
+
+    const rows = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* FlaggerRepository
+        return yield* repo.listByProject({ projectId: PROJECT_ID })
+      }),
+    )
+
+    expect(rows.map((row) => row.slug)).toEqual(["frustration"])
+  })
+
+  it("findByProjectAndSlug returns null for a row whose slug this build doesn't recognize", async () => {
+    await insertRawRow("some-future-strategy", "unknown2")
+
+    const row = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* FlaggerRepository
+        return yield* repo.findByProjectAndSlug({ projectId: PROJECT_ID, slug: "some-future-strategy" as FlaggerSlug })
+      }),
+    )
+
+    expect(row).toBeNull()
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/flagger-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/flagger-repository.ts
@@ -1,6 +1,7 @@
 import {
   FLAGGER_DEFAULT_ENABLED,
   FLAGGER_DEFAULT_SAMPLING,
+  FLAGGER_STRATEGY_SLUGS,
   type Flagger,
   FlaggerRepository,
   type FlaggerRepositoryShape,
@@ -14,12 +15,20 @@ import type { Operator } from "../client.ts"
 import { flaggers } from "../schema/flaggers.ts"
 
 const logger = createLogger("db-postgres/flagger-repository")
+const knownFlaggerSlugs = new Set<string>(FLAGGER_STRATEGY_SLUGS)
 
-// A row's slug can be ahead of this build's FLAGGER_STRATEGY_SLUGS during a rollout — e.g. a
-// backfill migration provisions a newly added strategy before the app code that recognizes it
-// deploys. Skip such rows instead of failing the whole batch so unrelated flaggers keep working.
+// Unknown strategy slugs are skipped so a newer DB row cannot fail reads of known flaggers.
 const toDomainFlagger = (row: typeof flaggers.$inferSelect): Flagger | null => {
-  const parsed = flaggerSchema.safeParse({
+  if (!knownFlaggerSlugs.has(row.slug)) {
+    logger.warn("Skipping unrecognized flagger row", {
+      flaggerId: row.id,
+      projectId: row.projectId,
+      slug: row.slug,
+    })
+    return null
+  }
+
+  return flaggerSchema.parse({
     id: row.id,
     organizationId: row.organizationId,
     projectId: row.projectId,
@@ -29,17 +38,6 @@ const toDomainFlagger = (row: typeof flaggers.$inferSelect): Flagger | null => {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   })
-
-  if (!parsed.success) {
-    logger.warn("Skipping unrecognized flagger row", {
-      flaggerId: row.id,
-      projectId: row.projectId,
-      slug: row.slug,
-    })
-    return null
-  }
-
-  return parsed.data
 }
 
 const toDomainFlaggers = (rows: readonly (typeof flaggers.$inferSelect)[]): Flagger[] =>

--- a/packages/platform/db-postgres/src/repositories/flagger-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/flagger-repository.ts
@@ -7,13 +7,19 @@ import {
   flaggerSchema,
 } from "@domain/flaggers"
 import { RepositoryError, SqlClient, type SqlClientShape } from "@domain/shared"
+import { createLogger } from "@repo/observability"
 import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { flaggers } from "../schema/flaggers.ts"
 
-const toDomainFlagger = (row: typeof flaggers.$inferSelect): Flagger =>
-  flaggerSchema.parse({
+const logger = createLogger("db-postgres/flagger-repository")
+
+// A row's slug can be ahead of this build's FLAGGER_STRATEGY_SLUGS during a rollout — e.g. a
+// backfill migration provisions a newly added strategy before the app code that recognizes it
+// deploys. Skip such rows instead of failing the whole batch so unrelated flaggers keep working.
+const toDomainFlagger = (row: typeof flaggers.$inferSelect): Flagger | null => {
+  const parsed = flaggerSchema.safeParse({
     id: row.id,
     organizationId: row.organizationId,
     projectId: row.projectId,
@@ -23,6 +29,21 @@ const toDomainFlagger = (row: typeof flaggers.$inferSelect): Flagger =>
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   })
+
+  if (!parsed.success) {
+    logger.warn("Skipping unrecognized flagger row", {
+      flaggerId: row.id,
+      projectId: row.projectId,
+      slug: row.slug,
+    })
+    return null
+  }
+
+  return parsed.data
+}
+
+const toDomainFlaggers = (rows: readonly (typeof flaggers.$inferSelect)[]): Flagger[] =>
+  rows.map(toDomainFlagger).filter((flagger): flagger is Flagger => flagger !== null)
 
 export const FlaggerRepositoryLive = Layer.effect(
   FlaggerRepository,
@@ -40,7 +61,7 @@ export const FlaggerRepositoryLive = Layer.effect(
                 .orderBy(asc(flaggers.slug)),
             )
             .pipe(
-              Effect.map((rows) => rows.map(toDomainFlagger)),
+              Effect.map(toDomainFlaggers),
               Effect.mapError((cause) => new RepositoryError({ operation: "listByProject", cause })),
             )
         }),
@@ -97,12 +118,7 @@ export const FlaggerRepositoryLive = Layer.effect(
                 .returning(),
             )
             .pipe(
-              Effect.map((rows) =>
-                rows
-                  .map(toDomainFlagger)
-                  .slice()
-                  .sort((a, b) => a.slug.localeCompare(b.slug)),
-              ),
+              Effect.map((rows) => toDomainFlaggers(rows).sort((a, b) => a.slug.localeCompare(b.slug))),
               Effect.mapError((cause) => new RepositoryError({ operation: "saveManyForProject", cause })),
             )
         }),
@@ -142,12 +158,7 @@ export const FlaggerRepositoryLive = Layer.effect(
                 .returning(),
             )
             .pipe(
-              Effect.map((rows) =>
-                rows
-                  .map(toDomainFlagger)
-                  .slice()
-                  .sort((a, b) => a.slug.localeCompare(b.slug)),
-              ),
+              Effect.map((rows) => toDomainFlaggers(rows).sort((a, b) => a.slug.localeCompare(b.slug))),
               Effect.mapError((cause) => new RepositoryError({ operation: "updateEnabledForProject", cause })),
             )
         }),


### PR DESCRIPTION
## What does this PR do?

Fixes a production `ZodError` in `packages/platform/db-postgres/src/repositories/flagger-repository.ts` (Datadog issue [`865a9956-843a-11f1-8789-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/865a9956-843a-11f1-8789-da7ad0900005), ~90 occurrences within a few hours today, first seen 2026-07-20 12:57 UTC).

**Root cause:** the `20260716185032_backfill-new-flagger-slugs` migration inserts a flagger row per project for every currently registered strategy slug, including `bluffing`, `pii-leakage`, and `incompletion`. DB migrations and application deploys in this pipeline aren't atomic, so the migration ran against production ahead of the app release that recognizes those three new slugs (production was still running an older build whose `FLAGGER_STRATEGY_SLUGS` — `packages/domain/flaggers/src/flagger-strategies/types.ts` — doesn't include them yet). As a result, every project's `flaggers` table gained rows with slugs the running code doesn't recognize.

`toDomainFlagger` in `flagger-repository.ts` used `flaggerSchema.parse(...)` (throwing) inside `rows.map(...)`, so a single unrecognized row failed the *entire* batch — breaking `listByProject` (and therefore the `process deterministic-flaggers` worker job) for every project in production, not just the flagger with the unrecognized slug.

**Fix:** switch `toDomainFlagger` to `flaggerSchema.safeParse(...)` and drop unrecognized rows (logging a warning with the row id/project id/slug for visibility) instead of throwing. `listByProject`, `saveManyForProject`, and `updateEnabledForProject` now filter out unparseable rows via a shared `toDomainFlaggers` helper; `findByProjectAndSlug`/`update` already tolerated a `null` result so no signature change was needed there. This is a platform/adapter-layer fix — reads are now resilient to forward-incompatible data — and makes any future staged rollout of a new flagger strategy safe regardless of migration/deploy ordering, rather than a one-off patch for these three slugs.

## Related issue (if applicable)

Datadog Error Tracking issue: https://app.datadoghq.eu/error-tracking/issue/865a9956-843a-11f1-8789-da7ad0900005

## How was this tested?

Added `packages/platform/db-postgres/src/repositories/flagger-repository.test.ts` (PGlite-backed), inserting a raw row with an unrecognized slug (simulating what the backfill migration wrote) alongside a normal row:

- `listByProject` skips the unrecognized row and still returns the recognized one, instead of throwing.
- `findByProjectAndSlug` returns `null` for a row with an unrecognized slug instead of throwing.

Confirmed both tests reproduce the exact production `ZodError` and fail without the fix (temporarily reverted the fix locally to verify), then pass with it applied. Ran the full `@platform/db-postgres` test suite (264 tests, all passing) and `pnpm --filter @platform/db-postgres typecheck` (via `tsgo`) with no errors.

**Verification in production:** after this deploys, occurrences of Datadog issue `865a9956-843a-11f1-8789-da7ad0900005` should drop to zero (the underlying rows remain in the DB — now enabled but simply skipped by builds that don't yet recognize their slug — and will be picked up correctly once the corresponding app release, `bluffing`/`pii-leakage`/`incompletion` support, reaches production).

## Checklist

- [x] Lint, type-checking, and tests pass locally
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have signed the CLA


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnFqw9KicP1GpVHdpV6ehu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when stored flagger records contain unrecognized strategy slugs.
  - Listing and project updates now skip invalid/unrecognized records instead of failing.
  - Single-item lookups for unknown slugs return no result.
  - Added warning logs when records are skipped due to unrecognized strategies.
- **Tests**
  - Added repository tests using an in-memory Postgres setup to cover skipping, null lookups, and rejection on invalid sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->