### PR TITLE
fix(notifications): link signals by slug in notification deep links

### DIFF
--- a/apps/web/src/domains/signals/signals.functions.ts
+++ b/apps/web/src/domains/signals/signals.functions.ts
@@ -671,7 +671,12 @@ export const getSignalIdBySlug = createServerFn({ method: "GET" })
         const signalRepository = yield* SignalRepository
         return yield* signalRepository.findBySlug({ projectId, slug: data.signalSlug }).pipe(
           Effect.map((issue) => ({ signalId: issue.id })),
-          Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+          Effect.catchTag("NotFoundError", () =>
+            signalRepository.findById(SignalId(data.signalSlug)).pipe(
+              Effect.map((issue) => (issue.projectId === data.projectId ? { signalId: issue.id } : null)),
+              Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+            ),
+          ),
         )
       }).pipe(withScopedPostgres(SignalRepositoryLive, pgClient, orgId), withTracing),
     )

--- a/packages/domain/email/src/templates/notifications/-incident-source.ts
+++ b/packages/domain/email/src/templates/notifications/-incident-source.ts
@@ -3,10 +3,11 @@ import { SignalRepository } from "@domain/signals"
 import { UserRepository } from "@domain/users"
 import { Effect } from "effect"
 
-/** Live-resolved display name of an incident's source. `description` is issue-only. `null` name when the source was deleted. */
+/** Live-resolved display name of an incident's source. `description`/`slug` are issue-only. `null` fields when the source was deleted. */
 interface ResolvedIncidentSource {
   readonly name: string | null
   readonly description: string | null
+  readonly slug: string | null
 }
 
 const loadError = (cause: unknown) => ({
@@ -15,14 +16,14 @@ const loadError = (cause: unknown) => ({
   cause,
 })
 
-const MISSING: ResolvedIncidentSource = { name: null, description: null }
+const MISSING: ResolvedIncidentSource = { name: null, description: null, slug: null }
 
 export const resolveIncidentSource = (input: { readonly sourceType: string; readonly sourceId: string }) =>
   Effect.gen(function* () {
     if (input.sourceType !== "signal") return MISSING
     const repo = yield* SignalRepository
     return yield* repo.findById(SignalId(input.sourceId)).pipe(
-      Effect.map((i): ResolvedIncidentSource => ({ name: i.name, description: i.description ?? null })),
+      Effect.map((i): ResolvedIncidentSource => ({ name: i.name, description: i.description ?? null, slug: i.slug })),
       Effect.catchTag("NotFoundError", () => Effect.succeed(MISSING)),
       Effect.catchTag("RepositoryError", (cause) => Effect.fail(loadError(cause))),
     )

--- a/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-closed/index.tsx
@@ -9,12 +9,11 @@ import { resolveAssigneeName, resolveIncidentSource } from "../-incident-source.
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentClosedEmail } from "./EmailTemplate.tsx"
 
-const buildSignalUrl = (
-  ctx: NotificationEmailRenderContext,
-  payload: Parameters<NotificationEmailRenderer<"incident.closed">>[0],
-): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.sourceId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"> = (payload, ctx) =>
@@ -23,7 +22,7 @@ export const incidentClosedRenderer: NotificationEmailRenderer<"incident.closed"
     const source = yield* resolveIncidentSource(payload)
     const assigneeName = yield* resolveAssigneeName(payload.assigneeId)
     const sourceName = source.name ?? (isMonitorIncident ? "a monitored target" : "a signal")
-    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, payload)
+    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, source.slug)
 
     const chartUrl = buildChartUrl({
       notificationId: ctx.notificationId,

--- a/packages/domain/email/src/templates/notifications/incident-event/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-event/index.tsx
@@ -9,12 +9,11 @@ import { resolveAssigneeName, resolveIncidentSource } from "../-incident-source.
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentEventEmail } from "./EmailTemplate.tsx"
 
-const buildSignalUrl = (
-  ctx: NotificationEmailRenderContext,
-  payload: Parameters<NotificationEmailRenderer<"incident.event">>[0],
-): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.sourceId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> = (payload, ctx) =>
@@ -32,7 +31,7 @@ export const incidentEventRenderer: NotificationEmailRenderer<"incident.event"> 
       incidentKind: payload.incidentKind,
       condition: payload.condition,
     })
-    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, payload)
+    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, source.slug)
     const ctaUrl = isMonitorIncident ? monitor?.url : signalUrl
     const subject = `${heading}: ${sourceName}`
 

