### PR TITLE
feat(web): drag-to-resize span detail panel in Spans tab

### DIFF
--- a/apps/web/src/lib/hooks/useResizablePanelHeight.ts
+++ b/apps/web/src/lib/hooks/useResizablePanelHeight.ts
@@ -1,20 +1,37 @@
 import { useMountEffect } from "@repo/ui"
 import { useCallback, useRef, useState } from "react"
 
-export const MIN_PANEL_HEIGHT = 140
-const DEFAULT_PANEL_HEIGHT = 320
-// Reserve this much above the detail panel so the filters bar and a few tree rows stay visible.
-export const MIN_CONTENT_ABOVE = 160
-// Drag the panel shorter than this and it closes instead of clamping to the minimum.
-const CLOSE_DRAG_THRESHOLD = 96
-const KEYBOARD_STEP = 24
+const DEFAULT_KEYBOARD_STEP = 24
 
-// Vertical sibling of the span-tree `useResizablePanel`: drags the span detail panel taller/shorter.
-export function useDetailResize(onClose: () => void) {
+interface Options {
+  readonly minHeight: number
+  readonly minContentAbove: number
+  readonly closeThreshold: number
+  readonly defaultHeight: number | "half"
+  readonly onClose: () => void
+  readonly keyboardStep?: number
+}
+
+/**
+ * Drag/keyboard resize for a panel pinned to the bottom of a flex container.
+ *
+ * Attach `panelRef` to the panel root (its `parentElement` is the sizing
+ * container) and apply `height` where the panel's resizable area lives.
+ * `minContentAbove` reserves space so the content above never collapses;
+ * dragging shorter than `closeThreshold` calls `onClose` instead of clamping.
+ */
+export function useResizablePanelHeight({
+  minHeight,
+  minContentAbove,
+  closeThreshold,
+  defaultHeight,
+  onClose,
+  keyboardStep = DEFAULT_KEYBOARD_STEP,
+}: Options) {
   const panelRef = useRef<HTMLDivElement>(null)
-  const [height, setHeight] = useState(DEFAULT_PANEL_HEIGHT)
+  const [height, setHeight] = useState(typeof defaultHeight === "number" ? defaultHeight : minHeight)
   const [isDragging, setIsDragging] = useState(false)
-  const drag = useRef<{ startY: number; startHeight: number; max: number } | null>(null)
+  const drag = useRef<{ startY: number; startHeight: number } | null>(null)
   const moveRef = useRef<((event: PointerEvent) => void) | null>(null)
   const upRef = useRef<(() => void) | null>(null)
 
@@ -34,14 +51,16 @@ export function useDetailResize(onClose: () => void) {
 
   const maxHeight = useCallback(() => {
     const panel = panelRef.current?.parentElement
-    if (!panel) return DEFAULT_PANEL_HEIGHT
-    return Math.max(MIN_PANEL_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
-  }, [])
+    if (!panel) return Number.POSITIVE_INFINITY
+    return Math.max(minHeight, panel.offsetHeight - minContentAbove)
+  }, [minHeight, minContentAbove])
 
   useMountEffect(() => {
     const panel = panelRef.current?.parentElement
     if (!panel) return
-    setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), Math.round(panel.offsetHeight / 2))))
+    if (defaultHeight === "half") {
+      setHeight(Math.max(minHeight, Math.min(maxHeight(), Math.round(panel.offsetHeight / 2))))
+    }
     const observer = new ResizeObserver(() => setHeight((prev) => Math.min(prev, maxHeight())))
     observer.observe(panel)
     return () => {
@@ -54,7 +73,7 @@ export function useDetailResize(onClose: () => void) {
     (event: React.PointerEvent) => {
       event.preventDefault()
       if (!panelRef.current?.parentElement) return
-      drag.current = { startY: event.clientY, startHeight: height, max: maxHeight() }
+      drag.current = { startY: event.clientY, startHeight: height }
       setIsDragging(true)
       document.body.style.userSelect = "none"
       document.body.style.cursor = "ns-resize"
@@ -63,14 +82,14 @@ export function useDetailResize(onClose: () => void) {
         const current = drag.current
         if (!current) return
         const raw = current.startHeight + (current.startY - moveEvent.clientY)
-        if (raw < CLOSE_DRAG_THRESHOLD) {
+        if (raw < closeThreshold) {
           drag.current = null
           setIsDragging(false)
           cleanup()
           onClose()
           return
         }
-        setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(current.max, raw)))
+        setHeight(Math.max(minHeight, Math.min(maxHeight(), raw)))
       }
       const onUp = () => {
         drag.current = null
@@ -83,17 +102,17 @@ export function useDetailResize(onClose: () => void) {
       document.addEventListener("pointerup", onUp)
       document.addEventListener("pointercancel", onUp)
     },
-    [height, maxHeight, cleanup, onClose],
+    [height, minHeight, maxHeight, closeThreshold, cleanup, onClose],
   )
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
       event.preventDefault()
-      const delta = event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP
-      setHeight((prev) => Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), prev + delta)))
+      const delta = event.key === "ArrowUp" ? keyboardStep : -keyboardStep
+      setHeight((prev) => Math.max(minHeight, Math.min(maxHeight(), prev + delta)))
     },
