### PR TITLE
fix(utils): keep intentionally-cased words intact in toTitle

### DIFF
--- a/packages/utils/src/extractLeadingEmoji.test.ts
+++ b/packages/utils/src/extractLeadingEmoji.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
+
+describe("extractLeadingEmoji", () => {
+  it("extracts a leading emoji and trims the separating space", () => {
+    expect(extractLeadingEmoji("🚀 Launch")).toEqual(["🚀", "Launch"])
+  })
+
+  it("extracts an emoji written with a variation selector", () => {
+    expect(extractLeadingEmoji("❤️ Loved")).toEqual(["❤️", "Loved"])
+  })
+
+  it("returns the text untouched when there is no leading emoji", () => {
+    expect(extractLeadingEmoji("Hello world")).toEqual([null, "Hello world"])
+  })
+
+  it("ignores an emoji that is not at the start", () => {
+    expect(extractLeadingEmoji("Launch 🚀")).toEqual([null, "Launch 🚀"])
+  })
+
+  it("handles an empty string", () => {
+    expect(extractLeadingEmoji("")).toEqual([null, ""])
+  })
+
+  // Keycap bases (0-9, #, *) are `Emoji_Component`s but only render as emoji
+  // when combined with U+20E3. Treating a bare one as an emoji mangled titles
+  // that simply start with a number.
+  describe("titles starting with a keycap base", () => {
+    it.each([
+      "2024 roadmap",
+      "3 apples",
+      "1. First step",
+      "0 to 60",
+      "5xx errors",
+      "#hashtag title",
+      "*starred",
+    ])("leaves %j untouched", (title) => {
+      expect(extractLeadingEmoji(title)).toEqual([null, title])
+    })
+  })
+})

--- a/packages/utils/src/extractLeadingEmoji.ts
+++ b/packages/utils/src/extractLeadingEmoji.ts
@@ -1,5 +1,9 @@
+// `\p{Emoji_Component}` also covers the keycap bases (`0`-`9`, `#`, `*`), which
+// only render as emoji when followed by U+20E3 (e.g. `1\uFE0F\u20E3`). Without the
+// lookahead a title such as "2024 roadmap" has its leading digit peeled off as
+// an emoji, leaving "024 roadmap" as the name.
 const EMOJI_REGEX =
-  /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|\p{Emoji_Component}(?:\u200D\p{Emoji_Presentation})*)\s*/u
+  /^(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}\p{Emoji_Modifier}?|(?![0-9#*])\p{Emoji_Component}(?:\u200D\p{Emoji_Presentation})*)\s*/u
 
 export function extractLeadingEmoji(text: string): [string | null, string] {
   const match = text.match(EMOJI_REGEX)

--- a/packages/utils/src/to-title.test.ts
+++ b/packages/utils/src/to-title.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { toTitle } from "./to-title.ts"
+
+describe("toTitle", () => {
+  it("promotes the first letter of all-lowercase words", () => {
+    expect(toTitle("chrome")).toBe("Chrome")
+    expect(toTitle("ios")).toBe("Ios")
+    expect(toTitle("hello world")).toBe("Hello World")
+  })
+
+  it("preserves words that already carry an uppercase letter", () => {
+    // Regression: these were mangled to "IPhone" / "IOS", which is how a
+    // session's browser/OS name was rendered in account settings.
+    expect(toTitle("iPhone")).toBe("iPhone")
+    expect(toTitle("iOS")).toBe("iOS")
+    expect(toTitle("MacOS")).toBe("MacOS")
+    expect(toTitle("GitHub")).toBe("GitHub")
+  })
+
+  it("mixes promoted and preserved words in one string", () => {
+    expect(toTitle("iOS device")).toBe("iOS Device")
+    expect(toTitle("chrome on macOS")).toBe("Chrome On macOS")
+  })
+
+  it("titlecases contractions", () => {
+    expect(toTitle("don't")).toBe("Don't")
+  })
+
+  it("leaves numbers, punctuation and whitespace untouched", () => {
+    expect(toTitle("windows 11")).toBe("Windows 11")
+    expect(toTitle("")).toBe("")
+  })
+})

--- a/packages/utils/src/to-title.ts
+++ b/packages/utils/src/to-title.ts
@@ -10,5 +10,9 @@
  * non-letter (numbers, punctuation, whitespace) is left untouched.
  */
 export function toTitle(str: string): string {
-  return str.replace(/[A-Za-z]+('[A-Za-z]+)?/g, (word) => word.charAt(0).toUpperCase() + word.slice(1))
+  return str.replace(/[A-Za-z]+('[A-Za-z]+)?/g, (word) =>
+    // A word that already carries an uppercase letter is intentionally cased
+    // ("iPhone", "iOS", "MacOS") - promoting its first letter would mangle it.
+    /[A-Z]/.test(word) ? word : word.charAt(0).toUpperCase() + word.slice(1),
+  )
 }


### PR DESCRIPTION
`toTitle` uppercases the first letter of every word, so a word that already carries an uppercase letter gets mangled.

## Problem

```ts
toTitle("iPhone") // "IPhone"
toTitle("iOS")    // "IOS"
toTitle("iOS device") // "IOS Device"
```

This is user-visible: `apps/web/.../settings/account.tsx` renders a session's `browserName` / `osName` through `toTitle`, so a session from an iOS device is listed as **"IOS"**.

It also contradicts the function's own docstring, which states that `"MacOS"`, `"iPhone"` and `"GitHub"` *"all survive intact"* while `"chrome"` / `"ios"` get their first letter promoted. `MacOS` and `GitHub` happen to survive only because they already start with an uppercase letter; `iPhone` does not.

## Fix

Only promote the first letter when the word contains no uppercase letter. That satisfies every example in the docstring:

| input | before | after |
|---|---|---|
| `chrome` | `Chrome` | `Chrome` |
| `ios` | `Ios` | `Ios` |
| `iPhone` | `IPhone` | `iPhone` |
| `iOS` | `IOS` | `iOS` |
| `MacOS` | `MacOS` | `MacOS` |
| `GitHub` | `GitHub` | `GitHub` |
| `don't` | `Don't` | `Don't` |

## Tests

Added `to-title.test.ts` (the module had no tests) covering promotion, preservation of intentionally-cased words, mixed strings, contractions and non-letter characters. `packages/utils` passes apart from the pre-existing locale-dependent `formatChartWindowCaption` failure, which also fails on a clean checkout. Biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing capitalization in title-cased text, including mixed-case words such as “iPhone” and “GitHub.”
  - Prevented titles beginning with digits or symbols from being incorrectly interpreted as emojis.
  - Continued correctly handling emoji variation selectors and keycap characters.

- **Tests**
  - Added coverage for title casing, contractions, punctuation, whitespace, emoji extraction, and mixed-case words.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->