### PR TITLE
fix(flaggers): skip user-centric flaggers on taxonomy sample dumps

### DIFF
--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -158,6 +158,10 @@ Context compaction mirrors the moments stance: the analyzed window is the last r
 
 Every production flagger LLM call is traced into the `latitude-flaggers` dogfood project, and the flaggers run on that project too. To bound recursion to one level (`src/reflag.ts`): a flagger running on a flagger-generated session stamps its own LLM output with the no-reflag tag, and screening skips any session whose tags carry it. Session tags are the union of span tags, and flagger telemetry sessions are effectively per-trace, so the union semantics are safe.
 
+## Taxonomy dogfood (embedded samples)
+
+Taxonomy naming LLM calls (`taxonomy:propose-themes`, `taxonomy:name-cluster`) are dogfooded into `latitude-taxonomy`. Their user prompts paste foreign conversation transcripts under a `Samples:` block. User-centric strategies (`classifiesAssistantResponseOnly: false` — today `frustration` and `jailbreaking`) would otherwise treat wording inside those samples as the naming agent's own user and false-positive. Screening drops those strategies with reason `embedded-samples` (`src/embedded-samples.ts`); the classify path short-circuits the same way for in-flight work. Assistant-centric flaggers still run on taxonomy output. The annotation reviewer also rejects matches whose only evidence is nested sample/transcript material, for every strategy.
+
 ## Quality tooling
 
 - **Offline benchmark harness** (`tools/ai-benchmarks`): replays public datasets through the real classifier (no deterministic routing, no sampling, no hints) — measures classifier accuracy in isolation. Registered targets: `flaggers:jailbreaking` (JailbreakBench) and `flaggers:refusal` (XSTest) with committed baselines; the other strategies have none.

--- a/packages/domain/flaggers/src/embedded-samples.test.ts
+++ b/packages/domain/flaggers/src/embedded-samples.test.ts
@@ -1,0 +1,43 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
+import { describe, expect, it } from "vitest"
+import {
+  embedsTaxonomyConversationSamples,
+  isUserCentricFlaggerStrategy,
+  shouldSkipUserCentricFlaggerForEmbeddedSamples,
+} from "./embedded-samples.ts"
+import { frustrationStrategy, refusalStrategy } from "./flagger-strategies/index.ts"
+
+describe("embedsTaxonomyConversationSamples", () => {
+  it("is true for taxonomy naming telemetry tags", () => {
+    expect(embedsTaxonomyConversationSamples([...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster])).toBe(true)
+    expect(embedsTaxonomyConversationSamples([...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes])).toBe(true)
+  })
+
+  it("is false for unrelated tags", () => {
+    expect(embedsTaxonomyConversationSamples([...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify])).toBe(false)
+    expect(embedsTaxonomyConversationSamples([])).toBe(false)
+  })
+})
+
+describe("shouldSkipUserCentricFlaggerForEmbeddedSamples", () => {
+  it("skips frustration on taxonomy name-cluster sessions", () => {
+    expect(
+      shouldSkipUserCentricFlaggerForEmbeddedSamples(frustrationStrategy, [
+        ...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster,
+      ]),
+    ).toBe(true)
+  })
+
+  it("does not skip assistant-centric strategies on taxonomy sessions", () => {
+    expect(isUserCentricFlaggerStrategy(refusalStrategy)).toBe(false)
+    expect(
+      shouldSkipUserCentricFlaggerForEmbeddedSamples(refusalStrategy, [
+        ...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster,
+      ]),
+    ).toBe(false)
+  })
+
+  it("does not skip frustration on ordinary sessions", () => {
+    expect(shouldSkipUserCentricFlaggerForEmbeddedSamples(frustrationStrategy, [])).toBe(false)
+  })
+})

