### PR TITLE
fix(telemetry): resolve Claude Code memory dir across git worktrees

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Memory spans now emit from git worktrees (e.g. Conductor).** The hook derived the auto-memory directory as the transcript's sibling (`dirname(transcript)/memory`), but Claude Code keeps one memory store per repository under the **main worktree**, while a linked worktree's session transcript lives under that worktree's own project directory. The two paths differ, so every memory operation from a worktree session was silently skipped. The classifier now recognizes any `~/.claude/projects/<store>/memory/<record>` path under the shared projects root, setting `gen_ai.memory.store.id` to the owning `<store>` slug — so a worktree session writing the repo's main-worktree store is captured. Sessions run directly in the repo root are unaffected.
+- **Memory spans now emit from git worktrees.** The hook derived the auto-memory directory as the transcript's sibling (`dirname(transcript)/memory`), but Claude Code keeps one memory store per repository under the **main worktree**, while a linked worktree's session transcript lives under that worktree's own project directory. The two paths differ, so every memory operation from a worktree session was silently skipped. The classifier now recognizes any `~/.claude/projects/<store>/memory/<record>` path under the shared projects root, setting `gen_ai.memory.store.id` to the owning `<store>` slug — so a worktree session writing the repo's main-worktree store is captured. Sessions run directly in the repo root are unaffected.
 
 ## [0.0.13] - 2026-07-21
 

--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14] - 2026-07-22
+
+### Fixed
+
+- **Memory spans now emit from git worktrees (e.g. Conductor).** The hook derived the auto-memory directory as the transcript's sibling (`dirname(transcript)/memory`), but Claude Code keeps one memory store per repository under the **main worktree**, while a linked worktree's session transcript lives under that worktree's own project directory. The two paths differ, so every memory operation from a worktree session was silently skipped. The classifier now recognizes any `~/.claude/projects/<store>/memory/<record>` path under the shared projects root, setting `gen_ai.memory.store.id` to the owning `<store>` slug — so a worktree session writing the repo's main-worktree store is captured. Sessions run directly in the repo root are unaffected.
+
 ## [0.0.13] - 2026-07-21
 
 ### Added

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "./config.ts"
 import { collectTraceContext } from "./context.ts"
 import type { Logger } from "./logger.ts"
 import { createLogger } from "./logger.ts"
-import { memoryDirFromTranscript } from "./memory.ts"
+import { memoryProjectsRoot } from "./memory.ts"
 import { buildOtlpRequest, buildSubagentSpans, chunkOtlpRequest } from "./otlp.ts"
 import type { RedactConfig } from "./redaction.ts"
 import { deleteRequest, loadRequestsByMessageId, pruneStaleRequests } from "./request-store.ts"
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
     logger.debug(`context tags=${context.tags.length} metadata=${Object.keys(context.metadata).length}`)
 
     const memory: MemoryEmitOptions | undefined = config.memory
-      ? { dir: memoryDirFromTranscript(transcriptPath), captureContent: config.memoryContent }
+      ? { projectsRoot: memoryProjectsRoot(transcriptPath), captureContent: config.memoryContent }
       : undefined
 
     const { rows, newOffset, newBuffer } = readIncremental(transcriptPath, prior.offset, prior.buffer)

--- a/packages/telemetry/claude-code/src/memory.test.ts
+++ b/packages/telemetry/claude-code/src/memory.test.ts
@@ -2,22 +2,23 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, describe, expect, it } from "vitest"
-import { classifyMemoryTool, memoryDirFromTranscript } from "./memory.ts"
+import { classifyMemoryTool, memoryProjectsRoot } from "./memory.ts"
 import type { MemoryEmitOptions, ToolCall } from "./types.ts"
 
-const DIR = "/home/u/.claude/projects/-home-u-repo/memory"
+const ROOT = "/home/u/.claude/projects"
+const DIR = `${ROOT}/-home-u-repo/memory`
 
 function tool(partial: Partial<ToolCall> & Pick<ToolCall, "name" | "input">): ToolCall {
   return { id: "t1", startMs: 1, endMs: 2, ...partial }
 }
 
 function opts(overrides: Partial<MemoryEmitOptions> = {}): MemoryEmitOptions {
-  return { dir: DIR, captureContent: false, ...overrides }
+  return { projectsRoot: ROOT, captureContent: false, ...overrides }
 }
 
