### PR TITLE
fix(flaggers): stop thrashing false positives on fail→remediate→retry

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/display.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/display.ts
@@ -71,7 +71,7 @@ export const FLAGGER_DISPLAY: Record<FlaggerSlug, FlaggerDisplay> = {
     name: "Thrashing",
     description: "The agent cycles between tools without making progress",
     instructions:
-      "Use this queue when the agent repeatedly invokes the same tools or tool sequences, oscillates between states, or accumulates tool calls without advancing toward the goal. Do not use this queue for legitimate retries after transient errors or for iterative refinement that is visibly converging.",
+      "Use this queue when the agent repeatedly invokes the same tools or tool sequences, oscillates between states, or accumulates tool calls without advancing toward the goal. Do not use this queue for legitimate retries after transient errors, a single fail→remediate→retry recovery, or iterative refinement that is visibly converging.",
     mode: "llm",
     suppressedBy: [],
   },

--- a/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
@@ -3,6 +3,19 @@ import { describe, expect, it } from "vitest"
 import { assistant, assistantToolCall, makeTrace, user } from "./test-helpers.ts"
 import { extractToolCallSequence, findDominantToolUsage, trashingStrategy } from "./trashing.ts"
 
+describe("trashingStrategy targeting", () => {
+  it("does not use assistant-only targeting (tool-call sequence evidence)", () => {
+    expect(trashingStrategy.classifiesAssistantResponseOnly).toBe(false)
+  })
+
+  it("excludes single fail→remediate→retry recovery from thrashing matches", () => {
+    const prompt = trashingStrategy.buildSystemPrompt?.(makeTrace([])) ?? ""
+    expect(prompt).toContain("fail→remediate→retry")
+    expect(prompt).toContain("do not infer \"didn't verify\"")
+    expect(trashingStrategy.annotator?.instructions).toContain("fail→remediate→retry")
+  })
+})
+
 describe("trashingStrategy.detectDeterministically", () => {
   describe("matched (≥3 identical tool+args signatures)", () => {
     it("matches when the same tool+args appears exactly 3 times", () => {

--- a/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/trashing.test.ts
@@ -11,7 +11,7 @@ describe("trashingStrategy targeting", () => {
   it("excludes single fail→remediate→retry recovery from thrashing matches", () => {
     const prompt = trashingStrategy.buildSystemPrompt?.(makeTrace([])) ?? ""
     expect(prompt).toContain("fail→remediate→retry")
-    expect(prompt).toContain("do not infer \"didn't verify\"")
+    expect(prompt).toContain('do not infer "didn\'t verify"')
     expect(trashingStrategy.annotator?.instructions).toContain("fail→remediate→retry")
   })
 })

--- a/packages/domain/flaggers/src/flagger-strategies/trashing.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/trashing.ts
@@ -52,6 +52,11 @@ DO NOT FLAG
 ================================================================================
 
 - Legitimate retries after a transient error (timeout, 5xx, rate limit) — typically 1-3 retries
+- A single retry of a failed operation after an intervening remediation attempt
+  (e.g. op fails → enrich/install/fix prerequisite → retry op once). That is
+  converging recovery, even when the retried call uses identical arguments.
+  Flag only when that fail→remediate→retry cycle itself repeats without progress,
+  or when the identical call repeats with no intervening remediation at all.
 - Iterative refinement that is visibly CONVERGING (each call uses output of the previous)
 - Parallel independent calls to gather distinct pieces of information
 - Polling a long-running job with backoff
@@ -67,7 +72,10 @@ ANALYSIS APPROACH
 2. Look for the patterns above — repetition, oscillation, cycles, accumulation.
 3. Ask: does each call CHANGE STATE or PRODUCE NEW INFORMATION that the next call uses?
    If calls repeat with no such change, that is thrashing.
-4. Point to the specific repeated or oscillating sub-sequence as your evidence.
+4. Evidence lists tool calls (name + args), not tool results. Treat intervening
+   distinct calls as state-changing progress; do not infer "didn't verify" from
+   a missing confirmation step when results are not shown.
+5. Point to the specific repeated or oscillating sub-sequence as your evidence.
 
 ================================================================================
 DECISION RULE
@@ -238,11 +246,14 @@ const longestConsecutiveSignatureRun = (
 // ---------------------------------------------------------------------------
 
 export const trashingStrategy: FlaggerStrategy = {
+  // Thrashing judges the tool-call sequence, not assistant prose.
+  classifiesAssistantResponseOnly: false,
+
   annotator: {
     name: "Thrashing",
     description: "The agent cycles between tools without making progress",
     instructions:
-      "Use this queue when the agent repeatedly invokes the same tools or tool sequences, oscillates between states, or accumulates tool calls without advancing toward the goal. Do not use this queue for legitimate retries after transient errors or for iterative refinement that is visibly converging.",
+      "Use this queue when the agent repeatedly invokes the same tools or tool sequences, oscillates between states, or accumulates tool calls without advancing toward the goal. Do not use this queue for legitimate retries after transient errors, a single fail→remediate→retry recovery, or iterative refinement that is visibly converging.",
   },
 
   hintKinds: ["tool:loop", "tool:error", "outlier:tokens", "outlier:duration", "outlier:cost", "moment:stalling"],

--- a/packages/domain/flaggers/src/flagger-strategies/types.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/types.ts
@@ -60,12 +60,13 @@ export interface FlaggerStrategy {
    * flag it (e.g. refusal, laziness, forgetting — issues that live in the
    * assistant's output).
    *
-   * Set to `false` for strategies that judge user-authored or injected input
-   * content (e.g. frustration judges the user's wording, jailbreaking judges
-   * user/tool injection attempts). For those, the assistant-only guidance would
-   * suppress every true match, so they instead get nested-content guidance that
-   * still ignores material the agent was merely asked to analyze without
-   * restricting the judgement to the assistant response.
+   * Set to `false` for strategies that judge user-authored input, injected
+   * content, or non-text assistant behavior such as tool-call sequences
+   * (e.g. frustration, jailbreaking, thrashing). For those, the assistant-only
+   * guidance would suppress every true match or hide the evidence the reviewer
+   * needs, so they instead get nested-content guidance that still ignores
+   * material the agent was merely asked to analyze without restricting the
+   * judgement to assistant prose.
    */
   readonly classifiesAssistantResponseOnly?: boolean
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -1073,6 +1073,78 @@ ${"Detailed grounding, workflow, callout, and formatting rules. ".repeat(120)}`.
     )
   })
 
+  it("uses nested-content targeting for thrashing so the reviewer sees tool-call evidence", async () => {
+    const { repository } = createFakeTraceRepository({
+      findByTraceId: () =>
+        Effect.succeed(
+          makeTraceDetail([
+            {
+              role: "user",
+              parts: [{ type: "text", content: "Create outreach for this lead." }],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "tool_call", name: "bash", arguments: { command: "outreach create --lead-id lead-1" } }],
+            },
+            {
+              role: "tool",
+              parts: [
+                {
+                  type: "tool_response",
+                  name: "bash",
+                  content: "OUTREACH_CREATE_FAILED: contact has no enriched email",
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool_call",
+                  name: "bash",
+                  arguments: { command: "enrich contact email --person person-1" },
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              parts: [{ type: "tool_call", name: "bash", arguments: { command: "outreach create --lead-id lead-1" } }],
+            },
+          ]),
+        ),
+    })
+
+    const { calls, layer: aiLayer } = createClassifyAndApproveAI()
+
+    const result = await Effect.runPromise(
+      runFlaggerUseCase({ ...INPUT, flaggerSlug: "trashing" }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, repository),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
+            Layer.succeed(FlaggerRepository, defaultFlaggerRepo),
+            aiLayer,
+            defaultCacheLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ matched: true, feedback: "Flagger matched with concrete evidence." })
+    expect(calls.generate).toHaveLength(2)
+    expect(calls.generate[0].system).toContain("Thrashing")
+    expect(calls.generate[0].system).toContain("fail→remediate→retry")
+    expect(calls.generate[0].system).not.toContain("the evaluated agent's assistant response")
+    expect(calls.generate[0].prompt).toContain("TOOL CALL SEQUENCE")
+    expect(calls.generate[0].prompt).toContain("outreach create")
+    expect(calls.generate[0].prompt).toContain("Judge the evaluated agent's conversation for this issue")
+    expect(calls.generate[0].prompt).not.toContain("Classify only text inside <evaluated_trace_assistant_response>")
+    expect(calls.generate[1].prompt).toContain("Evidence shown to the classifier:")
+    expect(calls.generate[1].prompt).toContain("TOOL CALL SEQUENCE")
+    expect(calls.generate[1].prompt).toContain("enrich contact email")
+  })
+
   it("does not call the LLM flagger for frustration when there are no user messages", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Thrashing was incorrectly matching a single fail → remediate prerequisite → retry once sequence (dogfood signal [Operation retried without verifying prerequisite fix succeeded](https://console.latitude.so/projects/latitude-flaggers/signals/operation-retried-without-verifying-prerequisite-fix-succeeded) on classify trace `b9fd8cc0f0a2cfd3092a468087a682fc`).

Sample sequence: `outreach create` fails for missing enriched email → read enrich skill → `enrich contact email` → identical `outreach create` again. That is converging recovery, not thrashing.

## Root cause

Two compounding issues in the thrashing strategy:

1. **Assistant-only targeting (default).** Thrashing judges tool-call sequences, but `classifiesAssistantResponseOnly` was left at the default `true`. The adversarial reviewer only received assistant *text* responses (often empty for tool-only turns), so it never saw the tool sequence evidence and could not reject the false positive.
2. **Prompt gap.** DO NOT FLAG covered transient retries and converging refinement, but not the common fail → fix prerequisite → retry-once pattern. The classifier also inferred "didn't verify enrichment success" even though the evidence lists calls, not tool results.

## Fix

- Set `classifiesAssistantResponseOnly: false` on thrashing so classifier + reviewer use nested-content targeting and the reviewer sees `TOOL CALL SEQUENCE`.
- Explicitly exclude single fail→remediate→retry recovery in the system prompt and annotator instructions.
- Tell the model not to infer missing verification from absent tool results.
- Tests for targeting, prompt language, and reviewer evidence wiring.

## Signal note

Left the Latitude signal unmuted for human verification after deploy, per investigation instructions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7d8371d-45d1-59bd-9603-26f8cfd7c3f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7d8371d-45d1-59bd-9603-26f8cfd7c3f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

