### PR TITLE
feat: onboarding empty state for the Memory page

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
@@ -1809,10 +1809,7 @@ export function getCodingAgentTelemetryPrompt(): string {
   return "Install the `latitude-telemetry` skill from `github.com/latitude-dev/skills`, and use it to add Latitude tracing to this app following best practices."
 }
 
-/**
- * Mirrors the memory-tracing docs prompt
- * (https://docs.latitude.so/telemetry/memory#instrument-with-your-coding-agent).
- */
+/** Mirrors the memory-tracing docs prompt (docs.latitude.so/telemetry/memory). */
 export function getMemoryTelemetryPrompt(): string {
   return "Install the `latitude-telemetry` skill from `github.com/latitude-dev/skills`, and use it to add Latitude memory observability to this app's long-term memory, following best practices."
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
@@ -1809,6 +1809,14 @@ export function getCodingAgentTelemetryPrompt(): string {
   return "Install the `latitude-telemetry` skill from `github.com/latitude-dev/skills`, and use it to add Latitude tracing to this app following best practices."
 }
 
+/**
+ * Mirrors the memory-tracing docs prompt
+ * (https://docs.latitude.so/telemetry/memory#instrument-with-your-coding-agent).
+ */
+export function getMemoryTelemetryPrompt(): string {
+  return "Install the `latitude-telemetry` skill from `github.com/latitude-dev/skills`, and use it to add Latitude memory observability to this app's long-term memory, following best practices."
+}
+
 export type CodingMachineAgentId = "claude-code" | "openclaw" | "hermes" | "pi"
 
 export function getCodingMachineTelemetryInstallCommand(agent: CodingMachineAgentId): string {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
@@ -1,5 +1,8 @@
-import { Icon, Text } from "@repo/ui"
-import { BrainIcon } from "lucide-react"
+import { Button, CodeBlock, cn, Icon, Skeleton, Text } from "@repo/ui"
+import { BrainIcon, ExternalLinkIcon } from "lucide-react"
+import { getMemoryTelemetryPrompt } from "../../-components/onboarding-integration-snippets.ts"
+
+const MEMORY_DOCS_HREF = "https://docs.latitude.so/telemetry/memory"
 
 export function MemoryUnavailableState() {
   return (
@@ -19,20 +22,156 @@ export function MemoryUnavailableState() {
   )
 }
 
-export function MemoryEmptyState({ isLoading = false }: { readonly isLoading?: boolean }) {
+/**
+ * Empty state for a project with no memory captured. Memory is opt-in — no
+ * auto-instrumentation emits it — so unlike Tools/Users this is a "you must
+ * instrument it" onboarding, not a "wait for data" notice. A skeleton of a
+ * populated store (filetree + a record diff) sits behind a compact card whose
+ * primary action is a copy-paste coding-agent prompt. Mirrors the layering of
+ * `TracesEmptyOnboarding`.
+ */
+export function MemoryEmptyState() {
   return (
-    <div className="h-full w-full flex items-center justify-center p-8">
-      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
-        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
-          <Icon icon={BrainIcon} size="lg" color="foregroundMuted" />
+    <div className="relative h-full w-full overflow-hidden">
+      <MemoryPreviewBackdrop />
+      {/* Fade the skeleton into the page background top-to-bottom. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-background/60 to-background"
+      />
+      {/* Solid background masked to a center ellipse — grounds the card by
+          dissolving the skeleton behind it with no card/modal edge. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-background [-webkit-mask-image:radial-gradient(ellipse_70%_55%_at_50%_50%,black_35%,transparent_72%)] [mask-image:radial-gradient(ellipse_70%_55%_at_50%_50%,black_35%,transparent_72%)]"
+      />
+      <div className="absolute inset-0 flex items-center justify-center overflow-y-auto p-8">
+        <MemoryConnectCard />
+      </div>
+    </div>
+  )
+}
+
+function MemoryConnectCard() {
+  const prompt = getMemoryTelemetryPrompt()
+  return (
+    <div className="flex w-full max-w-md flex-col items-start gap-5">
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
+        <Icon icon={BrainIcon} size="lg" color="foregroundMuted" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Text.H3 weight="medium">Track how your agent's memory evolves</Text.H3>
+        <Text.H5 color="foregroundMuted">
+          See what your agent reads and writes to its memory. Point your memory operations at Latitude to start tracking
+          them.
+        </Text.H5>
+      </div>
+
+      <div className="flex w-full flex-col gap-1.5">
+        <Text.H6 color="foregroundMuted">Ask your coding agent</Text.H6>
+        <CodeBlock value={prompt} copyable wrapLines />
+      </div>
+
+      <a href={MEMORY_DOCS_HREF} target="_blank" rel="noopener noreferrer">
+        <Button variant="outline">
+          <Icon size="sm" icon={ExternalLinkIcon} />
+          Read the docs
+        </Button>
+      </a>
+    </div>
+  )
+}
+
+/** Indent + bar width per faux filetree row; one row reads as the selected record. */
+const TREE_ROWS: readonly { readonly indent: string; readonly width: string; readonly selected?: boolean }[] = [
+  { indent: "pl-2", width: "w-24" },
+  { indent: "pl-8", width: "w-20", selected: true },
+  { indent: "pl-8", width: "w-28" },
+  { indent: "pl-2", width: "w-20" },
+  { indent: "pl-8", width: "w-16" },
+  { indent: "pl-8", width: "w-24" },
+  { indent: "pl-2", width: "w-16" },
+  { indent: "pl-8", width: "w-28" },
+  { indent: "pl-2", width: "w-24" },
+]
+
+/** Kind + bar width per faux unified-diff line. */
+const DIFF_ROWS: readonly { readonly kind: "context" | "add" | "remove"; readonly width: string }[] = [
+  { kind: "context", width: "w-16" },
+  { kind: "remove", width: "w-52" },
+  { kind: "add", width: "w-64" },
+  { kind: "context", width: "w-40" },
+  { kind: "add", width: "w-48" },
+  { kind: "context", width: "w-24" },
+  { kind: "context", width: "w-56" },
+  { kind: "remove", width: "w-36" },
+  { kind: "add", width: "w-44" },
+  { kind: "context", width: "w-32" },
+  { kind: "context", width: "w-48" },
+  { kind: "context", width: "w-16" },
+]
+
+/** A static (non-pulsing) skeleton bar — this is a decorative preview, not loading. */
+function Shape({ className }: { readonly className?: string }) {
+  return <Skeleton animate={false} className={className} />
+}
+
+/** Non-interactive skeleton of a populated store — the filetree beside a record diff. */
+function MemoryPreviewBackdrop() {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="flex h-full flex-col">
+        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-6">
+          <Shape className="h-4 w-4 rounded" />
+          <Shape className="h-4 w-40" />
+          <div className="ml-auto flex items-center gap-1.5">
+            <Shape className="h-5 w-5 rounded-full" />
+            <Shape className="h-5 w-5 rounded-full" />
+            <Shape className="h-5 w-5 rounded-full" />
+          </div>
         </div>
-        <div className="flex flex-col items-center gap-2">
-          <Text.H3 centered>{isLoading ? "Loading memory" : "No memory stores yet"}</Text.H3>
-          <Text.H5 color="foregroundMuted" centered>
-            {isLoading
-              ? "Preparing your memory view."
-              : "Memory stores appear when your traces emit memory operations (create, update, search) carrying a store id."}
-          </Text.H5>
+        <div className="flex min-h-0 flex-1 flex-row">
+          <div className="flex w-[280px] min-w-[280px] shrink-0 flex-col border-r">
+            <div className="flex h-9 shrink-0 items-center border-b px-3">
+              <Shape className="h-3 w-20" />
+            </div>
+            <div className="flex flex-col gap-1 p-2">
+              {TREE_ROWS.map((row, i) => (
+                <div
+                  key={`tree-${i}`}
+                  className={cn("flex h-7 items-center gap-2 rounded pr-2", row.indent, row.selected && "bg-accent")}
+                >
+                  <Shape className="h-3.5 w-3.5 shrink-0 rounded" />
+                  <Shape className={cn("h-3", row.width)} />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4">
+              <Shape className="h-3.5 w-3.5 rounded" />
+              <Shape className="h-3.5 w-28" />
+              <Shape className="h-4 w-10 rounded" />
+              <Shape className="ml-auto h-3 w-12" />
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col p-3">
+              {DIFF_ROWS.map((row, i) => (
+                <div
+                  key={`diff-${i}`}
+                  className={cn(
+                    "flex h-[22px] items-center gap-2 px-1",
+                    row.kind === "add" && "bg-success/10",
+                    row.kind === "remove" && "bg-destructive/10",
+                  )}
+                >
+                  <Shape className="h-2.5 w-5 shrink-0" />
+                  <Shape className="h-2.5 w-5 shrink-0" />
+                  <Shape className={cn("ml-1 h-3", row.width)} />
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/-components/memory-empty-state.tsx
@@ -22,25 +22,14 @@ export function MemoryUnavailableState() {
   )
 }
 
-/**
- * Empty state for a project with no memory captured. Memory is opt-in — no
- * auto-instrumentation emits it — so unlike Tools/Users this is a "you must
- * instrument it" onboarding, not a "wait for data" notice. A skeleton of a
- * populated store (filetree + a record diff) sits behind a compact card whose
- * primary action is a copy-paste coding-agent prompt. Mirrors the layering of
- * `TracesEmptyOnboarding`.
- */
 export function MemoryEmptyState() {
   return (
     <div className="relative h-full w-full overflow-hidden">
       <MemoryPreviewBackdrop />
-      {/* Fade the skeleton into the page background top-to-bottom. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-background/60 to-background"
       />
-      {/* Solid background masked to a center ellipse — grounds the card by
-          dissolving the skeleton behind it with no card/modal edge. */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 bg-background [-webkit-mask-image:radial-gradient(ellipse_70%_55%_at_50%_50%,black_35%,transparent_72%)] [mask-image:radial-gradient(ellipse_70%_55%_at_50%_50%,black_35%,transparent_72%)]"
@@ -73,17 +62,16 @@ function MemoryConnectCard() {
         <CodeBlock value={prompt} copyable wrapLines />
       </div>
 
-      <a href={MEMORY_DOCS_HREF} target="_blank" rel="noopener noreferrer">
-        <Button variant="outline">
+      <Button asChild variant="outline">
+        <a href={MEMORY_DOCS_HREF} target="_blank" rel="noopener noreferrer">
           <Icon size="sm" icon={ExternalLinkIcon} />
           Read the docs
-        </Button>
-      </a>
+        </a>
+      </Button>
     </div>
   )
 }
 
-/** Indent + bar width per faux filetree row; one row reads as the selected record. */
 const TREE_ROWS: readonly { readonly indent: string; readonly width: string; readonly selected?: boolean }[] = [
   { indent: "pl-2", width: "w-24" },
   { indent: "pl-8", width: "w-20", selected: true },
@@ -96,7 +84,6 @@ const TREE_ROWS: readonly { readonly indent: string; readonly width: string; rea
   { indent: "pl-2", width: "w-24" },
 ]
 
-/** Kind + bar width per faux unified-diff line. */
 const DIFF_ROWS: readonly { readonly kind: "context" | "add" | "remove"; readonly width: string }[] = [
   { kind: "context", width: "w-16" },
   { kind: "remove", width: "w-52" },
@@ -112,20 +99,20 @@ const DIFF_ROWS: readonly { readonly kind: "context" | "add" | "remove"; readonl
   { kind: "context", width: "w-16" },
 ]
 
-/** A static (non-pulsing) skeleton bar — this is a decorative preview, not loading. */
 function Shape({ className }: { readonly className?: string }) {
   return <Skeleton animate={false} className={className} />
 }
 
-/** Non-interactive skeleton of a populated store — the filetree beside a record diff. */
 function MemoryPreviewBackdrop() {
   return (
     <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
       <div className="flex h-full flex-col">
-        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-6">
-          <Shape className="h-4 w-4 rounded" />
-          <Shape className="h-4 w-40" />
-          <div className="ml-auto flex items-center gap-1.5">
+        <div className="flex h-14 shrink-0 items-center justify-between border-b px-6">
+          <div className="flex items-center gap-2.5">
+            <Shape className="h-4 w-4 rounded" />
+            <Shape className="h-4 w-40" />
+          </div>
+          <div className="flex items-center gap-1.5">
             <Shape className="h-5 w-5 rounded-full" />
             <Shape className="h-5 w-5 rounded-full" />
             <Shape className="h-5 w-5 rounded-full" />
@@ -140,7 +127,7 @@ function MemoryPreviewBackdrop() {
               {TREE_ROWS.map((row, i) => (
                 <div
                   key={`tree-${i}`}
-                  className={cn("flex h-7 items-center gap-2 rounded pr-2", row.indent, row.selected && "bg-accent")}
+                  className={cn("flex h-7 items-center gap-2 rounded pr-2", row.indent, { "bg-accent": row.selected })}
                 >
                   <Shape className="h-3.5 w-3.5 shrink-0 rounded" />
                   <Shape className={cn("h-3", row.width)} />
@@ -149,25 +136,26 @@ function MemoryPreviewBackdrop() {
             </div>
           </div>
           <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <div className="flex h-11 shrink-0 items-center gap-2 border-b px-4">
-              <Shape className="h-3.5 w-3.5 rounded" />
-              <Shape className="h-3.5 w-28" />
-              <Shape className="h-4 w-10 rounded" />
-              <Shape className="ml-auto h-3 w-12" />
+            <div className="flex h-11 shrink-0 items-center justify-between border-b px-4">
+              <div className="flex items-center gap-2">
+                <Shape className="h-3.5 w-3.5 rounded" />
+                <Shape className="h-3.5 w-28" />
+                <Shape className="h-4 w-10 rounded" />
+              </div>
+              <Shape className="h-3 w-12" />
             </div>
             <div className="flex min-h-0 flex-1 flex-col p-3">
               {DIFF_ROWS.map((row, i) => (
                 <div
                   key={`diff-${i}`}
-                  className={cn(
-                    "flex h-[22px] items-center gap-2 px-1",
-                    row.kind === "add" && "bg-success/10",
-                    row.kind === "remove" && "bg-destructive/10",
-                  )}
+                  className={cn("flex h-[22px] items-center gap-2 px-1", {
+                    "bg-success/10": row.kind === "add",
+                    "bg-destructive/10": row.kind === "remove",
+                  })}
                 >
                   <Shape className="h-2.5 w-5 shrink-0" />
                   <Shape className="h-2.5 w-5 shrink-0" />
-                  <Shape className={cn("ml-1 h-3", row.width)} />
+                  <Shape className={cn("h-3", row.width)} />
                 </div>
               ))}
             </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/index.tsx
@@ -78,7 +78,7 @@ function MemoryPage() {
   return (
     <Layout>
       {showEmptyState ? (
-        <MemoryEmptyState isLoading={isLoading} />
+        <MemoryEmptyState />
       ) : (
         <MemoryStoresView
           stores={stores}


### PR DESCRIPTION
The Memory page showed a bare "No memory stores yet" with no next step. This replaces it with an onboarding screen that shows a developer how to start capturing memory.

Memory has no automatic instrumentation (the OTEL memory convention is still emerging), so an empty Memory page is the expected state until someone instruments their memory operations. The screen is built for that case.

## the card

A compact card with:
- a title, and a one-line description that doubles as a CTA: "Point your memory operations at Latitude to start tracking them"
- a copy-paste prompt for a coding agent (the primary action), from a new `getMemoryTelemetryPrompt()` that returns the same prompt published in `docs/telemetry/memory.mdx`
- a link to the setup docs (`/telemetry/memory`)

The copy is state-agnostic on purpose: it does not say memory "isn't captured automatically," because the setup skill can instrument memory too, and a first-time user may have just done so and be waiting for the first trace to land.

## the backdrop

Behind the card sits a static skeleton of a populated store: a record filetree next to a unified diff, with add and remove rows tinted. It fades into the page with a gradient plus a radial mask so the card reads without a modal edge, following the layering of `TracesEmptyOnboarding`. It is decorative and non-interactive, built from `Skeleton` shapes with `animate={false}` so nothing pulses, and uses no real or mocked data.

## scope

Only the flag-on, zero-stores state changed. `MemoryUnavailableState` (shown when the `memoryObservability` flag is off) is untouched. Part of the memory observability work (LAT-729).

Typecheck and Biome pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Memory empty state with an onboarding-style centered card.
  * Added a copyable telemetry setup prompt for enabling Memory observability.
  * Included a “Read the docs” link for the Memory telemetry guide.
  * Added a decorative skeleton preview backdrop for the empty-state UI.
* **Bug Fixes**
  * Updated the empty Memory view rendering so it consistently shows the new onboarding experience when there are no memory stores (and the data is not loading).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->