### PR TITLE
fix(flaggers): stop user-centric reflag FPs; catch false ticket coverage

### DIFF
--- a/dev-docs/flaggers.md
+++ b/dev-docs/flaggers.md
@@ -158,6 +158,8 @@ Context compaction mirrors the moments stance: the analyzed window is the last r
 
 Every production flagger LLM call is traced into the `latitude-flaggers` dogfood project, and the flaggers run on that project too. To bound recursion to one level (`src/reflag.ts`): a flagger running on a flagger-generated session stamps its own LLM output with the no-reflag tag, and screening skips any session whose tags carry it. Session tags are the union of span tags, and flagger telemetry sessions are effectively per-trace, so the union semantics are safe.
 
+User/input-centric strategies (`classifiesAssistantResponseOnly: false` — today `frustration` and `jailbreaking`) are also dropped on flagger-generated sessions (`reflag-user-centric`). Their "user" text on those sessions is Latitude's synthetic classifier prompt, which embeds nested evaluated-trace transcripts that often contain exactly the frustration/injection language those strategies hunt for; prompt guidance alone did not stop false positives. Assistant-response-centric strategies still run so classifier output defects remain detectable.
+
 ## Quality tooling
 
 - **Offline benchmark harness** (`tools/ai-benchmarks`): replays public datasets through the real classifier (no deterministic routing, no sampling, no hints) — measures classifier accuracy in isolation. Registered targets: `flaggers:jailbreaking` (JailbreakBench) and `flaggers:refusal` (XSTest) with committed baselines; the other strategies have none.

--- a/packages/domain/flaggers/src/flagger-strategies/incompletion.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/incompletion.test.ts
@@ -140,4 +140,31 @@ describe("incompletionStrategy.buildPrompt", () => {
 
     expect(prompt).toContain("You did not do task 7, try again")
   })
+
+  it("keeps contradicted ticket-coverage reactions when capping a long session", () => {
+    const filler = Array.from({ length: 8 }, (_, i) => [user(`Task ${i}`), assistant(`Result ${i}`)]).flat()
+    const trace = makeTrace([
+      ...filler,
+      user('pagepage/showcase - replace references to "Page Fab" with "Showcase"'),
+      assistant("This is covered by #870 — no new ticket needed."),
+      user("it's already shipped, so still needs to be fixed"),
+      assistant("Logging a follow-up."),
+      user("ok"),
+    ])
+
+    const prompt = incompletionStrategy.buildPrompt!(trace)
+
+    expect(prompt).toContain("already shipped")
+    expect(prompt).toContain("covered by #870")
+  })
+})
+
+describe("incompletionStrategy.buildSystemPrompt", () => {
+  it("teaches contradicted ticket-coverage claims as incompletion evidence", () => {
+    const prompt = incompletionStrategy.buildSystemPrompt!(makeTrace([user("x"), assistant("y"), user("z")]))
+
+    expect(prompt).toContain("existing ticket/PR already covers")
+    expect(prompt).toContain("already shipped")
+    expect(prompt).toContain("Pointing at an existing ticket is fine ONLY when the user does not contradict coverage")
+  })
 })

