### PR TITLE
fix(telemetry): release breaking instrumentation API as v4

### DIFF
--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-23
+
 ### Changed
 
 - **Breaking:** `instrumentations` now accepts an array of instances created by opt-in `@latitude-data/telemetry/instrumentations/*` factories instead of an integration-name object map.

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",


### PR DESCRIPTION
PR #4178 changed the public `instrumentations` configuration from an integration-name object map to an array of instrumentation instances. This bumps `@latitude-data/telemetry` to 4.0.0 so the breaking API ships under a new major version.

The existing instrumentation isolation notes now live in the 4.0.0 changelog section, which also lets the publish workflow extract the matching GitHub release notes.

Refs #4178

## Validation

- `pnpm --filter @latitude-data/telemetry typecheck`
- `pnpm --filter @latitude-data/telemetry check`
- `pnpm --filter @latitude-data/telemetry test` (148 tests)
- changelog release-note extraction for 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released the telemetry TypeScript package as version 4.0.0.
  * Added the 4.0.0 release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->