### PR TITLE
fix(taxonomy): target resource_name for shadow-span Datadog config

### DIFF
--- a/apps/workflows/datadog/setup-datadog.sh
+++ b/apps/workflows/datadog/setup-datadog.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# One-time Datadog APM setup for the taxonomy adaptive shadow comparison.
-# Creates the retention filter (100% keep, 15-day indexing) and the span-based
+# Datadog APM setup for the taxonomy adaptive shadow comparison.
+# Creates the retention filter (100% keep of the shadow spans, which Datadog's
+# default intelligent retention would otherwise only sample) and the span-based
 # metrics (15-month durable history) over the taxonomy.gardenTaxonomyWorkflow.shadow
 # span. Run this BEFORE enabling shadow in prod — neither is retroactive.
 #
@@ -10,31 +11,56 @@
 #
 #   DD_APP_KEY=xxx DD_API_KEY=yyy ./apps/workflows/datadog/setup-datadog.sh
 #
-# Idempotent-ish: re-running prints a 409 for anything that already exists and
-# continues (each call prints its HTTP status). Site is datadoghq.eu.
+# Idempotent: every object is deleted (if present) and recreated on each run, so
+# re-running repairs a drifted definition instead of leaving the stale one in
+# place. The span name lands in Datadog's `resource_name`, not `operation_name`.
+# Site is datadoghq.eu.
 
 set -euo pipefail
 : "${DD_API_KEY:?set DD_API_KEY}" "${DD_APP_KEY:?set DD_APP_KEY}"
 
 DD=https://api.datadoghq.eu/api/v2/apm/config
-Q='service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow'
+Q='service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow'
+RETENTION_FILTER_NAME='Taxonomy adaptive shadow spans'
 HDR=(-H "DD-API-KEY: ${DD_API_KEY}" -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" -H 'Content-Type: application/json')
 
 FAILED=0
-post() { # <url> <json>  — prints body + status; 2xx or 409 (already exists) ok, else records a failure
+post() { # <url> <json>  — create; prints body + status; non-2xx records a failure
   local response status body
   response="$(curl -sS -X POST "$1" "${HDR[@]}" -d "$2" -w $'\n%{http_code}')"
   status="${response##*$'\n'}"
   body="${response%$'\n'*}"
   printf '%s\n-> HTTP %s\n' "${body}" "${status}"
   case "${status}" in
-    2* | 409) ;; # created, or already exists on a rerun
+    2*) ;;
     *) FAILED=$((FAILED + 1)) ;;
   esac
 }
 
+del() { # <url>  — delete; 2xx or 404 (nothing to delete) ok, else records a failure
+  local status
+  status="$(curl -sS -o /dev/null -X DELETE "$1" "${HDR[@]}" -w '%{http_code}')"
+  case "${status}" in
+    2* | 404) ;;
+    *) printf 'delete %s -> HTTP %s\n' "$1" "${status}"; FAILED=$((FAILED + 1)) ;;
+  esac
+}
+
 echo "== retention filter =="
-post "${DD}/retention-filters" '{"data":{"type":"apm_retention_filter","attributes":{"name":"Taxonomy adaptive shadow spans","filter_type":"spans-sampling-processor","filter":{"query":"'"${Q}"'"},"rate":1.0,"enabled":true}}}'
+# Retention filters have no client-supplied id, so converge by deleting every
+# filter that carries our name before recreating (avoids duplicates on rerun).
+existing="$(curl -sS "${DD}/retention-filters" "${HDR[@]}" | python3 -c '
+import sys, json
+name = sys.argv[1]
+for f in json.load(sys.stdin).get("data", []):
+    if f.get("attributes", {}).get("name") == name:
+        print(f["id"])
+' "${RETENTION_FILTER_NAME}")"
+for fid in ${existing}; do
+  echo "-- deleting existing ${fid}"
+  del "${DD}/retention-filters/${fid}"
+done
+post "${DD}/retention-filters" '{"data":{"type":"apm_retention_filter","attributes":{"name":"'"${RETENTION_FILTER_NAME}"'","filter_type":"spans-sampling-processor","filter":{"query":"'"${Q}"'"},"rate":1.0,"enabled":true}}}'
 
 GRP='[{"path":"@taxonomy.projectId","tag_name":"project_id"},{"path":"@taxonomy.organizationId","tag_name":"organization_id"},{"path":"@taxonomy.customBehaviorId","tag_name":"custom_behavior_id"}]'
 
@@ -42,6 +68,7 @@ echo "== distribution span metrics =="
 while IFS='|' read -r id path; do
   [ -z "${id}" ] && continue
   echo "-- ${id}"