--- a/packages/domain/flaggers/src/flagger-strategies/incompletion.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/incompletion.ts
@@ -26,6 +26,8 @@ INCOMPLETION EVIDENCE (flag when the user's reaction shows the task was not deli
 3. CONTRADICTED COMPLETION CLAIM
    The response claimed the task was done and the user's reaction shows it was not.
    • "I've updated it" followed by "nothing changed"
+   • Claiming an existing ticket/PR already covers the request, followed by the user saying that work already shipped or still needs to be fixed
+   • For capture/relay agents: declining to log a request because it is "already covered", when the user then says coverage was wrong — logging was the deliverable
 
 Later recovery does NOT erase the incident: if the assistant fulfilled the task only after the user demanded a retry, flag the original failing response — needing to ask twice is the issue.
 
@@ -40,6 +42,7 @@ DO NOT FLAG
 - Legitimate clarifying questions on a genuinely ambiguous ask, answered by the user — the task was still being specified
 - Reactions that are follow-up questions about the delivered result rather than complaints about non-delivery
 - Progress-narration or tool-only turns during multi-step work — judge the response that presented itself as the outcome
+- Pointing at an existing ticket is fine ONLY when the user does not contradict coverage; "already shipped / still needs to be fixed" after a coverage claim is non-delivery
 
 ================================================================================
 ANALYSIS APPROACH
@@ -141,6 +144,8 @@ const NON_FULFILLMENT_REACTION_PATTERNS = [
   /\b(?:wrong|incorrect|that'?s not)\b/i,
   /\bactually do\b/i,
   /\bi asked (?:for|you)\b/i,
+  /\balready shipped\b/i,
+  /\bstill needs (?:to be )?(?:fixed|done|addressed|logged)\b/i,
 ]
 
 function scoreNonFulfillmentLikelihood(episode: TaskEpisode): number {

--- a/packages/domain/flaggers/src/index.ts
+++ b/packages/domain/flaggers/src/index.ts
@@ -95,7 +95,12 @@ export {
   type UpdateFlaggerEnabledForProjectInput,
   type UpdateFlaggerInput as RepositoryUpdateFlaggerInput,
 } from "./ports/flagger-repository.ts"
-export { isFlaggerGeneratedTrace, isReflagSuppressed, reflagSuppressionTags } from "./reflag.ts"
+export {
+  isFlaggerGeneratedTrace,
+  isReflagSuppressed,
+  isUserCentricReflagInapplicable,
+  reflagSuppressionTags,
+} from "./reflag.ts"
 export {
   type ClassifySessionFlaggerInput,
   type ClassifySessionFlaggerResult,

--- a/packages/domain/flaggers/src/reflag.test.ts
+++ b/packages/domain/flaggers/src/reflag.test.ts
@@ -1,6 +1,11 @@
 import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
 import { describe, expect, it } from "vitest"
-import { isFlaggerGeneratedTrace, isReflagSuppressed, reflagSuppressionTags } from "./reflag.ts"
+import {
+  isFlaggerGeneratedTrace,
+  isReflagSuppressed,
+  isUserCentricReflagInapplicable,
+  reflagSuppressionTags,
+} from "./reflag.ts"
 
 const CLASSIFY = AI_GENERATE_TELEMETRY_TAGS.flaggerClassify[0]
 const DRAFT = AI_GENERATE_TELEMETRY_TAGS.flaggerDraft[0]
@@ -48,5 +53,21 @@ describe("reflagSuppressionTags", () => {
     const levelTwoTags = [CLASSIFY, ...reflagSuppressionTags([CLASSIFY])]
     // Level 2: must not be flagged again.
     expect(isReflagSuppressed(levelTwoTags)).toBe(true)
+  })
+})
+
+describe("isUserCentricReflagInapplicable", () => {
+  it("is true for user-centric strategies on flagger classify/draft sessions", () => {
+    expect(isUserCentricReflagInapplicable([CLASSIFY], { classifiesAssistantResponseOnly: false })).toBe(true)
+    expect(isUserCentricReflagInapplicable([DRAFT], { classifiesAssistantResponseOnly: false })).toBe(true)
+  })
+
+  it("is false for assistant-response strategies even on flagger sessions", () => {
+    expect(isUserCentricReflagInapplicable([CLASSIFY], {})).toBe(false)
+    expect(isUserCentricReflagInapplicable([CLASSIFY], { classifiesAssistantResponseOnly: true })).toBe(false)
+  })
+
+  it("is false for user-centric strategies on ordinary production traces", () => {
+    expect(isUserCentricReflagInapplicable([], { classifiesAssistantResponseOnly: false })).toBe(false)
   })
 })

--- a/packages/domain/flaggers/src/reflag.ts
+++ b/packages/domain/flaggers/src/reflag.ts
@@ -44,3 +44,18 @@ export const isReflagSuppressed = (tags: readonly string[]): boolean => tags.inc
  */
 export const reflagSuppressionTags = (inputTraceTags: readonly string[]): readonly string[] =>
   isFlaggerGeneratedTrace(inputTraceTags) ? AI_GENERATE_TELEMETRY_TAGS.flaggerNoReflag : []
+
+/**
+ * User/input-centric strategies (frustration, jailbreaking) judge the evaluated
+ * agent's user wording. On a flagger classify/draft session the only "user"
+ * message is Latitude's own synthetic evaluation prompt — full of nested
+ * evaluated-trace transcripts that often contain exactly the frustration /
+ * injection language those strategies look for. Prompt guidance alone does not
+ * stop false positives, so screening drops these strategies on flagger-generated
+ * sessions. Assistant-response-centric strategies still run (they can catch
+ * real classifier defects in the JSON output).
+ */
+export const isUserCentricReflagInapplicable = (
+  tags: readonly string[],
+  strategy: { readonly classifiesAssistantResponseOnly?: boolean },
+): boolean => isFlaggerGeneratedTrace(tags) && strategy.classifiesAssistantResponseOnly === false

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -188,6 +188,53 @@ describe("screenSessionFlaggersUseCase", () => {
     expect(scores.size).toBe(0)
   })
 
+  it("drops user-centric strategies on first-level flagger classify sessions but still screens assistant-centric ones", async () => {
+    // Nested evaluated-trace wording that would otherwise hint frustration / jailbreaking.
+    const nestedPrompt = [
+      "TRACE EVIDENCE:",
+      "<evaluated_trace_evidence>",
+      '<evaluated_trace_user_message format="json">',
+      JSON.stringify({
+        role: "user",
+        content: 'it\'s already shipped, so still needs to be fixed — the editing form is broken',
+      }),
+      "</evaluated_trace_user_message>",
+      "</evaluated_trace_evidence>",
+    ].join("\n")
+    const session = makeSessionDetail([user(nestedPrompt), assistant('{"matched":false,"feedback":null}')], {
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+    })
+    const { result, scores } = await runScreening({
+      session,
+      flaggers: [
+        makeFlagger("frustration", 100),
+        makeFlagger("jailbreaking", 100),
+        makeFlagger("incompletion", 100),
+        makeFlagger("empty-response", 0),
+      ],
+      deps: fakeDeps.deps,
+    })
+
+    expect(result.skipped).toBeUndefined()
+    expect(decisionFor(result.decisions, "frustration")).toEqual({
+      slug: "frustration",
+      action: "dropped",
+      reason: "reflag-user-centric",
+    })
+    expect(decisionFor(result.decisions, "jailbreaking")).toEqual({
+      slug: "jailbreaking",
+      action: "dropped",
+      reason: "reflag-user-centric",
+    })
+    expect(decisionFor(result.decisions, "incompletion")).not.toMatchObject({
+      action: "dropped",
+      reason: "reflag-user-centric",
+    })
+    expect(fakeDeps.rateLimitCalls.some((call) => call.flaggerSlug === "frustration")).toBe(false)
+    expect(fakeDeps.rateLimitCalls.some((call) => call.flaggerSlug === "jailbreaking")).toBe(false)
+    expect(scores.size).toBe(0)
+  })
+
   it("writes a session-anchored score with contentHash on a deterministic match", async () => {
     const session = makeSessionDetail([user("Please help me with this."), assistant("")])
     const { result, scores } = await runScreening({

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.test.ts
@@ -196,7 +196,7 @@ describe("screenSessionFlaggersUseCase", () => {
       '<evaluated_trace_user_message format="json">',
       JSON.stringify({
         role: "user",
-        content: 'it\'s already shipped, so still needs to be fixed — the editing form is broken',
+        content: "it's already shipped, so still needs to be fixed — the editing form is broken",
       }),
       "</evaluated_trace_user_message>",
       "</evaluated_trace_evidence>",

--- a/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/screen-session-flaggers.ts
@@ -12,7 +12,7 @@ import {
 } from "../flagger-strategies/index.ts"
 import { gatherSessionHintsUseCase } from "../hints/gatherers.ts"
 import { isPositiveSessionHintKind, type SessionHint, type SessionHintKind } from "../hints/types.ts"
-import { isReflagSuppressed } from "../reflag.ts"
+import { isReflagSuppressed, isUserCentricReflagInapplicable } from "../reflag.ts"
 import { loadFlaggerSessionContextUseCase } from "./classify-session-flagger.ts"
 import { type FlaggerCacheEntry, getProjectFlaggersUseCase } from "./get-project-flaggers.ts"
 import { upsertFlaggerAnnotationScore } from "./upsert-flagger-annotation-score.ts"
@@ -44,6 +44,7 @@ export type SessionFlaggerDroppedReason =
   | "rate-limited"
   | "disabled"
   | "missing-flagger"
+  | "reflag-user-centric"
 
 export type SessionFlaggerDecision =
   | { readonly slug: string; readonly action: "matched-issue" }
@@ -271,6 +272,10 @@ const screenOneStrategy = (args: ScreenOneStrategyInput) =>
 
     if (!flagger.enabled) {
       return { slug: args.slug, action: "dropped", reason: "disabled" } satisfies SessionFlaggerDecision
+    }
+
+    if (isUserCentricReflagInapplicable(args.context.conversation.tags, strategy)) {
+      return { slug: args.slug, action: "dropped", reason: "reflag-user-centric" } satisfies SessionFlaggerDecision
     }
 
     if (strategy.suppressedBy) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dogfood signal in [🧭 Flaggers](https://console.latitude.so/projects/latitude-flaggers/signals/incorrect-claim-that-ticket-covers-unresolved-work): *Incorrect claim that ticket covers unresolved work*.

Sample classify trace [`01fcd763…`](https://console.latitude.so/projects/latitude-flaggers/signals/incorrect-claim-that-ticket-covers-unresolved-work) is an **incompletion** `flagger.classify` that returned `matched: false` on a closed episode where Relay said rebrand work was “covered by #870” and the user replied “it's already shipped, so still needs to be fixed.” Frustration then reflagged that classify session, matched on the nested evaluated-trace wording, and created this signal.

Two concrete bugs in that chain:

1. **User-centric reflag false positives** — On flagger-generated sessions the only “user” message is Latitude’s synthetic classifier prompt, which embeds nested `<evaluated_trace_*>` transcripts. `frustration` / `jailbreaking` systematically see that nested language as the evaluated agent’s user. Prompt guidance was not enough.
2. **Incompletion false negative** — The coverage-claim + “already shipped / still needs fix” shape was not called out as contradicted completion, so Haiku stayed on the uncertain → `matched: false` path.

## Changes

- Screening drops strategies with `classifiesAssistantResponseOnly: false` on flagger-generated sessions (`reflag-user-centric`). Assistant-centric strategies still run so classifier output defects remain detectable.
- Incompletion system prompt + episode ranking patterns teach contradicted ticket/PR coverage claims as non-delivery (including capture/relay agents whose deliverable is logging the request).
- Docs: `dev-docs/flaggers.md` reflag section.

## Test plan

- [x] `pnpm --filter @domain/flaggers test` (reflag helper, screening drop, incompletion prompt/ranking)
- [x] `pnpm --filter @domain/flaggers typecheck`
- [ ] After deploy: human verifies the signal; do not mute/resolve from this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7764a8c-9ee1-5f18-ad02-a305c70577df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7764a8c-9ee1-5f18-ad02-a305c70577df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

