### PR TITLE
Add backoffice taxonomy gardening action

### DIFF
--- a/apps/web/src/domains/admin/taxonomy.functions.test.ts
+++ b/apps/web/src/domains/admin/taxonomy.functions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { adminGetProjectTaxonomyInputSchema } from "./taxonomy.functions.ts"
+import { adminGetProjectTaxonomyInputSchema, adminTriggerProjectGardeningInputSchema } from "./taxonomy.functions.ts"
 
 describe("adminGetProjectTaxonomyInputSchema", () => {
   it("accepts a valid projectId", () => {
@@ -16,5 +16,23 @@ describe("adminGetProjectTaxonomyInputSchema", () => {
 
   it("rejects missing projectId", () => {
     expect(adminGetProjectTaxonomyInputSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe("adminTriggerProjectGardeningInputSchema", () => {
+  it("accepts a valid projectId", () => {
+    expect(adminTriggerProjectGardeningInputSchema.safeParse({ projectId: "proj-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty projectId", () => {
+    expect(adminTriggerProjectGardeningInputSchema.safeParse({ projectId: "" }).success).toBe(false)
+  })
+
+  it("rejects a projectId above the max length", () => {
+    expect(adminTriggerProjectGardeningInputSchema.safeParse({ projectId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing projectId", () => {
+    expect(adminTriggerProjectGardeningInputSchema.safeParse({}).success).toBe(false)
   })
 })

--- a/apps/web/src/domains/admin/taxonomy.functions.ts
+++ b/apps/web/src/domains/admin/taxonomy.functions.ts
@@ -1,12 +1,14 @@
-import { type AdminProjectTaxonomy, getProjectTaxonomyUseCase } from "@domain/admin"
-import { ProjectId } from "@domain/shared"
-import { AdminTaxonomyRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { type AdminProjectTaxonomy, getProjectDetailsUseCase, getProjectTaxonomyUseCase } from "@domain/admin"
+import { QueuePublisher } from "@domain/queue"
+import { OrganizationId, ProjectId } from "@domain/shared"
+import { triggerProjectGardeningUseCase } from "@domain/taxonomy"
+import { AdminProjectRepositoryLive, AdminTaxonomyRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
 import { adminMiddleware } from "../../server/admin-middleware.ts"
-import { getAdminPostgresClient } from "../../server/clients.ts"
+import { getAdminPostgresClient, getQueuePublisher } from "../../server/clients.ts"
 
 export interface AdminTaxonomySubcategoryDto {
   id: string
@@ -91,4 +93,29 @@ export const adminGetProjectTaxonomy = createServerFn({ method: "GET" })
     )
 
     return toDto(taxonomy)
+  })
+
+export const adminTriggerProjectGardeningInputSchema = z.object({
+  projectId: z.string().min(1).max(256),
+})
+
+export const adminTriggerProjectGardening = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminTriggerProjectGardeningInputSchema)
+  .handler(async ({ data }): Promise<{ queued: true }> => {
+    const project = await Effect.runPromise(
+      getProjectDetailsUseCase({ projectId: ProjectId(data.projectId) }).pipe(
+        withPostgres(AdminProjectRepositoryLive, getAdminPostgresClient()),
+        withTracing,
+      ),
+    )
+    const publisher = await getQueuePublisher()
+
+    return await Effect.runPromise(
+      triggerProjectGardeningUseCase({
+        organizationId: OrganizationId(project.organization.id),
+        projectId: ProjectId(project.id),
+        reason: "manual",
+      }).pipe(Effect.provideService(QueuePublisher, publisher), withTracing),
+    )
   })

--- a/apps/web/src/routes/backoffice/projects/$projectId.tsx
+++ b/apps/web/src/routes/backoffice/projects/$projectId.tsx
@@ -1,7 +1,7 @@
 import { ClaudeCodeIcon, Icon, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { ArrowRightIcon, BrainCircuitIcon, CheckIcon, MinusIcon } from "lucide-react"
+import { ArrowRightIcon, BrainCircuitIcon, CheckIcon, MinusIcon, SproutIcon } from "lucide-react"
 import { adminGetProject } from "../../../domains/admin/projects.functions.ts"
 import { adminGetProjectTaxonomy } from "../../../domains/admin/taxonomy.functions.ts"
 import { ActionRow, ActionsSection } from "../-components/actions-section/section.tsx"
@@ -15,6 +15,7 @@ import {
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 import { MetricsSection } from "./-components/metrics-section.tsx"
 import { SessionIntelligenceBackfillButton } from "./-components/session-intelligence-backfill-button.tsx"
+import { TaxonomyGardeningButton } from "./-components/taxonomy-gardening-button.tsx"
 import { TaxonomySection } from "./-components/taxonomy-section.tsx"
 import { WrappedTriggerButton } from "./-components/wrapped-trigger-button.tsx"
 
@@ -144,6 +145,12 @@ function BackofficeProjectDetailPage() {
           title="Reset and backfill session intelligence"
           description="Delete this project's existing taxonomy and session-intelligence rows, then start AnalyzeSessionWorkflow for the latest 1,500 sessions. Requires typed confirmation."
           action={<SessionIntelligenceBackfillButton projectId={project.id} projectName={project.name} />}
+        />
+        <ActionRow
+          icon={SproutIcon}
+          title="Garden behavior taxonomy"
+          description="Use recent behavior observations to update the taxonomy when the project is eligible."
+          action={<TaxonomyGardeningButton projectId={project.id} projectName={project.name} />}
         />
       </ActionsSection>
 

--- a/apps/web/src/routes/backoffice/projects/-components/taxonomy-gardening-button.tsx
+++ b/apps/web/src/routes/backoffice/projects/-components/taxonomy-gardening-button.tsx
@@ -1,0 +1,69 @@
+import { Alert, Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useRouter } from "@tanstack/react-router"
+import { useState } from "react"
+import { adminTriggerProjectGardening } from "../../../../domains/admin/taxonomy.functions.ts"
+import { toUserMessage } from "../../../../lib/errors.ts"
+
+interface TaxonomyGardeningButtonProps {
+  readonly projectId: string
+  readonly projectName: string
+}
+
+export function TaxonomyGardeningButton({ projectId, projectName }: TaxonomyGardeningButtonProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true)
+    try {
+      await adminTriggerProjectGardening({ data: { projectId } })
+      toast({
+        description: `Behavior taxonomy gardening request accepted for ${projectName}.`,
+      })
+      setIsOpen(false)
+      void router.invalidate()
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not garden behavior taxonomy",
+        description: toUserMessage(error),
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setIsOpen(true)}>
+        Garden taxonomy
+      </Button>
+      <Modal.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Modal.Content dismissible size="large">
+          <Modal.Header
+            title="Garden behavior taxonomy"
+            description={
+              <Text.H5 color="foregroundMuted">
+                Update the behavior taxonomy for <span className="font-medium text-foreground">{projectName}</span>.
+              </Text.H5>
+            }
+          />
+          <Modal.Body>
+            <Alert
+              variant="warning"
+              description="Gardening uses recent behavior observations and may be skipped or coalesced if the project is not eligible or is already scheduled."
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <CloseTrigger />
+            <Button type="button" size="sm" disabled={isSubmitting} onClick={() => void handleConfirm()}>
+              {isSubmitting ? "Gardening…" : "Garden taxonomy"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  )
+}

--- a/apps/workers/src/scripts/backfill-conversation-intelligence.ts
+++ b/apps/workers/src/scripts/backfill-conversation-intelligence.ts
@@ -11,7 +11,7 @@ import {
   getRedisClient,
   getWorkflowStarter,
 } from "../clients.ts"
-import { runGardenProjectJob } from "../workers/taxonomy.ts"
+import { readObservationCounts, runGardenProjectJob } from "../workers/taxonomy.ts"
 
 const DEFAULT_LIMIT_PER_PROJECT = 200
 
@@ -326,7 +326,10 @@ void Effect.runPromise(
         console.log(`Gardening taxonomy for project ${project.project_id}`)
         yield* runGardenProjectJob(
           { organizationId: project.organization_id, projectId: project.project_id, reason: "manual" },
-          { clickhouseClient: clickhouse, postgresClient: getPostgresClient(), redisClient: redis, workflowStarter },
+          {
+            workflowStarter,
+            readObservationCounts: (input) => readObservationCounts(clickhouse, input),
+          },
         )
       }
     }

--- a/apps/workers/src/workers/taxonomy.test.ts
+++ b/apps/workers/src/workers/taxonomy.test.ts
@@ -133,24 +133,6 @@ const enoughObservationCounts = () =>
     noise: TAXONOMY_GARDENING_MIN_OBSERVATIONS,
   })
 
-const createFakeRedisClient = () => {
-  const values = new Map<string, string>()
-  return {
-    get: async (key: string) => values.get(key) ?? null,
-    set: async (key: string, value: string, ...args: unknown[]) => {
-      if (args.includes("NX") && values.has(key)) return null
-      values.set(key, value)
-      return "OK"
-    },
-    del: async (key: string) => values.delete(key),
-    eval: async (_script: string, _keyCount: number, key: string, token: string) => {
-      if (values.get(key) !== token) return 0
-      values.delete(key)
-      return 1
-    },
-  }
-}
-
 const makeObservation = (
   index: number,
   projectId = PROJECT_ID,
@@ -411,10 +393,8 @@ describe("taxonomy gardening worker", () => {
       runGardenProjectJob(
         { organizationId: ORGANIZATION_ID, projectId: PROJECT_ID, reason: "manual" },
         {
-          clickhouseClient: ch.client,
-          postgresClient: pg.appPostgresClient,
-          redisClient: createFakeRedisClient() as never,
           workflowStarter: workflowStarter as never,
+          readObservationCounts: enoughObservationCounts,
         },
       ),
     )
@@ -423,9 +403,56 @@ describe("taxonomy gardening worker", () => {
       {
         workflow: "gardenTaxonomyWorkflow",
         input: { organizationId: ORGANIZATION_ID, projectId: PROJECT_ID, dimension: "topic", trigger: "manual" },
-        workflowId: `org:${ORGANIZATION_ID}:taxonomy:garden:${PROJECT_ID}`,
+        workflowId: `org:${ORGANIZATION_ID}:taxonomy:gardenProject:${PROJECT_ID}`,
       },
     ])
+  })
+
+  it("does not start the garden workflow below the recent-observation minimum", async () => {
+    const { started, starter } = recordingWorkflowStarter()
+
+    await Effect.runPromise(
+      runGardenProjectJob(
+        { organizationId: ORGANIZATION_ID, projectId: PROJECT_ID, reason: "manual" },
+        {
+          workflowStarter: starter as never,
+          readObservationCounts: () =>
+            Effect.succeed({
+              total: TAXONOMY_GARDENING_MIN_OBSERVATIONS - 1,
+              assigned: 0,
+              noise: TAXONOMY_GARDENING_MIN_OBSERVATIONS - 1,
+            }),
+        },
+      ),
+    )
+
+    expect(started).toHaveLength(0)
+  })
+
+  it("collapses WorkflowAlreadyStartedError from an already-running global workflow into a no-op", async () => {
+    let calls = 0
+    const starter = {
+      start: () => {
+        calls += 1
+        return Effect.fail(
+          new WorkflowAlreadyStartedError({
+            workflowId: `org:${ORGANIZATION_ID}:taxonomy:gardenProject:${PROJECT_ID}`,
+            workflow: "gardenTaxonomyWorkflow",
+          }),
+        )
+      },
+      signalWithStart: () => Effect.void,
+    }
+
+    await expect(
+      Effect.runPromise(
+        runGardenProjectJob(
+          { organizationId: ORGANIZATION_ID, projectId: PROJECT_ID, reason: "manual" },
+          { workflowStarter: starter as never, readObservationCounts: enoughObservationCounts },
+        ),
+      ),
+    ).resolves.toBeUndefined()
+    expect(calls).toBe(1)
   })
 
   it("starts the scoped workflow deduped on the behavior, passing the job reason as trigger", async () => {

--- a/apps/workers/src/workers/taxonomy.ts
+++ b/apps/workers/src/workers/taxonomy.ts
@@ -65,6 +65,11 @@ interface TaxonomyRuntimeDeps {
   readonly workflowStarter?: WorkflowStarterShape
 }
 
+interface GardenProjectDeps {
+  readonly workflowStarter?: WorkflowStarterShape
+  readonly readObservationCounts: (input: ObservationCountsInput) => Effect.Effect<TaxonomyObservationCounts, unknown>
+}
+
 interface ActiveProjectRow {
   readonly organization_id: string
   readonly project_id: string
@@ -117,7 +122,7 @@ const listGardenableCustomBehaviorsEffect = (adminPostgresClient: PostgresClient
     catch: (cause) => cause,
   })
 
-const readObservationCounts = (clickhouseClient: ClickHouseClient, input: ObservationCountsInput) =>
+export const readObservationCounts = (clickhouseClient: ClickHouseClient, input: ObservationCountsInput) =>
   Effect.gen(function* () {
     const repo = yield* TaxonomyObservationRepository
     return yield* repo.getCounts(input)
@@ -250,35 +255,66 @@ export const runGardenCustomBehaviorSweepJob = (
     Effect.asVoid,
   )
 
-export const runGardenProjectJob = (payload: GardenProjectPayload, deps: TaxonomyRuntimeDeps) => {
+export const runGardenProjectJob = (payload: GardenProjectPayload, deps: GardenProjectDeps) => {
   if (deps.workflowStarter) {
-    const workflowId = `org:${payload.organizationId}:taxonomy:garden:${payload.projectId}`
-    return deps.workflowStarter
-      .start(
-        "gardenTaxonomyWorkflow",
-        {
+    const workflowStarter = deps.workflowStarter
+    const organizationId = OrganizationId(payload.organizationId)
+    const projectId = ProjectId(payload.projectId)
+    const workflowId = taxonomyGardenProjectDedupeKey({ organizationId, projectId })
+    return Effect.gen(function* () {
+      const counts = yield* deps.readObservationCounts({
+        organizationId,
+        projectId,
+        since: lookbackStart(new Date()),
+      })
+      if (counts.total < TAXONOMY_GARDENING_MIN_OBSERVATIONS) {
+        yield* Effect.sync(() =>
+          logger.info("Taxonomy gardening skipped: insufficient recent observations", {
+            metric: "taxonomy.gardenProject.workflowStart",
+            outcome: "skipped",
+            organizationId: payload.organizationId,
+            projectId: payload.projectId,
+            observations: counts.total,
+          }),
+        )
+        return
+      }
+
+      const started = yield* workflowStarter
+        .start(
+          "gardenTaxonomyWorkflow",
+          {
+            organizationId: payload.organizationId,
+            projectId: payload.projectId,
+            dimension: "topic",
+            trigger: payload.reason,
+          },
+          { workflowId },
+        )
+        .pipe(
+          Effect.as(true),
+          Effect.catchTag("WorkflowAlreadyStartedError", () =>
+            Effect.sync(() => {
+              logger.info("GardenTaxonomyWorkflow already running", {
+                metric: "taxonomy.gardenProject.workflowStart",
+                outcome: "already_running",
+                organizationId: payload.organizationId,
+                projectId: payload.projectId,
+                workflowId,
+              })
+            }).pipe(Effect.as(false)),
+          ),
+        )
+      if (!started) return
+      yield* Effect.sync(() =>
+        logger.info("Started GardenTaxonomyWorkflow", {
+          metric: "taxonomy.gardenProject.workflowStart",
           organizationId: payload.organizationId,
           projectId: payload.projectId,
-          dimension: "topic",
-          trigger: payload.reason,
-        },
-        { workflowId },
+          workflowId,
+        }),
       )
-      .pipe(
-        Effect.tap(() =>
-          Effect.sync(() =>
-            logger.info("Started GardenTaxonomyWorkflow", {
-              metric: "taxonomy.gardenProject.workflowStart",
-              organizationId: payload.organizationId,
-              projectId: payload.projectId,
-              workflowId,
-            }),
-          ),
-        ),
-        withTracing,
-        Effect.withSpan("taxonomy.gardenProject.startWorkflow"),
-        Effect.asVoid,
-      )
+    }).pipe(withTracing, Effect.withSpan("taxonomy.gardenProject.startWorkflow"), Effect.asVoid)
   }
 
   // The Temporal workflow is the only gardening orchestrator; without a
@@ -368,11 +404,8 @@ export const createTaxonomyWorker = ({
   consumer.subscribe("taxonomy", {
     gardenProject: (payload) =>
       runGardenProjectJob(payload as GardenProjectPayload, {
-        clickhouseClient,
-        postgresClient,
-        redisClient,
-        publisher,
         workflowStarter,
+        readObservationCounts: (input) => readObservationCounts(clickhouseClient, input),
       }),
     gardenSweep: (payload) =>
       runGardenSweepJob(payload as GardenSweepPayload, {


### PR DESCRIPTION
Adds a project-level action to request behavior taxonomy gardening from the backoffice. The server function accepts only a project ID, resolves the organization through the admin project repository, and publishes the existing throttled gardening task. The project page shows a confirmation modal that explains eligibility and coalescing behavior.

The worker now checks the recent-observation minimum before starting a global gardening workflow. Manual and cron requests share the same Temporal workflow ID, and an already-running workflow is treated as a no-op. This prevents empty runs from replacing an existing taxonomy and prevents concurrent gardening for the same project.

## Validation

- `pnpm --filter @app/web check`
- `pnpm --filter @app/workers check`
- pre-commit workspace format and knip hooks
- `git diff --check`

Focused Vitest runs and package typechecks are blocked locally by unresolved existing workspace dependencies including `js-tiktoken`, `rosetta-ai`, `diff`, and `@domain/conversation-intelligence`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a backoffice action to manually start behavior taxonomy gardening for a project.
  * Added confirmation, progress, success, and error feedback for the gardening action.
  * Gardening now starts only when sufficient recent observations are available.
* **Bug Fixes**
  * Repeated gardening requests are safely treated as no-ops when a workflow is already running.
  * Gardening requests complete without errors when workflow scheduling is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->