### PR TITLE
fix: stop undeclared-tool false positives from truncated Claude Code toolsets

### DIFF
--- a/packages/domain/flaggers/src/helpers.test.ts
+++ b/packages/domain/flaggers/src/helpers.test.ts
@@ -103,6 +103,43 @@ describe("detectToolCallErrorsFlagger", () => {
     expect(result).toEqual({ matched: false })
   })
 
+  it("matches a call to a tool missing from the declared toolset", () => {
+    const result = detectToolCallErrorsFlagger({
+      ...makeTrace([assistantToolCall("call-web", "WebSearch")]),
+      definedTools: ["Bash", "Read"],
+    })
+
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain('"WebSearch"')
+      expect(result.feedback).toContain("not in the declared toolset")
+    }
+  })
+
+  it("does not match an undeclared tool that executed successfully", () => {
+    const result = detectToolCallErrorsFlagger({
+      ...makeTrace([assistantToolCall("call-web", "WebSearch"), toolResponse("call-web", { results: ["ok"] })]),
+      definedTools: ["Bash", "Read"],
+    })
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("still matches when an undeclared tool returns an error", () => {
+    const result = detectToolCallErrorsFlagger({
+      ...makeTrace([
+        assistantToolCall("call-web", "WebSearch"),
+        toolResponse("call-web", { isError: true, error: "InputValidationError" }),
+      ]),
+      definedTools: ["Bash", "Read"],
+    })
+
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toMatch(/not in the declared toolset|returned error/)
+    }
+  })
+
   it("does not match expected tool 4xx responses", () => {
     const result = detectToolCallErrorsFlagger(
       makeTrace([

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -34,7 +34,10 @@ const match = (feedback: string, messageIndex?: number): DeterministicFlaggerMat
   ...(messageIndex !== undefined ? { messageIndex } : {}),
 })
 
+export type ToolCallErrorFindingKind = "malformed" | "duplicate" | "undeclared" | "unknown-id" | "error"
+
 export interface ToolCallErrorFinding {
+  readonly kind: ToolCallErrorFindingKind
   readonly feedback: string
   readonly messageIndex: number
   readonly toolName?: string | undefined
@@ -76,6 +79,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
         if (!toolCallId || !toolName) {
           const label = toolName ? `tool "${toolName}"` : "an unnamed tool"
           findings.push({
+            kind: "malformed",
             feedback: `Malformed tool call: ${label} with missing or empty tool_call id`,
             messageIndex: msgIdx,
             ...(toolName ? { toolName } : {}),
@@ -85,6 +89,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
 
         if (callById.has(toolCallId)) {
           findings.push({
+            kind: "duplicate",
             feedback: `Duplicate tool_call id emitted for tool "${toolName}"`,
             messageIndex: msgIdx,
             toolName,
@@ -97,6 +102,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
 
         if (definedTools && !definedTools.has(toolName)) {
           findings.push({
+            kind: "undeclared",
             feedback: `Assistant called tool "${toolName}" which is not in the declared toolset`,
             messageIndex: msgIdx,
             toolName,
@@ -116,6 +122,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
         // survived in the window.
         if (!hasAnyToolCall) continue
         findings.push({
+          kind: "unknown-id",
           feedback: `Tool response references an unknown tool_call id "${toolCallId || "<empty>"}"`,
           messageIndex: msgIdx,
           ...(toolCallId ? { toolCallId } : {}),
@@ -126,6 +133,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
       if (toolResponseIndicatesFailure(part.response)) {
         const snippet = extractToolErrorSnippet(part.response)
         findings.push({
+          kind: "error",
           feedback: snippet
             ? `Tool "${call.name}" returned error: ${snippet}`
             : `Tool "${call.name}" returned an error`,
@@ -142,12 +150,7 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
 
   if (successfulCallIds.size === 0) return findings
   return findings.filter(
-    (finding) =>
-      !(
-        finding.toolCallId &&
-        successfulCallIds.has(finding.toolCallId) &&
-        finding.feedback.includes("which is not in the declared toolset")
-      ),
+    (finding) => !(finding.kind === "undeclared" && finding.toolCallId && successfulCallIds.has(finding.toolCallId)),
   )
 }
 

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -55,6 +55,7 @@ const conversationHasAnyToolCall = (conversation: ConversationMessagesOnly): boo
 export function collectToolCallErrorFindings(conversation: ToolErrorConversation): readonly ToolCallErrorFinding[] {
   const findings: ToolCallErrorFinding[] = []
   const callById = new Map<string, { name: string; messageIndex: number }>()
+  const successfulCallIds = new Set<string>()
   const hasAnyToolCall = conversationHasAnyToolCall(conversation)
   const definedTools =
     conversation.definedTools && conversation.definedTools.length > 0 ? new Set(conversation.definedTools) : null
@@ -132,11 +133,22 @@ export function collectToolCallErrorFindings(conversation: ToolErrorConversation
           toolName: call.name,
           toolCallId,
         })
+      } else if (toolCallId) {
+        // Successful execution proves availability; incomplete definedTools must not flag it.
+        successfulCallIds.add(toolCallId)
       }
     }
   }
 
-  return findings
+  if (successfulCallIds.size === 0) return findings
+  return findings.filter(
+    (finding) =>
+      !(
+        finding.toolCallId &&
+        successfulCallIds.has(finding.toolCallId) &&
+        finding.feedback.includes("which is not in the declared toolset")
+      ),
+  )
 }
 
 export function detectToolCallErrorsFlagger(conversation: ToolErrorConversation): DeterministicFlaggerMatch {

--- a/packages/domain/flaggers/src/hints/gatherers.test.ts
+++ b/packages/domain/flaggers/src/hints/gatherers.test.ts
@@ -75,6 +75,17 @@ describe("toolErrorsGatherer", () => {
     expect(flagged[0]?.evidence).toContain("not in the declared toolset")
   })
 
+  it("emits nothing when an undeclared tool executed successfully", async () => {
+    const conversation = {
+      ...makeTrace([
+        { role: "assistant", parts: [{ type: "tool_call", id: "call-1", name: "WebSearch", arguments: {} }] },
+        tool("call-1", { results: ["ok"] }),
+      ]),
+      definedTools: ["search"],
+    }
+    expect(await runGatherer(toolErrorsGatherer, { ...makeHintContext(makeTrace([])), conversation })).toEqual([])
+  })
+
   it("emits nothing for healthy tool traffic", async () => {
     const conversation = makeTrace([
       { role: "assistant", parts: [{ type: "tool_call", id: "call-1", name: "fetch", arguments: {} }] },

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -69,6 +69,7 @@ export {
   detectOutputSchemaValidationFlagger,
   detectToolCallErrorsFlagger,
   type ToolCallErrorFinding,
+  type ToolCallErrorFindingKind,
 } from "./helpers.ts"
 export {
   gatherSessionHintsUseCase,

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -527,6 +527,23 @@ describe("screenSessionFlaggersUseCase", () => {
     expect(written[0]?.feedback).toContain("not in the declared toolset")
   })
 
+  it("does not flag an undeclared tool that executed successfully", async () => {
+    const call = assistantToolCall("WebSearch", { query: "x" })
+    const callId = (call.parts[0] as { id: string }).id
+    const session = makeSessionDetail(
+      [user("Search the web."), call, tool(callId, { results: ["ok"] }), assistant("Here are the results.")],
+      { definedTools: ["search", "read_file"] },
+    )
+    const { result, scores } = await runScreening({
+      session,
+      flaggers: [makeFlagger("tool-call-errors", 0)],
+      deps: fakeDeps.deps,
+    })
+
+    expect(decisionFor(result.decisions, "tool-call-errors")?.action).toBe("dropped")
+    expect([...scores.values()]).toEqual([])
+  })
+
   it("hints trashing (tool:error) from a failed tool response", async () => {
     const session = makeSessionDetail([
       user("Fetch the data."),

--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-07-21
+
+### Fixed
+
+- **Oversized tool-definition lists no longer drop tool names.** When an `llm_request` span exceeded the byte budget, tool schemas were capped by keeping only the leading full entries (often just `Agent` / `Artifact` on real Claude Code sessions). Session `definedTools` then missed names like `WebSearch`, and the undeclared-tool flagger false-positived on successful calls. Capping now keeps every tool name (full schema when it fits, name-only stub otherwise).
+
 ## [0.0.11] - 2026-07-16
 
 ### Changed

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -896,6 +896,59 @@ describe("span size capping", () => {
     expect(getAttr(interaction.attributes, "user_prompt_length")).toBe("200000")
     expect(getAttr(interaction.attributes, "latitude.truncation")).toBe("user prompt clamped")
   })
+
+  it("preserves every tool name when tool-definition schemas exceed the byte budget", () => {
+    const fatDescription = "d".repeat(8_000)
+    const toolNames = ["Agent", "Artifact", "Bash", "Read", "ToolSearch", "WebFetch", "WebSearch"]
+    const tools = toolNames.map((name) => ({
+      name,
+      description: fatDescription,
+      input_schema: { type: "object", properties: { q: { type: "string" } } },
+    }))
+    // Captured payloads replace transcript reconstruction, so the span only exceeds
+    // SPAN_BYTE_BUDGET when the captured request itself is oversized.
+    const captured: StoredRequest = {
+      messageId: "msg_tools_cap",
+      capturedAt: "2026-07-21T12:00:00.000Z",
+      url: "https://api.anthropic.com/v1/messages",
+      request: {
+        model: "claude-opus-4-8",
+        max_tokens: 32000,
+        system: [{ type: "text", text: "s".repeat(80_000) }],
+        tools,
+        messages: Array.from({ length: 20 }, (_, i) => ({
+          role: "user" as const,
+          content: `prompt ${i} ${"h".repeat(4_000)}`,
+        })),
+      },
+    }
+    const req = buildOtlpRequest({
+      sessionId: "sess-cap",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          messageId: "msg_tools_cap",
+          userText: "search the web",
+          toolCalls: [
+            {
+              id: "toolu_web",
+              name: "WebSearch",
+              input: { query: "AI agents" },
+              output: "results",
+            },
+          ],
+        }),
+      ],
+      requestsByMessageId: new Map([["msg_tools_cap", captured]]),
+    })
+    const llm = unwrap(otlpSpans(req).find((s) => s.name === "llm_request"))
+    const truncation = unwrap(getAttr(llm.attributes, "latitude.truncation"))
+    expect(truncation).toContain("tool definitions:")
+    expect(truncation).toMatch(/name-only|names/)
+    const defs = JSON.parse(unwrap(getAttr(llm.attributes, "gen_ai.tool.definitions"))) as Array<{ name: string }>
+    expect(defs.map((d) => d.name)).toEqual(toolNames)
+    expect(JSON.stringify(defs).length).toBeLessThanOrEqual(16 * 1024)
+  })
 })
 
 describe("redaction", () => {

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -905,8 +905,7 @@ describe("span size capping", () => {
       description: fatDescription,
       input_schema: { type: "object", properties: { q: { type: "string" } } },
     }))
-    // Captured payloads replace transcript reconstruction, so the span only exceeds
-    // SPAN_BYTE_BUDGET when the captured request itself is oversized.
+    // Captured payloads replace reconstruction — oversize the captured request to hit the budget.
     const captured: StoredRequest = {
       messageId: "msg_tools_cap",
       capturedAt: "2026-07-21T12:00:00.000Z",

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -558,7 +558,7 @@ function capLlmRequestPayload(args: {
 
   const notes: string[] = []
   if (args.toolDefs && toolDefsJson && toolDefsJson.length > TOOL_DEFS_CAP) {
-    const r = capArrayJson(args.toolDefs, TOOL_DEFS_CAP)
+    const r = capToolDefinitions(args.toolDefs, TOOL_DEFS_CAP)
     toolDefsJson = r.json
     if (r.note) notes.push(`tool definitions: ${r.note}`)
   }
@@ -652,20 +652,59 @@ function capPartsJson(parts: MessagePart[], maxBytes: number): CapResult {
   return { json: JSON.stringify(parts.map((p) => shrinkPart(p, perPart))), note: `shrunk ${parts.length} part(s)` }
 }
 
-// Keeps whole leading entries that fit the budget. Used for tool definitions, where
-// each entry is self-contained and order carries no recency meaning.
-function capArrayJson(items: unknown[], maxBytes: number): CapResult {
-  const full = JSON.stringify(items)
+function toolNameStub(tool: unknown): unknown {
+  if (!tool || typeof tool !== "object") return tool
+  const name = (tool as { name?: unknown }).name
+  return typeof name === "string" ? { name } : tool
+}
+
+// Never drop tool names when capping — definedTools / undeclared-tool detection key
+// off names alone; only schemas are optional under the byte budget.
+function capToolDefinitions(tools: unknown[], maxBytes: number): CapResult {
+  const full = JSON.stringify(tools)
   if (full.length <= maxBytes) return { json: full }
-  let budget = maxBytes - 2
-  let end = 0
-  while (end < items.length) {
-    const cost = JSON.stringify(items[end]).length + 1
-    if (cost > budget) break
-    budget -= cost
-    end++
+
+  const stubs = tools.map(toolNameStub)
+  const stubCosts = stubs.map((stub) => JSON.stringify(stub).length + 1)
+  const suffixStubBytes = new Array<number>(tools.length + 1)
+  suffixStubBytes[tools.length] = 0
+  for (let i = tools.length - 1; i >= 0; i--) {
+    suffixStubBytes[i] = suffixStubBytes[i + 1]! + stubCosts[i]!
   }
-  return { json: JSON.stringify(items.slice(0, end)), note: `kept ${end} of ${items.length} entries` }
+
+  let budget = maxBytes - 2
+  const out: unknown[] = []
+  let fullCount = 0
+  for (let i = 0; i < tools.length; i++) {
+    const fullCost = JSON.stringify(tools[i]).length + 1
+    if (fullCost + suffixStubBytes[i + 1]! <= budget) {
+      out.push(tools[i])
+      budget -= fullCost
+      fullCount++
+      continue
+    }
+    for (let j = i; j < tools.length; j++) {
+      const stubCost = stubCosts[j]!
+      if (stubCost > budget) {
+        return {
+          json: JSON.stringify(out),
+          note: `kept ${out.length} of ${tools.length} names (${fullCount} full schemas, ${out.length - fullCount} name-only)`,
+        }
+      }
+      out.push(stubs[j])
+      budget -= stubCost
+    }
+    break
+  }
+
+  const stubCount = out.length - fullCount
+  return {
+    json: JSON.stringify(out),
+    note:
+      stubCount > 0
+        ? `kept all ${tools.length} names (${fullCount} full schemas, ${stubCount} name-only)`
+        : `kept ${fullCount} of ${tools.length} entries`,
+  }
 }
 
 function shrinkPart(part: MessagePart, maxBytes: number): MessagePart {

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -658,8 +658,7 @@ function toolNameStub(tool: unknown): unknown {
   return typeof name === "string" ? { name } : tool
 }
 
-// Never drop tool names when capping — definedTools / undeclared-tool detection key
-// off names alone; only schemas are optional under the byte budget.
+// Never drop tool names when capping — definedTools keys off names; only schemas are optional.
 function capToolDefinitions(tools: unknown[], maxBytes: number): CapResult {
   const full = JSON.stringify(tools)
   if (full.length <= maxBytes) return { json: full }
@@ -700,10 +699,7 @@ function capToolDefinitions(tools: unknown[], maxBytes: number): CapResult {
   const stubCount = out.length - fullCount
   return {
     json: JSON.stringify(out),
-    note:
-      stubCount > 0
-        ? `kept all ${tools.length} names (${fullCount} full schemas, ${stubCount} name-only)`
-        : `kept ${fullCount} of ${tools.length} entries`,
+    note: `kept all ${tools.length} names (${fullCount} full schemas, ${stubCount} name-only)`,
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Signal

[Call to unavailable tool](https://console.latitude.so/projects/guilh-m/signals/call-to-unavailable-tool) in project Guilhèm (`tool-call-errors` flagger).

Sample: trace `06462d7489523f67abed43b63e57b0b8` — assistant called `WebSearch`, got real search results back, and the flagger still wrote `Assistant called tool "WebSearch" which is not in the declared toolset`.

## Cause

The Claude Code hook caps oversized `gen_ai.tool.definitions` by keeping only the leading full schemas that fit in 16 KB. On this span that meant `kept 2 of 52 entries` (`Agent`, `Artifact`). Session `definedTools` therefore looked like a tiny subset, and the undeclared-tool check treated successful `WebSearch` calls as unavailable.

## Fix

1. **`@latitude-data/claude-code-telemetry` 0.0.12** — when tool schemas exceed the budget, keep every tool name (full schema while it fits, name-only stub for the rest).
2. **`tool-call-errors` flagger** — if a tool call gets a successful response, do not flag it as undeclared. Incomplete `definedTools` (old clients, other truncating emitters) must not invent unavailable-tool signal.

## Verification

- `pnpm --filter @latitude-data/claude-code-telemetry test`
- `pnpm --filter @domain/flaggers test`

Signal left open for human verification after deploy. Server-side flagger change takes effect on deploy; Claude Code clients pick up the telemetry fix via `@latest` on the next Stop hook run after npm publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0256274-b2e7-58bc-bc4c-3c973c9f4d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0256274-b2e7-58bc-bc4c-3c973c9f4d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false tool-error findings when an assistant calls a tool not in the declared toolset but the tool execution succeeds.
  * Improved oversized tool-definition handling so tool names aren’t dropped when payloads exceed the span size limit.
  * Continued to report genuine tool failures accurately, with consistent classification for different error scenarios.
* **Tests**
  * Expanded unit coverage for undeclared-tool success vs failure cases.
  * Added telemetry tests ensuring tool-definition payloads are properly capped while preserving every tool name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->