### PR TITLE
feat(telemetry): emit memory-operation spans for Claude Code auto memory

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-07-21
+
+### Added
+
+- **Memory observability for Claude Code auto memory.** Claude Code writes its own persistent [auto memory](https://code.claude.com/docs/en/memory) (per-repository markdown under `~/.claude/projects/<project>/memory/`) through ordinary `Read`/`Write`/`Edit` tools. The hook now emits a child memory-operation span under the `tool_execution` span whenever such a tool targets a file inside that directory, using the OpenTelemetry `gen_ai.memory.*` conventions — so auto memory shows up on Latitude's Memory page with per-record change history and diffs. `Write` → `upsert_memory`, `Edit`/`MultiEdit` → `update_memory`, `Read` → `search_memory`; `gen_ai.memory.store.id` is the `<project>` slug and `gen_ai.memory.record.id` is the file path within the memory dir. Edit bodies are read from disk at hook time (the tool call carries only a diff); subagent auto memory is covered via the same path.
+- `LATITUDE_CLAUDE_CODE_MEMORY` (default `1`) to disable memory-operation spans, and `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT` (default `1`) to emit them without record bodies (structure and counts only). Bodies also honor `LATITUDE_REDACT_ATTRIBUTES` via the `gen_ai.memory.records` key.
+
 ## [0.0.12] - 2026-07-21
 
 ### Fixed

--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Memory observability for Claude Code auto memory.** Claude Code writes its own persistent [auto memory](https://code.claude.com/docs/en/memory) (per-repository markdown under `~/.claude/projects/<project>/memory/`) through ordinary `Read`/`Write`/`Edit` tools. The hook now emits a child memory-operation span under the `tool_execution` span whenever such a tool targets a file inside that directory, using the OpenTelemetry `gen_ai.memory.*` conventions — so auto memory shows up on Latitude's Memory page with per-record change history and diffs. `Write` → `upsert_memory`, `Edit`/`MultiEdit` → `update_memory`, `Read` → `search_memory`; `gen_ai.memory.store.id` is the `<project>` slug and `gen_ai.memory.record.id` is the file path within the memory dir. Edit bodies are read from disk at hook time (the tool call carries only a diff); subagent auto memory is covered via the same path.
-- `LATITUDE_CLAUDE_CODE_MEMORY` (default `1`) to disable memory-operation spans, and `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT` (default `1`) to emit them without record bodies (structure and counts only). Bodies also honor `LATITUDE_REDACT_ATTRIBUTES` via the `gen_ai.memory.records` key.
+- `LATITUDE_CLAUDE_CODE_MEMORY` (default `1`) emits memory-operation spans; set it to `0` to disable them. `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT` (default `1`) includes record bodies; set it to `0` to emit structure and counts only. Bodies also honor `LATITUDE_REDACT_ATTRIBUTES` via the `gen_ai.memory.records` key.
 
 ## [0.0.12] - 2026-07-21
 

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -51,6 +51,7 @@ For each turn, the hook emits one trace with three span kinds:
 - **`interaction`** — the user prompt and turn-level timing / counts.
 - **`llm_request`** — one per model call. Carries the model name, token usage (input/output/cache), input and output messages, and — when the preload is active — the full system prompt (`gen_ai.system_instructions`), tool schemas (`gen_ai.tool.definitions`), and exact request parameters. A tool-loop turn produces N sibling `llm_request` spans, one per distinct assistant `message.id`.
 - **`tool_execution`** — one per tool call. Canonical `gen_ai.tool.*` attributes: `name`, `call.id`, `call.arguments`, `call.result`. Failures set `error.type` and OTel status code 2.
+- **memory operation** — a child of the `tool_execution` span whenever a successful `Read`/`Write`/`Edit`/`MultiEdit` targets a file inside Claude Code's [auto-memory](https://code.claude.com/docs/en/memory) directory (`~/.claude/projects/<project>/memory/`). Carries the standard `gen_ai.memory.*` attributes so memory shows up on the Memory page with per-record history and diffs. `Write` → `upsert_memory`, `Edit`/`MultiEdit` → `update_memory`, `Read` → `search_memory`. `gen_ai.memory.store.id` is the `<project>` slug, `gen_ai.memory.record.id` is the file path within the memory dir. Record bodies ride `gen_ai.memory.records` (captured by default; see privacy below).
 
 All spans share the session id so they group together in the Latitude UI.
 
@@ -95,6 +96,8 @@ Everything the installer writes. Edit `~/.claude/settings.json` directly if you 
 | `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
 | `BUN_OPTIONS` | written when `launchctl` isn't used (all non-macOS platforms, or macOS with `--no-launchctl`) | — | `--preload=<absolute-path-to-intercept.js>`. See "how it works" above. |
 | `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to pause the hook without uninstalling. |
+| `LATITUDE_CLAUDE_CODE_MEMORY` | no | `1` | Set to `0` to stop emitting memory-operation spans for auto-memory file ops. |
+| `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT` | no | `1` | Set to `0` to emit memory spans without record bodies (structure and counts only). |
 | `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
 | `LATITUDE_REDACT_ATTRIBUTES` | no | — | JSON array or comma-separated custom attribute patterns to mask before export. |
 | `LATITUDE_REDACT_MASK` | no | `******` | Mask value for custom redaction. |
@@ -150,6 +153,8 @@ If that's not what you want, either:
 - Don't install the hook.
 - Set `LATITUDE_CLAUDE_CODE_ENABLED=0` in your shell before starting a sensitive session.
 - Run `uninstall`.
+
+This includes **auto-memory content**: the bodies of memory files Claude reads and writes ride `gen_ai.memory.records` by default. Memory can hold accumulated notes about your repo. Set `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT=0` to keep memory spans but drop the bodies (structure and counts only), `LATITUDE_CLAUDE_CODE_MEMORY=0` to drop memory spans entirely, or add `gen_ai.memory.records` to `LATITUDE_REDACT_ATTRIBUTES` to mask them.
 
 For field-level PII controls while keeping the hook enabled, set `LATITUDE_REDACT_ATTRIBUTES` and optionally `LATITUDE_REDACT_MASK`. Patterns are exact strings, regex source strings, or `/pattern/flags` strings, and redaction happens before export.
 

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/config.ts
+++ b/packages/telemetry/claude-code/src/config.ts
@@ -7,6 +7,8 @@ interface Config {
   enabled: boolean
   debug: boolean
   redact: RedactConfig | undefined
+  memory: boolean
+  memoryContent: boolean
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -16,5 +18,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   const enabled = (env.LATITUDE_CLAUDE_CODE_ENABLED ?? "1") !== "0" && apiKey !== "" && project !== ""
   const debug = env.LATITUDE_DEBUG === "1"
   const redact = parseRedactEnv(env)
-  return { apiKey, baseUrl, project, enabled, debug, redact }
+  const memory = (env.LATITUDE_CLAUDE_CODE_MEMORY ?? "1") !== "0"
+  const memoryContent = (env.LATITUDE_CLAUDE_CODE_MEMORY_CONTENT ?? "1") !== "0"
+  return { apiKey, baseUrl, project, enabled, debug, redact, memory, memoryContent }
 }

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "./config.ts"
 import { collectTraceContext } from "./context.ts"
 import type { Logger } from "./logger.ts"
 import { createLogger } from "./logger.ts"
+import { memoryDirFromTranscript } from "./memory.ts"
 import { buildOtlpRequest, buildSubagentSpans, chunkOtlpRequest } from "./otlp.ts"
 import type { RedactConfig } from "./redaction.ts"
 import { deleteRequest, loadRequestsByMessageId, pruneStaleRequests } from "./request-store.ts"
@@ -21,7 +22,15 @@ import {
   readIncremental,
   readSubagentMeta,
 } from "./transcript.ts"
-import type { AgentSpanLink, HookPayload, OtlpSpan, SubagentInvocation, TraceContext, Turn } from "./types.ts"
+import type {
+  AgentSpanLink,
+  HookPayload,
+  MemoryEmitOptions,
+  OtlpSpan,
+  SubagentInvocation,
+  TraceContext,
+  Turn,
+} from "./types.ts"
 
 type AgentLinkMap = Record<string, { traceId: string; parentSpanId: string }>
 
@@ -101,6 +110,10 @@ async function main(): Promise<void> {
     const context = collectTraceContext(payload)
     logger.debug(`context tags=${context.tags.length} metadata=${Object.keys(context.metadata).length}`)
 
+    const memory: MemoryEmitOptions | undefined = config.memory
+      ? { dir: memoryDirFromTranscript(transcriptPath), captureContent: config.memoryContent }
+      : undefined
+
     const { rows, newOffset, newBuffer } = readIncremental(transcriptPath, prior.offset, prior.buffer)
     const turns = buildTurns(rows)
     logger.debug(`read ${rows.length} row(s); ${turns.length} new turn(s); newOffset=${newOffset}`)
@@ -123,6 +136,7 @@ async function main(): Promise<void> {
       requestsByMessageId: mainRequests,
       redact: config.redact,
       agentLinks,
+      memory,
     })
 
     const linkMap: AgentLinkMap = { ...(prior.agentLinks ?? {}) }
@@ -142,6 +156,7 @@ async function main(): Promise<void> {
       linkMap,
       context,
       redact: config.redact,
+      memory,
       logger,
     })
 
@@ -253,9 +268,10 @@ function emitSubagents(args: {
   linkMap: AgentLinkMap
   context: TraceContext
   redact?: RedactConfig | undefined
+  memory?: MemoryEmitOptions | undefined
   logger: Logger
 }): SubagentEmission {
-  const { sessionId, mainTranscriptPath, linkMap, context, redact, logger } = args
+  const { sessionId, mainTranscriptPath, linkMap, context, redact, memory, logger } = args
   const spans: OtlpSpan[] = []
   const saves: Array<{ key: string; state: SubagentSave }> = []
 
@@ -325,6 +341,7 @@ function emitSubagents(args: {
         context,
         requestsByMessageId,
         redact,
+        memory,
       }),
     )
     saves.push({

--- a/packages/telemetry/claude-code/src/memory.test.ts
+++ b/packages/telemetry/claude-code/src/memory.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, it } from "vitest"
+import { classifyMemoryTool, memoryDirFromTranscript } from "./memory.ts"
+import type { MemoryEmitOptions, ToolCall } from "./types.ts"
+
+const DIR = "/home/u/.claude/projects/-home-u-repo/memory"
+
+function tool(partial: Partial<ToolCall> & Pick<ToolCall, "name" | "input">): ToolCall {
+  return { id: "t1", startMs: 1, endMs: 2, ...partial }
+}
+
+function opts(overrides: Partial<MemoryEmitOptions> = {}): MemoryEmitOptions {
+  return { dir: DIR, captureContent: false, ...overrides }
+}
+
+describe("memoryDirFromTranscript", () => {
+  it("resolves the sibling memory dir of the transcript", () => {
+    expect(memoryDirFromTranscript("/home/u/.claude/projects/-home-u-repo/sess.jsonl")).toBe(DIR)
+  })
+})
+
+describe("classifyMemoryTool", () => {
+  it("returns null for a non-file tool", () => {
+    expect(classifyMemoryTool(tool({ name: "Bash", input: { command: "ls" } }), opts())).toBeNull()
+  })
+
+  it("returns null for a file outside the memory dir", () => {
+    expect(classifyMemoryTool(tool({ name: "Edit", input: { file_path: "/home/u/repo/src/a.ts" } }), opts())).toBeNull()
+  })
+
+  it("maps Write to upsert_memory with the store slug and record path", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Write", input: { file_path: `${DIR}/MEMORY.md`, content: "hi" } }),
+      opts(),
+    )
+    expect(op).toMatchObject({ operation: "upsert_memory", storeId: "-home-u-repo", recordId: "MEMORY.md", count: 1 })
+    expect(op?.body).toBeUndefined()
+  })
+
+  it("maps Edit/MultiEdit to update_memory and preserves nested record ids", () => {
+    const edit = classifyMemoryTool(tool({ name: "Edit", input: { file_path: `${DIR}/a/b.md` } }), opts())
+    expect(edit).toMatchObject({ operation: "update_memory", recordId: "a/b.md" })
+    const multi = classifyMemoryTool(tool({ name: "MultiEdit", input: { file_path: `${DIR}/a/b.md` } }), opts())
+    expect(multi?.operation).toBe("update_memory")
+  })
+
+  it("maps Read to search_memory", () => {
+    const op = classifyMemoryTool(tool({ name: "Read", input: { file_path: `${DIR}/MEMORY.md` } }), opts())
+    expect(op?.operation).toBe("search_memory")
+  })
+
+  it("captures the Write body from input.content", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Write", input: { file_path: `${DIR}/x.md`, content: "hello" } }),
+      opts({ captureContent: true }),
+    )
+    expect(op?.body).toBe("hello")
+  })
+
+  it("captures the Edit body via the injected readFile", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Edit", input: { file_path: `${DIR}/x.md`, old_string: "a", new_string: "b" } }),
+      opts({ captureContent: true, readFile: () => "full body" }),
+    )
+    expect(op?.body).toBe("full body")
+  })
+
+  it("falls back to count-only when the Edit readFile fails", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Edit", input: { file_path: `${DIR}/x.md` } }),
+      opts({ captureContent: true, readFile: () => undefined }),
+    )
+    expect(op?.operation).toBe("update_memory")
+    expect(op?.body).toBeUndefined()
+  })
+
+  it("captures the Read body from output, stripping line-number prefixes", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Read", input: { file_path: `${DIR}/x.md` }, output: "     1\t# Title\n     2\tbody line" }),
+      opts({ captureContent: true }),
+    )
+    expect(op?.body).toBe("# Title\nbody line")
+  })
+
+  it("reads the Read body from text content blocks", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Read", input: { file_path: `${DIR}/x.md` }, output: [{ type: "text", text: "1\thi" }] }),
+      opts({ captureContent: true }),
+    )
+    expect(op?.body).toBe("hi")
+  })
+})
+
+describe("classifyMemoryTool default disk read", () => {
+  const root = mkdtempSync(join(tmpdir(), "cc-memory-"))
+  const memDir = join(root, "proj", "memory")
+  mkdirSync(memDir, { recursive: true })
+  writeFileSync(join(memDir, "topic.md"), "real disk content")
+  afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+  it("reads the edited file from disk when no readFile is injected", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Edit", input: { file_path: join(memDir, "topic.md"), old_string: "a", new_string: "b" } }),
+      { dir: memDir, captureContent: true },
+    )
+    expect(op).toMatchObject({ operation: "update_memory", storeId: "proj", recordId: "topic.md" })
+    expect(op?.body).toBe("real disk content")
+  })
+})

--- a/packages/telemetry/claude-code/src/memory.ts
+++ b/packages/telemetry/claude-code/src/memory.ts
@@ -2,9 +2,7 @@ import { readFileSync } from "node:fs"
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
 import type { MemoryEmitOptions, MemoryOp, ToolCall } from "./types.ts"
 
-// Claude Code auto memory is written through ordinary file tools, not the structured
-// memory tool — the only marker is the file path being inside the auto-memory dir.
-// Write overwrites-or-creates, so it maps to upsert (the ledger decides add vs update).
+// Auto memory rides ordinary file tools, so operations are keyed by tool name, not a memory tool.
 const MEMORY_TOOL_OPERATIONS: Record<string, MemoryOp["operation"]> = {
   Write: "upsert_memory",
   Edit: "update_memory",

--- a/packages/telemetry/claude-code/src/memory.ts
+++ b/packages/telemetry/claude-code/src/memory.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs"
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
+import type { MemoryEmitOptions, MemoryOp, ToolCall } from "./types.ts"
+
+// Claude Code auto memory is written through ordinary file tools, not the structured
+// memory tool — the only marker is the file path being inside the auto-memory dir.
+// Write overwrites-or-creates, so it maps to upsert (the ledger decides add vs update).
+const MEMORY_TOOL_OPERATIONS: Record<string, MemoryOp["operation"]> = {
+  Write: "upsert_memory",
+  Edit: "update_memory",
+  MultiEdit: "update_memory",
+  Read: "search_memory",
+}
+
+// The transcript lives at ~/.claude/projects/<project>/<session>.jsonl; the auto-memory
+// directory is its sibling.
+export function memoryDirFromTranscript(transcriptPath: string): string {
+  return join(dirname(transcriptPath), "memory")
+}
+
+export function classifyMemoryTool(tool: ToolCall, opts: MemoryEmitOptions): MemoryOp | null {
+  const operation = MEMORY_TOOL_OPERATIONS[tool.name]
+  if (!operation) return null
+
+  const input = tool.input as Record<string, unknown> | undefined
+  const filePath = typeof input?.file_path === "string" ? input.file_path : undefined
+  if (!filePath) return null
+
+  const resolved = resolve(filePath)
+  const rel = relative(opts.dir, resolved)
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null
+
+  const op: MemoryOp = {
+    operation,
+    storeId: basename(dirname(opts.dir)),
+    recordId: rel.split(sep).join("/"),
+    count: 1,
+  }
+
+  if (opts.captureContent) {
+    const body = extractBody(tool, operation, resolved, opts.readFile ?? defaultReadFile)
+    if (body !== undefined) op.body = body
+  }
+
+  return op
+}
+
+function extractBody(
+  tool: ToolCall,
+  operation: MemoryOp["operation"],
+  resolvedPath: string,
+  readFile: (path: string) => string | undefined,
+): string | undefined {
+  if (operation === "upsert_memory") {
+    const content = (tool.input as Record<string, unknown> | undefined)?.content
+    return typeof content === "string" ? content : undefined
+  }
+  if (operation === "update_memory") {
+    return readFile(resolvedPath)
+  }
+  const text = outputToText(tool.output)
+  return text !== undefined ? stripLineNumbers(text) : undefined
+}
+
+function defaultReadFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8")
+  } catch {
+    return undefined
+  }
+}
+
+function outputToText(output: unknown): string | undefined {
+  if (typeof output === "string") return output
+  if (Array.isArray(output)) {
+    const parts = output
+      .filter((b): b is { type: string; text?: unknown } => !!b && typeof b === "object" && "type" in b)
+      .filter((b) => b.type === "text")
+      .map((b) => (typeof b.text === "string" ? b.text : ""))
+    if (parts.length > 0) return parts.join("")
+  }
+  return undefined
+}
+
+// The Read tool returns file content with a `<line>\t` prefix per line; strip it so the
+// recorded body matches the file on disk (token counts and diffs read the real content).
+function stripLineNumbers(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^\s*\d+\t/, ""))
+    .join("\n")
+}

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -1268,4 +1268,15 @@ describe("memory operation child spans", () => {
     const spans = build([{ id: "tu1", name: "Write", input: { file_path: `${MEM}/x.md`, content: "hi" } }], undefined)
     expect(spans.some((s) => MEM_OPS.includes(s.name))).toBe(false)
   })
+
+  it("keeps gen_ai.memory.records valid JSON when a huge body is capped", () => {
+    const huge = "x".repeat(200_000)
+    const spans = build([{ id: "tu1", name: "Write", input: { file_path: `${MEM}/big.md`, content: huge } }], memory())
+    const mem = unwrap(spans.find((s) => s.name === "upsert_memory"))
+    const raw = unwrap(getAttr(mem.attributes, "gen_ai.memory.records"))
+    const parsed = JSON.parse(raw) as Array<{ id: string; content: string }>
+    expect(parsed[0]?.id).toBe("big.md")
+    expect(parsed[0]?.content).toContain("[latitude: truncated")
+    expect(parsed[0]?.content.length).toBeLessThan(huge.length)
+  })
 })

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest"
 import { buildOtlpRequest, buildSubagentSpans, chunkOtlpRequest } from "./otlp.ts"
 import type { StoredRequest } from "./request-store.ts"
-import type { AgentSpanLink, AssistantCall, OtlpKeyValue, SubagentInvocation, ToolCall, Turn, Usage } from "./types.ts"
+import type {
+  AgentSpanLink,
+  AssistantCall,
+  MemoryEmitOptions,
+  OtlpKeyValue,
+  SubagentInvocation,
+  ToolCall,
+  Turn,
+  Usage,
+} from "./types.ts"
 
 function unwrap<T>(value: T | undefined | null): T {
   expect(value).toBeDefined()
@@ -1159,5 +1168,104 @@ describe("buildSubagentSpans", () => {
     for (const s of [...stop1, ...stop2]) {
       expect(s.startTimeUnixNano).toBe(fullStart.get(s.spanId))
     }
+  })
+})
+
+describe("memory operation child spans", () => {
+  const MEM = "/home/u/.claude/projects/-proj/memory"
+  const MEM_OPS = ["upsert_memory", "update_memory", "search_memory"]
+
+  function memory(overrides: Partial<MemoryEmitOptions> = {}): MemoryEmitOptions {
+    return { dir: MEM, captureContent: true, readFile: () => "disk body", ...overrides }
+  }
+
+  function build(
+    toolCalls: (Partial<ToolCall> & Pick<ToolCall, "id" | "name" | "input">)[],
+    mem: MemoryEmitOptions | undefined,
+  ) {
+    return otlpSpans(
+      buildOtlpRequest({ sessionId: "s1", turnStartNumber: 1, turns: [baseTurn({ toolCalls })], memory: mem }),
+    )
+  }
+
+  it("emits an upsert_memory child under a Write to the memory dir", () => {
+    const spans = build(
+      [
+        {
+          id: "tu1",
+          name: "Write",
+          input: { file_path: `${MEM}/MEMORY.md`, content: "hello" },
+          output: "File created",
+        },
+      ],
+      memory(),
+    )
+    const toolSpan = unwrap(spans.find((s) => s.name === "tool:Write"))
+    const mem = unwrap(spans.find((s) => s.name === "upsert_memory"))
+    expect(mem.parentSpanId).toBe(toolSpan.spanId)
+    expect(mem.kind).toBe(3)
+    expect(getAttr(mem.attributes, "gen_ai.memory.store.id")).toBe("-proj")
+    expect(getAttr(mem.attributes, "gen_ai.memory.record.id")).toBe("MEMORY.md")
+    expect(getAttr(mem.attributes, "gen_ai.memory.record.count")).toBe("1")
+    expect(JSON.parse(unwrap(getAttr(mem.attributes, "gen_ai.memory.records")))).toEqual([
+      { id: "MEMORY.md", content: "hello" },
+    ])
+  })
+
+  it("emits update_memory carrying the disk body for an Edit", () => {
+    const spans = build(
+      [{ id: "tu1", name: "Edit", input: { file_path: `${MEM}/topic.md`, old_string: "a", new_string: "b" } }],
+      memory(),
+    )
+    const mem = unwrap(spans.find((s) => s.name === "update_memory"))
+    expect(JSON.parse(unwrap(getAttr(mem.attributes, "gen_ai.memory.records")))).toEqual([
+      { id: "topic.md", content: "disk body" },
+    ])
+  })
+
+  it("emits search_memory for a Read", () => {
+    const spans = build(
+      [{ id: "tu1", name: "Read", input: { file_path: `${MEM}/topic.md` }, output: "1\thi" }],
+      memory(),
+    )
+    expect(spans.some((s) => s.name === "search_memory")).toBe(true)
+  })
+
+  it("ignores files outside the memory dir", () => {
+    const spans = build(
+      [{ id: "tu1", name: "Write", input: { file_path: "/home/u/repo/a.ts", content: "x" } }],
+      memory(),
+    )
+    expect(spans.some((s) => MEM_OPS.includes(s.name))).toBe(false)
+  })
+
+  it("emits structure only when captureContent is off", () => {
+    const spans = build(
+      [{ id: "tu1", name: "Write", input: { file_path: `${MEM}/x.md`, content: "hi" } }],
+      memory({ captureContent: false }),
+    )
+    const mem = unwrap(spans.find((s) => s.name === "upsert_memory"))
+    expect(getAttr(mem.attributes, "gen_ai.memory.record.id")).toBe("x.md")
+    expect(getAttr(mem.attributes, "gen_ai.memory.records")).toBeUndefined()
+  })
+
+  it("skips the memory span when the tool call errored", () => {
+    const spans = build(
+      [
+        {
+          id: "tu1",
+          name: "Edit",
+          input: { file_path: `${MEM}/x.md`, old_string: "a", new_string: "b" },
+          isError: true,
+        },
+      ],
+      memory(),
+    )
+    expect(spans.some((s) => s.name === "update_memory")).toBe(false)
+  })
+
+  it("emits no memory spans when memory is not configured", () => {
+    const spans = build([{ id: "tu1", name: "Write", input: { file_path: `${MEM}/x.md`, content: "hi" } }], undefined)
+    expect(spans.some((s) => MEM_OPS.includes(s.name))).toBe(false)
   })
 })

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -1,10 +1,13 @@
 import { createHash } from "node:crypto"
 import { arch, hostname, platform, release } from "node:os"
+import { classifyMemoryTool } from "./memory.ts"
 import { type RedactConfig, redactAttributes } from "./redaction.ts"
 import type { AnthropicMessage, AnthropicMessageBlock, AnthropicSystem, StoredRequest } from "./request-store.ts"
 import type {
   AgentSpanLink,
   AssistantCall,
+  MemoryEmitOptions,
+  MemoryOp,
   OtlpExportRequest,
   OtlpKeyValue,
   OtlpResourceSpans,
@@ -33,6 +36,7 @@ const SYSTEM_CAP = 16 * 1024
 const TOOL_DEFS_CAP = 16 * 1024
 const TOOL_ARGS_CAP = 16 * 1024
 const USER_PROMPT_CAP = 64 * 1024
+const MEMORY_RECORDS_CAP = 64 * 1024
 // Each POST is kept under this size so it completes well inside the client
 // timeout even on modest uplinks; one logical trace may span several POSTs
 // (the server groups spans by trace_id, so splitting is transparent).
@@ -50,6 +54,7 @@ export function buildOtlpRequest(opts: {
   // Out-param: populated with one link per parent Agent tool call emitted, so the
   // caller can (re-)attach subagent spans under it on later turns.
   agentLinks?: AgentSpanLink[]
+  memory?: MemoryEmitOptions | undefined
 }): OtlpExportRequest {
   const contextAttrs = buildContextAttrs(opts.context)
   const history = opts.conversationHistory ?? []
@@ -68,6 +73,7 @@ export function buildOtlpRequest(opts: {
         priorTurns,
         requestsByMessageId,
         opts.agentLinks,
+        opts.memory,
       ),
     )
   })
@@ -100,6 +106,7 @@ function buildTurnSpans(
   priorTurns: Turn[],
   requestsByMessageId: Map<string, StoredRequest>,
   agentLinks: AgentSpanLink[] | undefined,
+  memory: MemoryEmitOptions | undefined,
 ): OtlpSpan[] {
   const traceId = hashHex(`${sessionId}:${turnNum}`, 32)
   const turnSpanId = hashHex(`${traceId}:turn`, 16)
@@ -121,6 +128,7 @@ function buildTurnSpans(
     priorTurns,
     requestsByMessageId,
     agentLinks,
+    memory,
   })
   return out
 }
@@ -142,6 +150,7 @@ interface TreeCtx {
   priorTurns: Turn[]
   requestsByMessageId: Map<string, StoredRequest>
   agentLinks: AgentSpanLink[] | undefined
+  memory: MemoryEmitOptions | undefined
   // Emission window (subagent incremental re-emission). Defaults emit everything.
   emitInteraction?: boolean
   callFrom?: number
@@ -294,6 +303,16 @@ function emitCallAndTools(out: OtlpSpan[], ctx: TreeCtx, call: AssistantCall, ca
     // interaction so the timeline reads as: llm_request → tool → llm_request → tool → ...
     out.push(buildToolSpan(traceId, ctx.turnSpanId, toolSpanId, sessionId, userId, tool, ctx.contextAttrs))
 
+    // Claude Code auto memory rides ordinary file tools; a successful Read/Write/Edit on a
+    // path inside the memory dir gets a child memory-operation span for the ledger.
+    if (ctx.memory && !tool.isError) {
+      const op = classifyMemoryTool(tool, ctx.memory)
+      if (op) {
+        const memSpanId = hashHex(`${traceId}:${callSalt}:tool:${idx}:${tool.id}:mem`, 16)
+        out.push(buildMemorySpan(traceId, toolSpanId, memSpanId, sessionId, userId, tool, op, ctx.contextAttrs))
+      }
+    }
+
     if (!isSubagent && tool.name === "Agent") {
       ctx.agentLinks?.push({ toolUseId: tool.id, promptId: tool.promptId, traceId, parentSpanId: toolSpanId })
     }
@@ -307,6 +326,7 @@ function emitCallAndTools(out: OtlpSpan[], ctx: TreeCtx, call: AssistantCall, ca
         userId,
         subagent: tool.subagent,
         contextAttrs: ctx.contextAttrs,
+        memory: ctx.memory,
         requestsByMessageId: ctx.requestsByMessageId,
         emitInteraction: true,
         fromCall: 0,
@@ -324,6 +344,7 @@ interface SubagentTreeCtx {
   subagent: SubagentInvocation
   contextAttrs: OtlpKeyValue[]
   requestsByMessageId: Map<string, StoredRequest>
+  memory: MemoryEmitOptions | undefined
   // Emission window over the subagent's calls, flattened across its turns. The
   // interaction span is emitted only when emitInteraction is set. Defaults emit all.
   emitInteraction: boolean
@@ -361,6 +382,7 @@ function emitSubagentTree(out: OtlpSpan[], ctx: SubagentTreeCtx): void {
       priorTurns: subagent.turns.slice(0, subIdx),
       requestsByMessageId: ctx.requestsByMessageId,
       agentLinks: undefined,
+      memory: ctx.memory,
       emitInteraction: ctx.emitInteraction,
       callFrom: Math.max(0, ctx.fromCall - globalIdx),
       callTo: Math.min(count, ctx.toCall - globalIdx),
@@ -386,6 +408,7 @@ export function buildSubagentSpans(opts: {
   context?: TraceContext | undefined
   requestsByMessageId?: Map<string, StoredRequest> | undefined
   redact?: RedactConfig | undefined
+  memory?: MemoryEmitOptions | undefined
 }): OtlpSpan[] {
   const out: OtlpSpan[] = []
   const totalCalls = opts.subagent.turns.reduce((sum, t) => sum + t.calls.length, 0)
@@ -397,6 +420,7 @@ export function buildSubagentSpans(opts: {
     subagent: opts.subagent,
     contextAttrs: buildContextAttrs(opts.context),
     requestsByMessageId: opts.requestsByMessageId ?? new Map<string, StoredRequest>(),
+    memory: opts.memory,
     emitInteraction: opts.emitInteraction ?? true,
     fromCall: opts.fromCall ?? 0,
     toCall: opts.toCall ?? totalCalls,
@@ -461,6 +485,43 @@ function buildToolSpan(
       ...contextAttrs,
     ]),
     status: { code: call.isError ? 2 : 1 },
+  }
+}
+
+// A child of the tool span, shaped to match the SDK memory helper (CLIENT kind, the
+// gen_ai.memory.* attributes) so the consume side classifies and materializes it with
+// no special-casing. Emitted only for a successful memory-dir file op.
+function buildMemorySpan(
+  traceId: string,
+  parentSpanId: string,
+  spanId: string,
+  sessionId: string,
+  userId: string | undefined,
+  tool: ToolCall,
+  op: MemoryOp,
+  contextAttrs: OtlpKeyValue[],
+): OtlpSpan {
+  const recordsJson =
+    op.body !== undefined ? clamp(safeJson([{ id: op.recordId, content: op.body }]), MEMORY_RECORDS_CAP) : undefined
+  return {
+    traceId,
+    spanId,
+    parentSpanId,
+    name: op.operation,
+    kind: 3,
+    startTimeUnixNano: msToNs(tool.startMs),
+    endTimeUnixNano: msToNs(tool.endMs),
+    attributes: stripUndef([
+      str("gen_ai.operation.name", op.operation),
+      str("gen_ai.memory.store.id", op.storeId),
+      str("gen_ai.memory.record.id", op.recordId),
+      int("gen_ai.memory.record.count", op.count),
+      recordsJson !== undefined ? str("gen_ai.memory.records", recordsJson) : undefined,
+      str("session.id", sessionId),
+      userId ? str("user.id", userId) : undefined,
+      ...contextAttrs,
+    ]),
+    status: { code: 1 },
   }
 }
 

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -303,8 +303,7 @@ function emitCallAndTools(out: OtlpSpan[], ctx: TreeCtx, call: AssistantCall, ca
     // interaction so the timeline reads as: llm_request → tool → llm_request → tool → ...
     out.push(buildToolSpan(traceId, ctx.turnSpanId, toolSpanId, sessionId, userId, tool, ctx.contextAttrs))
 
-    // Claude Code auto memory rides ordinary file tools; a successful Read/Write/Edit on a
-    // path inside the memory dir gets a child memory-operation span for the ledger.
+    // A successful file op inside the auto-memory dir gets a child memory span for the ledger.
     if (ctx.memory && !tool.isError) {
       const op = classifyMemoryTool(tool, ctx.memory)
       if (op) {
@@ -488,9 +487,7 @@ function buildToolSpan(
   }
 }
 
-// A child of the tool span, shaped to match the SDK memory helper (CLIENT kind, the
-// gen_ai.memory.* attributes) so the consume side classifies and materializes it with
-// no special-casing. Emitted only for a successful memory-dir file op.
+// Child of the tool span, matching the SDK memory helper's gen_ai.memory.* shape.
 function buildMemorySpan(
   traceId: string,
   parentSpanId: string,
@@ -501,8 +498,9 @@ function buildMemorySpan(
   op: MemoryOp,
   contextAttrs: OtlpKeyValue[],
 ): OtlpSpan {
-  const recordsJson =
-    op.body !== undefined ? clamp(safeJson([{ id: op.recordId, content: op.body }]), MEMORY_RECORDS_CAP) : undefined
+  // Cap the body, not the serialized array, so the attribute stays valid JSON for the materializer.
+  const body = op.body !== undefined ? clamp(op.body, MEMORY_RECORDS_CAP) : undefined
+  const recordsJson = body !== undefined ? safeJson([{ id: op.recordId, content: body }]) : undefined
   return {
     traceId,
     spanId,

--- a/packages/telemetry/claude-code/src/types.ts
+++ b/packages/telemetry/claude-code/src/types.ts
@@ -84,6 +84,20 @@ export interface ToolCall {
   endMs: number
 }
 
+export interface MemoryOp {
+  operation: "upsert_memory" | "update_memory" | "search_memory"
+  storeId: string
+  recordId: string
+  count: number
+  body?: string
+}
+
+export interface MemoryEmitOptions {
+  dir: string
+  captureContent: boolean
+  readFile?: (path: string) => string | undefined
+}
+
 export interface SubagentInvocation {
   agentId: string
   agentType: string


### PR DESCRIPTION
Claude Code writes its own persistent auto memory — Claude-authored notes under `~/.claude/projects/<project>/memory/` (a `MEMORY.md` index plus topic files), separate from `CLAUDE.md`. It does this through ordinary `Read`/`Write`/`Edit` tools rather than the structured API memory tool, so the only thing marking a file op as "memory" is the path. This adds an emitter so those operations flow into the memory-observability ledger and surfaces we already built.

Part of the memory-observability effort (LAT-729); sibling to #4128, which added the SDK emitter for the API memory tool.

## what it does

The `claude-code-telemetry` Stop hook already emits a `tool_execution` span per tool call. When a successful `Read`/`Write`/`Edit`/`MultiEdit` targets a file inside the auto-memory dir, the hook now also emits a child memory-operation span under that tool span, carrying the OTel `gen_ai.memory.*` attributes. That is enough for the existing pipeline to classify it on the Spans tab and materialize it into `memory_events` / `memory_blobs` / `memory_current`, so Claude Code memory shows up on the Memory page with per-record history and diffs.

| tool | operation | record body |
| --- | --- | --- |
| `Write` | `upsert_memory` | `input.content` |
| `Edit` / `MultiEdit` | `update_memory` | read from disk at hook time |
| `Read` | `search_memory` | the tool result, line-number prefixes stripped |

- `gen_ai.memory.store.id` is the `<project>` slug (one store per repo, matching how Claude Code partitions auto memory); `gen_ai.memory.record.id` is the file path within the memory dir (splits on `/` for the Memory-page tree).
- The child span mirrors the SDK helper's shape (CLIENT kind, same attribute keys) and is parented under the tool span with a deterministic id, so incremental re-emission stays idempotent. Subagent auto memory rides the same code path.
- Errored tool calls emit no memory span.

## why a child span, and why disk reads for edits

A child span keeps the raw tool call intact while adding first-class memory semantics, instead of rewriting the tool span. `Write` maps to `upsert_memory` because the transcript cannot distinguish create from overwrite — the ledger already resolves add-vs-update from prior events. `Edit`/`MultiEdit` carry only a diff, so the hook reads the file from disk to get the full post-edit body (the "span = full record snapshot" model the ledger expects); the hook runs locally right after the turn, so disk is the settled state.

## consume side unchanged

Nothing changes outside the package. Classification reads `gen_ai.operation.name`, materialization reads the `gen_ai.memory.*` attributes, and `listMemoryOperationSpansByTraceId` selects by `trace_id + operation` only (no parent/kind/depth filter), so a span nested under a tool span is picked up as-is.

## configuration

- `LATITUDE_CLAUDE_CODE_MEMORY` (default on) toggles memory spans.
- `LATITUDE_CLAUDE_CODE_MEMORY_CONTENT` (default on) toggles record bodies; off emits structure and counts only. Bodies also honor `LATITUDE_REDACT_ATTRIBUTES` via the `gen_ai.memory.records` key.

Content is on by default because the feature is hollow without bodies, and this is a local dev tool writing to the operator's own project.

## scope cuts and known gaps

- The session-start `MEMORY.md` auto-load is a context injection, not a tool call, so it produces no read span.
- Multiple edits to one file in a single turn each read the same final body, producing no-op versions (blobs dedup; the ledger orders by end time).
- Deletions via `rm` are not captured; relocating the memory dir with `autoMemoryDirectory` is not honored (the dir derives from the transcript path).

## validation

- 72 unit tests (new `memory.test.ts` plus memory cases in `otlp.test.ts`), including a real temp-file disk read; typecheck / build / format / knip green.
- Emit-side end-to-end against the built hook: a Write -> Edit -> Read transcript produces the three memory spans with correct attributes and the disk-read edit body.
- Live run against local ingest with a seeded key and project returned HTTP 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry child spans for Claude Code auto-memory tool activity (Read/Write/Edit/MultiEdit), including memory store/record identifiers and optional record content.
  * Introduced environment controls to disable memory-operation spans and to emit only memory structure/counts, with redaction support for memory record bodies.
  * Large memory payloads are safely truncated while keeping valid telemetry output.
* **Documentation**
  * Updated README and changelog to describe the new memory-operation span behavior and privacy/configuration options.
* **Tests**
  * Added coverage for memory tool classification and memory-operation span emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->