### PR TITLE
fix(ci): fix Prime Intellect telemetry PyPI publish command

### DIFF
--- a/.github/workflows/publish-prime-intellect-telemetry.yml
+++ b/.github/workflows/publish-prime-intellect-telemetry.yml
@@ -113,11 +113,9 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_version.outputs.should_publish == 'true'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           cd packages/telemetry/prime-intellect
-          uv publish --username __token__ --password "$UV_PUBLISH_TOKEN"
+          uv publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.check_version.outputs.should_publish == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The publish job for `latitude-telemetry-prime-intellect` failed with:

```text
error: the argument '--username <USERNAME>' cannot be used with '--token <TOKEN>'
```

Cause: the workflow set `UV_PUBLISH_TOKEN` in the step env (which `uv publish` treats as `--token`) and also passed `--username` / `--password`. Those modes are mutually exclusive.

Fix: drop `UV_PUBLISH_TOKEN` and use the same invocation as Hermes / the other Python publish workflows:

```bash
uv publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
```

After merge, re-run the publish workflow (or wait for the next packages publish) so `0.1.0` can land on PyPI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fd60c45-4e88-46ab-8c82-387a285ab247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fd60c45-4e88-46ab-8c82-387a285ab247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to authenticate directly with the configured PyPI token.
  * No user-facing product functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->