### PR TITLE
Fix signal seen timestamps in the signals list

### DIFF
--- a/apps/web/src/domains/signals/signals.functions.test.ts
+++ b/apps/web/src/domains/signals/signals.functions.test.ts
@@ -1,0 +1,40 @@
+import { SignalId } from "@domain/shared"
+import { describe, expect, it } from "vitest"
+import { toSignalRowMetricRecord } from "./signals.functions.ts"
+
+describe("toSignalRowMetricRecord", () => {
+  it("serializes occurrence timestamps from the selected score window", () => {
+    const firstSeenAt = new Date("2026-07-01T10:00:00.000Z")
+    const lastSeenAt = new Date("2026-07-12T15:30:00.000Z")
+
+    expect(
+      toSignalRowMetricRecord({
+        metric: {
+          signalId: SignalId("sig_123"),
+          occurrences: 4,
+          affectedSessions: 2,
+          firstSeenAt,
+          lastSeenAt,
+        },
+        totalSessions: 8,
+        trend: [],
+      }),
+    ).toEqual({
+      occurrences: 4,
+      firstSeenAt: firstSeenAt.toISOString(),
+      lastSeenAt: lastSeenAt.toISOString(),
+      affectedSessionsPercent: 0.25,
+      trend: [],
+    })
+  })
+
+  it("keeps zero-occurrence rows timestamp-free", () => {
+    expect(toSignalRowMetricRecord({ metric: undefined, totalSessions: 8, trend: [] })).toEqual({
+      occurrences: 0,
+      firstSeenAt: null,
+      lastSeenAt: null,
+      affectedSessionsPercent: 0,
+      trend: [],
+    })
+  })
+})

--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -10,6 +10,7 @@ import {
   ScoreRepository,
   type SignalDimension,
   type SignalEscalationThresholdBucket,
+  type SignalWindowMetric,
 } from "@domain/scores"
 import {
   evaluationDraftSchema,
@@ -177,12 +178,32 @@ const signalRowMetricsInputSchema = z.object({
 
 export interface SignalRowMetricRecord {
   readonly occurrences: number
+  readonly firstSeenAt: string | null
+  readonly lastSeenAt: string | null
   readonly affectedSessionsPercent: number
   readonly trend: readonly ReturnType<typeof toSignalsBucketRecord>[]
 }
 
 export interface SignalRowMetricsRecord {
   readonly metricsBySignalId: Readonly<Record<string, SignalRowMetricRecord>>
+}
+
+export function toSignalRowMetricRecord({
+  metric,
+  totalSessions,
+  trend,
+}: {
+  readonly metric: SignalWindowMetric | undefined
+  readonly totalSessions: number
+  readonly trend: readonly ReturnType<typeof toSignalsBucketRecord>[]
+}): SignalRowMetricRecord {
+  return {
+    occurrences: metric?.occurrences ?? 0,
+    firstSeenAt: metric?.firstSeenAt.toISOString() ?? null,
+    lastSeenAt: metric?.lastSeenAt.toISOString() ?? null,
+    affectedSessionsPercent: !metric || totalSessions === 0 ? 0 : Math.min(metric.affectedSessions / totalSessions, 1),
+    trend,
+  }
 }
 
 const signalInputSchema = z.object({
@@ -510,16 +531,13 @@ export const getSignalRowMetrics = createServerFn({ method: "GET" })
               const metric = metricsBySignalId.get(signalId)
               return [
                 signalId,
-                {
-                  occurrences: metric?.occurrences ?? 0,
-                  affectedSessionsPercent:
-                    !metric || sessionCount.totalCount === 0
-                      ? 0
-                      : Math.min(metric.affectedSessions / sessionCount.totalCount, 1),
+                toSignalRowMetricRecord({
+                  metric,
+                  totalSessions: sessionCount.totalCount,
                   trend:
                     trendBySignalId.get(signalId) ??
                     fillBuckets({ scaffold: trendScaffold, buckets: [] }).map(toSignalsBucketRecord),
-                },
+                }),
               ]
             }),
           ),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/-components/signals-view.tsx
@@ -282,7 +282,10 @@ export function SignalsView({
         const metrics = rowMetricsBySignalId[issue.id]
         if (!metrics) return <AnalyticsCellSkeleton />
         if (metrics.occurrences === 0) return <span className="truncate text-muted-foreground">Never</span>
-        return <SeenAtCell lastSeenAtIso={issue.lastSeenAt} firstSeenAtIso={issue.firstSeenAt} />
+        if (!metrics.lastSeenAt || !metrics.firstSeenAt) {
+          return <span className="truncate text-muted-foreground">Never</span>
+        }
+        return <SeenAtCell lastSeenAtIso={metrics.lastSeenAt} firstSeenAtIso={metrics.firstSeenAt} />
       },
     },
     {


### PR DESCRIPTION
The signals list used signal metadata dates for the Seen at column even though its row metrics already queried occurrence data. Manually created signals often have matching creation and update dates, so the column displayed the first-seen value as the last-seen value.

This change adds occurrence-based first-seen and last-seen timestamps to row metrics and renders those values in the table. The timestamps follow the selected analytics time range, while signals without occurrences still display "Never."

## Test plan

- `pnpm --filter @app/web exec vitest run src/domains/signals/signals.functions.test.ts`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`