### PR TITLE
fix(flaggers): stop frustration false positives on external business outcomes

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/display.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/display.ts
@@ -23,7 +23,7 @@ export const FLAGGER_DISPLAY: Record<FlaggerSlug, FlaggerDisplay> = {
     name: "Frustration",
     description: "The conversation shows clear user frustration or dissatisfaction",
     instructions:
-      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration.",
+      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications, isolated terse replies, or frustration aimed at external factors (campaigns, ads platforms, business metrics, third-party tools, the user's own code/manager) rather than the assistant.",
     mode: "llm",
     suppressedBy: [],
   },

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { frustrationStrategy } from "./frustration.ts"
+import { makeTrace, user } from "./test-helpers.ts"
+
+describe("frustrationStrategy", () => {
+  it("requires assistant-directed frustration and rejects external-factor examples in the prompt", () => {
+    const systemPrompt = frustrationStrategy.buildSystemPrompt?.(makeTrace([user("hello")]))
+    expect(systemPrompt).toBeTruthy()
+
+    expect(systemPrompt).toContain("target of the frustration must be the assistant")
+    expect(systemPrompt).toContain("Lead volume/quality")
+    expect(systemPrompt).toContain("this volume is ridiculous")
+    expect(systemPrompt).toContain("Google Ads is done")
+    expect(systemPrompt).toContain("Do not treat complaints about an external platform")
+    expect(systemPrompt).toContain("If the quoted evidence is only about an external factor")
+  })
+
+  it("gives the annotation reviewer an external-factor rejection clause", () => {
+    expect(frustrationStrategy.annotationReviewerGuidance).toContain(
+      "Reject when the evidence is only dissatisfaction with an external factor",
+    )
+    expect(frustrationStrategy.annotationReviewerGuidance).toContain("lead volume/quality")
+    expect(frustrationStrategy.annotationReviewerGuidance).toContain(
+      "dissatisfaction with the assistant's recommendations",
+    )
+  })
+
+  it("documents external-factor exclusions in annotator instructions", () => {
+    expect(frustrationStrategy.annotator?.instructions).toContain("external factors")
+    expect(frustrationStrategy.annotator?.instructions).toContain("campaigns")
+  })
+})

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.ts
@@ -11,6 +11,8 @@ You are a triage flagger for LLM telemetry traces. Decide whether the USER'S OWN
 
 Judge only the user-authored messages. The user must express frustration themselves; do not infer it from assistant mistakes alone.
 
+The target of the frustration must be the assistant (its answers, behavior, competence, or helpfulness). Dissatisfaction with an external situation the user is discussing does not count, even when the assistant is helping with that situation.
+
 ================================================================================
 FRUSTRATION SIGNALS (flag when the user's wording clearly shows these)
 ================================================================================
@@ -45,7 +47,12 @@ DO NOT FLAG
 
 - Neutral corrections without emotional charge ("actually, I meant Y")
 - Isolated terse replies ("no", "wrong") without other signals
-- Frustration directed at EXTERNAL factors (the user's own code, their manager, a third-party API) — not at the assistant
+- Frustration directed at EXTERNAL factors — not at the assistant. Examples:
+  • The user's own code, product, business, manager, customers, or competitors
+  • A third-party platform, API, ads account, campaign, vendor, or tool
+  • Lead volume/quality, conversion rates, CPA, ROAS, budgets, or other business/performance metrics
+  • Domain outcomes the assistant did not author ("this volume is ridiculous", "Google Ads is done", "PMax isn't generating good leads", "I'm going to be out of business")
+  Do not treat complaints about an external platform or campaign as complaints about "the assistant's recommendations" unless the user also attacks the assistant itself ("you're not helping", "your advice is useless", "stop guessing").
 - Profanity inside content being discussed (e.g., a log file the user pasted)
 - Mild expressive interjections ("ugh", "hmm") without complaint context
 - Questions phrased firmly but not angrily
@@ -54,9 +61,15 @@ DO NOT FLAG
 DECISION RULE
 ================================================================================
 
-Flag only when the user's own words are direct evidence of dissatisfaction with the assistant. When uncertain, return matched=false.
+Flag only when the user's own words are direct evidence of dissatisfaction with the assistant. If the quoted evidence is only about an external factor, business metric, or third-party platform, return matched=false — even when the tone is strong. When uncertain, return matched=false.
 
 Return no explanation outside the structured output.
+`.trim()
+
+const FRUSTRATION_ANNOTATION_REVIEWER_GUIDANCE = `
+For this Frustration flagger, approve only when the annotation's evidence shows the user directing frustration at the assistant (its answers, behavior, competence, or helpfulness).
+
+Reject when the evidence is only dissatisfaction with an external factor the user is discussing — for example campaign performance, lead volume/quality, an ads platform, a third-party API, the user's own business/code/manager, or other domain metrics — even if the tone is strong or the assistant was advising on that topic. Reject annotations that reframe external-factor complaints as "dissatisfaction with the assistant's recommendations" without quoting assistant-directed language from the user.
 `.trim()
 
 export const frustrationStrategy: FlaggerStrategy = {
@@ -67,8 +80,10 @@ export const frustrationStrategy: FlaggerStrategy = {
     name: "Frustration",
     description: "The conversation shows clear user frustration or dissatisfaction",
     instructions:
-      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration.",
+      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications, isolated terse replies, or frustration aimed at external factors (campaigns, ads platforms, business metrics, third-party tools, the user's own code/manager) rather than the assistant.",
   },
+
+  annotationReviewerGuidance: FRUSTRATION_ANNOTATION_REVIEWER_GUIDANCE,
 
   hintKinds: [
     "pattern:frustration",

--- a/packages/domain/flaggers/src/flagger-strategies/types.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/types.ts
@@ -104,6 +104,14 @@ export interface FlaggerStrategy {
     conversation: FlaggerConversation,
     result: { readonly feedback?: string | undefined; readonly messageIndex?: number | undefined },
   ): boolean
+
+  /**
+   * Extra adversarial-reviewer guidance appended after the shared base clauses.
+   * Use for strategy-specific rejection rules the generic reviewer prompt
+   * cannot express (e.g. frustration must target the assistant, not an
+   * external business outcome).
+   */
+  readonly annotationReviewerGuidance?: string
 }
 
 export interface LlmCapableFlaggerStrategy extends FlaggerStrategy {

--- a/packages/domain/flaggers/src/hints/pattern-gatherers.test.ts
+++ b/packages/domain/flaggers/src/hints/pattern-gatherers.test.ts
@@ -60,6 +60,25 @@ describe("frustrationPatternGatherer", () => {
     )
   })
 
+  it("does not fire on domain/metric complaints that only look lexically negative", async () => {
+    for (const message of [
+      "This volume is ridiculous.",
+      "The lead quality is terrible.",
+      "Our CPA is awful right now.",
+      "Google Ads is broken for franchise leads.",
+    ]) {
+      expect(await runGatherer(frustrationPatternGatherer, ctx([user(message)]))).toEqual([])
+    }
+  })
+
+  it("still fires when the negative predicate targets the assistant turn", async () => {
+    for (const message of ["This is ridiculous.", "That answer is useless.", "Your suggestion is terrible."]) {
+      const hints = await runGatherer(frustrationPatternGatherer, ctx([user(message)]))
+      expect(hints).toHaveLength(1)
+      expect(hints[0]?.kind).toBe("pattern:frustration")
+    }
+  })
+
   it("does not fire on all-caps log pastes (no frustration lexical signal)", async () => {
     expect(
       await runGatherer(frustrationPatternGatherer, ctx([user("ERROR: UNAUTHORIZED — what does that mean?")])),

--- a/packages/domain/flaggers/src/hints/pattern-gatherers.ts
+++ b/packages/domain/flaggers/src/hints/pattern-gatherers.ts
@@ -28,10 +28,12 @@ const FRUSTRATION_USER_PATTERNS: readonly RegExp[] = [
   /\bfor the (?:second|third|fourth|fifth|nth|last) time\b/i,
   /\bi (?:keep|have to keep) (?:telling|saying|asking|repeating)\b/i,
 
-  // Direct dissatisfaction with the assistant's output.
-  // Two shapes: "X is/are/was useless" (linking verb) and "X's useless" (contraction).
-  /\b(?:is|are|was|were)\s+(?:useless|garbage|broken|terrible|awful|ridiculous|pointless|worthless)\b/i,
+  // Direct dissatisfaction with the assistant's output. Constrain the subject so
+  // domain complaints ("this volume is ridiculous", "the API is broken") do not
+  // raise a hint — the LLM still judges target of frustration when other hints fire.
+  /\b(?:this|that|it)\s+(?:is|are|was|were)\s+(?:useless|garbage|broken|terrible|awful|ridiculous|pointless|worthless)\b/i,
   /\b(?:you|this|that|it)'?s\s+(?:useless|garbage|broken|terrible|awful|ridiculous|pointless|worthless)\b/i,
+  /\b(?:the )?(?:answer|response|output|suggestion|advice|result)\s+(?:is|are|was|were)\s+(?:useless|garbage|broken|terrible|awful|ridiculous|pointless|worthless)\b/i,
   /\byou'?re\s+(?:not (?:listening|reading|helping|understanding)|making (?:things|this) up|hallucinating|guessing)\b/i,
   /\bstop (?:hallucinating|guessing|making (?:things|stuff) up)\b/i,
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1054,6 +1054,8 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0].system).toContain("USER'S OWN WORDING")
     expect(calls.generate[0].system).toContain("Judge only the user-authored messages")
+    expect(calls.generate[0].system).toContain("target of the frustration must be the assistant")
+    expect(calls.generate[0].system).toContain("Lead volume/quality")
     expect(calls.generate[0].prompt).toContain("USER MESSAGES")
     expect(calls.generate[0].prompt).toContain("This still isn't working")
     expect(calls.generate[0].prompt).toContain("You're not listening")
@@ -1070,6 +1072,9 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     // The annotation reviewer must likewise drop the assistant-only clause.
     expect(calls.generate[1].system).not.toContain(
       "Approve only when the proposed annotation describes a problem in the evaluated agent's own assistant response",
+    )
+    expect(calls.generate[1].system).toContain(
+      "Reject when the evidence is only dissatisfaction with an external factor",
     )
   })
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -165,6 +165,7 @@ const buildAnnotationReviewerSystemPrompt = (strategy: FlaggerStrategy): string 
     ANNOTATION_REVIEWER_BASE_SYSTEM_PROMPT,
     ...(classifiesAssistantResponseOnly(strategy) ? [ANNOTATION_REVIEWER_ASSISTANT_ONLY_CLAUSE] : []),
     ANNOTATION_REVIEWER_REJECTION_CLAUSE,
+    ...(strategy.annotationReviewerGuidance ? [strategy.annotationReviewerGuidance] : []),
   ].join("\n\n")
 
 const annotationReviewOutputSchema = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Signal in project `latitude-flaggers`: [User frustration with poor lead quality and volume](https://console.latitude.so/projects/latitude-flaggers/signals/user-frustration-with-poor-lead-quality-and-volume) (`rwiqdf373y29anhgqlpj19tp`).

Sample classify trace: `f2a6eeb87eb2610ee3655eded062b69b`.

The evaluated Opteo Google Ads session had a user upset about lead volume/quality and whether Google Ads still works ("This volume is ridiculous", "Is Google done for generating good leads?", risk of going out of business). The frustration flagger matched anyway and the annotation reframed those external complaints as dissatisfaction with "the assistant's recommendations".

That violates the existing DO NOT FLAG rule for external factors. The match created this signal.

## Fix

1. **Classifier prompt** — require assistant-directed wording; expand DO NOT FLAG with concrete campaign / ads / lead-metric examples; forbid reframing external venting as assistant dissatisfaction.
2. **Adversarial reviewer** — add strategy-specific `annotationReviewerGuidance` so frustration reviews reject external-factor-only evidence.
3. **Lexical hint** — stop `pattern:frustration` from firing on bare `"<noun> is ridiculous/terrible/..."` phrases (e.g. "This volume is ridiculous") while still matching assistant-targeted forms ("This is ridiculous", "That answer is useless").

Do not mute or resolve the signal here; verify after deploy.

## Test plan

- [x] `pnpm --filter @domain/flaggers test`
- [x] New unit coverage for prompt/reviewer guidance and pattern-gatherer external-factor cases
- [ ] After deploy, spot-check similar Google Ads / campaign-venting sessions do not re-match frustration

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0af4c852-1a9b-5196-818b-c6744fecb4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0af4c852-1a9b-5196-818b-c6744fecb4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

