### PR TITLE
fix(flaggers): stop frustration false positives on flagger reflag sessions

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
@@ -1,0 +1,40 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
+import { describe, expect, it } from "vitest"
+
+import { frustrationStrategy } from "./frustration.ts"
+import { makeTrace, user } from "./test-helpers.ts"
+
+describe("frustrationStrategy.hasRequiredContext", () => {
+  it("requires at least one user text message", () => {
+    expect(frustrationStrategy.hasRequiredContext(makeTrace([]))).toBe(false)
+    expect(frustrationStrategy.hasRequiredContext(makeTrace([user("This still isn't working.")]))).toBe(true)
+  })
+
+  it("skips flagger.classify reflag sessions (user role is the classifier prompt)", () => {
+    const trace = {
+      ...makeTrace([
+        user(
+          [
+            "TRACE EVIDENCE:",
+            "<evaluated_trace_evidence>",
+            "TOOL CALL SEQUENCE: code → code → code → web_search",
+            "The agent abandoned the code path after Buildr API failures.",
+            "</evaluated_trace_evidence>",
+          ].join("\n"),
+        ),
+      ]),
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+    }
+
+    expect(frustrationStrategy.hasRequiredContext(trace)).toBe(false)
+  })
+
+  it("skips flagger.draft reflag sessions too", () => {
+    const trace = {
+      ...makeTrace([user("You're not helping at all.")]),
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerDraft],
+    }
+
+    expect(frustrationStrategy.hasRequiredContext(trace)).toBe(false)
+  })
+})

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.ts
@@ -1,4 +1,5 @@
 import type { FlaggerConversation } from "../conversation.ts"
+import { isFlaggerGeneratedTrace } from "../reflag.ts"
 import { extractUserTextMessages } from "./shared.ts"
 import type { FlaggerStrategy } from "./types.ts"
 
@@ -36,8 +37,9 @@ FRUSTRATION SIGNALS (flag when the user's wording clearly shows these)
    • "I can't trust anything you say"
 
 5. ABANDONMENT / GIVE-UP
-   User states they will stop using the assistant for this task.
+   The USER states they will stop using the assistant for this task.
    • "I'll do it myself", "never mind", "forget it"
+   The assistant abandoning a tool/code path after errors is not this signal.
 
 ================================================================================
 DO NOT FLAG
@@ -49,6 +51,8 @@ DO NOT FLAG
 - Profanity inside content being discussed (e.g., a log file the user pasted)
 - Mild expressive interjections ("ugh", "hmm") without complaint context
 - Questions phrased firmly but not angrily
+- An agent thrashing on tools, retrying failed API/code calls, or abandoning a code path — that is not user frustration
+- Classifier / evaluation prompts whose user-role text only supplies nested tool-call evidence about another agent
 
 ================================================================================
 DECISION RULE
@@ -80,6 +84,8 @@ export const frustrationStrategy: FlaggerStrategy = {
   ],
 
   hasRequiredContext(conversation: FlaggerConversation): boolean {
+    // Reflag sessions put the classifier prompt in the user role — never end-user wording.
+    if (isFlaggerGeneratedTrace(conversation.tags)) return false
     return extractUserTextMessages(conversation).length > 0
   },
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1109,6 +1109,60 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate).toHaveLength(0)
   })
 
+  it("does not call the LLM flagger for frustration on flagger.classify reflag sessions", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail(
+            [
+              {
+                role: "user",
+                parts: [
+                  {
+                    type: "text",
+                    content:
+                      "TOOL CALL SEQUENCE: code x6 then web_search. The agent abandoned the code path after API failures.",
+                  },
+                ],
+              },
+              {
+                role: "assistant",
+                parts: [
+                  {
+                    type: "text",
+                    content: '{"matched":true,"feedback":"Agent thrashed on code tool calls.","messageIndex":"6"}',
+                  },
+                ],
+              },
+            ],
+            [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+          ),
+        ),
+    })
+
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: () => Effect.die("AI should not be called for frustration on flagger-generated sessions"),
+    })
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "frustration" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(0)
+  })
+
   it("propagates AI generation errors for LLM-classified flaggers", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Frustration was matching on `flagger.classify` reflag traces in the dogfood Flaggers project and describing nested agent tool thrashing as user frustration.

Signal: [Code tool API retrieval failures lead to abandoned code path](https://console.latitude.so/projects/latitude-flaggers/signals/code-tool-api-retrieval-failures-lead-to-abandoned-code-path) (`i706ihfvp26ktgwl7zuxwqmh`)

Sample: thrashing correctly classified a Buildr session that looped on failed `code` tool API calls, then abandoned that path for `web_search`. Frustration then ran on that `flagger.classify` trace (`79e13890213fc65a2193fcf240a25080`), treated the classifier prompt (user role) as end-user wording, and annotated the nested tool-abandonment story.

## Fix

Frustration needs a real end-user turn. On flagger-generated sessions the user role is the classifier prompt, so `hasRequiredContext` now returns false when tags mark the session as `flagger:classify` / `flagger:draft`. Screening drops those as `missing-context` and the classify path never calls the LLM.

Also tightened the frustration prompt so agent tool/code-path abandonment is not treated as user give-up.

## Test plan

- [x] Unit tests for `hasRequiredContext` on classify/draft tags
- [x] `runFlaggerUseCase` does not call the LLM for frustration on `flagger:classify` sessions
- [x] `pnpm --filter @domain/flaggers test`
- [ ] After deploy, confirm new thrashing classify traces are not annotated by frustration; leave the existing signal for human verification (do not mute/resolve)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe9faf61-ff53-5655-b73d-f1f16af597b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe9faf61-ff53-5655-b73d-f1f16af597b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