-    [maxHeight],
+    [minHeight, maxHeight, keyboardStep],
   )
 
   return { panelRef, height, isDragging, onPointerDown, onKeyDown }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/session-detail-drawer/session-spans-tab.tsx
@@ -1,6 +1,6 @@
 import { Button, Icon, Text } from "@repo/ui"
 import { ArrowUpRightIcon } from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import type { SessionDetailRecord } from "../../../../../../domains/sessions/sessions.functions.ts"
 import { useSpansBySessionCollection } from "../../../../../../domains/spans/spans.collection.ts"
 import type { TraceRecord } from "../../../../../../domains/traces/traces.functions.ts"
@@ -53,7 +53,6 @@ export function SessionSpansTab({
     startTimeFrom: session.startTime,
     startTimeTo: session.endTime,
   })
-  const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
   const treeContainerRef = useRef<HTMLDivElement | null>(null)
   const groups = useMemo(() => groupSessionSpans(spans ?? [], traces), [spans, traces])
   const filteredGroups = useMemo(() => filterSessionSpanGroups(groups, filters), [filters, groups])
@@ -84,16 +83,12 @@ export function SessionSpansTab({
       (group) =>
         group.traceId === selectedSpan.traceId && group.spans.some((span) => span.spanId === selectedSpan.spanId),
     )
-    if (!isVisible) {
-      onSelectSpan(null)
-      setIsMinimized(false)
-    }
+    if (!isVisible) onSelectSpan(null)
   }, [filteredGroups, isLoading, onSelectSpan, selectedSpan])
 
   // TODO(frontend-use-effect-policy): external conversation/deep-link selection needs imperative scrolling after load.
   useEffect(() => {
     if (!selectedSpan || groups.length === 0) return
-    setIsMinimized(true)
     requestAnimationFrame(() => {
       scrollSpanIntoView(treeContainerRef.current, selectedSpan.spanId, selectedSpan.traceId)
     })
@@ -102,7 +97,6 @@ export function SessionSpansTab({
   function handleSelectSpan(selection: SpanTreeSelection | null) {
     if (!selection || (selectedSpan && spanSelectionKey(selection) === spanSelectionKey(selectedSpan))) {
       onSelectSpan(null)
-      setIsMinimized(false)
       return
     }
     onSelectSpan(selection)
@@ -110,7 +104,6 @@ export function SessionSpansTab({
 
   function handleOpenTrace(traceId: string) {
     onSelectSpan(null)
-    setIsMinimized(false)
     onOpenTrace(traceId, { targetTab: "trace" })
   }
 
@@ -198,8 +191,6 @@ export function SessionSpansTab({
         }))}
         selectedSpan={selectedSpan}
         onSelectSpan={handleSelectSpan}
-        isMinimized={isMinimized && selectedSpan !== null}
-        onToggleMinimized={() => setIsMinimized((current) => !current)}
         isActive={isActive}
       />
       {selectedSpan && selectedGroup && (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@repo/ui"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { useSpansByTraceCollection } from "../../../../../../../domains/spans/spans.collection.ts"
 import { SpanDetail } from "./spans-tab/span-detail/index.tsx"
 import { filterSpansWithAncestors } from "./spans-tab/span-filters.ts"
@@ -27,7 +27,6 @@ export function SpansTab({
   const { filters, clearFilters, toggleErrors, toggleTools, toggleMemory, selectModel } = useSpanFilters()
   // Shares the cached spans collection with the Trace tab's fetch (same key → one fetch).
   const { data: spans, isLoading } = useSpansByTraceCollection({ projectId, traceId, startTimeFrom, startTimeTo })
-  const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
   const treeContainerRef = useRef<HTMLDivElement | null>(null)
   const filteredSpans = useMemo(() => (spans ? filterSpansWithAncestors(spans, filters) : []), [filters, spans])
 
@@ -46,7 +45,6 @@ export function SpansTab({
   // alone is not sufficient.
   useEffect(() => {
     if (!selectedSpanId || !spans || spans.length === 0) return
-    setIsMinimized(true)
     requestAnimationFrame(() => {
       scrollSpanIntoView(treeContainerRef.current, selectedSpanId)
     })
@@ -55,7 +53,6 @@ export function SpansTab({
   function handleSelectSpan(spanId: string) {
     if (spanId === "" || spanId === selectedSpanId) {
       onSelectSpan("")
-      setIsMinimized(false)
       return
     }
     onSelectSpan(spanId)
@@ -63,11 +60,6 @@ export function SpansTab({
 
   function handleCloseDetail() {
     onSelectSpan("")
-    setIsMinimized(false)
-  }
-
-  function handleToggleMinimized() {
-    setIsMinimized((prev) => !prev)
   }
 
   if (isLoading) {
@@ -120,8 +112,6 @@ export function SpansTab({
         spans={filteredSpans}
         selectedSpanId={selectedSpanId}
         onSelectSpan={handleSelectSpan}
-        isMinimized={isMinimized && selectedSpanId !== ""}
-        onToggleMinimized={handleToggleMinimized}
         isActive={isActive}
       />
       {selectedSpanId !== "" && (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx
@@ -1,7 +1,8 @@
-import { Skeleton, Text } from "@repo/ui"
+import { cn, Skeleton, Text } from "@repo/ui"
 import { XIcon } from "lucide-react"
 import { useSpanDetail } from "../../../../../../../../../domains/spans/spans.collection.ts"
 import { SpanDetailContent } from "./span-detail-content.tsx"
+import { MIN_CONTENT_ABOVE, MIN_PANEL_HEIGHT, useDetailResize } from "./use-detail-resize.ts"
 
 export function SpanDetail({
   projectId,
@@ -19,9 +20,39 @@ export function SpanDetail({
   readonly onClose: () => void
 }) {
   const { data: span, isLoading } = useSpanDetail({ projectId, traceId, spanId, startTimeFrom, startTimeTo })
+  const { panelRef, height, isDragging, onPointerDown, onKeyDown } = useDetailResize(onClose)
+  const maxHeight = panelRef.current?.parentElement
+    ? Math.max(MIN_PANEL_HEIGHT, panelRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
+    : height
 
   return (
-    <div className="flex flex-col flex-1 overflow-hidden border-t border-border">
+    <div
+      ref={panelRef}
+      className="relative flex shrink-0 flex-col overflow-hidden border-t border-border"
+      style={{ height }}
+    >
+      {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize span detail"
+        aria-valuenow={height}
+        aria-valuemin={MIN_PANEL_HEIGHT}
+        aria-valuemax={maxHeight}
+        tabIndex={0}
+        onPointerDown={onPointerDown}
+        onKeyDown={onKeyDown}
+        className="group absolute inset-x-0 -top-1 z-10 flex h-2 cursor-ns-resize touch-none items-center justify-center focus-visible:outline-none"
+      >
+        <div
+          className={cn(
+            "h-1 w-10 rounded-full transition-opacity",
+            isDragging
+              ? "bg-muted-foreground/60 opacity-100"
+              : "bg-border opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
+          )}
+        />
+      </div>
       <div className="flex flex-row items-center justify-between shrink-0 px-4 py-2 border-b border-border">
         {isLoading ? (
           <Skeleton className="h-5 w-40" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/index.tsx
@@ -1,8 +1,12 @@
 import { cn, Skeleton, Text } from "@repo/ui"
 import { XIcon } from "lucide-react"
 import { useSpanDetail } from "../../../../../../../../../domains/spans/spans.collection.ts"
+import { useResizablePanelHeight } from "../../../../../../../../../lib/hooks/useResizablePanelHeight.ts"
 import { SpanDetailContent } from "./span-detail-content.tsx"
-import { MIN_CONTENT_ABOVE, MIN_PANEL_HEIGHT, useDetailResize } from "./use-detail-resize.ts"
+
+const MIN_PANEL_HEIGHT = 140
+const MIN_CONTENT_ABOVE = 160
+const CLOSE_DRAG_THRESHOLD = 96
 
 export function SpanDetail({
   projectId,
@@ -20,7 +24,13 @@ export function SpanDetail({
   readonly onClose: () => void
 }) {
   const { data: span, isLoading } = useSpanDetail({ projectId, traceId, spanId, startTimeFrom, startTimeTo })
-  const { panelRef, height, isDragging, onPointerDown, onKeyDown } = useDetailResize(onClose)
+  const { panelRef, height, isDragging, onPointerDown, onKeyDown } = useResizablePanelHeight({
+    minHeight: MIN_PANEL_HEIGHT,
+    minContentAbove: MIN_CONTENT_ABOVE,
+    closeThreshold: CLOSE_DRAG_THRESHOLD,
+    defaultHeight: "half",
+    onClose,
+  })
   const maxHeight = panelRef.current?.parentElement
     ? Math.max(MIN_PANEL_HEIGHT, panelRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
     : height

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/use-detail-resize.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/use-detail-resize.ts
@@ -41,6 +41,7 @@ export function useDetailResize(onClose: () => void) {
   useMountEffect(() => {
     const panel = panelRef.current?.parentElement
     if (!panel) return
+    setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), Math.round(panel.offsetHeight / 2))))
     const observer = new ResizeObserver(() => setHeight((prev) => Math.min(prev, maxHeight())))
     observer.observe(panel)
     return () => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/use-detail-resize.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/use-detail-resize.ts
@@ -1,0 +1,99 @@
+import { useMountEffect } from "@repo/ui"
+import { useCallback, useRef, useState } from "react"
+
+export const MIN_PANEL_HEIGHT = 140
+const DEFAULT_PANEL_HEIGHT = 320
+// Reserve this much above the detail panel so the filters bar and a few tree rows stay visible.
+export const MIN_CONTENT_ABOVE = 160
+// Drag the panel shorter than this and it closes instead of clamping to the minimum.
+const CLOSE_DRAG_THRESHOLD = 96
+const KEYBOARD_STEP = 24
+
+// Vertical sibling of the span-tree `useResizablePanel`: drags the span detail panel taller/shorter.
+export function useDetailResize(onClose: () => void) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [height, setHeight] = useState(DEFAULT_PANEL_HEIGHT)
+  const [isDragging, setIsDragging] = useState(false)
+  const drag = useRef<{ startY: number; startHeight: number; max: number } | null>(null)
+  const moveRef = useRef<((event: PointerEvent) => void) | null>(null)
+  const upRef = useRef<(() => void) | null>(null)
+
+  const cleanup = useCallback(() => {
+    if (moveRef.current) {
+      document.removeEventListener("pointermove", moveRef.current)
+      moveRef.current = null
+    }
+    if (upRef.current) {
+      document.removeEventListener("pointerup", upRef.current)
+      document.removeEventListener("pointercancel", upRef.current)
+      upRef.current = null
+    }
+    document.body.style.removeProperty("user-select")
+    document.body.style.removeProperty("cursor")
+  }, [])
+
+  const maxHeight = useCallback(() => {
+    const panel = panelRef.current?.parentElement
+    if (!panel) return DEFAULT_PANEL_HEIGHT
+    return Math.max(MIN_PANEL_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
+  }, [])
+
+  useMountEffect(() => {
+    const panel = panelRef.current?.parentElement
+    if (!panel) return
+    const observer = new ResizeObserver(() => setHeight((prev) => Math.min(prev, maxHeight())))
+    observer.observe(panel)
+    return () => {
+      observer.disconnect()
+      cleanup()
+    }
+  })
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      event.preventDefault()
+      if (!panelRef.current?.parentElement) return
+      drag.current = { startY: event.clientY, startHeight: height, max: maxHeight() }
+      setIsDragging(true)
+      document.body.style.userSelect = "none"
+      document.body.style.cursor = "ns-resize"
+
+      const onMove = (moveEvent: PointerEvent) => {
+        const current = drag.current
+        if (!current) return
+        const raw = current.startHeight + (current.startY - moveEvent.clientY)
+        if (raw < CLOSE_DRAG_THRESHOLD) {
+          drag.current = null
+          setIsDragging(false)
+          cleanup()
+          onClose()
+          return
+        }
+        setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(current.max, raw)))
+      }
+      const onUp = () => {
+        drag.current = null
+        setIsDragging(false)
+        cleanup()
+      }
+      moveRef.current = onMove
+      upRef.current = onUp
+      document.addEventListener("pointermove", onMove)
+      document.addEventListener("pointerup", onUp)
+      document.addEventListener("pointercancel", onUp)
+    },
+    [height, maxHeight, cleanup, onClose],
+  )
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+      event.preventDefault()
+      const delta = event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP
+      setHeight((prev) => Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), prev + delta)))
+    },
+    [maxHeight],
+  )
+
+  return { panelRef, height, isDragging, onPointerDown, onKeyDown }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
@@ -8,7 +8,6 @@ export const INDENT_PX = 16
 export const MIN_TREE_WIDTH = 180
 export const MIN_WATERFALL_WIDTH = 120
 export const DEFAULT_TREE_FRACTION = 0.5
-export const MINIMIZED_MAX_HEIGHT = 192
 export const KEYBOARD_STEP = 8
 export const KEYBOARD_STEP_LARGE = 32
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -1,13 +1,6 @@
 import { cn, Text, Tooltip } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  ChevronsDownUpIcon,
-  ChevronsUpDownIcon,
-  MaximizeIcon,
-  MinimizeIcon,
-} from "lucide-react"
+import { ChevronDownIcon, ChevronRightIcon, ChevronsDownUpIcon, ChevronsUpDownIcon } from "lucide-react"
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../../../components/hotkey-badge.tsx"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
@@ -17,13 +10,7 @@ import {
   spanTreeSelectionKey,
   toggleCollapsedSpan,
 } from "./grouped-tree-state.ts"
-import {
-  MIN_TREE_WIDTH,
-  MIN_WATERFALL_WIDTH,
-  MINIMIZED_MAX_HEIGHT,
-  ROW_HEIGHT,
-  WATERFALL_H_INSET_PX,
-} from "./helpers.ts"
+import { MIN_TREE_WIDTH, MIN_WATERFALL_WIDTH, ROW_HEIGHT, WATERFALL_H_INSET_PX } from "./helpers.ts"
 import { TreeRow } from "./tree-row.tsx"
 import { buildSpanTree, flattenTree, formatDuration, getTraceTimeRange, type TraceTimeRange } from "./tree-utils.ts"
 import { useResizablePanel } from "./use-resizable-panel.ts"
@@ -64,18 +51,12 @@ function TreeAxisHeader({
   hasCollapsible,
   isAllCollapsed,
   onToggleAll,
-  selectedSpan,
-  isMinimized,
-  onToggleMinimized,
 }: {
   readonly treeWidth: number
   readonly timeRange: TraceTimeRange
   readonly hasCollapsible: boolean
   readonly isAllCollapsed: boolean
   readonly onToggleAll: () => void
-  readonly selectedSpan: SpanTreeSelection | null
-  readonly isMinimized: boolean
-  readonly onToggleMinimized: () => void
 }) {
   return (
     <div
@@ -105,23 +86,6 @@ function TreeAxisHeader({
             }
           >
             {isAllCollapsed ? "Expand all" : "Collapse all"} <HotkeyBadge hotkey="E" />
-          </Tooltip>
-        )}
-        {selectedSpan && (
-          <Tooltip
-            asChild
-            side="bottom"
-            trigger={
-              <button
-                type="button"
-                className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted"
-                onClick={onToggleMinimized}
-              >
-                {isMinimized ? <MaximizeIcon className="h-3.5 w-3.5" /> : <MinimizeIcon className="h-3.5 w-3.5" />}
-              </button>
-            }
-          >
-            {isMinimized ? "Expand tree" : "Minimize tree"}
           </Tooltip>
         )}
       </div>
@@ -232,15 +196,11 @@ export function GroupedSpanTree({
   groups,
   selectedSpan,
   onSelectSpan,
-  isMinimized,
-  onToggleMinimized,
   isActive,
 }: {
   readonly groups: readonly SpanTreeGroup[]
   readonly selectedSpan: SpanTreeSelection | null
   readonly onSelectSpan: (selection: SpanTreeSelection | null) => void
-  readonly isMinimized: boolean
-  readonly onToggleMinimized: () => void
   readonly isActive: boolean
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -357,14 +317,7 @@ export function GroupedSpanTree({
   ])
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        "relative flex flex-col overflow-hidden",
-        isMinimized ? "shrink-0 border-b border-border" : "flex-1",
-      )}
-      style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
-    >
+    <div ref={containerRef} className="relative flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-1 flex-col overflow-y-auto">
         <TreeAxisHeader
           treeWidth={resolvedTreeWidth}
@@ -372,9 +325,6 @@ export function GroupedSpanTree({
           hasCollapsible={collapsibleSelections.length > 0}
           isAllCollapsed={isAllCollapsed}
           onToggleAll={toggleAll}
-          selectedSpan={selectedSpan}
-          isMinimized={isMinimized}
-          onToggleMinimized={onToggleMinimized}
         />
         {renderGroups.map(({ group, visibleNodes, collapsed: groupCollapsed, rowTimeRange }) => {
           const isTraceCollapsed = collapsedTraces.has(group.traceId)
@@ -434,15 +384,11 @@ export function SpanTree({
   spans,
   selectedSpanId,
   onSelectSpan,
-  isMinimized,
-  onToggleMinimized,
   isActive,
 }: {
   readonly spans: readonly SpanRecord[]
   readonly selectedSpanId: string
   readonly onSelectSpan: (spanId: string) => void
-  readonly isMinimized: boolean
-  readonly onToggleMinimized: () => void
   readonly isActive: boolean
 }) {
   const traceId = spans[0]?.traceId ?? ""
@@ -452,8 +398,6 @@ export function SpanTree({
       groups={[{ traceId, spans }]}
       selectedSpan={selectedSpan}
       onSelectSpan={(selection) => onSelectSpan(selection?.spanId ?? "")}
-      isMinimized={isMinimized}
-      onToggleMinimized={onToggleMinimized}
       isActive={isActive}
     />
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/memory/$store/-components/record-content-view.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, cn, Icon, Sheet, Skeleton, Text, useMountEffect } from "@repo/ui"
+import { CodeBlock, cn, Icon, Sheet, Skeleton, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import {
@@ -16,7 +16,7 @@ import {
   UserRoundIcon,
   UsersRoundIcon,
 } from "lucide-react"
-import { type ReactNode, useCallback, useRef, useState } from "react"
+import { type ReactNode, useCallback, useState } from "react"
 import {
   useMemoryRecord,
   useMemoryRecordChangeDiff,
@@ -28,6 +28,7 @@ import type {
   MemoryRecordUserRecord,
   MemoryRecordVersionRecord,
 } from "../../../../../../../domains/memories/memories.functions.ts"
+import { useResizablePanelHeight } from "../../../../../../../lib/hooks/useResizablePanelHeight.ts"
 import { looksLikeJson } from "../../../-components/memory-changes/looks-like-json.ts"
 import { MemoryRecordDiff } from "../../../-components/memory-changes/memory-record-diff.tsx"
 import { SessionDetailDrawer } from "../../../-components/session-detail-drawer.tsx"
@@ -275,98 +276,7 @@ const MIN_PANEL_HEIGHT = 96
 const DEFAULT_PANEL_HEIGHT = 160
 // Reserve this much for the editor header + code area + panel header so the code never vanishes.
 const MIN_CONTENT_ABOVE = 200
-// Drag the list shorter than this and it closes instead of clamping to the minimum.
 const CLOSE_DRAG_THRESHOLD = 64
-const KEYBOARD_STEP = 24
-
-// Vertical sibling of the span-tree `useResizablePanel`: drags the activity list taller/shorter.
-function usePanelResize(setOpen: (open: boolean) => void) {
-  const footerRef = useRef<HTMLDivElement>(null)
-  const [height, setHeight] = useState(DEFAULT_PANEL_HEIGHT)
-  const [isDragging, setIsDragging] = useState(false)
-  const drag = useRef<{ startY: number; startHeight: number; max: number } | null>(null)
-  const moveRef = useRef<((event: PointerEvent) => void) | null>(null)
-  const upRef = useRef<(() => void) | null>(null)
-
-  const cleanup = useCallback(() => {
-    if (moveRef.current) {
-      document.removeEventListener("pointermove", moveRef.current)
-      moveRef.current = null
-    }
-    if (upRef.current) {
-      document.removeEventListener("pointerup", upRef.current)
-      document.removeEventListener("pointercancel", upRef.current)
-      upRef.current = null
-    }
-    document.body.style.removeProperty("user-select")
-    document.body.style.removeProperty("cursor")
-  }, [])
-
-  const maxHeight = useCallback(() => {
-    const panel = footerRef.current?.parentElement
-    if (!panel) return DEFAULT_PANEL_HEIGHT
-    return Math.max(MIN_PANEL_HEIGHT, panel.offsetHeight - MIN_CONTENT_ABOVE)
-  }, [])
-
-  useMountEffect(() => {
-    const panel = footerRef.current?.parentElement
-    if (!panel) return
-    const observer = new ResizeObserver(() => setHeight((prev) => Math.min(prev, maxHeight())))
-    observer.observe(panel)
-    return () => {
-      observer.disconnect()
-      cleanup()
-    }
-  })
-
-  const onPointerDown = useCallback(
-    (event: React.PointerEvent) => {
-      event.preventDefault()
-      if (!footerRef.current?.parentElement) return
-      drag.current = { startY: event.clientY, startHeight: height, max: maxHeight() }
-      setIsDragging(true)
-      document.body.style.userSelect = "none"
-      document.body.style.cursor = "ns-resize"
-
-      const onMove = (moveEvent: PointerEvent) => {
-        const current = drag.current
-        if (!current) return
-        const raw = current.startHeight + (current.startY - moveEvent.clientY)
-        if (raw < CLOSE_DRAG_THRESHOLD) {
-          drag.current = null
-          setIsDragging(false)
-          cleanup()
-          setOpen(false)
-          return
-        }
-        setHeight(Math.max(MIN_PANEL_HEIGHT, Math.min(current.max, raw)))
-      }
-      const onUp = () => {
-        drag.current = null
-        setIsDragging(false)
-        cleanup()
-      }
-      moveRef.current = onMove
-      upRef.current = onUp
-      document.addEventListener("pointermove", onMove)
-      document.addEventListener("pointerup", onUp)
-      document.addEventListener("pointercancel", onUp)
-    },
-    [height, maxHeight, cleanup, setOpen],
-  )
-
-  const onKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
-      event.preventDefault()
-      const delta = event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP
-      setHeight((prev) => Math.max(MIN_PANEL_HEIGHT, Math.min(maxHeight(), prev + delta)))
-    },
-    [maxHeight],
-  )
-
-  return { footerRef, height, isDragging, onPointerDown, onKeyDown }
-}
 
 type TabId = "changes" | "reads" | "users"
 const TABS: readonly { readonly id: TabId; readonly label: string; readonly icon: LucideIcon }[] = [
@@ -396,7 +306,13 @@ function RecordActivityPanel({
 }) {
   const [open, setOpen] = useState(true)
   const [activeTab, setActiveTab] = useState<TabId>("changes")
-  const { footerRef, height, isDragging, onPointerDown, onKeyDown } = usePanelResize(setOpen)
+  const { panelRef, height, isDragging, onPointerDown, onKeyDown } = useResizablePanelHeight({
+    minHeight: MIN_PANEL_HEIGHT,
+    minContentAbove: MIN_CONTENT_ABOVE,
+    closeThreshold: CLOSE_DRAG_THRESHOLD,
+    defaultHeight: DEFAULT_PANEL_HEIGHT,
+    onClose: () => setOpen(false),
+  })
 
   const reads = useMemoryRecordReads({ projectId, storeId, recordId, enabled: open })
   const users = useMemoryRecordUsers({ projectId, storeId, recordId, enabled: open })
@@ -412,12 +328,12 @@ function RecordActivityPanel({
     if (!open) setOpen(true)
   }
 
-  const maxHeight = footerRef.current?.parentElement
-    ? Math.max(MIN_PANEL_HEIGHT, footerRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
+  const maxHeight = panelRef.current?.parentElement
+    ? Math.max(MIN_PANEL_HEIGHT, panelRef.current.parentElement.offsetHeight - MIN_CONTENT_ABOVE)
     : DEFAULT_PANEL_HEIGHT
 
   return (
-    <div ref={footerRef} className="relative shrink-0 border-t bg-background">
+    <div ref={panelRef} className="relative shrink-0 border-t bg-background">
       {open ? (
         // biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events
         <div


### PR DESCRIPTION
Replaces the Expand/Minimize tree toggle in the Spans tab with a drag-to-resize span detail panel, matching the pointer-event resize pattern already used elsewhere (the memory activity panel, the span tree/waterfall splitter).

## before

Selecting a span in the Spans tab showed its details in a bottom panel whose size was controlled by an "Expand tree"/"Minimize tree" button — a binary toggle between a 192px-capped tree (detail takes the rest) and a 50/50 split. There was no way to pick an in-between size.

## now

The detail panel carries an explicit height and exposes a `role="separator"` grab handle on its top border. Drag it (or focus it and use ↑/↓) to resize; the tree above takes the remaining space via flex. Dragging the panel nearly shut collapses it and deselects the span, same as the ✕ button. The panel opens at 50% of the available height, clamped so it never drops below a minimum or crowds out the tree, and a `ResizeObserver` keeps it in bounds when the drawer resizes.

The toggle button, its icons, and the `isMinimized`/`onToggleMinimized` state threaded through the tree components and both drawer wrappers are gone.

## shared surface

The Spans tab renders from one set of components (`GroupedSpanTree`, `SpanTree`, `SpanDetail`), so the change lands in both the Session drawer and the Trace drawer. The new resize logic lives in `span-detail/use-detail-resize.ts`, the vertical sibling of the tree's existing horizontal `useResizablePanel`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resizable span detail panels with pointer and keyboard controls.
  * Panels can be resized within available space and closed by dragging below the minimum height.
  * Improved accessibility with resize-handle keyboard support and ARIA attributes.

* **Improvements**
  * Simplified span tree controls by removing minimize/maximize behavior.
  * Standardized resizing behavior across span details and record activity panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->