--- a/packages/domain/flaggers/src/embedded-samples.ts
+++ b/packages/domain/flaggers/src/embedded-samples.ts
@@ -1,0 +1,27 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
+import type { FlaggerStrategy } from "./flagger-strategies/types.ts"
+
+/**
+ * Taxonomy naming prompts paste foreign conversation transcripts into the
+ * evaluated agent's user message ("Samples:…"). User-centric flaggers
+ * (frustration, jailbreaking) read that pasted wording as if it were the
+ * naming agent's own user and systematically false-positive.
+ *
+ * Assistant-centric flaggers still run — they judge the naming model's own
+ * JSON/name output, which is what dogfooding taxonomy is for.
+ */
+const TAXONOMY_SAMPLE_EMBEDDING_TAGS: readonly string[] = [
+  ...AI_GENERATE_TELEMETRY_TAGS.taxonomyProposeThemes,
+  ...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster,
+]
+
+export const embedsTaxonomyConversationSamples = (tags: readonly string[]): boolean =>
+  tags.some((tag) => TAXONOMY_SAMPLE_EMBEDDING_TAGS.includes(tag))
+
+export const isUserCentricFlaggerStrategy = (strategy: FlaggerStrategy): boolean =>
+  strategy.classifiesAssistantResponseOnly === false
+
+export const shouldSkipUserCentricFlaggerForEmbeddedSamples = (
+  strategy: FlaggerStrategy,
+  tags: readonly string[],
+): boolean => isUserCentricFlaggerStrategy(strategy) && embedsTaxonomyConversationSamples(tags)

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.ts
@@ -49,6 +49,7 @@ DO NOT FLAG
 - Profanity inside content being discussed (e.g., a log file the user pasted)
 - Mild expressive interjections ("ugh", "hmm") without complaint context
 - Questions phrased firmly but not angrily
+- Frustration expressed only inside nested conversation samples, transcripts, or examples the evaluated agent was asked to name, cluster, classify, summarize, or evaluate (e.g. labeled Samples blocks with nested user:/assistant: turns) — that is source material, not the evaluated agent's user
 
 ================================================================================
 DECISION RULE

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1071,6 +1071,65 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate[1].system).not.toContain(
       "Approve only when the proposed annotation describes a problem in the evaluated agent's own assistant response",
     )