+  del "${DD}/metrics/${id}"
   post "${DD}/metrics" '{"data":{"type":"spans_metrics","id":"'"${id}"'","attributes":{"compute":{"aggregation_type":"distribution","include_percentiles":true,"path":"'"${path}"'"},"filter":{"query":"'"${Q}"'"},"group_by":'"${GRP}"'}}}'
 done <<'METRICS'
 taxonomy.shadow.partition_ari|@taxonomy.shadow.diff.partitionAri
@@ -55,10 +82,11 @@ taxonomy.adaptive.rel_sep_p50|@taxonomy.adaptive.relSep.p50
 METRICS
 
 echo "== fallback count metric =="
+del "${DD}/metrics/taxonomy.adaptive.fallback"
 post "${DD}/metrics" '{"data":{"type":"spans_metrics","id":"taxonomy.adaptive.fallback","attributes":{"compute":{"aggregation_type":"count"},"filter":{"query":"'"${Q}"' -@taxonomy.adaptive.fallbackReason:none"},"group_by":[{"path":"@taxonomy.projectId","tag_name":"project_id"},{"path":"@taxonomy.adaptive.fallbackReason","tag_name":"fallback_reason"}]}}}'
 
 if [ "${FAILED}" -gt 0 ]; then
-  echo "== ${FAILED} call(s) failed (non-2xx, non-409) — see statuses above =="
+  echo "== ${FAILED} call(s) failed (non-2xx) — see statuses above =="
   exit 1
 fi
 echo "== done =="

--- a/apps/workflows/datadog/taxonomy-shadow-comparison-dashboard.json
+++ b/apps/workflows/datadog/taxonomy-shadow-comparison-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Taxonomy adaptive clustering — shadow comparison (LAT-773)",
-  "description": "Reads the APM span `taxonomy.gardenTaxonomyWorkflow.shadow` emitted by the workflows service to compare the static (production) taxonomy tree against the adaptive candidate tree while shadow mode is enabled environment-wide. The app ships logs to CloudWatch only, so this dashboard uses the APM spans channel, not Datadog Logs. Requires a Datadog APM retention filter that keeps operation_name:taxonomy.gardenTaxonomyWorkflow.shadow and span facets on the @taxonomy.* numeric attributes charted here. Apply with the Datadog MCP upsert_datadog_dashboard (title/description/template_variables/widgets); the spans-source request syntax should be validated on first apply.",
+  "description": "Reads the APM span `taxonomy.gardenTaxonomyWorkflow.shadow` emitted by the workflows service to compare the static (production) taxonomy tree against the adaptive candidate tree while shadow mode is enabled environment-wide. The app ships logs to CloudWatch only, so this dashboard uses the APM spans channel, not Datadog Logs. Requires a Datadog APM retention filter that keeps resource_name:taxonomy.gardenTaxonomyWorkflow.shadow and span facets on the @taxonomy.* numeric attributes charted here. Apply with the Datadog MCP upsert_datadog_dashboard (title/description/template_variables/widgets); the spans-source request syntax should be validated on first apply.",
   "layout_type": "ordered",
   "template_variables": [
     { "name": "organization", "prefix": "@taxonomy.organizationId", "available_values": [], "default": "*" },
@@ -10,7 +10,7 @@
     {
       "definition": {
         "type": "note",
-        "content": "## Taxonomy adaptive clustering — shadow comparison\n\nInternal engineering view over the `taxonomy.gardenTaxonomyWorkflow.shadow` APM span emitted by the **workflows** service. Each span carries the static (production) tree shape, the adaptive (candidate) tree shape, and their diff, so we can compare the two clustering algorithms without swapping what gets persisted.\n\n**Pilot tell:** a project row where `static.rootChildCount` ≈ 1 while adaptive is 3–5 — static collapsed everything under one root child, adaptive split it into real top-level clusters.\n\n**Decision-grade reads need ~1–2 weeks of turnover** — gardening runs are infrequent per project, so give the window time to accumulate representative runs.\n\n> Requires a Datadog APM retention filter keeping `operation_name:taxonomy.gardenTaxonomyWorkflow.shadow` and span facets on these numeric attributes.",
+        "content": "## Taxonomy adaptive clustering — shadow comparison\n\nInternal engineering view over the `taxonomy.gardenTaxonomyWorkflow.shadow` APM span emitted by the **workflows** service. Each span carries the static (production) tree shape, the adaptive (candidate) tree shape, and their diff, so we can compare the two clustering algorithms without swapping what gets persisted.\n\n**Pilot tell:** a project row where `static.rootChildCount` ≈ 1 while adaptive is 3–5 — static collapsed everything under one root child, adaptive split it into real top-level clusters.\n\n**Decision-grade reads need ~1–2 weeks of turnover** — gardening runs are infrequent per project, so give the window time to accumulate representative runs.\n\n> Requires a Datadog APM retention filter keeping `resource_name:taxonomy.gardenTaxonomyWorkflow.shadow` and span facets on these numeric attributes.",
         "background_color": "yellow",
         "font_size": "14",
         "text_align": "left",
@@ -40,7 +40,7 @@
                       "data_source": "spans",
                       "name": "static_root",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.shadow.static.rootChildCount" },
                       "group_by": [
@@ -52,7 +52,7 @@
                       "data_source": "spans",
                       "name": "adaptive_root",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.shadow.adaptive.rootChildCount" },
                       "group_by": [
@@ -64,7 +64,7 @@
                       "data_source": "spans",
                       "name": "partition_ari",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.shadow.diff.partitionAri" },
                       "group_by": [
@@ -76,7 +76,7 @@
                       "data_source": "spans",
                       "name": "obs_sampled",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.adaptive.observationsSampled" },
                       "group_by": [
@@ -111,7 +111,7 @@
                       "data_source": "spans",
                       "name": "root_child_delta",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.shadow.diff.rootChildDelta" },
                       "group_by": [{ "facet": "@taxonomy.projectId", "limit": 50 }]
@@ -150,7 +150,7 @@
                       "data_source": "spans",
                       "name": "rej_undersized",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "sum", "metric": "@taxonomy.adaptive.rejection.undersizedChild" }
                     },
@@ -158,7 +158,7 @@
                       "data_source": "spans",
                       "name": "rej_dominant",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "sum", "metric": "@taxonomy.adaptive.rejection.dominantChild" }
                     },
@@ -166,7 +166,7 @@
                       "data_source": "spans",
                       "name": "rej_low_score",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "sum", "metric": "@taxonomy.adaptive.rejection.lowScore" }
                     },
@@ -174,7 +174,7 @@
                       "data_source": "spans",
                       "name": "rej_low_relsep",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": {
                         "aggregation": "sum",
@@ -208,7 +208,7 @@
                       "data_source": "spans",
                       "name": "adaptive_dur",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.adaptive.durationMs" }
                     },
