### PR TITLE
fix(flaggers): skip user-centric strategies on reflag classify traces

### DIFF
--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -158,6 +158,8 @@ Context compaction mirrors the moments stance: the analyzed window is the last r
 
 Every production flagger LLM call is traced into the `latitude-flaggers` dogfood project, and the flaggers run on that project too. To bound recursion to one level (`src/reflag.ts`): a flagger running on a flagger-generated session stamps its own LLM output with the no-reflag tag, and screening skips any session whose tags carry it. Session tags are the union of span tags, and flagger telemetry sessions are effectively per-trace, so the union semantics are safe.
 
+User/input-centric strategies (`classifiesAssistantResponseOnly: false` — today `frustration` and `jailbreaking`) are also dropped on first-level flagger-generated sessions (`isUserCentricReflagInapplicable`). Their "user" turn is Latitude prompt scaffolding that embeds nested evaluated evidence (task episodes, quoted corrections, jailbreak examples from the original session), which looks like a true positive for those categories. Assistant-response-centric strategies still run so reflag can catch bad classifications.
+
 ## Quality tooling
 
 - **Offline benchmark harness** (`tools/ai-benchmarks`): replays public datasets through the real classifier (no deterministic routing, no sampling, no hints) — measures classifier accuracy in isolation. Registered targets: `flaggers:jailbreaking` (JailbreakBench) and `flaggers:refusal` (XSTest) with committed baselines; the other strategies have none.

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -95,7 +95,12 @@ export {
   type UpdateFlaggerEnabledForProjectInput,
   type UpdateFlaggerInput as RepositoryUpdateFlaggerInput,
 } from "./ports/flagger-repository.ts"
-export { isFlaggerGeneratedTrace, isReflagSuppressed, reflagSuppressionTags } from "./reflag.ts"
+export {
+  isFlaggerGeneratedTrace,
+  isReflagSuppressed,
+  isUserCentricReflagInapplicable,
+  reflagSuppressionTags,
+} from "./reflag.ts"
 export {
   type ClassifySessionFlaggerInput,
   type ClassifySessionFlaggerResult,

--- a/packages/domain/flaggers/src/reflag.test.ts
+++ b/packages/domain/flaggers/src/reflag.test.ts
@@ -1,6 +1,11 @@
 import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
 import { describe, expect, it } from "vitest"
-import { isFlaggerGeneratedTrace, isReflagSuppressed, reflagSuppressionTags } from "./reflag.ts"
+import {
+  isFlaggerGeneratedTrace,
+  isReflagSuppressed,
+  isUserCentricReflagInapplicable,
+  reflagSuppressionTags,
+} from "./reflag.ts"
 
 const CLASSIFY = AI_GENERATE_TELEMETRY_TAGS.flaggerClassify[0]
 const DRAFT = AI_GENERATE_TELEMETRY_TAGS.flaggerDraft[0]
@@ -48,5 +53,22 @@ describe("reflagSuppressionTags", () => {
     const levelTwoTags = [CLASSIFY, ...reflagSuppressionTags([CLASSIFY])]
     // Level 2: must not be flagged again.
     expect(isReflagSuppressed(levelTwoTags)).toBe(true)
+  })
+})
+
+describe("isUserCentricReflagInapplicable", () => {
+  it("skips user-centric strategies on flagger.classify / flagger.draft traces", () => {
+    expect(isUserCentricReflagInapplicable([CLASSIFY], false)).toBe(true)
+    expect(isUserCentricReflagInapplicable([DRAFT], false)).toBe(true)
+  })
+
+  it("still allows assistant-response-centric strategies on flagger-generated traces", () => {
+    expect(isUserCentricReflagInapplicable([CLASSIFY], true)).toBe(false)
+    expect(isUserCentricReflagInapplicable([CLASSIFY], undefined)).toBe(false)
+  })
+
+  it("does not skip user-centric strategies on ordinary production traces", () => {
+    expect(isUserCentricReflagInapplicable([], false)).toBe(false)
+    expect(isUserCentricReflagInapplicable(["live"], false)).toBe(false)
   })
 })

--- a/packages/domain/flaggers/src/reflag.ts
+++ b/packages/domain/flaggers/src/reflag.ts
@@ -44,3 +44,18 @@ export const isReflagSuppressed = (tags: readonly string[]): boolean => tags.inc
  */
 export const reflagSuppressionTags = (inputTraceTags: readonly string[]): readonly string[] =>
   isFlaggerGeneratedTrace(inputTraceTags) ? AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag : []
