### PR TITLE
feat(web): agent-dispatch history on the signal detail page

### DIFF
--- a/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
+++ b/apps/web/src/domains/agent-dispatch/agent-dispatch.functions.ts
@@ -417,6 +417,45 @@ export const listAgentDispatches = createServerFn({ method: "GET" })
     return rows
   })
 
+export const signalAgentDispatchesQueryKey = (projectId: string, signalId: string) =>
+  ["signal-agent-dispatches", projectId, signalId] as const
+
+export const listSignalAgentDispatches = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ projectId: z.string(), signalId: z.string() }))
+  .handler(async ({ data }): Promise<readonly AgentDispatchRecord[]> => {
+    const { organizationId } = await requireSession()
+    const projectId = ProjectId(data.projectId)
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const dispatchRepo = yield* AgentDispatchRepository
+        const configRepo = yield* AgentDispatchConfigRepository
+        const dispatches = yield* dispatchRepo.listBySource({
+          projectId,
+          sourceType: "signal",
+          sourceId: data.signalId,
+        })
+        const configs = yield* configRepo.listByProjectIncludingDefaults(projectId)
+        const configById = new Map(configs.map((config) => [config.id, config]))
+
+        return dispatches.map((dispatch) => {
+          const config = configById.get(dispatch.configId)
+          const routineUrl =
+            config?.kind === "claude_code" && config.target && "routineTriggerId" in config.target
+              ? `https://claude.ai/code/routines/${config.target.routineTriggerId}`
+              : null
+          return { ...toDispatchRecord(dispatch), routineUrl }
+        })
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(AgentDispatchRepositoryLive, AgentDispatchConfigRepositoryLive),
+          getPostgresClient(),
+          organizationId,
+        ),
+        withTracing,
+      ),
+    )
+  })
+
 export const listCursorRepositories = createServerFn({ method: "GET" })
   .inputValidator(z.object({ integrationId: z.string() }))
   .handler(async ({ data }) => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings/-components/agent-dispatch-section.tsx
@@ -88,7 +88,7 @@ const DEEP_LINK_LABELS: Record<AgentDispatchKindKey, string> = {
   webhook: "View delivery",
 }
 
-const DISPATCH_ERROR_TITLES: Record<string, string> = {
+export const DISPATCH_ERROR_TITLES: Record<string, string> = {
   auth: "Authentication error",
   config: "Dispatch request rejected",
   rate_limited: "Rate limited",
@@ -171,7 +171,7 @@ const ACTIVE_DISPATCH_TRIGGERS = [
   "monitor.incident",
 ] as const
 
-const DISPATCH_TRIGGER_TITLES: Record<string, string> = {
+export const DISPATCH_TRIGGER_TITLES: Record<string, string> = {
   "signal.discovered": "New signal",
   "incident.opened": "Escalating signal",
   "signal.regressed": "Regressed signal",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-dispatch-history.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-dispatch-history.tsx
@@ -1,0 +1,99 @@
+import { Button, cn, Icon, Popover, PopoverContent, PopoverTrigger, Status, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { ExternalLink, History } from "lucide-react"
+import type { AgentDispatchRecord } from "../../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
+import {
+  AGENT_DISPATCH_KIND_ICONS,
+  AGENT_DISPATCH_KIND_LABELS,
+  DISPATCH_ERROR_TITLES,
+  DISPATCH_TRIGGER_TITLES,
+} from "../../../settings/-components/agent-dispatch-section.tsx"
+
+const kindLabel = (kind: AgentDispatchRecord["kind"]): string => (kind ? AGENT_DISPATCH_KIND_LABELS[kind] : "an agent")
+
+function statusVariant(status: string) {
+  if (status === "dispatched") return "success" as const
+  if (status === "failed") return "destructive" as const
+  return "neutral" as const
+}
+
+function DispatchRow({ dispatch }: { readonly dispatch: AgentDispatchRecord }) {
+  const label = dispatch.kind ? AGENT_DISPATCH_KIND_LABELS[dispatch.kind] : "Agent"
+  const KindIcon = dispatch.kind ? AGENT_DISPATCH_KIND_ICONS[dispatch.kind] : History
+  const trigger = DISPATCH_TRIGGER_TITLES[dispatch.trigger] ?? dispatch.trigger.replaceAll(".", " ")
+  const errorTitle = dispatch.errorCategory
+    ? (DISPATCH_ERROR_TITLES[dispatch.errorCategory] ?? dispatch.errorCategory)
+    : null
+  const href = dispatch.externalUrl ?? dispatch.routineUrl
+
+  const content = (
+    <>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Icon icon={KindIcon} size="sm" className="shrink-0" />
+          <Text.H5 weight="semibold" ellipsis>
+            {label}
+          </Text.H5>
+        </div>
+        <Status variant={statusVariant(dispatch.status)} label={dispatch.status} className="shrink-0 capitalize" />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <Text.H6 color="foregroundMuted">{trigger}</Text.H6>
+        <Text.H6 color="foregroundMuted">{relativeTime(new Date(dispatch.claimedAt))}</Text.H6>
+      </div>
+      {errorTitle ? <Text.H6 color="destructive">{errorTitle}</Text.H6> : null}
+    </>
+  )
+
+  const baseClassName = "flex flex-col gap-1 px-2 py-3 first:pt-2 last:pb-2"
+
+  return href ? (
+    <a href={href} target="_blank" rel="noreferrer" className={cn(baseClassName, "cursor-pointer hover:bg-muted")}>
+      {content}
+    </a>
+  ) : (
+    <div className={baseClassName}>{content}</div>
+  )
+}
+
+export function SignalDispatchHistory({
+  dispatches,
+  projectSlug,
+  triggerClassName,
+}: {
+  readonly dispatches: readonly AgentDispatchRecord[]
+  readonly projectSlug: string
+  readonly triggerClassName?: string
+}) {
+  const latest = dispatches[0]
+
+  return (
+    <Popover modal={false}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className={cn("text-sm", triggerClassName)}>
+          <Icon icon={latest?.kind ? AGENT_DISPATCH_KIND_ICONS[latest.kind] : History} size="sm" />
+          {`Sent to ${kindLabel(latest?.kind ?? null)}`}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="max-w-72 p-2">
+        <div className="flex items-center justify-between gap-2 px-2 pt-1 pb-2">
+          <Text.H6 weight="semibold">Dispatch history</Text.H6>
+          <Link
+            to="/projects/$projectSlug/settings/integrations"
+            params={{ projectSlug }}
+            className="flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            View all
+            <Icon icon={ExternalLink} size="xs" />
+          </Link>
+        </div>
+        <div className="flex max-h-80 flex-col divide-y divide-border overflow-y-auto">
+          {dispatches.map((dispatch) => (
+            <DispatchRow key={dispatch.id} dispatch={dispatch} />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-send-to.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/signals/$signalSlug/-components/signal-send-to.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   CloseTrigger,
   CopyButton,
   DropdownMenuContent,
@@ -20,16 +21,18 @@ import {
 } from "@repo/ui"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { Clipboard, Loader2, Plus, Sparkles } from "lucide-react"
+import { ChevronDown, Clipboard, Loader2, Plus, Sparkles } from "lucide-react"
 import { useState } from "react"
 import {
   getSignalDispatchPrompt,
   listCursorRepositories,
   listSendToDestinations,
+  listSignalAgentDispatches,
   type SendToDestinationRecord,
   sendSignalToIntegration,
   sendToDestinationsQueryKey,
   setProjectDispatchRepo,
+  signalAgentDispatchesQueryKey,
 } from "../../../../../../../domains/agent-dispatch/agent-dispatch.functions.ts"
 import { toUserMessage } from "../../../../../../../lib/errors.ts"
 import {
@@ -37,6 +40,7 @@ import {
   AGENT_DISPATCH_KIND_LABELS,
   projectDispatchSettingsQueryKey,
 } from "../../../settings/-components/agent-dispatch-section.tsx"
+import { SignalDispatchHistory } from "./signal-dispatch-history.tsx"
 
 const MCP_DOCS_URL = "https://docs.latitude.so/getting-started/mcp"
 
@@ -75,8 +79,15 @@ export function SignalSendTo({
   readonly disabled?: boolean
 }) {
   const { toast } = useToast()
+  const queryClient = useQueryClient()
   const [promptModalOpen, setPromptModalOpen] = useState(false)
   const [cursorRepoModal, setCursorRepoModal] = useState<SendToDestinationRecord | null>(null)
+
+  const { data: dispatches } = useQuery({
+    queryKey: signalAgentDispatchesQueryKey(projectId, signalId),
+    queryFn: () => listSignalAgentDispatches({ data: { projectId, signalId } }),
+    enabled: !disabled && signalId.length > 0,
+  })
 
   const { data: destinations, isLoading: destinationsLoading } = useQuery({
     queryKey: sendToDestinationsQueryKey(projectId),
@@ -88,6 +99,7 @@ export function SignalSendTo({
       sendSignalToIntegration({
         data: { projectId, signalId, kind: destination.kind, sendId: crypto.randomUUID() },
       }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: signalAgentDispatchesQueryKey(projectId, signalId) }),
     onSuccess: (result, destination) => {
       const label = AGENT_DISPATCH_KIND_LABELS[destination.kind]
       if (result.status === "dispatched") {
@@ -135,78 +147,68 @@ export function SignalSendTo({
   const sendingKind = sendMutation.isPending ? sendMutation.variables?.kind : undefined
 
   const hasCloudDestinations = (destinations?.length ?? 0) > 0
+  const hasDispatches = !disabled && !!dispatches && dispatches.length > 0
 
-  return (
-    <>
-      <DropdownMenuRoot modal={false}>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="sm" className="text-sm" disabled={disabled || sendMutation.isPending}>
-            {sendMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-            ) : (
-              <Icon icon={Sparkles} size="sm" />
-            )}
-            {sendMutation.isPending ? "Sending…" : "Send to agent"}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuPortal>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel className="font-medium text-muted-foreground">Cloud agents</DropdownMenuLabel>
-            {destinationsLoading ? (
-              <DropdownMenuItem disabled className="items-center gap-2">
-                <Text.H5 color="foregroundMuted">Loading integrations…</Text.H5>
-              </DropdownMenuItem>
-            ) : hasCloudDestinations ? (
-              destinations?.map((destination) =>
-                !destination.ready && destination.kind !== "cursor" ? (
-                  <DropdownMenuItem key={destination.kind} asChild className="cursor-pointer items-center gap-2">
-                    <Link to="/projects/$projectSlug/settings/signals" params={{ projectSlug }} hash={destination.kind}>
-                      <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
-                      <Text.H5>{`Finish setting up ${AGENT_DISPATCH_KIND_LABELS[destination.kind]}`}</Text.H5>
-                    </Link>
-                  </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem
-                    key={destination.kind}
-                    disabled={sendMutation.isPending}
-                    className="cursor-pointer items-center gap-2"
-                    onSelect={() => {
-                      if (sendMutation.isPending) return
-                      if (!destination.ready) {
-                        setCursorRepoModal(destination)
-                        return
-                      }
-                      sendMutation.mutate(destination)
-                    }}
-                  >
-                    {sendingKind === destination.kind ? (
-                      <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" aria-hidden />
-                    ) : (
-                      <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
-                    )}
-                    <Text.H5>
-                      {sendingKind === destination.kind ? "Sending…" : AGENT_DISPATCH_KIND_LABELS[destination.kind]}
-                    </Text.H5>
-                  </DropdownMenuItem>
-                ),
-              )
-            ) : (
-              <DropdownMenuItem asChild className="cursor-pointer items-center gap-2">
-                <Link to="/projects/$projectSlug/settings/integrations" params={{ projectSlug }}>
-                  <Icon icon={Plus} size="sm" />
-                  <Text.H5>Set up cloud agents</Text.H5>
-                </Link>
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel className="font-medium text-muted-foreground">Local agents</DropdownMenuLabel>
-            <DropdownMenuItem className="cursor-pointer items-center gap-2" onSelect={() => setPromptModalOpen(true)}>
-              <Icon icon={Clipboard} size="sm" />
-              <Text.H5>Copy prompt</Text.H5>
+  const menuContent = (
+    <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuLabel className="font-medium text-muted-foreground">Cloud agents</DropdownMenuLabel>
+      {destinationsLoading ? (
+        <DropdownMenuItem disabled className="items-center gap-2">
+          <Text.H5 color="foregroundMuted">Loading integrations…</Text.H5>
+        </DropdownMenuItem>
+      ) : hasCloudDestinations ? (
+        destinations?.map((destination) =>
+          !destination.ready && destination.kind !== "cursor" ? (
+            <DropdownMenuItem key={destination.kind} asChild className="cursor-pointer items-center gap-2">
+              <Link to="/projects/$projectSlug/settings/signals" params={{ projectSlug }} hash={destination.kind}>
+                <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
+                <Text.H5>{`Finish setting up ${AGENT_DISPATCH_KIND_LABELS[destination.kind]}`}</Text.H5>
+              </Link>
             </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenuPortal>
-      </DropdownMenuRoot>
+          ) : (
+            <DropdownMenuItem
+              key={destination.kind}
+              disabled={sendMutation.isPending}
+              className="cursor-pointer items-center gap-2"
+              onSelect={() => {
+                if (sendMutation.isPending) return
+                if (!destination.ready) {
+                  setCursorRepoModal(destination)
+                  return
+                }
+                sendMutation.mutate(destination)
+              }}
+            >
+              {sendingKind === destination.kind ? (
+                <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" aria-hidden />
+              ) : (
+                <Icon icon={AGENT_DISPATCH_KIND_ICONS[destination.kind]} size="sm" />
+              )}
+              <Text.H5>
+                {sendingKind === destination.kind ? "Sending…" : AGENT_DISPATCH_KIND_LABELS[destination.kind]}
+              </Text.H5>
+            </DropdownMenuItem>
+          ),
+        )
+      ) : (
+        <DropdownMenuItem asChild className="cursor-pointer items-center gap-2">
+          <Link to="/projects/$projectSlug/settings/integrations" params={{ projectSlug }}>
+            <Icon icon={Plus} size="sm" />
+            <Text.H5>Set up cloud agents</Text.H5>
+          </Link>
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel className="font-medium text-muted-foreground">Local agents</DropdownMenuLabel>
+      <DropdownMenuItem className="cursor-pointer items-center gap-2" onSelect={() => setPromptModalOpen(true)}>
+        <Icon icon={Clipboard} size="sm" />
+        <Text.H5>Copy prompt</Text.H5>
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  )
+
+  const modals = (
+    <>
       {promptModalOpen ? (
         <CopyPromptModal projectId={projectId} signalId={signalId} onClose={() => setPromptModalOpen(false)} />
       ) : null}
@@ -222,6 +224,60 @@ export function SignalSendTo({
           destination={cursorRepoModal}
         />
       ) : null}
+    </>
+  )
+
+  // Already dispatched: the primary button opens the dispatch-history popover;
+  // the resend menu tucks behind the chevron as a joined split button.
+  if (hasDispatches) {
+    return (
+      <>
+        <ButtonGroup>
+          <SignalDispatchHistory
+            dispatches={dispatches}
+            projectSlug={projectSlug}
+            triggerClassName="rounded-r-none border-r-0"
+          />
+          <DropdownMenuRoot modal={false}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-l-none px-1.5"
+                aria-label="Send again to agent"
+                disabled={sendMutation.isPending}
+              >
+                {sendMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                ) : (
+                  <Icon icon={ChevronDown} size="sm" />
+                )}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuPortal>{menuContent}</DropdownMenuPortal>
+          </DropdownMenuRoot>
+        </ButtonGroup>
+        {modals}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <DropdownMenuRoot modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="text-sm" disabled={disabled || sendMutation.isPending}>
+            {sendMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Icon icon={Sparkles} size="sm" />
+            )}
+            {sendMutation.isPending ? "Sending…" : "Send to agent"}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuPortal>{menuContent}</DropdownMenuPortal>
+      </DropdownMenuRoot>
+      {modals}
     </>
   )
 }

--- a/dev-docs/agent-dispatch.md
+++ b/dev-docs/agent-dispatch.md
@@ -55,6 +55,8 @@ The signal detail page has a **Send to** button (`signal-send-to.tsx`) with two 
 
 Manual sends keep the feature flag, config-enabled check, org RLS, and ledger idempotency (`<vendor>:<configId>:manual:<signalId>:<sendId>`; each click mints a new `sendId`), but deliberately bypass trigger subscription, signal mute, and guardrails — an explicit human click is its own approval. Transport failures are returned to the user without background retry.
 
+Once a signal has any ledger rows (`AgentDispatchRepository.listBySource` via the `listSignalAgentDispatches` server fn — signal or monitor, automatic or manual), the detail page swaps the plain **Send to** button for a **dispatch-history** button plus a **Send again to agent** dropdown (the same selector). The history button opens a popover listing that signal's dispatches — kind, trigger, status, relative time, and deep link — so a run can be correlated back to the signal that triggered it; a single dispatch labels the button with its target, multiple show a count.
+
 Guardrails: `maxDispatchesPerDay`, `cooldownMinutes` per config. The current UI uses defaults and does not expose these controls.
 
 ## Data model

--- a/packages/domain/agent-dispatch/src/ports/repositories.ts
+++ b/packages/domain/agent-dispatch/src/ports/repositories.ts
@@ -103,6 +103,11 @@ export interface AgentDispatchRepositoryShape {
     readonly errorDetail: string
   }) => Effect.Effect<boolean, RepositoryError, SqlClient>
   readonly listByProject: (projectId: ProjectId) => Effect.Effect<readonly AgentDispatch[], RepositoryError, SqlClient>
+  readonly listBySource: (input: {
+    readonly projectId: ProjectId
+    readonly sourceType: "signal" | "monitor"
+    readonly sourceId: string
+  }) => Effect.Effect<readonly AgentDispatch[], RepositoryError, SqlClient>
 }
 
 export class AgentDispatchRepository extends Context.Service<AgentDispatchRepository, AgentDispatchRepositoryShape>()(

--- a/packages/platform/db-postgres/src/repositories/agent-dispatch-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/agent-dispatch-repository.test.ts
@@ -66,6 +66,42 @@ describe("AgentDispatchRepositoryLive", () => {
     expect(afterDispatch.claimed).toBe(false)
   })
 
+  it("lists dispatches for a single source newest-first, scoped to project and source", async () => {
+    const claim = (idempotencyKey: string, sourceId: string, projectId = PROJECT) =>
+      run(
+        Effect.gen(function* () {
+          const repo = yield* AgentDispatchRepository
+          return yield* repo.claim({
+            configId: CONFIG,
+            projectId,
+            idempotencyKey,
+            trigger: "manual" as const,
+            sourceType: "signal" as const,
+            sourceId,
+          })
+        }),
+      )
+
+    await claim("cursor:cfg:manual:sigA:1", "sigA")
+    await claim("linear:cfg:manual:sigA:2", "sigA")
+    await claim("cursor:cfg:manual:sigB:1", "sigB")
+    await claim("cursor:cfg:manual:sigA:1", "sigA", ProjectId("c".repeat(24)))
+
+    const forSignalA = await run(
+      Effect.gen(function* () {
+        const repo = yield* AgentDispatchRepository
+        return yield* repo.listBySource({ projectId: PROJECT, sourceType: "signal", sourceId: "sigA" })
+      }),
+    )
+
+    expect(forSignalA).toHaveLength(2)
+    expect(forSignalA.every((dispatch) => dispatch.sourceId === "sigA")).toBe(true)
+    expect(forSignalA.every((dispatch) => dispatch.projectId === PROJECT)).toBe(true)
+    const [newest, oldest] = forSignalA
+    if (!newest || !oldest) throw new Error("unreachable")
+    expect(newest.claimedAt.getTime()).toBeGreaterThanOrEqual(oldest.claimedAt.getTime())
+  })
+
   it("marks claimed rows failed by idempotency key", async () => {
     const input = {
       configId: CONFIG,

--- a/packages/platform/db-postgres/src/repositories/agent-dispatch-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/agent-dispatch-repository.ts
@@ -163,4 +163,27 @@ export const AgentDispatchRepositoryLive = Layer.succeed(AgentDispatchRepository
         .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatches")))
       return rows.map(toDomainDispatch)
     }),
+
+  listBySource: ({ projectId, sourceType, sourceId }) =>
+    Effect.gen(function* () {
+      const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+      const rows = yield* sqlClient
+        .query((db, organizationId) =>
+          db
+            .select()
+            .from(agentDispatches)
+            .where(
+              and(
+                eq(agentDispatches.organizationId, organizationId),
+                eq(agentDispatches.projectId, projectId),
+                eq(agentDispatches.sourceType, sourceType),
+                eq(agentDispatches.sourceId, sourceId),
+              ),
+            )
+            .orderBy(desc(agentDispatches.claimedAt))
+            .limit(50),
+        )
+        .pipe(Effect.mapError((e) => toRepositoryError(e, "listAgentDispatchesBySource")))
+      return rows.map(toDomainDispatch)
+    }),
 })

--- a/packages/platform/db-postgres/src/seeds/agent-dispatch/index.ts
+++ b/packages/platform/db-postgres/src/seeds/agent-dispatch/index.ts
@@ -1,0 +1,141 @@
+import { Effect } from "effect"
+import { agentDispatches } from "../../schema/agent-dispatches.ts"
+import { type SeedContext, SeedError, type Seeder } from "../types.ts"
+
+interface DispatchFixture {
+  readonly key: string
+  readonly kind: "cursor" | "claude_code" | "linear" | "webhook"
+  readonly signalKey: string
+  readonly trigger: "signal.discovered" | "signal.regressed" | "incident.opened" | "manual"
+  readonly idSuffix: string
+  readonly status: "claimed" | "dispatched" | "failed"
+  readonly claimedDaysAgo: number
+  readonly claimedHour: number
+  readonly dispatchedDaysAgo?: number
+  readonly externalAgentId?: string
+  readonly externalUrl?: string
+  readonly errorCategory?: string
+  readonly errorDetail?: string
+}
+
+// Attaches dispatch-ledger rows to a handful of seeded signals so the signal
+// detail page can be reviewed in each "Send to agent" state: no dispatch
+// (every other signal), a single dispatch (logistics, combination), and
+// multiple dispatches (billing → history popover). Kind is parsed from the
+// idempotency key's first segment, so no integration/config row is required.
+const DISPATCH_FIXTURES: readonly DispatchFixture[] = [
+  {
+    key: "billing-cursor-auto",
+    kind: "cursor",
+    signalKey: "billing",
+    trigger: "signal.discovered",
+    idSuffix: "window-6d",
+    status: "dispatched",
+    claimedDaysAgo: 6,
+    claimedHour: 9,
+    dispatchedDaysAgo: 6,
+    externalAgentId: "bc_9f2c1a",
+    externalUrl: "https://cursor.com/agents?id=bc_9f2c1a",
+  },
+  {
+    key: "billing-cursor-manual",
+    kind: "cursor",
+    signalKey: "billing",
+    trigger: "manual",
+    idSuffix: "send-8ab21",
+    status: "dispatched",
+    claimedDaysAgo: 2,
+    claimedHour: 14,
+    dispatchedDaysAgo: 2,
+    externalAgentId: "bc_44de77",
+    externalUrl: "https://cursor.com/agents?id=bc_44de77",
+  },
+  {
+    key: "billing-linear-failed",
+    kind: "linear",
+    signalKey: "billing",
+    trigger: "manual",
+    idSuffix: "send-1c93f",
+    status: "failed",
+    claimedDaysAgo: 0,
+    claimedHour: 6,
+    errorCategory: "auth",
+    errorDetail: "Linear rejected this API key.",
+  },
+  {
+    key: "logistics-claude",
+    kind: "claude_code",
+    signalKey: "logistics",
+    trigger: "signal.regressed",
+    idSuffix: "window-4h",
+    status: "dispatched",
+    claimedDaysAgo: 0,
+    claimedHour: 8,
+    dispatchedDaysAgo: 0,
+  },
+  {
+    key: "combination-webhook",
+    kind: "webhook",
+    signalKey: "combination",
+    trigger: "manual",
+    idSuffix: "send-77c02",
+    status: "claimed",
+    claimedDaysAgo: 0,
+    claimedHour: 11,
+  },
+]
+
+const buildAgentDispatchRows = (ctx: SeedContext): (typeof agentDispatches.$inferInsert)[] => {
+  const { scope } = ctx
+  const signalId = (signalKey: string) => scope.cuid(`issue:${signalKey}`)
+  const configId = (kind: string) => scope.cuid(`agent-dispatch-config:${kind}`)
+
+  return DISPATCH_FIXTURES.map((fixture) => {
+    const source = signalId(fixture.signalKey)
+    const config = configId(fixture.kind)
+    const idempotencyKey = `${fixture.kind}:${config}:${fixture.trigger}:${source}:${fixture.idSuffix}`
+
+    return {
+      id: scope.cuid(`agent-dispatch:${fixture.key}`),
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      configId: config,
+      idempotencyKey,
+      trigger: fixture.trigger,
+      sourceType: "signal",
+      sourceId: source,
+      claimedAt: scope.dateDaysAgo(fixture.claimedDaysAgo, fixture.claimedHour, 0),
+      dispatchedAt:
+        fixture.dispatchedDaysAgo === undefined
+          ? null
+          : scope.dateDaysAgo(fixture.dispatchedDaysAgo, fixture.claimedHour, 5),
+      externalAgentId: fixture.externalAgentId ?? null,
+      externalRunId: null,
+      externalUrl: fixture.externalUrl ?? null,
+      status: fixture.status,
+      errorCategory: fixture.errorCategory ?? null,
+      errorDetail: fixture.errorDetail ?? null,
+    }
+  })
+}
+
+const seedAgentDispatches: Seeder = {
+  name: "agent-dispatch/signal-dispatch-history",
+  run: (ctx: SeedContext) =>
+    Effect.tryPromise({
+      try: async () => {
+        const rows = buildAgentDispatchRows(ctx)
+        for (const row of rows) {
+          const { id, ...set } = row
+          await ctx.db.insert(agentDispatches).values(row).onConflictDoUpdate({
+            target: agentDispatches.id,
+            set,
+          })
+        }
+        console.log(`  -> agent dispatches: ${rows.length} signal dispatch events`)
+      },
+      catch: (error) => new SeedError({ reason: "Failed to seed agent dispatches", cause: error }),
+    }).pipe(Effect.asVoid),
+}
+
+export const agentDispatchSeeders: readonly Seeder[] = [seedAgentDispatches]

--- a/packages/platform/db-postgres/src/seeds/all.ts
+++ b/packages/platform/db-postgres/src/seeds/all.ts
@@ -1,3 +1,4 @@
+import { agentDispatchSeeders } from "./agent-dispatch/index.ts"
 import { alertIncidentSeeders } from "./alert-incidents/index.ts"
 import { apiKeySeeders } from "./api-keys/index.ts"
 import { customBehaviorQaSeeders } from "./custom-behaviors/index.ts"
@@ -44,6 +45,9 @@ export const contentSeeders: readonly Seeder[] = [
   // Must run after notificationSeeders so it fully controls which of its own
   // incidents read as "Notified" vs "Muted".
   ...monitorSeeders,
+  // Attaches agent-dispatch ledger rows to seeded signals; only depends on
+  // signalSeeders having run.
+  ...agentDispatchSeeders,
 ]
 
 export const allSeeders: readonly Seeder[] = [


### PR DESCRIPTION
## What

On the signal detail page, the **Send to agent** button now reflects whether the signal has already been dispatched to an agent.

- **Never dispatched** — the plain **Send to agent** dropdown, unchanged.
- **Dispatched** — a split button: a **dispatch-history pill** joined to a **chevron dropdown**.
  - The pill shows the most recent send (e.g. "Sent to Cursor") and opens a popover listing every dispatch for that signal — agent kind, trigger, status, and time — so a run correlates back to the signal that triggered it. Rows with an external URL (or Claude routine) are clickable. A **View all** link jumps to the full dispatch history in settings.
  - The chevron (aria-label "Send again to agent") resends through the same selector.

## Why

Agent dispatch already records every send in the `agent_dispatches` ledger, but the signal detail page only ever offered "send", with no visibility into what had already been dispatched. This surfaces that history in place and makes re-sending explicit.

## How

- **domain** — `AgentDispatchRepository.listBySource({ projectId, sourceType, sourceId })` (port + Postgres impl + test), scoped so a single signal's dispatches are fetched directly rather than filtered from the project-wide list.
- **web** — `listSignalAgentDispatches` server fn; `SignalDispatchHistory` popover; `SignalSendTo` rebuilt around the `ButtonGroup` split button, with the send menu and modals shared across both states. Successful/failed sends invalidate the history query so the pill updates.
- **docs** — `dev-docs/agent-dispatch.md` "Manual sends" section documents the detail-page history + resend flow.

## Seeds / how to review

Agent dispatch had no seed coverage. A new `seeds/agent-dispatch` seeder attaches ledger rows to existing seeded signals, so all states are reviewable locally **without configuring a real integration** (kind is parsed from the idempotency key):

| Signal | State |
| --- | --- |
| *Telecom agent applies unsupported account credits* (billing) | 3 dispatches → popover: Cursor auto (dispatched + link), Cursor manual (dispatched + link), Linear (failed / auth) |
| *Telecom agent leaves connectivity troubleshooting incomplete* (logistics) | 1 dispatch → Claude Code (dispatched) |
| *Retail agent skips account authentication* (combination) | 1 dispatch → Webhook (claimed / in-flight) |
| every other signal | none → plain "Send to agent" |

Run `pnpm seed` (idempotent) to populate.

## Testing

- New `listBySource` repository test (PGlite testkit).
- Typecheck (`@domain/agent-dispatch`, `@platform/db-postgres`, `@app/web`), Biome, and knip all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dispatch history to signal pages, including status, trigger, timing, and links to external runs.
  * Added a “Send again to agent” option for signals with previous dispatches.
  * Added support for loading and displaying recent dispatch records per signal.
  * Added representative dispatch history data for seeded environments.

* **Documentation**
  * Documented the updated dispatch-history and resend experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->