--- a/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
+++ b/packages/domain/email/src/templates/notifications/incident-opened/index.tsx
@@ -9,12 +9,11 @@ import { resolveAssigneeName, resolveIncidentSource } from "../-incident-source.
 import type { NotificationEmailRenderContext, NotificationEmailRenderer } from "../types.ts"
 import { IncidentOpenedEmail } from "./EmailTemplate.tsx"
 
-const buildSignalUrl = (
-  ctx: NotificationEmailRenderContext,
-  payload: Parameters<NotificationEmailRenderer<"incident.opened">>[0],
-): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.sourceId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"> = (payload, ctx) =>
@@ -23,7 +22,7 @@ export const incidentOpenedRenderer: NotificationEmailRenderer<"incident.opened"
     const source = yield* resolveIncidentSource(payload)
     const assigneeName = yield* resolveAssigneeName(payload.assigneeId)
     const sourceName = source.name ?? (isMonitorIncident ? "a monitored target" : "a signal")
-    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, payload)
+    const signalUrl = isMonitorIncident ? undefined : buildSignalUrl(ctx, source.slug)
 
     const chartUrl = buildChartUrl({
       notificationId: ctx.notificationId,

--- a/packages/domain/email/src/templates/notifications/signal-assigned/index.tsx
+++ b/packages/domain/email/src/templates/notifications/signal-assigned/index.tsx
@@ -15,9 +15,11 @@ const loadError = (cause: unknown) => ({
   cause,
 })
 
-const buildSignalUrl = (ctx: NotificationEmailRenderContext, signalId: string): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signalId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 /**
@@ -43,7 +45,7 @@ export const signalAssignedRenderer: NotificationEmailRenderer<"issue.assigned">
     const signalName = issue?.name ?? "a signal"
     const actorName = actor ? (actor.name?.trim().length ? actor.name : actor.email) : "A teammate"
     const subject = `You were assigned to ${signalName}`
-    const signalUrl = buildSignalUrl(ctx, payload.signalId)
+    const signalUrl = buildSignalUrl(ctx, issue?.slug ?? null)
 
     const html = yield* Effect.tryPromise({
       try: () =>

--- a/packages/domain/email/src/templates/notifications/signal-discovered/index.tsx
+++ b/packages/domain/email/src/templates/notifications/signal-discovered/index.tsx
@@ -14,9 +14,11 @@ const loadError = (cause: unknown) => ({
   cause,
 })
 
-const buildSignalUrl = (ctx: NotificationEmailRenderContext, signalId: string): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signalId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 export const signalDiscoveredRenderer: NotificationEmailRenderer<"signal.discovered"> = (payload, ctx) =>
@@ -28,7 +30,7 @@ export const signalDiscoveredRenderer: NotificationEmailRenderer<"signal.discove
     )
 
     const signalName = signal?.name ?? "a signal"
-    const signalUrl = buildSignalUrl(ctx, payload.signalId)
+    const signalUrl = buildSignalUrl(ctx, signal?.slug ?? null)
     const subject = `Signal discovered: ${signalName}`
     const html = yield* Effect.tryPromise({
       try: () =>

--- a/packages/domain/email/src/templates/notifications/signal-regressed/index.tsx
+++ b/packages/domain/email/src/templates/notifications/signal-regressed/index.tsx
@@ -14,9 +14,11 @@ const loadError = (cause: unknown) => ({
   cause,
 })
 
-const buildSignalUrl = (ctx: NotificationEmailRenderContext, signalId: string): string | undefined => {
+const buildSignalUrl = (ctx: NotificationEmailRenderContext, slug: string | null): string | undefined => {
   if (!ctx.project) return undefined
-  return `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signalId)}`
+  return slug
+    ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(slug)}`
+    : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
 }
 
 export const signalRegressedRenderer: NotificationEmailRenderer<"signal.regressed"> = (payload, ctx) =>
@@ -28,7 +30,7 @@ export const signalRegressedRenderer: NotificationEmailRenderer<"signal.regresse
     )
 
     const signalName = signal?.name ?? "a signal"
-    const signalUrl = buildSignalUrl(ctx, payload.signalId)
+    const signalUrl = buildSignalUrl(ctx, signal?.slug ?? null)
     const subject = `Signal regressed: ${signalName}`
     const html = yield* Effect.tryPromise({
       try: () =>

--- a/packages/domain/integrations/src/templates/notifications/incident-closed.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-closed.ts
@@ -10,22 +10,25 @@ import {
   trendChartBlock,
   triageContextSuffix,
 } from "./blocks.ts"
-import { resolveAssigneeName, resolveSourceName } from "./source-name.ts"
+import { resolveAssigneeName, resolveSource } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentClosedRenderer: SlackNotificationRenderer<"incident.closed"> = (payload, ctx) =>
   Effect.gen(function* () {
     const projectName = ctx.project?.name ?? ctx.organization.name
     const isMonitorIncident = payload.sourceType === "monitor"
-    const signalUrl = ctx.project
-      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${payload.sourceId}`
-      : ctx.webAppUrl
     const monitorUrl =
       monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
       ctx.webAppUrl
     const duration = humanizeDurationMs(payload.recovery.durationMs)
 
-    const sourceName = yield* resolveSourceName(payload)
+    const source = yield* resolveSource(payload)
+    const sourceName = source?.name ?? null
+    const signalUrl = ctx.project
+      ? source
+        ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(source.slug)}`
+        : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
+      : ctx.webAppUrl
     const assigneeName = yield* resolveAssigneeName(payload.assigneeId)
 
     const attribution = monitorAttributionBlocks({

--- a/packages/domain/integrations/src/templates/notifications/incident-event.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-event.ts
@@ -10,7 +10,7 @@ import {
   severityColor,
   triageContextSuffix,
 } from "./blocks.ts"
-import { resolveAssigneeName, resolveSourceName } from "./source-name.ts"
+import { resolveAssigneeName, resolveSource } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentEventRenderer: SlackNotificationRenderer<"incident.event"> = (payload, ctx) =>
@@ -18,14 +18,17 @@ export const incidentEventRenderer: SlackNotificationRenderer<"incident.event"> 
     const name = INCIDENT_NOTIFICATION_KEY_LABEL[payload.incidentKind] ?? "Incident"
     const color = severityColor(payload.severity)
     const isMonitorIncident = payload.sourceType === "monitor"
-    const signalUrl = ctx.project
-      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${payload.sourceId}`
-      : ctx.webAppUrl
     const monitorUrl =
       monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
       ctx.webAppUrl
 
-    const sourceName = yield* resolveSourceName(payload)
+    const source = yield* resolveSource(payload)
+    const sourceName = source?.name ?? null
+    const signalUrl = ctx.project
+      ? source
+        ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(source.slug)}`
+        : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
+      : ctx.webAppUrl
     const assigneeName = yield* resolveAssigneeName(payload.assigneeId)
 
     const attribution = monitorAttributionBlocks({

--- a/packages/domain/integrations/src/templates/notifications/incident-opened.ts
+++ b/packages/domain/integrations/src/templates/notifications/incident-opened.ts
@@ -10,21 +10,24 @@ import {
   trendChartBlock,
   triageContextSuffix,
 } from "./blocks.ts"
-import { resolveAssigneeName, resolveSourceName } from "./source-name.ts"
+import { resolveAssigneeName, resolveSource } from "./source-name.ts"
 import type { SlackNotificationRenderer } from "./types.ts"
 
 export const incidentOpenedRenderer: SlackNotificationRenderer<"incident.opened"> = (payload, ctx) =>
   Effect.gen(function* () {
     const projectName = ctx.project?.name ?? ctx.organization.name
     const isMonitorIncident = payload.sourceType === "monitor"
-    const signalUrl = ctx.project
-      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${payload.sourceId}`
-      : ctx.webAppUrl
     const monitorUrl =
       monitorDeepLink({ webAppUrl: ctx.webAppUrl, projectSlug: ctx.project?.slug, monitorSlug: payload.monitorSlug }) ??
       ctx.webAppUrl
 
-    const sourceName = yield* resolveSourceName(payload)
+    const source = yield* resolveSource(payload)
+    const sourceName = source?.name ?? null
+    const signalUrl = ctx.project
+      ? source
+        ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(source.slug)}`
+        : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
+      : ctx.webAppUrl
     const assigneeName = yield* resolveAssigneeName(payload.assigneeId)
 
     const attribution = monitorAttributionBlocks({

--- a/packages/domain/integrations/src/templates/notifications/signal-discovered.ts
+++ b/packages/domain/integrations/src/templates/notifications/signal-discovered.ts
@@ -15,7 +15,9 @@ export const signalDiscoveredRenderer: SlackNotificationRenderer<"signal.discove
     const projectName = ctx.project?.name ?? ctx.organization.name
     const signalName = signal?.name ?? "A new signal"
     const signalUrl = ctx.project
-      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.signalId)}`
+      ? signal
+        ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signal.slug)}`
+        : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
       : ctx.webAppUrl
 
     return {

--- a/packages/domain/integrations/src/templates/notifications/signal-regressed.ts
+++ b/packages/domain/integrations/src/templates/notifications/signal-regressed.ts
@@ -15,7 +15,9 @@ export const signalRegressedRenderer: SlackNotificationRenderer<"signal.regresse
     const projectName = ctx.project?.name ?? ctx.organization.name
     const signalName = signal?.name ?? "A resolved signal"
     const signalUrl = ctx.project
-      ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(payload.signalId)}`
+      ? signal
+        ? `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals/${encodeURIComponent(signal.slug)}`
+        : `${ctx.webAppUrl}/projects/${ctx.project.slug}/signals`
       : ctx.webAppUrl
 
     return {

--- a/packages/domain/integrations/src/templates/notifications/source-name.ts
+++ b/packages/domain/integrations/src/templates/notifications/source-name.ts
@@ -3,12 +3,12 @@ import { SignalRepository } from "@domain/signals"
 import { UserRepository } from "@domain/users"
 import { Effect } from "effect"
 
-export const resolveSourceName = (input: { readonly sourceType: string; readonly sourceId: string }) =>
+export const resolveSource = (input: { readonly sourceType: string; readonly sourceId: string }) =>
   Effect.gen(function* () {
     if (input.sourceType !== "signal") return null
     const repo = yield* SignalRepository
     return yield* repo.findById(SignalId(input.sourceId)).pipe(
-      Effect.map((i): string | null => i.name),
+      Effect.map((i): { name: string; slug: string } | null => ({ name: i.name, slug: i.slug })),
       Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
       Effect.catchTag("RepositoryError", () => Effect.succeed(null)),
     )

--- a/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
+++ b/packages/domain/integrations/src/use-cases/dispatch-slack-notification.test.ts
@@ -219,7 +219,7 @@ describe("dispatchSlackNotificationUseCase", () => {
       blocks: expect.arrayContaining([
         expect.objectContaining({
           text: expect.objectContaining({
-            text: "A new signal was discovered: *<https://app.example.com/projects/frontend/signals/ssssssssssssssssssssssss|Bad JSON output>*.",
+            text: "A new signal was discovered: *<https://app.example.com/projects/frontend/signals/bad-json-output|Bad JSON output>*.",
           }),
         }),
         expect.objectContaining({
@@ -231,7 +231,7 @@ describe("dispatchSlackNotificationUseCase", () => {
         expect.objectContaining({
           elements: expect.arrayContaining([
             expect.objectContaining({
-              url: "https://app.example.com/projects/frontend/signals/ssssssssssssssssssssssss",
+              url: "https://app.example.com/projects/frontend/signals/bad-json-output",
             }),
           ]),
         }),


### PR DESCRIPTION
Fixes the broken "View signal" links reported in Slack (e.g. `https://console.latitude.so/projects/monorepo-chat/signals/pzaylh2k1zae20jhm3sirbj2`).

## what broke

#4154 made signal detail pages slug-addressed (`/projects/:projectSlug/signals/:signalSlug`), and the page resolves the URL param strictly as a slug. Notification deep links were never migrated: Slack (`signal.discovered`, `signal.regressed`, the three incident kinds), the matching emails, the in-app bell, and the "Copy signal link" action all still embedded the signal cuid id, so every link 404s.

## the fix

Two complementary parts:

**Renderers emit slug URLs.** The Slack and email signal renderers already fetch the signal to display its name, so they now use its `slug` for the URL. The incident renderers resolved only the source name; `resolveSourceName` becomes `resolveSource` (Slack) and `resolveIncidentSource` gains `slug` (email) so those templates can do the same. When the signal was deleted between notify and click, links fall back to the project signals list instead of a dead URL.

**Slug resolution falls back to id.** `getSignalIdBySlug` in `apps/web` now tries a project-scoped `findById` when the slug lookup misses (same dual-lookup pattern as the signals search direct match). This is what repairs links that are already out the door — Slack history, delivered emails, copied links — since those can't be edited retroactively. It also covers the in-app bell and "Copy signal link", which still pass ids and are left unchanged.

Updated the Slack dispatch test assertions from id URLs to slug URLs. Not run locally; relying on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Notification links now use the signal’s readable slug for more reliable direct navigation.
  - When a signal can’t be resolved, links fall back to the project’s signals list instead of using an invalid identifier.
  - Signal lookup now supports direct ID resolution while verifying the project match.
  - Email and Slack notifications consistently display resolved signal details and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->