@@ -216,7 +216,7 @@
                       "data_source": "spans",
                       "name": "static_dur",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.adaptive.staticDurationMs" }
                     }
@@ -246,7 +246,7 @@
                       "data_source": "spans",
                       "name": "rel_sep_p50",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "avg", "metric": "@taxonomy.adaptive.relSep.p50" }
                     }
@@ -272,7 +272,7 @@
                       "data_source": "spans",
                       "name": "fallbacks",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project -@taxonomy.adaptive.fallbackReason:none"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project -@taxonomy.adaptive.fallbackReason:none"
                       },
                       "compute": { "aggregation": "count", "metric": "count" }
                     }
@@ -302,7 +302,7 @@
                       "data_source": "spans",
                       "name": "peak_rss",
                       "search": {
-                        "query": "service:workflows operation_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
+                        "query": "service:workflows resource_name:taxonomy.gardenTaxonomyWorkflow.shadow $organization $project"
                       },
                       "compute": { "aggregation": "max", "metric": "@taxonomy.adaptive.peakRssBytes" }
                     }


### PR DESCRIPTION
## What

The `taxonomy.gardenTaxonomyWorkflow.shadow` span name lands in Datadog's **`resource_name`** (the OTEL span-kind maps `operation_name` to `Internal`). Our shadow-comparison artifacts all queried `operation_name:…`, so they matched **nothing**:

- retention filter kept 0 spans (spans survived only via `manual.keep` / diversity sampling)
- the 9 span metrics never collected
- the dashboard rendered "No data"

## Change

- `taxonomy-shadow-comparison-dashboard.json`: every widget query `operation_name:` → `resource_name:` (16 spots).
- `setup-datadog.sh`: same fix in the shared query, and made the script **idempotent** (delete-then-create) so re-running repairs a drifted definition instead of skipping on `409`. `post()` no longer treats `409` as success.

## Prod state

Already reconciled by hand: retention filter + 9 metrics recreated with the corrected filter, dashboard `suz-mb6-27u` created. This PR just brings the repo in line with prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Datadog span filtering to use the correct resource name, improving taxonomy shadow workflow tracking.
  * Made monitoring setup reliably repeatable by replacing existing retention filters and metrics before recreating them.
  * Added stricter validation for required Datadog credentials and improved setup failure handling.
* **Monitoring**
  * Updated taxonomy shadow comparison dashboard queries to consistently use resource-based filtering across all related widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->