### PR TITLE
fix(flaggers): stop Frustration meta-flagging nested classify evidence

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/display.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/display.ts
@@ -23,7 +23,7 @@ export const FLAGGER_DISPLAY: Record<FlaggerSlug, FlaggerDisplay> = {
     name: "Frustration",
     description: "The conversation shows clear user frustration or dissatisfaction",
     instructions:
-      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration.",
+      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration. Do not use it when the only frustration language is inside nested evaluated-trace evidence the agent was asked to classify.",
     mode: "llm",
     suppressedBy: [],
   },

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.test.ts
@@ -1,0 +1,80 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
+import { describe, expect, it } from "vitest"
+import { frustrationStrategy } from "./frustration.ts"
+import { assistant, makeTrace, system, user } from "./test-helpers.ts"
+
+describe("frustrationStrategy.hasRequiredContext", () => {
+  it("is true when the conversation has a user message", () => {
+    expect(frustrationStrategy.hasRequiredContext(makeTrace([user("This is useless.")]))).toBe(true)
+  })
+
+  it("is false for flagger.classify telemetry (no human user)", () => {
+    const classifyPrompt = [
+      "TRACE EVIDENCE:",
+      "<evaluated_trace_evidence>",
+      '<evaluated_trace_user_message format="json">',
+      JSON.stringify({ role: "user", content: "I already asked you to verify the poses." }),
+      "</evaluated_trace_user_message>",
+      "</evaluated_trace_evidence>",
+    ].join("\n")
+
+    const trace = {
+      ...makeTrace([
+        system("You are a triage flagger for Incompletion."),
+        user(classifyPrompt),
+        assistant('{"matched":true,"feedback":"Task not completed","messageIndex":"25"}'),
+      ]),
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+    }
+
+    expect(frustrationStrategy.hasRequiredContext(trace)).toBe(false)
+  })
+
+  it("is false for flagger.draft telemetry", () => {
+    const trace = {
+      ...makeTrace([user("I already told you this is broken.")]),
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerDraft],
+    }
+
+    expect(frustrationStrategy.hasRequiredContext(trace)).toBe(false)
+  })
+})
+
+describe("frustrationStrategy.validateMatch", () => {
+  const trace = makeTrace([
+    system("You are helpful."), // 0
+    user("I already told you to use TypeScript."), // 1
+    assistant("Sorry — switching to TypeScript now."), // 2
+  ])
+
+  it("rejects a match without a messageIndex", () => {
+    expect(frustrationStrategy.validateMatch!(trace, { feedback: "User is frustrated." })).toBe(false)
+  })
+
+  it("rejects a match anchored on an assistant response", () => {
+    expect(
+      frustrationStrategy.validateMatch!(trace, {
+        feedback: "User is frustrated.",
+        messageIndex: 2,
+      }),
+    ).toBe(false)
+  })
+
+  it("rejects a match anchored on a system message", () => {
+    expect(
+      frustrationStrategy.validateMatch!(trace, {
+        feedback: "User is frustrated.",
+        messageIndex: 0,
+      }),
+    ).toBe(false)
+  })
+
+  it("accepts a match anchored on the frustrated user message", () => {
+    expect(
+      frustrationStrategy.validateMatch!(trace, {
+        feedback: "User restated a prior correction.",
+        messageIndex: 1,
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/domain/flaggers/src/flagger-strategies/frustration.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/frustration.ts
@@ -1,4 +1,5 @@
 import type { FlaggerConversation } from "../conversation.ts"
+import { isFlaggerGeneratedTrace } from "../reflag.ts"
 import { extractUserTextMessages } from "./shared.ts"
 import type { FlaggerStrategy } from "./types.ts"
 
@@ -49,12 +50,14 @@ DO NOT FLAG
 - Profanity inside content being discussed (e.g., a log file the user pasted)
 - Mild expressive interjections ("ugh", "hmm") without complaint context
 - Questions phrased firmly but not angrily
+- Frustration language that appears only inside nested/quoted transcripts, session hints, or source material the agent was asked to classify, evaluate, or transform (including content inside <evaluated_trace_*> / <session_hints> tags). That is the agent's input, not a user complaining to this assistant.
+- Assistant output that merely describes an issue in nested evaluated content (incompletion, deflection, refusal, etc.) — that is not this conversation's user expressing dissatisfaction
 
 ================================================================================
 DECISION RULE
 ================================================================================
 
-Flag only when the user's own words are direct evidence of dissatisfaction with the assistant. When uncertain, return matched=false.
+Flag only when the user's own words are direct evidence of dissatisfaction with the assistant. messageIndex is REQUIRED and must be the transcript index of the user message that shows the frustration. When uncertain, return matched=false.
 
 Return no explanation outside the structured output.
 `.trim()
@@ -67,7 +70,7 @@ export const frustrationStrategy: FlaggerStrategy = {
     name: "Frustration",
     description: "The conversation shows clear user frustration or dissatisfaction",
     instructions:
-      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration.",
+      "Use this flagger when the user expresses annoyance, disappointment, repeated dissatisfaction, loss of trust, or has to restate/correct themselves because the assistant is not helping. Do not use it for neutral clarifications or isolated terse replies without real evidence of frustration. Do not use it when the only frustration language is inside nested evaluated-trace evidence the agent was asked to classify.",
   },
 
   hintKinds: [
@@ -79,8 +82,16 @@ export const frustrationStrategy: FlaggerStrategy = {
     "span:error",
   ],
 
+  // flagger.classify / flagger.draft telemetry has no human user — the "user"
+  // turn is Latitude's orchestration prompt carrying nested evaluated evidence.
   hasRequiredContext(conversation: FlaggerConversation): boolean {
+    if (isFlaggerGeneratedTrace(conversation.tags)) return false
     return extractUserTextMessages(conversation).length > 0
+  },
+
+  validateMatch(conversation, result) {
+    if (result.messageIndex === undefined) return false
+    return conversation.allMessages[result.messageIndex]?.role === "user"
   },
 
   buildSystemPrompt(): string {

--- a/packages/domain/flaggers/src/hints/pattern-gatherers.test.ts
+++ b/packages/domain/flaggers/src/hints/pattern-gatherers.test.ts
@@ -16,6 +16,7 @@ import {
   nsfwPatternGatherer,
   piiPatternGatherer,
   refusalPatternGatherer,
+  stripNestedFlaggerEvidence,
 } from "./pattern-gatherers.ts"
 
 const ctx = (messages: Parameters<typeof makeTrace>[0]) => makeHintContext(makeTrace(messages))
@@ -77,6 +78,75 @@ describe("frustrationPatternGatherer", () => {
 
   it("returns nothing on an empty conversation", async () => {
     expect(await runGatherer(frustrationPatternGatherer, ctx([]))).toEqual([])
+  })
+
+  it("does not fire on frustration language only inside nested flagger evidence tags", async () => {
+    const classifyUserPrompt = [
+      "EVALUATED AGENT CONTEXT:",
+      "<evaluated_agent_context_summary>",
+      "Claude Code helps with software engineering.",
+      "</evaluated_agent_context_summary>",
+      "",
+      "<session_hints>",
+      "- [pattern:frustration] @m16 I already asked you previously to verify angles",
+      "</session_hints>",
+      "",
+      "<evaluated_trace_evidence>",
+      "--- Episode ---",
+      '<evaluated_trace_user_message format="json">',
+      JSON.stringify({
+        role: "user",
+        content:
+          "Okay, all poses are stored in the asanas folder. Now make sure you run the model through all the poses, as I already asked you previously.",
+      }),
+      "</evaluated_trace_user_message>",
+      '<evaluated_trace_assistant_response index="25" format="json">',
+      JSON.stringify({
+        role: "assistant",
+        content: "Let me confirm one thing first — my hypothesis about why the wide ones failed.",
+      }),
+      "</evaluated_trace_assistant_response>",
+      "</evaluated_trace_evidence>",
+    ].join("\n")
+
+    expect(await runGatherer(frustrationPatternGatherer, ctx([user(classifyUserPrompt)]))).toEqual([])
+  })
+
+  it("still fires when frustration language remains outside nested evidence tags", async () => {
+    const hints = await runGatherer(
+      frustrationPatternGatherer,
+      ctx([
+        user(
+          [
+            "I already told you this classifier is wrong.",
+            "<evaluated_trace_evidence>",
+            '<evaluated_trace_user_message format="json">',
+            JSON.stringify({ role: "user", content: "neutral nested content" }),
+            "</evaluated_trace_user_message>",
+            "</evaluated_trace_evidence>",
+          ].join("\n"),
+        ),
+      ]),
+    )
+
+    expect(hints).toHaveLength(1)
+    expect(hints[0]).toMatchObject({ kind: "pattern:frustration", anchor: { messageIndex: 0 } })
+  })
+})
+
+describe("stripNestedFlaggerEvidence", () => {
+  it("removes nested evaluated-trace and session-hint blocks", () => {
+    const stripped = stripNestedFlaggerEvidence(
+      [
+        "Keep this.",
+        "<session_hints>- [pattern:frustration] I already asked</session_hints>",
+        "<evaluated_trace_evidence>I already told you</evaluated_trace_evidence>",
+        "Also keep this.",
+      ].join(" "),
+    )
+
+    expect(stripped).toBe("Keep this. Also keep this.")
+    expect(stripped).not.toMatch(/already (asked|told)/i)
   })
 })
 

--- a/packages/domain/flaggers/src/hints/pattern-gatherers.ts
+++ b/packages/domain/flaggers/src/hints/pattern-gatherers.ts
@@ -15,6 +15,16 @@ const MAX_HINTS_PER_PATTERN = 3
 
 const evidence = (text: string): string => truncateExcerpt(text, FLAGGER_HINT_EVIDENCE_MAX_CHARS)
 
+// Latitude flagger.classify / draft prompts inject nested evaluated-session
+// evidence under these tags. Lexical pattern matches inside them are about the
+// nested session, not this conversation's user — strip before matching.
+const NESTED_FLAGGER_EVIDENCE_BLOCK_PATTERN =
+  /<(evaluated_trace_evidence|evaluated_trace_user_message|evaluated_trace_assistant_response|session_hints|evaluated_agent_context_summary)\b[^>]*>[\s\S]*?<\/\1>/gi
+
+export function stripNestedFlaggerEvidence(text: string): string {
+  return text.replace(NESTED_FLAGGER_EVIDENCE_BLOCK_PATTERN, " ").replace(/\s+/g, " ").trim()
+}
+
 // Deliberately conservative (no caps-run/profanity detection — log pastes and
 // excited users false-positive too often); a hit only raises a hint, the LLM
 // judges whether the frustration targets the assistant.
@@ -79,7 +89,7 @@ export const frustrationPatternGatherer: SessionHintGatherer = {
 
         for (const part of iterMessageParts(message.parts)) {
           if (!isRecord(part) || part.type !== "text" || typeof part.content !== "string") continue
-          const text = part.content.trim()
+          const text = stripNestedFlaggerEvidence(part.content)
           if (!text || !FRUSTRATION_USER_PATTERNS.some((pattern) => pattern.test(text))) continue
 
           hints.push({ kind: "pattern:frustration", anchor: { messageIndex }, evidence: evidence(text) })

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1033,7 +1033,11 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
         ),
     })
 
-    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI({
+      matched: true,
+      feedback: "Flagger matched with concrete evidence.",
+      messageIndex: "2",
+    })
 
     const result = await Effect.runPromise(
       runFlaggerUseCase({ ...INPUT, flaggerSlug: "frustration" }).pipe(
@@ -1050,7 +1054,11 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
       ),
     )
 
-    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
+    expect(result).toEqual({
+      matched: true,
+      feedback: "Flagger matched with concrete evidence.",
+      messageIndex: 2,
+    })
     expect(calls.generate).toHaveLength(2)
     expect(calls.generate[0].system).toContain("USER'S OWN WORDING")
     expect(calls.generate[0].system).toContain("Judge only the user-authored messages")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Signal

[Deflection from verification tasks via preliminary questions](https://console.latitude.so/projects/latitude-flaggers/signals/deflection-from-verification-tasks-via-preliminary-questions) in 🧭 Flaggers (`jwhc80lr85kvfyxvxbrgoydp`).

Sample classify trace: `cd9f885bf9a6c1c132f1880d9f9f2ea9`. An Incompletion flagger correctly matched a nested Claude Code session where the assistant said "let me confirm one thing first" instead of verifying poses. Meta-flagging then ran Frustration on that `flagger.classify` telemetry and wrote a SYSTEM annotation whose feedback restated the nested incompletion issue.

## Cause

`flagger.classify` user turns are Latitude orchestration prompts that embed the evaluated session under `<evaluated_trace_*>` / `<session_hints>`. Nested wording like "as I already asked you previously" fired `pattern:frustration`, the Frustration LLM treated that nested text as this conversation's user, and it anchored `messageIndex` on the classifier assistant JSON (index 2), not a user message.

## Fix

- Skip Frustration when the conversation is flagger-generated (`flagger:classify` / `flagger:draft`) — those traces have no human user.
- `validateMatch` requires a user-message `messageIndex`.
- Strip nested flagger evidence tags before lexical frustration pattern matching.
- Tighten Frustration DO NOT FLAG / annotator copy for nested evaluated content.

## Test plan

- [x] `pnpm --filter @domain/flaggers test`
- [ ] After deploy, confirm new Frustration reflags on `flagger.classify` sessions with only nested re-assertion language do not create scores (do not mute/resolve the existing signal until verified)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ac2ba18-067c-5842-afeb-9a986ade6ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ac2ba18-067c-5842-afeb-9a986ade6ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