+
+/**
+ * User/input-centric strategies (`classifiesAssistantResponseOnly: false`) judge
+ * the evaluated agent's conversation partner — real end-user wording, injection
+ * attempts, and similar. On a `flagger.classify` / `flagger.draft` trace the "user"
+ * turn is Latitude-built prompt scaffolding that embeds nested evaluated evidence
+ * (task episodes, quoted corrections, jailbreak examples from the *original*
+ * session). Those look like true positives to frustration/jailbreaking. Skip
+ * user-centric strategies on flagger-generated traces; assistant-response-centric
+ * strategies still run so we can catch bad classifications.
+ */
+export const isUserCentricReflagInapplicable = (
+  tags: readonly string[],
+  classifiesAssistantResponseOnly: boolean | undefined,
+): boolean => isFlaggerGeneratedTrace(tags) && classifiesAssistantResponseOnly === false

--- a/packages/domain/flaggers/src/use-cases/classify-session-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/classify-session-flagger.test.ts
@@ -1,3 +1,4 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import { CacheStore, ChSqlClient, FlaggerId, generateId, OrganizationId, SqlClient } from "@domain/shared"
 import { createFakeChSqlClient, createFakeSqlClient } from "@domain/shared/testing"
@@ -6,6 +7,7 @@ import { createFakeSessionRepository, createFakeSpanRepository } from "@domain/s
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import type { Flagger } from "../entities/flagger.ts"
+import { assistant, makeSessionDetail, user } from "../flagger-strategies/test-helpers.ts"
 import { FlaggerRepository } from "../ports/flagger-repository.ts"
 import { createFakeFlaggerRepository } from "../testing/fake-flagger-repository.ts"
 import { classifySessionFlaggerUseCase } from "./classify-session-flagger.ts"
