### PR TITLE
fix(spans): classify nested Vercel wrappers as agent_step, keep root as invoke_agent

### DIFF
--- a/apps/workers/src/workers/span-ingestion.test.ts
+++ b/apps/workers/src/workers/span-ingestion.test.ts
@@ -398,10 +398,8 @@ describe("createSpanIngestionWorker", () => {
 
     expect(rows).toHaveLength(2)
 
-    // The root wrapper is classified `invoke_agent` and keeps its SDK-reported
-    // usage verbatim — the trace/session rollup excludes non-billable operations,
-    // so there is no double-count and no need to zero the span (which would
-    // destroy the reported values). Nested wrappers resolve to `agent_step`.
+    // The root wrapper keeps its SDK-reported usage verbatim; the rollup excludes it by
+    // operation, so there is no double-count and no need to zero the span.
     expect(rows[0]?.name).toBe("ai.generateText")
     expect(rows[0]?.trace_id).toBe("11111111111111111111111111111111")
     expect(rows[0]?.operation).toBe("invoke_agent")

--- a/apps/workers/src/workers/span-ingestion.test.ts
+++ b/apps/workers/src/workers/span-ingestion.test.ts
@@ -337,7 +337,7 @@ describe("createSpanIngestionWorker", () => {
     }
   })
 
-  it("persists Vercel outer wrappers faithfully as invoke_agent (rollup gating, not zeroing, prevents double-count)", async () => {
+  it("persists a trace-root Vercel wrapper as invoke_agent (rollup gating, not zeroing, prevents double-count)", async () => {
     const consumer = new TestQueueConsumer()
     const disk = new FakeStorageDisk()
     const pub = createFakeEventsPublisher()
@@ -398,10 +398,10 @@ describe("createSpanIngestionWorker", () => {
 
     expect(rows).toHaveLength(2)
 
-    // The wrapper is classified `invoke_agent` and keeps its SDK-reported usage
-    // verbatim — the trace/session rollup excludes non-billable operations, so
-    // there is no double-count and no need to zero the span (which would destroy
-    // the reported values).
+    // The root wrapper is classified `invoke_agent` and keeps its SDK-reported
+    // usage verbatim — the trace/session rollup excludes non-billable operations,
+    // so there is no double-count and no need to zero the span (which would
+    // destroy the reported values). Nested wrappers resolve to `agent_step`.
     expect(rows[0]?.name).toBe("ai.generateText")
     expect(rows[0]?.trace_id).toBe("11111111111111111111111111111111")
     expect(rows[0]?.operation).toBe("invoke_agent")

--- a/packages/domain/spans/src/otlp/resolvers/index.ts
+++ b/packages/domain/spans/src/otlp/resolvers/index.ts
@@ -37,6 +37,7 @@ interface ResolveAttributesInput {
   readonly statusCode: string
   readonly spanName?: string
   readonly scopeName?: string
+  readonly hasParent?: boolean
 }
 
 export function resolveAttributes({
@@ -44,10 +45,11 @@ export function resolveAttributes({
   statusCode,
   spanName = "",
   scopeName = "",
+  hasParent = true,
 }: ResolveAttributesInput): ResolvedAttributes {
   const provider = resolveProvider(spanAttrs, spanName)
   const model = first(modelCandidates, spanAttrs) ?? ""
-  const operation = resolveOperation(spanAttrs, spanName, scopeName)
+  const operation = resolveOperation(spanAttrs, spanName, scopeName, hasParent)
 
   return {
     operation,

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -31,11 +31,8 @@ const GENAI_OPERATION: Record<string, Operation> = {
   rerank: "reranker",
 }
 
-// Bare ai.generateText/streamText/generateObject/streamObject wrappers carry a lossy
-// summary (no tool results); the per-leaf .doGenerate/.doStream `chat` turns hold the real
-// conversation. A wrapper nested under an agent is one step of that agent (agent_step), kept
-// out of the rollup and off the agent graph; only a trace-root wrapper stands alone as the
-// agent itself (invoke_agent, applied in resolveOperation).
+// Vercel wrappers duplicate their leaves' usage; agent_step keeps them out of the rollup,
+// while a trace-root wrapper is the agent itself (invoke_agent, in resolveOperation).
 const VERCEL_OPERATION: Record<string, Operation> = {
   "ai.generateText": "agent_step",
   "ai.generateText.doGenerate": "chat",

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -32,16 +32,18 @@ const GENAI_OPERATION: Record<string, Operation> = {
 }
 
 // Bare ai.generateText/streamText/generateObject/streamObject wrappers carry a lossy
-// summary (no tool results); classify them invoke_agent so the rollup excludes them and
-// the per-leaf .doGenerate/.doStream `chat` turns hold the real conversation.
+// summary (no tool results); the per-leaf .doGenerate/.doStream `chat` turns hold the real
+// conversation. A wrapper nested under an agent is one step of that agent (agent_step), kept
+// out of the rollup and off the agent graph; only a trace-root wrapper stands alone as the
+// agent itself (invoke_agent, applied in resolveOperation).
 const VERCEL_OPERATION: Record<string, Operation> = {
-  "ai.generateText": "invoke_agent",
+  "ai.generateText": "agent_step",
   "ai.generateText.doGenerate": "chat",
-  "ai.streamText": "invoke_agent",
+  "ai.streamText": "agent_step",
   "ai.streamText.doStream": "chat",
-  "ai.generateObject": "invoke_agent",
+  "ai.generateObject": "agent_step",
   "ai.generateObject.doGenerate": "chat",
-  "ai.streamObject": "invoke_agent",
+  "ai.streamObject": "agent_step",
   "ai.streamObject.doStream": "chat",
   "ai.embed": "embeddings",
   "ai.embed.doEmbed": "embeddings",
@@ -49,6 +51,13 @@ const VERCEL_OPERATION: Record<string, Operation> = {
   "ai.embedMany.doEmbed": "embeddings",
   "ai.toolCall": "execute_tool",
 }
+
+const VERCEL_ROOT_AGENT_OPERATION_IDS: ReadonlySet<string> = new Set([
+  "ai.generateText",
+  "ai.streamText",
+  "ai.generateObject",
+  "ai.streamObject",
+])
 
 // Latitude's openai-agents TS bridge tags non-LLM spans with latitude.span.kind=agents.*
 // (its LLM span already sets gen_ai.operation.name=chat). Map only these wrapper/tool spans.
@@ -104,7 +113,12 @@ const operationCandidates = [
 // CrewAI's OpenInference instrumentor carries the whole conversation on the AGENT span (no
 // LLM leaf), so classify those `chat` for the rollup; other frameworks' AGENT spans keep
 // `invoke_agent` (they have real LLM leaves).
-export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: string, scopeName = ""): string {
+export function resolveOperation(
+  spanAttrs: readonly OtlpKeyValue[],
+  spanName: string,
+  scopeName = "",
+  hasParent = true,
+): string {
   if (
     scopeName.startsWith(CREWAI_OPENINFERENCE_SCOPE) &&
     stringAttr(spanAttrs, "openinference.span.kind") === "AGENT"
@@ -114,6 +128,9 @@ export function resolveOperation(spanAttrs: readonly OtlpKeyValue[], spanName: s
   if (scopeName === OPENCLAW_TELEMETRY_SCOPE) {
     const mapped = OPENCLAW_SPAN_OPERATION[spanName]
     if (mapped) return mapped
+  }
+  if (!hasParent && VERCEL_ROOT_AGENT_OPERATION_IDS.has(stringAttr(spanAttrs, "ai.operationId") ?? "")) {
+    return "invoke_agent"
   }
   return first(operationCandidates, spanAttrs) ?? operationFromClaudeCodeNativeSpanName(spanName) ?? "unspecified"
 }

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -415,13 +415,10 @@ describe("resolveAttributes", () => {
 
     it("maps Vercel operation IDs (nested wrappers → agent_step, leaves → chat)", () => {
       const cases: [string, string][] = [
-        // Nested wrappers carry a lossy summary and are one step of the agent —
-        // classified agent_step so the rollup excludes them.
         ["ai.generateText", "agent_step"],
         ["ai.streamText", "agent_step"],
         ["ai.generateObject", "agent_step"],
         ["ai.streamObject", "agent_step"],
-        // Leaves hold the faithful per-call exchange.
         ["ai.generateText.doGenerate", "chat"],
         ["ai.streamText.doStream", "chat"],
         ["ai.generateObject.doGenerate", "chat"],

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -413,14 +413,14 @@ describe("resolveAttributes", () => {
       }
     })
 
-    it("maps Vercel operation IDs (bare wrappers → invoke_agent, leaves → chat)", () => {
+    it("maps Vercel operation IDs (nested wrappers → agent_step, leaves → chat)", () => {
       const cases: [string, string][] = [
-        // Bare wrappers carry a lossy summary and end after their leaves —
-        // classified as inert wrappers so the rollup excludes them.
-        ["ai.generateText", "invoke_agent"],
-        ["ai.streamText", "invoke_agent"],
-        ["ai.generateObject", "invoke_agent"],
-        ["ai.streamObject", "invoke_agent"],
+        // Nested wrappers carry a lossy summary and are one step of the agent —
+        // classified agent_step so the rollup excludes them.
+        ["ai.generateText", "agent_step"],
+        ["ai.streamText", "agent_step"],
+        ["ai.generateObject", "agent_step"],
+        ["ai.streamObject", "agent_step"],
         // Leaves hold the faithful per-call exchange.
         ["ai.generateText.doGenerate", "chat"],
         ["ai.streamText.doStream", "chat"],
@@ -435,6 +435,15 @@ describe("resolveAttributes", () => {
         const attrs: OtlpKeyValue[] = [strAttr("ai.operationId", opId)]
         const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset" })
         expect(result.operation).toBe(expected)
+      }
+    })
+
+    it("maps a trace-root Vercel wrapper (no parent) → invoke_agent", () => {
+      const wrappers = ["ai.generateText", "ai.streamText", "ai.generateObject", "ai.streamObject"]
+      for (const opId of wrappers) {
+        const attrs: OtlpKeyValue[] = [strAttr("ai.operationId", opId)]
+        const result = resolveAttributes({ spanAttrs: attrs, statusCode: "unset", hasParent: false })
+        expect(result.operation).toBe("invoke_agent")
       }
     })
 

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -583,10 +583,6 @@ describe("TravelPlanner trace — Vercel AI SDK", () => {
     })
 
     it("resolves nested generateText/streamText wrappers to 'agent_step' and inner leaves to 'chat'", () => {
-      // The bare `ai.generateText` / `ai.streamText` wrappers carry a lossy
-      // summary; nested under an agent they are one step of it (`agent_step`),
-      // excluded from the conversation/usage rollup and off the agent graph. The
-      // inner `.doGenerate` / `.doStream` leaves hold the real turn.
       expect(findSpan("llm1Outer").operation).toBe("agent_step")
       expect(findSpan("llm2Outer").operation).toBe("agent_step")
       expect(findSpan("llm1Inner").operation).toBe("chat")

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -582,13 +582,13 @@ describe("TravelPlanner trace — Vercel AI SDK", () => {
       expect(findSpan("llm1Outer").model).toBe("")
     })
 
-    it("resolves bare generateText/streamText wrappers to 'invoke_agent' and inner leaves to 'chat'", () => {
+    it("resolves nested generateText/streamText wrappers to 'agent_step' and inner leaves to 'chat'", () => {
       // The bare `ai.generateText` / `ai.streamText` wrappers carry a lossy
-      // summary and end after their leaves, so they are classified as inert
-      // wrappers (`invoke_agent`) and excluded from the conversation/usage
-      // rollup; the inner `.doGenerate` / `.doStream` leaves hold the real turn.
-      expect(findSpan("llm1Outer").operation).toBe("invoke_agent")
-      expect(findSpan("llm2Outer").operation).toBe("invoke_agent")
+      // summary; nested under an agent they are one step of it (`agent_step`),
+      // excluded from the conversation/usage rollup and off the agent graph. The
+      // inner `.doGenerate` / `.doStream` leaves hold the real turn.
+      expect(findSpan("llm1Outer").operation).toBe("agent_step")
+      expect(findSpan("llm2Outer").operation).toBe("agent_step")
       expect(findSpan("llm1Inner").operation).toBe("chat")
       expect(findSpan("llm2Inner").operation).toBe("chat")
     })
@@ -1008,6 +1008,50 @@ describe("Vercel AI SDK streamObject / generateObject output", () => {
     const textPart = parts.find((p) => p.type === "text")
     expect(textPart).toBeDefined()
     expect((textPart as { content: string }).content).toContain("Barcelona")
+  })
+})
+
+describe("Vercel AI SDK wrapper operation by tree position", () => {
+  function buildWrapper(spanId: string, parentSpanId?: string): OtlpSpan {
+    return {
+      traceId: TRACE_ID,
+      spanId,
+      ...(parentSpanId ? { parentSpanId } : {}),
+      name: "ai.generateText",
+      kind: 1,
+      startTimeUnixNano: "1710590600000000000",
+      endTimeUnixNano: "1710590601000000000",
+      attributes: [str("ai.operationId", "ai.generateText")],
+      status: { code: 1 },
+    }
+  }
+
+  function transformWrappers(...wrappers: OtlpSpan[]) {
+    return transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", SERVICE_NAME)] },
+            scopeSpans: [{ scope: { name: SCOPE_NAME, version: SCOPE_VERSION }, spans: wrappers }],
+          },
+        ],
+      },
+      CONTEXT,
+    ).spans
+  }
+
+  it("resolves a trace-root ai.generateText wrapper to 'invoke_agent'", () => {
+    const spans = transformWrappers(buildWrapper("c0c0c0c0c0c00001", undefined))
+    expect(spans[0]?.operation).toBe("invoke_agent")
+  })
+
+  it("resolves a nested ai.generateText wrapper to 'agent_step'", () => {
+    const spans = transformWrappers(
+      buildWrapper("c0c0c0c0c0c00001", undefined),
+      buildWrapper("c0c0c0c0c0c00002", "c0c0c0c0c0c00001"),
+    )
+    const nested = spans.find((s) => s.spanId === "c0c0c0c0c0c00002")
+    expect(nested?.operation).toBe("agent_step")
   })
 })
 

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -128,6 +128,10 @@ function hasValidIdLengths(normalizedTraceId: string, spanId: string): boolean {
   return normalizedTraceId.length <= TRACE_ID_LENGTH && spanId.length <= SPAN_ID_LENGTH
 }
 
+function hasParentSpan(parentSpanId: string | undefined): boolean {
+  return !!parentSpanId && !/^0+$/.test(parentSpanId)
+}
+
 function transformSpan({
   span,
   traceId,
@@ -158,6 +162,7 @@ function transformSpan({
     statusCode,
     spanName: span.name ?? "",
     scopeName,
+    hasParent: hasParentSpan(span.parentSpanId),
   })
   const content = parseContent(spanAttrs)
   const serviceName = stringAttr(resourceAttrs, "service.name") ?? ""


### PR DESCRIPTION
## Summary

The Vercel AI SDK emits a nested pair of spans for every generation: an outer wrapper (`ai.generateText`, `ai.streamText`, `ai.generateObject`, `ai.streamObject`) and an inner leaf (`.doGenerate` / `.doStream`). The wrapper only carries a lossy summary with usage numbers that duplicate the leaf; the leaf holds the real turn (messages, tools, per-call usage).

We used to classify the outer wrapper as `invoke_agent`. That kept it out of the cost/token rollup, which was the point, but it broke two other things. This PR classifies a *nested* wrapper as `agent_step` and keeps `invoke_agent` only for a *trace-root* wrapper.

## Why

`invoke_agent` was overloaded to mean "exclude from the rollup," and that meaning collided with the two other systems keyed off the operation:

- **False subagents.** Vercel generations almost always run inside the caller's own agent, which is itself an `invoke_agent` span. The agent-graph builder treats `invoke_agent` nested under `invoke_agent` as a subagent, so every plain `generateText` call showed up as a spawned subagent that never existed.
- **Wrong semantics.** The wrapper owns a single LLM response and nothing agentic. Labeling it `invoke_agent` misrepresents it in the UI and in any operation-based analytics.

`chat` was not an option: both spans report usage, so counting the wrapper as `chat` would double the session's cost and tokens.

## What changed

`agent_step` clears every constraint at once. It sits in none of the rollup allowlists (cost, tokens, messages, system instructions), so usage still comes only from the `chat` leaves with no double-count. It is also not an agent-graph candidate (only `execute_tool` and `invoke_agent` are), so a nested wrapper becomes transparent: its `chat` leaves and any `ai.toolCall` children attribute to the nearest real `invoke_agent` ancestor, which is the caller's actual agent.

The root case is different and worth keeping. A top-level `ai.generateText` running a tool loop with no wrapping agent genuinely is the agent, and classifying it `invoke_agent` gives it a named "Main agent" node. So the rule is positional: a Vercel wrapper with no parent span resolves to `invoke_agent`; nested, it resolves to `agent_step`.

Mechanically, `resolveOperation` now takes a `hasParent` flag that `transform.ts` derives from the OTLP `parentSpanId` (empty or all-zero means root). The classification is otherwise unchanged, and this only affects the classic AI SDK telemetry path (`ai.operationId`); the v7 `@ai-sdk/otel` path keys off `gen_ai.operation.name` and is untouched.

On system instructions: migration `00043` added `invoke_agent` to that rollup allowlist, but both the wrapper and the leaves carry system instructions, so the `chat` leaves cover it and moving nested wrappers off `invoke_agent` loses nothing there.

## Testing

`@domain/spans` passes (935 tests) and typechecks. Added resolver and transform cases for both the nested (`agent_step`) and root (`invoke_agent`) wrappers. Updated the `apps/workers` ingestion test wording; its wrapper is a root span, so it still asserts `invoke_agent` and passes. I did not run the chdb-backed `apps/workers` suite locally since it times out here; only comments and a test title changed in that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operation classification for Vercel AI spans based on their position within a trace.
  * Root-level agent wrappers are now identified as `invoke_agent`, while nested wrappers are classified as `agent_step`.
  * Leaf generation spans continue to be classified as `chat`.
  * Improved rollup handling to prevent duplicate counting of trace values.
* **Tests**
  * Updated and expanded coverage to validate wrapper vs. leaf operation resolution across root and nested scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->