### PR TITLE
feat(infra): wire GitHub App credentials as ECS secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,16 @@ LAT_MAILPIT_FROM=noreply@latitude.local
 # LAT_GITHUB_CLIENT_ID=your-github-client-id
 # LAT_GITHUB_CLIENT_SECRET=your-github-client-secret
 
+# GitHub App (integration; distinct from the GitHub SSO OAuth app above)
+# LAT_GITHUB_APP_ID=your-github-app-id
+# LAT_GITHUB_APP_SLUG=your-github-app-slug
+# LAT_GITHUB_APP_PRIVATE_KEY=base64-of-the-app-private-key-pem
+# LAT_GITHUB_WEBHOOK_SECRET=your-github-app-webhook-secret
+# LAT_GITHUB_APP_CLIENT_ID=your-github-app-client-id
+# LAT_GITHUB_APP_CLIENT_SECRET=your-github-app-client-secret
+# Only for GitHub Enterprise Server; leave unset for github.com
+# LAT_GITHUB_BASE_URL=
+
 # Amazon Bedrock (default generation provider; also a reranking provider)
 LAT_AWS_REGION=eu-central-1
 # LAT_AWS_ACCESS_KEY_ID=

--- a/infra/lib/ecs.ts
+++ b/infra/lib/ecs.ts
@@ -362,6 +362,12 @@ function createTaskDefinition(
       secrets["google-oauth-client-secret"].arn,
       secrets["github-oauth-client-id"].arn,
       secrets["github-oauth-client-secret"].arn,
+      secrets["github-app-id"].arn,
+      secrets["github-app-slug"].arn,
+      secrets["github-app-private-key"].arn,
+      secrets["github-app-webhook-secret"].arn,
+      secrets["github-app-client-id"].arn,
+      secrets["github-app-client-secret"].arn,
       secrets["stripe-secret-key"].arn,
       secrets["stripe-webhook-secret"].arn,
       secrets["stripe-pro-price-id"].arn,
@@ -407,6 +413,12 @@ function createTaskDefinition(
         googleOauthClientSecretArn,
         githubOauthClientIdArn,
         githubOauthClientSecretArn,
+        githubAppIdArn,
+        githubAppSlugArn,
+        githubAppPrivateKeyArn,
+        githubAppWebhookSecretArn,
+        githubAppClientIdArn,
+        githubAppClientSecretArn,
         stripeSecretKeyArn,
         stripeWebhookSecretArn,
         stripeProPriceIdArn,
@@ -537,6 +549,15 @@ function createTaskDefinition(
           { name: "LAT_GITHUB_CLIENT_SECRET", valueFrom: githubOauthClientSecretArn },
         ]
 
+        const githubAppSecrets = [
+          { name: "LAT_GITHUB_APP_ID", valueFrom: githubAppIdArn },
+          { name: "LAT_GITHUB_APP_SLUG", valueFrom: githubAppSlugArn },
+          { name: "LAT_GITHUB_APP_PRIVATE_KEY", valueFrom: githubAppPrivateKeyArn },
+          { name: "LAT_GITHUB_WEBHOOK_SECRET", valueFrom: githubAppWebhookSecretArn },
+          { name: "LAT_GITHUB_APP_CLIENT_ID", valueFrom: githubAppClientIdArn },
+          { name: "LAT_GITHUB_APP_CLIENT_SECRET", valueFrom: githubAppClientSecretArn },
+        ]
+
         const temporalSecret = { name: "LAT_TEMPORAL_API_KEY", valueFrom: temporalApiKeyArn }
 
         const stripeSelfServeSecrets = [
@@ -562,10 +583,10 @@ function createTaskDefinition(
         ]
 
         const serviceSpecificSecrets: Record<string, { name: string; valueFrom: string }[]> = {
-          api: [temporalSecret],
-          web: [...oauthSecrets, ...stripeSelfServeSecrets, temporalSecret, ...supportSecrets],
+          api: [temporalSecret, ...githubAppSecrets],
+          web: [...oauthSecrets, ...stripeSelfServeSecrets, temporalSecret, ...supportSecrets, ...githubAppSecrets],
           workflows: [temporalSecret, ...stripeOverageSecrets],
-          workers: [temporalSecret, ...bullBoardSecrets],
+          workers: [temporalSecret, ...bullBoardSecrets, ...githubAppSecrets],
         }
 
         const secrets = [...baseSecrets, ...(serviceSpecificSecrets[serviceConfig.name] ?? [])]

--- a/infra/lib/secrets.ts
+++ b/infra/lib/secrets.ts
@@ -260,6 +260,72 @@ export function createApplicationSecrets(baseName: string, environment: string):
   secrets["github-oauth-client-secret"] = githubOauthClientSecret.secret
   secretVersions["github-oauth-client-secret"] = githubOauthClientSecret.secretVersion
 
+  const githubAppId = createSingleSecret(
+    baseName,
+    "github-app-id",
+    "GitHub App ID — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_APP_ID ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-id"] = githubAppId.secret
+  secretVersions["github-app-id"] = githubAppId.secretVersion
+
+  const githubAppSlug = createSingleSecret(
+    baseName,
+    "github-app-slug",
+    "GitHub App slug — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_APP_SLUG ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-slug"] = githubAppSlug.secret
+  secretVersions["github-app-slug"] = githubAppSlug.secretVersion
+
+  const githubAppPrivateKey = createSingleSecret(
+    baseName,
+    "github-app-private-key",
+    "GitHub App private key (base64 of the .pem) — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_APP_PRIVATE_KEY ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-private-key"] = githubAppPrivateKey.secret
+  secretVersions["github-app-private-key"] = githubAppPrivateKey.secretVersion
+
+  const githubAppWebhookSecret = createSingleSecret(
+    baseName,
+    "github-app-webhook-secret",
+    "GitHub App webhook secret — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_WEBHOOK_SECRET ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-webhook-secret"] = githubAppWebhookSecret.secret
+  secretVersions["github-app-webhook-secret"] = githubAppWebhookSecret.secretVersion
+
+  const githubAppClientId = createSingleSecret(
+    baseName,
+    "github-app-client-id",
+    "GitHub App OAuth client ID — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_APP_CLIENT_ID ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-client-id"] = githubAppClientId.secret
+  secretVersions["github-app-client-id"] = githubAppClientId.secretVersion
+
+  const githubAppClientSecret = createSingleSecret(
+    baseName,
+    "github-app-client-secret",
+    "GitHub App OAuth client secret — replace placeholder-change-me in Secrets Manager",
+    process.env.LAT_GITHUB_APP_CLIENT_SECRET ?? "placeholder-change-me",
+    environment,
+    immutableSecretResourceOptions,
+  )
+  secrets["github-app-client-secret"] = githubAppClientSecret.secret
+  secretVersions["github-app-client-secret"] = githubAppClientSecret.secretVersion
+
   const stripeSecretKey = createSingleSecret(
     baseName,
     "stripe-secret-key",

--- a/specs/github-integration.md
+++ b/specs/github-integration.md
@@ -552,7 +552,7 @@ Five phases, **one PR each** (repo convention: each phase maps to its own PR int
 
 ### Phase 1 — App foundation: install flow, receiver, worker skeleton
 
-- [ ] **P1-0** *(manual — Alex)*: **register the GitHub Apps** (one for staging, one for production; repeat these steps twice). Latitude's GitHub org → **Settings → Developer settings → GitHub Apps → New GitHub App**:
+- [x] **P1-0** *(manual — Alex)*: **register the GitHub Apps** (one for staging, one for production; repeat these steps twice). Latitude's GitHub org → **Settings → Developer settings → GitHub Apps → New GitHub App**:
   1. **GitHub App name**: `Latitude` (production) / `Latitude Staging`. **Homepage URL**: `https://latitude.so`.
   2. **Identifying and authorizing users** — **Callback URL**: `https://console.latitude.so/integrations/github/setup/callback` (staging: same path on the staging web host). Check **"Request user authorization (OAuth) during installation"** (required for the anti-spoofing claim check, 5.2). Leave "Expire user authorization tokens" checked (default; we use the token once).
   3. **Post installation** — **Setup URL**: the same callback URL as step 2. Check **"Redirect on update"**.


### PR DESCRIPTION
## What

Wires the six **GitHub App** integration credentials into the ECS deployment as AWS Secrets Manager secrets, injected into the **api**, **web**, and **workers** services (ingest/workflows don't need them).

| Env var | Secret name (`latitude-<env>-…`) | Sensitivity |
| --- | --- | --- |
| `LAT_GITHUB_APP_ID` | `github-app-id` | id |
| `LAT_GITHUB_APP_SLUG` | `github-app-slug` | id |
| `LAT_GITHUB_APP_PRIVATE_KEY` | `github-app-private-key` | secret (base64 of the `.pem`) |
| `LAT_GITHUB_WEBHOOK_SECRET` | `github-app-webhook-secret` | secret |
| `LAT_GITHUB_APP_CLIENT_ID` | `github-app-client-id` | secret |
| `LAT_GITHUB_APP_CLIENT_SECRET` | `github-app-client-secret` | secret |

## How

- `infra/lib/secrets.ts` — six `createSingleSecret` blocks following the existing `github-oauth-*` pattern. Seeded with a `placeholder-change-me` on first create; real values are set out-of-band per environment (`protect: true` + `ignoreChanges: ["secretString"]` on the version, so Pulumi never overwrites them after create).
- `infra/lib/ecs.ts` — six ARNs added to the task-role policy + the positional `pulumi.all`/destructure, and a `githubAppSecrets` array attached to `api`, `web`, `workers`.
- `.env.example` — documents the six vars + the optional `LAT_GITHUB_BASE_URL` (GHES only; left unwired since Latitude runs against github.com).

## Notes

- These are the GitHub App's **own** OAuth credentials (`LAT_GITHUB_APP_CLIENT_*`), **distinct** from the GitHub SSO sign-in app (`LAT_GITHUB_CLIENT_*`) — not reused or overwritten.
- The private key is stored **base64-encoded** so it travels as a single-line env var; the consumer (Phase 1) will `Buffer.from(..., "base64")`-decode it before handing to Octokit.
- `latitude-infra` typecheck passes.
- Part of `specs/github-integration.md` — this is the **P1-2 infra wiring** sub-part (the `isGithubIntegrationConfigured` helper + URL builders ship with the Phase 1 implementation). Marks **P1-0** (manual App registration) done in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for GitHub App credentials, including GitHub Enterprise Server endpoints.
  * GitHub App secrets are now securely provisioned for the application’s API, web, and worker services.

* **Documentation**
  * Updated the GitHub integration checklist to reflect progress on registering GitHub Apps for staging and production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->