+    // User-centric strategies still get nested-sample rejection in the reviewer.
+    expect(calls.generate[1].system).toContain(
+      "Reject annotations whose only evidence is nested transcripts, conversation samples",
+    )
+  })
+
+  it("skips frustration classification when the conversation is a taxonomy naming sample dump", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail(
+            [
+              {
+                role: "user",
+                parts: [
+                  {
+                    type: "text",
+                    content:
+                      "Samples:\n0: user: I did not get any email\nassistant: I didn't actually send it. Let me try again.",
+                  },
+                ],
+              },
+              {
+                role: "assistant",
+                parts: [
+                  {
+                    type: "text",
+                    content:
+                      '{"name":"SkillFlow Architecture Adoption","description":"User wants an explanatory email comparing skills vs skill flows."}',
+                  },
+                ],
+              },
+            ],
+            [...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster],
+          ),
+        ),
+    })
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: () => Effect.die("AI should not run for taxonomy embedded-sample frustration"),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "frustration" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(0)
   })
 
   it("does not call the LLM flagger for frustration when there are no user messages", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -22,11 +22,11 @@ import {
   FLAGGER_PROMPT_MAX_HINTS,
 } from "../constants.ts"
 import type { FlaggerConversation } from "../conversation.ts"
+import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import { getFlaggerStrategy, isLlmCapableStrategy } from "../flagger-strategies/index.ts"
 import { isRecord, iterMessageParts, truncateExcerpt } from "../flagger-strategies/shared.ts"
 import type { FlaggerStrategy } from "../flagger-strategies/types.ts"
 import type { SessionHint } from "../hints/types.ts"
-import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import { reflagSuppressionTags } from "../reflag.ts"
 
 export interface RunFlaggerResult {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -26,6 +26,7 @@ import { getFlaggerStrategy, isLlmCapableStrategy } from "../flagger-strategies/
 import { isRecord, iterMessageParts, truncateExcerpt } from "../flagger-strategies/shared.ts"
 import type { FlaggerStrategy } from "../flagger-strategies/types.ts"
 import type { SessionHint } from "../hints/types.ts"
+import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import { reflagSuppressionTags } from "../reflag.ts"
 
 export interface RunFlaggerResult {
@@ -154,6 +155,10 @@ const ANNOTATION_REVIEWER_ASSISTANT_ONLY_CLAUSE = `
 Approve only when the proposed annotation describes a problem in the evaluated agent's own assistant response. Reject annotations whose evidence is only quoted/source content inside a user message, or whose evidence is that the evaluated agent found a problem in some other content.
 `.trim()
 
+const ANNOTATION_REVIEWER_NESTED_CONTENT_CLAUSE = `
+Reject annotations whose only evidence is nested transcripts, conversation samples, examples, or source material that the evaluated agent was asked to analyze, classify, name, cluster, summarize, evaluate, or transform. Problems described inside that supplied material are not problems with the evaluated agent.
+`.trim()
+
 const ANNOTATION_REVIEWER_REJECTION_CLAUSE = `
 Reject annotations that contradict the match, describe normal or allowed behavior, say no issue was found, switch to another issue category, describe only a schema/format/contract violation for a non-schema flagger, or rely on facts not present in the evidence.
 
@@ -164,6 +169,7 @@ const buildAnnotationReviewerSystemPrompt = (strategy: FlaggerStrategy): string 
   [
     ANNOTATION_REVIEWER_BASE_SYSTEM_PROMPT,
     ...(classifiesAssistantResponseOnly(strategy) ? [ANNOTATION_REVIEWER_ASSISTANT_ONLY_CLAUSE] : []),
+    ANNOTATION_REVIEWER_NESTED_CONTENT_CLAUSE,
     ANNOTATION_REVIEWER_REJECTION_CLAUSE,
   ].join("\n\n")
 
@@ -646,7 +652,7 @@ const ASSISTANT_ONLY_PROMPT_FOOTER =
 // agent was merely asked to analyze, without restricting the judgement to the
 // assistant response.
 const NESTED_CONTENT_PROMPT_FOOTER =
-  "Judge the evaluated agent's conversation for this issue as defined above. Do not flag nested transcripts, examples, or source material that the evaluated agent was merely asked to analyze, classify, or transform — that content is the agent's input, not its behavior. Return structured output only."
+  "Judge the evaluated agent's conversation for this issue as defined above. Do not flag nested transcripts, labeled Samples blocks, examples, or source material that the evaluated agent was merely asked to analyze, classify, name, cluster, summarize, evaluate, or transform — that content is the agent's input, not its behavior. Return structured output only."
 
 const renderHintAnchor = (hint: SessionHint): string => {
   const anchor = hint.anchor
@@ -706,7 +712,8 @@ const buildFlaggerPrompt = (
 // never the agent's own behavior. Applies to every strategy.
 const EVALUATED_TRACE_NESTED_CONTENT_GUIDANCE = `
 Evaluation target:
-The evidence may contain nested transcripts, examples, quoted instructions, or source material that the evaluated agent was asked to analyze, classify, or transform. That nested content is the evaluated agent's input, not its behavior — do not flag content solely because it appears in such supplied material.
+The evidence may contain nested transcripts, labeled Samples blocks, examples, quoted instructions, or source material that the evaluated agent was asked to analyze, classify, name, cluster, summarize, evaluate, or transform. That nested content is the evaluated agent's input, not its behavior — do not flag content solely because it appears in such supplied material.
+For user-centric issues, only flag when the evaluated agent's actual user expressed the issue outside nested sample/transcript blocks. Frustration, jailbreak attempts, or other user wording that appears only inside nested "user:"/"assistant:" turns or Samples sections must not match.
 Do not treat a malformed or incomplete structured response as this issue unless this flagger is specifically about output format or schema validity.
 `.trim()
 
@@ -861,6 +868,11 @@ export const classifyConversationForFlaggerUseCase = Effect.fn("flaggers.classif
 
   if (!strategy || !isLlmCapableStrategy(strategy) || !strategy.hasRequiredContext(input.conversation)) {
     return { matched: false }
+  }
+
+  if (shouldSkipUserCentricFlaggerForEmbeddedSamples(strategy, input.conversation.tags)) {
+    yield* Effect.annotateCurrentSpan("flagger.skipped", "embedded-samples")
+    return { matched: false } satisfies RunFlaggerResult
   }
 
   const ai = yield* AI

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -188,6 +188,36 @@ describe("screenSessionFlaggersUseCase", () => {
     expect(scores.size).toBe(0)
   })
 
+  it("drops user-centric flaggers on taxonomy name-cluster sessions that embed foreign samples", async () => {
+    const session = makeSessionDetail(
+      [
+        user(
+          "FORBIDDEN names:\n- Other Topic\n\nSamples:\n0: user: I did not get any email\nassistant: I didn't actually send it",
+        ),
+        assistant('{"name":"Email Delivery","description":"User asks the assistant to send an email."}'),
+      ],
+      { tags: [...AI_GENERATE_TELEMETRY_TAGS.taxonomyNameCluster] },
+    )
+    const { result, scores } = await runScreening({
+      session,
+      flaggers: [makeFlagger("frustration", 100), makeFlagger("empty-response", 0)],
+      deps: fakeDeps.deps,
+    })
+
+    expect(decisionFor(result.decisions, "frustration")).toEqual({
+      slug: "frustration",
+      action: "dropped",
+      reason: "embedded-samples",
+    })
+    expect(decisionFor(result.decisions, "empty-response")).toEqual({
+      slug: "empty-response",
+      action: "dropped",
+      reason: "unmatched",
+    })
+    expect(result.classifications).toEqual([])
+    expect(scores.size).toBe(0)
+  })
+
   it("writes a session-anchored score with contentHash on a deterministic match", async () => {
     const session = makeSessionDetail([user("Please help me with this."), assistant("")])
     const { result, scores } = await runScreening({

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
@@ -10,6 +10,7 @@ import {
   listFlaggerStrategySlugs,
   suppressorSlug,
 } from "../flagger-strategies/index.ts"
+import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import { gatherSessionHintsUseCase } from "../hints/gatherers.ts"
 import { isPositiveSessionHintKind, type SessionHint, type SessionHintKind } from "../hints/types.ts"
 import { isReflagSuppressed } from "../reflag.ts"
@@ -44,6 +45,7 @@ export type SessionFlaggerDroppedReason =
   | "rate-limited"
   | "disabled"
   | "missing-flagger"
+  | "embedded-samples"
 
 export type SessionFlaggerDecision =
   | { readonly slug: string; readonly action: "matched-issue" }
@@ -289,6 +291,10 @@ const screenOneStrategy = (args: ScreenOneStrategyInput) =>
 
     if (!strategy.hasRequiredContext(args.context.conversation)) {
       return { slug: args.slug, action: "dropped", reason: "missing-context" } satisfies SessionFlaggerDecision
+    }
+
+    if (shouldSkipUserCentricFlaggerForEmbeddedSamples(strategy, args.context.conversation.tags)) {
+      return { slug: args.slug, action: "dropped", reason: "embedded-samples" } satisfies SessionFlaggerDecision
     }
 
     const result = strategy.detectDeterministically

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
@@ -2,6 +2,7 @@ import type { ScoreDraftClosedError, ScoreDraftUpdateConflictError } from "@doma
 import { type BadRequestError, deterministicSampling, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
 import { Effect } from "effect"
 import { computeFlaggerAnchorContentHash, type FlaggerSessionContext } from "../conversation.ts"
+import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import {
   type FlaggerStrategy,
   type FlaggerSuppressor,
@@ -10,7 +11,6 @@ import {
   listFlaggerStrategySlugs,
   suppressorSlug,
 } from "../flagger-strategies/index.ts"
-import { shouldSkipUserCentricFlaggerForEmbeddedSamples } from "../embedded-samples.ts"
 import { gatherSessionHintsUseCase } from "../hints/gatherers.ts"
 import { isPositiveSessionHintKind, type SessionHint, type SessionHintKind } from "../hints/types.ts"
 import { isReflagSuppressed } from "../reflag.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Signal in `latitude-taxonomy`: [False task completion claim then repeated tool failures](https://console.latitude.so/projects/latitude-taxonomy/signals/false-task-completion-claim-then-repeated-tool-failures) (`clbrlhv82jnacipg3d19mljw`).

Trace [`c8f5ba487b17474c314caf05fece3b69`](https://console.latitude.so/projects/latitude-taxonomy/traces/c8f5ba487b17474c314caf05fece3b69) is a `taxonomy.name-cluster` call. The naming prompt pastes foreign conversation samples under `Samples:`, including a user saying they never got an email. The frustration flagger treated that nested wording as dissatisfaction with the taxonomy naming agent and wrote a false-positive annotation (`flaggerSlug: frustration`, `messageIndex: 1`).

The taxonomy assistant output itself was fine (`SkillFlow Architecture Adoption` JSON). This is not a naming bug.

## Fix

- Drop user-centric strategies (`classifiesAssistantResponseOnly: false` — frustration, jailbreaking) when session tags include `taxonomy:propose-themes` or `taxonomy:name-cluster` (`embedded-samples` reason at screening; same short-circuit on classify for in-flight work).
- Leave assistant-centric flaggers on taxonomy dogfood so we still catch bad naming output.
- Strengthen nested-sample guidance in the classifier/reviewer prompts and frustration's DO NOT FLAG list as a general safety net.

## Validation

- `pnpm --filter @domain/flaggers test` (326 passed)
- New coverage: screening drop for taxonomy+frustration, classify short-circuit, embedded-samples helper unit tests, reviewer nested-sample clause assertion

Do not mute/resolve the signal — verify after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-297242b2-dbf7-5b22-8c27-86c11baac0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-297242b2-dbf7-5b22-8c27-86c11baac0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