@@ -90,6 +92,60 @@ describe("classifySessionFlaggerUseCase gating", () => {
 
     const result = await Effect.runPromise(
       classifySessionFlaggerUseCase(INPUT).pipe(Effect.provide(dyingLayers(disabledFlaggerRepo))),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("returns { matched: false } for frustration on a flagger.classify session without calling AI", async () => {
+    const session = makeSessionDetail(
+      [
+        user("as I already asked you previously — nested prior-instruction restatement inside classify evidence"),
+        assistant('{"matched":true,"feedback":"user repeated prior instruction","messageIndex":"2"}'),
+      ],
+      { tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify] },
+    )
+    const { repository: sessionRepo } = createFakeSessionRepository({
+      findBySessionId: () => Effect.succeed(session),
+    })
+    const { repository: spanRepo } = createFakeSpanRepository({
+      findLatestOutputTraceId: () => Effect.die("spans must not be queried for single-trace sessions"),
+    })
+    const { repository: flaggerRepo } = createFakeFlaggerRepository([], {
+      findByProjectAndSlug: () =>
+        Effect.succeed({
+          id: FlaggerId(generateId()),
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          slug: "frustration",
+          enabled: true,
+          sampling: 100,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as Flagger),
+    })
+    const { layer: aiLayer } = createFakeAI({
+      generate: () => Effect.die("AI must not be called for user-centric reflag"),
+    })
+
+    const result = await Effect.runPromise(
+      classifySessionFlaggerUseCase({ ...INPUT, flaggerSlug: "frustration" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(SessionRepository, sessionRepo),
+            Layer.succeed(SpanRepository, spanRepo),
+            Layer.succeed(FlaggerRepository, flaggerRepo),
+            Layer.succeed(CacheStore, {
+              get: () => Effect.succeed(null),
+              set: () => Effect.void,
+              delete: () => Effect.void,
+            }),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            aiLayer,
+          ),
+        ),
+      ),
     )
 
     expect(result).toEqual({ matched: false })

--- a/packages/domain/flaggers/src/use-cases/classify-session-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/classify-session-flagger.ts
@@ -10,6 +10,7 @@ import { getFlaggerStrategy, isLlmCapableStrategy } from "../flagger-strategies/
 import type { FlaggerSlug } from "../flagger-strategies/types.ts"
 import type { SessionHint } from "../hints/types.ts"
 import { FlaggerRepository } from "../ports/flagger-repository.ts"
+import { isUserCentricReflagInapplicable } from "../reflag.ts"
 import { classifyConversationForFlaggerUseCase } from "./run-flagger.ts"
 
 export interface ClassifySessionFlaggerInput {
@@ -101,6 +102,14 @@ export const classifySessionFlaggerUseCase = Effect.fn("flaggers.classifySession
     ),
   )
   if (context === null) {
+    return { matched: false } satisfies ClassifySessionFlaggerResult
+  }
+
+  if (
+    isUserCentricReflagInapplicable(context.conversation.tags, strategy.classifiesAssistantResponseOnly) ||
+    !strategy.hasRequiredContext(context.conversation)
+  ) {
+    yield* Effect.annotateCurrentSpan("flagger.skipped", "missing-context")
     return { matched: false } satisfies ClassifySessionFlaggerResult
   }
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1071,6 +1071,11 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     expect(calls.generate[1].system).not.toContain(
       "Approve only when the proposed annotation describes a problem in the evaluated agent's own assistant response",
     )
+    // Nested-content rejection still applies so quoted corrections in supplied
+    // evaluation evidence are not approved as frustration of the evaluated agent.
+    expect(calls.generate[1].system).toContain(
+      "Reject annotations whose evidence is only nested transcripts, examples, quoted instructions",
+    )
   })
 
   it("does not call the LLM flagger for frustration when there are no user messages", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -154,6 +154,10 @@ const ANNOTATION_REVIEWER_ASSISTANT_ONLY_CLAUSE = `
 Approve only when the proposed annotation describes a problem in the evaluated agent's own assistant response. Reject annotations whose evidence is only quoted/source content inside a user message, or whose evidence is that the evaluated agent found a problem in some other content.
 `.trim()
 
+const ANNOTATION_REVIEWER_NESTED_CONTENT_CLAUSE = `
+Reject annotations whose evidence is only nested transcripts, examples, quoted instructions, or source material the evaluated agent was asked to analyze, classify, or transform — that content is the agent's input, not behavior of the agent or its conversation partner.
+`.trim()
+
 const ANNOTATION_REVIEWER_REJECTION_CLAUSE = `
 Reject annotations that contradict the match, describe normal or allowed behavior, say no issue was found, switch to another issue category, describe only a schema/format/contract violation for a non-schema flagger, or rely on facts not present in the evidence.
 
@@ -164,6 +168,7 @@ const buildAnnotationReviewerSystemPrompt = (strategy: FlaggerStrategy): string 
   [
     ANNOTATION_REVIEWER_BASE_SYSTEM_PROMPT,
     ...(classifiesAssistantResponseOnly(strategy) ? [ANNOTATION_REVIEWER_ASSISTANT_ONLY_CLAUSE] : []),
+    ANNOTATION_REVIEWER_NESTED_CONTENT_CLAUSE,
     ANNOTATION_REVIEWER_REJECTION_CLAUSE,
   ].join("\n\n")
 

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -174,6 +174,53 @@ describe("screenSessionFlaggersUseCase", () => {
     expect(result.classifications).toEqual([])
   })
 
+  it("drops user-centric strategies on a flagger.classify reflag session (nested evidence is not a real user)", async () => {
+    const nestedEvidence = [
+      "EVALUATED AGENT CONTEXT:",
+      "<evaluated_trace_evidence>",
+      "USER MESSAGES:",
+      "Okay, all poses are stored in the asanas folder. Now make sure you run the model through all the poses, and for each pose, as I already asked you previously, how to get into the pose.",
+      "Okay, all poses are stored in the asanas folder. Now make sure you run the model through all the poses, and for each pose, as I already asked you previously, how to get into the pose.",
+      "</evaluated_trace_evidence>",
+    ].join("\n")
+    const session = makeSessionDetail(
+      [
+        user(nestedEvidence),
+        assistant('{"matched":true,"feedback":"user repeated prior instruction","messageIndex":"2"}'),
+      ],
+      { tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify] },
+    )
+    const { result, scores } = await runScreening({
+      session,
+      flaggers: [makeFlagger("frustration", 100), makeFlagger("jailbreaking", 100), makeFlagger("laziness", 100)],
+      momentLabels: [makeMomentLabel("user_frustration"), makeMomentLabel("stalling")],
+      analyses: [analyzedAnalysis()],
+      deps: fakeDeps.deps,
+    })
+
+    expect(decisionFor(result.decisions, "frustration")).toEqual({
+      slug: "frustration",
+      action: "dropped",
+      reason: "missing-context",
+    })
+    expect(decisionFor(result.decisions, "jailbreaking")).toEqual({
+      slug: "jailbreaking",
+      action: "dropped",
+      reason: "missing-context",
+    })
+    // Assistant-response-centric strategies still screen — bad classifications are the point of reflag.
+    expect(decisionFor(result.decisions, "laziness")).toEqual({
+      slug: "laziness",
+      action: "classify",
+      reason: "hinted",
+      hintKinds: ["moment:stalling"],
+    })
+    expect(result.classifications.some((c) => c.flaggerSlug === "frustration")).toBe(false)
+    expect(result.classifications.some((c) => c.flaggerSlug === "jailbreaking")).toBe(false)
+    expect(result.classifications.some((c) => c.flaggerSlug === "laziness")).toBe(true)
+    expect(scores.size).toBe(0)
+  })
+
   it("skips entirely for a no-reflag session, even on a deterministic match (recursion break)", async () => {
     const session = makeSessionDetail([user("Please help."), assistant("")], {
       tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify, ...AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag],

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
@@ -12,7 +12,7 @@ import {
 } from "../flagger-strategies/index.ts"
 import { gatherSessionHintsUseCase } from "../hints/gatherers.ts"
 import { isPositiveSessionHintKind, type SessionHint, type SessionHintKind } from "../hints/types.ts"
-import { isReflagSuppressed } from "../reflag.ts"
+import { isReflagSuppressed, isUserCentricReflagInapplicable } from "../reflag.ts"
 import { loadFlaggerSessionContextUseCase } from "./classify-session-flagger.ts"
 import { type FlaggerCacheEntry, getProjectFlaggersUseCase } from "./get-project-flaggers.ts"
 import { upsertFlaggerAnnotationScore } from "./upsert-flagger-annotation-score.ts"
@@ -287,7 +287,10 @@ const screenOneStrategy = (args: ScreenOneStrategyInput) =>
       }
     }
 
-    if (!strategy.hasRequiredContext(args.context.conversation)) {
+    if (
+      isUserCentricReflagInapplicable(args.context.conversation.tags, strategy.classifiesAssistantResponseOnly) ||
+      !strategy.hasRequiredContext(args.context.conversation)
+    ) {
       return { slug: args.slug, action: "dropped", reason: "missing-context" } satisfies SessionFlaggerDecision
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dogfood signal [Assistant fails to acknowledge or act on prior user instructions](https://console.latitude.so/projects/latitude-flaggers/signals/assistant-fails-to-acknowledge-or-act-on-prior-user-instructions) was a false positive from meta-flagging.

Sample trace [`d503eceb66ea01672a3ee733aeb4e1c4`](https://console.latitude.so/projects/latitude-flaggers/traces/d503eceb66ea01672a3ee733aeb4e1c4) is a `frustration` `flagger.classify` call for a Claude Code session. The nested evidence includes the evaluated agent's user repeating the same pose-instruction request with "as I already asked you previously". Meta-`frustration` then annotated that nested restatement as if it were dissatisfaction directed at the classifier, and signal discovery clustered the score into a "prior instructions" signal.

There is no real end user talking to a flagger classify prompt — the "user" turn is Latitude scaffolding that embeds the original session. User/input-centric strategies (`frustration`, `jailbreaking`) should not run on those traces.

## Fix

- Add `isUserCentricReflagInapplicable` and drop those strategies during screening (`missing-context`) and again in `classifySessionFlagger` for already-queued runs
- Assistant-response-centric strategies still reflag so we can catch bad classifications
- Annotation reviewer always rejects evidence that is only nested/supplied analysis material
- Regression coverage for the helper, screening (nested prior-instruction evidence), and classify gating; `dev-docs/flaggers.md` updated

Related open drafts for the same class of bug: #4149, #4146, #4135.

Signal left open for human verification after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fcc9436-92c3-5b6b-b833-fd375339ab09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fcc9436-92c3-5b6b-b833-fd375339ab09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

