### PR TITLE
fix(workflows): make session backfills failure tolerant

### DIFF
--- a/apps/workflows/src/workflows/analyze-session-workflow.test.ts
+++ b/apps/workflows/src/workflows/analyze-session-workflow.test.ts
@@ -13,13 +13,16 @@ const { mockActivities, signalState, patchedState } = vi.hoisted(() => {
   const signalState: { handler: ((input: { readonly debounceMs?: number }) => void) | undefined } = {
     handler: undefined,
   }
-  const patchedState = { enabled: true }
+  const patchedState: { default: boolean; readonly byId: Record<string, boolean> } = {
+    default: true,
+    byId: {},
+  }
   return { mockActivities, signalState, patchedState }
 })
 
 vi.mock("@temporalio/workflow", () => ({
   defineSignal: vi.fn((name: string) => ({ name })),
-  patched: () => patchedState.enabled,
+  patched: (id: string) => patchedState.byId[id] ?? patchedState.default,
   proxyActivities: () => mockActivities,
   setHandler: vi.fn((_signal, handler) => {
     signalState.handler = handler
@@ -56,7 +59,10 @@ describe("analyzeSessionWorkflow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     signalState.handler = undefined
-    patchedState.enabled = true
+    patchedState.default = true
+    for (const id of Object.keys(patchedState.byId)) {
+      delete patchedState.byId[id]
+    }
     mockActivities.segmentAnalyzeSessionActivity.mockName("segment").mockResolvedValue({ replayed: true })
     mockActivities.detectAnalyzeSessionLabelsActivity.mockName("label").mockResolvedValue({ replayed: true })
     mockActivities.loadAnalyzeSessionActivity.mockName("load").mockResolvedValue({ found: true, rawMessages: [] })
@@ -84,28 +90,22 @@ describe("analyzeSessionWorkflow", () => {
     expect(setHandler).toHaveBeenCalledWith({ name: "traceCompleted" }, expect.any(Function))
   })
 
-  it("runs named idempotent analysis activities in order", async () => {
+  it("runs one persist activity per pass for new executions", async () => {
     await expect(analyzeSessionWorkflow(input)).resolves.toEqual({
       action: "recorded",
       status: "analyzed",
       momentCount: 0,
     })
 
-    expect(activityOrder()).toEqual(["load", "hash", "eligibility", "embed", "persist"])
-    expect(mockActivities.segmentAnalyzeSessionActivity).not.toHaveBeenCalled()
-    expect(mockActivities.detectAnalyzeSessionLabelsActivity).not.toHaveBeenCalled()
-    expect(mockActivities.embedAnalyzeSessionTurnsActivity).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        sessionId: input.sessionId,
-        analysisHash: "h".repeat(64),
-      }),
-    )
+    expect(activityOrder()).toEqual(["persist"])
+    expect(mockActivities.loadAnalyzeSessionActivity).not.toHaveBeenCalled()
+    expect(mockActivities.hashAnalyzeSessionActivity).not.toHaveBeenCalled()
+    expect(mockActivities.checkAnalyzeSessionEligibilityActivity).not.toHaveBeenCalled()
+    expect(mockActivities.embedAnalyzeSessionTurnsActivity).not.toHaveBeenCalled()
   })
 
   it("replays the legacy segment + label warm-up sequence for pre-patch executions", async () => {
-    patchedState.enabled = false
+    patchedState.default = false
 
     await expect(analyzeSessionWorkflow(input)).resolves.toEqual({
       action: "recorded",
@@ -116,7 +116,8 @@ describe("analyzeSessionWorkflow", () => {
     expect(activityOrder()).toEqual(["load", "hash", "eligibility", "embed", "segment", "label", "persist"])
   })
 
-  it("short-circuits hash-current sessions before expensive activities", async () => {
+  it("short-circuits hash-current sessions before expensive activities during legacy replay", async () => {
+    patchedState.byId["analyze-session-persist-only-v1"] = false
     mockActivities.checkAnalyzeSessionEligibilityActivity.mockResolvedValueOnce({
       eligible: false,
       reason: "hash_current",
@@ -129,7 +130,8 @@ describe("analyzeSessionWorkflow", () => {
     expect(mockActivities.persistAnalyzeSessionActivity).not.toHaveBeenCalled()
   })
 
-  it("persists skipped ineligible sessions without expensive activities", async () => {
+  it("persists skipped ineligible sessions without expensive activities during legacy replay", async () => {
+    patchedState.byId["analyze-session-persist-only-v1"] = false
     mockActivities.checkAnalyzeSessionEligibilityActivity.mockResolvedValueOnce({
       eligible: false,
       reason: "too_short",
@@ -149,11 +151,12 @@ describe("analyzeSessionWorkflow", () => {
     await analyzeSessionWorkflow({ ...input, debounceMs: 123 })
 
     expect(sleep).not.toHaveBeenCalled()
-    expect(mockActivities.loadAnalyzeSessionActivity).toHaveBeenCalled()
+    expect(mockActivities.persistAnalyzeSessionActivity).toHaveBeenCalledOnce()
+    expect(mockActivities.loadAnalyzeSessionActivity).not.toHaveBeenCalled()
   })
 
   it("replays the internal debounce for pre-patch executions", async () => {
-    patchedState.enabled = false
+    patchedState.default = false
 
     await analyzeSessionWorkflow({ ...input, debounceMs: 123 })
 
@@ -173,12 +176,13 @@ describe("analyzeSessionWorkflow", () => {
       momentCount: 0,
     })
 
-    expect(mockActivities.loadAnalyzeSessionActivity).toHaveBeenCalledTimes(2)
-    expect(mockActivities.hashAnalyzeSessionActivity).toHaveBeenCalledTimes(2)
     expect(mockActivities.persistAnalyzeSessionActivity).toHaveBeenCalledTimes(2)
+    expect(mockActivities.loadAnalyzeSessionActivity).not.toHaveBeenCalled()
+    expect(mockActivities.hashAnalyzeSessionActivity).not.toHaveBeenCalled()
   })
 
-  it("falls through to persist when the embedding warm-up fails", async () => {
+  it("falls through to persist when the embedding warm-up fails during legacy replay", async () => {
+    patchedState.byId["analyze-session-persist-only-v1"] = false
     mockActivities.embedAnalyzeSessionTurnsActivity.mockRejectedValueOnce(new Error("embedding warm-up failed"))
 
     await expect(analyzeSessionWorkflow(input)).resolves.toEqual({

--- a/apps/workflows/src/workflows/analyze-session-workflow.ts
+++ b/apps/workflows/src/workflows/analyze-session-workflow.ts
@@ -25,6 +25,11 @@ const {
 })
 
 const runAnalyzeSessionPass = async (input: AnalyzeSessionWorkflowInput): Promise<AnalyzeSessionWorkflowResult> => {
+  // Keep the legacy activity sequence for histories recorded before this marker.
+  if (patched("analyze-session-persist-only-v1")) {
+    return persistAnalyzeSessionActivity(input)
+  }
+
   const loaded = await loadAnalyzeSessionActivity(input)
   const hashed = await hashAnalyzeSessionActivity({ ...input, ...loaded })
   const eligibility = await checkAnalyzeSessionEligibilityActivity({ ...input, ...loaded, ...hashed })

--- a/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.test.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.test.ts
@@ -1,8 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { callOrder, childExecutions, mockActivities } = vi.hoisted(() => {
+const {
+  callOrder,
+  childErrors,
+  childExecutions,
+  childResults,
+  mockActivities,
+  mockWorkflowLog,
+  parentCancellationState,
+  patchedState,
+} = vi.hoisted(() => {
   const callOrder: string[] = []
+  const childErrors: Record<string, Error> = {}
+  const childResults: Record<string, unknown> = {}
   const childExecutions: Array<{ readonly args: unknown[]; readonly workflowId: string }> = []
+  const mockWorkflowLog = { warn: vi.fn() }
+  const parentCancellationState = { consideredCancelled: false }
+  const patchedState: { default: boolean; readonly byId: Record<string, boolean> } = { default: true, byId: {} }
   const mockActivities = {
     listRecentBackfillSessionsActivity: vi.fn(async () => {
       callOrder.push("list-sessions")
@@ -26,14 +40,32 @@ const { callOrder, childExecutions, mockActivities } = vi.hoisted(() => {
       callOrder.push("wait-observations")
     }),
   }
-  return { callOrder, childExecutions, mockActivities }
+  return {
+    callOrder,
+    childErrors,
+    childExecutions,
+    childResults,
+    mockActivities,
+    mockWorkflowLog,
+    parentCancellationState,
+    patchedState,
+  }
 })
 
 vi.mock("@temporalio/workflow", () => ({
+  CancellationScope: { current: () => parentCancellationState },
+  patched: (id: string) => patchedState.byId[id] ?? patchedState.default,
   proxyActivities: () => mockActivities,
+  isCancellation: (error: unknown) => error instanceof Error && error.name === "CancelledFailure",
+  log: mockWorkflowLog,
   executeChild: async (_workflow: unknown, options: { args: unknown[]; workflowId: string }) => {
     callOrder.push(options.workflowId.includes(":taxonomy:garden:") ? "garden" : "analyze")
     childExecutions.push({ args: options.args, workflowId: options.workflowId })
+    const sessionId = (options.args[0] as { readonly sessionId?: string }).sessionId
+    if (sessionId) {
+      if (childErrors[sessionId]) throw childErrors[sessionId]
+      return childResults[sessionId] ?? { action: "recorded", status: "analyzed", momentCount: 0 }
+    }
     return { status: "completed" }
   },
 }))
@@ -60,13 +92,25 @@ describe("backfillRecentSessionIntelligenceWorkflow", () => {
   beforeEach(() => {
     callOrder.length = 0
     childExecutions.length = 0
+    for (const sessionId of Object.keys(childErrors)) delete childErrors[sessionId]
+    for (const sessionId of Object.keys(childResults)) delete childResults[sessionId]
+    parentCancellationState.consideredCancelled = false
+    patchedState.default = true
+    for (const id of Object.keys(patchedState.byId)) delete patchedState.byId[id]
     vi.clearAllMocks()
   })
 
   it("resets only selected sessions before analyzing and gardening", async () => {
     const result = await backfillRecentSessionIntelligenceWorkflow(input)
 
-    expect(result).toEqual({ action: "completed", sessionsFound: 2 })
+    expect(result).toEqual({
+      action: "completed",
+      sessionsFound: 2,
+      sessionsCompleted: 2,
+      sessionsFailed: 0,
+      failedSessionIds: [],
+      failedSessionIdsTruncated: false,
+    })
     expect(mockActivities.listRecentBackfillSessionsActivity).toHaveBeenCalledWith(input)
     expect(mockActivities.resetSessionIntelligenceForSessionsActivity).toHaveBeenCalledWith({
       organizationId: "org-1",
@@ -106,5 +150,31 @@ describe("backfillRecentSessionIntelligenceWorkflow", () => {
         workflowId: "org:org-1:taxonomy:garden:project-1:recent-backfill",
       },
     ])
+  })
+
+  it("continues subsequent batches after a child failure and still gardens", async () => {
+    childErrors["session-1"] = new Error("analysis failed")
+
+    await expect(backfillRecentSessionIntelligenceWorkflow(input)).resolves.toEqual({
+      action: "completed",
+      sessionsFound: 2,
+      sessionsCompleted: 1,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+      failedSessionIdsTruncated: false,
+    })
+
+    expect(callOrder).toEqual(["list-sessions", "reset-sessions", "analyze", "analyze", "wait-observations", "garden"])
+  })
+
+  it("propagates workflow cancellation", async () => {
+    const cancellation = new Error("cancelled")
+    cancellation.name = "CancelledFailure"
+    childErrors["session-1"] = cancellation
+
+    parentCancellationState.consideredCancelled = true
+
+    await expect(backfillRecentSessionIntelligenceWorkflow(input)).rejects.toThrow("cancelled")
+    expect(callOrder).toEqual(["list-sessions", "reset-sessions", "analyze"])
   })
 })

--- a/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-backfill-workflow.ts
@@ -1,10 +1,11 @@
-import { executeChild, proxyActivities } from "@temporalio/workflow"
+import { CancellationScope, executeChild, isCancellation, log, patched, proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
-import { analyzeSessionWorkflow } from "./analyze-session-workflow.ts"
+import { type AnalyzeSessionWorkflowResult, analyzeSessionWorkflow } from "./analyze-session-workflow.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 import { gardenTaxonomyWorkflow } from "./taxonomy-gardening-workflow.ts"
 
 const DEFAULT_SESSION_CHILD_CONCURRENCY = 10
+const MAX_FAILED_SESSION_IDS = 100
 
 const {
   listRecentBackfillSessionsActivity,
@@ -31,6 +32,10 @@ export interface BackfillRecentSessionIntelligenceWorkflowInput {
 export interface BackfillRecentSessionIntelligenceWorkflowResult {
   readonly action: "completed"
   readonly sessionsFound: number
+  readonly sessionsCompleted: number
+  readonly sessionsFailed: number
+  readonly failedSessionIds: readonly string[]
+  readonly failedSessionIdsTruncated: boolean
 }
 
 export const backfillRecentSessionIntelligenceWorkflow = async (
@@ -44,25 +49,65 @@ export const backfillRecentSessionIntelligenceWorkflow = async (
   })
 
   const childConcurrency = Math.max(1, input.sessionConcurrency ?? DEFAULT_SESSION_CHILD_CONCURRENCY)
+  const continueAfterChildFailure = patched("recent-session-intelligence-backfill-continue-child-failures-v1")
+  const failedSessionIds: string[] = []
+  let sessionsCompleted = 0
+  let sessionsFailed = 0
+
   for (let index = 0; index < sessions.length; index += childConcurrency) {
     const batch = sessions.slice(index, index + childConcurrency)
-    await Promise.all(
-      batch.map((session) =>
-        executeChild(analyzeSessionWorkflow, {
-          args: [
-            {
-              organizationId: input.organizationId,
-              projectId: input.projectId,
-              sessionId: session.sessionId,
-              triggeringTraceId: session.triggeringTraceId,
-              triggeringStartTime: session.triggeringStartTime,
-              reason: "backfill",
-            },
-          ],
-          workflowId: `org:${input.organizationId}:conversation-intelligence:recentBackfillAnalyzeSession:${input.projectId}:${session.sessionId}`,
-          workflowIdReusePolicy: "ALLOW_DUPLICATE",
-        }),
-      ),
+    const executeAnalyzeSession = (session: (typeof sessions)[number]) =>
+      executeChild(analyzeSessionWorkflow, {
+        args: [
+          {
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            sessionId: session.sessionId,
+            triggeringTraceId: session.triggeringTraceId,
+            triggeringStartTime: session.triggeringStartTime,
+            reason: "backfill",
+          },
+        ],
+        workflowId: `org:${input.organizationId}:conversation-intelligence:recentBackfillAnalyzeSession:${input.projectId}:${session.sessionId}`,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+      })
+
+    const classifyResult = (sessionId: string, result: AnalyzeSessionWorkflowResult): boolean => {
+      if (result.action !== "recorded" || result.status !== "failed") return true
+      log.warn("Session analysis child resolved as failed", {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sessionId,
+        status: result.status,
+      })
+      return false
+    }
+
+    const outcomes = continueAfterChildFailure
+      ? await Promise.all(
+          batch.map(async (session) => {
+            try {
+              return classifyResult(session.sessionId, await executeAnalyzeSession(session))
+            } catch (error) {
+              if (isCancellation(error) && CancellationScope.current().consideredCancelled) throw error
+              log.warn("Session analysis child execution failed", {
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                sessionId: session.sessionId,
+                reason: error instanceof Error ? error.message : "unknown",
+              })
+              return false
+            }
+          }),
+        )
+      : await Promise.all(
+          batch.map(async (session) => classifyResult(session.sessionId, await executeAnalyzeSession(session))),
+        )
+    sessionsCompleted += outcomes.filter(Boolean).length
+    const failedSessions = batch.filter((_, outcomeIndex) => !outcomes[outcomeIndex])
+    sessionsFailed += failedSessions.length
+    failedSessionIds.push(
+      ...failedSessions.slice(0, MAX_FAILED_SESSION_IDS - failedSessionIds.length).map((session) => session.sessionId),
     )
   }
 
@@ -77,5 +122,12 @@ export const backfillRecentSessionIntelligenceWorkflow = async (
     })
   }
 
-  return { action: "completed", sessionsFound: sessions.length }
+  return {
+    action: "completed",
+    sessionsFound: sessions.length,
+    sessionsCompleted,
+    sessionsFailed,
+    failedSessionIds,
+    failedSessionIdsTruncated: sessionsFailed > failedSessionIds.length,
+  }
 }

--- a/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.test.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.test.ts
@@ -1,24 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { childExecutions, mockActivities } = vi.hoisted(() => {
+const { childExecutions, childResults, mockActivities } = vi.hoisted(() => {
   const childExecutions: Array<{ readonly args: unknown[]; readonly workflowId: string }> = []
+  const childResults: Record<string, unknown> = {}
   const mockActivities = {
     listSessionIntelligenceBackfillProjectsActivity: vi.fn(async () => [
       { organizationId: "org-1", projectId: "project-1" },
       { organizationId: "org-2", projectId: "project-2" },
     ]),
   }
-  return { childExecutions, mockActivities }
+  return { childExecutions, childResults, mockActivities }
 })
 
 vi.mock("@temporalio/workflow", () => ({
   proxyActivities: () => mockActivities,
   executeChild: async (_workflow: unknown, options: { args: unknown[]; workflowId: string }) => {
     childExecutions.push({ args: options.args, workflowId: options.workflowId })
-    return {
-      action: "completed",
-      sessionsFound: options.workflowId.includes("project-1") ? 2 : 3,
-    }
+    const projectId = (options.args[0] as { readonly projectId: string }).projectId
+    return (
+      childResults[projectId] ??
+      (projectId === "project-1"
+        ? {
+            action: "completed",
+            sessionsFound: 2,
+            sessionsCompleted: 1,
+            sessionsFailed: 1,
+            failedSessionIds: ["session-1"],
+            failedSessionIdsTruncated: false,
+          }
+        : {
+            action: "completed",
+            sessionsFound: 3,
+            sessionsCompleted: 3,
+            sessionsFailed: 0,
+            failedSessionIds: [],
+            failedSessionIdsTruncated: false,
+          })
+    )
   },
 }))
 
@@ -31,6 +49,7 @@ import { backfillRecentSessionIntelligenceForProjectsWorkflow } from "./recent-s
 describe("backfillRecentSessionIntelligenceForProjectsWorkflow", () => {
   beforeEach(() => {
     childExecutions.length = 0
+    for (const projectId of Object.keys(childResults)) delete childResults[projectId]
     vi.clearAllMocks()
   })
 
@@ -43,7 +62,15 @@ describe("backfillRecentSessionIntelligenceForProjectsWorkflow", () => {
       gardenAfter: true,
     })
 
-    expect(result).toEqual({ action: "completed", projectsFound: 2, sessionsFound: 5 })
+    expect(result).toEqual({
+      action: "completed",
+      projectsFound: 2,
+      sessionsFound: 5,
+      sessionsCompleted: 4,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+      failedSessionIdsTruncated: false,
+    })
     expect(mockActivities.listSessionIntelligenceBackfillProjectsActivity).toHaveBeenCalledWith({})
     expect(childExecutions).toEqual([
       {
@@ -73,5 +100,32 @@ describe("backfillRecentSessionIntelligenceForProjectsWorkflow", () => {
         workflowId: "org:org-2:conversation-intelligence:recentBackfill:project-2:2026-06-07T00:00:00.000Z",
       },
     ])
+  })
+
+  it("caps child failure-id samples while preserving exact counts and legacy child results", async () => {
+    childResults["project-1"] = {
+      action: "completed",
+      sessionsFound: 101,
+      sessionsCompleted: 0,
+      sessionsFailed: 101,
+      failedSessionIds: Array.from({ length: 101 }, (_, index) => `session-${index + 1}`),
+      failedSessionIdsTruncated: true,
+    }
+    childResults["project-2"] = { action: "completed", sessionsFound: 3 }
+
+    await expect(
+      backfillRecentSessionIntelligenceForProjectsWorkflow({
+        sessionLimitPerProject: 500,
+        startedAfter: "2026-06-07T00:00:00.000Z",
+        projectConcurrency: 1,
+      }),
+    ).resolves.toMatchObject({
+      projectsFound: 2,
+      sessionsFound: 104,
+      sessionsCompleted: 3,
+      sessionsFailed: 101,
+      failedSessionIds: Array.from({ length: 100 }, (_, index) => `session-${index + 1}`),
+      failedSessionIdsTruncated: true,
+    })
   })
 })

--- a/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.ts
+++ b/apps/workflows/src/workflows/recent-session-intelligence-projects-backfill-workflow.ts
@@ -6,6 +6,15 @@ import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 const DEFAULT_LOOKBACK_DAYS = 3
 const DEFAULT_PROJECT_CONCURRENCY = 2
 const DEFAULT_SESSION_CONCURRENCY_PER_PROJECT = 10
+const MAX_FAILED_SESSION_IDS = 100
+
+type BackfillChildResult = {
+  readonly sessionsFound?: number
+  readonly sessionsCompleted?: number
+  readonly sessionsFailed?: number
+  readonly failedSessionIds?: readonly unknown[]
+  readonly failedSessionIdsTruncated?: boolean
+}
 
 const { listSessionIntelligenceBackfillProjectsActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -31,6 +40,10 @@ export interface BackfillRecentSessionIntelligenceForProjectsWorkflowResult {
   readonly action: "completed"
   readonly projectsFound: number
   readonly sessionsFound: number
+  readonly sessionsCompleted: number
+  readonly sessionsFailed: number
+  readonly failedSessionIds: readonly string[]
+  readonly failedSessionIdsTruncated: boolean
 }
 
 const startedAfterForInput = (input: BackfillRecentSessionIntelligenceForProjectsWorkflowInput): string => {
@@ -49,7 +62,11 @@ export const backfillRecentSessionIntelligenceForProjectsWorkflow = async (
   })
 
   const projectConcurrency = Math.max(1, input.projectConcurrency ?? DEFAULT_PROJECT_CONCURRENCY)
+  const failedSessionIds: string[] = []
+  let failedSessionIdsTruncated = false
   let sessionsFound = 0
+  let sessionsCompleted = 0
+  let sessionsFailed = 0
   for (let index = 0; index < projects.length; index += projectConcurrency) {
     const batch = projects.slice(index, index + projectConcurrency)
     const results = await Promise.all(
@@ -70,8 +87,29 @@ export const backfillRecentSessionIntelligenceForProjectsWorkflow = async (
         }),
       ),
     )
-    sessionsFound += results.reduce((sum, result) => sum + result.sessionsFound, 0)
+    for (const result of results) {
+      const childResult = result as BackfillChildResult
+      const childSessionsFound = childResult.sessionsFound ?? 0
+      const childSessionsFailed = childResult.sessionsFailed ?? 0
+      sessionsFound += childSessionsFound
+      sessionsCompleted += childResult.sessionsCompleted ?? childSessionsFound - childSessionsFailed
+      sessionsFailed += childSessionsFailed
+      failedSessionIdsTruncated ||= childResult.failedSessionIdsTruncated === true
+      if (!Array.isArray(childResult.failedSessionIds)) continue
+      for (const sessionId of childResult.failedSessionIds) {
+        if (failedSessionIds.length === MAX_FAILED_SESSION_IDS) break
+        if (typeof sessionId === "string") failedSessionIds.push(sessionId)
+      }
+    }
   }
 
-  return { action: "completed", projectsFound: projects.length, sessionsFound }
+  return {
+    action: "completed",
+    projectsFound: projects.length,
+    sessionsFound,
+    sessionsCompleted,
+    sessionsFailed,
+    failedSessionIds,
+    failedSessionIdsTruncated: failedSessionIdsTruncated || sessionsFailed > failedSessionIds.length,
+  }
 }

--- a/apps/workflows/src/workflows/session-intelligence-backfill-workflow.test.ts
+++ b/apps/workflows/src/workflows/session-intelligence-backfill-workflow.test.ts
@@ -1,8 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { callOrder, childExecutions, mockActivities, patchedState } = vi.hoisted(() => {
+const {
+  callOrder,
+  childDelays,
+  childErrors,
+  childExecutions,
+  childResults,
+  mockActivities,
+  mockWorkflowLog,
+  parentCancellationState,
+  patchedState,
+} = vi.hoisted(() => {
   const callOrder: string[] = []
-  const patchedState = { enabled: true }
+  const childDelays: Record<string, () => Promise<void>> = {}
+  const childErrors: Record<string, Error> = {}
+  const childResults: Record<string, unknown> = {}
+  const mockWorkflowLog = { warn: vi.fn() }
+  const parentCancellationState = { consideredCancelled: false }
+  const patchedState: { default: boolean; readonly byId: Record<string, boolean> } = { default: true, byId: {} }
   const childExecutions: Array<{ readonly args: unknown[]; readonly workflowId: string }> = []
   const mockActivities = {
     resetSessionIntelligenceForProjectActivity: vi.fn(async () => {
@@ -30,14 +45,33 @@ const { callOrder, childExecutions, mockActivities, patchedState } = vi.hoisted(
       callOrder.push("wait-observations")
     }),
   }
-  return { callOrder, childExecutions, mockActivities, patchedState }
+  return {
+    callOrder,
+    childDelays,
+    childErrors,
+    childExecutions,
+    childResults,
+    mockActivities,
+    mockWorkflowLog,
+    parentCancellationState,
+    patchedState,
+  }
 })
 
 vi.mock("@temporalio/workflow", () => ({
-  patched: () => patchedState.enabled,
+  CancellationScope: { current: () => parentCancellationState },
+  patched: (id: string) => patchedState.byId[id] ?? patchedState.default,
   proxyActivities: () => mockActivities,
+  isCancellation: (error: unknown) => error instanceof Error && error.name === "CancelledFailure",
+  log: mockWorkflowLog,
   executeChild: async (_workflow: unknown, options: { args: unknown[]; workflowId: string }) => {
     childExecutions.push({ args: options.args, workflowId: options.workflowId })
+    const sessionId = (options.args[0] as { readonly sessionId?: string }).sessionId
+    if (sessionId) {
+      await childDelays[sessionId]?.()
+      if (childErrors[sessionId]) throw childErrors[sessionId]
+      return childResults[sessionId] ?? childResults["*"] ?? { action: "recorded", status: "analyzed", momentCount: 0 }
+    }
     return { status: "completed" }
   },
 }))
@@ -63,14 +97,26 @@ describe("backfillSessionIntelligenceWorkflow", () => {
   beforeEach(() => {
     callOrder.length = 0
     childExecutions.length = 0
-    patchedState.enabled = true
+    for (const sessionId of Object.keys(childDelays)) delete childDelays[sessionId]
+    for (const sessionId of Object.keys(childErrors)) delete childErrors[sessionId]
+    for (const sessionId of Object.keys(childResults)) delete childResults[sessionId]
+    parentCancellationState.consideredCancelled = false
+    patchedState.default = true
+    for (const id of Object.keys(patchedState.byId)) delete patchedState.byId[id]
     vi.clearAllMocks()
   })
 
   it("uses distinct child workflow ids for backoffice session analysis", async () => {
     const result = await backfillSessionIntelligenceWorkflow(input)
 
-    expect(result).toEqual({ action: "completed", sessionsFound: 2 })
+    expect(result).toEqual({
+      action: "completed",
+      sessionsFound: 2,
+      sessionsCompleted: 2,
+      sessionsFailed: 0,
+      failedSessionIds: [],
+      failedSessionIdsTruncated: false,
+    })
     expect(childExecutions).toEqual([
       {
         args: [
@@ -103,5 +149,118 @@ describe("backfillSessionIntelligenceWorkflow", () => {
         workflowId: "org:org-1:taxonomy:garden:project-1:backfill",
       },
     ])
+  })
+
+  it("continues after child failures and still gardens with mixed patch markers", async () => {
+    patchedState.byId["session-intelligence-backfill-child-concurrency-10-v1"] = false
+    childErrors["session-1"] = new Error("analysis failed")
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toEqual({
+      action: "completed",
+      sessionsFound: 2,
+      sessionsCompleted: 1,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+      failedSessionIdsTruncated: false,
+    })
+
+    expect(childExecutions.map(({ workflowId }) => workflowId)).toContain(
+      "org:org-1:taxonomy:garden:project-1:backfill",
+    )
+  })
+
+  it("counts resolved failed analysis statuses and logs the status", async () => {
+    childResults["session-1"] = { action: "recorded", status: "failed", momentCount: 0 }
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toMatchObject({
+      sessionsFound: 2,
+      sessionsCompleted: 1,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+      failedSessionIdsTruncated: false,
+    })
+    expect(mockWorkflowLog.warn).toHaveBeenCalledWith("Session analysis child resolved as failed", {
+      organizationId: "org-1",
+      projectId: "project-1",
+      sessionId: "session-1",
+      status: "failed",
+    })
+  })
+
+  it("counts skipped analyses as completed", async () => {
+    childResults["session-1"] = { action: "skipped", reason: "hash-current" }
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toMatchObject({
+      sessionsFound: 2,
+      sessionsCompleted: 2,
+      sessionsFailed: 0,
+      failedSessionIds: [],
+      failedSessionIdsTruncated: false,
+    })
+  })
+
+  it("records independently cancelled children and rethrows parent cancellation", async () => {
+    const cancellation = new Error("child cancelled")
+    cancellation.name = "CancelledFailure"
+    childErrors["session-1"] = cancellation
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toMatchObject({
+      sessionsCompleted: 1,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+    })
+    expect(mockWorkflowLog.warn).toHaveBeenCalledWith("Session analysis child execution failed", {
+      organizationId: "org-1",
+      projectId: "project-1",
+      sessionId: "session-1",
+      reason: "child cancelled",
+    })
+
+    parentCancellationState.consideredCancelled = true
+    await expect(backfillSessionIntelligenceWorkflow(input)).rejects.toThrow("child cancelled")
+  })
+
+  it("keeps failed-session samples in input order and caps them", async () => {
+    mockActivities.listBackfillSessionsActivity.mockResolvedValueOnce(
+      Array.from({ length: 101 }, (_, index) => ({
+        sessionId: `session-${index + 1}`,
+        triggeringTraceId: `trace-${index + 1}`,
+        triggeringStartTime: "2026-01-01T00:00:00.000Z",
+      })),
+    )
+    childResults["*"] = { action: "recorded", status: "failed", momentCount: 0 }
+    childDelays["session-1"] = async () => {
+      await Promise.resolve()
+    }
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toMatchObject({
+      sessionsFound: 101,
+      sessionsCompleted: 0,
+      sessionsFailed: 101,
+      failedSessionIds: Array.from({ length: 100 }, (_, index) => `session-${index + 1}`),
+      failedSessionIdsTruncated: true,
+    })
+  })
+
+  it("classifies resolved analysis failures for legacy histories", async () => {
+    patchedState.byId["session-intelligence-backfill-continue-child-failures-v1"] = false
+    childResults["session-1"] = { action: "recorded", status: "failed", momentCount: 0 }
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).resolves.toMatchObject({
+      sessionsFound: 2,
+      sessionsCompleted: 1,
+      sessionsFailed: 1,
+      failedSessionIds: ["session-1"],
+    })
+  })
+
+  it("preserves rejected child failures for legacy histories", async () => {
+    patchedState.default = false
+    childErrors["session-1"] = new Error("analysis failed")
+
+    await expect(backfillSessionIntelligenceWorkflow(input)).rejects.toThrow("analysis failed")
+    expect(childExecutions.map(({ workflowId }) => workflowId)).not.toContain(
+      "org:org-1:taxonomy:garden:project-1:backfill",
+    )
   })
 })

--- a/apps/workflows/src/workflows/session-intelligence-backfill-workflow.ts
+++ b/apps/workflows/src/workflows/session-intelligence-backfill-workflow.ts
@@ -1,11 +1,12 @@
-import { executeChild, patched, proxyActivities } from "@temporalio/workflow"
+import { CancellationScope, executeChild, isCancellation, log, patched, proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
-import { analyzeSessionWorkflow } from "./analyze-session-workflow.ts"
+import { type AnalyzeSessionWorkflowResult, analyzeSessionWorkflow } from "./analyze-session-workflow.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 import { gardenTaxonomyWorkflow } from "./taxonomy-gardening-workflow.ts"
 
 const LEGACY_BACKFILL_CHILD_CONCURRENCY = 5
 const BACKFILL_CHILD_CONCURRENCY = 10
+const MAX_FAILED_SESSION_IDS = 100
 
 const {
   listBackfillSessionsActivity,
@@ -31,6 +32,10 @@ export interface BackfillSessionIntelligenceWorkflowInput {
 export interface BackfillSessionIntelligenceWorkflowResult {
   readonly action: "completed"
   readonly sessionsFound: number
+  readonly sessionsCompleted: number
+  readonly sessionsFailed: number
+  readonly failedSessionIds: readonly string[]
+  readonly failedSessionIdsTruncated: boolean
 }
 
 export const backfillSessionIntelligenceWorkflow = async (
@@ -43,26 +48,65 @@ export const backfillSessionIntelligenceWorkflow = async (
   const childConcurrency = patched("session-intelligence-backfill-child-concurrency-10-v1")
     ? BACKFILL_CHILD_CONCURRENCY
     : LEGACY_BACKFILL_CHILD_CONCURRENCY
+  const continueAfterChildFailure = patched("session-intelligence-backfill-continue-child-failures-v1")
+  const failedSessionIds: string[] = []
+  let sessionsCompleted = 0
+  let sessionsFailed = 0
 
   for (let index = 0; index < sessions.length; index += childConcurrency) {
     const batch = sessions.slice(index, index + childConcurrency)
-    await Promise.all(
-      batch.map((session) =>
-        executeChild(analyzeSessionWorkflow, {
-          args: [
-            {
-              organizationId: input.organizationId,
-              projectId: input.projectId,
-              sessionId: session.sessionId,
-              triggeringTraceId: session.triggeringTraceId,
-              triggeringStartTime: session.triggeringStartTime,
-              reason: "backfill",
-            },
-          ],
-          workflowId: `org:${input.organizationId}:conversation-intelligence:backfillAnalyzeSession:${input.projectId}:${session.sessionId}`,
-          workflowIdReusePolicy: "ALLOW_DUPLICATE",
-        }),
-      ),
+    const executeAnalyzeSession = (session: (typeof sessions)[number]) =>
+      executeChild(analyzeSessionWorkflow, {
+        args: [
+          {
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            sessionId: session.sessionId,
+            triggeringTraceId: session.triggeringTraceId,
+            triggeringStartTime: session.triggeringStartTime,
+            reason: "backfill",
+          },
+        ],
+        workflowId: `org:${input.organizationId}:conversation-intelligence:backfillAnalyzeSession:${input.projectId}:${session.sessionId}`,
+        workflowIdReusePolicy: "ALLOW_DUPLICATE",
+      })
+
+    const classifyResult = (sessionId: string, result: AnalyzeSessionWorkflowResult): boolean => {
+      if (result.action !== "recorded" || result.status !== "failed") return true
+      log.warn("Session analysis child resolved as failed", {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        sessionId,
+        status: result.status,
+      })
+      return false
+    }
+
+    const outcomes = continueAfterChildFailure
+      ? await Promise.all(
+          batch.map(async (session) => {
+            try {
+              return classifyResult(session.sessionId, await executeAnalyzeSession(session))
+            } catch (error) {
+              if (isCancellation(error) && CancellationScope.current().consideredCancelled) throw error
+              log.warn("Session analysis child execution failed", {
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                sessionId: session.sessionId,
+                reason: error instanceof Error ? error.message : "unknown",
+              })
+              return false
+            }
+          }),
+        )
+      : await Promise.all(
+          batch.map(async (session) => classifyResult(session.sessionId, await executeAnalyzeSession(session))),
+        )
+    sessionsCompleted += outcomes.filter(Boolean).length
+    const failedSessions = batch.filter((_, outcomeIndex) => !outcomes[outcomeIndex])
+    sessionsFailed += failedSessions.length
+    failedSessionIds.push(
+      ...failedSessions.slice(0, MAX_FAILED_SESSION_IDS - failedSessionIds.length).map((session) => session.sessionId),
     )
   }
 
@@ -77,5 +121,12 @@ export const backfillSessionIntelligenceWorkflow = async (
     })
   }
 
-  return { action: "completed", sessionsFound: sessions.length }
+  return {
+    action: "completed",
+    sessionsFound: sessions.length,
+    sessionsCompleted,
+    sessionsFailed,
+    failedSessionIds,
+    failedSessionIdsTruncated: sessionsFailed > failedSessionIds.length,
+  }
 }


### PR DESCRIPTION
## What changed

New `analyzeSessionWorkflow` executions run each pass through the persist activity instead of passing loaded messages, a duplicated document, and embeddings through Temporal history. Patch markers keep existing workflow histories on their recorded command sequence.

Full and recent backfills now isolate session child failures. They continue processing later batches, wait for observation stability, and run taxonomy gardening after partial failures. Parent cancellation still stops the workflow. Results include exact completion and failure counts plus a capped sample of failed session IDs, and multi-project backfills aggregate those results without creating another oversized Temporal payload.

## Why

A large conversation produced an activity result above Temporal's payload limit. Its session-analysis child failed before persistence, and the backfill's `Promise.all` rejected the parent before taxonomy gardening ran. Since the backoffice action resets existing intelligence first, this left the project with a partial rebuild.

## Verification

- `pnpm --filter @app/workflows exec vitest run src/workflows/analyze-session-workflow.test.ts src/workflows/session-intelligence-backfill-workflow.test.ts src/workflows/recent-session-intelligence-backfill-workflow.test.ts src/workflows/recent-session-intelligence-projects-backfill-workflow.test.ts`
- `pnpm --filter @app/workflows check`
- `git diff --check`

The package typecheck was attempted but remains blocked by existing workspace dependency resolution and Effect typing errors outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backfill workflows now report completed and failed session totals.
  * Results include sample failed session IDs and indicate when the sample is truncated.
  * Backfills can continue processing after individual session failures while preserving cancellation behavior.
  * Session analysis can use a streamlined persistence-only path for newer workflow executions.

* **Bug Fixes**
  * Improved handling of legacy workflow replay, skipped analyses, failed embeddings, and in-flight completions.
  * Failed sessions are now classified and reported more consistently across session and project backfills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->