### PR TITLE
Add DNS record for jobs subdomain

### DIFF
--- a/infra/lib/dns.ts
+++ b/infra/lib/dns.ts
@@ -192,6 +192,15 @@ export function createDnsRecords(
       allowOverwrite: true,
     })
 
+    records.jobsA = new aws.route53.Record(`${name}-jobs-a`, {
+      zoneId: hostedZoneId,
+      name: "jobs.latitude.so",
+      type: "A",
+      records: ["54.193.184.88"],
+      ttl: 300,
+      allowOverwrite: true,
+    })
+
     // SPF record for notifications.latitude.so
     records.notificationsSpf = new aws.route53.Record(`${name}-notifications-spf`, {
       zoneId: hostedZoneId,


### PR DESCRIPTION
Adds a production Route 53 A record that points `jobs.latitude.so` to `54.193.184.88` with a 300-second TTL.

The Pulumi production preview showed one record to create and 218 unchanged resources. The record has been deployed and verified with `dig`.

## Validation

- `pnpm --filter latitude-infra typecheck`
- Pulumi production preview and deployment
- `dig +short jobs.latitude.so A` → `54.193.184.88`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production DNS routing for `jobs.latitude.so`.
  * The new address points to the jobs service and supports automatic record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->