-describe("memoryDirFromTranscript", () => {
-  it("resolves the sibling memory dir of the transcript", () => {
-    expect(memoryDirFromTranscript("/home/u/.claude/projects/-home-u-repo/sess.jsonl")).toBe(DIR)
+describe("memoryProjectsRoot", () => {
+  it("resolves the shared projects root above the transcript's project dir", () => {
+    expect(memoryProjectsRoot("/home/u/.claude/projects/-home-u-repo/sess.jsonl")).toBe(ROOT)
   })
 })
 
@@ -26,8 +27,24 @@ describe("classifyMemoryTool", () => {
     expect(classifyMemoryTool(tool({ name: "Bash", input: { command: "ls" } }), opts())).toBeNull()
   })
 
-  it("returns null for a file outside the memory dir", () => {
+  it("returns null for a file outside the projects root", () => {
     expect(classifyMemoryTool(tool({ name: "Edit", input: { file_path: "/home/u/repo/src/a.ts" } }), opts())).toBeNull()
+  })
+
+  it("returns null for a non-memory subdirectory of a project", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Edit", input: { file_path: `${ROOT}/-home-u-repo/todos/x.md` } }),
+      opts(),
+    )
+    expect(op).toBeNull()
+  })
+
+  it("classifies a store under a different project slug than the session (git worktree)", () => {
+    const op = classifyMemoryTool(
+      tool({ name: "Edit", input: { file_path: `${ROOT}/-home-u-src-repo/memory/topic.md` } }),
+      opts(),
+    )
+    expect(op).toMatchObject({ operation: "update_memory", storeId: "-home-u-src-repo", recordId: "topic.md" })
   })
 
   it("maps Write to upsert_memory with the store slug and record path", () => {
@@ -94,16 +111,16 @@ describe("classifyMemoryTool", () => {
 })
 
 describe("classifyMemoryTool default disk read", () => {
-  const root = mkdtempSync(join(tmpdir(), "cc-memory-"))
-  const memDir = join(root, "proj", "memory")
+  const projectsRoot = mkdtempSync(join(tmpdir(), "cc-memory-"))
+  const memDir = join(projectsRoot, "proj", "memory")
   mkdirSync(memDir, { recursive: true })
   writeFileSync(join(memDir, "topic.md"), "real disk content")
-  afterAll(() => rmSync(root, { recursive: true, force: true }))
+  afterAll(() => rmSync(projectsRoot, { recursive: true, force: true }))
 
   it("reads the edited file from disk when no readFile is injected", () => {
     const op = classifyMemoryTool(
       tool({ name: "Edit", input: { file_path: join(memDir, "topic.md"), old_string: "a", new_string: "b" } }),
-      { dir: memDir, captureContent: true },
+      { projectsRoot, captureContent: true },
     )
     expect(op).toMatchObject({ operation: "update_memory", storeId: "proj", recordId: "topic.md" })
     expect(op?.body).toBe("real disk content")

--- a/packages/telemetry/claude-code/src/memory.ts
+++ b/packages/telemetry/claude-code/src/memory.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs"
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path"
 import type { MemoryEmitOptions, MemoryOp, ToolCall } from "./types.ts"
 
 // Auto memory rides ordinary file tools, so operations are keyed by tool name, not a memory tool.
@@ -10,10 +10,12 @@ const MEMORY_TOOL_OPERATIONS: Record<string, MemoryOp["operation"]> = {
   Read: "search_memory",
 }
 
-// The transcript lives at ~/.claude/projects/<project>/<session>.jsonl; the auto-memory
-// directory is its sibling.
-export function memoryDirFromTranscript(transcriptPath: string): string {
-  return join(dirname(transcriptPath), "memory")
+// The transcript lives at <projectsRoot>/<project>/<session>.jsonl, so its grandparent is the
+// shared projects root. Auto memory is NOT necessarily the transcript's sibling: with git
+// worktrees (e.g. Conductor) each session runs in a linked worktree, but Claude Code keeps one
+// memory store under the repo's main worktree — a different <project> dir under the same root.
+export function memoryProjectsRoot(transcriptPath: string): string {
+  return dirname(dirname(transcriptPath))
 }
 
 export function classifyMemoryTool(tool: ToolCall, opts: MemoryEmitOptions): MemoryOp | null {
@@ -25,13 +27,13 @@ export function classifyMemoryTool(tool: ToolCall, opts: MemoryEmitOptions): Mem
   if (!filePath) return null
 
   const resolved = resolve(filePath)
-  const rel = relative(opts.dir, resolved)
-  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null
+  const location = memoryLocation(opts.projectsRoot, resolved)
+  if (!location) return null
 
   const op: MemoryOp = {
     operation,
-    storeId: basename(dirname(opts.dir)),
-    recordId: rel.split(sep).join("/"),
+    storeId: location.storeId,
+    recordId: location.recordId,
     count: 1,
   }
 
@@ -41,6 +43,17 @@ export function classifyMemoryTool(tool: ToolCall, opts: MemoryEmitOptions): Mem
   }
 
   return op
+}
+
+// Matches <projectsRoot>/<store>/memory/<record...>, keyed on any project's memory dir so a
+// worktree session writing the repo's main-worktree store still resolves. store = the project
+// slug that owns the memory (one store per repo); record = the path under that store's memory dir.
+function memoryLocation(projectsRoot: string, resolvedPath: string): { storeId: string; recordId: string } | null {
+  const rel = relative(projectsRoot, resolvedPath)
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null
+  const [storeId, memoryDir, ...record] = rel.split(sep)
+  if (!storeId || memoryDir !== "memory" || record.length === 0) return null
+  return { storeId, recordId: record.join("/") }
 }
 
 function extractBody(

--- a/packages/telemetry/claude-code/src/memory.ts
+++ b/packages/telemetry/claude-code/src/memory.ts
@@ -10,10 +10,7 @@ const MEMORY_TOOL_OPERATIONS: Record<string, MemoryOp["operation"]> = {
   Read: "search_memory",
 }
 
-// The transcript lives at <projectsRoot>/<project>/<session>.jsonl, so its grandparent is the
-// shared projects root. Auto memory is NOT necessarily the transcript's sibling: with git
-// worktrees (e.g. Conductor) each session runs in a linked worktree, but Claude Code keeps one
-// memory store under the repo's main worktree — a different <project> dir under the same root.
+// Grandparent of the transcript: git worktrees keep memory under the repo's main worktree, not the session's own project dir.
 export function memoryProjectsRoot(transcriptPath: string): string {
   return dirname(dirname(transcriptPath))
 }
@@ -45,9 +42,7 @@ export function classifyMemoryTool(tool: ToolCall, opts: MemoryEmitOptions): Mem
   return op
 }
 
-// Matches <projectsRoot>/<store>/memory/<record...>, keyed on any project's memory dir so a
-// worktree session writing the repo's main-worktree store still resolves. store = the project
-// slug that owns the memory (one store per repo); record = the path under that store's memory dir.
+// Match <projectsRoot>/<store>/memory/<record> for any store slug, so a worktree writing the repo's main-worktree store resolves.
 function memoryLocation(projectsRoot: string, resolvedPath: string): { storeId: string; recordId: string } | null {
   const rel = relative(projectsRoot, resolvedPath)
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return null

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -1172,11 +1172,12 @@ describe("buildSubagentSpans", () => {
 })
 
 describe("memory operation child spans", () => {
-  const MEM = "/home/u/.claude/projects/-proj/memory"
+  const ROOT = "/home/u/.claude/projects"
+  const MEM = `${ROOT}/-proj/memory`
   const MEM_OPS = ["upsert_memory", "update_memory", "search_memory"]
 
   function memory(overrides: Partial<MemoryEmitOptions> = {}): MemoryEmitOptions {
-    return { dir: MEM, captureContent: true, readFile: () => "disk body", ...overrides }
+    return { projectsRoot: ROOT, captureContent: true, readFile: () => "disk body", ...overrides }
   }
 
   function build(
@@ -1231,12 +1232,24 @@ describe("memory operation child spans", () => {
     expect(spans.some((s) => s.name === "search_memory")).toBe(true)
   })
 
-  it("ignores files outside the memory dir", () => {
+  it("ignores files outside the projects root", () => {
     const spans = build(
       [{ id: "tu1", name: "Write", input: { file_path: "/home/u/repo/a.ts", content: "x" } }],
       memory(),
     )
     expect(spans.some((s) => MEM_OPS.includes(s.name))).toBe(false)
+  })
+
+  it("emits the child span for a store under a different slug than the session (git worktree)", () => {
+    const spans = build(
+      [{ id: "tu1", name: "Write", input: { file_path: `${ROOT}/-main-worktree/memory/x.md`, content: "hi" } }],
+      memory(),
+    )
+    const toolSpan = unwrap(spans.find((s) => s.name === "tool:Write"))
+    const mem = unwrap(spans.find((s) => s.name === "upsert_memory"))
+    expect(mem.parentSpanId).toBe(toolSpan.spanId)
+    expect(getAttr(mem.attributes, "gen_ai.memory.store.id")).toBe("-main-worktree")
+    expect(getAttr(mem.attributes, "gen_ai.memory.record.id")).toBe("x.md")
   })
 
   it("emits structure only when captureContent is off", () => {

--- a/packages/telemetry/claude-code/src/types.ts
+++ b/packages/telemetry/claude-code/src/types.ts
@@ -93,7 +93,7 @@ export interface MemoryOp {
 }
 
 export interface MemoryEmitOptions {
-  dir: string
+  projectsRoot: string
   captureContent: boolean
   readFile?: (path: string) => string | undefined
 }


### PR DESCRIPTION
Follow-up to #4140, which added memory-observability spans for Claude Code auto memory. Those spans never emitted for a session running in a git worktree, so a share of real usage was silently dropped.

## the bug

The hook located the auto-memory directory as the transcript's sibling: `dirname(transcript)/memory`. That only holds when the session's working directory is the same directory Claude Code stores memory under. With git worktrees it isn't. Claude Code keeps one memory store per repository, under the **main worktree**, while a linked worktree's session writes its transcript under that worktree's own project directory. The two paths differ, so `classifyMemoryTool`'s containment check failed and every `Read`/`Write`/`Edit` against the memory store was skipped — no child memory span, nothing on the Memory page.

A session run directly in the repo root was unaffected, since there the two directories coincide — which is why it went unnoticed.

## the fix

Match the memory store structurally instead of assuming a fixed location. Any path shaped like `<projectsRoot>/<store>/memory/<record>` — for any `<store>` under the shared projects root (`dirname(dirname(transcript))`) — is a memory operation, with `gen_ai.memory.store.id` set to the owning `<store>` slug and `gen_ai.memory.record.id` to the path under that store's memory dir.

- A session in the repo root behaves exactly as before (the store slug equals the transcript's slug).
- A worktree session writing the repo's main-worktree store now resolves to that store.
- Subagents ride the same projects root.

`MemoryEmitOptions.dir` becomes `projectsRoot`, and `memoryDirFromTranscript` becomes `memoryProjectsRoot`. The consume side is untouched: classification and materialization read the `gen_ai.memory.*` attributes, and the store id is still a single project slug.

A fully relocated `autoMemoryDirectory` outside `~/.claude/projects` stays an unhandled case, unchanged from before.

## validation

- Unit tests for the worktree case (a store under a different slug than the session) in both `memory.test.ts` and `otlp.test.ts`, plus a non-memory-subdirectory boundary case. Typecheck, build, format, and knip are green.
- Checked end to end against prod: with this build installed, a memory write from a git worktree session emits the `upsert_memory`/`update_memory` spans with `store.id` set to the main-clone slug — where the previous build emitted plain tool spans with no memory child.

Bumps `@latitude-data/claude-code-telemetry` to 0.0.14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Claude Code telemetry auto-memory spans being silently skipped during Git worktree sessions.
  - Memory operations now correctly attribute `store` and `record` identifiers to the owning repository’s memory store.
  - Kept behavior unchanged for sessions run from the repository root.

- **Tests**
  - Expanded coverage for worktree-style paths, invalid/non-memory locations, and memory content capture.

- **Chores**
  - Bumped the Claude Code telemetry package to version 0.0.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->